### PR TITLE
bcc: apply upstream patch

### DIFF
--- a/pkgs/by-name/bc/bcc/package.nix
+++ b/pkgs/by-name/bc/bcc/package.nix
@@ -5,6 +5,7 @@
   cmake,
   elfutils,
   fetchFromGitHub,
+  fetchpatch,
   flex,
   iperf,
   lib,
@@ -42,6 +43,12 @@ python3Packages.buildPythonApplication rec {
 
     (replaceVars ./absolute-ausyscall.patch {
       ausyscall = lib.getExe' audit "ausyscall";
+    })
+
+    (fetchpatch {
+      # https://github.com/iovisor/bcc/issues/5501
+      url = "https://github.com/iovisor/bcc/commit/c3f35ecca18b1ce926bd272f60f6d4465656a80b.patch";
+      hash = "sha256-Fr5SqDUpQzZj8yPST0V1QExNMCSoRbOXG5ZaChDXTZQ=";
     })
   ];
 


### PR DESCRIPTION
Fixes an issue with recent kernels (6.19 and later): https://github.com/iovisor/bcc/issues/5501. Tested by running `execsnoop` on 7.0.0 and 6.18.22.