### PR TITLE
p3x-onenote: 2025.10.111 -> 2026.4.132, add update script

### DIFF
--- a/pkgs/by-name/p3/p3x-onenote/package.nix
+++ b/pkgs/by-name/p3/p3x-onenote/package.nix
@@ -8,7 +8,9 @@
 
 let
   pname = "p3x-onenote";
-  version = "2025.10.111";
+  onenote = lib.importJSON ./sources.json;
+
+  version = onenote.version;
 
   plat =
     {
@@ -17,12 +19,7 @@ let
     }
     .${stdenv.hostPlatform.system};
 
-  hash =
-    {
-      aarch64-linux = "sha256-sfnRzY+1flUdIM1ey9u00j9eiDa4u5bY/f3fupV+FKM=";
-      x86_64-linux = "sha256-lgZjVVBWPloqMWX0oryNB0lxgmJCBqC7pp0AjeUMjQM=";
-    }
-    .${stdenv.hostPlatform.system};
+  hash = onenote.hash.${stdenv.hostPlatform.system};
 
   src = fetchurl {
     url = "https://github.com/patrikx3/onenote/releases/download/v${version}/P3X-OneNote-${version}${plat}.AppImage";

--- a/pkgs/by-name/p3/p3x-onenote/package.nix
+++ b/pkgs/by-name/p3/p3x-onenote/package.nix
@@ -13,7 +13,6 @@ let
   plat =
     {
       aarch64-linux = "-arm64";
-      armv7l-linux = "-armv7l";
       x86_64-linux = "";
     }
     .${stdenv.hostPlatform.system};
@@ -21,7 +20,6 @@ let
   hash =
     {
       aarch64-linux = "sha256-sfnRzY+1flUdIM1ey9u00j9eiDa4u5bY/f3fupV+FKM=";
-      armv7l-linux = "sha256-ZnFSJE1VmvqSKZHBsMtvBbypsbY35z9X5T4bYT0DytU=";
       x86_64-linux = "sha256-lgZjVVBWPloqMWX0oryNB0lxgmJCBqC7pp0AjeUMjQM=";
     }
     .${stdenv.hostPlatform.system};
@@ -58,7 +56,6 @@ appimageTools.wrapType2 {
     platforms = [
       "x86_64-linux"
       "aarch64-linux"
-      "armv7l-linux"
     ];
     mainProgram = "p3x-onenote";
   };

--- a/pkgs/by-name/p3/p3x-onenote/package.nix
+++ b/pkgs/by-name/p3/p3x-onenote/package.nix
@@ -45,6 +45,8 @@ appimageTools.wrapType2 {
       --delete-original $out/p3x-onenote.desktop
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = {
     homepage = "https://github.com/patrikx3/onenote";
     description = "Linux Electron Onenote - A Linux compatible version of OneNote";

--- a/pkgs/by-name/p3/p3x-onenote/sources.json
+++ b/pkgs/by-name/p3/p3x-onenote/sources.json
@@ -1,0 +1,7 @@
+{
+  "version": "2025.10.111",
+  "hash": {
+    "x86_64-linux": "sha256-lgZjVVBWPloqMWX0oryNB0lxgmJCBqC7pp0AjeUMjQM=",
+    "aarch64-linux": "sha256-sfnRzY+1flUdIM1ey9u00j9eiDa4u5bY/f3fupV+FKM="
+  }
+}

--- a/pkgs/by-name/p3/p3x-onenote/sources.json
+++ b/pkgs/by-name/p3/p3x-onenote/sources.json
@@ -1,7 +1,7 @@
 {
-  "version": "2025.10.111",
+  "version": "2026.4.132",
   "hash": {
-    "x86_64-linux": "sha256-lgZjVVBWPloqMWX0oryNB0lxgmJCBqC7pp0AjeUMjQM=",
-    "aarch64-linux": "sha256-sfnRzY+1flUdIM1ey9u00j9eiDa4u5bY/f3fupV+FKM="
+    "x86_64-linux": "sha256-RUauH8F7D1K2Oq85nsLaGuPpZ1+T5lLcmHuFNUpVBGw=",
+    "aarch64-linux": "sha256-N6swIn2L8AZKEpZakpESzuOhcONaJ757BcxzeIaecgg="
   }
 }

--- a/pkgs/by-name/p3/p3x-onenote/update.sh
+++ b/pkgs/by-name/p3/p3x-onenote/update.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq nix
+
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname "$0")"
+
+latest_version() {
+    curl -s "https://api.github.com/repos/patrikx3/onenote/releases/latest" | jq -r '.tag_name | sub("^v"; "")'
+}
+
+fetch_sri() {
+    local version=$1
+    local plat=$2
+    local system=$3
+    local hashi
+
+    hash=$(nix-prefetch-url https://github.com/patrikx3/onenote/releases/download/v${version}/P3X-OneNote-${version}${plat}.AppImage)
+    error=$?
+
+    if [ $error -gt 0 ]; then
+        echo "ERROR $error Fetching $version for $system" >&2
+        return $error
+    fi
+
+    nix hash convert --hash-algo sha256 --to sri $hash --extra-experimental-features nix-command
+}
+
+system_plat() {
+    case "$1" in
+        x86_64-linux) echo "" ;;
+        aarch64-linux) echo "-arm64" ;;
+        *) echo "BAD SYSTEM: $1" >&2; exit 2 ;;
+    esac
+}
+
+generate_json() {
+    local version="$1"
+    local systems=("x86_64-linux" "aarch64-linux")
+
+    echo "{"
+    echo "  \"version\": \"${version}\","
+    echo "  \"hash\": {"
+
+    local first=1
+    for system in "${systems[@]}"; do
+        local plat
+        plat=$(system_plat "$system")
+
+        local sri
+        sri=$(fetch_sri "$version" "$plat" "$system")
+
+        # JSON comma handling
+        if [ $first -eq 0 ]; then
+            echo ","
+        fi
+        first=0
+
+        echo -n "    \"${system}\": \"${sri}\""
+    done
+
+    echo ""
+    echo "  }"
+    echo "}"
+}
+
+if [ -z "${VERSION:-}" ]; then
+    echo "VERSION not set, fetching latest release…" >&2
+    VERSION="$(latest_version)"
+fi
+
+echo "p3x-onenote: v$VERSION"
+JSON=$(generate_json "$VERSION")
+echo "$JSON" > "$SCRIPT_DIR/sources.json"
+
+cat "$SCRIPT_DIR/sources.json"


### PR DESCRIPTION
The automated PRs only updated the x86_64 and required manual changes to update the remaining ones.
Adding an auto update script which fetches the latest version from GitHub and generates a sources.json containing the supported arches and the hashes.
From v2026.4.112 the support for armv7l has been dropped.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
