### PR TITLE
[25.11] fluxcd: 2.7.5 -> 2.8.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25079,6 +25079,13 @@
     github = "StayBlue";
     githubId = 23127866;
   };
+  stealthybox = {
+    email = "leigh@null.net";
+    github = "stealthybox";
+    githubId = 2754700;
+    name = "Leigh Capili";
+    keys = [ { fingerprint = "05E7 89C9 142C DD05 8261 4EF8 5943 2144 444F B382"; } ];
+  };
   steamwalker = {
     email = "steamwalker@xs4all.nl";
     github = "steamwalker";
@@ -25367,6 +25374,13 @@
     github = "0Supa";
     githubId = 36031171;
     name = "Supa";
+  };
+  superherointj = {
+    email = "sergiomarcelo@yandex.com";
+    github = "superherointj";
+    githubId = 5861043;
+    matrix = "@superherointj:matrix.org";
+    name = "Sérgio Marcelo";
   };
   SuperSandro2000 = {
     email = "sandro.jaeckel@gmail.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25375,6 +25375,13 @@
     githubId = 36031171;
     name = "Supa";
   };
+  superherointj = {
+    email = "sergiomarcelo@yandex.com";
+    github = "superherointj";
+    githubId = 5861043;
+    matrix = "@superherointj:matrix.org";
+    name = "Sérgio Marcelo";
+  };
   SuperSandro2000 = {
     email = "sandro.jaeckel@gmail.com";
     matrix = "@sandro:supersandro.de";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25079,6 +25079,13 @@
     github = "StayBlue";
     githubId = 23127866;
   };
