### PR TITLE
python3Packages.indevolt-api: 1.6.0 -> 1.6.5; fix hash

### DIFF
--- a/pkgs/development/python-modules/indevolt-api/default.nix
+++ b/pkgs/development/python-modules/indevolt-api/default.nix
@@ -4,7 +4,6 @@
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
-  wheel,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -16,7 +15,7 @@ buildPythonPackage (finalAttrs: {
     owner = "Xirt";
     repo = "indevolt-api";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-WcTfEsf6ypMdutY3Ab5WavNRYGiWtUehzlrNO7z8jgk=";
+    hash = "sha256-VoRRP00nhexkfowT2dOUOMUPiTevwb8rGIWg2pv8woU=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/indevolt-api/default.nix
+++ b/pkgs/development/python-modules/indevolt-api/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "indevolt-api";
-  version = "1.6.0";
+  version = "1.6.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Xirt";
     repo = "indevolt-api";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-VoRRP00nhexkfowT2dOUOMUPiTevwb8rGIWg2pv8woU=";
+    hash = "sha256-Fhi9+6nWt7upUuA045SwPCwWevZDZTWnTiTBHsaR9W4=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
- Fix hash
  - Diff: https://github.com/Xirt/indevolt-api/compare/7e31683dd6f8e33929725769fe1ce77b40a1874f...bdd833bbe14786e9de8e35bc45e2cdefff61204f
- 1.6.0 -> 1.6.5
  - Diff: https://github.com/Xirt/indevolt-api/compare/v1.6.0...v1.6.5
  - Changelog: https://github.com/Xirt/indevolt-api/releases/tag/v1.6.5
  - Not bumping to 1.7.* because `home-assistant.tests.components.indevolt` would fail

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `python3{13,14}Packages.indevolt-api`, `home-assistant.tests.components.indevolt`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
