### PR TITLE
nixos/step-ca: add flag to enable debug logging

### DIFF
--- a/nixos/modules/services/security/step-ca.nix
+++ b/nixos/modules/services/security/step-ca.nix
@@ -22,7 +22,7 @@ in
         example = true;
         description = ''
           Sets the environment variable to run step-ca with debug logging by adding `STEPDEBUG = "1"` to
-          {option}`systemd.step-ca.environment`.
+          {option}`systemd.services.step-ca.environment`.
         '';
       };
       address = lib.mkOption {

--- a/nixos/modules/services/security/step-ca.nix
+++ b/nixos/modules/services/security/step-ca.nix
@@ -16,6 +16,15 @@ in
       enable = lib.mkEnableOption "the smallstep certificate authority server";
       openFirewall = lib.mkEnableOption "opening the certificate authority server port";
       package = lib.mkPackageOption pkgs "step-ca" { };
+      enableDebugLog = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        example = true;
+        description = ''
+          Sets the environment variable to run step-ca with debug logging by adding `STEPDEBUG = "1"` to
+          {option}`systemd.step-ca.environment`.
+        '';
+      };
       address = lib.mkOption {
         type = lib.types.str;
         example = "127.0.0.1";
@@ -92,6 +101,9 @@ in
         restartTriggers = [ configFile ];
         unitConfig = {
           ConditionFileNotEmpty = ""; # override upstream
+        };
+        environment = lib.mkIf (cfg.enableDebugLog) {
+          STEPDEBUG = "1";
         };
         serviceConfig = {
           Type = "notify";


### PR DESCRIPTION
Allow to conventiently enable debug logs (https://smallstep.com/docs/step-ca/configuration/#environment-variables) via service module.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
