### PR TITLE
libfyaml: fixed building issues

### DIFF
--- a/pkgs/by-name/li/libfyaml/package.nix
+++ b/pkgs/by-name/li/libfyaml/package.nix
@@ -25,6 +25,11 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/pantoniou/libfyaml/commit/0982fcefc6a16d4c8cb5b06747d3fc8e630de3ae.diff";
       hash = "sha256-aDubIn+et+1fWE7XU7a5AGZVacVFbAbC1PoSDrA6hXw=";
     })
+    # backport "Fix C11 atomics detection and buggy macros for C++ compatibility"
+    (fetchpatch {
+      url = "https://github.com/pantoniou/libfyaml/commit/1026d76850909dc9b1c5f95b8cd94e865a313fd5.diff";
+      hash = "sha256-0YfOqdqHdELFMqr52TDAC3BNFLkcuxvuJY5b9yZ7NFk=";
+    })
     (fetchpatch {
       url = "https://github.com/pantoniou/libfyaml/commit/9192deaac095f9881cc1e5756dede683f36b09d6.diff";
       hash = "sha256-cNL9wQtxIRg/ShZLJP4qHYNFRrYo9kRG+/U+3FiUeaI=";

--- a/pkgs/by-name/li/libfyaml/package.nix
+++ b/pkgs/by-name/li/libfyaml/package.nix
@@ -34,6 +34,10 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/pantoniou/libfyaml/commit/9192deaac095f9881cc1e5756dede683f36b09d6.diff";
       hash = "sha256-cNL9wQtxIRg/ShZLJP4qHYNFRrYo9kRG+/U+3FiUeaI=";
     })
+    # On Darwin, AX_PTHREAD returns empty PTHREAD_LIBS with -pthread in PTHREAD_CFLAGS;
+    # don't force -lpthread when PTHREAD_CFLAGS already provides pthread support.
+    # Pending PR: https://github.com/pantoniou/libfyaml/pull/294
+    ./pthread-darwin.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libfyaml/package.nix
+++ b/pkgs/by-name/li/libfyaml/package.nix
@@ -38,6 +38,16 @@ stdenv.mkDerivation (finalAttrs: {
     # don't force -lpthread when PTHREAD_CFLAGS already provides pthread support.
     # Pending PR: https://github.com/pantoniou/libfyaml/pull/294
     ./pthread-darwin.patch
+
+    # backport "build: don't output 'none required' to LIBM if no linker flags needed for it"
+    (fetchpatch {
+      url = "https://github.com/pantoniou/libfyaml/commit/24b18e7363b336962fe160c1dc05ca57ba95783c.diff";
+      hash = "sha256-g5QKI4HuS8MEQ9ddIQNC0j+28Dh9zLAp5RaZX5SWBHk=";
+    })
+    (fetchpatch {
+      url = "https://github.com/pantoniou/libfyaml/commit/9f2492ca27bb1fda64f2b12edc2da17406208b93.diff";
+      hash = "sha256-E4wS+P7R3VGrBpD7swWMMi/QPTF+9rzAeEyxhbmdiwk=";
+    })
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libfyaml/pthread-darwin.patch
+++ b/pkgs/by-name/li/libfyaml/pthread-darwin.patch
@@ -1,0 +1,12 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -99,6 +99,7 @@
+ AX_PTHREAD([], [AC_MSG_ERROR("Missing required pthread support")])
+ 
+-# in some cases PTHREAD_LIBS is empty - force -lpthread */
+-if test "x$PTHREAD_LIBS" = "x"; then
++# In some cases PTHREAD_LIBS is empty; force -lpthread only when PTHREAD_CFLAGS
++# also provides no pthread support (e.g. on Darwin, -pthread in CFLAGS suffices).
++if test "x$PTHREAD_LIBS" = "x" && test "x$PTHREAD_CFLAGS" = "x"; then
+ 	PTHREAD_LIBS="-lpthread"
+ fi


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Resolves issues (And code introduced by) the below packages in a universal way. Unclear if #500522 would solve the problem if it was merged.

aides https://github.com/NixOS/nixpkgs/pull/513484. fixes https://github.com/NixOS/nixpkgs/issues/514566. fixes https://github.com/NixOS/nixpkgs/issues/514738. aides #512801

ZHF: #516381

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
