### PR TITLE
[Backport release-25.11] wireshark: 4.6.4 -> 4.6.5

### DIFF
--- a/pkgs/by-name/wi/wireshark/package.nix
+++ b/pkgs/by-name/wi/wireshark/package.nix
@@ -226,7 +226,7 @@ stdenv.mkDerivation (finalAttrs: {
       experts. It runs on UNIX, macOS and Windows.
     '';
     homepage = "https://www.wireshark.org";
-    changelog = "https://www.wireshark.org/docs/relnotes/wireshark-${finalAttrs.src.tag}.html";
+    changelog = "https://www.wireshark.org/docs/relnotes/wireshark-${finalAttrs.version}.html";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/wi/wireshark/package.nix
+++ b/pkgs/by-name/wi/wireshark/package.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
     repo = "wireshark";
     owner = "wireshark";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-U30OJ8m+L/EVLN7NrqWNl77IMaO2cnw2N5uWzLVJE30=";
+    hash = "sha256-Zvrwxjp4LK2J3QnxmPxKKrU01YHQvPyp54UWzeGNCjA=";
   };
 
   patches = [

--- a/pkgs/by-name/wi/wireshark/package.nix
+++ b/pkgs/by-name/wi/wireshark/package.nix
@@ -59,7 +59,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wireshark-${if withQt then "qt" else "cli"}";
-  version = "4.6.4";
+  version = "4.6.5";
 
   outputs = [
     "out"
@@ -70,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
     repo = "wireshark";
     owner = "wireshark";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-h254dXxloBC5xQYcpeaLlAj2Ip4eQWHYSPPJLkIwQZw=";
+    hash = "sha256-U30OJ8m+L/EVLN7NrqWNl77IMaO2cnw2N5uWzLVJE30=";
   };
 
   patches = [


### PR DESCRIPTION


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 515403`
Commit: `28e54549dc45d788248775865405b1ea45c631fc`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 24 packages built:</summary>
  <ul>
    <li>compactor</li>
    <li>dbmonster</li>
    <li>hfinger</li>
    <li>hfinger.dist</li>
    <li>ostinato</li>
    <li>python312Packages.dissect-cobaltstrike</li>
    <li>python312Packages.dissect-cobaltstrike.dist</li>
    <li>python312Packages.manuf</li>
    <li>python312Packages.manuf.dist</li>
    <li>python312Packages.pyshark</li>
    <li>python312Packages.pyshark.dist</li>
    <li>python313Packages.dissect-cobaltstrike</li>
    <li>python313Packages.dissect-cobaltstrike.dist</li>
    <li>python313Packages.manuf</li>
    <li>python313Packages.manuf.dist</li>
    <li>python313Packages.pyshark</li>
    <li>python313Packages.pyshark.dist</li>
    <li>termshark</li>
    <li>tshark (wireshark-cli)</li>
    <li>tshark.dev (wireshark-cli.dev)</li>
    <li>wifite2</li>
    <li>wifite2.dist</li>
    <li>wireshark (wireshark-qt)</li>
    <li>wireshark.dev (wireshark-qt.dev)</li>
  </ul>
</details>

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
