### PR TITLE
zsh-simple-abbreviations: init at v1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6704,6 +6704,11 @@
     github = "developer-guy";
     githubId = 16693043;
   };
+  DeveloperC286 = {
+    name = "DeveloperC286";
+    github = "DeveloperC286";
+    githubId = 65925405;
+  };
   devhell = {
     email = ''"^"@regexmail.net'';
     github = "devhell";

--- a/pkgs/by-name/zs/zsh-simple-abbreviations/package.nix
+++ b/pkgs/by-name/zs/zsh-simple-abbreviations/package.nix
@@ -6,6 +6,7 @@
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
   pname = "zsh-simple-abbreviations";
   version = "1.1.0";
 

--- a/pkgs/by-name/zs/zsh-simple-abbreviations/package.nix
+++ b/pkgs/by-name/zs/zsh-simple-abbreviations/package.nix
@@ -1,0 +1,42 @@
+{
+  stdenvNoCC,
+  lib,
+  fetchFromGitHub,
+  gitUpdater,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "zsh-simple-abbreviations";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "DeveloperC286";
+    repo = "zsh-simple-abbreviations";
+    rev = "v${finalAttrs.version}";
+    sha256 = "15vax5nl90yw1wi1s31j0hi6f5j09v9gqkgszzhl764r1c0s47rr";
+  };
+
+  strictDeps = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    install -Dm644 zsh-simple-abbreviations.zsh "$out/share/${finalAttrs.pname}/${finalAttrs.pname}.zsh"
+    mkdir -p "$out/share/${finalAttrs.pname}"
+    cp -R src "$out/share/${finalAttrs.pname}/"
+  '';
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
+  };
+
+  meta = {
+    description = "A simple manager for abbreviations in Z shell (Zsh).";
+    homepage = "https://github.com/DeveloperC286/zsh-simple-abbreviations";
+    license = lib.licenses.agpl3Only;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
+      DeveloperC286
+    ];
+  };
+})


### PR DESCRIPTION
Adding 

* https://github.com/DeveloperC286/zsh-simple-abbreviations

to nixpkgs, it is a simple manager for abbreviations in Z shell (Zsh). This is so I can install it using Home Manager as I do with my other Zsh plugins.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
