### PR TITLE
ungoogled-chromium: 147.0.7727.116-1 -> 147.0.7727.137-1

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -828,11 +828,11 @@
     }
   },
   "ungoogled-chromium": {
-    "version": "147.0.7727.116",
+    "version": "147.0.7727.137",
     "deps": {
       "depot_tools": {
-        "rev": "3d94d7c3056847db821c6451be61054c36d7c6d5",
-        "hash": "sha256-hWfmidLPY0bXI58xAwkGnmb3GnSsKIUlDM91MYWfgpM="
+        "rev": "f2f7ec41f2c170d6f1899406f11a48411760a683",
+        "hash": "sha256-/4Zz169PVxRGFubknL+5hbUX9uRnOGArjt0dA8u0I88="
       },
       "gn": {
         "version": "0-unstable-2026-03-05",
@@ -840,16 +840,16 @@
         "hash": "sha256-3AfExm7NL5GJXyC5JCPbGC70D59doRfIZIgpt6MLy9Y="
       },
       "ungoogled-patches": {
-        "rev": "147.0.7727.116-1",
-        "hash": "sha256-MmVLgbT+uzFzRt7faNvnWrlDwChDPth5eVqcGBXwUu4="
+        "rev": "147.0.7727.137-1",
+        "hash": "sha256-MtsTk7aV7qpeXYBTxfEauCJlcoWYxdsQFbtN9ockSME="
       },
       "npmHash": "sha256-ByB1Ea5tduIJZXyydeBWsoS8OPABOgwHe+dNXRssdvc="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "dbcf1b1bfb506cc580859bcb5ff9460a8443af90",
-        "hash": "sha256-pcrElIGFOcPQjJUF1ceHMRjS3YLjbTa9cM3Qg/G3u6I=",
+        "rev": "68ba233a543d25e75c30f1228dd3bafa2da96937",
+        "hash": "sha256-ktIkQRYWcyKnZKEhvxFGssMZ///ctd/Ue3VIYPvQzuM=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -919,8 +919,8 @@
       },
       "src/third_party/angle": {
         "url": "https://chromium.googlesource.com/angle/angle.git",
-        "rev": "82ab43bfda5a3f59e1876fd3c828f047c689bc12",
-        "hash": "sha256-6WjecQRoyCLUoSbqDMpmsJ5tZazPF171KWnjxxK8hd4="
+        "rev": "534e0d1c1d0fcb4b57fd6a3fb9284cd14eaa28cd",
+        "hash": "sha256-o3UV8X27G7wpaDiKDzgMZN64+d9JQrvcQXpSybxi/h4="
       },
       "src/third_party/angle/third_party/glmark2/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glmark2/glmark2",
@@ -959,8 +959,8 @@
       },
       "src/third_party/dawn": {
         "url": "https://dawn.googlesource.com/dawn.git",
-        "rev": "ff7b4f6c5d964879b5f4356ef6e732adeed2f627",
-        "hash": "sha256-pURclm6gi0am32tohZTB4iT2BWa55uRBJNRVW0gjDcY="
+        "rev": "049880d58d6636a819168c00f44f8a4ed1e33e51",
+        "hash": "sha256-AHUos4ejvcsHTDdretkDHAeyLugtI6Jg14Hb9MbbPPs="
       },
       "src/third_party/dawn/third_party/glfw": {
         "url": "https://chromium.googlesource.com/external/github.com/glfw/glfw",
@@ -1484,8 +1484,8 @@
       },
       "src/third_party/skia": {
         "url": "https://skia.googlesource.com/skia.git",
-        "rev": "f8cd2da0256752afb0059bf17e4bf2bec422967e",
-        "hash": "sha256-dtSWBpCaewkKMW3Jc1PNDQh0jSQHIPduaXsIU9rcTa0="
+        "rev": "6e0fbe154ccaf018b2dd1f0e42eec285e7d79d00",
+        "hash": "sha256-oqfNOSQB+5sbAnw4tPBXn22rk6Ai5b2aZNLJUyM181k="
       },
       "src/third_party/smhasher/src": {
         "url": "https://chromium.googlesource.com/external/smhasher.git",
@@ -1619,8 +1619,8 @@
       },
       "src/third_party/webrtc": {
         "url": "https://webrtc.googlesource.com/src.git",
-        "rev": "997079137283f693a0fac6a5350ae7f6f2cf3b59",
-        "hash": "sha256-SOV9YS8Dk1HFCo00Qe6zttJOP0PEBS4B6Ah79OXmTew="
+        "rev": "28452dff1bf86fec881a47949d4dedd4a2fe1f09",
+        "hash": "sha256-KBz94jvdVgxWuTuSoeHKNdY7wEJDGqG3xVsSVB3ubRQ="
       },
       "src/third_party/wuffs/src": {
         "url": "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git",
@@ -1649,8 +1649,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "9b21082faf16a5f029a4316272c9a627d8b33eb4",
-        "hash": "sha256-dT1f9Df1K1ZLp346Tpqn6Lkq2HDYWWQIAuhqXMIIydk="
+        "rev": "c152c31c55cd54fd239772532a86c802d95b4617",
+        "hash": "sha256-7qEPh9l94LqyaA9qW0ZfFmmFyMNTjTJaeunLgDhtFuM="
       }
     }
   }


### PR DESCRIPTION
Same underlying changes as #514558

https://chromereleases.googleblog.com/2026/04/stable-channel-update-for-desktop_28.html

This update includes 30 security fixes.

CVEs:
CVE-2026-7363 CVE-2026-7361 CVE-2026-7344 CVE-2026-7343 CVE-2026-7333 CVE-2026-7360 CVE-2026-7359 CVE-2026-7358 CVE-2026-7334 CVE-2026-7357 CVE-2026-7356 CVE-2026-7354 CVE-2026-7353 CVE-2026-7352 CVE-2026-7351 CVE-2026-7350 CVE-2026-7349 CVE-2026-7348 CVE-2026-7335 CVE-2026-7336 CVE-2026-7337 CVE-2026-7347 CVE-2026-7346 CVE-2026-7345 CVE-2026-7338 CVE-2026-7342 CVE-2026-7341 CVE-2026-7339 CVE-2026-7340 CVE-2026-7355

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
