### PR TITLE
pkgsStatic.cmake: fix build

### DIFF
--- a/pkgs/by-name/cm/cmake/package.nix
+++ b/pkgs/by-name/cm/cmake/package.nix
@@ -124,6 +124,10 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional cursesUI ncurses
     ++ lib.optional qt5UI qtbase;
 
+  # bootstrap is not autoconf and rejects --enable-static/--disable-shared
+  # FIXME: rebuild avoidance, drop optionalDrvAttr in staging
+  dontAddStaticConfigureFlags = lib.optionalDrvAttr stdenv.hostPlatform.isStatic true;
+
   preConfigure = ''
     substituteInPlace Modules/Platform/UnixPaths.cmake \
       --subst-var-by libc_bin ${lib.getBin stdenv.cc.libc} \
@@ -131,6 +135,10 @@ stdenv.mkDerivation (finalAttrs: {
       --subst-var-by libc_lib ${lib.getLib stdenv.cc.libc}
     # CC_FOR_BUILD and CXX_FOR_BUILD are used to bootstrap cmake
     configureFlags="--parallel=''${NIX_BUILD_CORES:-1} CC=$CC_FOR_BUILD CXX=$CXX_FOR_BUILD $configureFlags $cmakeFlags"
+  ''
+  + lib.optionalString (stdenv.hostPlatform.isStatic && useSharedLibraries) ''
+    # FindLibArchive ignores libarchive.pc's Libs.private
+    export NIX_LDFLAGS+=" $($PKG_CONFIG --static --libs-only-l libarchive)"
   '';
 
   # The configuration script is not autoconf-based, although being similar;
@@ -175,6 +183,11 @@ stdenv.mkDerivation (finalAttrs: {
 
     (lib.cmakeBool "CMAKE_USE_OPENSSL" useOpenSSL)
     (lib.cmakeBool "BUILD_CursesDialog" cursesUI)
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isStatic [
+    # kwsys's DynamicLoader test is inimical to -static
+    # doCheck is off anyway so just skip building tests
+    (lib.cmakeBool "BUILD_TESTING" false)
   ];
 
   # make install attempts to use the just-built cmake


### PR DESCRIPTION
bootstrap is not autoconf and rejects the --enable-static/
  --disable-shared flags injected by the static stdenv adapter;
  set dontAddStaticConfigureFlags to avoid them

FindLibArchive doesn't handle static libarchive correctly, use pkg-config to find correct entry manually and pass via NIX_LDFLAGS.

kwsys's DynamicLoader test is inimical to -static so disable BUILD_TESTING in that case.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
