### PR TITLE
ocenaudio: update package version 

### DIFF
--- a/pkgs/by-name/oc/ocenaudio/package.nix
+++ b/pkgs/by-name/oc/ocenaudio/package.nix
@@ -37,6 +37,11 @@ stdenv.mkDerivation (finalAttrs: {
     libpulseaudio
   ];
 
+  autoPatchelfIgnoreMissingDeps = [
+    "libqtocenai.so.*"
+    "libqtocencore.so.*"
+  ];
+
   dontBuild = true;
   dontStrip = true;
 

--- a/pkgs/by-name/oc/ocenaudio/package.nix
+++ b/pkgs/by-name/oc/ocenaudio/package.nix
@@ -14,12 +14,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ocenaudio";
-  version = "3.15.3";
+  version = "3.18.2";
 
   src = fetchurl {
     name = "ocenaudio.deb";
     url = "https://www.ocenaudio.com/downloads/index.php/ocenaudio_debian12.deb?version=v${finalAttrs.version}";
-    hash = "sha256-Nc4G+p6KLlID59kVYmlU+UE7vIPYeTqQeCEv9hrJnh0=";
+    hash = "sha256-oDOAPusm5Siiokcl8UkOy5FhhT1y5nd4qcFfmF9yTF4=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Follow up #504102

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

## Without `autoPatchelfIgnoreMissingDeps`, i get the following error:

```
> auto-patchelf: 2 dependencies could not be satisfied
> error: auto-patchelf could not satisfy dependency libqtocenai.so.3.15 wanted by /nix/store/w98wdwk346dpiw70nwj1m35kygcn00fn-ocenaudio-3.18.2/lib/libqtocendemucs.so.3.15.4
> error: auto-patchelf could not satisfy dependency libqtocencore.so.3.15 wanted by /nix/store/w98wdwk346dpiw70nwj1m35kygcn00fn-ocenaudio-3.18.2/lib/libqtocendemucs.so.3.15.4
> auto-patchelf failed to find all the required dependencies.
```

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


