### PR TITLE
thunderbird-cli{,-bridge,-mcp}: init at 1.0.2

### DIFF
--- a/pkgs/by-name/th/thunderbird-cli-bridge/package.nix
+++ b/pkgs/by-name/th/thunderbird-cli-bridge/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "thunderbird-cli-bridge";
+  version = "1.0.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "vitalio-sh";
+    repo = "thunderbird-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jtIXOHjijFkwdh5FWrqdSfEwbEmWQud8Qr2jsTEwJts=";
+  };
+
+  forceEmptyCache = true;
+  dontNpmBuild = true;
+
+  npmWorkspace = "bridge";
+  npmDepsHash = "sha256-ixzfebmKITD1lnPNQq765S1f+i7xBTTWWdZoJOqY7qg=";
+
+  # TODO: revisit this when https://github.com/NixOS/nixpkgs/pull/333759 has landed
+  postInstall = ''
+    rm -rf $out/lib/node_modules/thunderbird-cli/node_modules/thunderbird-cli-bridge
+    rm -rf $out/lib/node_modules/thunderbird-cli/node_modules/.bin/tb
+    rm -rf $out/lib/node_modules/thunderbird-cli/node_modules/.bin/tb-bridge
+    rm -rf $out/lib/node_modules/thunderbird-cli/node_modules/.bin/tb-mcp
+    rm -rf $out/lib/node_modules/thunderbird-cli/node_modules/thunderbird-cli
+    rm -rf $out/lib/node_modules/thunderbird-cli/node_modules/thunderbird-cli-mcp
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "HTTP/WebSocket bridge daemon between thunderbird-cli (or any HTTP client) and the Thunderbird-cli WebExtension. Stateless proxy, localhost-only.";
+    homepage = "https://github.com/vitalio-sh/thunderbird-cli";
+    changelog = "https://github.com/vitalio-sh/thunderbird-cli/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ drupol ];
+    mainProgram = "tb-bridge";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/th/thunderbird-cli-mcp/package.nix
+++ b/pkgs/by-name/th/thunderbird-cli-mcp/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "thunderbird-cli-mcp";
+  version = "1.0.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "vitalio-sh";
+    repo = "thunderbird-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jtIXOHjijFkwdh5FWrqdSfEwbEmWQud8Qr2jsTEwJts=";
+  };
+
+  forceEmptyCache = true;
+  dontNpmBuild = true;
+
+  npmWorkspace = "mcp";
+  npmDepsHash = "sha256-ixzfebmKITD1lnPNQq765S1f+i7xBTTWWdZoJOqY7qg=";
+
+  # TODO: revisit this when https://github.com/NixOS/nixpkgs/pull/333759 has landed
+  postInstall = ''
+    rm -rf $out/lib/node_modules/thunderbird-cli/node_modules/thunderbird-cli-bridge
+    rm -rf $out/lib/node_modules/thunderbird-cli/node_modules/.bin/tb
+    rm -rf $out/lib/node_modules/thunderbird-cli/node_modules/.bin/tb-bridge
+    rm -rf $out/lib/node_modules/thunderbird-cli/node_modules/.bin/tb-mcp
+    rm -rf $out/lib/node_modules/thunderbird-cli/node_modules/thunderbird-cli
+    rm -rf $out/lib/node_modules/thunderbird-cli/node_modules/thunderbird-cli-mcp
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "MCP server that gives full access to your email through Mozilla Thunderbird";
+    homepage = "https://github.com/vitalio-sh/thunderbird-cli";
+    changelog = "https://github.com/vitalio-sh/thunderbird-cli/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ drupol ];
+    mainProgram = "tb-mcp";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/th/thunderbird-cli/package.nix
+++ b/pkgs/by-name/th/thunderbird-cli/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "thunderbird-cli";
+  version = "1.0.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "vitalio-sh";
+    repo = "thunderbird-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jtIXOHjijFkwdh5FWrqdSfEwbEmWQud8Qr2jsTEwJts=";
+  };
+
+  forceEmptyCache = true;
+  dontNpmBuild = true;
+
+  npmWorkspace = "cli";
+  npmDepsHash = "sha256-ixzfebmKITD1lnPNQq765S1f+i7xBTTWWdZoJOqY7qg=";
+
+  # TODO: revisit this when https://github.com/NixOS/nixpkgs/pull/333759 has landed
+  postInstall = ''
+    rm -rf $out/lib/node_modules/thunderbird-cli/node_modules/thunderbird-cli-bridge
+    rm -rf $out/lib/node_modules/thunderbird-cli/node_modules/.bin/tb
+    rm -rf $out/lib/node_modules/thunderbird-cli/node_modules/.bin/tb-bridge
+    rm -rf $out/lib/node_modules/thunderbird-cli/node_modules/.bin/tb-mcp
+    rm -rf $out/lib/node_modules/thunderbird-cli/node_modules/thunderbird-cli
+    rm -rf $out/lib/node_modules/thunderbird-cli/node_modules/thunderbird-cli-mcp
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Low-level CLI to manage Mozilla Thunderbird email from the shell";
+    homepage = "https://github.com/vitalio-sh/thunderbird-cli";
+    changelog = "https://github.com/vitalio-sh/thunderbird-cli/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ drupol ];
+    mainProgram = "tb";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
https://github.com/vitalio-sh/thunderbird-cli/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
