### PR TITLE
treefmt: use structuredAttrs instead of passAsFile in test

### DIFF
--- a/pkgs/by-name/tr/treefmt/tests.nix
+++ b/pkgs/by-name/tr/treefmt/tests.nix
@@ -72,10 +72,6 @@ in
     runCommand "run-nixfmt-example"
       {
         nativeBuildInputs = [ nixfmtExamplePackage ];
-        passAsFile = [
-          "input"
-          "expected"
-        ];
         input = ''
           {
             foo="bar";
@@ -90,18 +86,19 @@ in
             list = [ ];
           }
         '';
+        __structuredAttrs = true;
       }
       ''
         export XDG_CACHE_HOME=$(mktemp -d)
         # The example config assumes the tree root has a .git/index file
         mkdir .git && touch .git/index
 
-        # Copy the input file, then format it using the wrapped treefmt
-        cp $inputPath input.nix
+        # Create the input file, then format it using the wrapped treefmt
+        printf "%s" "$input" > input.nix
         treefmt
 
         # Assert that input.nix now matches expected
-        if diff -u $expectedPath input.nix; then
+        if diff -u <(printf "%s" "$expected") input.nix; then
           touch $out
         else
           echo


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
