### PR TITLE
field-monitor: 49.1 -> 50.0

### DIFF
--- a/pkgs/by-name/fi/field-monitor/package.nix
+++ b/pkgs/by-name/fi/field-monitor/package.nix
@@ -21,9 +21,11 @@
   xdg-desktop-portal,
   blueprint-compiler,
   libxml2,
+  nix-update-script,
   spice-protocol,
   spice-gtk,
   vte-gtk4,
+  gcr_4,
   gtk-vnc,
   usbredir,
   libepoxy,
@@ -32,7 +34,7 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "field-monitor";
-  version = "49.1";
+  version = "50.0";
 
   strictDeps = true;
 
@@ -40,12 +42,12 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "theCapypara";
     repo = "field-monitor";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-vtRubZwIQRV3ySFwdPgZ1Eyxh32FPsAvissxjrV3JcE=";
+    hash = "sha256-IVHzMUjjVZHDTI6Jjq7i8wrENPerKzEiDT15otPFx9A=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
-    hash = "sha256-zBCt/ptxAQ3TAzklmjbajQZ4Ou1+xlvH/k74yW34t9g=";
+    hash = "sha256-c4ANjQ1OoDMMifAUpU8iNE9lSBamAR+XbEmYrYphixU=";
   };
 
   mesonBuildType = "release";
@@ -66,6 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    gcr_4
     glib
     gsettings-desktop-schemas
     gtk-vnc
@@ -86,6 +89,8 @@ stdenv.mkDerivation (finalAttrs: {
     gst-plugins-base
     gst-plugins-good
   ]);
+
+  passthru.updateScript = nix-update-script { };
 
   postInstall = ''
     wrapProgram $out/bin/de.capypara.FieldMonitor --prefix PATH ':' "$out/libexec"


### PR DESCRIPTION
Updates Field Monitor to [v50.0](https://github.com/theCapypara/field-monitor/releases/tag/v50.0).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
