### PR TITLE
rke2: fix BoringCrypto ldflag mismatch causing fatal startup error (#515110)

### DIFF
--- a/pkgs/applications/networking/cluster/rke2/builder.nix
+++ b/pkgs/applications/networking/cluster/rke2/builder.nix
@@ -4,13 +4,12 @@ lib:
   rke2Commit,
   rke2TarballHash,
   rke2VendorHash,
-  updateScript ? null,
+  updateScript,
   k8sImageTag,
   etcdVersion,
   pauseVersion,
   ccmVersion,
   dockerizedVersion,
-  helmJobVersion,
   imagesVersions,
 }:
 
@@ -23,7 +22,6 @@ lib:
   makeWrapper,
   fetchzip,
   fetchurl,
-  versionCheckHook,
 
   # Runtime dependencies
   procps,
@@ -44,6 +42,7 @@ lib:
 
   # Testing dependencies
   nixosTests,
+  testers,
 }:
 buildGoModule (finalAttrs: {
   pname = "rke2";
@@ -75,29 +74,22 @@ buildGoModule (finalAttrs: {
   ];
 
   # Passing boringcrypto to GOEXPERIMENT variable to build with goboring library
-  env.GOEXPERIMENT = "boringcrypto";
+  GOEXPERIMENT = "boringcrypto";
 
-  # https://github.com/rancher/rke2/blob/104ddbf3de65ab5490aedff36df2332d503d90fe/scripts/build-binary#L27-L39
-  ldflags =
-    let
-      K3S_PKG = "github.com/k3s-io/k3s";
-      HELMCTR_PKG = "github.com/k3s-io/helm-controller";
-      RKE2_PKG = "github.com/rancher/rke2";
-    in
-    [
-      "-w"
-      "-X ${K3S_PKG}/pkg/version.GitCommit=${lib.substring 0 6 rke2Commit}"
-      "-X ${K3S_PKG}/pkg/version.Program=${finalAttrs.pname}"
-      "-X ${K3S_PKG}/pkg/version.Version=v${finalAttrs.version}"
-      "-X ${K3S_PKG}/pkg/version.UpstreamGolang=go${go.version}"
-      "-X ${HELMCTR_PKG}/pkg/controllers/chart.DefaultJobImage=rancher/klipper-helm:${helmJobVersion}"
-      "-X ${RKE2_PKG}/pkg/images.DefaultRegistry=docker.io"
-      "-X ${RKE2_PKG}/pkg/images.DefaultEtcdImage=rancher/hardened-etcd:${etcdVersion}"
-      "-X ${RKE2_PKG}/pkg/images.DefaultKubernetesImage=rancher/hardened-kubernetes:${k8sImageTag}"
-      "-X ${RKE2_PKG}/pkg/images.DefaultPauseImage=rancher/mirrored-pause:${pauseVersion}"
-      "-X ${RKE2_PKG}/pkg/images.DefaultRuntimeImage=rancher/rke2-runtime:${dockerizedVersion}"
-      "-X ${RKE2_PKG}/pkg/images.DefaultCloudControllerManagerImage=rancher/rke2-cloud-provider:${ccmVersion}"
-    ];
+  # See: https://github.com/rancher/rke2/blob/e7f87c6dd56fdd76a7dab58900aeea8946b2c008/scripts/build-binary#L27-L38
+  ldflags = [
+    "-w"
+    "-X github.com/k3s-io/k3s/pkg/version.GitCommit=${lib.substring 0 6 rke2Commit}"
+    "-X github.com/k3s-io/k3s/pkg/version.Program=${finalAttrs.pname}"
+    "-X github.com/k3s-io/k3s/pkg/version.Version=v${finalAttrs.version}"
+    "-X github.com/k3s-io/k3s/pkg/version.UpstreamGolang=go${go.version}-X:boringcrypto"
+    "-X github.com/rancher/rke2/pkg/images.DefaultRegistry=docker.io"
+    "-X github.com/rancher/rke2/pkg/images.DefaultEtcdImage=rancher/hardened-etcd:${etcdVersion}"
+    "-X github.com/rancher/rke2/pkg/images.DefaultKubernetesImage=rancher/hardened-kubernetes:${k8sImageTag}"
+    "-X github.com/rancher/rke2/pkg/images.DefaultPauseImage=rancher/mirrored-pause:${pauseVersion}"
+    "-X github.com/rancher/rke2/pkg/images.DefaultRuntimeImage=rancher/rke2-runtime:${dockerizedVersion}"
+    "-X github.com/rancher/rke2/pkg/images.DefaultCloudControllerManagerImage=rancher/rke2-cloud-provider:${ccmVersion}"
+  ];
 
   tags = [
     "no_cri_dockerd"
@@ -137,19 +129,25 @@ buildGoModule (finalAttrs: {
     go tool nm $out/bin/.rke2-wrapped | grep '_Cfunc__goboringcrypto_' > /dev/null
     runHook postInstallCheck
   '';
-  nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
 
   passthru = {
     inherit updateScript;
     tests =
       let
-        versionedPackage =
-          "rke2_" + lib.replaceStrings [ "." ] [ "_" ] (lib.versions.majorMinor rke2Version);
+        moduleTests =
+          let
+            package_version =
+              "rke2_" + lib.replaceStrings [ "." ] [ "_" ] (lib.versions.majorMinor rke2Version);
+          in
+          lib.mapAttrs (name: value: nixosTests.rke2.${name}.${package_version}) nixosTests.rke2;
       in
-      lib.mapAttrs (name: _: nixosTests.rke2.${name}.${versionedPackage}) (
-        lib.filterAttrs (n: _: n != "all") nixosTests.rke2
-      );
+      {
+        version = testers.testVersion {
+          package = finalAttrs.finalPackage;
+          version = "v${finalAttrs.version}";
+        };
+      }
+      // moduleTests;
   }
   // (lib.mapAttrs (_: value: fetchurl value) imagesVersions);
 
@@ -159,7 +157,6 @@ buildGoModule (finalAttrs: {
     changelog = "https://github.com/rancher/rke2/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
-      maevii
       rorosen
       zimbatm
       zygot


### PR DESCRIPTION
## Motivation

When `GOEXPERIMENT=boringcrypto` is set (as it is in this derivation), Go's `runtime.Version()` returns `go1.26.1-X:boringcrypto` instead of `go1.26.1`. k3s's `ValidateGolang()` does an exact string match between the `UpstreamGolang` ldflag and `runtime.Version()`, causing rke2 to fatal immediately on startup:

```
Failed to validate golang version: incorrect golang build version -
kubernetes v1.34.5 should be built with go1.26.1, runtime version is go1.26.1-X:boringcrypto
```

See https://github.com/k3s-io/k3s/blob/master/pkg/cli/cmds/golang.go for the validation logic.

## Changes

- Append `-X:boringcrypto` to the `UpstreamGolang` ldflag in `builder.nix` to match `runtime.Version()` output when built with BoringCrypto.

Fixes #515110.

---

Add a :+1: reaction to [pull requests you find important](https://github.com/NixOS/nixpkgs/issues/515110).

The Nixpkgs maintainers manually maintain their PRs based on the updates they receive from the bot, so it is not necessary to ping them repeatedly.