### PR TITLE
nixos/nginx: drop DHE usage

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -202,11 +202,6 @@ let
 
             ssl_protocols ${cfg.sslProtocols};
             ${optionalString (cfg.sslCiphers != null) "ssl_ciphers ${cfg.sslCiphers};"}
-            ${optionalString (cfg.sslDhparam != false)
-              "ssl_dhparam ${
-                if cfg.sslDhparam == true then config.security.dhparams.params.nginx.path else cfg.sslDhparam
-              };"
-            }
 
             ${optionalString cfg.recommendedTlsSettings ''
               # Consider https://ssl-config.mozilla.org/#server=nginx&config=intermediate as the lower bound
@@ -981,13 +976,6 @@ in
         description = "Allowed TLS protocol versions.";
       };
 
-      sslDhparam = mkOption {
-        type = types.either types.path types.bool;
-        default = false;
-        example = "/path/to/dhparams.pem";
-        description = "Path to DH parameters file, or `true` to generate with `security.dhparms.params.nginx`.";
-      };
-
       proxyResolveWhileRunning = mkOption {
         type = types.bool;
         default = false;
@@ -1287,6 +1275,13 @@ in
   };
 
   imports = [
+    (mkRemovedOptionModule [ "services" "nginx" "sslDhparam" ] ''
+      DHE cipher suites have been removed from the default nginx cipher list.
+
+      No additional configuration is required as ECDHE is used by default already.
+
+      If you wish to use Hybrid PQ key exchange, you can set services.nginx.recommendedTlsSettings = true.
+    '')
     (mkRemovedOptionModule [ "services" "nginx" "stateDir" ] ''
       The Nginx log directory has been moved to /var/log/nginx, the cache directory
       to /var/cache/nginx. The option services.nginx.stateDir has been removed.
@@ -1656,8 +1651,6 @@ in
           ) (filter (vhostConfig: vhostConfig.useACMEHost != null) acmeEnabledVhosts);
       in
       listToAttrs acmePairs;
-
-    security.dhparams.params.nginx = lib.mkIf (cfg.sslDhparam == true) { };
 
     users.users = optionalAttrs (cfg.user == "nginx") {
       nginx = {

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -970,7 +970,7 @@ in
       sslCiphers = mkOption {
         type = types.nullOr types.str;
         # Keep in sync with https://ssl-config.mozilla.org/#server=nginx&config=intermediate
-        default = "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305";
+        default = "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305";
         description = "Ciphers to choose from when negotiating TLS handshakes.";
       };
 

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -981,9 +981,6 @@ in
           "ECDHE-RSA-AES256-GCM-SHA384"
           "ECDHE-ECDSA-CHACHA20-POLY1305"
           "ECDHE-RSA-CHACHA20-POLY1305"
-          "DHE-RSA-AES128-GCM-SHA256"
-          "DHE-RSA-AES256-GCM-SHA384"
-          "DHE-RSA-CHACHA20-POLY1305"
         ];
         description = ''
           List of available cipher suites to choose from when negotiating TLS sessions.

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -206,11 +206,6 @@ let
                 if lib.isList cfg.sslCiphers then (lib.concatStringsSep ":" cfg.sslCiphers) else cfg.sslCiphers
               };"
             }
-            ${optionalString (cfg.sslDhparam != false)
-              "ssl_dhparam ${
-                if cfg.sslDhparam == true then config.security.dhparams.params.nginx.path else cfg.sslDhparam
-              };"
-            }
 
             ${optionalString cfg.recommendedTlsSettings ''
               # Consider https://ssl-config.mozilla.org/#server=nginx&config=intermediate as the lower bound
@@ -999,13 +994,6 @@ in
         description = "Allowed TLS protocol versions.";
       };
 
-      sslDhparam = mkOption {
-        type = types.either types.path types.bool;
-        default = false;
-        example = "/path/to/dhparams.pem";
-        description = "Path to DH parameters file, or `true` to generate with `security.dhparms.params.nginx`.";
-      };
-
       proxyResolveWhileRunning = mkOption {
         type = types.bool;
         default = false;
@@ -1305,6 +1293,13 @@ in
   };
 
   imports = [
+    (mkRemovedOptionModule [ "services" "nginx" "sslDhparam" ] ''
+      DHE cipher suites have been removed from the default nginx cipher list.
+
+      No additional configuration is required as ECDHE is used by default already.
+
+      If you wish to use Hybrid PQ key exchange, you can set services.nginx.recommendedTlsSettings = true.
+    '')
     (mkRemovedOptionModule [ "services" "nginx" "stateDir" ] ''
       The Nginx log directory has been moved to /var/log/nginx, the cache directory
       to /var/cache/nginx. The option services.nginx.stateDir has been removed.
@@ -1674,8 +1669,6 @@ in
           ) (filter (vhostConfig: vhostConfig.useACMEHost != null) acmeEnabledVhosts);
       in
       listToAttrs acmePairs;
-
-    security.dhparams.params.nginx = lib.mkIf (cfg.sslDhparam == true) { };
 
     users.users = optionalAttrs (cfg.user == "nginx") {
       nginx = {


### PR DESCRIPTION
The first commit drops the DHE ciphers to stay inline with Mozilla's SSL configuration recommendations as of 5.8 and the second commit removes the `services.nginx.sslDhparam` option which was only necessary to configure DHE which is now deprecated as of https://github.com/NixOS/nixpkgs/pull/513396.

## Further reading

https://ssl-config.mozilla.org/#server=nginx&config=intermediate&guideline=6.0
https://wiki.mozilla.org/Security/Server_Side_TLS#Version_History

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
