### PR TITLE
NixOS/mosh: add timeout configuration

### DIFF
--- a/nixos/modules/programs/mosh.nix
+++ b/nixos/modules/programs/mosh.nix
@@ -45,4 +45,6 @@ in
       };
     };
   };
+
+  meta.maintainers = [ lib.maintainers.me-and ];
 }

--- a/nixos/modules/programs/mosh.nix
+++ b/nixos/modules/programs/mosh.nix
@@ -27,6 +27,38 @@ in
       '';
       default = true;
     };
+    networkTimeout = lib.mkOption {
+      description = ''
+        How long (in seconds) `mosh-server` will wait to receive an update from
+        the client before exiting.  Since `mosh` is very useful for mobile
+        clients with intermittent operation and connectivity, its authors
+        suggest setting this variable to a high value, such as 604800 (one
+        week) or 3592000 (30 days).  Otherwise, `mosh-server` will wait
+        indefinitely for a client to reappear.  This is somewhat similar to the
+        `TMOUT` variable found in many Bourne shells.  However, it is not a
+        login-session inactivity timeout; it only applies to network
+        connectivity.
+      '';
+      default = null;
+      type = lib.types.nullOr lib.types.numbers.positive;
+      example = 604800;
+    };
+    signalTimeout = lib.mkOption {
+      description = ''
+        How long (in seconds) `mosh-server` will ignore `SIGUSR1` while waiting
+        to receive an update from the client.  Otherwise, `SIGUSR1` will always
+        terminate `mosh-server`.  Users and administrators may implement
+        scripts to clean up disconnected Mosh sessions.  With this variable
+        set, a user or administrator can issue
+
+            $ pkill -SIGUSR1 mosh-server
+
+        to kill disconnected sessions without killing connected login sessions.
+      '';
+      default = null;
+      type = lib.types.nullOr lib.types.numbers.positive;
+      example = 60;
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -43,6 +75,10 @@ in
         setuid = false;
         setgid = true;
       };
+    };
+    environment.sessionVariables = {
+      MOSH_SERVER_NETWORK_TMOUT = cfg.networkTimeout;
+      MOSH_SERVER_SIGNAL_TMOUT = cfg.signalTimeout;
     };
   };
 


### PR DESCRIPTION
Add options for configuring the environment variables used by the Mosh `mosh-server` command to determine (a) how long a connection should be idle before it is automatically terminated, and (b) how long a connection should be idle before it terminates if it receives `SIGUSR1`.

See https://github.com/mobile-shell/mosh/blob/decd9b705eb81626f694335b8d5940538beb06da/man/mosh-server.1#L87-L122 for documentation on these Mosh features.

I've also added myself as a module maintainer.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
