### PR TITLE
nixpkgs-manual.epub: use structuredAttrs instead of passAsFile

### DIFF
--- a/doc/doc-support/epub.nix
+++ b/doc/doc-support/epub.nix
@@ -37,16 +37,16 @@ runCommand "manual.epub"
       </book>
     '';
 
-    passAsFile = [ "epub" ];
+    __structuredAttrs = true;
   }
   ''
     mkdir scratch
-    xsltproc \
+    printf "%s" "$epub" | xsltproc \
       --param chapter.autolabel 0 \
       --nonet \
       --output scratch/ \
       ${docbook_xsl_ns}/xml/xsl/docbook/epub/docbook.xsl \
-      $epubPath
+      -
 
     echo "application/epub+zip" > mimetype
     zip -0Xq -b "$TMPDIR" "$out" mimetype

--- a/nixos/doc/manual/default.nix
+++ b/nixos/doc/manual/default.nix
@@ -250,17 +250,17 @@ rec {
             </chapter>
           </book>
         '';
-        passAsFile = [ "doc" ];
+        __structuredAttrs = true;
       }
       ''
         # Generate the epub manual.
         dst=$out/${common.outputPath}
 
-        xsltproc \
+        printf "%s" "$doc" | xsltproc \
           --param chapter.autolabel 0 \
           --nonet --xinclude --output $dst/epub/ \
           ${docbook_xsl_ns}/xml/xsl/docbook/epub/docbook.xsl \
-          $docPath
+          -
 
         echo "application/epub+zip" > mimetype
         manual="$dst/nixos-manual.epub"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
