### PR TITLE
cerberus: re-enable install-check tests

### DIFF
--- a/pkgs/by-name/ce/cerberus/package.nix
+++ b/pkgs/by-name/ce/cerberus/package.nix
@@ -90,11 +90,13 @@ ocamlPackages.buildDunePackage (finalAttrs: {
     runHook postInstall
   '';
 
-  doInstallCheck = false;
+  doInstallCheck = true;
   installCheckPhase = ''
     runHook preInstallCheck
 
+    # Bypass `dune exec` so its stderr warnings don't pollute test output.
     PATH="$out/bin":$PATH
+    export WITH_CERB=cerberus
 
     patchShebangs --build tests
 


### PR DESCRIPTION
Re-enables the cerberus tests disabled in #512807. The failures came from Dune 3.21's `deprecated_coq_lang` warning polluting stderr via `dune exec`. Setting `WITH_CERB=cerberus` runs the installed binary directly. Verified: 188 passed, 0 failed.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
