### PR TITLE
locate-dominating-file: drop resholve.mkDerivation, use makeWrapper

### DIFF
--- a/pkgs/by-name/lo/locate-dominating-file/package.nix
+++ b/pkgs/by-name/lo/locate-dominating-file/package.nix
@@ -1,22 +1,21 @@
 {
   bats,
-  bash,
-  fetchFromGitHub,
-  lib,
-  resholve,
   coreutils,
+  fetchFromGitHub,
   getopt,
+  lib,
+  makeWrapper,
+  stdenvNoCC,
 }:
-let
-  version = "0.0.1";
-in
-resholve.mkDerivation {
+
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "locate-dominating-file";
-  inherit version;
+  version = "0.0.1";
+
   src = fetchFromGitHub {
     owner = "roman";
     repo = "locate-dominating-file";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-gwh6fAw7BV7VFIkQN02QIhK47uxpYheMk64UeLyp2IY=";
   };
 
@@ -26,16 +25,15 @@ resholve.mkDerivation {
     done
   '';
 
-  buildInputs = [
-    getopt
-    coreutils
-  ];
+  nativeBuildInputs = [ makeWrapper ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     (bats.withLibraries (p: [
       p.bats-support
       p.bats-assert
     ]))
+    coreutils
+    getopt
   ];
 
   doCheck = true;
@@ -51,20 +49,20 @@ resholve.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/bin
-    cp src/locate-dominating-file.sh $out/bin/locate-dominating-file
+    install -Dm0755 src/locate-dominating-file.sh $out/bin/locate-dominating-file
 
     runHook postInstall
   '';
 
-  solutions.default = {
-    scripts = [ "bin/locate-dominating-file" ];
-    interpreter = "${bash}/bin/bash";
-    inputs = [
-      coreutils
-      getopt
-    ];
-  };
+  postFixup = ''
+    wrapProgram $out/bin/locate-dominating-file \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          getopt
+        ]
+      }
+  '';
 
   meta = {
     homepage = "https://github.com/roman/locate-dominating-file";
@@ -74,4 +72,4 @@ resholve.mkDerivation {
     platforms = lib.platforms.all;
     mainProgram = "locate-dominating-file";
   };
-}
+})


### PR DESCRIPTION
wrapProgram with PATH covers the runtime input list. The bats test
suite still runs against the source via nativeCheckInputs.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test