### PR TITLE
fingerd: init at 0.2.2-unstable-2025-11-20

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1190,6 +1190,7 @@
   ./services/networking/fastnetmon-advanced.nix
   ./services/networking/fedimintd.nix
   ./services/networking/ferm.nix
+  ./services/networking/fingerd.nix
   ./services/networking/firefox-syncserver.nix
   ./services/networking/fireqos.nix
   ./services/networking/firewall-firewalld.nix

--- a/nixos/modules/services/networking/fingerd.nix
+++ b/nixos/modules/services/networking/fingerd.nix
@@ -1,0 +1,96 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.fingerd;
+in
+{
+  meta.maintainers = with lib.maintainers; [ philocalyst ];
+
+  options.services.fingerd = {
+    enable = lib.mkEnableOption "the fingerd finger protocol daemon (Go implementation; unprivileged on Linux per golang/go#1435)";
+
+    package = lib.mkPackageOption pkgs "fingerd" { };
+
+    listen = lib.mkOption {
+      type = lib.types.str;
+      default = ":79";
+      example = ":1079";
+      description = ''
+        Address to listen on. Use ":1079" with packet redirection for port 79.
+        See the package documentation for security recommendations.
+      '';
+    };
+
+    homesDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/home";
+      description = "Directory containing user home directories.";
+    };
+
+    aliasFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = "/etc/finger.conf";
+      description = "Path to alias file. Set to null or empty string to disable.";
+    };
+
+    extraFlags = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Additional command-line flags to pass to fingerd.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.fingerd = {
+      description = "Finger daemon (Go implementation)";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        ExecStart = lib.escapeShellArgs (
+          [
+            (lib.getExe cfg.package)
+            "-listen"
+            cfg.listen
+            "-homes-dir"
+            cfg.homesDir
+          ]
+          ++ lib.optionals (cfg.aliasFile != null && cfg.aliasFile != "") [
+            "-alias-file"
+            cfg.aliasFile
+          ]
+          ++ cfg.extraFlags
+        );
+
+        Restart = "always";
+        DynamicUser = true;
+        AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
+        NoNewPrivileges = true;
+        ProtectHome = "read-only";
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        RestrictSUIDSGID = true;
+        RestrictNamespaces = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+        ];
+        ReadOnlyPaths = [
+          "/etc"
+          cfg.homesDir
+        ];
+      };
+    };
+  };
+}

--- a/nixos/modules/services/networking/fingerd.nix
+++ b/nixos/modules/services/networking/fingerd.nix
@@ -7,6 +7,7 @@
 
 let
   cfg = config.services.fingerd;
