### PR TITLE
python313Packages.flask-admin: 2.0.2 -> 2.1.0

### DIFF
--- a/pkgs/development/python-modules/flask-admin/default.nix
+++ b/pkgs/development/python-modules/flask-admin/default.nix
@@ -13,6 +13,8 @@
   # sqlalchemy
   flask-sqlalchemy,
   sqlalchemy,
+  # sqlalchemy-lite
+  flask-sqlalchemy-lite,
   # sqlalchemy-with-utils
   arrow,
   colour,
@@ -50,14 +52,14 @@
 
 buildPythonPackage rec {
   pname = "flask-admin";
-  version = "2.0.2";
+  version = "2.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "flask-admin";
     repo = "flask-admin";
     tag = "v${version}";
-    hash = "sha256-HjK+ddMtT8QJ/KSFj9v28jflf2f6M+Gx1rJjCdWUUFM=";
+    hash = "sha256-xEVsYYwpcHMyvlmUYDviM5MLVz8bWLShUW6GOpfAmro=";
   };
 
   build-system = [ flit-core ];
@@ -74,6 +76,9 @@ buildPythonPackage rec {
     sqlalchemy = [
       flask-sqlalchemy
       sqlalchemy
+    ];
+    sqlalchemy-lite = [
+      flask-sqlalchemy-lite
     ];
     sqlalchemy-with-utils = optional-dependencies.sqlalchemy ++ [
       arrow
@@ -121,6 +126,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ]
   ++ lib.flatten [
+    optional-dependencies.sqlalchemy-lite
     optional-dependencies.sqlalchemy-with-utils
     optional-dependencies.mongoengine
     optional-dependencies.peewee


### PR DESCRIPTION
Diff: https://github.com/flask-admin/flask-admin/compare/v2.0.2...v2.1.0

Changelog: https://github.com/flask-admin/flask-admin/releases/tag/v2.1.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
