### PR TITLE
dgoss: drop resholve.mkDerivation, use makeWrapper

### DIFF
--- a/pkgs/by-name/dg/dgoss/package.nix
+++ b/pkgs/by-name/dg/dgoss/package.nix
@@ -1,44 +1,45 @@
 {
-  bash,
   coreutils,
   gnused,
   goss,
   lib,
-  resholve,
+  makeWrapper,
+  stdenvNoCC,
   which,
 }:
 
-resholve.mkDerivation rec {
+stdenvNoCC.mkDerivation {
   pname = "dgoss";
-  version = goss.version;
-  src = goss.src;
+  inherit (goss) version src;
+
+  nativeBuildInputs = [ makeWrapper ];
 
   dontConfigure = true;
   dontBuild = true;
 
   installPhase = ''
-    sed -i '2i GOSS_PATH=\$\{GOSS_PATH:-${goss}/bin/goss\}' extras/dgoss/dgoss
+    runHook preInstall
+
     install -D extras/dgoss/dgoss $out/bin/dgoss
+
+    runHook postInstall
   '';
 
-  solutions = {
-    default = {
-      scripts = [ "bin/dgoss" ];
-      interpreter = "${bash}/bin/bash";
-      inputs = [
-        coreutils
-        gnused
-        which
-      ];
-      keep = {
-        "$CONTAINER_RUNTIME" = true;
-      };
-    };
-  };
+  postFixup = ''
+    wrapProgram $out/bin/dgoss \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          gnused
+          goss
+          which
+        ]
+      }
+  '';
 
   meta = {
-    homepage = "https://github.com/goss-org/goss/blob/v${version}/extras/dgoss/README.md";
-    changelog = "https://github.com/goss-org/goss/releases/tag/v${version}";
+    homepage = "https://github.com/goss-org/goss/blob/v${goss.version}/extras/dgoss/README.md";
+    changelog = "https://github.com/goss-org/goss/releases/tag/v${goss.version}";
     description = "Convenience wrapper around goss that aims to bring the simplicity of goss to docker containers";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux;


### PR DESCRIPTION
wrapProgram with PATH covers the runtime input list. The previous
sed-injection of GOSS_PATH at line 2 is no longer needed: the
upstream script already does `GOSS_PATH=${GOSS_PATH:-$(which goss)}`,
so adding `goss` to the wrapper's PATH lets the existing fallback
resolve correctly.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test