### PR TITLE
hickory-dns: 0.26.0 -> 0.26.1

### DIFF
--- a/pkgs/by-name/hi/hickory-dns/package.nix
+++ b/pkgs/by-name/hi/hickory-dns/package.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "hickory-dns";
-  version = "0.26.0";
+  version = "0.26.1";
 
   src = fetchFromGitHub {
     owner = "hickory-dns";
     repo = "hickory-dns";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-1VryKiE7kri7XQmVpCmZjc98L9iN60UVz5bNgphjDAU=";
+    hash = "sha256-jRcq9b409O5bjta8hFLFBFC6ILf8QA2EZ8tQqk2m1Rk=";
   };
 
-  cargoHash = "sha256-El5NuGevzTpHJP5MVYjyED0UwV7xM9iwv/X7x5Gz/+I=";
+  cargoHash = "sha256-zszSkclNCLGVchWiNdtNLJeY2j5CmubjMjhwVwsvRP8=";
 
   buildFeatures = [
     "blocklist"

--- a/pkgs/by-name/hi/hickory-dns/package.nix
+++ b/pkgs/by-name/hi/hickory-dns/package.nix
@@ -89,6 +89,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     maintainers = with lib.maintainers; [
       adamcstephens
       colinsane
+      cpu
     ];
     platforms = lib.platforms.linux;
     license = with lib.licenses; [


### PR DESCRIPTION
Updates `hickory-dns` to 0.26.1. This addresses two security reports, [RUSTSEC-2026-0120](https://rustsec.org/advisories/RUSTSEC-2026-0120.html) and [RUSTSEC-2026-0119](https://rustsec.org/advisories/RUSTSEC-2026-0119.html). See the [upstream release notes](https://github.com/hickory-dns/hickory-dns/releases/tag/v0.26.1) for more information.

I've also added myself to the maintainers list to help out more in the future. For context I'm one of the upstream maintainers and also use the derivation/module on my own systems. Happy to drop this commit if the existing maintainers would prefer it (cc: @adamcstephens, @uninsane).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
