### PR TITLE
maintainers: remove sudoforge

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26341,12 +26341,6 @@
     githubId = 90754995;
     name = "sudo-mac";
   };
-  sudoforge = {
-    github = "sudoforge";
-    githubId = 3893293;
-    name = "sudoforge";
-    keys = [ { fingerprint = "7EBCE51F278D30AE1C34036341BF61468C327D5A"; } ];
-  };
   sudosubin = {
     email = "sudosubin@gmail.com";
     github = "sudosubin";

--- a/pkgs/by-name/gi/git-bug-migration/package.nix
+++ b/pkgs/by-name/gi/git-bug-migration/package.nix
@@ -36,7 +36,6 @@ buildGoModule (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       DeeUnderscore
-      sudoforge
     ];
     mainProgram = "git-bug-migration";
   };

--- a/pkgs/by-name/gi/git-bug/package.nix
+++ b/pkgs/by-name/gi/git-bug/package.nix
@@ -67,7 +67,6 @@ buildGoModule (finalAttrs: {
     maintainers = with lib.maintainers; [
       royneary
       DeeUnderscore
-      sudoforge
     ];
     mainProgram = "git-bug";
   };


### PR DESCRIPTION
sudoforge is leaving github, and as such, is submitting a change to
redact their username from the maintainers list.
