### PR TITLE
sequoia-parcimonie: init at 0.1.0

### DIFF
--- a/pkgs/by-name/se/sequoia-parcimonie/package.nix
+++ b/pkgs/by-name/se/sequoia-parcimonie/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitLab,
+  openssl,
+  nettle,
+  sqlite,
+  pkg-config,
+}:
+rustPlatform.buildRustPackage (final: {
+  pname = "sequoia-parcimonie";
+  version = "0.1.0";
+
+  src = fetchFromGitLab {
+    owner = "sequoia-pgp";
+    repo = "sequoia-parcimonie";
+    tag = "v${final.version}";
+    hash = "sha256-zWwIpzfyuF8dcO5g41HEyeHJY1MKykdwbdOkQ5tdqq0=";
+  };
+
+  cargoHash = "sha256-r8HvObNbAmM0hWEti/QSsBi0F1Pp5pCtTmHw5pZm580=";
+
+  buildInputs = [
+    openssl.dev
+    nettle.dev
+    sqlite.dev
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    homepage = "https://gitlab.com/sequoia-pgp/sequoia-parcimonie";
+    license = lib.licenses.lgpl2Plus;
+    mainProgram = "sq-parcimonie";
+  };
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
