### PR TITLE
pkgsStatic.diffutils: fix musl test failures

### DIFF
--- a/pkgs/tools/text/diffutils/default.nix
+++ b/pkgs/tools/text/diffutils/default.nix
@@ -63,8 +63,23 @@ stdenv.mkDerivation rec {
       ''
         sed -i -E 's:test-time::g' gnulib-tests/Makefile.in
       ''
+    else if stdenv.hostPlatform.isMusl then
+      # gnulib's getopt tests fail against musl
+      ''
+        sed -i -E 's:test-getopt-(gnu|posix)\$\(EXEEXT\)::g' gnulib-tests/Makefile.in
+      ''
     else
       null;
+
+  # ./configure decides to use weak symbols on pkgsStatic, which
+  # makes pthread_in_use() return false and the *-mt tests abort
+  # setlocale_null.c makes the same wrong choice with HAVE_WEAK_SYMBOLS
+  # FIXME: rebuild avoidance, swap to optionalString in staging
+  postConfigure = lib.optionalDrvAttr (stdenv.hostPlatform.isStatic && stdenv.hostPlatform.isMusl) ''
+    substituteInPlace lib/config.h \
+      --replace-fail '#define USE_POSIX_THREADS_WEAK 1' '#undef USE_POSIX_THREADS_WEAK' \
+      --replace-fail '#define HAVE_WEAK_SYMBOLS 1' '#undef HAVE_WEAK_SYMBOLS'
+  '';
 
   configureFlags =
     # "pr" need not be on the PATH as a run-time dep, so we need to tell


### PR DESCRIPTION
Fixing two different reasons diffutil's test suite fails in pkgsStatic

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
