### PR TITLE
buildkite-cli: 3.32.2 -> 3.40.0

### DIFF
--- a/pkgs/by-name/bu/buildkite-cli/package.nix
+++ b/pkgs/by-name/bu/buildkite-cli/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildGoModule,
   fetchFromGitHub,
+  gitMinimal,
   versionCheckHook,
   writableTmpDirAsHomeHook,
   nix-update-script,
@@ -10,16 +11,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "buildkite-cli";
-  version = "3.32.2";
+  version = "3.40.0";
 
   src = fetchFromGitHub {
     owner = "buildkite";
     repo = "cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-7jBYi9KGkeB6Pu4VDR8QSTG3U4QFFVih3MUp2Sldpqo=";
+    hash = "sha256-8Fij2SG6dLnyc4U2Q+jIx2ZDzbGd6ETTWiiz3ciRaE8=";
   };
 
-  vendorHash = "sha256-yi77gGlBIGEQQbYVVsQP74IVFuZo5GAPOdgYmaDnBAs=";
+  vendorHash = "sha256-pxVSzEc/pgPaMMBOl5LYjbmPVpjr1M2obFmeiGqfgik=";
 
   ldflags = [
     "-s"
@@ -27,6 +28,7 @@ buildGoModule (finalAttrs: {
   ];
 
   nativeCheckInputs = [
+    gitMinimal
     writableTmpDirAsHomeHook
   ];
 


### PR DESCRIPTION
Bumps buildkite-cli from 3.32.2 to 3.40.0.

Also adds `gitMinimal` to `nativeCheckInputs` as newer upstream tests require git in the test environment.

Changelog: https://github.com/buildkite/cli/releases/tag/v3.40.0

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test