### PR TITLE
tdl: 0.19.0 -> 0.20.2

### DIFF
--- a/pkgs/by-name/td/tdl/package.nix
+++ b/pkgs/by-name/td/tdl/package.nix
@@ -5,22 +5,32 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "tdl";
-  version = "0.19.0";
+  version = "0.20.2";
 
   src = fetchFromGitHub {
     owner = "iyear";
     repo = "tdl";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-EYS4EK0NmNHnvjMkf5AHrYpZeGw+n2ovFDLanbqpF4Y=";
+    hash = "sha256-xDCvZ6a7xW5kJ+3nsCQGASypzrosjihI0hlSobBWwj0=";
   };
 
-  vendorHash = "sha256-GpqgH23eK0h2BYxjN5TNUWEOT72smYdUoD1Iy6L2jL4=";
+  vendorHash = "sha256-dMuDmW3WtXU1Awuw7KKSCk1o/GKpBfsrqfvb3wVNGWw=";
+
+  postPatch = ''
+    rm go.work go.work.sum
+    go mod edit -replace github.com/iyear/tdl/core=./core
+    go mod edit -replace github.com/iyear/tdl/extension=./extension
+  '';
 
   ldflags = [
     "-s"
     "-w"
     "-X=github.com/iyear/tdl/pkg/consts.Version=${finalAttrs.version}"
   ];
+
+  env.GOGC = "50";
+
+  buildFlags = [ "-p=1" ];
 
   # Filter out the main executable
   subPackages = [ "." ];


### PR DESCRIPTION
Update from 0.19.0 to 0.20.2.
The repository uses a Go workspace (go.work), which buildGoModule does not natively support for vendoring. Added a postPatch phase to:
       - Remove go.work and go.work.sum.
       - Use go mod edit -replace to point the root go.mod to the local core and extension modules.
Added env.GOGC = "50"; and buildFlags = [ "-p=1" ]; to prevent OOM (Out Of Memory) errors during compilation.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
