### PR TITLE
codex-auth: init at 0.2.8

### DIFF
--- a/pkgs/by-name/co/codex-auth/package.nix
+++ b/pkgs/by-name/co/codex-auth/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  zigStdenv,
+  fetchFromGitHub,
+  zig_0_15,
+}:
+
+zigStdenv.mkDerivation rec {
+  __structuredAttrs = true;
+  pname = "codex-auth";
+  version = "0.2.8";
+
+  src = fetchFromGitHub {
+    owner = "Loongphy";
+    repo = "codex-auth";
+    rev = "v${version}";
+    hash = "sha256-J1aq5ieWkHqze4HF/7Lw+VIa+FxO7vmsXaDJc7VH+Wk=";
+  };
+
+  nativeBuildInputs = [
+    zig_0_15.hook
+  ];
+
+  strictDeps = true;
+
+  meta = {
+    description = "A CLI tool to switch and manage OpenAI Codex accounts";
+    homepage = "https://github.com/Loongphy/codex-auth";
+    changelog = "https://github.com/Loongphy/codex-auth/releases/tag/v${version}";
+    license = lib.licenses.mit;
+
+    maintainers = [ lib.maintainers.alyamanmas ];
+    mainProgram = "codex-auth";
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added new package `codex-auth` that allows for easy management of multiple accounts for OpenAI's coding agent, Codex. The project's homepage can be found [here](https://github.com/Loongphy/codex-auth).

Zig 0.15.2 was used as 0.16 was giving compilation errors (due to a breaking change most likely) and also because it is the Zig version the project uses for v0.2.8. Basic functionality has been tested.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
