### PR TITLE
requireFile: set `unfree` license by default

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -13,6 +13,8 @@
 - `hurl` has been updated to `8.x.x` which has some breaking changes. See [upstream changelog](https://github.com/Orange-OpenSource/hurl/releases/tag/8.0.0) for details.
 - `python3Packages.django-health-check` has been updated to major version 4. See its [migration guide](https://codingjoe.dev/django-health-check/migrate-to-v4/) and [changelog](https://github.com/codingjoe/django-health-check/releases/tag/4.0.0) for breaking changes.
 
+- `requireFile` now sets `meta.license = lib.licenses.unfree` by default. Users of `requireFile`-based derivations that preserve this default will need to explicitly allow their evaluation as described in [](#sec-allow-unfree).
+
 ## Other Notable Changes {#sec-nixpkgs-release-26.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -151,6 +151,8 @@ The list of Nix platform types for which the [Hydra](https://github.com/nixos/hy
 }
 ```
 
+Note that this does not affect whether reverse dependencies of the package are built on Hydra.
+
 ### `broken` {#var-meta-broken}
 
 If set to `true`, the package is marked as "broken", meaning that it won’t show up in [search.nixos.org](https://search.nixos.org/packages), and cannot be built or installed unless [explicitly allowed](#sec-allow-broken).

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -890,6 +890,7 @@ rec {
         url ? null,
         message ? null,
         hashMode ? "flat",
+        meta ? { },
       }@args:
       assert (message != null) || (url != null);
       assert (sha256 != null) || (sha1 != null) || (hash != null);
@@ -933,6 +934,10 @@ rec {
           printf '%s' ${lib.escapeShellArg msg}
           exit 1
         '';
+        meta = {
+          hydraPlatforms = [ ];
+        }
+        // meta;
       }
       // (lib.optionalAttrs (name == null) {
         # The case of providing `url`, but not `name`. This has

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -908,6 +908,7 @@ rec {
         url ? null,
         message ? null,
         hashMode ? "flat",
+        meta ? { },
       }@args:
       assert (message != null) || (url != null);
       assert (sha256 != null) || (sha1 != null) || (hash != null);
@@ -951,6 +952,10 @@ rec {
           printf '%s' ${lib.escapeShellArg msg}
           exit 1
         '';
+        meta = {
+          license = lib.licenses.unfree;
+        }
+        // meta;
       }
       // (lib.optionalAttrs (name == null) {
         # The case of providing `url`, but not `name`. This has

--- a/pkgs/by-name/ho/houdini/package.nix
+++ b/pkgs/by-name/ho/houdini/package.nix
@@ -122,7 +122,6 @@ buildFHSEnv {
     license = lib.licenses.unfree;
     platforms = [ "x86_64-linux" ];
     mainProgram = "houdini";
-    hydraPlatforms = [ ]; # requireFile src's should be excluded
     maintainers = with lib.maintainers; [
       canndrew
       kwohlfahrt

--- a/pkgs/by-name/rc/rcu/package.nix
+++ b/pkgs/by-name/rc/rcu/package.nix
@@ -189,6 +189,5 @@ python3Packages.buildPythonApplication rec {
     maintainers = with lib.maintainers; [
       m0streng0
     ];
-    hydraPlatforms = [ ]; # requireFile used as src
   };
 }

--- a/pkgs/by-name/rc/rcu/package.nix
+++ b/pkgs/by-name/rc/rcu/package.nix
@@ -34,6 +34,10 @@ python3Packages.buildPythonApplication rec {
         name = "rcu-${version}-source.tar.gz";
         hash = "sha256-9YhhsLqAcevjJmENWVWfA1ursPz3mgFz8mzLLSNlXVM=";
         url = "https://www.davisr.me/projects/rcu/";
+        meta = {
+          # `requireFile` sets `lib.licenses.unfree` by default
+          inherit (meta) license;
+        };
       };
     in
     runCommand "${src-tarball.name}-unpacked" { } ''


### PR DESCRIPTION
This avoids unfixable failures like https://hydra.nixos.org/build/327183659.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