+  stealthybox = {
+    email = "leigh@null.net";
+    github = "stealthybox";
+    githubId = 2754700;
+    name = "Leigh Capili";
+    keys = [ { fingerprint = "05E7 89C9 142C DD05 8261 4EF8 5943 2144 444F B382"; } ];
+  };
   steamwalker = {
     email = "steamwalker@xs4all.nl";
     github = "steamwalker";

--- a/pkgs/by-name/fl/fluxcd-operator-mcp/package.nix
+++ b/pkgs/by-name/fl/fluxcd-operator-mcp/package.nix
@@ -62,6 +62,7 @@ buildGoModule (finalAttrs: {
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [
       mattfield
+      stealthybox
     ];
     mainProgram = "flux-operator-mcp";
   };

--- a/pkgs/by-name/fl/fluxcd/package.nix
+++ b/pkgs/by-name/fl/fluxcd/package.nix
@@ -48,7 +48,7 @@ buildGoModule rec {
 
   # Required to workaround test error:
   #   panic: mkdir /homeless-shelter: permission denied
-  HOME = "$TMPDIR";
+  env.HOME = "$TMPDIR";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/fl/fluxcd/package.nix
+++ b/pkgs/by-name/fl/fluxcd/package.nix
@@ -5,6 +5,7 @@
   installShellFiles,
   lib,
   stdenv,
+  writableTmpDirAsHomeHook,
 }:
 
 let
@@ -46,11 +47,11 @@ buildGoModule rec {
 
   subPackages = [ "cmd/flux" ];
 
+  nativeBuildInputs = [ installShellFiles ];
+
   # Required to workaround test error:
   #   panic: mkdir /homeless-shelter: permission denied
-  env.HOME = "$TMPDIR";
-
-  nativeBuildInputs = [ installShellFiles ];
+  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
 
   doInstallCheck = true;
   installCheckPhase = ''

--- a/pkgs/by-name/fl/fluxcd/package.nix
+++ b/pkgs/by-name/fl/fluxcd/package.nix
@@ -39,6 +39,8 @@ buildGo126Module rec {
     rm source/cmd/flux/create_secret_git_test.go
   '';
 
+  env.CGO_ENABLED = 0;
+
   ldflags = [
     "-s"
     "-w"

--- a/pkgs/by-name/fl/fluxcd/package.nix
+++ b/pkgs/by-name/fl/fluxcd/package.nix
@@ -1,17 +1,18 @@
 {
-  buildGoModule,
+  buildGo126Module,
   fetchFromGitHub,
   fetchzip,
   installShellFiles,
   lib,
   stdenv,
+  writableTmpDirAsHomeHook,
 }:
 
 let
-  version = "2.7.5";
-  srcHash = "sha256-vTb1YE73xxCC4GlR6UW5Ibu+ck+N+KKYUg50csb7eUA=";
-  vendorHash = "sha256-AgWDvlXVZXXprWCeoNeAMDb6LeYfa9yG5afc7TNISQs=";
-  manifestsHash = "sha256-CmYuHhEiKxkSRtN+fri2/4ILxpwRy2xGwGqCqcfsQwU=";
+  version = "2.8.6";
+  srcHash = "sha256-pKP4g2pTMYtx/B/Y3ow7tvDdhCSuwbszzeLVXB0W7Bo=";
+  vendorHash = "sha256-VBafft9/AuXaHWvZymy7P9gaSuO8D6IZHfK68Ixp3mI=";
+  manifestsHash = "sha256-h/HR/rJwPWXiuoj9T+LajdsdT4Jo8/EuN+O1I7e9sjI=";
 
   manifests = fetchzip {
     url = "https://github.com/fluxcd/flux2/releases/download/v${version}/manifests.tar.gz";
@@ -20,7 +21,7 @@ let
   };
 in
 
-buildGoModule rec {
+buildGo126Module rec {
   pname = "fluxcd";
   inherit vendorHash version;
 
@@ -46,11 +47,11 @@ buildGoModule rec {
 
   subPackages = [ "cmd/flux" ];
 
+  nativeBuildInputs = [ installShellFiles ];
+
   # Required to workaround test error:
   #   panic: mkdir /homeless-shelter: permission denied
-  HOME = "$TMPDIR";
-
-  nativeBuildInputs = [ installShellFiles ];
+  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
 
   doInstallCheck = true;
   installCheckPhase = ''
@@ -78,9 +79,11 @@ buildGoModule rec {
     homepage = "https://fluxcd.io";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
-      bryanasdev000
       jlesquembre
       ryan4yin
+      SchahinRohani
+      stealthybox
+      superherointj
     ];
     mainProgram = "flux";
   };

--- a/pkgs/by-name/fl/fluxcd/package.nix
+++ b/pkgs/by-name/fl/fluxcd/package.nix
@@ -83,6 +83,7 @@ buildGo126Module rec {
       ryan4yin
       SchahinRohani
       stealthybox
+      superherointj
     ];
     mainProgram = "flux";
   };

--- a/pkgs/by-name/fl/fluxcd/package.nix
+++ b/pkgs/by-name/fl/fluxcd/package.nix
@@ -81,6 +81,7 @@ buildGo126Module rec {
     maintainers = with lib.maintainers; [
       jlesquembre
       ryan4yin
+      SchahinRohani
       stealthybox
     ];
     mainProgram = "flux";

--- a/pkgs/by-name/fl/fluxcd/package.nix
+++ b/pkgs/by-name/fl/fluxcd/package.nix
@@ -1,5 +1,5 @@
 {
-  buildGoModule,
+  buildGo126Module,
   fetchFromGitHub,
   fetchzip,
   installShellFiles,
@@ -9,10 +9,10 @@
 }:
 
 let
-  version = "2.7.5";
-  srcHash = "sha256-vTb1YE73xxCC4GlR6UW5Ibu+ck+N+KKYUg50csb7eUA=";
-  vendorHash = "sha256-AgWDvlXVZXXprWCeoNeAMDb6LeYfa9yG5afc7TNISQs=";
-  manifestsHash = "sha256-CmYuHhEiKxkSRtN+fri2/4ILxpwRy2xGwGqCqcfsQwU=";
+  version = "2.8.6";
+  srcHash = "sha256-pKP4g2pTMYtx/B/Y3ow7tvDdhCSuwbszzeLVXB0W7Bo=";
+  vendorHash = "sha256-VBafft9/AuXaHWvZymy7P9gaSuO8D6IZHfK68Ixp3mI=";
+  manifestsHash = "sha256-h/HR/rJwPWXiuoj9T+LajdsdT4Jo8/EuN+O1I7e9sjI=";
 
   manifests = fetchzip {
     url = "https://github.com/fluxcd/flux2/releases/download/v${version}/manifests.tar.gz";
@@ -21,7 +21,7 @@ let
   };
 in
 
-buildGoModule rec {
+buildGo126Module rec {
   pname = "fluxcd";
   inherit vendorHash version;
 
@@ -79,9 +79,9 @@ buildGoModule rec {
     homepage = "https://fluxcd.io";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
-      bryanasdev000
       jlesquembre
       ryan4yin
+      stealthybox
     ];
     mainProgram = "flux";
   };

--- a/pkgs/by-name/fl/fluxcd/update.sh
+++ b/pkgs/by-name/fl/fluxcd/update.sh
@@ -1,50 +1,21 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl gnugrep gnused jq
+#!nix-shell -i bash -p gnused nix-update
 
-set -x -eu -o pipefail
+set -eu -o pipefail
+set -x
 
-NIXPKGS_PATH="$(git rev-parse --show-toplevel)"
-FLUXCD_PATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+# Compute the relative dir of the update script
+SCRIPT_DIR="$(cd -- "$(dirname "$0")" >/dev/null 2>&1; pwd -P)"
 
-OLD_VERSION="$(nix-instantiate --eval -E "with import $NIXPKGS_PATH {}; fluxcd.version or (builtins.parseDrvName fluxcd.name).version" | tr -d '"')"
-LATEST_TAG=$(curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} --silent https://api.github.com/repos/fluxcd/flux2/releases/latest | jq -r '.tag_name')
-LATEST_VERSION=$(echo "${LATEST_TAG}" | sed 's/^v//')
+# Update version, src hash, and vendor hash
+nix-update fluxcd
 
-if [ ! "$OLD_VERSION" = "$LATEST_VERSION" ]; then
-    SRC_SHA256=$(nix-prefetch-url --quiet --unpack "https://github.com/fluxcd/flux2/archive/refs/tags/${LATEST_TAG}.tar.gz")
-    SRC_HASH=$(nix --extra-experimental-features nix-command hash convert --hash-algo sha256 --to sri "$SRC_SHA256")
-    MANIFESTS_SHA256=$(nix-prefetch-url --quiet --unpack "https://github.com/fluxcd/flux2/releases/download/${LATEST_TAG}/manifests.tar.gz")
-    MANIFESTS_HASH=$(nix --extra-experimental-features nix-command hash convert --hash-algo sha256 --to sri "$MANIFESTS_SHA256")
+# Read the potentially updated version from `nix-update fluxcd` using SCRIPT_DIR
+VERSION=$(sed -n 's/.*version = "\(.*\)".*/\1/p' "${SCRIPT_DIR}/package.nix" | head -1)
 
-    setKV () {
-        sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" "${FLUXCD_PATH}/package.nix"
-    }
-
-    setKV version "${LATEST_VERSION}"
-    setKV srcHash "${SRC_HASH}"
-    setKV manifestsHash "${MANIFESTS_HASH}"
-    setKV vendorHash "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" # The same as lib.fakeHash
-
-    set +e
-    VENDOR_SHA256=$(nix-build --no-out-link -A fluxcd "$NIXPKGS_PATH" 2>&1 >/dev/null | grep "got:" | cut -d':' -f2 | sed 's| ||g')
-    VENDOR_HASH=$(nix --extra-experimental-features nix-command hash convert --hash-algo sha256 --to sri "$VENDOR_SHA256")
-    set -e
-
-    if [ -n "${VENDOR_HASH:-}" ]; then
-        setKV vendorHash "${VENDOR_HASH}"
-    else
-        echo "Update failed. VENDOR_HASH is empty."
-        exit 1
-    fi
-
-    # `git` flag here is to be used by local maintainers to speed up the bump process
-    if [ $# -eq 1 ] && [ "$1" = "git" ]; then
-        git switch -c "package-fluxcd-${LATEST_VERSION}"
-        git add "$FLUXCD_PATH"/package.nix
-        git commit -m "fluxcd: ${OLD_VERSION} -> ${LATEST_VERSION}
-
-Release: https://github.com/fluxcd/flux2/releases/tag/v${LATEST_VERSION}"
-    fi
-else
-    echo "fluxcd is already up-to-date at $OLD_VERSION"
-fi
+# Update the additional fluxcd manifests hash
+# This is idempotent and will run regardless of whether nix-update changes the package.nix version
+# note: tag format is assumed to be v${VERSION} which matches the fetchZip in package.nix
+MANIFESTS_SHA256=$(nix-prefetch-url --quiet --unpack "https://github.com/fluxcd/flux2/releases/download/v${VERSION}/manifests.tar.gz")
+MANIFESTS_HASH=$(nix --extra-experimental-features nix-command hash convert --hash-algo sha256 --to sri "$MANIFESTS_SHA256")
+sed -i "s|manifestsHash = \".*\"|manifestsHash = \"${MANIFESTS_HASH}\"|" "${SCRIPT_DIR}/package.nix"


### PR DESCRIPTION
Manual backport of #514702 to `release-25.11`.
The automated backport failed due to conflicts (release branch has fluxcd 2.7.5, not 2.8.5).

We also bump go to buildGo126Module to meet the new build requirements on this release branch.

~Pre-req to #515072~ (fluxcd-operator-mcp maintainer backport).
edit:  this PR now contains #515072

Release: https://github.com/fluxcd/flux2/releases/tag/v2.8.6