### PR TITLE
tinycc: fix build on aarch64-darwin

### DIFF
--- a/pkgs/by-name/ti/tinycc/package.nix
+++ b/pkgs/by-name/ti/tinycc/package.nix
@@ -3,6 +3,7 @@
   copyPkgconfigItems,
   fetchFromRepoOrCz,
   makePkgconfigItem,
+  apple-sdk,
   perl,
   stdenv,
   texinfo,
@@ -63,18 +64,39 @@ stdenv.mkDerivation (finalAttrs: {
     "--cc=$CC"
     "--ar=$AR"
     "--crtprefix=${lib.getLib stdenv.cc.libc}/lib"
-    "--sysincludepaths=${lib.getDev stdenv.cc.libc}/include:{B}/include"
+    "--sysincludepaths=${
+      lib.concatStringsSep ":" (
+        [
+          "{B}/include"
+        ]
+        ++ lib.optionals stdenv.hostPlatform.isDarwin [
+          "${apple-sdk.sdkroot}/usr/include"
+        ]
+        ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+          "${lib.getDev stdenv.cc.libc}/include"
+        ]
+      )
+    }"
     # The first libpath will be the one in which tcc will look for libtcc1.a,
     # which is need for its tests.
     "--libpaths=$lib/lib/tcc:$lib/lib:${lib.getLib stdenv.cc.libc}/lib"
     # build cross compilers
     "--enable-cross"
   ]
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
+    # The bounds checker has an unresolved arm64 atomic helper on Darwin.
+    "--config-bcheck=no"
+  ]
   ++ lib.optionals stdenv.hostPlatform.isMusl [
     "--config-musl"
   ];
 
   enableParallelBuilding = true;
+
+  preBuild = lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) ''
+    # TCC cannot cross-compile x86 long double constants from aarch64-darwin.
+    makeFlagsArray+=("TCC_X=i386-win32 x86_64-win32 arm arm64 arm-wince c67 riscv64 arm64-osx")
+  '';
 
   env.NIX_CFLAGS_COMPILE = toString [
     "-Wno-error=implicit-int"
@@ -83,7 +105,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Test segfault for static build
   doInstallCheck =
-    !stdenv.hostPlatform.isStatic && stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+    !stdenv.hostPlatform.isStatic
+    && stdenv.buildPlatform.canExecute stdenv.hostPlatform
+    && !(stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64);
 
   postPatch = ''
     patchShebangs texi2pod.pl
@@ -143,8 +167,6 @@ stdenv.mkDerivation (finalAttrs: {
       onemoresuza
     ];
     platforms = lib.platforms.unix;
-    # https://www.mail-archive.com/tinycc-devel@nongnu.org/msg10199.html
-    broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64;
   };
 })
 # TODO: self-compilation


### PR DESCRIPTION
Fix `tinycc` evaluation and build on `aarch64-darwin`.

This uses the Apple SDK headers on Darwin, disables the currently broken arm64 Darwin bounds checker, skips unsupported x86 cross-runtime targets, and disables the upstream install check on this platform because its Darwin runtime tests still fail around generated Mach-O signing and atomics.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
