### PR TITLE
gui-for-singbox: 1.21.0 -> 1.23.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28964,6 +28964,13 @@
     githubId = 5604643;
     name = "Mikhail Volkhov";
   };
+  vollate = {
+    name = "Vollate";
+    email = "uint44t@gmail.com";
+    github = "vollate";
+    githubId = 90166078;
+    keys = [ { fingerprint = "A5B9 B2C5 8C04 DCB6 A157  566A 9CDF DE55 0783 E7BB"; } ];
+  };
   vonfry = {
     email = "nixos@vonfry.name";
     github = "Vonfry";

--- a/pkgs/by-name/gu/gui-for-singbox/frontend-runtime-path.patch
+++ b/pkgs/by-name/gu/gui-for-singbox/frontend-runtime-path.patch
@@ -1,0 +1,91 @@
+diff -ruN a/src/constant/kernel.ts b/src/constant/kernel.ts
+--- a/src/constant/kernel.ts
++++ b/src/constant/kernel.ts
+@@ -300,9 +300,9 @@
+       'run',
+       '--disable-color',
+       '-c',
+-      '$APP_BASE_PATH/$CORE_BASE_PATH/config.json',
++      '$CORE_BASE_PATH/config.json',
+       '-D',
+-      '$APP_BASE_PATH/$CORE_BASE_PATH',
++      '$CORE_BASE_PATH',
+     ],
+   }
+ }
+diff -ruN a/src/stores/env.ts b/src/stores/env.ts
+--- a/src/stores/env.ts
++++ b/src/stores/env.ts
+@@ -15,6 +15,7 @@
+     appName: '',
+     appVersion: '',
+     basePath: '',
++    configPath: '',
+     appPath: '',
+     os: '' as OS,
+     arch: '',
+diff -ruN a/src/stores/kernelApi.ts b/src/stores/kernelApi.ts
+--- a/src/stores/kernelApi.ts
++++ b/src/stores/kernelApi.ts
+@@ -248,8 +248,12 @@
+   const runCoreProcess = (isAlpha: boolean) => {
+     return new Promise<number | void>((resolve, reject) => {
+       let output: string
++      const coreWorkingDirectory =
++        envStore.env.os === 'linux' && envStore.env.configPath
++          ? `${envStore.env.configPath}/${CoreWorkingDirectory}`
++          : CoreWorkingDirectory
+       const pid = ExecBackground(
+-        CoreWorkingDirectory + '/' + getKernelFileName(isAlpha),
++        coreWorkingDirectory + '/' + getKernelFileName(isAlpha),
+         getKernelRuntimeArgs(isAlpha),
+         (out) => {
+           output = out
+@@ -263,8 +267,9 @@
+           reject(output)
+         },
+         {
+-          PidFile: CorePidFilePath,
++          PidFile: coreWorkingDirectory + '/pid.txt',
+           StopOutputKeyword: CoreStopOutputKeyword,
++          WorkingDirectory: envStore.env.configPath || envStore.env.basePath,
+           Env: getKernelRuntimeEnv(isAlpha),
+         },
+       ).catch((e) => reject(e))
+diff -ruN a/src/types/app.d.ts b/src/types/app.d.ts
+--- a/src/types/app.d.ts
++++ b/src/types/app.d.ts
+@@ -19,6 +19,7 @@
+   appName: string
+   appVersion: string
+   basePath: string
++  configPath: string
+   appPath: string
+   os: OS
+   arch: string
+diff -ruN a/src/utils/helper.ts b/src/utils/helper.ts
+--- a/src/utils/helper.ts
++++ b/src/utils/helper.ts
+@@ -822,9 +822,21 @@
+ export const processMagicVariables = (str: string) => {
+   const { env } = useEnvStore()
+   let result = str
++  const coreBasePath =
++    env.os === 'linux' && env.configPath
++      ? `${env.configPath}/${CoreWorkingDirectory}`
++      : CoreWorkingDirectory
++
++  if (env.os === 'linux') {
++    result = result.replaceAll('$APP_BASE_PATH/$CORE_BASE_PATH', coreBasePath)
++    result = result.replaceAll(
++      `${env.basePath}/${CoreWorkingDirectory}`,
++      coreBasePath,
++    )
++  }
+   Object.entries({
+     $APP_BASE_PATH: env.basePath,
+-    $CORE_BASE_PATH: CoreWorkingDirectory,
++    $CORE_BASE_PATH: coreBasePath,
+   }).forEach(([source, target]) => {
+     result = result.replaceAll(source, target)
+   })

--- a/pkgs/by-name/gu/gui-for-singbox/package.nix
+++ b/pkgs/by-name/gu/gui-for-singbox/package.nix
@@ -5,11 +5,13 @@
   fetchFromGitHub,
   autoPatchelfHook,
   copyDesktopItems,
+  glib-networking,
   nodejs,
   pkg-config,
   pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
+  wrapGAppsHook3,
   wails,
   webkitgtk_4_1,
   makeDesktopItem,
@@ -18,26 +20,28 @@
 
 let
   pname = "gui-for-singbox";
-  version = "1.21.0";
+  version = "1.23.2";
 
   src = fetchFromGitHub {
     owner = "GUI-for-Cores";
     repo = "GUI.for.SingBox";
     tag = "v${version}";
-    hash = "sha256-IGsH8QHoj2CvrSEc9eIisxySXQkjPSDBXsCPOXqANVM=";
+    hash = "sha256-CEJ0yzF2smBlLgZ4EH5UWV4Pc4vA2ZH80TjoudUKWZM=";
   };
 
   metaCommon = {
     homepage = "https://github.com/GUI-for-Cores/GUI.for.SingBox";
     hydraPlatforms = [ ]; # https://gui-for-cores.github.io/guide/#note
     license = with lib.licenses; [ gpl3Plus ];
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ vollate ];
   };
 
   frontend = stdenv.mkDerivation (finalAttrs: {
     inherit pname version src;
 
     sourceRoot = "${finalAttrs.src.name}/frontend";
+
+    patches = [ ./frontend-runtime-path.patch ];
 
     nativeBuildInputs = [
       nodejs
@@ -53,8 +57,8 @@ let
         sourceRoot
         ;
       pnpm = pnpm_10;
-      fetcherVersion = 2;
-      hash = "sha256-dWqwEnXPT+5N+36szm4AF1ChM9M6UJltct+EtQAofGQ=";
+      fetcherVersion = 3;
+      hash = "sha256-m9Rmc9Ww4jb2aQ+RXOwF71daZ6puspdMM/xidnk/YHs=";
     };
 
     buildPhase = ''
@@ -85,22 +89,20 @@ buildGo126Module {
 
   patches = [ ./xdg-path-and-restart-patch.patch ];
 
-  # As we need the $out reference, we can't use `replaceVars` here.
-  postPatch = ''
-    substituteInPlace bridge/bridge.go \
-      --subst-var out
-  '';
-
-  vendorHash = "sha256-EeIxt0BzSaZh1F38btUXN9kAvj12nlqEerVgWVGkiuk=";
+  vendorHash = "sha256-9uWrctbQ+vujb1Q8zT7Bv7rVyNY1rCM577c9caOKRNo=";
 
   nativeBuildInputs = [
     autoPatchelfHook
     copyDesktopItems
     pkg-config
     wails
+    wrapGAppsHook3
   ];
 
-  buildInputs = [ webkitgtk_4_1 ];
+  buildInputs = [
+    glib-networking
+    webkitgtk_4_1
+  ];
 
   preBuild = ''
     cp -r ${frontend} frontend/dist

--- a/pkgs/by-name/gu/gui-for-singbox/package.nix
+++ b/pkgs/by-name/gu/gui-for-singbox/package.nix
@@ -5,6 +5,8 @@
   fetchFromGitHub,
   autoPatchelfHook,
   copyDesktopItems,
+  gtk3,
+  makeWrapper,
   nodejs,
   pkg-config,
   pnpm_10,
@@ -18,13 +20,13 @@
 
 let
   pname = "gui-for-singbox";
-  version = "1.21.0";
+  version = "1.23.2";
 
   src = fetchFromGitHub {
     owner = "GUI-for-Cores";
     repo = "GUI.for.SingBox";
     tag = "v${version}";
-    hash = "sha256-IGsH8QHoj2CvrSEc9eIisxySXQkjPSDBXsCPOXqANVM=";
+    hash = "sha256-CEJ0yzF2smBlLgZ4EH5UWV4Pc4vA2ZH80TjoudUKWZM=";
   };
 
   metaCommon = {
@@ -38,6 +40,8 @@ let
     inherit pname version src;
 
     sourceRoot = "${finalAttrs.src.name}/frontend";
+
+    patches = [ ./frontend-runtime-path.patch ];
 
     nativeBuildInputs = [
       nodejs
@@ -54,7 +58,7 @@ let
         ;
       pnpm = pnpm_10;
       fetcherVersion = 2;
-      hash = "sha256-dWqwEnXPT+5N+36szm4AF1ChM9M6UJltct+EtQAofGQ=";
+      hash = "sha256-36i2WWTzp3FN7GSBA3va9f97AS+a6Vcj+qgVAw9eZf8=";
     };
 
     buildPhase = ''
@@ -85,17 +89,12 @@ buildGo126Module {
 
   patches = [ ./xdg-path-and-restart-patch.patch ];
 
-  # As we need the $out reference, we can't use `replaceVars` here.
-  postPatch = ''
-    substituteInPlace bridge/bridge.go \
-      --subst-var out
-  '';
-
-  vendorHash = "sha256-EeIxt0BzSaZh1F38btUXN9kAvj12nlqEerVgWVGkiuk=";
+  vendorHash = "sha256-9uWrctbQ+vujb1Q8zT7Bv7rVyNY1rCM577c9caOKRNo=";
 
   nativeBuildInputs = [
     autoPatchelfHook
     copyDesktopItems
+    makeWrapper
     pkg-config
     wails
   ];
@@ -133,6 +132,12 @@ buildGo126Module {
     install -Dm 0644 build/appicon.png $out/share/icons/hicolor/256x256/apps/gui-for-singbox.png
 
     runHook postInstall
+  '';
+
+  # The app fails to run correctly  without the GTK schema path in XDG_DATA_DIRS.
+  postFixup = ''
+    wrapProgram $out/bin/GUI.for.SingBox \
+      --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}"
   '';
 
   passthru = {

--- a/pkgs/by-name/gu/gui-for-singbox/package.nix
+++ b/pkgs/by-name/gu/gui-for-singbox/package.nix
@@ -33,7 +33,7 @@ let
     homepage = "https://github.com/GUI-for-Cores/GUI.for.SingBox";
     hydraPlatforms = [ ]; # https://gui-for-cores.github.io/guide/#note
     license = with lib.licenses; [ gpl3Plus ];
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ vollate ];
   };
 
   frontend = stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/by-name/gu/gui-for-singbox/xdg-path-and-restart-patch.patch
+++ b/pkgs/by-name/gu/gui-for-singbox/xdg-path-and-restart-patch.patch
@@ -1,6 +1,15 @@
+diff -ruN a/bridge/bridge.go b/bridge/bridge.go
 --- a/bridge/bridge.go
 +++ b/bridge/bridge.go
-@@ -93,7 +93,10 @@
+@@ -50,6 +50,7 @@
+ 
+ 	Env.BasePath = filepath.ToSlash(filepath.Dir(exePath))
+ 	Env.AppName = filepath.Base(exePath)
++	Env.ConfigPath = filepath.ToSlash(GetConfigPath())
+ 
+ 	if slices.Contains(os.Args, "tasksch") {
+ 		Env.FromTaskSch = true
+@@ -93,7 +94,10 @@
  
  func (a *App) RestartApp() FlagResult {
  	log.Printf("RestartApp")
@@ -12,3 +21,64 @@
  
  	cmd := exec.Command(exePath)
  	SetCmdWindowHidden(cmd)
+@@ -116,6 +120,7 @@
+ 		AppName:      Env.AppName,
+ 		AppVersion:   Env.AppVersion,
+ 		BasePath:     Env.BasePath,
++		ConfigPath:   Env.ConfigPath,
+ 		OS:           Env.OS,
+ 		ARCH:         Env.ARCH,
+ 		IsPrivileged: Env.IsPrivileged,
+@@ -258,7 +263,7 @@
+ }
+ 
+ func loadConfig() {
+-	b, err := os.ReadFile(Env.BasePath + "/data/user.yaml")
++	b, err := os.ReadFile(GetPath("data/user.yaml"))
+ 	if err == nil {
+ 		yaml.Unmarshal(b, &Config)
+ 	}
+diff -ruN a/bridge/types.go b/bridge/types.go
+--- a/bridge/types.go
++++ b/bridge/types.go
+@@ -21,6 +21,7 @@
+ 	AppName      string `json:"appName"`
+ 	AppVersion   string `json:"appVersion"`
+ 	BasePath     string `json:"basePath"`
++	ConfigPath   string `json:"configPath"`
+ 	OS           string `json:"os"`
+ 	ARCH         string `json:"arch"`
+ 	IsPrivileged bool   `json:"isPrivileged"`
+diff -ruN a/bridge/utils.go b/bridge/utils.go
+--- a/bridge/utils.go
++++ b/bridge/utils.go
+@@ -13,7 +13,29 @@
+ 	"golang.org/x/text/encoding/simplifiedchinese"
+ )
+ 
++func GetConfigPath() string {
++	if Env.OS == "linux" {
++		if xdgConfigHome := os.Getenv("XDG_CONFIG_HOME"); xdgConfigHome != "" {
++			return filepath.Join(xdgConfigHome, "GUI.for.SingBox")
++		}
++		if userConfigDir, err := os.UserConfigDir(); err == nil {
++			return filepath.Join(userConfigDir, "GUI.for.SingBox")
++		}
++	}
++
++	return Env.BasePath
++}
++
+ func GetPath(path string) string {
++	if Env.OS == "linux" && !filepath.IsAbs(path) {
++		cleanPath := filepath.ToSlash(filepath.Clean(path))
++		if cleanPath == "data" {
++			path = filepath.Join(GetConfigPath(), "data")
++		} else if strings.HasPrefix(cleanPath, "data/") {
++			path = filepath.Join(GetConfigPath(), cleanPath)
++		}
++	}
++
+ 	if !filepath.IsAbs(path) {
+ 		path = filepath.Join(Env.BasePath, path)
+ 	}


### PR DESCRIPTION
  Upstream changelog: https://github.com/GUI-for-Cores/GUI.for.SingBox/releases/tag/v1.23.2

  Also carries two patches on top of the upstream source:

  - `xdg-path-and-restart-patch.patch` — routes user config / kernel
    working dir under `$XDG_CONFIG_HOME/GUI.for.SingBox/` on Linux
    instead of `$out` (which is read-only), and makes RestartApp use
    `os.Executable()` so the wrapped nix-store path is respected.
  - `frontend-runtime-path.patch` — threads the XDG config path through
    to the frontend so the sing-box working directory and PID file
    resolve to a writable location at runtime.
  - Add `wrapGAppsHook3` and `glib-networking` to make sure the gtkwebkit handle network request correctly and fix the abnormal webview display due to missing gtk schema settings
  
  I have tested it on my `NixOS 26.05 (Yarara) x86_64` and it works perfectly.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
