### PR TITLE
nixos/nextcloud: don't leak occ commands to journal

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.md
+++ b/nixos/modules/services/web-apps/nextcloud.md
@@ -68,6 +68,11 @@ It requires elevated permissions to become the `nextcloud` user. Given the way t
 escalation is implemented, parameters passed via the environment to Nextcloud are
 currently ignored, except for `OC_PASS` and `NC_PASS`.
 
+::: {.warning}
+When Polkit is enabled, the command being executed by `nextcloud-occ` might be logged
+into the system's journal. Be careful to not leak secrets that way!
+:::
+
 Custom service units that need to run `nextcloud-occ` either need elevated privileges
 or the systemd configuration from `nextcloud-setup.service` (recommended):
 

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -145,15 +145,17 @@ let
         #       in the nix_read_secret() php function.
         #       When there's no CREDENTIALS_DIRECTORY we try to use systemd-run to
         #       load the credentials just as in a service unit.
-        # NOTE: If there are no credentials that are required at runtime then there's no need
-        #       to load any credentials.
-        if [[ $requiresRuntimeSystemdCredentials == true && -z "''${CREDENTIALS_DIRECTORY:-}" ]]; then
+        #
+        # `systemd-run` with `--description` is also being used since `nextcloud-occ` might be used
+        # to set sensitive data in `config.php` and persisting this into system logs is a bad idea.
+        if [[ $requiresRuntimeSystemdCredentials == true && -z "''${CREDENTIALS_DIRECTORY:-}" ]] || [[ "$USER" != nextcloud ]]; then
           exec ${lib.getExe' config.systemd.package "systemd-run"} \
             ${
               lib.escapeShellArgs (
                 map (credential: "--property=LoadCredential=${credential}") runtimeSystemdCredentials
               )
             } \
+            --description "Nextcloud OCC Command" \
             --uid=nextcloud \
             --same-dir \
             --pty \
@@ -166,24 +168,6 @@ let
             --quiet \
             -- \
             ${command}
-        elif [[ "$USER" != nextcloud ]]; then
-          if [[ -x /run/wrappers/bin/sudo ]]; then
-            exec /run/wrappers/bin/sudo \
-              --preserve-env=CREDENTIALS_DIRECTORY \
-              --preserve-env=OC_PASS \
-              --preserve-env=NC_PASS \
-              --user=nextcloud \
-              -- \
-              ${command}
-          else
-            exec ${lib.getExe' pkgs.util-linux "runuser"} \
-              --whitelist-environment=CREDENTIALS_DIRECTORY \
-              --whitelist-environment=OC_PASS \
-              --whitelist-environment=NC_PASS \
-              --user=nextcloud \
-              -- \
-              ${command}
-          fi
         else
           exec ${command}
         fi


### PR DESCRIPTION
Closes #513470

`nextcloud-occ` can be used to set sensitive parameters in `config.php`.
However, the entire argv unconditionally ends up in the journal's
metadata. Even with `--description=` being set, the full command is
logged and thus persisted.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
