### PR TITLE
ghasec: init at 0.15.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18081,6 +18081,11 @@
     githubId = 48838244;
     name = "Mislav Zanic";
   };
+  misogihagi = {
+    github = "misogihagi";
+    githubId = 47350059;
+    name = "misogihagi";
+  };
   misterio77 = {
     email = "eu@misterio.me";
     github = "Misterio77";
@@ -18587,7 +18592,7 @@
     github = "msgilligan";
     githubId = 61612;
     name = "Sean Gilligan";
-    keys = [ { fingerprint = "3B66 ACFA D10F 02AA B1D5  2CB1 8DD0 D81D 7D1F C61A"; } ];
+    keys = [ { fingerprint = "3B66 ACFA D10F 02AA B1D5  2CB1 8DD0 D81D 7D1F C61A"; } ];
   };
   mshnwq = {
     email = "mshnwq.com@gmail.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18081,6 +18081,11 @@
     githubId = 48838244;
     name = "Mislav Zanic";
   };
+  misogihagi = {
+    github = "misogihagi";
+    githubId = 47350059;
+    name = "misogihagi";
+  };
   misterio77 = {
     email = "eu@misterio.me";
     github = "Misterio77";

--- a/pkgs/by-name/gh/ghasec/package.nix
+++ b/pkgs/by-name/gh/ghasec/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  versionCheckHook,
+}:
+buildGoModule (finalAttrs: {
+  pname = "ghasec";
+  version = "0.11.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "koki-develop";
+    repo = "ghasec";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Z6UwSq0NlSgV3m7UeLVdWiJ81djhf+P1Y3xKjkbs6Yg=";
+    fetchSubmodules = true;
+  };
+
+  vendorHash = "sha256-At3MKC0PZ5v6TG+GyrtCDrzucI0hg0woCkDNOCj+xh0=";
+
+  checkPhase = "go test ."; # since CI fails in Version 0.11.2, specify the test command
+
+  env.CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/koki-develop/ghasec/cmd.version=${finalAttrs.version}"
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd 'ghasec' \
+      --bash <("$out/bin/ghasec" completion bash) \
+      --zsh <("$out/bin/ghasec" completion zsh) \
+      --fish <("$out/bin/ghasec" completion fish)
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgramArg = "--version";
+
+  meta = {
+    homepage = "https://github.com/koki-develop/ghasec/";
+    description = "🫴 Catch security risks in your GitHub Actions workflows.";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ misogihagi ];
+    mainProgram = "ghasec";
+  };
+})

--- a/pkgs/by-name/gh/ghasec/package.nix
+++ b/pkgs/by-name/gh/ghasec/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  versionCheckHook,
+}:
+buildGoModule (finalAttrs: {
+  pname = "ghasec";
+  version = "0.15.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "koki-develop";
+    repo = "ghasec";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-NeRijMEspqRuDMva6xaB46vWndzHqiDnkea66XvbmN8=";
+    fetchSubmodules = true;
+  };
+
+  vendorHash = "sha256-/r1Nil9sHdKlqH3TL7jCy1wnTfk+D41pwf0MWV81hpE=";
+
+  checkPhase = "go test ."; # since CI fails in Version 0.15.0, specified the test command
+
+  env.CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/koki-develop/ghasec/cmd.version=${finalAttrs.version}"
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd 'ghasec' \
+      --bash <("$out/bin/ghasec" completion bash) \
+      --zsh <("$out/bin/ghasec" completion zsh) \
+      --fish <("$out/bin/ghasec" completion fish)
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgramArg = "--version";
+
+  meta = {
+    homepage = "https://github.com/koki-develop/ghasec/";
+    description = "Security-focused linter for Github Actions workflows";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ misogihagi ];
+    mainProgram = "ghasec";
+  };
+})


### PR DESCRIPTION
## Description

Add `ghasec`, a CLI tool for Catch security risks in your GitHub Actions workflows. 

- **Homepage**: https://github.com/koki-develop/ghasec
- **License**: MIT

I have verified the build and basic functionality on `x86_64-linux`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
    - Ran `./result/bin/awesome-go-cli --version` and verified output.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
