### PR TITLE
.gitattributes: update lock file attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,26 @@
-**/deps.nix linguist-generated
+# node/js lock files
+**/package-lock.json linguist-generated
+**/yarn.nix linguist-generated
+**/yarn.lock linguist-generated
+
+# Rust lock files
+**/Cargo.lock linguist-generated
+pkgs/build-support/rust/**/Cargo.lock -linguist-generated
+
+# NuGet, Gradle and others
 **/deps.json linguist-generated
+
+# Ruby lock files
+**/gemset.nix linguist-generated
+**/Gemfile.lock linguist-generated
+
+# PHP lock files
+**/composer.lock linguist-generated
+
+# various package managers and tools
+**/deps.nix linguist-generated
 **/deps.toml linguist-generated
-**/node-packages.nix linguist-generated
+
 
 pkgs/applications/editors/emacs-modes/*-generated.nix linguist-generated
 pkgs/development/r-modules/*-packages.nix linguist-generated


### PR DESCRIPTION
- Mark additional lock files as generated (Rust, Ruby, PHP, and others).
- Remove node-packages.nix as it isn't used in Nixpkgs anymore.

See [the Github docs](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github) regarding `linguist-generated`. This is purely an aesthetic change that should automatically collapse these files when reviewing.

### Lock file usage stats in nixpkgs
The additional included lock files were partially selected based on those mentioned in #327064. Additionally, I created a short script to check how widespread certain files are used (and for generic names like deps.json, how they're mostly used).

#### Script
```bash
#!/usr/bin/env bash

set -x

fd deps.json | wc -l
fd deps.toml | wc -l
fd deps.nix | wc -l
fd node-packages.nix | wc -l
fd gemset.nix | wc -l
fd Gemfile.lock | wc -l
fd composer.lock | wc -l
fd package-lock.json | wc -l
fd yarn.nix | wc -l
fd yarn.lock | wc -l
fd Cargo.lock | wc -l
```

#### Example output
```
+ fd deps.json
+ wc -l
214
+ fd deps.toml
+ wc -l
2
+ fd deps.nix
+ wc -l
40
+ fd node-packages.nix
+ wc -l
0
+ fd gemset.nix
+ wc -l
139
+ fd Gemfile.lock
+ wc -l
134
+ fd composer.lock
+ wc -l
13
+ fd package-lock.json
+ wc -l
36
+ fd yarn.nix
+ wc -l
2
+ fd yarn.lock
+ wc -l
5
+ wc -l
+ fd Cargo.lock
102
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
