### PR TITLE
oversteer: fix changelog url

### DIFF
--- a/pkgs/by-name/ov/oversteer/package.nix
+++ b/pkgs/by-name/ov/oversteer/package.nix
@@ -34,18 +34,17 @@ let
     ]
   );
 
-  version = "0.8.3";
 in
-stdenv.mkDerivation {
-  inherit version;
+stdenv.mkDerivation (finalAttrs: {
+  version = "0.8.3";
 
   pname = "oversteer";
 
   src = fetchFromGitHub {
     owner = "berarma";
     repo = "oversteer";
-    rev = "v${version}";
-    sha256 = "sha256-X58U7lFH53nCaXnE7uXgV7aea6qntNfH5TIt68xSefY=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-X58U7lFH53nCaXnE7uXgV7aea6qntNfH5TIt68xSefY=";
   };
 
   buildInputs = [
@@ -101,11 +100,11 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = "https://github.com/berarma/oversteer";
-    changelog = "https://github.com/berarma/oversteer/releases/tag/${version}";
+    changelog = "https://github.com/berarma/oversteer/releases/tag/${finalAttrs.src.tag}";
     description = "Steering Wheel Manager for Linux";
     mainProgram = "oversteer";
     license = lib.licenses.gpl3Plus;
     maintainers = [ lib.maintainers.srounce ];
     platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
The changelog URL was invalid (detected via #514132). Cleaned up weird version passing introduced in #362937 which broke the changelog url.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
