### PR TITLE
radicle-explorer: refactor

### DIFF
--- a/pkgs/by-name/ra/radicle-explorer/package.nix
+++ b/pkgs/by-name/ra/radicle-explorer/package.nix
@@ -1,11 +1,9 @@
 {
-  radicle-httpd,
-  fetchFromGitHub,
   lib,
   buildNpmPackage,
-  writeText,
-  jq,
-  runCommand,
+  fetchFromGitHub,
+  radicle-httpd,
+  writers,
 }:
 
 let
@@ -14,106 +12,80 @@ let
   twemojiAssets = fetchFromGitHub {
     owner = "twitter";
     repo = "twemoji";
-    rev = "v14.0.2";
+    tag = "v14.0.2";
     hash = "sha256-YoOnZ5uVukzi/6bLi22Y8U5TpplPzB7ji42l+/ys5xI=";
     meta.license = [ lib.licenses.cc-by-40 ];
   };
-
-  mkPassthru = self: args: {
-    # radicle-explorer is configured through static build time configuration.
-    #
-    # Using this function you can override the this configuration, for example,
-    # to configure alternative preferred peers (which are shown in the UI by
-    # default).
-    #
-    # Example usage:
-    #
-    # ```nix
-    # radicle-explorer.withConfig {
-    #   preferredSeeds = [{
-    #     hostname = "seed.example.com";
-    #     port = 443;
-    #     scheme = "https";
-    #   }];
-    # }
-    # ```
-    withConfig =
-      config:
-      let
-        overrides = writeText "config-overrides.json" (builtins.toJSON config);
-        newConfig = runCommand "config.json" { } ''
-          ${jq}/bin/jq -s '.[0] * .[1]' ${(self args).src}/config/default.json ${overrides} > $out
-        '';
-      in
-      lib.fix (
-        final:
-        (self args).overrideAttrs (prev: {
-          preBuild = ''
-            ${prev.preBuild or ""}
-            cp ${newConfig} config/local.json
-          '';
-
-          passthru = prev.passthru // mkPassthru final args;
-        })
-      );
-  };
 in
-lib.fix (
-  self:
-  lib.makeOverridable (
-    {
-      npmDepsHash ? "sha256-8vmAs788PjdUTaQ5E8YLX0KiIPymJbH51oNaGZACe6I=",
-      patches ? [ ],
-    }@args:
-    buildNpmPackage {
-      pname = "radicle-explorer";
-      version = radicle-httpd.version;
-      inherit patches npmDepsHash;
 
-      # radicle-explorer uses the radicle-httpd API, and they are developed in the
-      # same repo. For this reason we pin the sources to each other, but due to
-      # radicle-httpd using a more limited sparse checkout we need to carry a
-      # separate hash.
-      src = radicle-httpd.src.override {
-        hash = "sha256-cnQsPWkRChC8yPrICRoUpGW2GGLB2TK9+3v8ZRGe3x0=";
-        sparseCheckout = [ ];
-      };
+buildNpmPackage (finalAttrs: {
+  pname = "radicle-explorer";
+  inherit (radicle-httpd) version;
 
-      postPatch = ''
-        patchShebangs --build ./scripts
-        mkdir -p "public/twemoji"
-        cp -t public/twemoji -r -- ${twemojiAssets}/assets/svg/*
-        : >scripts/install-twemoji-assets
-      '';
+  # radicle-explorer uses the radicle-httpd API, and they are developed in the
+  # same repo. For this reason we pin the sources to each other, but due to
+  # radicle-httpd using a more limited sparse checkout we need to carry a
+  # separate hash.
+  src = radicle-httpd.src.override {
+    hash = "sha256-cnQsPWkRChC8yPrICRoUpGW2GGLB2TK9+3v8ZRGe3x0=";
+    sparseCheckout = [ ];
+  };
 
-      dontConfigure = true;
-      doCheck = false;
+  npmDepsHash = "sha256-8vmAs788PjdUTaQ5E8YLX0KiIPymJbH51oNaGZACe6I=";
 
-      installPhase = ''
-        runHook preInstall
-        mkdir -p "$out"
-        cp -r -t "$out" build/*
-        runHook postInstall
-      '';
+  postPatch = ''
+    patchShebangs --build ./scripts
+    : >scripts/install-twemoji-assets
 
-      passthru = mkPassthru self args;
+    cp -r "${twemojiAssets}/assets/svg" public/twemoji
+  '';
 
-      meta = {
-        description = "Web frontend for Radicle";
-        longDescription = ''
-          Radicle Explorer is a web-frontend for Radicle which supports browsing
-          repositories, issues and patches on publicly available Radicle seeds.
+  preBuild = ''
+    if [[ $configFile ]]; then
+      cp "$configFile" config/local.json
+    fi
+  '';
 
-          This package builds the web interface, ready to be served by any web
-          server.
-        '';
+  installPhase = ''
+    runHook preInstall
 
-        homepage = "https://radicle.dev";
-        license = lib.licenses.gpl3;
+    mv build $out
 
-        teams = [ lib.teams.radicle ];
-        maintainers = with lib.maintainers; [ tazjin ];
-      };
-    }
-  )
-) { }
+    runHook postInstall
+  '';
+
+  # radicle-explorer is configured through static build time configuration.
+  #
+  # Using this function you can override this configuration, for example to
+  # configure alternative preferred peers (which are shown in the UI by default).
+  #
+  # Example usage:
+  #
+  # ```nix
+  # radicle-explorer.withConfig {
+  #   preferredSeeds = [{
+  #     hostname = "seed.example.com";
+  #     port = 443;
+  #     scheme = "https";
+  #   }];
+  # }
+  # ```
+  passthru.withConfig =
+    config:
+    finalAttrs.finalPackage.overrideAttrs { configFile = writers.writeJSON "config.json" config; };
+
+  meta = {
+    description = "Web frontend for Radicle";
+    longDescription = ''
+      Radicle Explorer is a web-frontend for Radicle which supports browsing
+      repositories, issues and patches on publicly available Radicle seeds.
+
+      This package builds the web interface, ready to be served by any web
+      server.
+    '';
+    homepage = "https://radicle.dev";
+    license = lib.licenses.gpl3;
+    teams = [ lib.teams.radicle ];
+    maintainers = with lib.maintainers; [ tazjin ];
+  };
+})


### PR DESCRIPTION
`withConfig` has been simplified to not merge the default config anymore, since this already seems to happen in the build process of radicle-explorer anyway.

Cleaned up the nested `lib.fix` and `makeOverridable` invocations.

Removed the `npmDepsHash` and `patches` overridable parameters. Use `overrideAttrs` instead:

```nix
radicle-explorer.overrideAttrs (finalAttrs: prevAttrs: {
  patches = prevAttrs.patches or [ ] ++ [ ... ];
  npmDepsHash = "sha256-...";
  npmDeps = fetchNpmDeps {
    inherit (finalAttrs) src;
    hash = finalAttrs.npmDepsHash;
  };
})
```

This should also work more reliably in combination with `withConfig`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
