### PR TITLE
joularjx: 2.9.0 -> 3.1.0

### DIFF
--- a/pkgs/by-name/jo/joularjx/package.nix
+++ b/pkgs/by-name/jo/joularjx/package.nix
@@ -8,18 +8,18 @@
 
 maven.buildMavenPackage rec {
   pname = "joularjx";
-  version = "2.9.0";
+  version = "3.1.0";
 
   src = fetchFromGitHub {
     owner = "joular";
     repo = "joularjx";
     rev = version;
-    hash = "sha256-/Drv6PVMmz3QNEu8zMokTKBZeYWMjuKczu18qKqNAx4=";
+    hash = "sha256-hr8a3Qr1LdFfGBLVJVkm6hhCW7knG4VpXj7nCtcptuU=";
   };
 
-  mvnHash = "sha256-TKHo0hZBjgBeUWYvbjF3MZ6Egp3qB2LGwWfrGrcVkOk=";
+  mvnHash = "sha256-3y39873pxlQD7d02sbVtZ2I/zcQtPZ30XrA2qY84EzA=";
 
-  mvnParameters = "-DskipTests";
+  mvnParameters = "-DskipTests -Dmaven.javadoc.skip=true";
 
   nativeBuildInputs = [ makeWrapper ];
 


### PR DESCRIPTION
Update to 3.1.0

Added -Dmaven.javadoc.skip=true to mvnParameters to fix build

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
