### PR TITLE
csvs-to-sqlite: 1.3.0 -> 1.3.1

### DIFF
--- a/pkgs/by-name/cs/csvs-to-sqlite/package.nix
+++ b/pkgs/by-name/cs/csvs-to-sqlite/package.nix
@@ -2,34 +2,19 @@
   lib,
   python3,
   fetchFromGitHub,
-  fetchpatch,
 }:
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "csvs-to-sqlite";
-  version = "1.3";
+  version = "1.3.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "simonw";
     repo = "csvs-to-sqlite";
     rev = finalAttrs.version;
-    hash = "sha256-wV6htULG3lg2IhG2bXmc/9vjcK8/+WA7jm3iJu4ZoOE=";
+    hash = "sha256-hjimoIoHJdDyKzoJfWdRONUh7yLsR/d8n8zYbb6BKhk=";
   };
-
-  patches = [
-    # https://github.com/simonw/csvs-to-sqlite/pull/92
-    (fetchpatch {
-      name = "pandas2-compatibility-1.patch";
-      url = "https://github.com/simonw/csvs-to-sqlite/commit/fcd5b9c7485bc7b95bf2ed9507f18a60728e0bcb.patch";
-      hash = "sha256-ZmaNWxsqeNw5H5gAih66DLMmzmePD4no1B5mTf8aFvI=";
-    })
-    (fetchpatch {
-      name = "pandas2-compatibility-2.patch";
-      url = "https://github.com/simonw/csvs-to-sqlite/commit/3d190aa44e8d3a66a9a3ca5dc11c6fe46da024df.patch";
-      hash = "sha256-uYUH0Mhn6LIf+AHcn6WuCo5zFuSNWOZBM+AoqkmMnSI=";
-    })
-  ];
 
   build-system = with python3.pkgs; [
     setuptools


### PR DESCRIPTION
Update version and remove outdated patch

Upstream changelog:

Upgraded for compatibility with recent Pandas and Click libraries. Thanks, [Luighi Viton-Zorrilla](https://github.com/LuighiV). https://github.com/simonw/csvs-to-sqlite/issues/99

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
