### PR TITLE
doc/using/configuration: document NIXPKGS_CONFIG lookup order

### DIFF
--- a/doc/using/configuration.chapter.md
+++ b/doc/using/configuration.chapter.md
@@ -31,6 +31,22 @@ Unfree software is not tested or built in Nixpkgs continuous integration, and th
 Most unfree licenses prohibit either executing or distributing the software.
 :::
 
+The `NIXPKGS_CONFIG` environment variable can override the configuration file location.
+Nixpkgs resolves the config in this order:
+
+1.  `$NIXPKGS_CONFIG`, if set and the file exists.
+2.  `~/.config/nixpkgs/config.nix`, if it exists.
+3.  `~/.nixpkgs/config.nix` (legacy), if it exists.
+4.  Empty configuration.
+
+On NixOS, `NIXPKGS_CONFIG` points to `/etc/nix/nixpkgs-config.nix` system-wide.
+Drop a file there to apply configuration to `nix-env`, `nix-shell`, and other user-level commands.
+NixOS does not create this file.
+The [`nixpkgs.config`](https://nixos.org/manual/nixos/stable/options#opt-nixpkgs.config) option does not affect `nix-env`, `nix-shell`, or other user-level commands.
+
+This lookup applies to non-flake usage like channels and `<nixpkgs>`.
+Flakes ignore it; pass `config` directly when importing `nixpkgs`.
+
 ## Installing broken packages {#sec-allow-broken}
 
 There are several ways to try compiling a package which has been marked as broken.

--- a/doc/using/configuration.chapter.md
+++ b/doc/using/configuration.chapter.md
@@ -31,6 +31,22 @@ Unfree software is not tested or built in Nixpkgs continuous integration, and th
 Most unfree licenses prohibit either executing or distributing the software.
 :::
 
+Set `NIXPKGS_CONFIG` to override the configuration file location.
+Nixpkgs resolves the config in this order:
+
+1.  `$NIXPKGS_CONFIG`, if set and the file exists.
+2.  `~/.config/nixpkgs/config.nix`.
+3.  `~/.nixpkgs/config.nix` (legacy).
+4.  Empty configuration.
+
+On NixOS, `NIXPKGS_CONFIG` points to `/etc/nix/nixpkgs-config.nix` system-wide.
+Drop a file there to apply configuration to `nix-env`, `nix-shell`, and other user-level commands.
+NixOS does not create this file.
+The [`nixpkgs.config`](https://nixos.org/manual/nixos/stable/options#opt-nixpkgs.config) option only affects the system evaluation.
+
+This lookup applies to non-flake usage like channels and `<nixpkgs>`.
+Flakes ignore it; pass `config` directly when importing `nixpkgs`.
+
 ## Installing broken packages {#sec-allow-broken}
 
 There are several ways to try compiling a package which has been marked as broken.


### PR DESCRIPTION
## Summary

The `NIXPKGS_CONFIG` environment variable, and the system-wide `/etc/nix/nixpkgs-config.nix` path NixOS sets it to, are not currently described in the Nixpkgs manual; the [Global configuration](https://nixos.org/manual/nixpkgs/stable/#chap-packageconfig) chapter only mentions `~/.config/nixpkgs/config.nix`. The mechanism is implemented at `pkgs/top-level/impure.nix:25-40` and the NixOS env var is set at `nixos/modules/programs/environment.nix:18`. This adds one paragraph documenting the lookup order, the NixOS-specific default, and the (potentially surprising) fact that NixOS does not generate `/etc/nix/nixpkgs-config.nix` itself — `nixpkgs.config` only configures the system Nixpkgs evaluation, not user-level Nix tools.

Closes #28085.

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test