### PR TITLE
simple-completion-language-server: unstable-2025-07-29 -> unstable-2026-04-21

### DIFF
--- a/pkgs/by-name/si/simple-completion-language-server/package.nix
+++ b/pkgs/by-name/si/simple-completion-language-server/package.nix
@@ -7,16 +7,16 @@
 
 rustPlatform.buildRustPackage {
   pname = "simple-completion-language-server";
-  version = "0-unstable-2025-07-29";
+  version = "0-unstable-2026-04-21";
 
   src = fetchFromGitHub {
     owner = "estin";
     repo = "simple-completion-language-server";
-    rev = "cc57b08ebc68805266beacb512a453e16f86bf17";
-    hash = "sha256-TiVzgwsP1KZxTxW71eQyp1bkDnyTaMJdBYmkdvl1RX0=";
+    rev = "f8319589ab87b18f441627999f4a8316dd712234";
+    hash = "sha256-PKJVaj5et+afrMk7x/H/d/ygabjDALGKM3fr/16EKoQ=";
   };
 
-  cargoHash = "sha256-M+kjdT9X69kdZcBHC2ChR7WGgxtcUaU8woE2bqhu8IM=";
+  cargoHash = "sha256-RgRmbQVZK/4U37CO8AjNQOqR/SXvL1TQU03LX7LnqPY=";
 
   buildFeatures = lib.optional withCitation [ "citation" ];
 


### PR DESCRIPTION
## Summary

Bumps `simple-completion-language-server` to upstream commit
[f8319589](https://github.com/estin/simple-completion-language-server/commit/f8319589ab87b18f441627999f4a8316dd712234)
(2026-04-21).

The key fix in this range is commit
[f8bcae87](https://github.com/estin/simple-completion-language-server/commit/f8bcae87)
(2026-02-27), which adds an explicit `textEdit` range to word completions.
This resolves a duplication bug in Helix where accepting a hyphenated
suggestion mid-word produced doubled prefixes - e.g. typing `home-ma` and
accepting `home-manager` would yield `home-home-manager`. See upstream issue
[estin/simple-completion-language-server#200](https://github.com/estin/simple-completion-language-server/issues/200).

## Tested via

- [x] `nix-build -A simple-completion-language-server` passes (all 11 upstream tests green)
- [x] Binary runs: `./result/bin/simple-completion-language-server --help`
- [x] `nix fmt` reports no formatting changes needed