### PR TITLE
minikube: set libvirt to LD_LIBRARY_PATH to avoid 'Failed to open libvirt.so.0' error

### DIFF
--- a/pkgs/by-name/mi/minikube/package.nix
+++ b/pkgs/by-name/mi/minikube/package.nix
@@ -60,7 +60,10 @@ buildGoModule (finalAttrs: {
   installPhase = ''
     install out/minikube -Dt $out/bin
 
-    wrapProgram $out/bin/minikube --set MINIKUBE_WANTUPDATENOTIFICATION false
+    wrapProgram $out/bin/minikube --set MINIKUBE_WANTUPDATENOTIFICATION false \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath (lib.optionals stdenv.hostPlatform.isLinux [ libvirt ])
+      }
     export HOME=$PWD
 
     for shell in bash zsh fish; do

--- a/pkgs/by-name/mi/minikube/package.nix
+++ b/pkgs/by-name/mi/minikube/package.nix
@@ -71,7 +71,10 @@ buildGoModule (finalAttrs: {
 
     installBin out/minikube
 
-    wrapProgram $out/bin/minikube --set MINIKUBE_WANTUPDATENOTIFICATION false
+    wrapProgram $out/bin/minikube --set MINIKUBE_WANTUPDATENOTIFICATION false \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath (lib.optionals stdenv.hostPlatform.isLinux [ libvirt ])
+      }
     ln -sv $out/bin/minikube $out/bin/kubectl
 
     for shell in bash zsh fish; do

--- a/pkgs/by-name/mi/minikube/package.nix
+++ b/pkgs/by-name/mi/minikube/package.nix
@@ -72,6 +72,7 @@ buildGoModule (finalAttrs: {
     installBin out/minikube
 
     wrapProgram $out/bin/minikube --set MINIKUBE_WANTUPDATENOTIFICATION false \
+      --prefix PATH : ${lib.makeBinPath (lib.optionals stdenv.hostPlatform.isLinux [ libvirt ])} \
       --prefix LD_LIBRARY_PATH : ${
         lib.makeLibraryPath (lib.optionals stdenv.hostPlatform.isLinux [ libvirt ])
       }


### PR DESCRIPTION
Currently `minikube start --driver=kvm2` fails with the following message:

  Exiting due to GUEST_PROVISION: error provisioning guest: Failed to start host: recreate: creating host: create: creating: creating network: failed opening libvirt connection: failed connecting to libvirt socket: virError(Code=1, Domain=0, Message='Failed to open libvirt.so.0')

This commit fixes this problem by adding libvirt to LD_LIBRARY_PATH.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
