### PR TITLE
ticktick: fix desktop icon path

### DIFF
--- a/pkgs/by-name/ti/ticktick/package.nix
+++ b/pkgs/by-name/ti/ticktick/package.nix
@@ -72,7 +72,8 @@ stdenv.mkDerivation (finalAttrs: {
     ln -sf "$out/opt/ticktick/ticktick" "$out/bin/ticktick"
 
     substituteInPlace "$out/share/applications/ticktick.desktop" \
-      --replace "Exec=/opt/TickTick/ticktick" "Exec=$out/bin/ticktick"
+      --replace-fail "Exec=/opt/TickTick/ticktick" "Exec=$out/bin/ticktick" \
+      --replace-fail "Icon=ticktick" "Icon=$out/share/icons/hicolor/256x256/apps/ticktick.png"
 
     runHook postInstall
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
The desktop entry sets `Icon=ticktick` which doesn't resolve on
non-NixOS systems. Use the absolute path instead.

Also switches `--replace` to `--replace-fail`.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
