### PR TITLE
openfhe: init at 1.5.1

### DIFF
--- a/pkgs/by-name/op/openfhe/package.nix
+++ b/pkgs/by-name/op/openfhe/package.nix
@@ -1,0 +1,106 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  autoconf,
+  automake,
+  libtool,
+  llvmPackages,
+  gmp,
+  ntl,
+  nix-update-script,
+  testers,
+  withNtl ? false,
+  withReducedNoise ? false,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "openfhe";
+  version = "1.5.1";
+
+  src = fetchFromGitHub {
+    owner = "openfheorg";
+    repo = "openfhe-development";
+    tag = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-BBHhnn5uQEsoUDPwFhe32oRDs5xJqh/YyUD5nd+hfp8=";
+  };
+
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail '/opt/homebrew/opt/libomp/lib'     '${lib.getLib llvmPackages.openmp}/lib' \
+      --replace-fail '/opt/homebrew/opt/libomp/include' '${lib.getDev llvmPackages.openmp}/include' \
+      --replace-fail '/usr/local/opt/libomp/lib'        '${lib.getLib llvmPackages.openmp}/lib' \
+      --replace-fail '/usr/local/opt/libomp/include'    '${lib.getDev llvmPackages.openmp}/include' \
+      --replace-fail '/opt/local/lib/libomp'            '${lib.getLib llvmPackages.openmp}/lib' \
+      --replace-fail '/opt/local/include/libomp'        '${lib.getDev llvmPackages.openmp}/include'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+  ]
+  # WITH_NTL=ON triggers an autoconf-version check in upstream's CMakeLists
+  # (gated by `if(WITH_TCM OR WITH_NTL)`), so autotools must be present even
+  # when linking against the system NTL.
+  ++ lib.optionals withNtl [
+    autoconf
+    automake
+    libtool
+  ];
+
+  buildInputs = lib.optionals withNtl [
+    gmp
+    ntl
+  ];
+
+  # OpenFHEConfig.cmake exports CMAKE_CXX_FLAGS (with OpenMP_CXX_FLAGS folded
+  # in) to consumers, so libomp on darwin must propagate, not just build.
+  propagatedBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ llvmPackages.openmp ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED" true)
+    (lib.cmakeBool "BUILD_STATIC" false)
+    (lib.cmakeBool "BUILD_UNITTESTS" finalAttrs.doCheck)
+    (lib.cmakeBool "BUILD_EXAMPLES" false)
+    (lib.cmakeBool "BUILD_BENCHMARKS" false)
+    (lib.cmakeBool "WITH_OPENMP" true)
+    (lib.cmakeBool "WITH_NATIVEOPT" false)
+    (lib.cmakeBool "WITH_NTL" withNtl)
+    (lib.cmakeBool "WITH_REDUCED_NOISE" withReducedNoise)
+    (lib.cmakeFeature "MATHBACKEND" (if withNtl then "6" else "4"))
+    (lib.cmakeFeature "INSTALL_CMAKE_DIR" "lib/cmake/OpenFHE")
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  checkPhase = ''
+    runHook preCheck
+    echo "=== core_tests ==="
+    unittest/core_tests -t
+    echo "=== pke_tests ==="
+    unittest/pke_tests -t
+    echo "=== binfhe_tests ==="
+    unittest/binfhe_tests -t
+    runHook postCheck
+  '';
+
+  passthru = {
+    tests.cmake-config = testers.hasCmakeConfigModules {
+      package = finalAttrs.finalPackage;
+      moduleNames = [ "OpenFHE" ];
+    };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Open-source library for fully homomorphic encryption (FHE)";
+    homepage = "https://www.openfhe.org/";
+    changelog = "https://github.com/openfheorg/openfhe-development/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ ryanorendorff ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})

--- a/pkgs/by-name/op/openfhe/package.nix
+++ b/pkgs/by-name/op/openfhe/package.nix
@@ -19,6 +19,8 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "openfhe";
   version = "1.5.1";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "openfheorg";
     repo = "openfhe-development";


### PR DESCRIPTION
Adds the OpenFHE package pinned at the most recent version as of this writing (1.5.1). This is a library for writing programs that use Fully Homomorphic Encryption (FHE) to compute over encrypted data without decrypting it first.  

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests` on mac
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
