### PR TITLE
python3Packages.parso: 0.8.5 -> 0.8.7; python3Packages.jedi: 0.19.2 -> 0.20.0

### DIFF
--- a/pkgs/development/python-modules/jedi/default.nix
+++ b/pkgs/development/python-modules/jedi/default.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   buildPythonPackage,
-  pythonAtLeast,
   fetchFromGitHub,
 
   # build-system
@@ -16,16 +15,16 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "jedi";
-  version = "0.19.2";
+  version = "0.20.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "davidhalter";
     repo = "jedi";
-    rev = "v${version}";
-    hash = "sha256-2nDQJS6LIaq91PG3Av85OMFfs1ZwId00K/kvog3PGXE=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-D0Zy8HJYq5l8Wp1M+J7p8Z+EBY/R5tYFa2uMYiqLIT8=";
     fetchSubmodules = true;
   };
 
@@ -42,38 +41,25 @@ buildPythonPackage rec {
     export HOME=$TMPDIR
   '';
 
-  disabledTests = [
-    # sensitive to platform, causes false negatives on darwin
-    "test_import"
-  ]
-  ++ lib.optionals (stdenv.targetPlatform.useLLVM or false) [
-    # InvalidPythonEnvironment: The python binary is potentially unsafe.
-    "test_create_environment_executable"
-    # AssertionError: assert ['', '.1000000000000001'] == ['', '.1']
-    "test_dict_keys_completions"
-    # AssertionError: assert ['', '.1000000000000001'] == ['', '.1']
-    "test_dict_completion"
-  ];
-
-  disabledTestPaths = lib.optionals (pythonAtLeast "3.14") [
-    # Jedi.api.environment.InvalidPythonEnvironment: The python binary is potentially unsafe
-    "test/test_inference/test_sys_path.py::test_venv_and_pths"
-    "test/test_api/test_environment.py::test_create_environment_venv_path"
-    "test/test_api/test_environment.py::test_create_environment_executable"
-    # can't find system env nor venv
-    "test/test_api/test_environment.py::test_find_system_environments"
-    "test/test_api/test_environment.py::test_scanning_venvs"
-    # https://github.com/davidhalter/jedi/issues/2064
-    "test/test_api/test_interpreter.py::test_string_annotation"
-    # type repr mismatch: Union[Type, int] vs Type | int
-    "test/test_inference/test_mixed.py::test_compiled_signature_annotation_string"
-  ];
+  disabledTests =
+    lib.optionals stdenv.hostPlatform.isDarwin [
+      # sensitive to platform, causes false negatives on darwin
+      "test_import"
+    ]
+    ++ lib.optionals stdenv.targetPlatform.useLLVM [
+      # InvalidPythonEnvironment: The python binary is potentially unsafe.
+      "test_create_environment_executable"
+      # AssertionError: assert ['', '.1000000000000001'] == ['', '.1']
+      "test_dict_keys_completions"
+      # AssertionError: assert ['', '.1000000000000001'] == ['', '.1']
+      "test_dict_completion"
+    ];
 
   meta = {
+    changelog = "https://github.com/davidhalter/jedi/blob/${finalAttrs.src.tag}/CHANGELOG.rst";
     description = "Autocompletion tool for Python that can be used for text editors";
     homepage = "https://github.com/davidhalter/jedi";
-    changelog = "https://github.com/davidhalter/jedi/blob/${version}/CHANGELOG.rst";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/parso/default.nix
+++ b/pkgs/development/python-modules/parso/default.nix
@@ -6,16 +6,16 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "parso";
-  version = "0.8.5";
+  version = "0.8.7";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "davidhalter";
     repo = "parso";
-    tag = "v${version}";
-    hash = "sha256-faSXCrOkybLr0bboF/8rPV/Humq8s158A3UOpdlYi0I=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-vpWoxLIvNt4QQh/r57iAvX3Zebet3mihb5efOWLhYI8=";
   };
 
   build-system = [ setuptools ];
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   meta = {
     description = "Python Parser";
     homepage = "https://parso.readthedocs.io/en/latest/";
-    changelog = "https://github.com/davidhalter/parso/blob/${src.tag}/CHANGELOG.rst";
+    changelog = "https://github.com/davidhalter/parso/blob/${finalAttrs.src.tag}/CHANGELOG.rst";
     license = lib.licenses.mit;
   };
-}
+})


### PR DESCRIPTION
https://github.com/davidhalter/parso/blob/v0.8.7/CHANGELOG.rst
https://github.com/davidhalter/jedi/blob/v0.20.0/CHANGELOG.rst

Finally proper Python 3.14 support for Jedi.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
