### PR TITLE
maddy: 0.8.2 -> 0.9.5

### DIFF
--- a/pkgs/by-name/ma/maddy/package.nix
+++ b/pkgs/by-name/ma/maddy/package.nix
@@ -12,16 +12,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "maddy";
-  version = "0.8.2";
+  version = "0.9.4";
 
   src = fetchFromGitHub {
     owner = "foxcpp";
     repo = "maddy";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-+tj2h1rAdr0SPgLGGzVf5sdFmhcwY76fkMm2P/gYFuo=";
+    sha256 = "sha256-U7czabdpOC+vb5ERFbbS5W4h7pOCwbEZuXbU/MXRvW4=";
   };
 
-  vendorHash = "sha256-+xsG7z2wSxoZ1vEJIDBtwDMiU7zKCtZOsYPUhv6HMpQ=";
+  vendorHash = "sha256-8dMS2kFlQ762u4Ifv1O1Capr8Jb7wsQuHSsJvHwa0j0=";
 
   tags = [ "libpam" ];
 
@@ -29,9 +29,14 @@ buildGoModule (finalAttrs: {
     "-s"
     "-w"
     "-X github.com/foxcpp/maddy.Version=${finalAttrs.version}"
+    "-X github.com/foxcpp/maddy.DefaultLibexecDirectory=/run/wrappers/bin"
   ];
 
-  subPackages = [ "cmd/maddy" ];
+  subPackages = [
+    "cmd/maddy"
+    "cmd/maddy-pam-helper"
+    "cmd/maddy-shadow-helper"
+  ];
 
   buildInputs = [ pam ];
 
@@ -49,15 +54,18 @@ buildGoModule (finalAttrs: {
 
     ln -s "$out/bin/maddy" "$out/bin/maddyctl"
 
+    mkdir -p "$out/libexec/maddy"
+    mv "$out/bin/maddy-pam-helper" "$out/bin/maddy-shadow-helper" "$out/libexec/maddy"
+
     mkdir -p $out/lib/systemd/system
 
     substitute dist/systemd/maddy.service $out/lib/systemd/system/maddy.service \
-      --replace "/usr/local/bin/maddy" "$out/bin/maddy" \
-      --replace "/bin/kill" "${coreutils}/bin/kill"
+      --replace-fail "/usr/local/bin/maddy" "$out/bin/maddy" \
+      --replace-fail "/bin/kill" "${coreutils}/bin/kill"
 
     substitute dist/systemd/maddy@.service $out/lib/systemd/system/maddy@.service \
-      --replace "/usr/local/bin/maddy" "$out/bin/maddy" \
-      --replace "/bin/kill" "${coreutils}/bin/kill"
+      --replace-fail "/usr/local/bin/maddy" "$out/bin/maddy" \
+      --replace-fail "/bin/kill" "${coreutils}/bin/kill"
   '';
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-error=strict-prototypes";
@@ -69,5 +77,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://maddy.email";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ nickcao ];
+    mainProgram = "maddy";
   };
 })

--- a/pkgs/by-name/ma/maddy/package.nix
+++ b/pkgs/by-name/ma/maddy/package.nix
@@ -12,13 +12,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "maddy";
-  version = "0.9.4";
+  version = "0.9.5";
 
   src = fetchFromGitHub {
     owner = "foxcpp";
     repo = "maddy";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-U7czabdpOC+vb5ERFbbS5W4h7pOCwbEZuXbU/MXRvW4=";
+    sha256 = "sha256-Lt5uj7DCu6Tx47Xdzg+CjGN543LCj2x8ph+1wvD3GCQ=";
   };
 
   vendorHash = "sha256-8dMS2kFlQ762u4Ifv1O1Capr8Jb7wsQuHSsJvHwa0j0=";


### PR DESCRIPTION
Diff: https://github.com/foxcpp/maddy/compare/v0.8.2...v0.9.5


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
