### PR TITLE
nixos: unset vm.mmap_rnd_compat_bits on loongarch64

### DIFF
--- a/nixos/modules/config/sysctl.nix
+++ b/nixos/modules/config/sysctl.nix
@@ -72,20 +72,25 @@ in
           {
             inherit (config.boot.kernelPackages.kernel) configfile;
           }
-          ''
-            mmap_rnd_bits_max=$(grep "^CONFIG_ARCH_MMAP_RND_BITS_MAX=" $configfile | grep --only-matching "[0-9]*$")
-            if [[ -z "$mmap_rnd_bits_max" ]]; then
-              echo "Unable to determine mmap_rnd_bits_max. Check your kernel configfile is valid."
-              exit 1
-            fi
-            mmap_rnd_compat_bits_max=$(grep "^CONFIG_ARCH_MMAP_RND_COMPAT_BITS_MAX=" $configfile | grep --only-matching "[0-9]*$")
-            if [[ -z "$mmap_rnd_compat_bits_max" ]]; then
-              echo "Unable to determine mmap_rnd_compat_bits_max. Check your kernel configfile is valid."
-              exit 1
-            fi
-            echo "vm.mmap_rnd_bits=$mmap_rnd_bits_max" >> $out
-            echo "vm.mmap_rnd_compat_bits=$mmap_rnd_compat_bits_max" >> $out
-          '';
+          (
+            ''
+              mmap_rnd_bits_max=$(grep "^CONFIG_ARCH_MMAP_RND_BITS_MAX=" $configfile | grep --only-matching "[0-9]*$")
+              if [[ -z "$mmap_rnd_bits_max" ]]; then
+                echo "Unable to determine mmap_rnd_bits_max. Check your kernel configfile is valid."
+                exit 1
+              fi
+              echo "vm.mmap_rnd_bits=$mmap_rnd_bits_max" >> $out
+            ''
+            # HAVE_ARCH_MMAP_RND_COMPAT_BITS is not defined for LoongArch64
+            + lib.optionalString (!pkgs.stdenv.hostPlatform.isLoongArch64) ''
+              mmap_rnd_compat_bits_max=$(grep "^CONFIG_ARCH_MMAP_RND_COMPAT_BITS_MAX=" $configfile | grep --only-matching "[0-9]*$")
+              if [[ -z "$mmap_rnd_compat_bits_max" ]]; then
+                echo "Unable to determine mmap_rnd_compat_bits_max. Check your kernel configfile is valid."
+                exit 1
+              fi
+              echo "vm.mmap_rnd_compat_bits=$mmap_rnd_compat_bits_max" >> $out
+            ''
+          );
       "sysctl.d/60-nixos.conf".text = lib.concatStrings (
         lib.mapAttrsToList (
           n: v: lib.optionalString (v != null) "${n}=${if v == false then "0" else toString v}\n"


### PR DESCRIPTION
Tentatively fixes https://github.com/NixOS/nixpkgs/pull/513771#issuecomment-4356819800 (still boots after this change at least)

<img width="1440" height="900" alt="Capture d’écran 2026-05-01 à 02 15 15" src="https://github.com/user-attachments/assets/0be94342-9f54-422d-b35e-3c642ee04eb6" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] loongarch64-linux
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
