### PR TITLE
wordpressPackages.plugins.so-clean-up-wp-seo: drop

### DIFF
--- a/pkgs/servers/web-apps/wordpress/packages/plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/plugins.json
@@ -137,12 +137,6 @@
     "sha256": "12gh5ih4rkbdcrzdjml9rrlipbp2ymwhwxvr8y7lawmrflsas3r5",
     "version": "2.0.3"
   },
-  "so-clean-up-wp-seo": {
-    "path": "so-clean-up-wp-seo/tags/4.0.2",
-    "rev": "3114751",
-    "sha256": "1kqgmmaw99b164v554siygrxa3z7lxqhn0bwg7s01cm5fdg6i3dl",
-    "version": "4.0.2"
-  },
   "sqlite-database-integration": {
     "path": "sqlite-database-integration/tags/2.2.17",
     "rev": "3451878",

--- a/pkgs/servers/web-apps/wordpress/packages/wordpress-plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/wordpress-plugins.json
@@ -22,7 +22,6 @@
 , "opengraph": "asl20"
 , "simple-login-captcha": "gpl2Plus"
 , "simple-mastodon-verification": "gpl2Plus"
-, "so-clean-up-wp-seo": "gpl3Plus"
 , "sqlite-database-integration": "gpl2Plus"
 , "static-mail-sender-configurator": "mit"
 , "surge": "gpl3Only"


### PR DESCRIPTION
Upstream [vanished](https://plugins.svn.wordpress.org/so-clean-up-wp-seo/) and the author put up an archived version of the plugin on [GitHub](https://github.com/senlin/so-clean-up-wp-seo) as well as a [forum post](https://wordpress.org/support/topic/from-now-on-only-available-via-github/) explaining that the plugin is effectively unmaintained.

This package has also been [broken on Hydra for a long time](https://hydra.nixos.org/job/nixpkgs/unstable/wordpressPackages.plugins.so-clean-up-wp-seo.x86_64-linux).

There's no mechanism to add aliases for this package set to notify consumers of the removal, so I didn't add one.

ZHF: #516381

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
