### PR TITLE
nixos/cloudflare-warp: add option to disable warp taskbar service

### DIFF
--- a/nixos/modules/services/networking/cloudflare-warp.nix
+++ b/nixos/modules/services/networking/cloudflare-warp.nix
@@ -34,6 +34,10 @@ in
     openFirewall = lib.mkEnableOption "opening UDP ports in the firewall" // {
       default = true;
     };
+
+    enableTaskbar = lib.mkEnableOption "the Warp taskbar user service" // {
+      default = true;
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -93,6 +97,8 @@ in
           Group = "root";
         };
     };
+
+    systemd.user.services.warp-taskbar.enable = cfg.enableTaskbar;
   };
 
   meta.maintainers = with lib.maintainers; [ treyfortmuller ];


### PR DESCRIPTION
Add the `services.cloudflare-warp.enableTaskbar` option, allowing the `warp-taskbar.service` user unit to be disabled. Defaults to true to respect original behaviour. Closes #385352.

As the taskbar service comes from the Warp package itself, disabling the taskbar via Nix will mask its systemd unit, meaning it can't be started manually unless re-enabled again. Not sure if it's something that should be put in the option description as it would be a niche use case to want the taskbar available but only when started manually.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
