### PR TITLE
cyberia: init at 0.2.8

### DIFF
--- a/pkgs/by-name/cy/cyberia/package.nix
+++ b/pkgs/by-name/cy/cyberia/package.nix
@@ -1,0 +1,69 @@
+{
+  rustPlatform,
+  fetchgit,
+  fetchNpmDeps,
+  cargo-tauri,
+  nodejs,
+  npmHooks,
+  pkg-config,
+  lib,
+  stdenv,
+  wrapGAppsHook4,
+  dbus,
+  glib-networking,
+  gtk3,
+  webkitgtk_4_1,
+  alsa-lib,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cyberia";
+  version = "0.2.3";
+
+  __structuredAttrs = true;
+
+  src = fetchgit {
+    url = "https://git.gay/zutyosh/Cyberia.git";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-REcp7rl3nDzgqaBBjbC+LN+WMKLdfyn3nn9Jvypo7Ps=";
+  };
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+  cargoHash = "sha256-FrYDjydBsW1nYc3xsiR5jaPDm4eRwoOb1DK6XOMyiLU=";
+
+  npmDeps = fetchNpmDeps {
+    name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
+    inherit (finalAttrs) src;
+    hash = "sha256-BUoR/+5gARwZndh7YYp7vA/InWkn30yF9kR6PXsITBo=";
+  };
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+
+    nodejs
+    npmHooks.npmConfigHook
+
+    pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapGAppsHook4 ];
+
+  buildInputs = [
+    dbus
+    gtk3
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    glib-networking
+    webkitgtk_4_1
+    alsa-lib
+  ];
+
+  meta = {
+    description = "VRCX style client for Resonite";
+    homepage = "https://git.gay/zutyosh/Cyberia";
+    changelog = "https://git.gay/zutyosh/Cyberia/releases/tag/v${finalAttrs.version}";
+    mainProgram = "cyberia";
+    platforms = lib.platforms.linux;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ toasteruwu ];
+  };
+})

--- a/pkgs/by-name/cy/cyberia/package.nix
+++ b/pkgs/by-name/cy/cyberia/package.nix
@@ -1,0 +1,73 @@
+{
+  rustPlatform,
+  fetchFromForgejo,
+  fetchNpmDeps,
+  cargo-tauri,
+  nodejs,
+  npmHooks,
+  pkg-config,
+  lib,
+  stdenv,
+  wrapGAppsHook4,
+  dbus,
+  glib-networking,
+  gtk3,
+  webkitgtk_4_1,
+  alsa-lib,
+  libappindicator,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cyberia";
+  version = "0.2.8";
+
+  __structuredAttrs = true;
+
+  src = fetchFromForgejo {
+    domain = "git.gay";
+    owner = "zutyosh";
+    repo = "Cyberia";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-MKq3Q0g02JiTnwyjUNv1CzCCmG43ZFCffRa7BmUU5SU=";
+  };
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+  cargoHash = "sha256-ghdZyJt/hE+r/D+FqyLrUNSvVDZf+FRv463K33XrNbs=";
+
+  npmDeps = fetchNpmDeps {
+    name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
+    inherit (finalAttrs) src;
+    hash = "sha256-aZsQHb1Hj7dmz/04E6KJ5AMKKTcN+4fSK8phwDg2YAU=";
+  };
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+
+    nodejs
+    npmHooks.npmConfigHook
+
+    pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapGAppsHook4 ];
+
+  buildInputs = [
+    dbus
+    gtk3
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    glib-networking
+    webkitgtk_4_1
+    alsa-lib
+    libappindicator
+  ];
+
+  meta = {
+    description = "VRCX style client for Resonite";
+    homepage = "https://git.gay/zutyosh/Cyberia";
+    changelog = "https://git.gay/zutyosh/Cyberia/releases/tag/v${finalAttrs.version}";
+    mainProgram = "cyberia";
+    platforms = lib.platforms.linux;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ toasteruwu ];
+  };
+})


### PR DESCRIPTION
Adds a package for https://git.gay/zutyosh/Cyberia, a desktop client for checking what your friends are up to in Resonite and texting them. Like VRCX, but for Resonite.

I believe this should work fine under Darwin, but i have no system to test it with. So im gonna try to make it build, but i will not be able to run it.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
