### PR TITLE
shunit2: drop resholve.mkDerivation, use makeWrapper

### DIFF
--- a/pkgs/by-name/sh/shunit2/package.nix
+++ b/pkgs/by-name/sh/shunit2/package.nix
@@ -1,95 +1,58 @@
 {
-  lib,
-  resholve,
-  fetchFromGitHub,
-  bash,
   coreutils,
-  gnused,
-  gnugrep,
+  fetchFromGitHub,
   findutils,
+  gnugrep,
+  gnused,
+  lib,
+  makeWrapper,
   ncurses,
+  stdenvNoCC,
 }:
 
-resholve.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "shunit2";
   version = "2.1.8";
 
   src = fetchFromGitHub {
     owner = "kward";
     repo = "shunit2";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-IZHkgkVqzeh+eEKCDJ87sqNhSA+DU6kBCNDdQaUEeiM=";
   };
 
+  nativeBuildInputs = [ makeWrapper ];
+
+  postPatch = ''
+    substituteInPlace shunit2 \
+      --replace-fail '/usr/bin/od' '${coreutils}/bin/od'
+  '';
+
   installPhase = ''
-    mkdir -p $out/bin/
-    cp ./shunit2 $out/bin/shunit2
-    chmod +x $out/bin/shunit2
+    runHook preInstall
+
+    install -Dm0755 shunit2 $out/bin/shunit2
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/shunit2 \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          findutils
+          gnugrep
+          gnused
+          ncurses
+        ]
+      }
   '';
 
   doInstallCheck = true;
   installCheckPhase = ''
     $out/bin/shunit2
   '';
-
-  solutions = {
-    shunit = {
-      # Caution: see __SHUNIT_CMD_ECHO_ESC before changing
-      interpreter = "${bash}/bin/sh";
-      scripts = [ "bin/shunit2" ];
-      inputs = [
-        coreutils
-        gnused
-        gnugrep
-        findutils
-        ncurses
-      ];
-      # resholve's Nix API is analogous to the CLI flags
-      # documented in 'man resholve'
-      fake = {
-        # "missing" functions shunit2 expects the user to declare
-        function = [
-          "oneTimeSetUp"
-          "oneTimeTearDown"
-          "setUp"
-          "tearDown"
-          "suite"
-          "noexec"
-        ];
-        # shunit2 is both bash and zsh compatible, and in
-        # some zsh-specific code it uses this non-bash builtin
-        builtin = [ "setopt" ];
-      };
-      fix = {
-        # stray absolute path; make it resolve from coreutils
-        "/usr/bin/od" = true;
-        /*
-          Caution: this one is contextually debatable. shunit2
-          sets this variable after testing whether `echo -e test`
-          yields `test` or `-e test`. Since we're setting the
-          interpreter, we can pre-test this. But if we go fiddle
-          the interpreter later, I guess we _could_ break it.
-        */
-        "$__SHUNIT_CMD_ECHO_ESC" = [ "echo -e" ];
-        "$SHUNIT_CMD_TPUT" = [ "tput" ]; # from ncurses
-      };
-      keep = {
-        # dynamically defined in shunit2:_shunit_mktempFunc
-        eval = [
-          "shunit_condition_"
-          "_shunit_test_"
-          "_shunit_prepForSourcing"
-        ];
-
-        # dynamic based on CLI flag
-        "$_SHUNIT_LINENO_" = true;
-      };
-      execer = [
-        # drop after https://github.com/abathur/binlore/issues/2
-        "cannot:${ncurses}/bin/tput"
-      ];
-    };
-  };
 
   meta = {
     homepage = "https://github.com/kward/shunit2";
@@ -102,4 +65,4 @@ resholve.mkDerivation rec {
     platforms = lib.platforms.unix;
     mainProgram = "shunit2";
   };
-}
+})


### PR DESCRIPTION
wrapProgram with PATH covers the runtime input list. The hardcoded
`/usr/bin/od` reference (previously rewritten by resholve's fix
directive) is now baked in via substituteInPlace. The fake.function
list (oneTimeSetUp/tearDown/etc) was only resholve's static-analysis
hint; runtime behavior is unaffected.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test