### PR TITLE
mgmt: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/by-name/mg/mgmt/package.nix
+++ b/pkgs/by-name/mg/mgmt/package.nix
@@ -12,18 +12,21 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "mgmt";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchFromGitHub {
     owner = "purpleidea";
     repo = "mgmt";
     tag = finalAttrs.version;
-    hash = "sha256-Qi9KkWzFOqmUp5CSHxzQabQ8bVnBbxxKS/W6aLBTv6k=";
+    hash = "sha256-nLk497gGrZ664VG9/yV6tqTtwAsN8EmuAEh5Vmq95hQ=";
   };
 
-  vendorHash = "sha256-XZTDqN5nQqze41Y/jOhT3mFHXeR2oPjXpz7CJuPOi8k=";
+  vendorHash = "sha256-w4j9cJwW2tnjXSnd3w3v81TwHI8tGYiImjG3LZ+Pjuc=";
+
+  proxyVendor = true;
 
   postPatch = ''
+    rm -rf vendor
     patchShebangs misc/header.sh
   '';
   preBuild = ''
@@ -60,5 +63,6 @@ buildGoModule (finalAttrs: {
       karpfediem
     ];
     mainProgram = "mgmt";
+    platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
Updated the mgmt to 1.0.2 and added proxyVendor = true and removed the vendor folder to fix build issues.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
