### PR TITLE
john: rolling-2404 -> rolling-2604

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27299,6 +27299,12 @@
     githubId = 79593869;
     name = "Gramdalf";
   };
+  therealhammer = {
+    email = "thierry.hammer@googlemail.com";
+    github = "therealhammer";
+    githubId = 32392096;
+    name = "Thierry Hammer";
+  };
   therealr5 = {
     email = "rouven@rfive.de";
     github = "rouven0";

--- a/pkgs/by-name/jo/john/opencl.patch
+++ b/pkgs/by-name/jo/john/opencl.patch
@@ -6,12 +6,12 @@ index 790705330..2acedbc56 100755
  
  	/* Names to try to load */
  	const char * const opencl_names[] = {
+-		"libOpenCL.so.1",	/* Linux/others */
 -		"libOpenCL.so",		/* Linux/others, hack via "development" sub-package's symlink */
 -		"OpenCL",		/* _WIN */
 -		"/System/Library/Frameworks/OpenCL.framework/OpenCL", /* __APPLE__ */
 -		"opencl.dll",		/* __CYGWIN__ */
--		"cygOpenCL-1.dll",	/* __CYGWIN__ */
--		"libOpenCL.so.1"	/* Linux/others, no "development" sub-package installed */
+-		"cygOpenCL-1.dll"	/* __CYGWIN__ */
 +		"@ocl_icd@/lib/libOpenCL.so"	/* NixOS */
  	};
  

--- a/pkgs/by-name/jo/john/package.nix
+++ b/pkgs/by-name/jo/john/package.nix
@@ -25,13 +25,13 @@
 
 stdenv.mkDerivation {
   pname = "john";
-  version = "rolling-2404";
+  version = "rolling-2604";
 
   src = fetchFromGitHub {
     owner = "openwall";
     repo = "john";
-    rev = "f9fedd238b0b1d69181c1fef033b85c787e96e57";
-    hash = "sha256-XMT5Sbp2XrAnfTHxXyJdw0kA/ZtfOiYrX/flCFLHJ6s=";
+    rev = "f514ece8ec4ae5e38ad75aaa322eac86d73dcd76";
+    hash = "sha256-Fzt9KnMFBTdPpQMSlXe/zG9LMylAZnC6uzU4yJ6HSUk=";
   };
 
   patches = lib.optionals withOpenCL [

--- a/pkgs/by-name/jo/john/package.nix
+++ b/pkgs/by-name/jo/john/package.nix
@@ -142,6 +142,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/openwall/john/";
     maintainers = with lib.maintainers; [
       cherrykitten
+      therealhammer
     ];
     platforms = lib.platforms.unix;
   };


### PR DESCRIPTION
# Changes 

Bump version of john (the ripper) from 2404 to 2604. 
Also changed the patch file because the opencl source changed. 



- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
