### PR TITLE
python3Packages.aiohttp: 3.13.4 -> 3.13.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1022,6 +1022,12 @@
     githubId = 56970006;
     keys = [ { fingerprint = "50E2 669C AB38 2F4A 5F72  1667 0D6B FC01 D45E DADD"; } ];
   };
+  akosseres = {
+    name = "Ákos Seres";
+    email = "seresakos2000@gmail.com";
+    github = "AkosSeres";
+    githubId = 11257907;
+  };
   akotro = {
     name = "Antonis Kotronakis";
     email = "mail@akotro.dev";

--- a/pkgs/applications/emulators/libretro/cores/puae.nix
+++ b/pkgs/applications/emulators/libretro/cores/puae.nix
@@ -5,13 +5,13 @@
 }:
 mkLibretroCore {
   core = "puae";
-  version = "0-unstable-2026-04-19";
+  version = "0-unstable-2026-05-01";
 
   src = fetchFromGitHub {
     owner = "libretro";
     repo = "libretro-uae";
-    rev = "bd2ef50e22f5ded91cae347e98352f5bd2e7e6c2";
-    hash = "sha256-/C483el8uS2ZhmRpsIXMa0kILxyMyLBqkkySJ78rj+A=";
+    rev = "20e019d4405e33472a3c20824c53bcd79f474a1b";
+    hash = "sha256-4yQtwE7Ghm2/43u2Xcht4WctTNkQjAhMTZtXj4EoJTA=";
   };
 
   makefile = "Makefile";

--- a/pkgs/applications/networking/cluster/helm/plugins/helm-schema.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/helm-schema.nix
@@ -8,16 +8,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "helm-schema";
-  version = "2.3.1";
+  version = "2.4.0";
 
   src = fetchFromGitHub {
     owner = "losisin";
     repo = "helm-values-schema-json";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-F4tfPZnvvagWEO25JOjtYPYDn+8k6sRH0k1UvHIQRzg=";
+    hash = "sha256-2u3cJaSxfHcP9cNknWMdmWm0OjeQX1N2SdJcDGi69Ls=";
   };
 
-  vendorHash = "sha256-2HnbASIZqOPM9WOlZeEQKYbkBHXBjV0JaeKKYAAwQ3w=";
+  vendorHash = "sha256-SWzKgQn9s4Nj54s0N6D+onIbpRwXRvJqWVG8LQ31KQA=";
 
   ldflags = [
     "-s"

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -1031,11 +1031,11 @@
     "vendorHash": "sha256-ofzbDmivXgH1i1Gjhpyp0bk3FDs5SnxwoRuNAWyMqyI="
   },
   "opentelekomcloud_opentelekomcloud": {
-    "hash": "sha256-F8V/eLkKJCC5zPfNh0NC6Z6c3aZjnEoXXa+po3I1NDw=",
+    "hash": "sha256-rhufSDVO6Yu5EXwduREFg3dkA/SkjzTyW3rR+Tqivbg=",
     "homepage": "https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud",
     "owner": "opentelekomcloud",
     "repo": "terraform-provider-opentelekomcloud",
-    "rev": "v1.36.63",
+    "rev": "v1.36.64",
     "spdx": "MPL-2.0",
     "vendorHash": "sha256-qtH6jjhzGRGaHYKjpJLPWjwRL5PQIyOPvI33BVf4cO4="
   },

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -959,13 +959,13 @@
     "vendorHash": "sha256-OAd8SeTqTrH0kMoM2LsK3vM2PI23b3gl57FaJYM9hM0="
   },
   "newrelic_newrelic": {
-    "hash": "sha256-12IlR/UfehtJJQ3aEfXIP189it2GB0EA1PlzbdZyAnk=",
+    "hash": "sha256-j4DQRsw7QP7d83HTIchgSVt3CPUCIJ8CKmuMSKr5GaQ=",
     "homepage": "https://registry.terraform.io/providers/newrelic/newrelic",
     "owner": "newrelic",
     "repo": "terraform-provider-newrelic",
-    "rev": "v3.85.0",
+    "rev": "v3.85.1",
     "spdx": "MPL-2.0",
-    "vendorHash": "sha256-SuraRxReVafvUhniew0gfhlgpHbFJGBMcQOhIqnXYgM="
+    "vendorHash": "sha256-zFg0xT6iLBxnM9ysKB/Dmveffp6Ohbj9akgr6lbU8MI="
   },
   "ns1-terraform_ns1": {
     "hash": "sha256-MX/Wd9Lztjn7uwDzJjs4bsSSp0PFzUgsu4jXke9jHL8=",

--- a/pkgs/by-name/cl/cloudfoundry-cli/package.nix
+++ b/pkgs/by-name/cl/cloudfoundry-cli/package.nix
@@ -8,15 +8,15 @@
 
 buildGoModule (finalAttrs: {
   pname = "cloudfoundry-cli";
-  version = "8.18.0";
+  version = "8.18.3";
 
   src = fetchFromGitHub {
     owner = "cloudfoundry";
     repo = "cli";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-M7fqd7xidW6+9Er/JhIQWliKWWm0YncCFcxry0b6JNk=";
+    sha256 = "sha256-0+osaSI+qOBGMbkVBvoT69qbXLZLHHOs6ML3kx6OIMQ=";
   };
-  vendorHash = "sha256-9BDcCZkOft0H8EEn582/eXg6fd/NzPOBGLnqECP1Dyg=";
+  vendorHash = "sha256-8ozKd8kT+QDgk1t86AIdlRObZPooO77mEFGKcpGCy3s=";
 
   subPackages = [ "." ];
 

--- a/pkgs/by-name/co/codeql/package.nix
+++ b/pkgs/by-name/co/codeql/package.nix
@@ -15,7 +15,7 @@
 
 stdenv.mkDerivation rec {
   pname = "codeql";
-  version = "2.25.2";
+  version = "2.25.3";
 
   dontConfigure = true;
   dontBuild = true;
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   src = fetchzip {
     url = "https://github.com/github/codeql-cli-binaries/releases/download/v${version}/codeql.zip";
-    hash = "sha256-ENPcgyZpvxMK/FXAMQmNLRFH9o6K82EOEpzzJR+YO5s=";
+    hash = "sha256-dOoGJk3YT35XlykbXcpkURXP7HUNorJPUdPF0K9v92U=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ek/eksctl/package.nix
+++ b/pkgs/by-name/ek/eksctl/package.nix
@@ -8,16 +8,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "eksctl";
-  version = "0.225.0";
+  version = "0.226.0";
 
   src = fetchFromGitHub {
     owner = "weaveworks";
     repo = "eksctl";
     rev = finalAttrs.version;
-    hash = "sha256-aGIn6/CHC/0RGgVQJbye09V5cT2gXYhvihUv4J/1l6g=";
+    hash = "sha256-XjiM4o4xJPY+ZFtvWi5K99tQaZwNxiCla/jUeQQo+5E=";
   };
 
-  vendorHash = "sha256-6f/w++wQdedkzvwkktDvpmpkR5eCJvG2twCSKxY49ZQ=";
+  vendorHash = "sha256-HP0EdZeM2Nz6LI3EjVT7qPl47Suh45OjWptEHgqqvhg=";
 
   doCheck = false;
 

--- a/pkgs/by-name/fa/faudio/package.nix
+++ b/pkgs/by-name/fa/faudio/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "faudio";
-  version = "26.04";
+  version = "26.05";
 
   src = fetchFromGitHub {
     owner = "FNA-XNA";
     repo = "FAudio";
     tag = finalAttrs.version;
-    hash = "sha256-Vbz/7C8yHgNJBnh8Tk5HsEcbpiQwqL0dj0T0afEZXRw=";
+    hash = "sha256-VrY6NbmnUk6fUEa3+NukcuPRaH+RbFrT9bnN4Rnuxuk=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/gg/ggml/package.nix
+++ b/pkgs/by-name/gg/ggml/package.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ggml";
-  version = "0.10.0";
+  version = "0.10.1";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "ggml-org";
     repo = "ggml";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-2Yu7kFKu2VaiGGkb0r+L59VbcWijtWZyJmuyXLb+414=";
+    hash = "sha256-fwENyDSRq6ecq0zKC4nnpJCs9X15et+JFTQKX4gLDng=";
   };
 
   # The cmake package does not handle absolute CMAKE_INSTALL_LIBDIR and CMAKE_INSTALL_INCLUDEDIR

--- a/pkgs/by-name/gh/gh-gei/package.nix
+++ b/pkgs/by-name/gh/gh-gei/package.nix
@@ -7,13 +7,13 @@
 
 buildDotnetModule rec {
   pname = "gh-gei";
-  version = "1.28.0";
+  version = "1.29.0";
 
   src = fetchFromGitHub {
     owner = "github";
     repo = "gh-gei";
     rev = "v${version}";
-    hash = "sha256-8KVEI6k3MWYYEJVi/fyXCDS6DpNwtEr1uz4JEz2R+WY=";
+    hash = "sha256-qHlORWmMBHo8PtuGG4JaWdkCdIdybNfzWDEM/JNlCOc=";
   };
 
   dotnet-sdk = dotnetCorePackages.sdk_8_0_4xx;

--- a/pkgs/by-name/gh/gh-ost/package.nix
+++ b/pkgs/by-name/gh/gh-ost/package.nix
@@ -7,13 +7,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "gh-ost";
-  version = "1.1.8";
+  version = "1.1.9";
 
   src = fetchFromGitHub {
     owner = "github";
     repo = "gh-ost";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-U92rdk/9JIMOjN1cJSdAVYgR1f7aKY0nyfBbwe7517M=";
+    hash = "sha256-wnHPFPA0ql6KWN9+ZvzIdXwaAhFdBc94UJK7+4no1NU=";
   };
 
   vendorHash = null;

--- a/pkgs/by-name/gh/ghalint/package.nix
+++ b/pkgs/by-name/gh/ghalint/package.nix
@@ -9,16 +9,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "ghalint";
-  version = "1.5.5";
+  version = "1.5.6";
 
   src = fetchFromGitHub {
     owner = "suzuki-shunsuke";
     repo = "ghalint";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-xAXcvvSwcJjdG2BCItBLdsu6vZiID5FmRYYF9PZe1QE=";
+    hash = "sha256-u85vX9lg5JKUvRjFloE4KZUm/qs8RmjoY/hybtJk/kc=";
   };
 
-  vendorHash = "sha256-XIalA/usvyvzrvGU7Ygf1DWSlTm1YYaN+X0Xm+YiiTI=";
+  vendorHash = "sha256-n++Rq79KHyRVhIXIdN9IOADTGEG73Wl2SUq/YEo++WM=";
 
   subPackages = [ "cmd/ghalint" ];
 

--- a/pkgs/by-name/go/goose/package.nix
+++ b/pkgs/by-name/go/goose/package.nix
@@ -7,17 +7,17 @@
 
 buildGoModule (finalAttrs: {
   pname = "goose";
-  version = "3.27.0";
+  version = "3.27.1";
 
   src = fetchFromGitHub {
     owner = "pressly";
     repo = "goose";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-wpnheZJ2+xnk8N/hE5Cyf38/yODQC5+SlDml9vH0oRw=";
+    hash = "sha256-dzeB5QXjQAyJlaM6I82C4gNoj7ELA4sgkfHkXADN9+Y=";
   };
 
   proxyVendor = true;
-  vendorHash = "sha256-0G6kE5ScpsIG2hLzZ9hnyig4LuN6rTdwirR+ldC2+ps=";
+  vendorHash = "sha256-JsLpcV5SSBin6U7Kj5O0mhXNdIwyV+xdteEJBxW8zuY=";
 
   # skipping: end-to-end tests require a docker daemon
   postPatch = ''

--- a/pkgs/by-name/gp/gpac/package.nix
+++ b/pkgs/by-name/gp/gpac/package.nix
@@ -63,12 +63,12 @@ let
     };
   };
   unstable = {
-    version = "2.4.0-unstable-2026-01-30";
+    version = "26.02.0-unstable-2026-04-29";
     src = fetchFromGitHub {
       owner = "gpac";
       repo = "gpac";
-      rev = "2166130136223373dad2ef3fb72e4cbd129cb468";
-      hash = "sha256-Iw4UAKjFnV+NiG77VOfHUHPle5+YAIavtGmtrD3Uebw=";
+      rev = "525bf1af642c30af04e4df5345e6d798c0a4d8a1";
+      hash = "sha256-G/4gefsS2hUKo8VEt80YZOaGJSjrzXFrdHO/u33BiDw=";
     };
     updateScript = unstableGitUpdater {
       tagFormat = "v*";

--- a/pkgs/by-name/gr/grafanactl/package.nix
+++ b/pkgs/by-name/gr/grafanactl/package.nix
@@ -8,16 +8,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "grafanactl";
-  version = "0.1.9";
+  version = "0.1.10";
 
   src = fetchFromGitHub {
     owner = "grafana";
     repo = "grafanactl";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-TJoTxVKfG2mfV05pkAxUJR7NKZbD9VIqRW4H8lyP2As=";
+    hash = "sha256-tlSV7yhk5ByiGm39IGo/PZHuHtyyV5QjHqDB5w3UWBM=";
   };
 
-  vendorHash = "sha256-zEE4iaZJBneYgo6avCOTG7tWZ88NDskPTYiCMb8pRR4=";
+  vendorHash = "sha256-DOEByenSD4BCQuyyLQvJxC7/UkPmpHZemMEKZbOwLbE=";
 
   ldflags = [
     "-X main.version=v${finalAttrs.version}"

--- a/pkgs/by-name/jp/jp-zip-codes/package.nix
+++ b/pkgs/by-name/jp/jp-zip-codes/package.nix
@@ -7,15 +7,15 @@
 
 stdenvNoCC.mkDerivation {
   pname = "jp-zip-code";
-  version = "0-unstable-2026-04-01";
+  version = "0-unstable-2026-05-01";
 
   # This package uses a mirror as the source because the
   # original provider uses the same URL for updated content.
   src = fetchFromGitHub {
     owner = "musjj";
     repo = "jp-zip-codes";
-    rev = "5404779eb05849c61c70c4489d117bcb36ea19ab";
-    hash = "sha256-pysW1hAj8acTFOytYw/ZXknUlRP+JUvh4Ia2I2CwA6A=";
+    rev = "fd586719e8b6c55763e015963eb2b7cb7383ffec";
+    hash = "sha256-88Vr1YySNT1Z+1rqxzT6Mccv/v6wL+HtW10Fmt3SXoA=";
   };
 
   installPhase = ''

--- a/pkgs/by-name/ka/kando/add-deep-link-note.patch
+++ b/pkgs/by-name/ka/kando/add-deep-link-note.patch
@@ -1,0 +1,12 @@
+diff --git a/src/main/index.ts b/src/main/index.ts
+index ad541ba..7879fdb 100644
+--- a/src/main/index.ts
++++ b/src/main/index.ts
+@@ -122,6 +122,7 @@ try {
+ 
+   if (!deepLinkSupport) {
+     console.error('Failed to register kando:// protocol. Deep links will not work.');
++    console.log("Note for nixpkgs: If you're using NixOS or home-manager on Linux, it should still work.")
+   }
+ 
+   // Choose the backend to use. We quit the app if no backend is found.

--- a/pkgs/by-name/ka/kando/package.nix
+++ b/pkgs/by-name/ka/kando/package.nix
@@ -26,16 +26,20 @@ let
 in
 buildNpmPackage.override { inherit nodejs; } rec {
   pname = "kando";
-  version = "2.1.2";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "kando-menu";
     repo = "kando";
     tag = "v${version}";
-    hash = "sha256-x+emk0N5AL5Nfk9d1+RehdLoEvqVe5DafZL1WRPFdrc=";
+    hash = "sha256-eCR+CL3EMV3eLXzpzKFGuec3YBWDnFjNyTEHpG51PLQ=";
   };
 
-  npmDepsHash = "sha256-zbPrQpm2IgIMqGvMzj6fzEV/lV/FszfU3fnFx3kPHr4=";
+  patches = [
+    ./add-deep-link-note.patch
+  ];
+
+  npmDepsHash = "sha256-VsWmM+CSAv3yFVelFNb3kUAeh4t+k04NFXVRz4AwFkI=";
 
   npmFlags = [ "--ignore-scripts" ];
 
@@ -130,6 +134,7 @@ buildNpmPackage.override { inherit nodejs; } rec {
       genericName = "Pie Menu";
       comment = "The Cross-Platform Pie Menu";
       categories = [ "Utility" ];
+      mimeTypes = [ "x-scheme-handler/kando" ];
     })
   ];
 

--- a/pkgs/by-name/li/libbluray/package.nix
+++ b/pkgs/by-name/li/libbluray/package.nix
@@ -7,7 +7,7 @@
   meson,
   ninja,
   withJava ? false,
-  jdk21_headless,
+  jdk21,
   jre21_minimal, # Newer JDK's depend on a release with a fix for https://code.videolan.org/videolan/libbluray/-/issues/46
   ant,
   stripJavaArchivesHook,
@@ -31,7 +31,7 @@ let
       "java.rmi"
       "java.xml"
     ];
-    jdk = jdk21_headless;
+    jdk = jdk21;
   };
 in
 stdenv.mkDerivation rec {
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
     pkg-config
   ]
   ++ lib.optionals withJava [
-    jdk21_headless
+    jdk21
     ant
     stripJavaArchivesHook
   ];

--- a/pkgs/by-name/li/lilypond-unstable/package.nix
+++ b/pkgs/by-name/li/lilypond-unstable/package.nix
@@ -7,11 +7,11 @@
 
 lilypond.overrideAttrs (
   finalAttrs: prevAttrs: {
-    version = "2.25.34";
+    version = "2.27.0";
 
     src = fetchzip {
       url = "https://lilypond.org/download/sources/v${lib.versions.majorMinor finalAttrs.version}/lilypond-${finalAttrs.version}.tar.gz";
-      hash = "sha256-UFuL8TZ7uLZhXgFoMGxAye04dNcvrw1gqQMOnE4P2fc=";
+      hash = "sha256-uZKpHmuYFkmj1kI+D09rPNLov83EO1QdXyUSSscBRPE=";
     };
 
     patches = [ ];

--- a/pkgs/by-name/li/lisette/package.nix
+++ b/pkgs/by-name/li/lisette/package.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "lisette";
-  version = "0.1.17";
+  version = "0.1.23";
 
   src = fetchFromGitHub {
     owner = "ivov";
     repo = "lisette";
     tag = "lisette-v${finalAttrs.version}";
-    hash = "sha256-PzQQd5tgn3g+Gq0qVe8p9FSbIIpR178fDXvGcwmdcvU=";
+    hash = "sha256-sSNQKVfclSXXt1hp1AVBUKAjLhG9RSKxpoC8zWvOSz4=";
   };
 
-  cargoHash = "sha256-3g8Vqr2PydVvp1k7E2fJGrDc1n5OjSQ7Ksl/UKEwWns=";
+  cargoHash = "sha256-MlRx0lXuGyz7P8DT2tCsxVQ/W5P+W5+8YBt43wTz2IE=";
 
   preCheck = ''
     export NO_COLOR=true

--- a/pkgs/by-name/lr/lrcget/package.nix
+++ b/pkgs/by-name/lr/lrcget/package.nix
@@ -22,13 +22,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "lrcget";
-  version = "2.0.1";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "tranxuanthang";
     repo = "lrcget";
     tag = version;
-    hash = "sha256-3dqE64IVvsrY33v3LoLUDJ+g6T5CvePIINWdqidDPdQ=";
+    hash = "sha256-cxQpCuyFsJeujcL2TPMH7n+Q6l4h+P1HvsrMoFmbWMI=";
   };
 
   patches = [
@@ -39,7 +39,7 @@ rustPlatform.buildRustPackage rec {
   cargoRoot = "src-tauri";
   buildAndTestSubdir = "src-tauri";
 
-  cargoHash = "sha256-YRPMzFChmk5laah8yyRtMaUYH/uSOLUIAtl7wTl/qU0=";
+  cargoHash = "sha256-9vyvRJsR4o7kWSLJyGIoiM/13ABWWTrRXVdyU2HfJ+E=";
 
   # FIXME: This is a workaround, because we have a git dependency node_modules/lrc-kit contains install scripts
   # but has no lockfile, which is something that will probably break.

--- a/pkgs/by-name/ma/matrix-alertmanager-receiver/package.nix
+++ b/pkgs/by-name/ma/matrix-alertmanager-receiver/package.nix
@@ -8,16 +8,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "matrix-alertmanager-receiver";
-  version = "2026.4.15";
+  version = "2026.4.29";
 
   src = fetchFromGitHub {
     owner = "metio";
     repo = "matrix-alertmanager-receiver";
     tag = finalAttrs.version;
-    hash = "sha256-E9L2lmLxA6X+iomNe4SwvLMh3I01zTgTE4Ot4VUstBs=";
+    hash = "sha256-QcxPWVA6l5AB42K/4nHszB1kz399+Cjkuu98Zpqq4oE=";
   };
 
-  vendorHash = "sha256-SOik+mNGpC/G8Hr2RtOBUxJu5McRRqv24FOFvaDxT3I=";
+  vendorHash = "sha256-ajJ+jSjq7+7QyxAU72bfKMf0KJQzxraQfiRrxQ63rEY=";
 
   env.CGO_ENABLED = "0";
 

--- a/pkgs/by-name/ma/matterircd/package.nix
+++ b/pkgs/by-name/ma/matterircd/package.nix
@@ -6,13 +6,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "matterircd";
-  version = "0.28.0";
+  version = "0.29.0";
 
   src = fetchFromGitHub {
     owner = "42wim";
     repo = "matterircd";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-qA07i31fGLLIfWoCBW1f5nvf4AWEIkSXZh22F6rRnpM=";
+    sha256 = "sha256-7pOhUeUT95nk6kk03xAaIYHgXwr09m6LSbib2YSi1Ck=";
   };
 
   vendorHash = null;

--- a/pkgs/by-name/mu/multica-cli/package.nix
+++ b/pkgs/by-name/mu/multica-cli/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+}:
+
+buildGoModule rec {
+  __structuredAttrs = true;
+
+  pname = "multica-cli";
+  version = "0.2.21";
+
+  src = fetchFromGitHub {
+    owner = "multica-ai";
+    repo = "multica";
+    rev = "v${version}";
+    hash = "sha256-13xhPBLV3aWf5ESn4L2rGXXFTrYVejF+HQnTCGlE1bg=";
+  };
+
+  sourceRoot = "${src.name}/server";
+
+  vendorHash = "sha256-1rifzInFK8od9XAYWEuHU16ni2+gaDhlDIHc7WeuLU4=";
+
+  subPackages = [ "cmd/multica" ];
+
+  env.CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${version}"
+    "-X main.commit=nixpkg"
+    "-X main.date=1970-01-01T00:00:00Z"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installShellCompletion --cmd multica \
+      --bash <($out/bin/multica completion bash) \
+      --zsh <($out/bin/multica completion zsh) \
+      --fish <($out/bin/multica completion fish)
+  '';
+
+  meta = {
+    description = "CLI for the Multica managed agents platform";
+    homepage = "https://github.com/multica-ai/multica";
+    changelog = "https://github.com/multica-ai/multica/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ akosseres ];
+    mainProgram = "multica";
+  };
+}

--- a/pkgs/by-name/no/nova/package.nix
+++ b/pkgs/by-name/no/nova/package.nix
@@ -6,16 +6,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "nova";
-  version = "3.11.14";
+  version = "3.12.0";
 
   src = fetchFromGitHub {
     owner = "FairwindsOps";
     repo = "nova";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-leMDcw17rD08zIcJ9mkcD0VJE0o8pS6F31nFjDLT67Q=";
+    hash = "sha256-eIsysSJw090BdGNG/5rPqwCE7Ci2HiKWEw+Gx9UXHYQ=";
   };
 
-  vendorHash = "sha256-OICuGfnMkx25GL5aoaozselXgJxOZt3vANCSan2ZGs8=";
+  vendorHash = "sha256-nXzJkcUbIGVxnuyx51NeXOI9Y/D/Fg/TkmrH7MLYzfQ=";
 
   ldflags = [
     "-X main.version=${finalAttrs.version}"

--- a/pkgs/by-name/op/openbox/package.nix
+++ b/pkgs/by-name/op/openbox/package.nix
@@ -15,6 +15,7 @@
   libsm,
   imlib2,
   pango,
+  bashNonInteractive,
   libstartup_notification,
   makeWrapper,
 }:
@@ -27,10 +28,12 @@ stdenv.mkDerivation (finalAttrs: {
     autoreconfHook
     pkg-config
     makeWrapper
+    python3
     python3.pkgs.wrapPython
   ];
 
   buildInputs = [
+    bashNonInteractive
     libxml2
     libxinerama
     libxcursor
@@ -46,6 +49,8 @@ stdenv.mkDerivation (finalAttrs: {
     pango
     imlib2
   ];
+
+  strictDeps = true;
 
   pythonPath = with python3.pkgs; [
     pyxdg

--- a/pkgs/by-name/op/openbox/package.nix
+++ b/pkgs/by-name/op/openbox/package.nix
@@ -18,6 +18,7 @@
   bashNonInteractive,
   libstartup_notification,
   makeWrapper,
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -93,6 +94,9 @@ stdenv.mkDerivation (finalAttrs: {
     wrapProgram "$out/bin/openbox-kde-session" --prefix XDG_DATA_DIRS : "$out/share"
     wrapPythonProgramsIn "$out/libexec" "$out ''${pythonPath[*]}"
   '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   meta = {
     description = "X window manager for non-desktop embedded systems";

--- a/pkgs/by-name/pa/pangolin-cli/package.nix
+++ b/pkgs/by-name/pa/pangolin-cli/package.nix
@@ -10,20 +10,20 @@
 
 buildGoModule (finalAttrs: {
   pname = "pangolin-cli";
-  version = "0.6.1";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "fosrl";
     repo = "cli";
     tag = finalAttrs.version;
-    hash = "sha256-WKwoQIE3ibIJKiEGM8kWJ/7O+HjSyRJkLF1qyaVshOE=";
+    hash = "sha256-0G5HsAa9I0ilPQ92qQIuYssfGvoZhLrF3kyO1+0JqEQ=";
   };
 
   ldflags = [
     "-X github.com/fosrl/cli/internal/version.Version=${finalAttrs.version}"
   ];
 
-  vendorHash = "sha256-eBrglhyqKy6pG9eF0yfJdCOLxeWys4atKAp9Jgtzdj8=";
+  vendorHash = "sha256-FCIp0VLmRO6TUPRDNd3Zl/CULwy00D8F4YTo/oQge+s=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/pa/patroni/package.nix
+++ b/pkgs/by-name/pa/patroni/package.nix
@@ -23,14 +23,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "patroni";
-  version = "4.1.1";
+  version = "4.1.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "zalando";
     repo = "patroni";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-IEoO50MaEnXevS0HOzend19UHNA12CjDAUBB8fZxTkI=";
+    hash = "sha256-P64smYmLJyuqMpqYY2lRbZwupfYBsg03FrzUZ6CBGpI=";
   };
 
   build-system = with python3Packages; [ setuptools ];

--- a/pkgs/by-name/st/stress-ng/package.nix
+++ b/pkgs/by-name/st/stress-ng/package.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "stress-ng";
-  version = "0.21.00";
+  version = "0.21.01";
 
   src = fetchFromGitHub {
     owner = "ColinIanKing";
     repo = "stress-ng";
     tag = "V${finalAttrs.version}";
-    hash = "sha256-kFIrbt/jJuQnuWmQUBuiFGuAfBb2pUtujhj6bwpDF4k=";
+    hash = "sha256-GC9FN8nHhBLS9E+7kN0aNAIo8VbUIPG26/bRUarsiIc=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/ti/tinfoil-cli/package.nix
+++ b/pkgs/by-name/ti/tinfoil-cli/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "tinfoil-cli";
-  version = "0.12.3";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "tinfoilsh";
     repo = "tinfoil-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ykaJRuMpcXKBBDFC5jft7BIcSREz3xYxxmNgVHWcacI=";
+    hash = "sha256-HfKcuonVpUzE2aTR1GX4jrlhrNPBotbZuEjRvJs0Xkc=";
   };
 
-  vendorHash = "sha256-+CZ4Jjl+Ynn0J0cNol9djSs1AkjD8YzVgg8qoRF2tDQ=";
+  vendorHash = "sha256-b6UmayV913SVyV5+1BMZiRM7SV/Asau6xkx87DWTf9k=";
 
   # The attestation test requires internet access
   checkFlags = [ "-skip=TestAttestationVerifySEV" ];

--- a/pkgs/by-name/ud/udunits/package.nix
+++ b/pkgs/by-name/ud/udunits/package.nix
@@ -32,6 +32,10 @@ stdenv.mkDerivation {
     expat
   ];
 
+  configureFlags = [
+    "CFLAGS=-std=gnu17"
+  ];
+
   meta = {
     homepage = "https://www.unidata.ucar.edu/software/udunits/";
     description = "C-based package for the programatic handling of units of physical quantities";

--- a/pkgs/by-name/zi/zigbee2mqtt/package.nix
+++ b/pkgs/by-name/zi/zigbee2mqtt/package.nix
@@ -14,20 +14,20 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "zigbee2mqtt";
-  version = "2.9.2";
+  version = "2.10.0";
 
   src = fetchFromGitHub {
     owner = "Koenkk";
     repo = "zigbee2mqtt";
     tag = finalAttrs.version;
-    hash = "sha256-LdrsHOeRXeNccpf1UNg20y82M75PGt070zVbmQYYsVg=";
+    hash = "sha256-PwpRa6sbHyWmaIG8U0nkZqxzjKuw44Cnez8yVhuajZQ=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_9;
     fetcherVersion = 3;
-    hash = "sha256-uYzY1ixKTughpc6JfoMmp4/RKdgP1cKBuMMLZspSx18=";
+    hash = "sha256-qhX7fEcxG5eFM3gM/OwMk5QSB4bnt9VS3ZxMh7VGdNw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lomiri/applications/lomiri-mediaplayer-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-mediaplayer-app/default.nix
@@ -116,8 +116,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Media Player application for Ubuntu Touch devices";
-    homepage = "https://gitlab.com/ubports/development/apps/lomiri-mediaplayer-app";
-    changelog = "https://gitlab.com/ubports/development/apps/lomiri-mediaplayer-app/-/blob/${
+    homepage = "https://gitlab.com/ubports/development/core/lomiri-mediaplayer-app";
+    changelog = "https://gitlab.com/ubports/development/core/lomiri-mediaplayer-app/-/blob/${
       if (!isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
     }/ChangeLog";
     license = with lib.licenses; [

--- a/pkgs/development/python-modules/accelerate/default.nix
+++ b/pkgs/development/python-modules/accelerate/default.nix
@@ -34,14 +34,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "accelerate";
-  version = "1.12.0";
+  version = "1.13.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "huggingface";
     repo = "accelerate";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-PwwaQSLOm+8Hd3trM1P+jRhYyoWM3QxOe5XT99haEmg=";
+    hash = "sha256-IfKePiU38fUd5HefaS7J1s8Mb6hVmldINemxAJY+83o=";
   };
 
   buildInputs = [ llvmPackages.openmp ];
@@ -180,15 +180,7 @@ buildPythonPackage (finalAttrs: {
   ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
     # RuntimeError: torch_shm_manager: execl failed: Permission denied
     "CheckpointTest"
-  ]
-  ++
-    lib.optionals
-      (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64 && (pythonAtLeast "3.14"))
-      [
-        # https://github.com/huggingface/accelerate/issues/3899
-        "test_accelerate_test"
-        "test_cpu"
-      ];
+  ];
 
   disabledTestPaths = lib.optionals (!(stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64)) [
     # numerous instances of torch.multiprocessing.spawn.ProcessRaisedException:

--- a/pkgs/development/python-modules/acme-tiny/default.nix
+++ b/pkgs/development/python-modules/acme-tiny/default.nix
@@ -11,13 +11,13 @@
 
 buildPythonPackage rec {
   pname = "acme-tiny";
-  version = "5.0.2";
+  version = "5.0.3";
   pyproject = true;
 
   src = fetchPypi {
     pname = "acme_tiny";
     inherit version;
-    hash = "sha256-s84ZVYPcLxOnxvqQBS+Ks0myMtvCZ62cv0co6u2E3dg=";
+    hash = "sha256-LV64B+JZhq69qbBJ2dFG8YW6/q1u+x6MxB1rQrm8pjw=";
   };
 
   patchPhase = ''

--- a/pkgs/development/python-modules/aioghost/default.nix
+++ b/pkgs/development/python-modules/aioghost/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "aioghost";
-  version = "0.4.11";
+  version = "0.4.12";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "TryGhost";
     repo = "aioghost";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-RRfPM86ulC+9VhW6trQoGhOKwhP45jn5a6PSw8PkEA4=";
+    hash = "sha256-wz0c2bJIUGkU5niIhJWXthsVToatsuoOzix+VBnETL0=";
   };
 
   build-system = [ hatchling ];

--- a/pkgs/development/python-modules/cloudpathlib/default.nix
+++ b/pkgs/development/python-modules/cloudpathlib/default.nix
@@ -27,14 +27,14 @@
 
 buildPythonPackage rec {
   pname = "cloudpathlib";
-  version = "0.23.0";
+  version = "0.24.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "drivendataorg";
     repo = "cloudpathlib";
     tag = "v${version}";
-    hash = "sha256-lRZYWGX3Yqs1GTIL3ugOiu+K9RF6vJdbKP/SZAStHLc=";
+    hash = "sha256-MpCgK1JnQ/Etp0EyH5z6iknrQeJ4Wn6rwBw2EjgVAic=";
   };
 
   postPatch =

--- a/pkgs/development/python-modules/copier/default.nix
+++ b/pkgs/development/python-modules/copier/default.nix
@@ -28,7 +28,7 @@
 
 buildPythonPackage rec {
   pname = "copier";
-  version = "9.14.3";
+  version = "9.15.0";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     postFetch = ''
       rm $out/tests/demo/doc/ma*ana.txt
     '';
-    hash = "sha256-wRYqpdMsxm2AHaLpdhsdkC6oDZP2a3VXJx/pNNrQieM=";
+    hash = "sha256-KHmnY8+65KdO9wzywiY8fYAVgyMChSUWbEW569IFYnk=";
   };
 
   env.POETRY_DYNAMIC_VERSIONING_BYPASS = version;

--- a/pkgs/development/python-modules/epitran/default.nix
+++ b/pkgs/development/python-modules/epitran/default.nix
@@ -17,14 +17,14 @@
 
 buildPythonPackage rec {
   pname = "epitran";
-  version = "1.34.0";
+  version = "1.35.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "dmort27";
     repo = "epitran";
     tag = "v${version}";
-    hash = "sha256-LKESBSLn2gpXx8kEXmykEkTboIMiS5gZ2Kb9rj1lDTk=";
+    hash = "sha256-XXEZEptrVH+wfWm85B8yZ+RI+6AUZjWFKMjst/V7aE0=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/hstspreload/default.nix
+++ b/pkgs/development/python-modules/hstspreload/default.nix
@@ -7,14 +7,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "hstspreload";
-  version = "2026.4.1";
+  version = "2026.5.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "sethmlarson";
     repo = "hstspreload";
     tag = finalAttrs.version;
-    hash = "sha256-ve2tBOuSL/GWpnOK+AuFtNNXtSPDWj7Cz5LiVAVjrwU=";
+    hash = "sha256-QmhQJqt75rP5YWBLJ3fA7Ud7o6AWIpUUSoJ5tAA9pPo=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/mediafile/default.nix
+++ b/pkgs/development/python-modules/mediafile/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "mediafile";
-  version = "0.16.2";
+  version = "0.17.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "beetbox";
     repo = "mediafile";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-H7WVA5JF6bmKCLV0siGt8Jp+WE1q8z4aQrugOUW06K0=";
+    hash = "sha256-FujuFkZH0wjZcd3wIpJw8mDvE/2/mew5tfxAyxA2RkI=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/modelsearch/default.nix
+++ b/pkgs/development/python-modules/modelsearch/default.nix
@@ -21,14 +21,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "modelsearch";
-  version = "1.3";
+  version = "1.3.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "wagtail";
     repo = "django-modelsearch";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-eQ0ZWUR9xXm0RkBpZ3Z+ruxlWvJdWed2sX6XkZIAZBk=";
+    hash = "sha256-UH1t/CXJ7OX250SoUZYKMIAHuCxYxOT6l79RXI/oMLs=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/nuclear/default.nix
+++ b/pkgs/development/python-modules/nuclear/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "nuclear";
-  version = "2.7.1";
+  version = "2.8.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "igrek51";
     repo = "nuclear";
     rev = version;
-    hash = "sha256-AMjFncP7dfKcbNJvHTtmVdLCZVNLqUTmQt+qdlzXhqQ=";
+    hash = "sha256-hoOvISKjl5XTxtv8I3BSkOI7oZFSL+yA3NiYceJGcIY=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/py2vega/default.nix
+++ b/pkgs/development/python-modules/py2vega/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "py2vega";
-  version = "0.6.1";
+  version = "0.7.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "QuantStack";
     repo = "py2vega";
     tag = version;
-    hash = "sha256-M6vrObEj4cB53nvEi1oQdVWABlqGwG3xc2unY44Yhuc=";
+    hash = "sha256-GU4mSOHsU/DPBdKFau6pOYQpaojXOfQIXrSG3skWr/I=";
   };
 
   pythonRelaxDeps = [ "gast" ];

--- a/pkgs/development/python-modules/pyghmi/default.nix
+++ b/pkgs/development/python-modules/pyghmi/default.nix
@@ -14,12 +14,12 @@
 
 buildPythonPackage rec {
   pname = "pyghmi";
-  version = "1.6.15";
+  version = "1.6.16";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-dautNibA/fg/ZMqn1iPXCIVVcnr4Eq33Ueg5vjM59TU=";
+    hash = "sha256-VqMQ54Mx9fkq3UAbzEApzm0LuRKEGXQARf8HGH7yZ6U=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/pynmeagps/default.nix
+++ b/pkgs/development/python-modules/pynmeagps/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pynmeagps";
-  version = "1.1.2";
+  version = "1.1.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "semuconsulting";
     repo = "pynmeagps";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-0Jgo2lQwftnJfzaaxN2dA9D1ACvWMuOLVac/P/I9ty4=";
+    hash = "sha256-uVIlr+zRwbaQqtInJqCebzMR5pe7dEls3gVzbW7TYkQ=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/sagemaker-mlflow/default.nix
+++ b/pkgs/development/python-modules/sagemaker-mlflow/default.nix
@@ -17,14 +17,14 @@
 
 buildPythonPackage rec {
   pname = "sagemaker-mlflow";
-  version = "0.2.0";
+  version = "0.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "aws";
     repo = "sagemaker-mlflow";
     tag = "v${version}";
-    hash = "sha256-EmfEqL+J+cZVdBfUJtAPHpUZCoDV4X1yRfVJYWky1HU=";
+    hash = "sha256-riCoUpao9QIrQMb7r9stJO/xTSsDfL+uNS664W5GRQc=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/sphinx-codeautolink/default.nix
+++ b/pkgs/development/python-modules/sphinx-codeautolink/default.nix
@@ -17,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "sphinx-codeautolink";
-  version = "0.17.5";
+  version = "0.18.1";
   pyproject = true;
 
   outputs = [
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     owner = "felix-hilden";
     repo = "sphinx-codeautolink";
     tag = "v${version}";
-    hash = "sha256-43XDCajH+uSHnofjK/gH4EAiv2ljjuBr8UbJtm/DsDI=";
+    hash = "sha256-kNnz8MzffqPCxS0uXdbw2ntcdGnz6KDBanFug5+SjOk=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/temporalio/default.nix
+++ b/pkgs/development/python-modules/temporalio/default.nix
@@ -25,7 +25,7 @@
 
 buildPythonPackage rec {
   pname = "temporalio";
-  version = "1.25.0";
+  version = "1.26.0";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     repo = "sdk-python";
     tag = version;
     fetchSubmodules = true;
-    hash = "sha256-o6QesUL9he2q5o+HDUA6Orb3uM6jWiWkN7uYbkhXopY=";
+    hash = "sha256-mCx7IP3/KUDTzmzgwBIpzi2UFf9gNFxlSrBpOyPm/xs=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {

--- a/pkgs/development/python-modules/url-normalize/default.nix
+++ b/pkgs/development/python-modules/url-normalize/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "url-normalize";
-  version = "2.2.1";
+  version = "3.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "niksite";
     repo = "url-normalize";
     tag = "v${version}";
-    hash = "sha256-ZFY1KMEHvteMFVM3QcYjCiTz3dLxRWyv/dZQMzVxGvo=";
+    hash = "sha256-RZORbZfeRfzGJFsLXJUuqXVFsD8TfcHzjBGb80cTetQ=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/url-normalize/default.nix
+++ b/pkgs/development/python-modules/url-normalize/default.nix
@@ -9,7 +9,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "url-normalize";
   version = "3.0.0";
   pyproject = true;
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "niksite";
     repo = "url-normalize";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-RZORbZfeRfzGJFsLXJUuqXVFsD8TfcHzjBGb80cTetQ=";
   };
 
@@ -34,10 +34,10 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "url_normalize" ];
 
   meta = {
-    changelog = "https://github.com/niksite/url-normalize/blob/${src.tag}/CHANGELOG.md";
     description = "URL normalization for Python";
     homepage = "https://github.com/niksite/url-normalize";
+    changelog = "https://github.com/niksite/url-normalize/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/development/tools/continuous-integration/woodpecker/common.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/common.nix
@@ -1,8 +1,8 @@
 { lib, fetchFromGitHub }:
 let
-  version = "3.13.0";
-  vendorHash = "sha256-EkOg1D+zeEbVBPr4fpCPI31CvMnTD7FZ2hhQW7UzN8A=";
-  nodeModulesHash = "sha256-wORM+24nE771llb1Q7bn6iDtlJpm3kOqO3wTLUQmjyQ=";
+  version = "3.14.0";
+  vendorHash = "sha256-fibx+Ky2cfP71tPzeiDybx+0f/+XvZbDXC7PAWQMRIY=";
+  nodeModulesHash = "sha256-8QhWOlEWkRPZA3uktm2hDSon+UCPPGznvn/4cXqyvTY=";
 in
 {
   inherit version vendorHash nodeModulesHash;
@@ -11,7 +11,7 @@ in
     owner = "woodpecker-ci";
     repo = "woodpecker";
     tag = "v${version}";
-    hash = "sha256-EeND2L5l37fo3JBlFORR4m0tXQWlJ2qqIXIdQ1vJdgM=";
+    hash = "sha256-FFGNjQa4W6T1BmbNh3rD1m7vtJFBWmgxocRV+OO5ZfA=";
   };
 
   postInstall = ''

--- a/pkgs/servers/monitoring/grafana/plugins/grafadruid-druid-datasource/default.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/grafadruid-druid-datasource/default.nix
@@ -2,8 +2,8 @@
 
 grafanaPlugin {
   pname = "grafadruid-druid-datasource";
-  version = "1.7.0";
-  zipHash = "sha256-aVAIk5x+zKdq5SYjsl5LekZ96LW7g/ykaq/lPUNUi7k=";
+  version = "1.8.0";
+  zipHash = "sha256-iCd6OejO+AQtN3tzEJUDZUGa4Fg1X9k4DzUXN9U0Udc=";
   meta = {
     description = "Connects Grafana to Druid";
     license = lib.licenses.asl20;

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -162,10 +162,23 @@ let
 
     // {
 
-      meta = {
-        description = "The default build environment for Unix packages in Nixpkgs";
-        platforms = lib.platforms.all;
-      };
+      meta =
+        let
+          pos = builtins.unsafeGetAttrPos "name" argsStdenv;
+        in
+        {
+          description = "The default build environment for Unix packages in Nixpkgs";
+          platforms = lib.platforms.all;
+          position = "${pos.file}:${toString pos.line}";
+          teams = [ lib.teams.stdenv ];
+          license = lib.licenses.mit;
+          identifiers.cpeParts = {
+            part = "a";
+            vendor = "nixos";
+            product = argsStdenv.name;
+            inherit version;
+          };
+        };
 
       inherit buildPlatform hostPlatform targetPlatform;
 


### PR DESCRIPTION
## Description

Bump aiohttp from 3.13.4 to 3.13.5.

[Release notes](https://github.com/aio-libs/aiohttp/releases/tag/v3.13.5)

cc @dotlambda

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
