### PR TITLE
haskell.{compiler,packages}.microhs: Support cross

### DIFF
--- a/pkgs/development/compilers/microhs/common.nix
+++ b/pkgs/development/compilers/microhs/common.nix
@@ -39,6 +39,7 @@ let
     # We delete them to be certain we are building from source
     postPatch = ''
       rm -r generated
+      cp ${./targets.conf} targets.conf
     '';
 
     doInstallCheck = true;

--- a/pkgs/development/compilers/microhs/stage1.nix
+++ b/pkgs/development/compilers/microhs/stage1.nix
@@ -21,7 +21,6 @@ stdenv.mkDerivation (
 
     makeFlags = [ "PREFIX=${placeholder "out"}" ];
     installTargets = [
-      "targets.conf"
       "oldinstall"
     ];
 

--- a/pkgs/development/compilers/microhs/targets.conf
+++ b/pkgs/development/compilers/microhs/targets.conf
@@ -1,0 +1,11 @@
+[default]
+cc = "$CC"
+ccflags = "-w -Wall -O3"
+cclibs = ""
+conf = "unix"
+
+[environment]
+cc = "$CC"
+ccflags = "$MHSCCFLAGS"
+cclibs = "$MHSCCLIBS"
+conf = "$MHSCONF"

--- a/pkgs/development/haskell-modules/microhs-builder.nix
+++ b/pkgs/development/haskell-modules/microhs-builder.nix
@@ -158,9 +158,10 @@ let
   };
 
   hsLibBuildInputs = lib.filter (p: p ? isHaskellLibrary && p.isHaskellLibrary) propagatedBuildInputs;
+  hsLibClosedBuildInputs = lib.closePropagation hsLibBuildInputs;
   compilerWithPkgs = wrapMhs {
     microhs = compiler;
-    packages = hsLibBuildInputs;
+    packages = hsLibClosedBuildInputs;
   };
 
   compilerCommand' = "mhs";
@@ -210,9 +211,16 @@ stdenv.mkDerivation {
 
     echo "Building with ${compilerWithPkgs}"
     mkdir -p "$CABALDIR/${compiler.haskellCompilerName}/packages"
-    ${lib.concatMapStrings (p: ''
-      ln -s ${p}/${compilerLibdir}/packages/${p.name}.pkg $CABALDIR/${compiler.haskellCompilerName}/packages/${p.name}.pkg
-    '') (lib.closePropagation hsLibBuildInputs)}
+    ${lib.concatMapStrings (
+      p:
+      let
+        name = "${p.pname}-${p.version}";
+      in
+      ''
+        printf 'Exposing dependency ${name}\n'
+        ln -s ${p}/${compilerLibdir}/packages/${name}-${p.version}.pkg $CABALDIR/${compiler.haskellCompilerName}/packages/${name}.pkg
+      ''
+    ) hsLibClosedBuildInputs}
 
     runHook postSetupCompilerEnvironment
   '';


### PR DESCRIPTION
Fix cross-compilation for `haskell.compiler.microhs` and `haskell.packages.microhs`.

Tested:

* `pkgsCross.riscv64.haskell.compiler.microhs`
* `pkgsCross.riscv64.haskell.packages.microhs.hscolour`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