+  fingerdExe = "${config.security.wrapperDir}/fingerd";
 in
 {
   meta.maintainers = with lib.maintainers; [ philocalyst ];
@@ -46,6 +47,13 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    security.wrappers.fingerd = {
+      owner = "root";
+      group = "root";
+      capabilities = "cap_net_bind_service+p";
+      source = lib.getExe cfg.package;
+    };
+
     systemd.services.fingerd = {
       description = "Finger daemon (Go implementation)";
       after = [ "network.target" ];
@@ -54,7 +62,7 @@ in
       serviceConfig = {
         ExecStart = lib.escapeShellArgs (
           [
-            (lib.getExe cfg.package)
+            fingerdExe
             "-listen"
             cfg.listen
             "-homes-dir"
@@ -69,8 +77,6 @@ in
 
         Restart = "always";
         DynamicUser = true;
-        AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
-        NoNewPrivileges = true;
         ProtectHome = "read-only";
         ProtectKernelTunables = true;
         ProtectKernelModules = true;

--- a/nixos/modules/services/networking/fingerd.nix
+++ b/nixos/modules/services/networking/fingerd.nix
@@ -13,7 +13,7 @@ in
   meta.maintainers = with lib.maintainers; [ philocalyst ];
 
   options.services.fingerd = {
-    enable = lib.mkEnableOption "the fingerd finger protocol daemon (Go implementation; unprivileged on Linux per golang/go#1435)";
+    enable = lib.mkEnableOption "the fingerd finger protocol daemon";
 
     package = lib.mkPackageOption pkgs "fingerd" { };
 
@@ -36,7 +36,7 @@ in
     aliasFile = lib.mkOption {
       type = lib.types.nullOr lib.types.path;
       default = "/etc/finger.conf";
-      description = "Path to alias file. Set to null or empty string to disable.";
+      description = "Path to alias file. Set to null to disable.";
     };
 
     extraFlags = lib.mkOption {
@@ -50,7 +50,9 @@ in
     security.wrappers.fingerd = {
       owner = "root";
       group = "root";
-      capabilities = "cap_net_bind_service+p";
+      # The package must stay an ordinary, unprivileged store artifact. The
+      # NixOS wrapper supplies the effective capability at runtime instead.
+      capabilities = "cap_net_bind_service+ep";
       source = lib.getExe cfg.package;
     };
 
@@ -68,7 +70,7 @@ in
             "-homes-dir"
             cfg.homesDir
           ]
-          ++ lib.optionals (cfg.aliasFile != null && cfg.aliasFile != "") [
+          ++ lib.optionals (cfg.aliasFile != null) [
             "-alias-file"
             cfg.aliasFile
           ]

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -547,6 +547,7 @@ in
   fider = runTest ./fider.nix;
   filebrowser = runTest ./filebrowser.nix;
   filesystems-overlayfs = runTest ./filesystems-overlayfs.nix;
+  fingerd = runTest ./fingerd.nix;
   firefly-iii = runTest ./firefly-iii.nix;
   firefly-iii-data-importer = runTest ./firefly-iii-data-importer.nix;
   firefox = runTest {

--- a/nixos/tests/fingerd.nix
+++ b/nixos/tests/fingerd.nix
@@ -1,0 +1,70 @@
+{ lib, ... }:
+let
+  testUser = "alice";
+  testPlan = "NixOS fingerd smoke test";
+  port = 1079;
+in
+{
+  name = "fingerd";
+  meta.maintainers = with lib.maintainers; [ philocalyst ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      imports = [ ../modules/profiles/minimal.nix ];
+
+      users.users.${testUser} = {
+        isNormalUser = true;
+        createHome = true;
+        description = "Alice Example";
+      };
+
+      services.fingerd = {
+        enable = true;
+        listen = ":${toString port}";
+        aliasFile = null;
+      };
+
+      systemd.services.fingerd-test-data = {
+        wantedBy = [ "multi-user.target" ];
+        before = [ "fingerd.service" ];
+        serviceConfig.Type = "oneshot";
+        script = ''
+          cat > /home/${testUser}/.plan <<'EOF'
+          ${testPlan}
+          EOF
+          chown ${testUser} /home/${testUser}/.plan
+          chmod 0644 /home/${testUser}/.plan
+        '';
+      };
+
+      environment.systemPackages = [
+        (pkgs.writeScriptBin "test-finger" ''
+          #!${pkgs.python3}/bin/python3
+
+          import socket
+
+          with socket.create_connection(("127.0.0.1", ${toString port}), timeout=5) as sock:
+              sock.sendall(b"${testUser}\r\n")
+              data = bytearray()
+              while True:
+                  chunk = sock.recv(4096)
+                  if not chunk:
+                      break
+                  data.extend(chunk)
+
+          print(data.decode("utf-8", errors="replace"))
+        '')
+      ];
+    };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("fingerd.service")
+    machine.wait_for_open_port(${toString port})
+
+    machine.succeed("test-finger | grep -F '${testUser}'")
+    machine.succeed("test-finger | grep -F '${testPlan}'")
+  '';
+}

--- a/nixos/tests/fingerd.nix
+++ b/nixos/tests/fingerd.nix
@@ -2,7 +2,7 @@
 let
   testUser = "alice";
   testPlan = "NixOS fingerd smoke test";
-  port = 1079;
+  port = 79;
 in
 {
   name = "fingerd";
@@ -21,7 +21,6 @@ in
 
       services.fingerd = {
         enable = true;
-        listen = ":${toString port}";
         aliasFile = null;
       };
 

--- a/pkgs/by-name/fi/fingerd/package.nix
+++ b/pkgs/by-name/fi/fingerd/package.nix
@@ -2,10 +2,11 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  stdenv,
   libcap,
-  versionCheckHook,
   nix-update-script,
+  nixosTests,
+  stdenv,
+  versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
@@ -45,6 +46,7 @@ buildGoModule (finalAttrs: {
 
   passthru = {
     updateScript = nix-update-script { };
+    tests.basic = nixosTests.fingerd;
   };
 
   meta = {

--- a/pkgs/by-name/fi/fingerd/package.nix
+++ b/pkgs/by-name/fi/fingerd/package.nix
@@ -13,6 +13,8 @@ buildGoModule (finalAttrs: {
   pname = "fingerd";
   version = "0.2.2-unstable-2025-11-20";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "PennockTech";
     repo = "fingerd";

--- a/pkgs/by-name/fi/fingerd/package.nix
+++ b/pkgs/by-name/fi/fingerd/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  stdenv,
+  libcap,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "fingerd";
+  version = "0.2.2-unstable-2025-11-20";
+
+  src = fetchFromGitHub {
+    owner = "PennockTech";
+    repo = "fingerd";
+    rev = "e013afe1594aa166aa00fcc38530aa5ab93030c8";
+    hash = "sha256-kBEdpiLv0cDNx0QKioPXCVck3n2r9GzY9cVRWb1fTa0=";
+  };
+
+  vendorHash = "sha256-14dLQw6E2QfPH1cYRgGR6ymvbFTsizk3Zsx5ZBpcN6s=";
+
+  subPackages = [ "." ];
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    libcap
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.fingerVersion=${finalAttrs.version}"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "-version";
+
+  # On Linux, does not run as root (avoids golang/go#1435 privilege drop issues);
+  # uses setcap CAP_NET_BIND_SERVICE for port 79 when needed. Run unprivileged.
+  postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
+    setcap 'cap_net_bind_service=+ep' $out/bin/fingerd
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Finger protocol server written in Go with security designed in from the beginning";
+    longDescription = ''
+      A finger protocol server, written in a safe programming language, with security
+      designed in from the beginning and guidance on sandboxing. No operating-system
+      information is revealed, only information explicitly chosen for disclosure.
+    '';
+    homepage = "https://github.com/PennockTech/fingerd";
+    changelog = "https://github.com/PennockTech/fingerd/commits/main/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ philocalyst ];
+    mainProgram = "fingerd";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fi/fingerd/package.nix
+++ b/pkgs/by-name/fi/fingerd/package.nix
@@ -2,10 +2,8 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  libcap,
   nix-update-script,
   nixosTests,
-  stdenv,
   versionCheckHook,
 }:
 
@@ -26,10 +24,6 @@ buildGoModule (finalAttrs: {
 
   subPackages = [ "." ];
 
-  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
-    libcap
-  ];
-
   ldflags = [
     "-s"
     "-w"
@@ -39,12 +33,6 @@ buildGoModule (finalAttrs: {
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "-version";
-
-  # On Linux, does not run as root (avoids golang/go#1435 privilege drop issues);
-  # uses setcap CAP_NET_BIND_SERVICE for port 79 when needed. Run unprivileged.
-  postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
-    setcap 'cap_net_bind_service=+ep' $out/bin/fingerd
-  '';
 
   passthru = {
     updateScript = nix-update-script { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Noticed that Nix didn't have a proper fingerd service, so here we are!
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
