### PR TITLE
pdfmm: drop resholve.mkDerivation, use makeWrapper

### DIFF
--- a/pkgs/by-name/pd/pdfmm/package.nix
+++ b/pkgs/by-name/pd/pdfmm/package.nix
@@ -1,18 +1,18 @@
 {
-  bash,
   coreutils,
   fetchFromGitHub,
   ghostscript,
-  locale,
-  zenity,
   gnused,
   lib,
-  resholve,
+  locale,
+  makeWrapper,
+  stdenvNoCC,
+  zenity,
 }:
 
-resholve.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "pdfmm";
-  version = "unstable-2019-01-24";
+  version = "0-unstable-2019-01-24";
 
   src = fetchFromGitHub {
     owner = "jpfleury";
@@ -21,33 +21,30 @@ resholve.mkDerivation {
     hash = "sha256-TOISD/2g7MwnLrtpMnfr2Ln0IiwlJVNavWl4eh/uwN0=";
   };
 
+  nativeBuildInputs = [ makeWrapper ];
+
   dontBuild = true;
 
   installPhase = ''
+    runHook preInstall
+
     install -Dm 0755 pdfmm $out/bin/pdfmm
+
+    runHook postInstall
   '';
 
-  solutions.default = {
-    scripts = [
-      "bin/pdfmm"
-    ];
-    interpreter = "${bash}/bin/bash";
-    inputs = [
-      coreutils
-      ghostscript
-      locale
-      zenity
-      gnused
-    ];
-    fake = {
-      # only need xmessage if zenity is unavailable
-      external = [ "xmessage" ];
-    };
-    execer = [
-      "cannot:${zenity}/bin/zenity"
-    ];
-    keep."$toutLu" = true;
-  };
+  postFixup = ''
+    wrapProgram $out/bin/pdfmm \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          ghostscript
+          gnused
+          locale
+          zenity
+        ]
+      }
+  '';
 
   meta = {
     description = "Graphical assistant to reduce the size of a PDF file";


### PR DESCRIPTION
Single-script package with one install step; wrapProgram with PATH covers the runtime input list. fake.external (xmessage fallback when zenity is unavailable) and execer directives have no runtime equivalent and are dropped — the script's own conditional logic handles the missing-xmessage case.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
