### PR TITLE
gcc-unwrapped: enable static-pie by default for static builds

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -256,6 +256,25 @@ let
           )
           && !isStatic;
 
+        # FIXME: placeholder name and probably should compose to create hasSharedLibraries
+        # instead of duplicating.
+        # Whether the platform supports relocatable / position-independent code natively
+        # even if shared libraries are disabled (so true in pkgsStatic on x86_64-linux)
+        # Bare metal targets — arm-none-eabi, various embedded … — lack such support
+        canReloc =
+          with final;
+          isAndroid
+          || isGnu
+          || isMusl
+          || isDarwin
+          || isSunOS
+          || isOpenBSD
+          || isFreeBSD
+          || isNetBSD
+          || isCygwin
+          || isMinGW
+          || isWindows;
+
         # The difference between `isStatic` and `hasSharedLibraries` is mainly the
         # addition of the `staticMarker` (see make-derivation.nix).  Some
         # platforms, like embedded machines without a libc (e.g. arm-none-eabi)

--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -21,6 +21,7 @@
   disableGdbPlugin ? !enablePlugin,
   enableShared,
   enableDefaultPie,
+  enableDefaultStaticPie,
   targetPrefix,
 
   langC,
@@ -285,6 +286,11 @@ let
     ]
     ++ lib.optionals enableDefaultPie [
       "--enable-default-pie"
+    ]
+    ++ lib.optionals enableDefaultStaticPie [
+      # Conceptually similar to setting --enable-default-pie.
+      # static -> static-pie, skipped if -r or -shared or -no-pie are set.
+      "--with-specs=%{!r:%{!shared:%{!no-pie:%{static:%<static -static-pie}}}}"
     ]
     ++ lib.optionals langJit [
       "--enable-host-shared"

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -223,6 +223,8 @@ pipe
 
       inherit patches;
 
+      __structuredAttrs = true;
+
       outputs = [
         "out"
         "man"

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -19,7 +19,7 @@
   cargo,
   staticCompiler ? false,
   enableShared ? stdenv.targetPlatform.hasSharedLibraries,
-  enableDefaultPie ? stdenv.targetPlatform.hasSharedLibraries,
+  enableDefaultPie ? stdenv.targetPlatform.canReloc,
   enableLTO ? stdenv.hostPlatform.hasSharedLibraries,
   texinfo ? null,
   perl ? null, # optional, for texi2pod (then pod2man)

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -20,6 +20,7 @@
   staticCompiler ? false,
   enableShared ? stdenv.targetPlatform.hasSharedLibraries,
   enableDefaultPie ? stdenv.targetPlatform.canReloc,
+  enableDefaultStaticPie ? enableDefaultPie, # static -> static-pie
   enableLTO ? stdenv.hostPlatform.hasSharedLibraries,
   texinfo ? null,
   perl ? null, # optional, for texi2pod (then pod2man)
@@ -145,6 +146,7 @@ let
       enableMultilib
       enablePlugin
       enableShared
+      enableDefaultStaticPie
       fetchpatch
       fetchurl
       flex

--- a/pkgs/test/cc-wrapper/hardening.nix
+++ b/pkgs/test/cc-wrapper/hardening.nix
@@ -505,6 +505,18 @@ nameDrvAfterAttrName (
       ignorePie = false;
     };
 
+    pieDisabledWithNoPie =
+      checkTestBin
+        (f2exampleWithStdEnv stdenv {
+          env = {
+            TEST_EXTRA_FLAGS = "-no-pie";
+          };
+        })
+        {
+          ignorePie = false;
+          expectFailure = true;
+        };
+
     relROExplicitEnabled =
       checkTestBin
         (f2exampleWithStdEnv stdenv {

--- a/pkgs/test/cc-wrapper/hardening.nix
+++ b/pkgs/test/cc-wrapper/hardening.nix
@@ -501,11 +501,9 @@ nameDrvAfterAttrName (
       )
     );
 
-    pieAlwaysEnabled = brokenIf stdenv.hostPlatform.isStatic (
-      checkTestBin (f2exampleWithStdEnv stdenv { }) {
-        ignorePie = false;
-      }
-    );
+    pieAlwaysEnabled = checkTestBin (f2exampleWithStdEnv stdenv { }) {
+      ignorePie = false;
+    };
 
     relROExplicitEnabled =
       checkTestBin


### PR DESCRIPTION
Enables static-pie by default for static builds by using `--with-specs` at GCC configure time to alter default flag behavior, improving our ASLR coverage.

Prerequisites:

- #515205

It is likely this counts as a breaking change and needs to wait for staging branch off, although I'm not sure. [Asked in the release management channel](https://matrix.to/#/!aGqRytqbCECitOFhbt:nixos.org/$YXDxxhCXBgWbnrdZbzNAur8QW3YJqqLrZLItWXNri1s?via=nixos.org&via=matrix.org&via=nixos.dev) for input.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 515233 --package hello --package libev --package pkgsStatic.hello --package pkgsStatic.libev --package bat --package pkgsStatic.bat`
Commit: `eecd41887b963fcb89608a5c4a1e451cb2c72085`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 6 packages built:</summary>
  <ul>
    <li>bat</li>
    <li>hello</li>
    <li>libev</li>
    <li>pkgsStatic.bat</li>
    <li>pkgsStatic.hello</li>
    <li>pkgsStatic.libev</li>
  </ul>
</details>
