### PR TITLE
qml-language-server: init at 1.7.0

### DIFF
--- a/pkgs/by-name/qm/qml-language-server/package.nix
+++ b/pkgs/by-name/qm/qml-language-server/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "qml-language-server";
+  version = "1.7.0";
+
+  src = fetchFromGitHub {
+    owner = "cushycush";
+    repo = "qml-language-server";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1VWTqzVWCJRW2X2xSivdGKul64OEwIVurNqBT3LloqQ=";
+  };
+
+  __structuredAttrs = true;
+
+  vendorHash = "sha256-J+0kFTKgluf+mabJepW+MGXUdHqYLFaUVAZEWcyHmyk=";
+
+  ldflags = [
+    "-s"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  # Regenerate the built-in grammars bundle
+  preBuild = ''
+    make gen-grammar
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Go-based Language Server for QML that provides intelligent code editing features";
+    homepage = "https://github.com/cushycush/qml-language-server";
+    changelog = "https://github.com/cushycush/qml-language-server/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pyrox0 ];
+    mainProgram = "qml-language-server";
+  };
+})


### PR DESCRIPTION
adds [qml-language-server](https://github.com/cushycush/qml-language-server), which is an alternative to `qmlls` that does not depend on an entire qt installation. Also provides more features afaik.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
