### PR TITLE
wahjam: init at 1.3.1-unstable-2023-05-30

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4512,6 +4512,12 @@
     githubId = 1945;
     name = "Casey Rodarmor";
   };
+  caseyavila = {
+    email = "casey@theavilas.org";
+    github = "caseyavila";
+    githubId = 53847249;
+    name = "Casey Avila";
+  };
   catap = {
     email = "kirill@korins.ky";
     github = "catap";

--- a/pkgs/by-name/wa/wahjam/package.nix
+++ b/pkgs/by-name/wa/wahjam/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  makeDesktopItem,
+  copyDesktopItems,
+  pkg-config,
+  libsForQt5,
+  libogg,
+  libvorbis,
+  libresample,
+  portaudio,
+  portmidi,
+}:
+
+stdenv.mkDerivation {
+  pname = "wahjam";
+  version = "1.3.1-unstable-2023-05-30";
+
+  src = fetchFromGitHub {
+    owner = "wahjam";
+    repo = "wahjam";
+    rev = "4fde74da3be1fa53cdc2d3bc4b577b40951d6809";
+    hash = "sha256-WYfLQxToyjAE+R2eaBKpDJGfkvrOTza8a6JbN9AL3aE=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    libsForQt5.qmake
+    libsForQt5.wrapQtAppsHook
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    libsForQt5.qtbase
+    libsForQt5.qtkeychain
+    libogg
+    libvorbis
+    libresample
+    portaudio
+    portmidi
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "wahjam";
+      desktopName = "Wahjam";
+      icon = "net.jammr.jammr";
+      exec = "wahjam";
+      comment = "Play with musicians over the internet";
+      categories = [ "AudioVideo" ];
+    })
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/icons/hicolor/scalable/apps
+
+    cp qtclient/wahjam $out/bin/wahjam
+    cp qtclient/net.jammr.jammr.svg $out/share/icons/hicolor/scalable/apps
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Software for musicians to play together over the internet";
+    mainProgram = "wahjam";
+    homepage = "https://github.com/wahjam/wahjam";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ caseyavila ];
+  };
+}

--- a/pkgs/by-name/wa/wahjam/package.nix
+++ b/pkgs/by-name/wa/wahjam/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  makeDesktopItem,
+  copyDesktopItems,
+  pkg-config,
+  libsForQt5,
+  libogg,
+  libvorbis,
+  libresample,
+  portaudio,
+  portmidi,
+}:
+
+stdenv.mkDerivation {
+  pname = "wahjam";
+  version = "1.3.1-unstable-2023-05-30";
+
+  src = fetchFromGitHub {
+    owner = "wahjam";
+    repo = "wahjam";
+    rev = "4fde74da3be1fa53cdc2d3bc4b577b40951d6809";
+    hash = "sha256-WYfLQxToyjAE+R2eaBKpDJGfkvrOTza8a6JbN9AL3aE=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    libsForQt5.qmake
+    libsForQt5.wrapQtAppsHook
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    libsForQt5.qtbase
+    libsForQt5.qtkeychain
+    libogg
+    libvorbis
+    libresample
+    portaudio
+    portmidi
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "wahjam";
+      desktopName = "Wahjam";
+      icon = "net.jammr.jammr";
+      exec = "wahjam";
+      comment = "Play with musicians over the internet";
+      categories = [ "AudioVideo" ];
+    })
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/icons/hicolor/scalable/apps
+
+    cp qtclient/wahjam $out/bin/wahjam
+    cp qtclient/net.jammr.jammr.svg $out/share/icons/hicolor/scalable/apps
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Software for musicians to play together over the internet";
+    mainProgram = "wahjam";
+    homepage = "https://github.com/wahjam/wahjam";
+    license = lib.licenses.gpl2;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ caseyavila ];
+  };
+}


### PR DESCRIPTION
Added `wahjam` package and myself to the maintainers list. Wahjam is GPL2 software which allows musicians to connect to NINJAM servers and play music together remotely. (http://wahjam.org/)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
