### PR TITLE
multica-cli: init at 0.2.21

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1015,6 +1015,12 @@
     githubId = 56970006;
     keys = [ { fingerprint = "50E2 669C AB38 2F4A 5F72  1667 0D6B FC01 D45E DADD"; } ];
   };
+  akosseres = {
+    name = "Ákos Seres";
+    email = "seresakos2000@gmail.com";
+    github = "AkosSeres";
+    githubId = 11257907;
+  };
   akotro = {
     name = "Antonis Kotronakis";
     email = "mail@akotro.dev";

--- a/pkgs/by-name/mu/multica-cli/package.nix
+++ b/pkgs/by-name/mu/multica-cli/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+}:
+
+buildGoModule rec {
+  __structuredAttrs = true;
+
+  pname = "multica-cli";
+  version = "0.2.21";
+
+  src = fetchFromGitHub {
+    owner = "multica-ai";
+    repo = "multica";
+    rev = "v${version}";
+    hash = "sha256-13xhPBLV3aWf5ESn4L2rGXXFTrYVejF+HQnTCGlE1bg=";
+  };
+
+  sourceRoot = "${src.name}/server";
+
+  vendorHash = "sha256-1rifzInFK8od9XAYWEuHU16ni2+gaDhlDIHc7WeuLU4=";
+
+  subPackages = [ "cmd/multica" ];
+
+  env.CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${version}"
+    "-X main.commit=nixpkg"
+    "-X main.date=1970-01-01T00:00:00Z"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installShellCompletion --cmd multica \
+      --bash <($out/bin/multica completion bash) \
+      --zsh <($out/bin/multica completion zsh) \
+      --fish <($out/bin/multica completion fish)
+  '';
+
+  meta = {
+    description = "CLI for the Multica managed agents platform";
+    homepage = "https://github.com/multica-ai/multica";
+    changelog = "https://github.com/multica-ai/multica/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ akosseres ];
+    mainProgram = "multica";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Packaged the CLI for the [Multica](https://github.com/multica-ai/multica) managed agents platform — local agent daemon and management tool, built from source (Go).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
