### PR TITLE
rubik: simplify font sources, use installFonts

### DIFF
--- a/pkgs/by-name/ru/rubik/package.nix
+++ b/pkgs/by-name/ru/rubik/package.nix
@@ -1,86 +1,29 @@
 {
-  stdenv,
+  stdenvNoCC,
   lib,
-  fetchurl,
+  fetchFromGitHub,
+  installFonts,
 }:
-let
-  # Latest commit touching the rubik tree
-  commit = "054aa9d546cd6308f8ff7139b332490e0967aebe";
-in
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "rubik";
   version = "2.200";
 
-  srcs = [
-    (fetchurl {
-      url = "https://raw.githubusercontent.com/googlefonts/rubik/${commit}/fonts/ttf/Rubik-Black.ttf";
-      sha256 = "0h4mxqz0b5as7g964bv98aanaghp4wgs2g5wnf7apxnd2fng14dn";
-    })
-    (fetchurl {
-      url = "https://raw.githubusercontent.com/googlefonts/rubik/${commit}/fonts/ttf/Rubik-BlackItalic.ttf";
-      sha256 = "0x8j3fwavkf1jf7s97ncvs0jk463v1fyajcxqxvv7lpk55sjnbpy";
-    })
-    (fetchurl {
-      url = "https://raw.githubusercontent.com/googlefonts/rubik/${commit}/fonts/ttf/Rubik-Bold.ttf";
-      sha256 = "0prjqdbdpnhwr66gjw9mc1590gmjl7fir8wnanzch6arvngmxaj9";
-    })
-    (fetchurl {
-      url = "https://raw.githubusercontent.com/googlefonts/rubik/${commit}/fonts/ttf/Rubik-BoldItalic.ttf";
-      sha256 = "1zyl55fkjr61k6yfvgi0cr2iz4s0kkv3mkjpdmpla9jnk10rd8lm";
-    })
-    (fetchurl {
-      url = "https://raw.githubusercontent.com/googlefonts/rubik/${commit}/fonts/ttf/Rubik-ExtraBold.ttf";
-      sha256 = "0vi01lc2dadgmw5z26nkfzn7vl3lsd0flhqqfp40nn8jvpdkb2mq";
-    })
-    (fetchurl {
-      url = "https://raw.githubusercontent.com/googlefonts/rubik/${commit}/fonts/ttf/Rubik-ExtraBoldItalic.ttf";
-      sha256 = "0ldcszzzrc44gldflman7kcfk38x77grjb3zjvxjvgn875ggwabk";
-    })
-    (fetchurl {
-      url = "https://raw.githubusercontent.com/googlefonts/rubik/${commit}/fonts/ttf/Rubik-Italic.ttf";
-      sha256 = "09x7fh6ad4w6027410vhkvisgy8vqm2mzdsc19z3szlrxi0gl0rx";
-    })
-    (fetchurl {
-      url = "https://raw.githubusercontent.com/googlefonts/rubik/${commit}/fonts/ttf/Rubik-Light.ttf";
-      sha256 = "19a6k0pprcra6nxk3l0k6wkg9g0qn5h1v71rw2m8im64kyjx4qpf";
-    })
-    (fetchurl {
-      url = "https://raw.githubusercontent.com/googlefonts/rubik/${commit}/fonts/ttf/Rubik-LightItalic.ttf";
-      sha256 = "0r9hbh9xnbp0584vjiiq72583j1ai3dw93gfy823c736y6bk0j2m";
-    })
-    (fetchurl {
-      url = "https://raw.githubusercontent.com/googlefonts/rubik/${commit}/fonts/ttf/Rubik-Medium.ttf";
-      sha256 = "01nky9la4qjd80dy200j8l7zl0r2h9zw90k7aghzlb5abk4i3zvf";
-    })
-    (fetchurl {
-      url = "https://raw.githubusercontent.com/googlefonts/rubik/${commit}/fonts/ttf/Rubik-MediumItalic.ttf";
-      sha256 = "1i81x9h2cr65bj85z5b2mki59532nvlbh92wb84zfhfdz97s30cq";
-    })
-    (fetchurl {
-      url = "https://raw.githubusercontent.com/googlefonts/rubik/${commit}/fonts/ttf/Rubik-Regular.ttf";
-      sha256 = "1vk4n6yc4x1vlwfrp26jhagyl5l86jwa4lalccc320crrwqfc521";
-    })
-    (fetchurl {
-      url = "https://raw.githubusercontent.com/googlefonts/rubik/${commit}/fonts/ttf/Rubik-SemiBold.ttf";
-      sha256 = "0blmy1ywsf9hr1a66cl12bjn32i072w6ncvsir0s5smm2c0gksvb";
-    })
-    (fetchurl {
-      url = "https://raw.githubusercontent.com/googlefonts/rubik/${commit}/fonts/ttf/Rubik-SemiBoldItalic.ttf";
-      sha256 = "1sj22d3jrlxl6ka0naf5nby3k0i7pzadk5b8xgdhcslwijwiib3y";
-    })
+  outputs = [
+    "out"
+    "webfont"
   ];
 
-  sourceRoot = ".";
+  src = fetchFromGitHub {
+    owner = "googlefonts";
+    repo = "rubik";
+    # Latest commit touching the rubik tree
+    rev = "054aa9d546cd6308f8ff7139b332490e0967aebe";
+    hash = "sha256-AkWMLbDIect48KLEYIIx/WNQ57P1Ivp5VrJP8mdj1oE=";
+  };
 
-  unpackCmd = ''
-    ttfName=$(basename $(stripHash $curSrc))
-    cp $curSrc ./$ttfName
-  '';
+  nativeBuildInputs = [ installFonts ];
 
-  installPhase = ''
-    mkdir -p $out/share/fonts/truetype
-    cp -a *.ttf $out/share/fonts/truetype/
-  '';
+  preInstall = "rm -r old/";
 
   meta = {
     homepage = "https://fonts.google.com/specimen/Rubik";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Part of #495640 
Sorry that the diff is kind of gross, note that the rev is the same one as used before just fetched different.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
