### PR TITLE
nixos/cloudflare-warp: fix routing with strict rp_filter

### DIFF
--- a/nixos/modules/services/networking/cloudflare-warp.nix
+++ b/nixos/modules/services/networking/cloudflare-warp.nix
@@ -43,6 +43,10 @@ in
       allowedUDPPorts = [ cfg.udpPort ];
     };
 
+    boot.kernel.sysctl = {
+      "net.ipv4.conf.all.src_valid_mark" = 1;
+    };
+
     systemd.tmpfiles.rules = [
       "d ${cfg.rootDir}    - root root"
       "z ${cfg.rootDir}    - root root"


### PR DESCRIPTION
Cloudflare WARP uses fwmark for policy-based routing, which causes packets to be dropped by the kernel when strict reverse path filtering (rp_filter = 1) is enabled (the default in NixOS).

This commit sets `net.ipv4.conf.all.src_valid_mark = 1` when the module is enabled. This instructs the kernel to consider fwmark during rp_filter validation, resolving the routing issue without needing to globally weaken the firewall to `checkReversePath = "loose"`.

Fixes #504119

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
