### PR TITLE
maigret: 0.5.0 > 0.6.0

### DIFF
--- a/pkgs/by-name/ma/maigret/package.nix
+++ b/pkgs/by-name/ma/maigret/package.nix
@@ -22,6 +22,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   pythonRemoveDeps = [
     "future-annotations"
     "future"
+    "PyPDF2"
     "six"
   ];
 
@@ -55,7 +56,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
       networkx
       platformdirs
       pycountry
-      pypdf2
+      pypdf
       pysocks
       python-bidi
       pyvis

--- a/pkgs/by-name/ma/maigret/package.nix
+++ b/pkgs/by-name/ma/maigret/package.nix
@@ -7,14 +7,14 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "maigret";
-  version = "0.5.0";
+  version = "0.6.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "soxoj";
     repo = "maigret";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-y5b7t4ji72o1PXoqEQ0vNHqE1vwdkB/3gtsCj5GZ4Xg=";
+    hash = "sha256-3X8mRgsI0y1F/gUTWeYw83mQJKglJporpw7l9jI1Hvw=";
   };
 
   pythonRelaxDeps = true;
@@ -43,6 +43,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
       chardet
       cloudscraper
       colorama
+      curl-cffi
       flask
       html5lib
       idna
@@ -86,18 +87,20 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   disabledTests = [
     # Tests require network access
+    "test_check_features_manually_cloudflare"
+    "test_check_features_manually_success"
+    "test_detect_known_engine"
+    "test_dialog_adds_site_negative"
+    "test_dialog_adds_site_positive"
+    "test_dialog_replace_site"
     "test_extract_ids_from_page"
     "test_import_aiohttp_cookies"
     "test_maigret_results"
     "test_pdf_report"
     "test_self_check_db_negative_enabled"
     "test_self_check_db_positive_enable"
-    "test_detect_known_engine"
-    "test_check_features_manually_success"
-    "test_dialog_adds_site_positive"
-    "test_dialog_replace_site"
-    "test_dialog_adds_site_negative"
-    #
+    "test_twitter_graphql_probe_claimed_vs_unclaimed"
+    # Sandbox issue
     "test_self_check_db"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [


### PR DESCRIPTION
Changelog: https://github.com/soxoj/maigret/releases/tag/v0.6.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
