### PR TITLE
terminal-notifier: build from source, cleanup, adopt

### DIFF
--- a/pkgs/by-name/te/terminal-notifier/package.nix
+++ b/pkgs/by-name/te/terminal-notifier/package.nix
@@ -1,40 +1,43 @@
 {
-  stdenv,
-  runtimeShell,
-  lib,
   fetchzip,
+  lib,
+  makeBinaryWrapper,
+  stdenv,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "terminal-notifier";
-
   version = "2.0.0";
 
   src = fetchzip {
-    url = "https://github.com/alloy/terminal-notifier/releases/download/${version}/terminal-notifier-${version}.zip";
-    sha256 = "0gi54v92hi1fkryxlz3k5s5d8h0s66cc57ds0vbm1m1qk3z4xhb0";
+    url = "https://github.com/alloy/terminal-notifier/releases/download/${finalAttrs.version}/terminal-notifier-${finalAttrs.version}.zip";
+    hash = "sha256-YMFO/pg41FDXBrqdwpgxGkDUii5zfNp9ni5EKNImJT4=";
     stripRoot = false;
   };
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
 
   dontBuild = true;
 
   installPhase = ''
-    mkdir -p $out/Applications
-    mkdir -p $out/bin
+    runHook preInstall
+
+    mkdir -p $out/{Applications,bin}
     cp -r terminal-notifier.app $out/Applications
-    cat >$out/bin/terminal-notifier <<EOF
-    #!${runtimeShell}
-    cd $out/Applications/terminal-notifier.app
-    exec ./Contents/MacOS/terminal-notifier "\$@"
-    EOF
-    chmod +x $out/bin/terminal-notifier
+    makeWrapper \
+      $out/Applications/terminal-notifier.app/Contents/MacOS/terminal-notifier \
+      $out/bin/terminal-notifier \
+      --chdir $out/Applications/terminal-notifier.app
+
+    runHook postInstall
   '';
 
   meta = {
-    maintainers = with lib.maintainers; [ amarshall ];
+    description = "Send macOS User Notifications from the command-line";
     homepage = "https://github.com/julienXX/terminal-notifier";
     license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ amarshall ];
     platforms = lib.platforms.darwin;
     mainProgram = "terminal-notifier";
   };
-}
+})

--- a/pkgs/by-name/te/terminal-notifier/package.nix
+++ b/pkgs/by-name/te/terminal-notifier/package.nix
@@ -1,29 +1,46 @@
 {
-  fetchzip,
+  apple-sdk,
+  fetchFromGitHub,
+  ibtool,
   lib,
   makeBinaryWrapper,
   stdenv,
+  xcbuildHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "terminal-notifier";
   version = "2.0.0";
 
-  src = fetchzip {
-    url = "https://github.com/alloy/terminal-notifier/releases/download/${finalAttrs.version}/terminal-notifier-${finalAttrs.version}.zip";
-    hash = "sha256-YMFO/pg41FDXBrqdwpgxGkDUii5zfNp9ni5EKNImJT4=";
-    stripRoot = false;
+  src = fetchFromGitHub {
+    owner = "julienXX";
+    repo = "terminal-notifier";
+    tag = finalAttrs.version;
+    hash = "sha256-Hd9cI3R2nQK2deBb5CBYz4DTHAEcO4vzqtA5qZwa1Ao=";
   };
 
-  nativeBuildInputs = [ makeBinaryWrapper ];
+  nativeBuildInputs = [
+    ibtool
+    makeBinaryWrapper
+    xcbuildHook
+  ];
 
-  dontBuild = true;
+  buildInputs = [
+    apple-sdk
+  ];
+
+  xcbuildFlags = [
+    "-target"
+    "terminal-notifier"
+    "-configuration"
+    "Release"
+  ];
 
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/{Applications,bin}
-    cp -r terminal-notifier.app $out/Applications
+    cp -r Products/Release/terminal-notifier.app $out/Applications/
     makeWrapper \
       $out/Applications/terminal-notifier.app/Contents/MacOS/terminal-notifier \
       $out/bin/terminal-notifier \

--- a/pkgs/by-name/te/terminal-notifier/package.nix
+++ b/pkgs/by-name/te/terminal-notifier/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ amarshall ];
     homepage = "https://github.com/julienXX/terminal-notifier";
     license = lib.licenses.mit;
     platforms = lib.platforms.darwin;


### PR DESCRIPTION
See individual commits for details.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
