### PR TITLE
neatvnc: 0.9.6 -> 1.0.0, wayvnc: 0.9.1 -> 0.10.0

### DIFF
--- a/pkgs/by-name/am/aml/package.nix
+++ b/pkgs/by-name/am/aml/package.nix
@@ -3,33 +3,34 @@
   stdenv,
   fetchFromGitHub,
   meson,
-  pkg-config,
   ninja,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "aml";
-  version = "0.3.0";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "any1";
     repo = "aml";
     tag = "v${finalAttrs.version}";
-    sha256 = "sha256-BX+MRqvnwwLPhz22m0gfJ2EkW31KQEi/YTgOCMcQk2Q=";
+    hash = "sha256-10gm6YphZrpLShj3NUj/AG24dSVLZAZbbnXr7GiF4DI=";
   };
 
   nativeBuildInputs = [
     meson
-    pkg-config
     ninja
   ];
 
+  strictDeps = true;
+
+  __structuredAttrs = true;
+
   meta = {
-    description = "Another main loop";
-    inherit (finalAttrs.src.meta) homepage;
+    description = "Andri's Main Loop";
+    homepage = "https://github.com/any1/aml";
     license = lib.licenses.isc;
-    platforms = lib.platforms.unix;
-    maintainers = [ ];
-    broken = stdenv.hostPlatform.isDarwin;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ nickcao ];
   };
 })

--- a/pkgs/by-name/ne/neatvnc/package.nix
+++ b/pkgs/by-name/ne/neatvnc/package.nix
@@ -8,21 +8,25 @@
   aml,
   ffmpeg,
   gnutls,
+  libdrm,
   libjpeg_turbo,
   libgbm,
+  nettle,
   pixman,
   zlib,
+  python3,
+  openssl,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "neatvnc";
-  version = "0.9.6";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "any1";
     repo = "neatvnc";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-VStlTsfXbFxTnRGdK1y7MLtCzxbHzraw5GGph3sS/kI=";
+    hash = "sha256-yEWNiazRxc8G7ToqOcTtCXEuBCgXO64v31Xx1YeOPCM=";
   };
 
   strictDeps = true;
@@ -37,17 +41,26 @@ stdenv.mkDerivation (finalAttrs: {
     aml
     ffmpeg
     gnutls
+    libdrm
     libjpeg_turbo
     libgbm
+    nettle
     pixman
     zlib
   ];
 
-  mesonFlags = [
-    (lib.mesonBool "tests" true)
+  nativeCheckInputs = [
+    python3
+    openssl
   ];
 
-  doCheck = true;
+  mesonFlags = [
+    (lib.mesonBool "tests" finalAttrs.finalPackage.doCheck)
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  __structuredAttrs = true;
 
   meta = {
     description = "VNC server library";

--- a/pkgs/by-name/wa/wayvnc/package.nix
+++ b/pkgs/by-name/wa/wayvnc/package.nix
@@ -9,6 +9,7 @@
   wayland-scanner,
   aml,
   jansson,
+  libdrm,
   libxkbcommon,
   libgbm,
   neatvnc,
@@ -19,13 +20,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wayvnc";
-  version = "0.9.1";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "any1";
     repo = "wayvnc";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-LINzkC18gitj1a8Giqlt/6LyydOdV+8YXRJmuxT/Nq8=";
+    hash = "sha256-+CAH2jcIIQqImonWeWxMQyTtEEuuQlaGyl/ajPfClh8=";
   };
 
   strictDeps = true;
@@ -45,6 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     aml
     jansson
+    libdrm
     libxkbcommon
     libgbm
     neatvnc
@@ -54,10 +56,12 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   mesonFlags = [
-    (lib.mesonBool "tests" true)
+    (lib.mesonBool "tests" finalAttrs.finalPackage.doCheck)
   ];
 
-  doCheck = true;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  __structuredAttrs = true;
 
   meta = {
     description = "VNC server for wlroots based Wayland compositors";
@@ -68,11 +72,11 @@ stdenv.mkDerivation (finalAttrs: {
       headless one, so it is also possible to run wayvnc without a physical
       display attached.
     '';
-    mainProgram = "wayvnc";
-    inherit (finalAttrs.src.meta) homepage;
+    homepage = "https://github.com/any1/wayvnc";
     changelog = "https://github.com/any1/wayvnc/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.isc;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ nickcao ];
+    mainProgram = "wayvnc";
   };
 })

--- a/pkgs/by-name/we/weston/package.nix
+++ b/pkgs/by-name/we/weston/package.nix
@@ -56,22 +56,23 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "weston";
-  version = "15.0.0";
+  version = "15.0.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "wayland";
     repo = "weston";
     rev = finalAttrs.version;
-    hash = "sha256-7FbQkXazsf6FkkNbE+Q6ilKACFa/CoOL2Q1oXHuaVX8=";
+    hash = "sha256-c6h8GQt1S3t2+K+8A4ncxBtWLtaV61EABdYA55o9i4o=";
   };
 
-  # Backport for https://gitlab.freedesktop.org/wayland/weston/-/issues/1100
   patches = [
+    # backend-vnc, gitlab-ci: Update to Neat VNC 1.0.0, aml 1.0.0
+    # https://gitlab.freedesktop.org/wayland/weston/-/merge_requests/2064
     (fetchpatch {
-      name = "weston-upstream-assertion-fix.patch";
-      url = "https://gitlab.freedesktop.org/wayland/weston/-/merge_requests/1993.patch";
-      hash = "sha256-705GIM7drTzv0N5Hk5dO18LWBnhhi1VoX8sfITHRYc4=";
+      url = "https://gitlab.freedesktop.org/wayland/weston/-/commit/8a1c91e771312d1e0d0cd92495ef717402784dae.patch";
+      hash = "sha256-9eBONM7OfzHhCuT8Wnq534KS51q2VtUyOOLjYHohEds=";
+      excludes = [ ".gitlab-ci.yml" ];
     })
   ];
 

--- a/pkgs/by-name/wl/wlvncc/package.nix
+++ b/pkgs/by-name/wl/wlvncc/package.nix
@@ -27,13 +27,13 @@
 
 stdenv.mkDerivation {
   pname = "wlvncc";
-  version = "0-unstable-2025-07-07";
+  version = "0-unstable-2026-04-29";
 
   src = fetchFromGitHub {
     owner = "any1";
     repo = "wlvncc";
-    rev = "bc6063aeacd4fbe9ac8f58f4ba3c5388b3e1f1f2";
-    hash = "sha256-Udu/CtrNBqnlgZCK2cS8VWNTfHJGXdijTnNIWnAW2Nw=";
+    rev = "cc0abf87c37920540f2439a556e6a480c28f8f46";
+    hash = "sha256-VPZJd4/yerWZeLl+NVH1EDtSokeS/XMS6lQUXOn9a7Q=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION

## Things done

Draft as this breaks weston and reframe.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
