### PR TITLE
ghcWithPackages: throw on non-derivation inputs

### DIFF
--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -48,7 +48,24 @@ let
 
   hoogleWithPackages' = if withHoogle then hoogleWithPackages selectPackages else null;
 
-  packages = selectPackages haskellPackages ++ [ hoogleWithPackages' ];
+  # Catches obviously-wrong inputs (functions, strings, etc.) but lets
+  # non-Haskell derivations through; shellFor passes libraryFrameworkDepends
+  # and similar mixed inputs in, and those are dropped later by the
+  # closure-side `isHaskellLibrary` filter.
+  checkPackage =
+    p:
+    if p == null || lib.isDerivation p then
+      p
+    else
+      throw ''
+        ghcWithPackages: expected a derivation, got a ${builtins.typeOf p}.
+        A common cause is missing parentheses around an override, e.g.
+          (hp: [ dontCheck hp.foo ])
+        should be written as
+          (hp: [ (dontCheck hp.foo) ]).
+      '';
+
+  packages = map checkPackage (selectPackages haskellPackages ++ [ hoogleWithPackages' ]);
 
   isHaLVM = ghc.isHaLVM or false;
   ghcCommand' = "ghc";


### PR DESCRIPTION
Assisted-by: claude-code with claude-opus-4-8[1m]-high

## Description of changes

`ghcWithPackages` previously fed the user-supplied package list straight through `lib.closePropagation` and a permissive `isHaskellLibrary`-attribute filter. Anything that didn't carry that attribute -- including a function like `dontCheck` accidentally passed without parentheses, e.g. `(hp: [ dontCheck hp.foo ])` -- got silently dropped, leaving the user with a GHC environment that quietly didn't contain the package they expected.

Validate each top-level entry up front: accept `null` (the `withHoogle = false` slot) or any derivation, otherwise throw with a message that names the unexpected type and points at the canonical fix (adding parentheses around the override). We deliberately do **not** require `isHaskellLibrary` at this stage, because `shellFor` (via `pkgs/development/haskell-modules/generic-builder.nix:1063,1066`) routes `propagatedBuildInputs` through `ghcWithPackages`, and on Darwin that list includes `libraryFrameworkDepends`. Those are real derivations without `isHaskellLibrary` and should still be silently dropped by the existing closure-side filter rather than raising an error.

This catches the canonical user mistake in the issue while preserving the existing semantics for every legitimate caller.

### Validation

Verified locally on x86_64-linux:

- `(hp: [ hp.mtl ])` -- evaluates and builds the GHC env; `mtl` registered in `package.conf.d`.
- `(hp: [ hp.mtl hp.text ])` -- both packages registered.
- `(hp: [ pkgs.haskell.lib.dontCheck hp.mtl ])` -- now throws:
  > ghcWithPackages: expected a derivation, got a lambda.
  > A common cause is missing parentheses around an override, e.g.
  >   (hp: [ dontCheck hp.foo ])
  > should be written as
  >   (hp: [ (dontCheck hp.foo) ]).
- `(hp: [ ])`, `ghcWithHoogle (hp: [ hp.mtl ])` -- both fine.
- `(hp: [ pkgs.curl hp.mtl ])` -- non-Haskell derivation passes the new check, dropped silently by the existing closure filter (drv hash matches the `[ hp.mtl ]` case).
- `nix-build -A haskellPackages.cabal-install` -- exercises the internal `buildHaskellPackages.ghcWithPackages (_: setupHaskellDepends)` call from `generic-builder.nix:1063`. Builds.
- `nix-build -E 'with import ./. {}; haskellPackages.shellFor { packages = p: [ p.lens ]; }'` -- exercises the `withPackages (_: otherBuildInputsHaskell ++ propagatedBuildInputs ++ ...)` path that motivated relaxing the validator. Builds.

### Behaviour change

Configurations that previously silently produced a misconfigured environment will now fail with the message above. That's the explicit ask in the linked issue; a release note may be warranted.

Fixes #30304

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md) and other READMEs

cc @peti (assignee on #30304), @maralorn, @sternenseemann