### PR TITLE
addchain: init at 0.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1541,6 +1541,12 @@
     githubId = 153175;
     name = "Andrew Marshall";
   };
+  ambiso = {
+    email = "ambisotopy@gmail.com";
+    github = "ambiso";
+    githubId = 3750466;
+    name = "Robin Leander Schröder";
+  };
   ambossmann = {
     email = "timogottszky+git@gmail.com";
     github = "Ambossmann";

--- a/pkgs/by-name/ad/addchain/package.nix
+++ b/pkgs/by-name/ad/addchain/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+buildGoModule rec {
+  pname = "addchain";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "mmcloughlin";
+    repo = "addchain";
+    tag = "v${version}";
+    fetchSubmodules = false;
+    hash = "sha256-msuZgNYqN1QldrbXJJ4BFXYhUsllAPt8W0KRrr8p6TM=";
+  };
+
+  vendorHash = "sha256-qxlVGkbm95WFmH0+48XRXwrF7HRUWFxYHFzmFOaj4GA=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/mmcloughlin/addchain/meta.buildversion=${version}"
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  subPackages = [ "cmd/addchain" ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "addchain generates short addition chains for exponents of cryptographic interest with results rivaling the best hand-optimized chains";
+    homepage = "https://github.com/mmcloughlin/addchain";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
+      ambiso
+    ];
+    mainProgram = "addchain";
+  };
+}


### PR DESCRIPTION
adds the addchain cli

addchain generates short addition chains for exponents of cryptographic interest with [results](https://github.com/mmcloughlin/addchain#results) rivaling the best hand-optimized chains.

https://github.com/mmcloughlin/addchain

also add myself as a maintainer

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs. (at least I hope so)

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
