### PR TITLE
rebuilderd: 0.25.0 -> 0.27.0

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -43,6 +43,8 @@
   [pnpm `fetcherVersion` section](#javascript-pnpm-fetcherVersion) of the manual
   for details.
 
+- `rebuilderd` has been updated to 0.27.0 introducing breaking changes. See upstream changelog for details: [0.26.0](https://github.com/kpcyrd/rebuilderd/releases/tag/v0.26.0), [0.27.0](https://github.com/kpcyrd/rebuilderd/releases/tag/v0.27.0)
+
 ## Other Notable Changes {#sec-nixpkgs-release-26.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/pkgs/by-name/re/rebuilderd/package.nix
+++ b/pkgs/by-name/re/rebuilderd/package.nix
@@ -7,6 +7,7 @@
   installShellFiles,
   scdoc,
   bzip2,
+  cacert,
   openssl,
   sqlite,
   xz,
@@ -20,13 +21,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rebuilderd";
-  version = "0.25.0";
+  version = "0.26.0";
 
   src = fetchFromGitHub {
     owner = "kpcyrd";
     repo = "rebuilderd";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-BuL9s3ewZ1NvR9GG51TVrAncB0PR78Wuw8by+loSP8Q=";
+    hash = "sha256-dymI88hqPnL7fOopqn5faXZ9ZnopmXpmzNFzHjtJi7c=";
   };
 
   postPatch = ''
@@ -40,7 +41,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail '/bin/echo' 'echo'
   '';
 
-  cargoHash = "sha256-4M5uWgksYsV8PGe0zn9ADv06q3Ga/GVoQ8HjS7GCnwo=";
+  cargoHash = "sha256-qdA1H0sacOgxDugVlDKtv26/A7LfDPOUBdncZ5C0XNQ=";
 
   nativeBuildInputs = [
     pkg-config
@@ -79,6 +80,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
         installManPage "$page"
       done
     '';
+
+  preCheck = ''
+    export SSL_CERT_FILE=${cacert.out}/etc/ssl/certs/ca-bundle.crt
+  '';
 
   checkFlags = [
     # Failing tests

--- a/pkgs/by-name/re/rebuilderd/package.nix
+++ b/pkgs/by-name/re/rebuilderd/package.nix
@@ -7,6 +7,7 @@
   installShellFiles,
   scdoc,
   bzip2,
+  cacert,
   openssl,
   sqlite,
   xz,
@@ -20,13 +21,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rebuilderd";
-  version = "0.25.0";
+  version = "0.27.0";
 
   src = fetchFromGitHub {
     owner = "kpcyrd";
     repo = "rebuilderd";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-BuL9s3ewZ1NvR9GG51TVrAncB0PR78Wuw8by+loSP8Q=";
+    hash = "sha256-f+WfmkV0P4VfaOXxX3t5t9g/uJYCh2A587HEq9OK5QU=";
   };
 
   postPatch = ''
@@ -40,7 +41,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail '/bin/echo' 'echo'
   '';
 
-  cargoHash = "sha256-4M5uWgksYsV8PGe0zn9ADv06q3Ga/GVoQ8HjS7GCnwo=";
+  cargoHash = "sha256-se5u7+SF3fW5WqdUA3qmztUw5oPa0YXbgOp9GIVOQu0=";
 
   nativeBuildInputs = [
     pkg-config
@@ -79,6 +80,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
         installManPage "$page"
       done
     '';
+
+  preCheck = ''
+    export SSL_CERT_FILE=${cacert.out}/etc/ssl/certs/ca-bundle.crt
+  '';
+
+  __darwinAllowLocalNetworking = true;
 
   checkFlags = [
     # Failing tests


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/kpcyrd/rebuilderd/releases/tag/v0.26.0
https://github.com/kpcyrd/rebuilderd/releases/tag/v0.27.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
