### PR TITLE
linux: disable deprecated `CRYPTO_USER_API`

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -849,6 +849,13 @@ let
       CRYPTO_DRBG_HASH = yes;
       CRYPTO_DRBG_CTR = yes;
 
+      # Deprecated because it has a large attack surface and seen as a mistake.
+      # https://lore.kernel.org/all/20260430011544.31823-1-ebiggers@kernel.org/
+      # "If you're in charge of the configuration for a Linux kernel, I strongly
+      # recommend disabling all CONFIG_CRYPTO_USER_API_* kconfig options"
+      # https://news.ycombinator.com/item?id=47956312
+      CRYPTO_USER_API = no;
+
       # Enable KFENCE
       # See: https://docs.kernel.org/dev-tools/kfence.html
       KFENCE = whenAtLeast "5.12" yes;


### PR DESCRIPTION
Known significant users of this API are [systemd](https://lists.freedesktop.org/archives/systemd-devel/2017-March/038490.html) and [iwd](https://lore.kernel.org/all/20260430011544.31823-1-ebiggers@kernel.org/).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
