### PR TITLE
[25.11] KDE security backports

### DIFF
--- a/pkgs/kde/frameworks/kcoreaddons/default.nix
+++ b/pkgs/kde/frameworks/kcoreaddons/default.nix
@@ -1,11 +1,20 @@
 {
   mkKdeDerivation,
+  fetchpatch,
   qttools,
   shared-mime-info,
   qtdeclarative,
 }:
 mkKdeDerivation {
   pname = "kcoreaddons";
+
+  patches = [
+    # https://kde.org/info/security/advisory-20260427-1.txt
+    (fetchpatch {
+      url = "https://invent.kde.org/frameworks/kcoreaddons/-/commit/6153c9ae025fa570174bb4a143df38fa2f46606b.diff";
+      hash = "sha256-eFHEW7wEuOXClCAoBeo3lpmNcDg1YMwhBcr24pE6Urk=";
+    })
+  ];
 
   hasPythonBindings = true;
 

--- a/pkgs/kde/gear/dolphin/default.nix
+++ b/pkgs/kde/gear/dolphin/default.nix
@@ -1,10 +1,16 @@
 {
   mkKdeDerivation,
+  fetchpatch,
   qtmultimedia,
 }:
 mkKdeDerivation {
   pname = "dolphin";
   patches = [
+    # https://kde.org/info/security/advisory-20260427-2.txt
+    (fetchpatch {
+      url = "https://invent.kde.org/system/dolphin/-/commit/42f099a5ba10e8948cae8f7e364c94129131326c.diff";
+      hash = "sha256-DethSnRpjD2rado9/Isdod6fl4hfH3rvL7Pfr+mZ5QU=";
+    })
     # backported fix for https://bugs.kde.org/show_bug.cgi?id=451050
     ./dolphin-samba-crash-fix.patch
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
