### PR TITLE
lib: remove unused let bindings and args@{} uses

### DIFF
--- a/lib/fileset/default.nix
+++ b/lib/fileset/default.nix
@@ -123,7 +123,6 @@ let
     pathExists
     seq
     typeOf
-    nixVersion
     ;
 
   inherit (lib.lists)
@@ -138,7 +137,6 @@ let
 
   inherit (lib.strings)
     isStringLike
-    versionOlder
     ;
 
   inherit (lib.filesystem)

--- a/lib/filesystem.nix
+++ b/lib/filesystem.nix
@@ -371,7 +371,6 @@ in
     let
       inherit (lib)
         concatMapAttrs
-        id
         makeScope
         recurseIntoAttrs
         removeSuffix

--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -19,7 +19,6 @@ let
     isString
     match
     typeOf
-    elemAt
     ;
 
 in

--- a/lib/network/internal.nix
+++ b/lib/network/internal.nix
@@ -23,7 +23,6 @@ let
   */
   ipv6Bits = 128;
   ipv6Pieces = 8; # 'x:x:x:x:x:x:x:x'
-  ipv6PieceBits = 16; # One piece in range from 0 to 0xffff.
   ipv6PieceMaxValue = 65535; # 2^16 - 1
 in
 let

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -468,7 +468,7 @@ rec {
     : 3\. Function argument
   */
   mergeUniqueOption =
-    args@{
+    {
       message,
       # WARNING: the default merge function assumes that the definition is a valid (option) value. You MUST pass a merge function if the return value needs to be
       #   - type checked beyond what .check does (which should be very little; only on the value head; not attribute values, etc)

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -51,7 +51,6 @@ let
     filter
     filterAttrs
     fix
-    fold
     foldAttrs
     foldl
     foldl'
@@ -4794,7 +4793,7 @@ runTests {
   # for sub-directories
   testPackagesFromDirectoryNestedScopes =
     let
-      inherit (lib) makeScope recurseIntoAttrs;
+      inherit (lib) makeScope;
       emptyScope = makeScope lib.callPackageWith (_: { });
     in
     {

--- a/lib/tests/modules/deferred-module-error.nix
+++ b/lib/tests/modules/deferred-module-error.nix
@@ -3,16 +3,10 @@ let
   inherit (lib)
     types
     mkOption
-    setDefaultModuleLocation
     evalModules
     ;
   inherit (types)
     deferredModule
-    lazyAttrsOf
-    submodule
-    str
-    raw
-    enum
     ;
 in
 {

--- a/lib/tests/modules/deferred-module.nix
+++ b/lib/tests/modules/deferred-module.nix
@@ -1,12 +1,11 @@
 { lib, ... }:
 let
-  inherit (lib) types mkOption setDefaultModuleLocation;
+  inherit (lib) types mkOption;
   inherit (types)
     deferredModule
     lazyAttrsOf
     submodule
     str
-    raw
     enum
     ;
 in

--- a/lib/tests/modules/disable-module-bad-key.nix
+++ b/lib/tests/modules/disable-module-bad-key.nix
@@ -1,15 +1,4 @@
 { lib, ... }:
-let
-  inherit (lib) mkOption types;
-
-  moduleWithKey =
-    { config, ... }:
-    {
-      config = {
-        enable = true;
-      };
-    };
-in
 {
   imports = [
     ./declare-enable.nix

--- a/lib/tests/modules/types-attrTag.nix
+++ b/lib/tests/modules/types-attrTag.nix
@@ -6,7 +6,6 @@
 }:
 let
   inherit (lib) mkOption types;
-  forceDeep = x: builtins.deepSeq x x;
   mergedSubOption = (options.merged.type.getSubOptions options.merged.loc).extensible;
 in
 {


### PR DESCRIPTION
Split from #514611
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] 0 rebuilds of normal packages (maybe manual/etc.)
- Tested, as applicable:
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
