### PR TITLE
zxfer: drop resholve.mkDerivation, use makeWrapper

### DIFF
--- a/pkgs/by-name/zx/zxfer/package.nix
+++ b/pkgs/by-name/zx/zxfer/package.nix
@@ -1,38 +1,42 @@
 {
   lib,
-  bash,
   fetchFromGitHub,
   installShellFiles,
+  makeWrapper,
+  stdenvNoCC,
+
   coreutils,
   gawk,
   gnugrep,
   gnused,
   openssh,
-  resholve,
   rsync,
   which,
   zfs,
 }:
 
-resholve.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "zxfer";
   version = "1.1.7";
 
   src = fetchFromGitHub {
     owner = "allanjude";
     repo = "zxfer";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-11SQJcD3GqPYBIgaycyKkc62/diVKPuuj2Or97j+NZY=";
   };
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+  ];
 
   # these may point to paths on remote systems, calculated at runtime, thus we cannot fix them
   # we can only set their initial values, and let them remain dynamic
   postPatch = ''
     substituteInPlace zxfer \
-      --replace 'LCAT=""'                'LCAT=${coreutils}/bin/cat' \
-      --replace 'LZFS=$( which zfs )'    'LZFS=${zfs}/bin/zfs'
+      --replace-fail 'LCAT=""'             'LCAT=${coreutils}/bin/cat' \
+      --replace-fail 'LZFS=$( which zfs )' 'LZFS=${zfs}/bin/zfs'
   '';
 
   installPhase = ''
@@ -44,45 +48,27 @@ resholve.mkDerivation rec {
     runHook postInstall
   '';
 
-  solutions.default = {
-    scripts = [ "bin/zxfer" ];
-    interpreter = "${bash}/bin/sh";
-    inputs = [
-      coreutils
-      gawk
-      gnugrep
-      gnused
-      openssh
-      rsync
-      which
-    ];
-    fake.external = [
-      "kldload" # bsd builtin
-      "kldstat" # bsd builtin
-      "svcadm" # solaris builtin
-    ];
-    keep = {
-      "$LCAT" = true;
-      "$LZFS" = true;
-      "$PROGRESS_DIALOG" = true;
-      "$RZFS" = true;
-      "$input_optionts" = true;
-      "$option_O" = true;
-      "$option_T" = true;
-    };
-    fix = {
-      "$AWK" = [ "awk" ];
-      "$RSYNC" = [ "rsync" ];
-    };
-    execer = [ "cannot:${rsync}/bin/rsync" ];
-  };
+  postFixup = ''
+    wrapProgram $out/bin/zxfer \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          gawk
+          gnugrep
+          gnused
+          openssh
+          rsync
+          which
+        ]
+      }
+  '';
 
   meta = {
     description = "Popular script for managing ZFS snapshot replication";
     homepage = "https://github.com/allanjude/zxfer";
-    changelog = "https://github.com/allanjude/zxfer/releases/tag/v${version}";
+    changelog = "https://github.com/allanjude/zxfer/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.bsd2;
     maintainers = [ ];
     mainProgram = "zxfer";
   };
-}
+})


### PR DESCRIPTION
wrapProgram with PATH covers the runtime input list. The script's internal `AWK=$( which awk )` / `RSYNC=$( which rsync )` resolution finds them via PATH at runtime, replacing what resholve's fix.\$AWK/\$RSYNC pinned at build time. The existing postPatch substitutions for LCAT and LZFS remain. fake/keep/execer have no runtime equivalent and are dropped.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
