### PR TITLE
f3: 9.0 -> 10.0

### DIFF
--- a/pkgs/by-name/f3/f3/package.nix
+++ b/pkgs/by-name/f3/f3/package.nix
@@ -9,19 +9,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "f3";
-  version = "9.0";
+  version = "10.0";
 
   src = fetchFromGitHub {
     owner = "AltraMayor";
     repo = "f3";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-ZajlFGXJcYUVe/wUFfdPYVW8stOo1Aqe8uD2Bm9KIk0=";
+    sha256 = "sha256-AyNk6qjPIu/Dodq9NLVgVQdslDnoeY7htqvXZCnj3a8=";
   };
 
   postPatch = ''
     sed -i 's/-oroot -groot//' Makefile
 
-    for f in f3write.h2w log-f3wr; do
+    for f in scripts/{f3write.h2w,log-f3wr}; do
      substituteInPlace $f \
        --replace '$(dirname $0)' $out/bin
     done
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional stdenv.hostPlatform.isLinux "install-extra";
 
   postInstall = ''
-    install -Dm555 -t $out/bin f3write.h2w log-f3wr
+    install -Dm555 -t $out/bin scripts/{f3write.h2w,log-f3wr}
     install -Dm444 -t $out/share/doc/f3 LICENSE README.rst
   '';
 


### PR DESCRIPTION
https://github.com/AltraMayor/f3/releases/tag/v10.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
