### PR TITLE
flexbv: init at 5.3127

### DIFF
--- a/pkgs/by-name/fl/flexbv/package.nix
+++ b/pkgs/by-name/fl/flexbv/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  dbus,
+  gtk3,
+  libdrm,
+  pango,
+  vulkan-loader,
+  libxtst,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "flexbv";
+  version = "5.3127";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchurl {
+    url = "https://pldaniels.com/flexbv5/releases/flexbv-std-${finalAttrs.version}-linux-x86_64.tar.gz";
+    hash = "sha256-22KMKkWpQ84LxsnrVYYahwPSbJk2zLFLEq4feRJWWWk=";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  autoPatchelfIgnoreMissingDeps = [
+    "libsteam_api.so"
+    "libGLES_CM.so.1"
+    "libpdfium.so"
+  ];
+
+  buildInputs = [
+    dbus
+    gtk3
+    libdrm
+    pango
+    vulkan-loader
+    libxtst
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 flexbv $out/bin/flexbv
+    install -Dm755 fbvpdf5 $out/bin/fbvpdf5
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://pldaniels.com/flexbv5/";
+    description = "Viewer for PCB layout boardview files";
+    changelog = "https://pldaniels.com/flexbv5/CHANGELOG.txt";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ kashw2 ];
+    mainProgram = "flexbv";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://pldaniels.com/flexbv5

Paul Daniels BoardView Software

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
