### PR TITLE
teleport: Use pnpm fetcherVersion 3; teleport_17: 17.7.20 -> 17.7.23; teleport_18: 18.7.2 -> 18.7.6

### DIFF
--- a/pkgs/build-support/teleport/default.nix
+++ b/pkgs/build-support/teleport/default.nix
@@ -82,7 +82,7 @@ let
         version
         ;
       pnpm = pnpm_10_29_2;
-      fetcherVersion = 2;
+      fetcherVersion = 3;
       hash = pnpmHash;
     };
 

--- a/pkgs/by-name/te/teleport_17/package.nix
+++ b/pkgs/by-name/te/teleport_17/package.nix
@@ -7,11 +7,11 @@
 }:
 
 buildTeleport {
-  version = "17.7.20";
-  hash = "sha256-zxP7vhDyxypotG58wzwlCx8JMoRSYC0adMe+zKfrOek=";
-  vendorHash = "sha256-uwSCPu3z9LCvN/vKJg/Q9rgk6wnjh4P4tq4a5suPNrg=";
-  cargoHash = "sha256-opLo7UmZzxrVxYZOwn4v4G5lhHFp5GrdOZe7uIb97q0=";
-  pnpmHash = "sha256-quHu43JccCpguSeHkGnpqL81oDN4p5WtAt/sOgMCCec=";
+  version = "17.7.23";
+  hash = "sha256-o1aYmNN4yytgJFQ7V1sPjq6r2pDzf4mG/juyYK5IF3A=";
+  vendorHash = "sha256-cL2U1GOV6PtxSl8N8gjKOHCpj5jhun5D+DbeWBixnxI=";
+  cargoHash = "sha256-cDcDfptq8z0pwjImuAovv/5XwoaPb/ostyxkyNEbkRM=";
+  pnpmHash = "sha256-NTH5YnqeZg/jEkjguSXGS3/MI/r8us11By/fZ1m1caQ=";
 
   wasm-bindgen-cli = wasm-bindgen-cli_0_2_95;
   inherit buildGoModule withRdpClient extPatches;

--- a/pkgs/by-name/te/teleport_18/package.nix
+++ b/pkgs/by-name/te/teleport_18/package.nix
@@ -7,11 +7,11 @@
 }:
 
 buildTeleport {
-  version = "18.7.2";
-  hash = "sha256-1ANYBYNhTzSA3zhgUgKks73piHdw+4iXGFmGUWHTYpE=";
-  vendorHash = "sha256-0HxDrsWWRjuaVGtbX7xwCMsj2dYRJr3wmpf8qInlyBE=";
-  pnpmHash = "sha256-XJ2SLCMoFFeoBQ3YKIlq4APNOhSS8ipTNQufQ1nkYqs=";
-  cargoHash = "sha256-SfVoh4HnHSOz1haPPV7a/RyA6LFjLRe78Mn2fVdVyEA=";
+  version = "18.7.6";
+  hash = "sha256-p7qwsUr6n6OAl/b20SgropAubfPfwBiVTvbReb2HpO8=";
+  vendorHash = "sha256-/ZY0J0yB/8qMG6vEIta7Nf2Uv3xTZ/WPoMz+Dj5hwZA=";
+  pnpmHash = "sha256-uRsS5m0Q4fAFvJ3Qp6xcEAB8QFriLXbeGtD0o0n46RE=";
+  cargoHash = "sha256-KkFwMSBXsRmDuaPU1n6FPq2P5UQiQnb7+HEDOhhmjd0=";
 
   wasm-bindgen-cli = wasm-bindgen-cli_0_2_99;
   buildGoModule = buildGo125Module;


### PR DESCRIPTION
Contains security fixes for both versions.

Changelog: https://github.com/gravitational/teleport/releases/tag/v17.7.23
Diff: https://github.com/gravitational/teleport/compare/v17.7.20...v17.7.23

Changelog: https://github.com/gravitational/teleport/releases/v18.7.6
Diff: http://github.com/gravitational/teleport/compare/v18.7.2...v18.7.6


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
