### PR TITLE
gping: 1.20.1 -> 1.20.2, fix updateScript, adopt

### DIFF
--- a/pkgs/by-name/gp/gping/package.nix
+++ b/pkgs/by-name/gp/gping/package.nix
@@ -13,6 +13,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "gping";
   version = "1.20.1";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "orf";
     repo = "gping";
@@ -41,14 +43,22 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeInstallCheckInputs = [ versionCheckHook ];
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "gping-v(.*)"
+    ];
+  };
 
   meta = {
     description = "Ping, but with a graph";
     homepage = "https://github.com/orf/gping";
     changelog = "https://github.com/orf/gping/releases/tag/gping-v${finalAttrs.version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ cafkafk ];
+    maintainers = with lib.maintainers; [
+      cafkafk
+      kybe236
+    ];
     mainProgram = "gping";
   };
 })

--- a/pkgs/by-name/gp/gping/package.nix
+++ b/pkgs/by-name/gp/gping/package.nix
@@ -11,16 +11,18 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "gping";
-  version = "1.20.1";
+  version = "1.20.2";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "orf";
     repo = "gping";
     tag = "gping-v${finalAttrs.version}";
-    hash = "sha256-whHbGZnxOQ/ISyWMl6miuogppZahgXxO3XmhcP6ymIo=";
+    hash = "sha256-5R47STjc8aQZ90SmsXXs86rLlE8YqWOzFRsFeSVkJKo=";
   };
 
-  cargoHash = "sha256-F0QBL7tCCdjnavClqrw8yYxFrY8y4f8h/gcHSpEqBiM=";
+  cargoHash = "sha256-P8v7RNZoycRpYRjjnT5rwBML9tuMvdGQU40uif5xj1c=";
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -41,14 +43,22 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeInstallCheckInputs = [ versionCheckHook ];
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "gping-v(.*)"
+    ];
+  };
 
   meta = {
     description = "Ping, but with a graph";
     homepage = "https://github.com/orf/gping";
-    changelog = "https://github.com/orf/gping/releases/tag/gping-v${finalAttrs.version}";
+    changelog = "https://github.com/orf/gping/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ cafkafk ];
+    maintainers = with lib.maintainers; [
+      cafkafk
+      kybe236
+    ];
     mainProgram = "gping";
   };
 })


### PR DESCRIPTION
[fixes `r-ryantm` not finding the right version for this pkg.](https://nixpkgs-update-logs.nix-community.org/gping/2026-04-30.log)

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
