### PR TITLE
rke2: fix BoringCrypto ldflag mismatch causing fatal startup error (#515110)

### DIFF
--- a/pkgs/applications/networking/cluster/rke2/builder.nix
+++ b/pkgs/applications/networking/cluster/rke2/builder.nix
@@ -82,7 +82,7 @@ buildGoModule (finalAttrs: {
     "-X github.com/k3s-io/k3s/pkg/version.GitCommit=${lib.substring 0 6 rke2Commit}"
     "-X github.com/k3s-io/k3s/pkg/version.Program=${finalAttrs.pname}"
     "-X github.com/k3s-io/k3s/pkg/version.Version=v${finalAttrs.version}"
-    "-X github.com/k3s-io/k3s/pkg/version.UpstreamGolang=go${go.version}"
+    "-X github.com/k3s-io/k3s/pkg/version.UpstreamGolang=go${go.version}-X:boringcrypto"
     "-X github.com/rancher/rke2/pkg/images.DefaultRegistry=docker.io"
     "-X github.com/rancher/rke2/pkg/images.DefaultEtcdImage=rancher/hardened-etcd:${etcdVersion}"
     "-X github.com/rancher/rke2/pkg/images.DefaultKubernetesImage=rancher/hardened-kubernetes:${k8sImageTag}"


### PR DESCRIPTION
## Motivation

When `GOEXPERIMENT=boringcrypto` is set (as it is in this derivation), Go's `runtime.Version()` returns `go1.26.1-X:boringcrypto` instead of `go1.26.1`. k3s's `ValidateGolang()` does an exact string match between the `UpstreamGolang` ldflag and `runtime.Version()`, causing rke2 to fatal immediately on startup:

```
Failed to validate golang version: incorrect golang build version -
kubernetes v1.34.5 should be built with go1.26.1, runtime version is go1.26.1-X:boringcrypto
```

See https://github.com/k3s-io/k3s/blob/master/pkg/cli/cmds/golang.go for the validation logic.

## Changes

- Append `-X:boringcrypto` to the `UpstreamGolang` ldflag in `builder.nix` to match `runtime.Version()` output when built with BoringCrypto.

Fixes #515110.

---

Add a :+1: reaction to [pull requests you find important](https://github.com/NixOS/nixpkgs/issues/515110).

The Nixpkgs maintainers manually maintain their PRs based on the updates they receive from the bot, so it is not necessary to ping them repeatedly.