### PR TITLE
nixos-test-driver: Make a library

### DIFF
--- a/nixos/lib/test-driver/default.nix
+++ b/nixos/lib/test-driver/default.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
 
-  buildPythonApplication,
+  buildPythonPackage,
   colorama,
   coreutils,
   imagemagick_light,
@@ -32,7 +32,7 @@
   extraPythonPackages ? (_: [ ]),
 }:
 
-buildPythonApplication {
+buildPythonPackage {
   pname = "nixos-test-driver";
   version = "1.1";
   pyproject = true;

--- a/nixos/lib/testing/driver.nix
+++ b/nixos/lib/testing/driver.nix
@@ -13,11 +13,13 @@ let
 
   # Reifies and correctly wraps the python test driver for
   # the respective qemu version and with or without ocr support
-  testDriver = config.pythonTestDriverPackage.override {
-    inherit (config) enableOCR extraPythonPackages;
-    qemu_pkg = config.qemu.package;
-    enableNspawn = config.containers != { };
-  };
+  testDriver = hostPkgs.python3Packages.toPythonApplication (
+    config.pythonTestDriverPackage.override {
+      inherit (config) enableOCR extraPythonPackages;
+      qemu_pkg = config.qemu.package;
+      enableNspawn = config.containers != { };
+    }
+  );
 
   pythonizeName =
     name:
@@ -123,7 +125,7 @@ in
     pythonTestDriverPackage = mkOption {
       description = "Package containing the python NixOS test driver implemetnation";
       type = types.package;
-      default = hostPkgs.nixos-test-driver;
+      default = hostPkgs.python3Packages.nixos-test-driver;
       readOnly = true;
     };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -195,14 +195,6 @@ with pkgs;
 
   inherit (nix-update) nix-update-script;
 
-  nixos-test-driver = pkgs.python3Packages.callPackage ../../nixos/lib/test-driver {
-    qemu_pkg = pkgs.qemu;
-    imagemagick_light = pkgs.imagemagick_light.override { inherit (pkgs) libtiff; };
-    tesseract4 = pkgs.tesseract4.override { enableLanguages = [ "eng" ]; };
-    # We want `pkgs.systemd`, *not* `python3Packages.system`.
-    systemd = pkgs.systemd;
-  };
-
   ### Push NixOS tests inside the fixed point
 
   # See also allTestsForSystem in nixos/release.nix

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11140,6 +11140,14 @@ self: super: with self; {
     nixl = pkgs.nixl.override { python3Packages = self; };
   };
 
+  nixos-test-driver = callPackage ../../nixos/lib/test-driver {
+    qemu_pkg = pkgs.qemu;
+    imagemagick_light = pkgs.imagemagick_light.override { inherit (pkgs) libtiff; };
+    tesseract4 = pkgs.tesseract4.override { enableLanguages = [ "eng" ]; };
+    # We want `pkgs.systemd`, *not* `python3Packages.systemd`.
+    systemd = pkgs.systemd;
+  };
+
   nixpkgs-plugin-update = callPackage ../development/python-modules/nixpkgs-plugin-update { };
 
   nixpkgs-pytools = callPackage ../development/python-modules/nixpkgs-pytools { };


### PR DESCRIPTION
This PR:
- exposes the `nixos-test-driver` as a library -- I'm not so sure on the override/packaging logic here...
- allows fully overriding the `pythonTestDriver` package by removing the `readOnly = true` that was introduced in https://github.com/NixOS/nixpkgs/pull/503686
  - See [the discussion](https://github.com/NixOS/nixpkgs/pull/503686#pullrequestreview-4013835595) in that PR for additional context on why that option was made read-only.

In my case I want to fully replace the driver downstream--not just patch it. This is possible by creating a new package which exposes the [nixos-test-driver and generate-driver-symbols](https://github.com/NixOS/nixpkgs/blob/master/nixos/lib/test-driver/src/pyproject.toml#L10-L11) bins. This workflow also benefits significantly from https://github.com/NixOS/nixpkgs/pull/510385.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
