### PR TITLE
[Backport staging-25.11] libexif: 0.6.25 -> 0.6.26

### DIFF
--- a/pkgs/by-name/li/libexif/package.nix
+++ b/pkgs/by-name/li/libexif/package.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libexif";
-  version = "0.6.25";
+  version = "0.6.26";
 
   src = fetchFromGitHub {
     owner = "libexif";
     repo = "libexif";
     rev = "libexif-${builtins.replaceStrings [ "." ] [ "_" ] version}-release";
-    sha256 = "sha256-H8YzfNO2FCrYAwEA4bkOpRdxISK9RXaHVuK8zz70TlM=";
+    sha256 = "sha256-H51RlMT3swWF8oLWu70eTnuumee5mRMSCWkMFX7mJSk=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
(cherry picked from commit 07f318c8ee924bc70e85499a4d30654826791402)

* * *

Manual backport of https://github.com/NixOS/nixpkgs/pull/509951

Conflicts came from a treewide to migrate packages to the `finalAttrs` pattern.

* * *

No package tests. Checked against `nixos-25.11`. “Verified” using:

```
 $ nix-build --attr libexif
```

Quoting @PhiliPdB

> Contains security fixes for:
> - [CVE-2026-40386](https://github.com/advisories/GHSA-p6wp-hhx9-7jj5) (#509518)
> - [CVE-2026-40385](https://github.com/advisories/GHSA-j9xr-5c85-xjhm) (#509517)
> - [CVE-2026-32775](https://github.com/advisories/GHSA-pq8m-942f-68cv)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
