### PR TITLE
python3Packages.iaqualink: 0.6.0 -> 0.7.0, python3Packages.httpx-retries: init at 0.5.0

### DIFF
--- a/pkgs/development/python-modules/httpx-retries/default.nix
+++ b/pkgs/development/python-modules/httpx-retries/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatch-fancy-pypi-readme,
+  hatchling,
+  httpx,
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "httpx-retries";
+  version = "0.5.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "will-ockmore";
+    repo = "httpx-retries";
+    tag = finalAttrs.version;
+    hash = "sha256-LElTcIWNsb2AVbk3dXcCnXeB8JhyM7Y64nTZGZWlVm8=";
+  };
+
+  build-system = [
+    hatch-fancy-pypi-readme
+    hatchling
+  ];
+
+  dependencies = [ httpx ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "httpx_retries" ];
+
+  meta = {
+    description = "Retry layer for HTTPX";
+    homepage = "https://github.com/will-ockmore/httpx-retries";
+    changelog = "https://github.com/will-ockmore/httpx-retries/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+})

--- a/pkgs/development/python-modules/iaqualink/default.nix
+++ b/pkgs/development/python-modules/iaqualink/default.nix
@@ -4,25 +4,25 @@
   fetchFromGitHub,
   hatch-vcs,
   hatchling,
+  httpx-retries,
   httpx,
   pytest-cov-stub,
   pytestCheckHook,
-  pythonOlder,
+  pyyaml,
   respx,
+  typer,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "iaqualink";
-  version = "0.6.0";
+  version = "0.7.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.12";
 
   src = fetchFromGitHub {
     owner = "flz";
     repo = "iaqualink-py";
-    tag = "v${version}";
-    hash = "sha256-s/ZhcbTaCvn7ei1O4+P4fKPojitl+4gsatc9PZx+W2g=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Bn4dcfTRkY+qc/c39ip+vZvlbqll7qZOl7phMgw9EjY=";
   };
 
   build-system = [
@@ -30,21 +30,34 @@ buildPythonPackage rec {
     hatchling
   ];
 
-  dependencies = [ httpx ] ++ httpx.optional-dependencies.http2;
+  dependencies = [
+    httpx
+    httpx-retries
+  ]
+  ++ httpx.optional-dependencies.http2;
+
+  optional-dependencies = {
+    cli = [
+      pyyaml
+      typer
+    ];
+  };
 
   nativeCheckInputs = [
     pytest-cov-stub
     pytestCheckHook
     respx
-  ];
+    typer
+  ]
+  ++ lib.flatten (builtins.attrValues finalAttrs.passthru.optional-dependencies);
 
   pythonImportsCheck = [ "iaqualink" ];
 
   meta = {
     description = "Python library for Jandy iAqualink";
     homepage = "https://github.com/flz/iaqualink-py";
-    changelog = "https://github.com/flz/iaqualink-py/releases/tag/${src.tag}";
+    changelog = "https://github.com/flz/iaqualink-py/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7252,6 +7252,8 @@ self: super: with self; {
 
   httpx-oauth = callPackage ../development/python-modules/httpx-oauth { };
 
+  httpx-retries = callPackage ../development/python-modules/httpx-retries { };
+
   httpx-socks = callPackage ../development/python-modules/httpx-socks { };
 
   httpx-sse = callPackage ../development/python-modules/httpx-sse { };


### PR DESCRIPTION
Changelog: https://github.com/flz/iaqualink-py/releases/tag/v0.7.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
