### PR TITLE
wgnord: drop resholve.mkDerivation, use makeWrapper

### DIFF
--- a/pkgs/by-name/wg/wgnord/package.nix
+++ b/pkgs/by-name/wg/wgnord/package.nix
@@ -12,14 +12,14 @@
   wireguard-tools,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "wgnord";
   version = "0.2.1";
 
   src = fetchFromGitHub {
     owner = "phirecc";
     repo = "wgnord";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-26cfYXtZVQ7kIRxY6oNGCqIjdw/hjwXhVKimVgolLgk=";
   };
 
@@ -35,9 +35,11 @@ stdenvNoCC.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
+
     install -Dm 755 wgnord -t $out/bin/
     install -Dm 644 countries.txt -t $out/share/
     install -Dm 644 countries_iso31662.txt -t $out/share/
+
     runHook postInstall
   '';
 
@@ -59,10 +61,10 @@ stdenvNoCC.mkDerivation rec {
   meta = {
     description = "NordVPN Wireguard (NordLynx) client in POSIX shell";
     homepage = "https://github.com/phirecc/wgnord";
-    changelog = "https://github.com/phirecc/wgnord/releases/tag/v${version}";
+    changelog = "https://github.com/phirecc/wgnord/releases/tag/v${finalAttrs.version}";
     maintainers = [ ];
     license = lib.licenses.mit;
     mainProgram = "wgnord";
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/wg/wgnord/package.nix
+++ b/pkgs/by-name/wg/wgnord/package.nix
@@ -1,5 +1,4 @@
 {
-  bash,
   coreutils,
   curl,
   fetchFromGitHub,
@@ -8,11 +7,12 @@
   iproute2,
   jq,
   lib,
-  resholve,
+  makeWrapper,
+  stdenvNoCC,
   wireguard-tools,
 }:
 
-resholve.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "wgnord";
   version = "0.2.1";
 
@@ -23,38 +23,38 @@ resholve.mkDerivation rec {
     hash = "sha256-26cfYXtZVQ7kIRxY6oNGCqIjdw/hjwXhVKimVgolLgk=";
   };
 
+  nativeBuildInputs = [ makeWrapper ];
+
   postPatch = ''
     substituteInPlace wgnord \
-      --replace '$conf_dir/countries.txt' "$out/share/countries.txt" \
-      --replace '$conf_dir/countries_iso31662.txt' "$out/share/countries_iso31662.txt"
+      --replace-fail '$conf_dir/countries.txt' "$out/share/countries.txt" \
+      --replace-fail '$conf_dir/countries_iso31662.txt' "$out/share/countries_iso31662.txt"
   '';
 
   dontBuild = true;
 
   installPhase = ''
+    runHook preInstall
     install -Dm 755 wgnord -t $out/bin/
     install -Dm 644 countries.txt -t $out/share/
     install -Dm 644 countries_iso31662.txt -t $out/share/
+    runHook postInstall
   '';
 
-  solutions.default = {
-    scripts = [ "bin/wgnord" ];
-    interpreter = "${bash}/bin/sh";
-    inputs = [
-      coreutils
-      curl
-      gnugrep
-      gnused
-      iproute2
-      jq
-      wireguard-tools
-    ];
-    fix.aliases = true; # curl command in an alias
-    execer = [
-      "cannot:${iproute2}/bin/ip"
-      "cannot:${wireguard-tools}/bin/wg-quick"
-    ];
-  };
+  postFixup = ''
+    wrapProgram $out/bin/wgnord \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          curl
+          gnugrep
+          gnused
+          iproute2
+          jq
+          wireguard-tools
+        ]
+      }
+  '';
 
   meta = {
     description = "NordVPN Wireguard (NordLynx) client in POSIX shell";


### PR DESCRIPTION
resholve depends on python27 (EOL); migrating consumers off it unblocks
removing Python 2 from nixpkgs. wgnord is a single-script POSIX shell
program; wrapProgram with PATH covers the runtime input list, and
patchShebangs (auto-run by stdenv's fixupPhase) rewrites the `#!/bin/sh`
shebang to bash from stdenv — same store path makeWrapper uses.

The fake/keep/execer directives have no runtime equivalent and are
dropped. Closure no longer pulls python27 or resholve.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
