### PR TITLE
venator: fix build; fix blank UI on NVIDIA GPU and X11

### DIFF
--- a/pkgs/by-name/ve/venator/package.nix
+++ b/pkgs/by-name/ve/venator/package.nix
@@ -26,7 +26,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-qjSB/XAxB/VbO4m9Gg/XP9332WaSm/d/ejSTrHRchHg=";
   };
 
-  cargoRoot = "venator-app";
   buildAndTestSubdir = "venator-app";
   # NOTE: don't put npmRoot here because it will break the build with "Found
   # version mismatched Tauri packages".
@@ -35,7 +34,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   postPatch = ''
     cp ${finalAttrs.src}/venator-app/package.json .
     cp ${finalAttrs.src}/venator-app/package-lock.json .
-    cp ${finalAttrs.src}/Cargo.lock venator-app/
   '';
 
   cargoHash = "sha256-OLtWDJuK9fXbpjUfidLP2nKdD49cWmqWI92bhV29054=";

--- a/pkgs/by-name/ve/venator/package.nix
+++ b/pkgs/by-name/ve/venator/package.nix
@@ -56,6 +56,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
     webkitgtk_4_1
   ];
 
+  # "Failed to create GBM buffer" on NVIDIA GPU and X11
+  # See https://github.com/tauri-apps/tauri/issues/9394
+  preFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    gappsWrapperArgs+=(
+      --set WEBKIT_DISABLE_COMPOSITING_MODE 1
+    )
+  '';
+
   passthru.updateScript = nix-update-script { };
 
   meta = {


### PR DESCRIPTION
- Fix the build
  - Looks like this package never built on Hydra: https://hydra.nixos.org/job/nixpkgs/unstable/venator.x86_64-linux
  - This probably wasn’t caught because, once `cargoHash` was generated, `venator.cargoDeps.vendorStaging` would have needed to be rebuilt to catch the failure.
  - Moving `Cargo.lock` in `postPatch` is ineffective because `postPatch` is not passed to `fetchCargoVendor`. Removing `cargoRoot` is the simpler solution.
- Fix blank UI on NVIDIA GPU and X11
  - Caught while testing basic functionality of the binary
  - https://github.com/tauri-apps/tauri/issues/9394

ZHF: #516381

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `venator{,.cargoDeps{,.vendorStaging}}`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
