### PR TITLE
send: use nodejs_22

### DIFF
--- a/pkgs/by-name/se/send/dannycoates-express-ws-drop-esm-loader.patch
+++ b/pkgs/by-name/se/send/dannycoates-express-ws-drop-esm-loader.patch
@@ -1,0 +1,130 @@
+From 4e1e354d17b558954c8e006bb432bb746922ec81 Mon Sep 17 00:00:00 2001
+From: Moraxyc <i@qaq.li>
+Date: Sat, 2 May 2026 04:26:09 +0800
+Subject: [PATCH] express-ws: convert ESM sources to CommonJS for Node.js 22
+
+---
+ express-ws/index.js               |  4 +---
+ express-ws/src/add-ws-method.js   |  8 +++++---
+ express-ws/src/index.js           | 14 ++++++++------
+ express-ws/src/trailing-slash.js  |  4 +++-
+ express-ws/src/websocket-url.js   |  6 ++++--
+ express-ws/src/wrap-middleware.js |  4 +++-
+ 6 files changed, 24 insertions(+), 16 deletions(-)
+
+diff --git a/express-ws/index.js b/express-ws/index.js
+index b0df682..bada276 100644
+--- a/express-ws/index.js
++++ b/express-ws/index.js
+@@ -1,4 +1,2 @@
+ /* eslint-disable-next-line no-underscore-dangle */
+-const _require = require('esm')(module);
+-
+-module.exports = _require('./src/index').default;
++module.exports = require("./src/index");
+diff --git a/express-ws/src/add-ws-method.js b/express-ws/src/add-ws-method.js
+index 8c3a279..633ff86 100644
+--- a/express-ws/src/add-ws-method.js
++++ b/express-ws/src/add-ws-method.js
+@@ -1,7 +1,7 @@
+-import wrapMiddleware from './wrap-middleware';
+-import websocketUrl from './websocket-url';
++const wrapMiddleware = require('./wrap-middleware');
++const websocketUrl = require('./websocket-url');
+ 
+-export default function addWsMethod(target) {
++function addWsMethod(target) {
+   /* This prevents conflict with other things setting `.ws`. */
+   if (target.ws === null || target.ws === undefined) {
+     target.ws = function addWsRoute(route, ...middlewares) {
+@@ -28,3 +28,5 @@ export default function addWsMethod(target) {
+     };
+   }
+ }
++
++module.exports = addWsMethod;
+diff --git a/express-ws/src/index.js b/express-ws/src/index.js
+index dab6c66..16f3a2b 100644
+--- a/express-ws/src/index.js
++++ b/express-ws/src/index.js
+@@ -3,14 +3,14 @@
+  *
+  * Here be dragons. */
+ 
+-import http from 'http';
+-import express from 'express';
+-import ws from 'ws';
++const http = require('http');
++const express = require('express');
++const ws = require('ws');
+ 
+-import websocketUrl from './websocket-url';
+-import addWsMethod from './add-ws-method';
++const websocketUrl = require('./websocket-url');
++const addWsMethod = require('./add-ws-method');
+ 
+-export default function expressWs(app, httpServer, options = {}) {
++function expressWs(app, httpServer, options = {}) {
+   let server = httpServer;
+ 
+   if (server === null || server === undefined) {
+@@ -84,3 +84,5 @@ export default function expressWs(app, httpServer, options = {}) {
+     }
+   };
+ }
++
++module.exports = expressWs;
+diff --git a/express-ws/src/trailing-slash.js b/express-ws/src/trailing-slash.js
+index c7cba79..791c43c 100644
+--- a/express-ws/src/trailing-slash.js
++++ b/express-ws/src/trailing-slash.js
+@@ -1,7 +1,9 @@
+-export default function addTrailingSlash(string) {
++function addTrailingSlash(string) {
+   let suffixed = string;
+   if (suffixed.charAt(suffixed.length - 1) !== '/') {
+     suffixed = `${suffixed}/`;
+   }
+   return suffixed;
+ }
++
++module.exports = addTrailingSlash;
+diff --git a/express-ws/src/websocket-url.js b/express-ws/src/websocket-url.js
+index 64b845f..d2f35eb 100644
+--- a/express-ws/src/websocket-url.js
++++ b/express-ws/src/websocket-url.js
+@@ -1,7 +1,7 @@
+-import trailingSlash from './trailing-slash';
++const trailingSlash = require('./trailing-slash');
+ 
+ /* The following fixes HenningM/express-ws#17, correctly. */
+-export default function websocketUrl(url) {
++function websocketUrl(url) {
+   if (url.indexOf('?') !== -1) {
+     const [baseUrl, query] = url.split('?');
+ 
+@@ -9,3 +9,5 @@ export default function websocketUrl(url) {
+   }
+   return `${trailingSlash(url)}.websocket`;
+ }
++
++module.exports = websocketUrl;
+diff --git a/express-ws/src/wrap-middleware.js b/express-ws/src/wrap-middleware.js
+index 09b0dbf..c8586d7 100644
+--- a/express-ws/src/wrap-middleware.js
++++ b/express-ws/src/wrap-middleware.js
+@@ -1,4 +1,4 @@
+-export default function wrapMiddleware(middleware) {
++function wrapMiddleware(middleware) {
+   return (req, res, next) => {
+     if (req.ws !== null && req.ws !== undefined) {
+       req.wsHandled = true;
+@@ -15,3 +15,5 @@ export default function wrapMiddleware(middleware) {
+     }
+   };
+ }
++
++module.exports = wrapMiddleware;
+-- 
+2.53.0
+

--- a/pkgs/by-name/se/send/package.nix
+++ b/pkgs/by-name/se/send/package.nix
@@ -3,24 +3,32 @@
   buildNpmPackage,
   fetchFromGitHub,
   makeBinaryWrapper,
-  nodejs_20,
+  nodejs_22,
   nix-update-script,
   nixosTests,
 }:
-buildNpmPackage rec {
+buildNpmPackage (finalAttrs: {
   pname = "send";
   version = "3.4.27";
 
   src = fetchFromGitHub {
     owner = "timvisee";
     repo = "send";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-tfntox8Sw3xzlCOJgY/LThThm+mptYY5BquYDjzHonQ=";
   };
 
-  nodejs = nodejs_20;
+  # @dannycoates/express-ws uses the unmaintained esm loader, which fails on nodejs_22.
+  postConfigure = ''
+    patch -p1 \
+      --directory=node_modules/@dannycoates \
+      < ${./dannycoates-express-ws-drop-esm-loader.patch}
+  '';
 
-  npmDepsHash = "sha256-ZVegUECrwkn/DlAwqx5VDmcwEIJV/jAAV99Dq29Tm2w=";
+  nodejs = nodejs_22;
+
+  npmDepsFetcherVersion = 2;
+  npmDepsHash = "sha256-QInXcYpZcAOJMS6QFtIapftyWsqA80ef+OiKJ9XEs98=";
 
   nativeBuildInputs = [
     makeBinaryWrapper
@@ -28,11 +36,8 @@ buildNpmPackage rec {
 
   env = {
     PUPPETEER_SKIP_CHROMIUM_DOWNLOAD = "true";
-
     NODE_OPTIONS = "--openssl-legacy-provider";
   };
-
-  makeCacheWritable = true;
 
   npmPackFlags = [ "--ignore-scripts" ];
 
@@ -40,7 +45,7 @@ buildNpmPackage rec {
     cp -r dist $out/lib/node_modules/send/
     ln -s $out/lib/node_modules/send/dist/version.json $out/lib/node_modules/send/version.json
 
-    makeWrapper ${lib.getExe nodejs} $out/bin/send \
+    makeWrapper ${lib.getExe finalAttrs.nodejs} $out/bin/send \
       --add-flags $out/lib/node_modules/send/server/bin/prod.js \
       --set "NODE_ENV" "production"
   '';
@@ -54,7 +59,7 @@ buildNpmPackage rec {
 
   meta = {
     description = "File Sharing Experiment";
-    changelog = "https://github.com/timvisee/send/releases/tag/v${version}";
+    changelog = "https://github.com/timvisee/send/releases/tag/v${finalAttrs.version}";
     homepage = "https://github.com/timvisee/send";
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [
@@ -63,4 +68,4 @@ buildNpmPackage rec {
     ];
     mainProgram = "send";
   };
-}
+})


### PR DESCRIPTION
nodejs_20 is EOL

#515284

`dannycoates-express-ws-drop-esm-loader.patch` is to replace the outdated `esm` runtime loader in `@dannycoates/express-ws` so it works with nodejs_22.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
