### PR TITLE
aaxtomp3: drop resholve.mkDerivation, use makeWrapper

### DIFF
--- a/pkgs/by-name/aa/aaxtomp3/package.nix
+++ b/pkgs/by-name/aa/aaxtomp3/package.nix
@@ -1,5 +1,4 @@
 {
-  bash,
   bc,
   coreutils,
   fetchFromGitHub,
@@ -11,64 +10,64 @@
   jq,
   lame,
   lib,
+  makeWrapper,
   mediainfo,
   mp4v2,
   ncurses,
-  resholve,
+  stdenvNoCC,
 }:
 
-resholve.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "aaxtomp3";
   version = "1.3";
 
   src = fetchFromGitHub {
     owner = "krumpetpirate";
     repo = "aaxtomp3";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-7a9ZVvobWH/gPxa3cFiPL+vlu8h1Dxtcq0trm3HzlQg=";
   };
 
+  nativeBuildInputs = [ makeWrapper ];
+
   postPatch = ''
     substituteInPlace AAXtoMP3 \
-      --replace 'AAXtoMP3' 'aaxtomp3'
+      --replace-fail 'AAXtoMP3' 'aaxtomp3'
     substituteInPlace interactiveAAXtoMP3 \
-      --replace 'AAXtoMP3' 'aaxtomp3' \
-      --replace 'call="./aaxtomp3"' 'call="$AAXTOMP3"'
+      --replace-fail 'AAXtoMP3' 'aaxtomp3' \
+      --replace-fail 'call="./aaxtomp3"' 'call="${placeholder "out"}/bin/aaxtomp3"'
   '';
 
   installPhase = ''
+    runHook preInstall
+
     install -Dm 755 AAXtoMP3 $out/bin/aaxtomp3
     install -Dm 755 interactiveAAXtoMP3 $out/bin/interactiveaaxtomp3
+
+    runHook postInstall
   '';
 
-  solutions.default = {
-    scripts = [
-      "bin/aaxtomp3"
-      "bin/interactiveaaxtomp3"
-    ];
-    interpreter = "${bash}/bin/bash";
-    inputs = [
-      bc
-      coreutils
-      ffmpeg
-      findutils
-      gawk
-      gnugrep
-      gnused
-      jq
-      lame
-      mediainfo
-      mp4v2
-      ncurses
-    ];
-    keep."$call" = true;
-    fix = {
-      "$AAXTOMP3" = [ "${placeholder "out"}/bin/aaxtomp3" ];
-      "$FIND" = [ "find" ];
-      "$GREP" = [ "grep" ];
-      "$SED" = [ "sed" ];
-    };
-  };
+  postFixup =
+    let
+      runtimePath = lib.makeBinPath [
+        bc
+        coreutils
+        ffmpeg
+        findutils
+        gawk
+        gnugrep
+        gnused
+        jq
+        lame
+        mediainfo
+        mp4v2
+        ncurses
+      ];
+    in
+    ''
+      wrapProgram $out/bin/aaxtomp3 --prefix PATH : ${runtimePath}
+      wrapProgram $out/bin/interactiveaaxtomp3 --prefix PATH : ${runtimePath}
+    '';
 
   meta = {
     description = "Convert Audible's .aax filetype to MP3, FLAC, M4A, or OPUS";
@@ -76,4 +75,4 @@ resholve.mkDerivation rec {
     license = lib.licenses.wtfpl;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
wrapProgram with PATH covers the runtime input list. The script's own uname-conditional logic sets \$FIND/\$GREP/\$SED to bare names and verifies them via type -P, which resolves correctly against PATH (so resholve's fix.\$FIND/\$GREP/\$SED was redundant).

The interactiveaaxtomp3 wrapper script's reference to the main binary is now baked in via postPatch using placeholder "out", replacing resholve's fix.\$AAXTOMP3 indirection.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
