### PR TITLE
distroshelf: 1.0.15 -> 1.4.8

### DIFF
--- a/pkgs/by-name/di/distroshelf/package.nix
+++ b/pkgs/by-name/di/distroshelf/package.nix
@@ -12,23 +12,25 @@
   pkg-config,
   glib,
   libadwaita,
+  libxml2,
+  vte-gtk4,
   nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "distroshelf";
-  version = "1.0.15";
+  version = "1.4.8";
 
   src = fetchFromGitHub {
     owner = "ranfdev";
     repo = "DistroShelf";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-4rNdp0g/QaiLnKGC4baYAq29dxluyZ+9TgeBlqidRp0=";
+    hash = "sha256-3O+KsOZzwH8E2rDSEgiVZK64B2wK1U/uDJ2z37NtJCg=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-5luI46rSgB+N0OKQzSopEhCCEnwAhMabRit9MtsSSVA=";
+    hash = "sha256-lNKWcpdIr1tm2m50B9uOqFQvhndAEM5ADmmPBPb8sj4=";
   };
 
   nativeBuildInputs = [
@@ -40,11 +42,13 @@ stdenv.mkDerivation (finalAttrs: {
     rustc
     desktop-file-utils
     pkg-config
+    libxml2
   ];
 
   buildInputs = [
     glib
     libadwaita
+    vte-gtk4
   ];
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
Updates distroshelf from 1.0.15 to 1.4.8. Added new dependencies `vte-gtk4` and `libxml2` to fix the build.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
