### PR TITLE
mons: drop resholve.mkDerivation, use makeWrapper

### DIFF
--- a/pkgs/by-name/mo/mons/package.nix
+++ b/pkgs/by-name/mo/mons/package.nix
@@ -1,17 +1,17 @@
 {
-  lib,
-  bash,
   coreutils,
   fetchFromGitHub,
   gawk,
   gnugrep,
   gnused,
   help2man,
-  resholve,
+  lib,
+  makeWrapper,
+  stdenvNoCC,
   xrandr,
 }:
 
-resholve.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "mons";
   version = "unstable-2020-03-20";
 
@@ -19,75 +19,40 @@ resholve.mkDerivation {
     owner = "Ventto";
     repo = "mons";
     rev = "375bbba3aa700c8b3b33645a7fb70605c8b0ff0c";
-    sha256 = "19r5y721yrxhd9jp99s29jjvm0p87vl6xfjlcj38bljq903f21cl";
+    hash = "sha256:19r5y721yrxhd9jp99s29jjvm0p87vl6xfjlcj38bljq903f21cl";
     fetchSubmodules = true;
   };
 
-  /*
-    Remove reference to `%LIBDIR%/liblist.sh`. This would be linked to the
-    non-resholved of the library in the final derivation.
+  nativeBuildInputs = [
+    help2man
+    makeWrapper
+  ];
 
-    Patching out the library check; it's bad on multiple levels:
-    1. The check literally breaks if it fails.
-       See https://github.com/Ventto/mons/pull/49
-    2. It doesn't need to do this; source would fail with a
-       sensible message if the script was missing.
-    3. resholve can't wrestle with test/[] (at least until
-       https://github.com/abathur/resholve/issues/78)
-  */
   postPatch = ''
+    # Bake in xrandr's path; the upstream `command -p[v]` lookups use a
+    # sanitized PATH that doesn't include nix-store paths.
     substituteInPlace mons.sh \
-      --replace "lib='%LIBDIR%/liblist.sh'" "" \
-      --replace '[ ! -r "$lib" ] && { "$lib: library not found."; exit 1; }' ""
+      --replace-fail 'XRANDR="$(command -pv xrandr)"' 'XRANDR="${xrandr}/bin/xrandr"' \
+      --replace-fail "command -vp xrandr >/dev/null 2>&1 || { echo 'xrandr: command not found.'; exit 1; }" ":"
   '';
-
-  solutions = {
-    mons = {
-      scripts = [
-        "bin/mons"
-        "lib/libshlist/liblist.sh"
-      ];
-      interpreter = "${bash}/bin/sh";
-      inputs = [
-        bash
-        coreutils
-        gawk
-        gnugrep
-        gnused
-        xrandr
-      ];
-      fix = {
-        "$lib" = [ "lib/libshlist/liblist.sh" ];
-        "$XRANDR" = [ "xrandr" ];
-      };
-      keep = {
-        /*
-          has a whole slate of *flag variables that it sets to either
-          the true or false builtin and then executes...
-        */
-        "$aFlag" = true;
-        "$dFlag" = true;
-        "$eFlag" = true;
-        "$mFlag" = true;
-        "$nFlag" = true;
-        "$oFlag" = true;
-        "$sFlag" = true;
-        "$OFlag" = true;
-        "$SFlag" = true;
-        "$pFlag" = true;
-        "$iFlag" = true;
-        "$xFlag" = true;
-        "$is_flag" = true;
-      };
-    };
-  };
-
-  nativeBuildInputs = [ help2man ];
 
   makeFlags = [
     "DESTDIR=$(out)"
     "PREFIX="
   ];
+
+  postFixup = ''
+    wrapProgram $out/bin/mons \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          gawk
+          gnugrep
+          gnused
+          xrandr
+        ]
+      }
+  '';
 
   meta = {
     description = "POSIX Shell script to quickly manage 2-monitors display";


### PR DESCRIPTION
The upstream Makefile already substitutes %LIBDIR% with the install
prefix during install, so the previous postPatch (a workaround for
resholve interfering with that substitution) is no longer needed.
liblist.sh ends up at $out/lib/libshlist/liblist.sh and the script's
$lib references it directly.

The script's `command -p[v] xrandr` lookups use a sanitized default
PATH that doesn't include nix-store paths, so `xrandr` is baked in
explicitly via substituteInPlace and the precondition check is
neutralized.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test