### PR TITLE
libressl: add 4.3.1, remove unsupported 4.1.2, add myself as maintainer

### DIFF
--- a/pkgs/by-name/li/libressl/default.nix
+++ b/pkgs/by-name/li/libressl/default.nix
@@ -111,13 +111,17 @@ let
         identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "openbsd" version;
       };
     };
+
   # https://github.com/libressl/portable/pull/1206
+  # This got merged in February 2026 and is included as of LibreSSL 4.3.0.
   common-cmake-install-full-dirs-patch = fetchpatch {
     url = "https://github.com/libressl/portable/commit/a15ea0710398eaeed3be53cf643e80a1e80c981d.patch";
     hash = "sha256-Mlf4SrGCCqALQicbGtmVGdkdfcE8DEGYkOuVyG2CozM=";
   };
 in
 {
+  # 4.1 was released April 2025 and became unsupported on April 28, 2026,
+  # one year after the release of OpenBSD 7.7.
   libressl_4_1 = generic {
     version = "4.1.2";
     hash = "sha256-+6Ti+ip/UjBt96OJlwoQ6YuX6w7bKZqf252/SZmcYeE=";
@@ -137,11 +141,20 @@ in
     ];
   };
 
+  # 4.2 was released October 2025 and will become unsupported on October 22,
+  # 2026, one year after the release of OpenBSD 7.8.
   libressl_4_2 = generic {
     version = "4.2.1";
     hash = "sha256-bVwvWFg1iOp5H0yGRQBAcdAN+lVKW/eIoAbKHrWr1ws=";
     patches = [
       common-cmake-install-full-dirs-patch
     ];
+  };
+
+  # 4.3 was released April 2026 and will become unsupported one year after the
+  # release of OpenBSD 7.9.
+  libressl_4_3 = generic {
+    version = "4.3.1";
+    hash = "sha256-wttCrOFOfVQZgm+rNadC7G5NEnJaBRpR0M6jwQug+lA=";
   };
 }

--- a/pkgs/by-name/li/libressl/default.nix
+++ b/pkgs/by-name/li/libressl/default.nix
@@ -120,27 +120,6 @@ let
   };
 in
 {
-  # 4.1 was released April 2025 and became unsupported on April 28, 2026,
-  # one year after the release of OpenBSD 7.7.
-  libressl_4_1 = generic {
-    version = "4.1.2";
-    hash = "sha256-+6Ti+ip/UjBt96OJlwoQ6YuX6w7bKZqf252/SZmcYeE=";
-    # Fixes build on loongarch64
-    # https://github.com/libressl/portable/pull/1184
-    postPatch = ''
-      mkdir -p include/arch/loongarch64
-      cp ${
-        fetchurl {
-          url = "https://github.com/libressl/portable/raw/refs/tags/v4.1.0/include/arch/loongarch64/opensslconf.h";
-          hash = "sha256-68dw5syUy1z6GadCMR4TR9+0UQX6Lw/CbPWvjHGAhgo=";
-        }
-      } include/arch/loongarch64/opensslconf.h
-    '';
-    patches = [
-      common-cmake-install-full-dirs-patch
-    ];
-  };
-
   # 4.2 was released October 2025 and will become unsupported on October 22,
   # 2026, one year after the release of OpenBSD 7.8.
   libressl_4_2 = generic {

--- a/pkgs/by-name/li/libressl/default.nix
+++ b/pkgs/by-name/li/libressl/default.nix
@@ -23,6 +23,9 @@ let
       pname = "libressl";
       inherit version;
 
+      strictDeps = true;
+      __structuredAttrs = true;
+
       src = fetchurl {
         url = "mirror://openbsd/LibreSSL/libressl-${version}.tar.gz";
         inherit hash;

--- a/pkgs/by-name/li/libressl/default.nix
+++ b/pkgs/by-name/li/libressl/default.nix
@@ -96,6 +96,7 @@ let
         maintainers = with lib.maintainers; [
           thoughtpolice
           fpletz
+          ruuda
         ];
         inherit knownVulnerabilities;
 

--- a/pkgs/by-name/li/libressl/default.nix
+++ b/pkgs/by-name/li/libressl/default.nix
@@ -61,6 +61,22 @@ let
 
       doCheck = !(stdenv.hostPlatform.isPower64 || stdenv.hostPlatform.isRiscV);
       preCheck = ''
+        # Bail if any shared object has executable stack enabled. This can
+        # happen when an object produced from an assmbly file in libcrypto is
+        # missing a .note.GNU-stack section. An executable stack is dangerous
+        # and unintentional, but without this check the derivation will build
+        # and even run if W^X is not enforced; it would fail dangerously.
+        objdump -p **/*.so | awk '
+          BEGIN { res = 0 }
+          /file format/ { file = $1 }
+          /STACK/ { stack = 1; next }
+          stack {
+            if ($0 ~ /flags.*x/) { print file " has executable stack"; res = 1 }
+            stack = 0
+          }
+          END { exit res }
+        '
+
         export PREVIOUS_${ldLibPathEnvName}=$${ldLibPathEnvName}
         export ${ldLibPathEnvName}="$${ldLibPathEnvName}:$(realpath tls/):$(realpath ssl/):$(realpath crypto/)"
       '';
@@ -139,5 +155,18 @@ in
   libressl_4_3 = generic {
     version = "4.3.1";
     hash = "sha256-wttCrOFOfVQZgm+rNadC7G5NEnJaBRpR0M6jwQug+lA=";
+    patches = [
+      # Fix for https://github.com/libressl/portable/issues/1278, where LibreSSL
+      # 4.3 started requiring executable stack because some objects were missing
+      # a .note.GNU-stack section; will probably be included in the next release.
+      (fetchpatch {
+        url = "https://raw.githubusercontent.com/libressl/portable/4dae91d056c6c75ba5cf2bc5e6148b8e02239119/patches/gnu-stack.patch";
+        hash = "sha256-Q1oWL4N8w5Zmjfq5QkTJR53NgZ4GqChSDaBicli5G2I=";
+        # This patch is written to be applied with -p0, with no leading path
+        # component, but Nix applies with -p1 by default, so we add it to not
+        # break compatibility with how other patches must be applied.
+        decode = "sed 's|^--- |--- a/|; s|^+++ |+++ b/|'";
+      })
+    ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7003,6 +7003,7 @@ with pkgs;
   inherit (callPackages ../by-name/li/libressl { })
     libressl_4_1
     libressl_4_2
+    libressl_4_3
     ;
 
   openssl = openssl_3_6;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7001,7 +7001,6 @@ with pkgs;
   zunclient = with python313Packages; toPythonApplication python-zunclient;
 
   inherit (callPackages ../by-name/li/libressl { })
-    libressl_4_1
     libressl_4_2
     libressl_4_3
     ;


### PR DESCRIPTION
* Add [LibreSSL 4.3.1](https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-4.3.1-relnotes.txt), which will be part of the upcoming OpenBSD 7.9 release.
* Remove LibreSSL 4.1.2, which became unsupported on April 28, 2026, one year after the release of OpenBSD 7.7 in which this LibreSSL was included.
* To make it easier to determine whether a package is still supported in the future, add a comment to every package that states until when the branch is supported.
* Add myself as a maintainer of this package. [I’ve been helping out with this package for the past 8 years](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+author%3Aruuda+libressl) and my personal webserver depends on it, so I’m happy to reduce the load on other maintainers.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
