### PR TITLE
iosevka: prepare for structuredAttrs, modernize, enable strictDeps, use go-toml

### DIFF
--- a/pkgs/by-name/io/iosevka/package.nix
+++ b/pkgs/by-name/io/iosevka/package.nix
@@ -85,22 +85,16 @@ buildNpmPackage rec {
       privateBuildPlan;
 
   inherit extraParameters;
-  passAsFile = [
-    "extraParameters"
-  ]
-  ++ lib.optionals (
-    !(builtins.isString privateBuildPlan && lib.hasPrefix builtins.storeDir privateBuildPlan)
-  ) [ "buildPlan" ];
 
   configurePhase = ''
     runHook preConfigure
     ${lib.optionalString (builtins.isAttrs privateBuildPlan) ''
-      remarshal -i "$buildPlanPath" -o private-build-plans.toml -if json -of toml
+      printf "%s" "$buildPlan" | remarshal -o private-build-plans.toml -if json -of toml
     ''}
     ${lib.optionalString
       (builtins.isString privateBuildPlan && (!lib.hasPrefix builtins.storeDir privateBuildPlan))
       ''
-        cp "$buildPlanPath" private-build-plans.toml
+        printf "%s" "$buildPlan" > private-build-plans.toml
       ''
     }
     ${lib.optionalString
@@ -111,7 +105,7 @@ buildNpmPackage rec {
     }
     ${lib.optionalString (extraParameters != null) ''
       echo -e "\n" >> params/parameters.toml
-      cat "$extraParametersPath" >> params/parameters.toml
+      printf "%s" "$extraParameters" >> params/parameters.toml
     ''}
     runHook postConfigure
   '';
@@ -136,6 +130,8 @@ buildNpmPackage rec {
 
   enableParallelBuilding = true;
   requiredSystemFeatures = [ "big-parallel" ];
+
+  __structuredAttrs = true;
 
   meta = {
     homepage = "https://typeof.net/Iosevka/";

--- a/pkgs/by-name/io/iosevka/package.nix
+++ b/pkgs/by-name/io/iosevka/package.nix
@@ -78,6 +78,8 @@ buildNpmPackage rec {
     cctools
   ];
 
+  strictDeps = true;
+
   buildPlan =
     if builtins.isAttrs privateBuildPlan then
       builtins.toJSON { buildPlans.${pname} = privateBuildPlan; }

--- a/pkgs/by-name/io/iosevka/package.nix
+++ b/pkgs/by-name/io/iosevka/package.nix
@@ -4,7 +4,7 @@
   buildNpmPackage,
   fetchFromGitHub,
   cctools,
-  remarshal,
+  go-toml,
   ttfautohint-nox,
   # Custom font set options.
   # See https://typeof.net/Iosevka/customizer
@@ -70,7 +70,7 @@ buildNpmPackage rec {
   npmDepsHash = "sha256-9v4PKlS8FNuhnhdJmu3J1Bl+uSPS4KqE3PBrOhf9jQw=";
 
   nativeBuildInputs = [
-    remarshal
+    go-toml
     ttfautohint-nox
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
@@ -91,7 +91,7 @@ buildNpmPackage rec {
   configurePhase = ''
     runHook preConfigure
     ${lib.optionalString (builtins.isAttrs privateBuildPlan) ''
-      printf "%s" "$buildPlan" | remarshal -o private-build-plans.toml -if json -of toml
+      printf "%s" "$buildPlan" | jsontoml -use-json-number > private-build-plans.toml
     ''}
     ${lib.optionalString
       (builtins.isString privateBuildPlan && (!lib.hasPrefix builtins.storeDir privateBuildPlan))

--- a/pkgs/by-name/io/iosevka/package.nix
+++ b/pkgs/by-name/io/iosevka/package.nix
@@ -63,7 +63,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "be5invis";
     repo = "iosevka";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-eOh1jdrgaMYhqxP+QSCBxqhkJUGYrWLTkYwGmKSNrRA=";
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
