### PR TITLE
 wine{64, Wow}Packages.*: add aarch64 support

### DIFF
--- a/pkgs/applications/emulators/wine/base.nix
+++ b/pkgs/applications/emulators/wine/base.nix
@@ -59,7 +59,7 @@
   vulkanSupport ? false,
   sdlSupport ? false,
   usbSupport ? false,
-  mingwSupport ? stdenv.hostPlatform.isDarwin,
+  mingwSupport ? stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isAarch64,
   waylandSupport ? false,
   x11Support ? false,
   ffmpegSupport ? false,
@@ -267,6 +267,16 @@ stdenv.mkDerivation (
             lib.concatMapStringsSep " " (ps: "-W ${ps}") stagingPatches.disabledPatchsets
           }
         '';
+
+    # Fix dcomp test for aarch64
+    postPatch = lib.optionalString (useStaging && stdenv.hostPlatform.isAarch64) ''
+      if [ -f dlls/dcomp/tests/dcomp.c ]; then
+        substituteInPlace dlls/dcomp/tests/dcomp.c \
+          --replace-fail \
+            '#error "Unsupported architecture"' \
+            '__asm__ __volatile__("mov %0, sp" : "=r"(stack_pointer));'
+      fi
+    '';
 
     configureFlags =
       prevConfigFlags

--- a/pkgs/applications/emulators/wine/default.nix
+++ b/pkgs/applications/emulators/wine/default.nix
@@ -12,7 +12,13 @@ args@{
   callPackage,
   darwin,
   wineRelease ? "stable",
-  wineBuild ? if stdenv.hostPlatform.system == "x86_64-linux" then "wineWow" else "wine32",
+  wineBuild ?
+    if stdenv.hostPlatform.system == "x86_64-linux" then
+      "wineWow"
+    else if stdenv.hostPlatform.isAarch64 then
+      "wine64"
+    else
+      "wine32",
   gettextSupport ? false,
   fontconfigSupport ? false,
   alsaSupport ? false,
@@ -39,7 +45,7 @@ args@{
   vulkanSupport ? false,
   sdlSupport ? false,
   usbSupport ? false,
-  mingwSupport ? stdenv.hostPlatform.isDarwin,
+  mingwSupport ? stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isAarch64,
   waylandSupport ? false,
   x11Support ? false,
   ffmpegSupport ? false,

--- a/pkgs/applications/emulators/wine/llvm-mingw.nix
+++ b/pkgs/applications/emulators/wine/llvm-mingw.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  autoPatchelfHook,
+  zlib,
+  stdenv,
+}:
+
+# Used as a workaround for ucrtAarch64.
+# compiler-rt due to pthread.h not being found during cross-build.
+
+let
+  version = "20260421";
+
+  hostArch =
+    if stdenv.hostPlatform.isAarch64 then
+      "aarch64"
+    else if stdenv.hostPlatform.isx86_64 then
+      "x86_64"
+    else
+      throw "llvm-mingw: unsupported host platform ${stdenv.hostPlatform.system}";
+
+  hashes = {
+    aarch64 = "sha256-6c+lqTKQy4Utxaa5DM3iVUA6YzMmSL4XFHDKPBrTeCg=";
+    x86_64 = "sha256-+LjM53mv/qtHvK7Gzm6edosWYJSjZhI+9kstCzicwSE=";
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "llvm-mingw-${hostArch}";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/mstorsjo/llvm-mingw/releases/download/${version}/llvm-mingw-${version}-ucrt-ubuntu-22.04-${hostArch}.tar.xz";
+    hash = hashes.${hostArch};
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+  buildInputs = [
+    (lib.getLib stdenv.cc.cc) # libstdc++
+    zlib
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r * $out/
+
+    runHook postInstall
+  '';
+
+  autoPatchelfIgnoreMissingDeps = [ "*.dll" ];
+  dontStrip = true;
+
+  meta = {
+    description = "LLVM/Clang/LLD-based mingw-w64 toolchain (prebuilt)";
+    homepage = "https://github.com/mstorsjo/llvm-mingw";
+    license = lib.licenses.zlib;
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/applications/emulators/wine/packages.nix
+++ b/pkgs/applications/emulators/wine/packages.nix
@@ -28,6 +28,8 @@ let
     mono
     ;
 
+  llvm-mingw = callPackage ./llvm-mingw.nix { };
+
   # Args to pass through to base.nix (support flags, etc.)
   baseArgs = removeAttrs args [
     "stdenv_32bit"
@@ -71,13 +73,19 @@ in
       pname = "wine64";
       inherit version patches;
       pkgArches = [ pkgs ];
-      mingwGccs = with pkgsCross; [ mingwW64.buildPackages.gcc ];
+      mingwGccs =
+        if pkgs.stdenv.hostPlatform.isAarch64 then
+          [ llvm-mingw ]
+        else
+          with pkgsCross; [ mingwW64.buildPackages.gcc ];
       geckos = [ gecko64 ];
       monos = [ mono ];
-      configureFlags = [ "--enable-win64" ];
+      configureFlags =
+        if pkgs.stdenv.hostPlatform.isAarch64 then [ "--enable-archs=aarch64" ] else [ "--enable-win64" ];
       platforms = [
         "x86_64-linux"
         "x86_64-darwin"
+        "aarch64-linux"
       ];
       mainProgram = "wine";
     }
@@ -119,16 +127,26 @@ in
       inherit version patches;
       mingwSupport = true; # Required because we request "--enable-archs=x86_64"
       pkgArches = [ pkgs ];
-      mingwGccs = with pkgsCross; [
-        mingw32.buildPackages.gcc
-        mingwW64.buildPackages.gcc
-      ];
+      mingwGccs =
+        if pkgs.stdenv.hostPlatform.isAarch64 then
+          [ llvm-mingw ]
+        else
+          with pkgsCross;
+          [
+            mingw32.buildPackages.gcc
+            mingwW64.buildPackages.gcc
+          ];
       geckos = [ gecko64 ];
       monos = [ mono ];
-      configureFlags = [ "--enable-archs=x86_64,i386" ];
+      configureFlags =
+        if pkgs.stdenv.hostPlatform.isAarch64 then
+          [ "--enable-archs=aarch64,x86_64,i386" ]
+        else
+          [ "--enable-archs=x86_64,i386" ];
       platforms = [
         "x86_64-linux"
         "x86_64-darwin"
+        "aarch64-linux"
       ];
       mainProgram = "wine";
     }


### PR DESCRIPTION
Fix : https://github.com/NixOS/nixpkgs/issues/412458
Depend on : https://github.com/NixOS/nixpkgs/pull/515784

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
