### PR TITLE
composia: init at 0.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1268,6 +1268,13 @@
     githubId = 58669111;
     name = "Alexandre Ros";
   };
+  alexma233 = {
+    email = "i@fur.im";
+    github = "alexma233";
+    githubId = 72970078;
+    keys = [ { fingerprint = "D64E B243 965E DCF4 B303  5F0C AE50 3C5E 4ECB A50B"; } ];
+    name = "AlexMa233";
+  };
   alexnabokikh = {
     email = "nabokikh@duck.com";
     github = "alexnabokikh";

--- a/pkgs/by-name/co/composia/package.nix
+++ b/pkgs/by-name/co/composia/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromForgejo,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "composia";
+  version = "0.1.2";
+
+  src = fetchFromForgejo {
+    domain = "forgejo.alexma.top";
+    owner = "alexma233";
+    repo = "composia";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-fca4lmjR2er+bfhI5yX3prL+02iFsaKfgmdTdaVeiOU=";
+  };
+
+  vendorHash = "sha256-LIts6L6jl2ZmHvOBboB9eBIf3VWraaVMca7/s7h65bU=";
+
+  subPackages = [
+    "cmd/composia"
+    "cmd/composia-controller"
+    "cmd/composia-agent"
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X forgejo.alexma.top/alexma233/composia/internal/version.Value=${finalAttrs.version}"
+  ];
+
+  meta = {
+    description = "Self-hosted Docker Compose control plane and CLI";
+    homepage = "https://docs.composia.xyz";
+    changelog = "https://forgejo.alexma.top/alexma233/composia/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ alexma233 ];
+    mainProgram = "composia";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/co/composia/package.nix
+++ b/pkgs/by-name/co/composia/package.nix
@@ -8,6 +8,8 @@ buildGoModule (finalAttrs: {
   pname = "composia";
   version = "0.1.2";
 
+  __structuredAttrs = true;
+
   src = fetchFromForgejo {
     domain = "forgejo.alexma.top";
     owner = "alexma233";
@@ -18,11 +20,7 @@ buildGoModule (finalAttrs: {
 
   vendorHash = "sha256-LIts6L6jl2ZmHvOBboB9eBIf3VWraaVMca7/s7h65bU=";
 
-  subPackages = [
-    "cmd/composia"
-    "cmd/composia-controller"
-    "cmd/composia-agent"
-  ];
+  subPackages = "cmd/composia cmd/composia-controller cmd/composia-agent";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/co/composia/package.nix
+++ b/pkgs/by-name/co/composia/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromForgejo,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "composia";
+  version = "0.2.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromForgejo {
+    domain = "forgejo.alexma.top";
+    owner = "alexma233";
+    repo = "composia";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-h5Smj0C+6ysO8Iwh0owkdo0FCkBgkKlxpBlCdMftkhw=";
+  };
+
+  vendorHash = "sha256-mLhKepFDJSaaRL1HV+Uf3gcFPS/YZrHL8z8Qw3zd6es=";
+
+  subPackages = "cmd/composia cmd/composia-controller cmd/composia-agent";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X forgejo.alexma.top/alexma233/composia/internal/version.Value=${finalAttrs.version}"
+  ];
+
+  meta = {
+    description = "Self-hosted Docker Compose control plane and CLI";
+    homepage = "https://docs.composia.xyz";
+    changelog = "https://forgejo.alexma.top/alexma233/composia/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ alexma233 ];
+    mainProgram = "composia";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/co/composia/package.nix
+++ b/pkgs/by-name/co/composia/package.nix
@@ -6,7 +6,7 @@
 
 buildGoModule (finalAttrs: {
   pname = "composia";
-  version = "0.1.2";
+  version = "0.2.1";
 
   __structuredAttrs = true;
 
@@ -15,10 +15,10 @@ buildGoModule (finalAttrs: {
     owner = "alexma233";
     repo = "composia";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-fca4lmjR2er+bfhI5yX3prL+02iFsaKfgmdTdaVeiOU=";
+    hash = "sha256-h5Smj0C+6ysO8Iwh0owkdo0FCkBgkKlxpBlCdMftkhw=";
   };
 
-  vendorHash = "sha256-LIts6L6jl2ZmHvOBboB9eBIf3VWraaVMca7/s7h65bU=";
+  vendorHash = "sha256-mLhKepFDJSaaRL1HV+Uf3gcFPS/YZrHL8z8Qw3zd6es=";
 
   subPackages = "cmd/composia cmd/composia-controller cmd/composia-agent";
 


### PR DESCRIPTION
Add Composia, a self-hosted Docker Compose control plane and CLI.

Composia lets users define services as plain `docker-compose.yaml` and metadata files, deploy them to one or more nodes, and keep direct file/CLI access without platform lock-in.

Homepage: https://docs.composia.xyz
Source: https://forgejo.alexma.top/alexma233/composia

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
