### PR TITLE
busybox: Handle CVE-2025-60876

### DIFF
--- a/pkgs/os-specific/linux/busybox/CVE-2025-60876.patch
+++ b/pkgs/os-specific/linux/busybox/CVE-2025-60876.patch
@@ -1,0 +1,40 @@
+From radoslav.kolev at suse.com  Fri Nov 21 09:21:18 2025
+From: radoslav.kolev at suse.com (Radoslav Kolev)
+Date: Fri, 21 Nov 2025 11:21:18 +0200
+Subject: [PATCH v2 1/1] wget: don't allow control characters or spaces in the
+ URL
+In-Reply-To: <20251121092118.3562853-1-radoslav.kolev@suse.com>
+References: <20251121092118.3562853-1-radoslav.kolev@suse.com>
+Message-ID: <20251121092118.3562853-2-radoslav.kolev@suse.com>
+
+Fixes CVE-2025-60876 malicious URL can be used to inject
+HTTP headers in the request.
+
+Signed-off-by: Radoslav Kolev <radoslav.kolev at suse.com>
+Reviewed-by: Emmanuel Deloget <logout at free.fr>
+---
+ networking/wget.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/networking/wget.c b/networking/wget.c
+index ec3767793..fa555427b 100644
+--- a/networking/wget.c
++++ b/networking/wget.c
+@@ -536,6 +536,15 @@ static void parse_url(const char *src_url, struct host_info *h)
+ {
+ 	char *url, *p, *sp;
+ 
++	/* Fix for CVE-2025-60876 - don't allow control characters or spaces in the URL */
++	/* otherwise a malicious URL can be used to inject HTTP headers in the request */
++	const unsigned char *u = (void *) src_url;
++	while (*u) {
++		if (*u <= ' ')
++			bb_simple_error_msg_and_die("Unencoded control character found in the URL!");
++		u++;
++	}
++
+ 	free(h->allocated);
+ 	h->allocated = url = xstrdup(src_url);
+ 
+-- 
+2.51.1

--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -92,6 +92,10 @@ stdenv.mkDerivation rec {
     })
     # https://lists.busybox.net/pipermail/busybox/2026-March/092010.html
     ./build-system-buffer-overflow.patch
+
+    # [PATCH v2 1/1] wget: don't allow control characters or spaces in the URL
+    # https://lists.busybox.net/pipermail/busybox/2025-November/091840.html
+    ./CVE-2025-60876.patch
   ]
   ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) ./clang-cross.patch;
 


### PR DESCRIPTION
Handle CVE-2025-60876 for `busybox`'s `wget` applet by using the current most up-to-date fix from their ML.

The patch [is the one used by Debian](https://udd.debian.org/patches.cgi?src=busybox&version=1%3A1.37.0-10.1) (search for `wget-disallow-control-chars-in-URLs-CVE-2025-60876.patch`), but taken directly from the busybox mailing list archive.

    curl --silent -L \
      'https://lists.busybox.net/pipermail/busybox/2025-November.txt.gz' \
      | gunzip \
      | grep -B7 -A32 'Message-ID: <20251121092118.3562853-2-radoslav.kolev@suse.com>' \
      > pkgs/os-specific/linux/busybox/CVE-2025-60876.patch

## Things done

Since there's no package tests, my testing was limited to `nix-build --attr busybox` on `nixos-unstable`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
