### PR TITLE
[25.11] linux_hardened: version update

### DIFF
--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -2,11 +2,11 @@
     "6.12": {
         "patch": {
             "extra": "-hardened1",
-            "name": "linux-hardened-v6.12.69-hardened1.patch",
-            "sha256": "15zgha5qvn8a6ibx4b8mn5bwsm9z4xnpx3kz49ncpnk3iagcr2vw",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.12.69-hardened1/linux-hardened-v6.12.69-hardened1.patch"
+            "name": "linux-hardened-v6.12.85-hardened1.patch",
+            "sha256": "16hqi6nh53zxr8idpdib0m05hc213dijmn479ay06piwcm74j064",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.12.85-hardened1/linux-hardened-v6.12.85-hardened1.patch"
         },
-        "sha256": "0rbnbynhm7w4ig8snq97px4ljr5k4zq1a97jqhwk4w0qy9bkcjab",
-        "version": "6.12.69"
+        "sha256": "1v8a0z6znmr2m26l4744wndaimsh24zz6q4d7m4p8s0ayjcwjnp3",
+        "version": "6.12.85"
     }
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This is for `nixos-25.11`

The `patches.json` is generated by the original `update.py` script with this patch:
https://github.com/NixOS/nixpkgs/pull/502342#issuecomment-4359951881

Which include:

linux/hardened/patches/6.12: v6.12.69-hardened1 -> v6.12.85-hardened1
linux/hardened/patches/6.18: init at v6.18.26-hardened1

Both kernel version patched upstream to include the fix of `copy.fail` CVE-2026-31431



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
