### PR TITLE
libavif: add rav1e support for AVIF encoding

### DIFF
--- a/pkgs/by-name/li/libavif/package.nix
+++ b/pkgs/by-name/li/libavif/package.nix
@@ -15,6 +15,7 @@
   gdk-pixbuf,
   makeWrapper,
   gtest,
+  rav1e,
 }:
 
 let
@@ -56,7 +57,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"
-    "-DAVIF_CODEC_AOM=SYSTEM" # best encoder (slow but small)
+    "-DAVIF_CODEC_AOM=SYSTEM" # reference encoder (slow but small)
+    "-DAVIF_CODEC_RAV1E=SYSTEM" # advanced encoder (required for large images)
     "-DAVIF_CODEC_DAV1D=SYSTEM" # best decoder (fast)
     "-DAVIF_BUILD_APPS=ON"
     "-DAVIF_BUILD_GDK_PIXBUF=ON"
@@ -87,6 +89,7 @@ stdenv.mkDerivation (finalAttrs: {
     dav1d
     libaom
     libyuv
+    rav1e
   ];
 
   env.PKG_CONFIG_GDK_PIXBUF_2_0_GDK_PIXBUF_MODULEDIR = gdkPixbufModuleDir;


### PR DESCRIPTION
Build libavif with rav1e codec. The rav1e encoder is essential for encoding larger images, as the aom encoder crashes on them. While nixpkgs already includes a rav1e binary, it lacks converting regular image files (or I was unable to to figure out how). For reference, Ubuntu also ships rav1e within their libavif-bin package.

I've verified my changes using `nix-shell`:
```nix
{ pkgs ? import <nixpkgs> {} }:

pkgs.mkShell {
  buildInputs = [
    (pkgs.libavif.overrideAttrs (finalAttrs: prevAttrs: {
      propagatedBuildInputs = (prevAttrs.propagatedBuildInputs or []) ++ [
        pkgs.rav1e
      ];
      cmakeFlags = (prevAttrs.cmakeFlags or []) ++ [
        "-DAVIF_CODEC_RAV1E=SYSTEM" # required for large images
      ];
    }))
  ];
}
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
