### PR TITLE
confluence-cli: init at 2.1.8

### DIFF
--- a/pkgs/by-name/co/confluence-cli/package.nix
+++ b/pkgs/by-name/co/confluence-cli/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage rec {
+  pname = "confluence-cli";
+  version = "2.1.8";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "pchuri";
+    repo = "confluence-cli";
+    rev = "v${version}";
+    hash = "sha256-iTC1kenUQXYLnZ1KxhMaXeEJF2tih8HjlOsxq1Xtjds=";
+  };
+
+  npmDepsHash = "sha256-T06O6M2hjp9v32FKgVATQ42nhHVEN5+Rv2GcXkdp7zI=";
+
+  dontNpmBuild = true;
+
+  meta = {
+    description = "Command-line interface for Atlassian Confluence";
+    homepage = "https://github.com/pchuri/confluence-cli";
+    license = lib.licenses.mit;
+    mainProgram = "confluence";
+    maintainers = [ ];
+  };
+}


### PR DESCRIPTION
Add confluence-cli, a Node.js-based command-line interface for interacting with Atlassian Confluence.

homepage: https://github.com/pchuri/confluence-cli

This package is built using buildNpmPackage with vendored dependencies via npmDepsHash.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

Verified `confluence --help` and `confluence-cli --help` execute successfully.