### PR TITLE
pdf2odt: drop resholve.mkDerivation, use makeWrapper

### DIFF
--- a/pkgs/by-name/pd/pdf2odt/package.nix
+++ b/pkgs/by-name/pd/pdf2odt/package.nix
@@ -1,20 +1,20 @@
 {
-  lib,
-  resholve,
-  fetchFromGitHub,
   bc,
   coreutils,
+  fetchFromGitHub,
   file,
+  findutils,
   gawk,
   ghostscript,
   gnused,
   imagemagick,
+  lib,
+  makeWrapper,
+  stdenvNoCC,
   zip,
-  runtimeShell,
-  findutils,
 }:
 
-resholve.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "pdf2odt";
   version = "20220827";
 
@@ -24,6 +24,8 @@ resholve.mkDerivation {
     rev = "a05fbdebcc39277d905d1ae66f585a19f467b406";
     hash = "sha256-995iF5Z1V4QEXeXUB8irG451TXpQBHZThJcEfHwfRtE=";
   };
+
+  nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
     runHook preInstall
@@ -36,25 +38,22 @@ resholve.mkDerivation {
     runHook postInstall
   '';
 
-  solutions.default = {
-    scripts = [ "bin/pdf2odt" ];
-    interpreter = runtimeShell;
-    inputs = [
-      bc
-      coreutils
-      file
-      findutils
-      gawk
-      ghostscript
-      gnused
-      imagemagick
-      zip
-    ];
-    execer = [
-      # zip can exec; confirmed 2 invocations in pdf2odt don't
-      "cannot:${zip}/bin/zip"
-    ];
-  };
+  postFixup = ''
+    wrapProgram $out/bin/pdf2odt \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          bc
+          coreutils
+          file
+          findutils
+          gawk
+          ghostscript
+          gnused
+          imagemagick
+          zip
+        ]
+      }
+  '';
 
   meta = {
     description = "PDF to ODT/ODS format converter";


### PR DESCRIPTION
wrapProgram with PATH covers the runtime input list. The pdf2ods
symlink remains; the upstream script picks output format from the
output file's extension, so the help-text `basename "$0"` showing
`.pdf2odt-wrapped` is purely cosmetic.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test