### PR TITLE
lazytrivy: 1.2.0 -> 1.3.3

### DIFF
--- a/pkgs/by-name/la/lazytrivy/package.nix
+++ b/pkgs/by-name/la/lazytrivy/package.nix
@@ -9,16 +9,18 @@
 
 buildGoModule (finalAttrs: {
   pname = "lazytrivy";
-  version = "1.2.0";
+  version = "1.3.3";
+
+  env.GOEXPERIMENT = "jsonv2";
 
   src = fetchFromGitHub {
     owner = "owenrumney";
     repo = "lazytrivy";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-fhHy54pIbYdj+mWCIx7Wla6x+J/w2f8+J+WSbt+WNwA=";
+    hash = "sha256-M7qhkHuyI6cpmRzvn8AJun3tyzTbU8QtUlK7Qo0xxU4=";
   };
 
-  vendorHash = "sha256-dIe6zjWc8DVU9YQbYfmNUcfSh6MsdZZ8/A/EYLmPNkE=";
+  vendorHash = "sha256-vzdGWlyk4Eqhh+r4RH4eVVA4YPnADCGYnh0tmeD8S8M=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
Update to 1.3.3

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
