### PR TITLE
wsl-vpnkit: drop resholve.mkDerivation, use makeWrapper

### DIFF
--- a/pkgs/by-name/ws/wsl-vpnkit/package.nix
+++ b/pkgs/by-name/ws/wsl-vpnkit/package.nix
@@ -1,7 +1,8 @@
 {
   lib,
-  resholve,
   fetchFromGitHub,
+  makeWrapper,
+  stdenvNoCC,
 
   # Runtime dependencies
   coreutils,
@@ -23,7 +24,7 @@ let
     '';
   });
 in
-resholve.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "wsl-vpnkit";
   inherit version;
 
@@ -34,46 +35,37 @@ resholve.mkDerivation {
     hash = "sha256-Igbr3L2W32s4uBepllSz07bkbI3qwAKMZkBrXLqGrGA=";
   };
 
+  nativeBuildInputs = [ makeWrapper ];
+
   postPatch = ''
     substituteInPlace wsl-vpnkit \
-      --replace "/app/wsl-vm" "${gvproxy}/bin/gvforwarder" \
-      --replace "/app/wsl-gvproxy.exe" "${gvproxyWin}/bin/gvproxy-windows.exe"
+      --replace-fail "/app/wsl-vm" "${gvproxy}/bin/gvforwarder" \
+      --replace-fail "/app/wsl-gvproxy.exe" "${gvproxyWin}/bin/gvproxy-windows.exe"
   '';
 
   installPhase = ''
-    mkdir -p $out/bin
-    cp wsl-vpnkit $out/bin
+    runHook preInstall
+
+    install -Dm 0755 wsl-vpnkit $out/bin/wsl-vpnkit
+
+    runHook postInstall
   '';
 
-  solutions.wsl-vpnkit = {
-    scripts = [ "bin/wsl-vpnkit" ];
-    interpreter = "none";
-    inputs = [
-      coreutils
-      dnsutils
-      gawk
-      gnugrep
-      iproute2
-      iptables
-      iputils
-      wget
-    ];
-
-    keep = {
-      "$VMEXEC_PATH" = true;
-      "$GVPROXY_PATH" = true;
-    };
-
-    execer = [
-      "cannot:${iproute2}/bin/ip"
-      "cannot:${wget}/bin/wget"
-    ];
-
-    fix = {
-      aliases = true;
-      ping = "${iputils}/bin/ping";
-    };
-  };
+  postFixup = ''
+    wrapProgram $out/bin/wsl-vpnkit \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          dnsutils
+          gawk
+          gnugrep
+          iproute2
+          iptables
+          iputils
+          wget
+        ]
+      }
+  '';
 
   meta = {
     description = "Provides network connectivity to Windows Subsystem for Linux (WSL) when blocked by VPN";

--- a/pkgs/by-name/ws/wsl-vpnkit/package.nix
+++ b/pkgs/by-name/ws/wsl-vpnkit/package.nix
@@ -17,21 +17,20 @@
 }:
 
 let
-  version = "0.4.1";
   gvproxyWin = gvproxy.overrideAttrs (_: {
     buildPhase = ''
       GOARCH=amd64 GOOS=windows go build -ldflags '-s -w' -o bin/gvproxy-windows.exe ./cmd/gvproxy
     '';
   });
 in
-stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "wsl-vpnkit";
-  inherit version;
+  version = "0.4.1";
 
   src = fetchFromGitHub {
     owner = "sakai135";
     repo = "wsl-vpnkit";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Igbr3L2W32s4uBepllSz07bkbI3qwAKMZkBrXLqGrGA=";
   };
 
@@ -70,9 +69,9 @@ stdenvNoCC.mkDerivation {
   meta = {
     description = "Provides network connectivity to Windows Subsystem for Linux (WSL) when blocked by VPN";
     homepage = "https://github.com/sakai135/wsl-vpnkit";
-    changelog = "https://github.com/sakai135/wsl-vpnkit/releases/tag/v${version}";
+    changelog = "https://github.com/sakai135/wsl-vpnkit/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ terlar ];
     mainProgram = "wsl-vpnkit";
   };
-}
+})


### PR DESCRIPTION
wrapProgram with PATH covers the runtime input list. The fix.aliases
directive has no runtime equivalent (aliases would only have mattered
if resholve were rewriting bare command names) and fix.ping is
redundant with iputils on PATH. execer directives are informational
only and dropped.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
