### PR TITLE
voicevox{,-engine}: 0.25.1 -> 0.25.2; voicevox-core.modelVersion: 0.16.3 -> 0.16.4

### DIFF
--- a/pkgs/by-name/vo/voicevox-core/package.nix
+++ b/pkgs/by-name/vo/voicevox-core/package.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # Update only together with voicevox and voicevox-engine
   # nixpkgs-update: no auto update
   version = "0.16.2";
-  passthru.modelVersion = "0.16.3";
+  passthru.modelVersion = "0.16.4";
 
   src = fetchFromGitHub {
     owner = "VOICEVOX";
@@ -70,7 +70,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       owner = "VOICEVOX";
       repo = "voicevox_vvm";
       tag = finalAttrs.passthru.modelVersion;
-      hash = "sha256-VqSNEHJV/g9R+4XknRGi/s4C7/uXEGCK5/NC2XwiPcI=";
+      hash = "sha256-/NU9CZcb+gHXHeno3NLF0EgPLw+6f8XyiAE2b9XJmuE=";
     };
 
     nativeBuildInputs = [ python3 ];

--- a/pkgs/by-name/vo/voicevox-engine/package.nix
+++ b/pkgs/by-name/vo/voicevox-engine/package.nix
@@ -7,14 +7,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "voicevox-engine";
-  version = "0.25.1";
+  version = "0.25.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "VOICEVOX";
     repo = "voicevox_engine";
     tag = finalAttrs.version;
-    hash = "sha256-4pZs5f6Fe4kHIKcyww1eq9uRTf7rk5KAr/00H8aH9qA=";
+    hash = "sha256-A+ym/ZfHUHqXSGOiIndUeozrK64uJILCmRUm+qSsSNE=";
   };
 
   patches = [
@@ -103,7 +103,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
       owner = "VOICEVOX";
       repo = "voicevox_resource";
       tag = finalAttrs.version;
-      hash = "sha256-YaUVlZnpxu/IhLrp1XdcxDyus7DRhyzu4VKfabTsPUY=";
+      hash = "sha256-Byv9ASl1qCeGWJiBtpGoPFgpbwtSdn48XvzIDS0SHN4=";
     };
 
     pyopenjtalk = python3Packages.callPackage ./pyopenjtalk.nix { };

--- a/pkgs/by-name/vo/voicevox/package.nix
+++ b/pkgs/by-name/vo/voicevox/package.nix
@@ -22,13 +22,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "voicevox";
-  version = "0.25.1";
+  version = "0.25.2";
 
   src = fetchFromGitHub {
     owner = "VOICEVOX";
     repo = "voicevox";
     tag = finalAttrs.version;
-    hash = "sha256-l9aFuhOylcQrHa+0R0P4Jy5iL2gA6xJsUJt8KvWIMuM=";
+    hash = "sha256-AORB6oxvDUNOxnwgIlAKkgtt0+NpU16Fc4qc1aMhxkQ=";
   };
 
   patches = [


### PR DESCRIPTION
https://github.com/VOICEVOX/voicevox/releases/tag/0.25.2
https://github.com/VOICEVOX/voicevox_engine/releases/tag/0.25.2
https://github.com/VOICEVOX/voicevox_vvm/releases/tag/0.16.4

(at the moment of making this PR, these are still marked as prerelease)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
