### PR TITLE
postgresql: use structuredAttrs instead of passAsFile in tests

### DIFF
--- a/pkgs/by-name/po/postgresqlTestHook/test.nix
+++ b/pkgs/by-name/po/postgresqlTestHook/test.nix
@@ -10,7 +10,6 @@ stdenv.mkDerivation {
   nativeCheckInputs = [ postgresql ];
   dontUnpack = true;
   doCheck = true;
-  passAsFile = [ "sql" ];
   sql = ''
     CREATE TABLE hello (
       message text
@@ -23,6 +22,8 @@ stdenv.mkDerivation {
   '';
   checkPhase = ''
     runHook preCheck
+    sqlPath=$TMPDIR/test.sql
+    printf "%s" "$sql" > $sqlPath
     psql <$sqlPath | grep 'it worked'
     TEST_RAN=1
     runHook postCheck
@@ -31,4 +32,5 @@ stdenv.mkDerivation {
     [[ $TEST_RAN == 1 && $TEST_POST_HOOK_RAN == 1 ]]
     touch $out
   '';
+  __structuredAttrs = true;
 }

--- a/pkgs/servers/sql/postgresql/ext/pgtap.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgtap.nix
@@ -35,7 +35,6 @@ postgresqlBuildExtension (finalAttrs: {
       postgresqlTestHook
       (postgresql.withPackages (_: [ finalAttrs.finalPackage ]))
     ];
-    passAsFile = [ "sql" ];
     sql = ''
       CREATE EXTENSION pgtap;
 
@@ -47,10 +46,13 @@ postgresqlBuildExtension (finalAttrs: {
     '';
     checkPhase = ''
       runHook preCheck
+      sqlPath=$TMPDIR/test.sql
+      printf "%s" "$sql" > $sqlPath
       psql -a -v ON_ERROR_STOP=1 -f $sqlPath
       runHook postCheck
     '';
     installPhase = "touch $out";
+    __structuredAttrs = true;
   };
 
   meta = {

--- a/pkgs/servers/sql/postgresql/postgresqlTestExtension.nix
+++ b/pkgs/servers/sql/postgresql/postgresqlTestExtension.nix
@@ -22,7 +22,6 @@ stdenvNoCC.mkDerivation (
       (postgresql.withPackages (ps: [ finalPackage ] ++ (map (p: ps."${p}") withPackages)))
     ];
     postgresqlTestUserOptions = "LOGIN SUPERUSER";
-    passAsFile = [ "sql" ];
     sql =
       sql
       + lib.concatMapStrings (
@@ -39,10 +38,13 @@ stdenvNoCC.mkDerivation (
       ) asserts;
     checkPhase = ''
       runHook preCheck
+      sqlPath=$TMPDIR/test.sql
+      printf "%s" "$sql" > $sqlPath
       psql -a -v ON_ERROR_STOP=1 -f "$sqlPath"
       runHook postCheck
     '';
     installPhase = "touch $out";
+    __structuredAttrs = true;
   }
   // lib.removeAttrs extraArgs [
     "asserts"


### PR DESCRIPTION
Tested via

* `nix-build -A postgresqlPackages.pgtap.tests`
* `nix-build -A postgresqlPackages.pgsodium.tests.extension` (uses `postgresqlTestExtension`)
* `nix-build -A postgresqlTestHook.tests`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
