### PR TITLE
ocamlPackages.omd: 1.3.2 -> 2.0.0.alpha4

### DIFF
--- a/pkgs/development/ocaml-modules/omd/default.nix
+++ b/pkgs/development/ocaml-modules/omd/default.nix
@@ -1,29 +1,48 @@
 {
   lib,
   buildDunePackage,
-  fetchurl,
+  fetchFromGitHub,
+  dune-build-info,
+  ppx_expect,
+  uucp,
+  uunf,
+  uutf,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "omd";
-  version = "1.3.2";
+  version = "2.0.0.alpha4";
 
-  minimalOCamlVersion = "4.03";
+  minimalOCamlVersion = "4.13";
 
-  src = fetchurl {
-    url = "https://github.com/ocaml/omd/releases/download/${version}/omd-${version}.tbz";
-    sha256 = "sha256-YCPhZCYx8I9njrVyWCCHnte7Wj/+53fN7evCjB+F+ts=";
+  src = fetchFromGitHub {
+    owner = "ocaml-community";
+    repo = "omd";
+    tag = finalAttrs.version;
+    hash = "sha256-5eZitDaNKSkLOsyPf5g5v9wdZZ3iVQGu8Ot4FHZZ3AI=";
   };
 
-  preBuild = ''
-    substituteInPlace src/dune --replace "bytes)" ")"
-  '';
+  buildInputs = [
+    dune-build-info
+  ];
+
+  propagatedBuildInputs = [
+    uucp
+    uunf
+    uutf
+  ];
+
+  doCheck = true;
+
+  checkInputs = [
+    ppx_expect
+  ];
 
   meta = {
     description = "Extensible Markdown library and tool in OCaml";
-    homepage = "https://github.com/ocaml/omd";
+    homepage = "https://github.com/ocaml-community/omd";
     license = lib.licenses.isc;
     maintainers = [ lib.maintainers.vbgl ];
     mainProgram = "omd";
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/ocaml-community/omd/releases/tag/2.0.0.alpha4

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
