### PR TITLE
cdktn-cli: 0.22.0 -> 0.22.1; bump node version

### DIFF
--- a/pkgs/by-name/cd/cdktn-cli/package.nix
+++ b/pkgs/by-name/cd/cdktn-cli/package.nix
@@ -8,7 +8,7 @@
   fixup-yarn-lock,
   go,
   makeWrapper,
-  nodejs_20,
+  nodejs_22,
   nix-update-script,
   patchelf,
   removeReferencesTo,
@@ -19,18 +19,18 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "cdktn-cli";
-  version = "0.22.0";
+  version = "0.22.1";
 
   src = fetchFromGitHub {
     owner = "open-constructs";
     repo = "cdk-terrain";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-KgDRQ76ePLJEdULMCTJTouMaWu0SCeV4NwNW2WpoaNY=";
+    hash = "sha256-yBCLxp7w/M2y7vDEI1ceAAJbyYpPT4mN4hZ3FKpaiJ0=";
   };
 
   offlineCache = fetchYarnDeps {
     yarnLock = "${finalAttrs.src}/yarn.lock";
-    hash = "sha256-0aOwRdfCTiQHmWzOk+ExLX+/EAryxheyILe7L7oyd4w=";
+    hash = "sha256-c5WQXZLbOuvy6Jj6TchV00HThFIePMdsGW1rWAUKnvo=";
   };
 
   hcl2json-go-modules =
@@ -63,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
     fixup-yarn-lock
     go
     makeWrapper
-    nodejs_20
+    nodejs_22
     patchelf
     removeReferencesTo
     yarn
@@ -129,7 +129,8 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p "$out/lib/node_modules/cdktn-cli"
     cp -rL node_modules packages/cdktn-cli/bundle packages/cdktn-cli/package.json "$out/lib/node_modules/cdktn-cli/"
 
-    makeWrapper "${lib.getExe nodejs_20}" "$out/bin/cdktn" \
+    makeWrapper "${lib.getExe nodejs_22}" "$out/bin/cdktn" \
+      --add-flags "--no-warnings=DEP0040" \
       --add-flags "$out/lib/node_modules/cdktn-cli/bundle/bin/cdktn.js"
 
     runHook postInstall
@@ -160,5 +161,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "cdktn";
     maintainers = with lib.maintainers; [ deejayem ];
     platforms = lib.platforms.unix;
+    # Uses @cdktf/node-pty-prebuilt-multiarch which is not yet available for node 22 on aarch64-linux
+    broken = stdenv.hostPlatform.system == "aarch64-linux";
   };
 })


### PR DESCRIPTION
Update to the latest version (0.22.1) and use nodejs_22, since nodejs_20 is EOL (https://github.com/NixOS/nixpkgs/issues/515284). This means I had to mark it broken on aarch64-linux, as cdktf/node-pty-prebuilt-multiarch is not available for node 22 there yet.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
