### PR TITLE
lix: add logDir to derivation input parameters

### DIFF
--- a/pkgs/tools/package-management/lix/common-lix.nix
+++ b/pkgs/tools/package-management/lix/common-lix.nix
@@ -103,6 +103,7 @@ assert lib.assertMsg (
 
   confDir,
   stateDir,
+  logDir,
   storeDir,
 }:
 let
@@ -346,6 +347,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     (lib.mesonOption "store-dir" storeDir)
     (lib.mesonOption "state-dir" stateDir)
+    (lib.mesonOption "log-dir" logDir)
     (lib.mesonOption "sysconfdir" confDir)
   ]
   ++ lib.optionals hasDtraceSupport [

--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -32,6 +32,7 @@
 
   storeDir ? "/nix/store",
   stateDir ? "/nix/var",
+  logDir ? "/nix/var/log/nix",
   confDir ? "/etc",
 }:
 let
@@ -72,6 +73,7 @@ let
           inherit
             storeDir
             stateDir
+            logDir
             confDir
             ;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixes #512948

This PR adds `logDir` to `lix`'s input parameters, which allows overriding `lix`'s default log output directory.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
