### PR TITLE
gnupg_25_experimental: init at 2.5.21

### DIFF
--- a/pkgs/by-name/gn/gnupg_25_experimental/25_static.patch
+++ b/pkgs/by-name/gn/gnupg_25_experimental/25_static.patch
@@ -1,0 +1,215 @@
+From 5eec11089067947bd850e069651cfa9bf4c48d07 Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Sun, 9 Feb 2025 08:51:32 +0100
+Subject: [PATCH] build: use pkg-config to find tss2-esys
+
+Otherwise, tss2-esys's dependencies (other tss2 libraries, OpenSSL)
+won't be linked when tss2-esys is a static library.
+---
+Link: https://dev.gnupg.org/D606
+
+ configure    | 132 ++++++++++++++++++++++++++++-----------------------
+ configure.ac |   5 +-
+ 2 files changed, 75 insertions(+), 62 deletions(-)
+
+diff --git a/configure b/configure
+index f5d8bef90..e7f4fb175 100755
+--- a/configure
++++ b/configure
+@@ -696,12 +696,12 @@ TEST_LIBTSS_FALSE
+ TEST_LIBTSS_TRUE
+ HAVE_LIBTSS_FALSE
+ HAVE_LIBTSS_TRUE
+-LIBTSS_CFLAGS
+-LIBTSS_LIBS
+ SWTPM
+ TSSSTARTUP
+ TPMSERVER
+ TSS_INCLUDE
++LIBTSS_LIBS
++LIBTSS_CFLAGS
+ W32SOCKLIBS
+ NETLIBS
+ CROSS_COMPILING_FALSE
+@@ -1030,7 +1030,9 @@ PKG_CONFIG_LIBDIR
+ SQLITE3_CFLAGS
+ SQLITE3_LIBS
+ LIBGNUTLS_CFLAGS
+-LIBGNUTLS_LIBS'
++LIBGNUTLS_LIBS
++LIBTSS_CFLAGS
++LIBTSS_LIBS'
+ 
+ 
+ # Initialize some variables set by options.
+@@ -1805,6 +1807,9 @@ Some influential environment variables:
+               C compiler flags for LIBGNUTLS, overriding pkg-config
+   LIBGNUTLS_LIBS
+               linker flags for LIBGNUTLS, overriding pkg-config
++  LIBTSS_CFLAGS
++              C compiler flags for LIBTSS, overriding pkg-config
++  LIBTSS_LIBS linker flags for LIBTSS, overriding pkg-config
+ 
+ Use these variables to override the choices made by `configure' or to help
+ it to find libraries and programs with nonstandard names/locations.
+@@ -15579,62 +15579,71 @@ else
+ fi
+ 
+   elif test "$with_tss" = intel; then
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing Esys_Initialize" >&5
+-$as_echo_n "checking for library containing Esys_Initialize... " >&6; }
+-if ${ac_cv_search_Esys_Initialize+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  ac_func_search_save_LIBS=$LIBS
+-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-
+-/* Override any GCC internal prototype to avoid an error.
+-   Use char because int might match the return type of a GCC
+-   builtin and then its argument prototype would still apply.  */
+-#ifdef __cplusplus
+-extern "C"
+-#endif
+-char Esys_Initialize ();
+-int
+-main ()
+-{
+-return Esys_Initialize ();
+-  ;
+-  return 0;
+-}
+-_ACEOF
+-for ac_lib in '' tss2-esys; do
+-  if test -z "$ac_lib"; then
+-    ac_res="none required"
+-  else
+-    ac_res=-l$ac_lib
+-    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+-  fi
+-  if ac_fn_c_try_link "$LINENO"; then :
+-  ac_cv_search_Esys_Initialize=$ac_res
+-fi
+-rm -f core conftest.err conftest.$ac_objext \
+-    conftest$ac_exeext
+-  if ${ac_cv_search_Esys_Initialize+:} false; then :
+-  break
+-fi
+-done
+-if ${ac_cv_search_Esys_Initialize+:} false; then :
+-
+-else
+-  ac_cv_search_Esys_Initialize=no
+-fi
+-rm conftest.$ac_ext
+-LIBS=$ac_func_search_save_LIBS
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_Esys_Initialize" >&5
+-$as_echo "$ac_cv_search_Esys_Initialize" >&6; }
+-ac_res=$ac_cv_search_Esys_Initialize
+-if test "$ac_res" != no; then :
+-  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+-  have_libtss=Intel
+-else
+-  as_fn_error $? "Intel TPM Software Stack requested but not found" "$LINENO" 5
++  pkg_failed=no
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for LIBTSS" >&5
++printf %s "checking for LIBTSS... " >&6; }
++if test -n "$LIBTSS_CFLAGS"; then
++    pkg_cv_LIBTSS_CFLAGS="$LIBTSS_CFLAGS"
++ elif test -n "$PKG_CONFIG"; then
++    if test -n "$PKG_CONFIG" && \
++    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"tss2-esys tss2-mu tss2-rc tss2-tctildr\""; } >&5
++  ($PKG_CONFIG --exists --print-errors "tss2-esys tss2-mu tss2-rc tss2-tctildr") 2>&5
++  ac_status=$?
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }; then
++  pkg_cv_LIBTSS_CFLAGS=`$PKG_CONFIG --cflags "tss2-esys tss2-mu tss2-rc tss2-tctildr" 2>/dev/null`
++		      test "x$?" != "x0" && pkg_failed=yes
++else
++  pkg_failed=yes
++fi
++ else
++    pkg_failed=untried
++fi
++if test -n "$LIBTSS_LIBS"; then
++    pkg_cv_LIBTSS_LIBS="$LIBTSS_LIBS"
++ elif test -n "$PKG_CONFIG"; then
++    if test -n "$PKG_CONFIG" && \
++    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"tss2-esys tss2-mu tss2-rc tss2-tctildr\""; } >&5
++  ($PKG_CONFIG --exists --print-errors "tss2-esys tss2-mu tss2-rc tss2-tctildr") 2>&5
++  ac_status=$?
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }; then
++  pkg_cv_LIBTSS_LIBS=`$PKG_CONFIG --libs "tss2-esys tss2-mu tss2-rc tss2-tctildr" 2>/dev/null`
++		      test "x$?" != "x0" && pkg_failed=yes
++else
++  pkg_failed=yes
++fi
++ else
++    pkg_failed=untried
++fi
++if test $pkg_failed = yes; then
++        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
++
++if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
++        _pkg_short_errors_supported=yes
++else
++        _pkg_short_errors_supported=no
++fi
++        if test $_pkg_short_errors_supported = yes; then
++	        LIBTSS_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "tss2-esys tss2-mu tss2-rc tss2-tctildr" 2>&1`
++        else
++	        LIBTSS_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "tss2-esys tss2-mu tss2-rc tss2-tctildr" 2>&1`
++        fi
++	# Put the nasty error message in config.log where it belongs
++	echo "$LIBTSS_PKG_ERRORS" >&5
++
++	as_fn_error $? "Intel TPM Software Stack requested but not found" "$LINENO" 5
++elif test $pkg_failed = untried; then
++        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
++	as_fn_error $? "Intel TPM Software Stack requested but not found" "$LINENO" 5
++else
++	LIBTSS_CFLAGS=$pkg_cv_LIBTSS_CFLAGS
++	LIBTSS_LIBS=$pkg_cv_LIBTSS_LIBS
++        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
++printf "%s\n" "yes" >&6; }
++	have_libtss=Intel
+ fi
+ 
+   else
+@@ -16768,7 +16783,6 @@ printf "%s\n" "$as_me: WARNING: Need Esys_TR_GetTpmHandle API (usually requires
+ 
+ fi
+ 
+-    LIBTSS_LIBS="$LIBS -ltss2-mu -ltss2-rc -ltss2-tctildr"
+ 
+ printf "%s\n" "#define HAVE_INTEL_TSS 1" >>confdefs.h
+ 
+diff --git a/configure.ac b/configure.ac
+index 94bc80583..e88d0f650 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1574,8 +1574,8 @@ if test "$build_tpm2d" = "yes"; then
+     AC_SEARCH_LIBS([TSS_Create],[tss ibmtss],have_libtss=IBM,
+                    [AC_MSG_ERROR([IBM TPM Software Stack requested but not found])])
+   elif test "$with_tss" = intel; then
+-    AC_SEARCH_LIBS([Esys_Initialize],[tss2-esys],have_libtss=Intel,
+-                   [AC_MSG_ERROR([Intel TPM Software Stack requested but not found])])
++    PKG_CHECK_MODULES([LIBTSS], [tss2-esys tss2-mu tss2-rc tss2-tctildr],have_libtss=Intel,
++                      [AC_MSG_ERROR([Intel TPM Software Stack requested but not found])])
+   else
+     AC_MSG_ERROR([Invalid TPM Software Stack requested: $with_tss])
+   fi
+@@ -1605,7 +1605,6 @@ if test "$build_tpm2d" = "yes"; then
+ 	AC_MSG_WARN([Need Esys_TR_GetTpmHandle API (usually requires Intel TSS 2.4.0 or later, disabling TPM support)])
+ 	have_libtss=no
+     ])
+-    LIBTSS_LIBS="$LIBS -ltss2-mu -ltss2-rc -ltss2-tctildr"
+     AC_DEFINE(HAVE_INTEL_TSS, 1, [Defined if we have the Intel TSS])
+   fi
+   LIBS="$_save_libs"
+-- 
+2.51.0

--- a/pkgs/by-name/gn/gnupg_25_experimental/fix-libusb-include-path.patch
+++ b/pkgs/by-name/gn/gnupg_25_experimental/fix-libusb-include-path.patch
@@ -1,0 +1,12 @@
+--- a/configure
++++ b/configure
+@@ -9281,8 +9281,7 @@ fi
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking libusb include dir" >&5
+ $as_echo_n "checking libusb include dir... " >&6; }
+    usb_incdir_found="no"
+-   for _incdir in "" "/usr/include/libusb-1.0" \
+-       "/usr/local/include/libusb-1.0" "/usr/pkg/include/libusb-1.0"; do
++   for _incdir in "$($PKG_CONFIG --variable=includedir libusb-1.0)/libusb-1.0"; do
+      _libusb_save_cppflags=$CPPFLAGS
+      if test -n "${_incdir}"; then
+        CPPFLAGS="-I${_incdir} ${CPPFLAGS}"

--- a/pkgs/by-name/gn/gnupg_25_experimental/package.nix
+++ b/pkgs/by-name/gn/gnupg_25_experimental/package.nix
@@ -1,0 +1,245 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  fetchFromGitLab,
+  buildPackages,
+  pkg-config,
+  texinfo,
+  gettext,
+  libassuan,
+  libgcrypt,
+  libgpg-error,
+  libiconv,
+  libksba,
+  npth,
+  adns,
+  bzip2,
+  gnutls,
+  libusb1,
+  openldap,
+  readline,
+  sqlite,
+  zlib,
+  openssh,
+  enableMinimal ? false,
+  withPcsc ? !enableMinimal,
+  pcsclite,
+  guiSupport ? stdenv.hostPlatform.isDarwin,
+  pinentry_mac,
+  pinentry-gtk2,
+  withTpm2Tss ? !stdenv.hostPlatform.isDarwin && !enableMinimal,
+  tpm2-tss,
+  nixosTests,
+}:
+
+assert guiSupport -> !enableMinimal;
+
+let
+  pinentry = if stdenv.hostPlatform.isDarwin then pinentry_mac else pinentry-gtk2;
+in
+
+stdenv.mkDerivation rec {
+  pname = "gnupg";
+  version = "2.5.19";
+
+  src = fetchurl {
+    url = "mirror://gnupg/gnupg/${pname}-${version}.tar.bz2";
+    hash = "sha256-ciqopCbdm0Tg0ZS3O/7jo+YX1lZ0zU0dBi5t8p8XiMY=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+  nativeBuildInputs = [
+    # XXX: do not add autoreconfHook without very careful testing!
+    # Problems that were identified during the last attempt:
+    #  • Prints a warning about being a development version not
+    #    suitable for production use.
+    #  • Smartcards do not work, at least without pcscd.
+
+    pkg-config
+    texinfo
+    libgpg-error
+  ];
+  buildInputs = [
+    gettext
+    libassuan
+    libgcrypt
+    libgpg-error
+    libiconv
+    libksba
+    npth
+  ]
+  ++ lib.optionals (!enableMinimal) [
+    adns
+    bzip2
+    gnutls
+    libusb1
+    openldap
+    readline
+    sqlite
+    zlib
+  ]
+  ++ lib.optionals withTpm2Tss [ tpm2-tss ];
+
+  # FreePG (https://freepg.org) is a set of commonly-used patches for GnuPG that
+  # have not been merged upstream. It is used by Arch Linux, Debian, Fedora and
+  # NixOS, and is maintained by Andrew Gallagher.
+  #
+  # The main purpose of including these patches in Nixpkgs is to maintain
+  # compatibility with OpenPGP.
+  #
+  freepgPatches = fetchFromGitLab {
+    owner = "freepg";
+    repo = "gnupg";
+    tag = "source-2.5.19-freepg";
+    hash = "sha256-3chtQlIV1DAgHSjIrPpiliLzDrrkrLP5KyRKisVI9Ts=";
+  };
+
+  patches = [
+    # Without this, scdaemon isn't linked to libusb, causing smartcards to not work correctly
+    ./fix-libusb-include-path.patch
+    # Use pkg-config to find tss2-esys to fix static building
+    # Submitted upstream: https://dev.gnupg.org/D606
+    # The diff is larger than upstream because configure.ac was modified,
+    # requiring configure to be regenerated. For reasons we don't totally
+    # understand, regenerating configure has all sorts of other undesirable
+    # side effects. So to unbreak things, instead of regenerating configure,
+    # we can include just the configure changes relevant to the static patch
+    # in the patch file.
+    ./25_static.patch
+  ]
+  ++ lib.map (v: "${freepgPatches}/master-freepg/" + v) [
+    "0002-gpg-accept-subkeys-with-a-good-revocation-but-no-sel.patch"
+    "0003-gpg-allow-import-of-previously-known-keys-even-witho.patch"
+    "0004-tests-add-test-cases-for-import-without-uid.patch"
+    "0005-gpg-drop-import-clean-from-default-keyserver-import-.patch"
+    "0008-avoid-systemd-deprecation-warning.patch"
+    "0009-Add-systemd-support-for-keyboxd.patch"
+    "0010-Ship-sample-systemd-unit-files.patch"
+    "0011-el-gamal-default-to-3072-bits.patch"
+    "0012-gpg-default-digest-algorithm-SHA512.patch"
+    "0013-gpg-Prefer-SHA-512-and-SHA-384-in-personal-digest.patch"
+    "0018-Avoid-simple-memory-dumps-via-ptrace.patch"
+    "0019-Disallow-compressed-signatures-and-certificates.patch"
+    "0020-ssh-agent-emulation-under-systemd-inject-SSH_AUTH_SO.patch"
+    "0022-gpg-emit-RSA-pubkey-algorithm-when-in-compatibility-.patch"
+    "0023-gpg-Reintroduce-openpgp-as-distinct-from-rfc4880.patch"
+    "0024-gpg-Emit-LibrePGP-material-only-in-compliance-gnupg.patch"
+    "0025-gpg-gpgconf-list-report-actual-compliance-mode.patch"
+    "0026-gpg-Default-to-compliance-openpgp.patch"
+    "0027-gpg-Fix-newlines-in-Cleartext-Signature-Framework-CS.patch"
+    "0028-Revert-Remove-the-default-keyserver.patch"
+    "0029-Add-keyboxd-systemd-support.patch"
+    "0033-Support-large-RSA-keygen-in-non-batch-mode.patch"
+    "0034-gpg-Verify-Text-mode-Signatures-over-binary-Literal-.patch"
+    "0037-fix-up-version-reporting.patch"
+    "0040-Add-missing-test-files-to-EXTRA_DIST.patch"
+    "0041-skip-trust-packets-during-import-restore.patch"
+    "0042-compat-ignore-truncated-line.patch"
+    "0043-fail-on-unprintable-armor-headers.patch"
+  ];
+
+  postPatch =
+    # Switch the default key server to keys.openpgp.org
+    # The original motivation in 2019 was to switch away from the then-default SKS network: https://github.com/NixOS/nixpkgs/pull/63952
+    # In 2021 upstream also switched away, but to keyserver.ubuntu.com: https://dev.gnupg.org/rG47c4e3e00a7ef55f954c14b3c237496e54a853c1,
+    # while NixOS kept the keys.openpgp.org default: https://github.com/NixOS/nixpkgs/pull/159604
+    # TODO: Should this patch be removed so that the now-uncompromised default is used once again?
+    # A significant difference between the two seems to be that keys.openpgp.org is verifying keys, while keyserver.ubuntu.com isn't: https://unix.stackexchange.com/a/694528
+    # The keys.openpgp.org also has a great FAQ: https://keys.openpgp.org/about/faq
+    ''
+      substituteInPlace dirmngr/server.c \
+        --replace-fail "hkps://keyserver.ubuntu.com"  "hkps://keys.openpgp.org"
+
+      substituteInPlace dirmngr/server.c \
+        --replace-fail "hkp://keyserver.ubuntu.com"  "hkp://keys.openpgp.org"
+    ''
+    + lib.optionalString (stdenv.hostPlatform.isLinux && withPcsc) ''
+      sed -i 's,"libpcsclite\.so[^"]*","${lib.getLib pcsclite}/lib/libpcsclite.so",g' scd/scdaemon.c
+    '';
+
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-Wno-implicit-function-declaration";
+
+  configureFlags = [
+    "--sysconfdir=/etc"
+    # Needed for large RSA key support (patch 0033)
+    "--enable-large-secmem"
+    "--with-libgpg-error-prefix=${libgpg-error.dev}"
+    "--with-libgcrypt-prefix=${libgcrypt.dev}"
+    "--with-libassuan-prefix=${libassuan.dev}"
+    "--with-ksba-prefix=${libksba.dev}"
+    "GPGRT_CONFIG=${lib.getDev libgpg-error}/bin/gpgrt-config"
+  ]
+  ++ lib.optional guiSupport "--with-pinentry-pgm=${pinentry}/${
+    pinentry.binaryPath or "bin/pinentry"
+  }"
+  ++ lib.optional withTpm2Tss "--with-tss=intel"
+  ++ lib.optional stdenv.hostPlatform.isDarwin "--disable-ccid-driver";
+
+  outputs = [
+    "out"
+    "info"
+    "man"
+    "doc"
+  ];
+
+  postInstall =
+    if enableMinimal then
+      ''
+        rm -r $out/{libexec,sbin,share}
+        for f in $(find $out/bin -type f -not -name gpg)
+        do
+          rm $f
+        done
+      ''
+    else
+      ''
+        # add gpg2 symlink to make sure git does not break when signing commits
+        ln -s $out/bin/gpg $out/bin/gpg2
+
+        # Make libexec tools available in PATH
+        for f in $out/libexec/*; do
+          if [[ "$(basename $f)" == "gpg-wks-client" ]]; then continue; fi
+          ln -s $f $out/bin/$(basename $f)
+        done
+      '';
+
+  enableParallelBuilding = true;
+
+  nativeCheckInputs = [
+    # A test would be skipped without SSH
+    openssh
+  ];
+  doCheck = !enableMinimal;
+
+  passthru.tests = nixosTests.gnupg;
+
+  meta = {
+    homepage = "https://gnupg.org";
+    changelog = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=${pname}.git;a=blob;f=NEWS;hb=refs/tags/${pname}-${version}";
+    description = "Experimental release of the GNU Privacy Guard, a GPL OpenPGP implementation.";
+    license = lib.licenses.gpl3Plus;
+    longDescription = ''
+      The GNU Privacy Guard is the GNU project's complete and free
+      implementation of the OpenPGP standard as defined by RFC4880.  GnuPG
+      "modern" (2.1) is the latest development with a lot of new features.
+      GnuPG allows to encrypt and sign your data and communication, features a
+      versatile key management system as well as access modules for all kind of
+      public key directories.  GnuPG, also known as GPG, is a command line tool
+      with features for easy integration with other applications.  A wealth of
+      frontend applications and libraries are available.  Version 2 of GnuPG
+      also provides support for S/MIME.
+    '';
+    maintainers = with lib.maintainers; [
+      fpletz
+      sgo
+    ];
+    teams = [ lib.teams.security-review ];
+    platforms = lib.platforms.all;
+    mainProgram = "gpg";
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnupg" version;
+  };
+}

--- a/pkgs/by-name/gn/gnupg_25_experimental/package.nix
+++ b/pkgs/by-name/gn/gnupg_25_experimental/package.nix
@@ -1,0 +1,243 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  fetchFromGitLab,
+  buildPackages,
+  pkg-config,
+  texinfo,
+  gettext,
+  libassuan,
+  libgcrypt,
+  libgpg-error,
+  libiconv,
+  libksba,
+  npth,
+  adns,
+  bzip2,
+  gnutls,
+  libusb1,
+  openldap,
+  readline,
+  sqlite,
+  zlib,
+  openssh,
+  enableMinimal ? false,
+  withPcsc ? !enableMinimal,
+  pcsclite,
+  guiSupport ? stdenv.hostPlatform.isDarwin,
+  pinentry_mac,
+  pinentry-gtk2,
+  pinentry ? if stdenv.hostPlatform.isDarwin then pinentry_mac else pinentry-gtk2,
+  withTpm2Tss ? !stdenv.hostPlatform.isDarwin && !enableMinimal,
+  tpm2-tss,
+  nixosTests,
+}:
+
+assert guiSupport -> !enableMinimal;
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gnupg";
+  version = "2.5.21";
+
+  src = fetchurl {
+    url = "mirror://gnupg/gnupg/gnupg-${finalAttrs.version}.tar.bz2";
+    hash = "sha256-468sjKpGpmqTKfp8aICvJgRRkU2BlZW+q8LCZZezE1I=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+  nativeBuildInputs = [
+    # XXX: do not add autoreconfHook without very careful testing!
+    # Problems that were identified during the last attempt:
+    #  • Prints a warning about being a development version not
+    #    suitable for production use.
+    #  • Smartcards do not work, at least without pcscd.
+
+    pkg-config
+    texinfo
+    libgpg-error
+  ];
+  buildInputs = [
+    gettext
+    libassuan
+    libgcrypt
+    libgpg-error
+    libiconv
+    libksba
+    npth
+  ]
+  ++ lib.optionals (!enableMinimal) [
+    adns
+    bzip2
+    gnutls
+    libusb1
+    openldap
+    readline
+    sqlite
+    zlib
+  ]
+  ++ lib.optionals withTpm2Tss [ tpm2-tss ];
+
+  # FreePG (https://freepg.org) is a set of commonly-used patches for GnuPG that
+  # have not been merged upstream. It is used by Arch Linux, Debian, Fedora and
+  # NixOS, and is maintained by Andrew Gallagher.
+  #
+  # The main purpose of including these patches in Nixpkgs is to maintain
+  # compatibility with OpenPGP.
+  #
+  freepgPatches = fetchFromGitLab {
+    owner = "freepg";
+    repo = "gnupg";
+    tag = "source-2.5.21-freepg";
+    hash = "sha256-P3XdRnnVJuYe80S6wTMmmCO4jWBbUIkHkLKA75qSnNg=";
+  };
+
+  patches = [
+    # Without this, scdaemon isn't linked to libusb, causing smartcards to not work correctly
+    ./fix-libusb-include-path.patch
+    # Use pkg-config to find tss2-esys to fix static building
+    # Submitted upstream: https://dev.gnupg.org/D606
+    # The diff is larger than upstream because configure.ac was modified,
+    # requiring configure to be regenerated. For reasons we don't totally
+    # understand, regenerating configure has all sorts of other undesirable
+    # side effects. So to unbreak things, instead of regenerating configure,
+    # we can include just the configure changes relevant to the static patch
+    # in the patch file.
+    ./25_static.patch
+  ]
+  ++ lib.map (v: "${finalAttrs.freepgPatches}/master-freepg/" + v) [
+    "0002-gpg-accept-subkeys-with-a-good-revocation-but-no-sel.patch"
+    "0003-gpg-allow-import-of-previously-known-keys-even-witho.patch"
+    "0004-tests-add-test-cases-for-import-without-uid.patch"
+    "0005-gpg-drop-import-clean-from-default-keyserver-import-.patch"
+    "0008-avoid-systemd-deprecation-warning.patch"
+    "0009-Add-systemd-support-for-keyboxd.patch"
+    "0010-Ship-sample-systemd-unit-files.patch"
+    "0011-el-gamal-default-to-3072-bits.patch"
+    "0012-gpg-default-digest-algorithm-SHA512.patch"
+    "0013-gpg-Prefer-SHA-512-and-SHA-384-in-personal-digest.patch"
+    "0018-Avoid-simple-memory-dumps-via-ptrace.patch"
+    "0019-Disallow-compressed-signatures-and-certificates.patch"
+    "0020-ssh-agent-emulation-under-systemd-inject-SSH_AUTH_SO.patch"
+    "0022-gpg-emit-RSA-pubkey-algorithm-when-in-compatibility-.patch"
+    "0023-gpg-Reintroduce-openpgp-as-distinct-from-rfc4880.patch"
+    "0024-gpg-Emit-LibrePGP-material-only-in-compliance-gnupg.patch"
+    "0025-gpg-gpgconf-list-report-actual-compliance-mode.patch"
+    "0026-gpg-Default-to-compliance-openpgp.patch"
+    "0027-gpg-Fix-newlines-in-Cleartext-Signature-Framework-CS.patch"
+    "0028-Revert-Remove-the-default-keyserver.patch"
+    "0029-Add-keyboxd-systemd-support.patch"
+    "0033-Support-large-RSA-keygen-in-non-batch-mode.patch"
+    "0034-gpg-Verify-Text-mode-Signatures-over-binary-Literal-.patch"
+    "0037-fix-up-version-reporting.patch"
+    "0040-Add-missing-test-files-to-EXTRA_DIST.patch"
+    "0041-skip-trust-packets-during-import-restore.patch"
+    "0042-compat-ignore-truncated-line.patch"
+    "0043-fail-on-unprintable-armor-headers.patch"
+  ];
+
+  postPatch =
+    # Switch the default key server to keys.openpgp.org
+    # The original motivation in 2019 was to switch away from the then-default SKS network: https://github.com/NixOS/nixpkgs/pull/63952
+    # In 2021 upstream also switched away, but to keyserver.ubuntu.com: https://dev.gnupg.org/rG47c4e3e00a7ef55f954c14b3c237496e54a853c1,
+    # while NixOS kept the keys.openpgp.org default: https://github.com/NixOS/nixpkgs/pull/159604
+    # TODO: Should this patch be removed so that the now-uncompromised default is used once again?
+    # A significant difference between the two seems to be that keys.openpgp.org is verifying keys, while keyserver.ubuntu.com isn't: https://unix.stackexchange.com/a/694528
+    # The keys.openpgp.org also has a great FAQ: https://keys.openpgp.org/about/faq
+    ''
+      substituteInPlace dirmngr/server.c \
+        --replace-fail "hkps://keyserver.ubuntu.com"  "hkps://keys.openpgp.org"
+
+      substituteInPlace dirmngr/server.c \
+        --replace-fail "hkp://keyserver.ubuntu.com"  "hkp://keys.openpgp.org"
+    ''
+    + lib.optionalString (stdenv.hostPlatform.isLinux && withPcsc) ''
+      sed -i 's,"libpcsclite\.so[^"]*","${lib.getLib pcsclite}/lib/libpcsclite.so",g' scd/scdaemon.c
+    '';
+
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-Wno-implicit-function-declaration";
+
+  configureFlags = [
+    "--sysconfdir=/etc"
+    # Needed for large RSA key support (patch 0033)
+    "--enable-large-secmem"
+    "--with-libgpg-error-prefix=${libgpg-error.dev}"
+    "--with-libgcrypt-prefix=${libgcrypt.dev}"
+    "--with-libassuan-prefix=${libassuan.dev}"
+    "--with-ksba-prefix=${libksba.dev}"
+    "GPGRT_CONFIG=${lib.getDev libgpg-error}/bin/gpgrt-config"
+  ]
+  ++ lib.optional guiSupport "--with-pinentry-pgm=${pinentry}/${
+    pinentry.binaryPath or "bin/pinentry"
+  }"
+  ++ lib.optional withTpm2Tss "--with-tss=intel"
+  ++ lib.optional stdenv.hostPlatform.isDarwin "--disable-ccid-driver";
+
+  outputs = [
+    "out"
+    "info"
+    "man"
+    "doc"
+  ];
+
+  postInstall =
+    if enableMinimal then
+      ''
+        rm -r $out/{libexec,sbin,share}
+        for f in $(find $out/bin -type f -not -name gpg)
+        do
+          rm $f
+        done
+      ''
+    else
+      ''
+        # add gpg2 symlink to make sure git does not break when signing commits
+        ln -s $out/bin/gpg $out/bin/gpg2
+
+        # Make libexec tools available in PATH
+        for f in $out/libexec/*; do
+          if [[ "$(basename $f)" == "gpg-wks-client" ]]; then continue; fi
+          ln -s $f $out/bin/$(basename $f)
+        done
+      '';
+
+  enableParallelBuilding = true;
+
+  nativeCheckInputs = [
+    # A test would be skipped without SSH
+    openssh
+  ];
+  doCheck = !enableMinimal;
+
+  passthru.tests = nixosTests.gnupg;
+
+  meta = {
+    homepage = "https://gnupg.org";
+    changelog = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob;f=NEWS;hb=refs/tags/gnupg-${finalAttrs.version}";
+    description = "Experimental release of the GNU Privacy Guard, a GPL OpenPGP implementation.";
+    license = lib.licenses.gpl3Plus;
+    longDescription = ''
+      The GNU Privacy Guard is the GNU project's complete and free
+      implementation of the OpenPGP standard as defined by RFC4880.  GnuPG
+      "modern" (2.1) is the latest development with a lot of new features.
+      GnuPG allows to encrypt and sign your data and communication, features a
+      versatile key management system as well as access modules for all kind of
+      public key directories.  GnuPG, also known as GPG, is a command line tool
+      with features for easy integration with other applications.  A wealth of
+      frontend applications and libraries are available.  Version 2 of GnuPG
+      also provides support for S/MIME.
+    '';
+    maintainers = with lib.maintainers; [
+      fpletz
+      sgo
+      dstremur
+    ];
+    teams = [ lib.teams.security-review ];
+    platforms = lib.platforms.all;
+    mainProgram = "gpg";
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnupg" finalAttrs.version;
+  };
+})

--- a/pkgs/by-name/gn/gnupg_25_experimental/static.patch
+++ b/pkgs/by-name/gn/gnupg_25_experimental/static.patch
@@ -1,0 +1,221 @@
+From 5eec11089067947bd850e069651cfa9bf4c48d07 Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Sun, 9 Feb 2025 08:51:32 +0100
+Subject: [PATCH] build: use pkg-config to find tss2-esys
+
+Otherwise, tss2-esys's dependencies (other tss2 libraries, OpenSSL)
+won't be linked when tss2-esys is a static library.
+---
+Link: https://dev.gnupg.org/D606
+
+ configure    | 132 ++++++++++++++++++++++++++++-----------------------
+ configure.ac |   5 +-
+ 2 files changed, 75 insertions(+), 62 deletions(-)
+
+diff --git a/configure b/configure
+index f5d8bef90..e7f4fb175 100755
+--- a/configure
++++ b/configure
+@@ -696,12 +696,12 @@ TEST_LIBTSS_FALSE
+ TEST_LIBTSS_TRUE
+ HAVE_LIBTSS_FALSE
+ HAVE_LIBTSS_TRUE
+-LIBTSS_CFLAGS
+-LIBTSS_LIBS
+ SWTPM
+ TSSSTARTUP
+ TPMSERVER
+ TSS_INCLUDE
++LIBTSS_LIBS
++LIBTSS_CFLAGS
+ W32SOCKLIBS
+ NETLIBS
+ CROSS_COMPILING_FALSE
+@@ -1030,7 +1030,9 @@ PKG_CONFIG_LIBDIR
+ SQLITE3_CFLAGS
+ SQLITE3_LIBS
+ LIBGNUTLS_CFLAGS
+-LIBGNUTLS_LIBS'
++LIBGNUTLS_LIBS
++LIBTSS_CFLAGS
++LIBTSS_LIBS'
+ 
+ 
+ # Initialize some variables set by options.
+@@ -1805,6 +1807,9 @@ Some influential environment variables:
+               C compiler flags for LIBGNUTLS, overriding pkg-config
+   LIBGNUTLS_LIBS
+               linker flags for LIBGNUTLS, overriding pkg-config
++  LIBTSS_CFLAGS
++              C compiler flags for LIBTSS, overriding pkg-config
++  LIBTSS_LIBS linker flags for LIBTSS, overriding pkg-config
+ 
+ Use these variables to override the choices made by `configure' or to help
+ it to find libraries and programs with nonstandard names/locations.
+@@ -16616,67 +16621,77 @@ else $as_nop
+ fi
+ 
+   elif test "$with_tss" = intel; then
+-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing Esys_Initialize" >&5
+-printf %s "checking for library containing Esys_Initialize... " >&6; }
+-if test ${ac_cv_search_Esys_Initialize+y}
+-then :
+-  printf %s "(cached) " >&6
+-else $as_nop
+-  ac_func_search_save_LIBS=$LIBS
+-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+ 
+-/* Override any GCC internal prototype to avoid an error.
+-   Use char because int might match the return type of a GCC
+-   builtin and then its argument prototype would still apply.  */
+-char Esys_Initialize ();
+-int
+-main (void)
+-{
+-return Esys_Initialize ();
+-  ;
+-  return 0;
+-}
+-_ACEOF
+-for ac_lib in '' tss2-esys
+-do
+-  if test -z "$ac_lib"; then
+-    ac_res="none required"
+-  else
+-    ac_res=-l$ac_lib
+-    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+-  fi
+-  if ac_fn_c_try_link "$LINENO"
+-then :
+-  ac_cv_search_Esys_Initialize=$ac_res
+-fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+-    conftest$ac_exeext
+-  if test ${ac_cv_search_Esys_Initialize+y}
+-then :
+-  break
+-fi
+-done
+-if test ${ac_cv_search_Esys_Initialize+y}
+-then :
++pkg_failed=no
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for LIBTSS" >&5
++printf %s "checking for LIBTSS... " >&6; }
+ 
+-else $as_nop
+-  ac_cv_search_Esys_Initialize=no
++if test -n "$LIBTSS_CFLAGS"; then
++    pkg_cv_LIBTSS_CFLAGS="$LIBTSS_CFLAGS"
++ elif test -n "$PKG_CONFIG"; then
++    if test -n "$PKG_CONFIG" && \
++    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"tss2-esys tss2-mu tss2-rc tss2-tctildr\""; } >&5
++  ($PKG_CONFIG --exists --print-errors "tss2-esys tss2-mu tss2-rc tss2-tctildr") 2>&5
++  ac_status=$?
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }; then
++  pkg_cv_LIBTSS_CFLAGS=`$PKG_CONFIG --cflags "tss2-esys tss2-mu tss2-rc tss2-tctildr" 2>/dev/null`
++		      test "x$?" != "x0" && pkg_failed=yes
++else
++  pkg_failed=yes
+ fi
+-rm conftest.$ac_ext
+-LIBS=$ac_func_search_save_LIBS
++ else
++    pkg_failed=untried
+ fi
+-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_Esys_Initialize" >&5
+-printf "%s\n" "$ac_cv_search_Esys_Initialize" >&6; }
+-ac_res=$ac_cv_search_Esys_Initialize
+-if test "$ac_res" != no
+-then :
+-  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+-  have_libtss=Intel
+-else $as_nop
+-  as_fn_error $? "Intel TPM Software Stack requested but not found" "$LINENO" 5
++if test -n "$LIBTSS_LIBS"; then
++    pkg_cv_LIBTSS_LIBS="$LIBTSS_LIBS"
++ elif test -n "$PKG_CONFIG"; then
++    if test -n "$PKG_CONFIG" && \
++    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"tss2-esys tss2-mu tss2-rc tss2-tctildr\""; } >&5
++  ($PKG_CONFIG --exists --print-errors "tss2-esys tss2-mu tss2-rc tss2-tctildr") 2>&5
++  ac_status=$?
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }; then
++  pkg_cv_LIBTSS_LIBS=`$PKG_CONFIG --libs "tss2-esys tss2-mu tss2-rc tss2-tctildr" 2>/dev/null`
++		      test "x$?" != "x0" && pkg_failed=yes
++else
++  pkg_failed=yes
++fi
++ else
++    pkg_failed=untried
+ fi
+ 
++
++
++if test $pkg_failed = yes; then
++        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
++
++if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
++        _pkg_short_errors_supported=yes
++else
++        _pkg_short_errors_supported=no
++fi
++        if test $_pkg_short_errors_supported = yes; then
++	        LIBTSS_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "tss2-esys tss2-mu tss2-rc tss2-tctildr" 2>&1`
++        else
++	        LIBTSS_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "tss2-esys tss2-mu tss2-rc tss2-tctildr" 2>&1`
++        fi
++	# Put the nasty error message in config.log where it belongs
++	echo "$LIBTSS_PKG_ERRORS" >&5
++
++	as_fn_error $? "Intel TPM Software Stack requested but not found" "$LINENO" 5
++elif test $pkg_failed = untried; then
++        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
++	as_fn_error $? "Intel TPM Software Stack requested but not found" "$LINENO" 5
++else
++	LIBTSS_CFLAGS=$pkg_cv_LIBTSS_CFLAGS
++	LIBTSS_LIBS=$pkg_cv_LIBTSS_LIBS
++        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
++printf "%s\n" "yes" >&6; }
++	have_libtss=Intel
++fi
+   else
+     as_fn_error $? "Invalid TPM Software Stack requested: $with_tss" "$LINENO" 5
+   fi
+@@ -16768,7 +16783,6 @@ printf "%s\n" "$as_me: WARNING: Need Esys_TR_GetTpmHandle API (usually requires
+ 
+ fi
+ 
+-    LIBTSS_LIBS="$LIBS -ltss2-mu -ltss2-rc -ltss2-tctildr"
+ 
+ printf "%s\n" "#define HAVE_INTEL_TSS 1" >>confdefs.h
+ 
+diff --git a/configure.ac b/configure.ac
+index 94bc80583..e88d0f650 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1574,8 +1574,8 @@ if test "$build_tpm2d" = "yes"; then
+     AC_SEARCH_LIBS([TSS_Create],[tss ibmtss],have_libtss=IBM,
+                    [AC_MSG_ERROR([IBM TPM Software Stack requested but not found])])
+   elif test "$with_tss" = intel; then
+-    AC_SEARCH_LIBS([Esys_Initialize],[tss2-esys],have_libtss=Intel,
+-                   [AC_MSG_ERROR([Intel TPM Software Stack requested but not found])])
++    PKG_CHECK_MODULES([LIBTSS], [tss2-esys tss2-mu tss2-rc tss2-tctildr],have_libtss=Intel,
++                      [AC_MSG_ERROR([Intel TPM Software Stack requested but not found])])
+   else
+     AC_MSG_ERROR([Invalid TPM Software Stack requested: $with_tss])
+   fi
+@@ -1605,7 +1605,6 @@ if test "$build_tpm2d" = "yes"; then
+ 	AC_MSG_WARN([Need Esys_TR_GetTpmHandle API (usually requires Intel TSS 2.4.0 or later, disabling TPM support)])
+ 	have_libtss=no
+     ])
+-    LIBTSS_LIBS="$LIBS -ltss2-mu -ltss2-rc -ltss2-tctildr"
+     AC_DEFINE(HAVE_INTEL_TSS, 1, [Defined if we have the Intel TSS])
+   fi
+   LIBS="$_save_libs"
+-- 
+2.51.0
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2369,6 +2369,7 @@ with pkgs;
   gnupg24 = callPackage ../tools/security/gnupg/24.nix {
     pinentry = if stdenv.hostPlatform.isDarwin then pinentry_mac else pinentry-gtk2;
   };
+
   gnupg = gnupg24;
 
   gnused = callPackage ../tools/text/gnused { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds gnupg version 2.5.19 as an experimental package. Default is still 2.4.9. 
As discussed in #435641
https://lists.gnupg.org/pipermail/gnupg-announce/2026q2/000504.html
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
