### PR TITLE
unix-privesc-check: drop resholve.mkDerivation, use makeWrapper

### DIFF
--- a/pkgs/by-name/un/unix-privesc-check/package.nix
+++ b/pkgs/by-name/un/unix-privesc-check/package.nix
@@ -1,13 +1,15 @@
 {
   lib,
-  resholve,
   fetchurl,
-  gawk,
+  makeWrapper,
+  stdenvNoCC,
+
   bash,
   binutils,
   coreutils,
   file,
   findutils,
+  gawk,
   glibc,
   gnugrep,
   gnused,
@@ -19,14 +21,12 @@
   which,
 }:
 
-# resholve does not yet support `finalAttrs` call pattern hence `rec`
-# https://github.com/abathur/resholve/issues/107
-resholve.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "unix-privesc-check";
   version = "1.4";
 
   src = fetchurl {
-    url = "https://pentestmonkey.net/tools/unix-privesc-check/unix-privesc-check-${version}.tar.gz";
+    url = "https://pentestmonkey.net/tools/unix-privesc-check/unix-privesc-check-${finalAttrs.version}.tar.gz";
     hash = "sha256-4fhef2n6ut0jdWo9dqDj2GSyHih2O2DOLmGBKQ0cGWk=";
   };
 
@@ -34,47 +34,37 @@ resholve.mkDerivation rec {
     ./unix-privesc-check.patch # https://github.com/NixOS/nixpkgs/pull/287629#issuecomment-1944428796
   ];
 
-  solutions = {
-    unix-privesc-check = {
-      scripts = [ "bin/unix-privesc-check" ];
-      interpreter = "${bash}/bin/bash";
-      inputs = [
-        gawk
-        bash
-        binutils # for strings command
-        coreutils
-        file
-        findutils # for xargs command
-        glibc # for ldd command
-        gnugrep
-        gnused
-        net-tools
-        openssh
-        postgresql # for psql command
-        ps
-        util-linux # for swapon command
-        which
-      ];
-      fake = {
-        external = [
-          "lanscan" # lanscan exists only for HP-UX OS
-          "mount" # Getting same error described in https://github.com/abathur/resholve/issues/29
-          "passwd" # Getting same error described in https://github.com/abathur/resholve/issues/29
-        ];
-      };
-      execer = [
-        "cannot:${glibc.bin}/bin/ldd"
-        "cannot:${postgresql}/bin/psql"
-        "cannot:${openssh}/bin/ssh-add"
-        "cannot:${util-linux.bin}/bin/swapon"
-      ];
-    };
-  };
+  nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
     runHook preInstall
+
     install -Dm 755 unix-privesc-check $out/bin/unix-privesc-check
+
     runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/unix-privesc-check \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          bash
+          binutils # for strings command
+          coreutils
+          file
+          findutils # for xargs command
+          gawk
+          glibc # for ldd command
+          gnugrep
+          gnused
+          net-tools
+          openssh
+          postgresql # for psql command
+          ps
+          util-linux # for swapon command
+          which
+        ]
+      }
   '';
 
   meta = {
@@ -85,4 +75,4 @@ resholve.mkDerivation rec {
     platforms = lib.platforms.unix;
     license = lib.licenses.gpl2Plus;
   };
-}
+})


### PR DESCRIPTION
wrapProgram with PATH covers the runtime input list. fake/execer directives have no runtime equivalent and are dropped — the script's own conditional logic handles missing tools (lanscan is HP-UX-only, mount/passwd guarded). Now uses finalAttrs since resholve's lack of support for it (abathur/resholve#107) no longer applies.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
