### PR TITLE
python3Packages.meraki: 2.1.0 -> 3.0.1

### DIFF
--- a/pkgs/development/python-modules/meraki/default.nix
+++ b/pkgs/development/python-modules/meraki/default.nix
@@ -3,43 +3,29 @@
   aiohttp,
   buildPythonPackage,
   fetchFromGitHub,
-  jinja2,
-  poetry-core,
-  pytest,
+  hatchling,
   requests,
-  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "meraki";
-  version = "2.1.0";
+  version = "3.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "meraki";
     repo = "dashboard-api-python";
     tag = version;
-    hash = "sha256-B9eda7ccpCRGuBB2XfRI/Fz+MVBUIjFZzHYWfckQT2g=";
+    hash = "sha256-XP0wvq9CoUpjGsIKmzgLrAmxhJ0F2mHDXJZdeU+AEkE=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail "setuptools>=78.1.1,<79.0.0" "setuptools"
-  '';
+  pythonRelaxDeps = [ "aiohttp" ];
 
-  pythonRelaxDeps = [
-    "pytest"
-    "setuptools"
-  ];
-
-  build-system = [ poetry-core ];
+  build-system = [ hatchling ];
 
   dependencies = [
     aiohttp
-    jinja2
-    pytest
     requests
-    setuptools
   ];
 
   # All tests require an API key


### PR DESCRIPTION
## Description

Update meraki from 2.1.0 to 3.0.1. Supersedes #504801.

Notable upstream changes:
- Build system switched from poetry-core/setuptools to hatchling
- Runtime dependencies simplified to just `aiohttp` and `requests`
- Requires Python >= 3.11

[Release notes](https://github.com/meraki/dashboard-api-python/releases/tag/3.0.1)

> **Note:** `pythonRelaxDeps` is used for `aiohttp` because nixpkgs master currently has 3.13.4 while meraki 3.0.1 requires >=3.13.5. The bump to 3.13.5 is already on `staging`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
