### PR TITLE
mew: 1.0-unstable-2025-06-20 -> 1.0-unstable-2026-03-18

### DIFF
--- a/pkgs/by-name/me/mew/package.nix
+++ b/pkgs/by-name/me/mew/package.nix
@@ -16,13 +16,13 @@
 }:
 stdenv.mkDerivation {
   pname = "mew";
-  version = "1.0-unstable-2025-06-20";
+  version = "1.0-unstable-2026-03-18";
 
   src = fetchFromCodeberg {
     owner = "sewn";
     repo = "mew";
-    rev = "af6440da8fe6683cf0b873e0a98c293bf02c3447";
-    hash = "sha256-NbpYITHO81fnaDY0dtolaUBdRqQNKwHQz/lBQMOHM5c=";
+    rev = "98dea211e634ccc2f75b4dae09fc2705666c6322";
+    hash = "sha256-u0TBWPBOdXNYwuwn9U1xqJsUShyOz9MIP1CNozcxbzg=";
   };
 
   nativeBuildInputs = [
@@ -41,6 +41,8 @@ stdenv.mkDerivation {
   makeFlags = [
     # The PREFIX var is hardcoded in the makefile.
     "PREFIX=$(out)"
+    # Disables the incompatible-pointer-types build check.
+    "CFLAGS=-Wno-error=incompatible-pointer-types"
   ];
 
   postFixup = ''


### PR DESCRIPTION
Had to add a cflag to disable a compiler enforced rule.

Closes: #516460

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
