### PR TITLE
hare: fix musl build

### DIFF
--- a/pkgs/by-name/ha/hare/package.nix
+++ b/pkgs/by-name/ha/hare/package.nix
@@ -10,9 +10,14 @@
   callPackage,
   enableCrossCompilation ? (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.is64bit),
   pkgsCross,
-  x86_64PkgsCrossToolchain ? pkgsCross.gnu64,
-  aarch64PkgsCrossToolchain ? pkgsCross.aarch64-multiplatform,
-  riscv64PkgsCrossToolchain ? pkgsCross.riscv64,
+  x86_64PkgsCrossToolchain ? if stdenv.hostPlatform.isMusl then pkgsCross.musl64 else pkgsCross.gnu64,
+  aarch64PkgsCrossToolchain ?
+    if stdenv.hostPlatform.isMusl then
+      pkgsCross.aarch64-multiplatform-musl
+    else
+      pkgsCross.aarch64-multiplatform,
+  riscv64PkgsCrossToolchain ?
+    if stdenv.hostPlatform.isMusl then pkgsCross.riscv64-musl else pkgsCross.riscv64,
 }:
 
 # There's no support for `aarch64` or `riscv64` for freebsd nor for openbsd on nix.


### PR DESCRIPTION
fixes `nix-build -A pkgsMusl.hare` as well as cross-compilation
of hare programs for musl users, e.g.
`nix-build -A pkgsMusl.pkgsCross.aarch64-multiplatform-musl.bonsai`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
