### PR TITLE
gitlab: 18.11.1 -> 18.11.12

### DIFF
--- a/pkgs/by-name/gi/gitaly/package.nix
+++ b/pkgs/by-name/gi/gitaly/package.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-  version = "18.11.1";
+  version = "18.11.2";
   package_version = "v${lib.versions.major version}";
   gitaly_package = "gitlab.com/gitlab-org/gitaly/${package_version}";
 
@@ -21,7 +21,7 @@ let
       owner = "gitlab-org";
       repo = "gitaly";
       rev = "v${version}";
-      hash = "sha256-se3JtkYR+Mi0Kse3fQXBwxQyHmbPu2DqTNGnRHZQdTc=";
+      hash = "sha256-UmoMZ55FqEVYTjfgdoZsbJcs/+4x80KKxq6Cfatv4K4=";
     };
 
     vendorHash = "sha256-123WUtoUaPIyDywcTKEhiZP2SYYHxAQoOPyCebsHYRI=";

--- a/pkgs/by-name/gi/gitlab-pages/package.nix
+++ b/pkgs/by-name/gi/gitlab-pages/package.nix
@@ -6,14 +6,14 @@
 
 buildGoModule (finalAttrs: {
   pname = "gitlab-pages";
-  version = "18.11.1";
+  version = "18.11.2";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitlab-pages";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-O9YzFUVhqy16sMmViLcJ4LMumyGsvPDehkQCGproSFs=";
+    hash = "sha256-lxmwTC02WHwlrMgvTs2lkDj4AX8ovFuW73OHB6CIWTo=";
   };
 
   vendorHash = "sha256-PUW4cgAiM1GTtvja894OZ4pe0SWChf5JsL4/fkns2kI=";

--- a/pkgs/by-name/gi/gitlab/data.json
+++ b/pkgs/by-name/gi/gitlab/data.json
@@ -1,17 +1,17 @@
 {
-  "version": "18.11.1",
-  "repo_hash": "sha256-ksqJuXklQYFAosyPKAtTDgcq+qJ6TRd2PJ4wu0JpMMI=",
+  "version": "18.11.2",
+  "repo_hash": "sha256-TAc3bNFwq/QKR+X/P9BqQHA2T5viD+SAOXXUZ7StDP4=",
   "yarn_hash": "sha256-k8JHi0f/XfSV4kICyPW01Erk3YnKw33yeUWYrOaPdTM=",
   "frontend_islands_yarn_hash": "sha256-EvGQin+5DqqIgM36jlVkVI49WcJzVvceYnkSS9ybfcY=",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v18.11.1-ee",
+  "rev": "v18.11.2-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "18.11.1",
-    "GITLAB_KAS_VERSION": "18.11.1",
-    "GITLAB_PAGES_VERSION": "18.11.1",
+    "GITALY_SERVER_VERSION": "18.11.2",
+    "GITLAB_KAS_VERSION": "18.11.2",
+    "GITLAB_PAGES_VERSION": "18.11.2",
     "GITLAB_SHELL_VERSION": "14.49.0",
     "GITLAB_ELASTICSEARCH_INDEXER_VERSION": "5.14.1",
-    "GITLAB_WORKHORSE_VERSION": "18.11.1"
+    "GITLAB_WORKHORSE_VERSION": "18.11.2"
   }
 }

--- a/pkgs/by-name/gi/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/by-name/gi/gitlab/gitlab-workhorse/default.nix
@@ -10,7 +10,7 @@ in
 buildGoModule (finalAttrs: {
   pname = "gitlab-workhorse";
 
-  version = "18.11.1";
+  version = "18.11.2";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitLab {


### PR DESCRIPTION
https://docs.gitlab.com/releases/patches/patch-release-gitlab-18-11-2-released/


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
