### PR TITLE
[Backport release-25.11] kanidm_1_9: 1.9.2 -> 1.9.3, kanidm_1_8: mark insecure

### DIFF
--- a/pkgs/servers/kanidm/1_8.nix
+++ b/pkgs/servers/kanidm/1_8.nix
@@ -2,5 +2,5 @@ import ./generic.nix {
   version = "1.8.6";
   hash = "sha256-+NZs8HHHmWGmlNNymIlbV7E28RiaGLmvtZkCWZJQvMk=";
   cargoHash = "sha256-NKCQRIxvWAT5saMO85noYZtm7h0OPFhWFqudvkQPYTE=";
-  eolDate = "2026-03-16";
+  unsupported = true;
 }

--- a/pkgs/servers/kanidm/1_9.nix
+++ b/pkgs/servers/kanidm/1_9.nix
@@ -1,5 +1,5 @@
 import ./generic.nix {
-  version = "1.9.2";
-  hash = "sha256-OmUWh60WZ4HH9dFCKiWZ66jMRJx6P003HNWfU0ywIO0=";
-  cargoHash = "sha256-xQ5FR+GiGZLLEt5GnLnc/vtZdx0YY5hsd06vkF+e6sM=";
+  version = "1.9.3";
+  hash = "sha256-YI2nShQhsCd1vn7S4VeCELfcU0HsmZrFs60kllJJFAo=";
+  cargoHash = "sha256-b6kBDA/CDJHbybfvbRRZ++q9H+SVRu0BmgkwzN2i/YU=";
 }

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -44,8 +44,8 @@
       # so users choosing to allow don't have to rebuild them every time.
       permittedInsecurePackages = [
         "olm-3.2.16" # see PR #347899
-        "kanidm_1_7-1.7.4"
-        "kanidmWithSecretProvisioning_1_7-1.7.4"
+        "kanidm_1_8-1.8.6"
+        "kanidmWithSecretProvisioning_1_8-1.8.6"
       ];
     };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
