### PR TITLE
fluxcd: rewrite update script to use nix-update

### DIFF
--- a/pkgs/by-name/fl/fluxcd/update.sh
+++ b/pkgs/by-name/fl/fluxcd/update.sh
@@ -1,50 +1,21 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl gnugrep gnused jq
+#!nix-shell -i bash -p gnused nix-update
 
-set -x -eu -o pipefail
+set -eu -o pipefail
+set -x
 
-NIXPKGS_PATH="$(git rev-parse --show-toplevel)"
-FLUXCD_PATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+# Compute the relative dir of the update script
+SCRIPT_DIR="$(cd -- "$(dirname "$0")" >/dev/null 2>&1; pwd -P)"
 
-OLD_VERSION="$(nix-instantiate --eval -E "with import $NIXPKGS_PATH {}; fluxcd.version or (builtins.parseDrvName fluxcd.name).version" | tr -d '"')"
-LATEST_TAG=$(curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} --silent https://api.github.com/repos/fluxcd/flux2/releases/latest | jq -r '.tag_name')
-LATEST_VERSION=$(echo "${LATEST_TAG}" | sed 's/^v//')
+# Update version, src hash, and vendor hash
+nix-update fluxcd
 
-if [ ! "$OLD_VERSION" = "$LATEST_VERSION" ]; then
-    SRC_SHA256=$(nix-prefetch-url --quiet --unpack "https://github.com/fluxcd/flux2/archive/refs/tags/${LATEST_TAG}.tar.gz")
-    SRC_HASH=$(nix --extra-experimental-features nix-command hash convert --hash-algo sha256 --to sri "$SRC_SHA256")
-    MANIFESTS_SHA256=$(nix-prefetch-url --quiet --unpack "https://github.com/fluxcd/flux2/releases/download/${LATEST_TAG}/manifests.tar.gz")
-    MANIFESTS_HASH=$(nix --extra-experimental-features nix-command hash convert --hash-algo sha256 --to sri "$MANIFESTS_SHA256")
+# Read the potentially updated version from `nix-update fluxcd` using SCRIPT_DIR
+VERSION=$(sed -n 's/.*version = "\(.*\)".*/\1/p' "${SCRIPT_DIR}/package.nix" | head -1)
 
-    setKV () {
-        sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" "${FLUXCD_PATH}/package.nix"
-    }
-
-    setKV version "${LATEST_VERSION}"
-    setKV srcHash "${SRC_HASH}"
-    setKV manifestsHash "${MANIFESTS_HASH}"
-    setKV vendorHash "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" # The same as lib.fakeHash
-
-    set +e
-    VENDOR_SHA256=$(nix-build --no-out-link -A fluxcd "$NIXPKGS_PATH" 2>&1 >/dev/null | grep "got:" | cut -d':' -f2 | sed 's| ||g')
-    VENDOR_HASH=$(nix --extra-experimental-features nix-command hash convert --hash-algo sha256 --to sri "$VENDOR_SHA256")
-    set -e
-
-    if [ -n "${VENDOR_HASH:-}" ]; then
-        setKV vendorHash "${VENDOR_HASH}"
-    else
-        echo "Update failed. VENDOR_HASH is empty."
-        exit 1
-    fi
-
-    # `git` flag here is to be used by local maintainers to speed up the bump process
-    if [ $# -eq 1 ] && [ "$1" = "git" ]; then
-        git switch -c "package-fluxcd-${LATEST_VERSION}"
-        git add "$FLUXCD_PATH"/package.nix
-        git commit -m "fluxcd: ${OLD_VERSION} -> ${LATEST_VERSION}
-
-Release: https://github.com/fluxcd/flux2/releases/tag/v${LATEST_VERSION}"
-    fi
-else
-    echo "fluxcd is already up-to-date at $OLD_VERSION"
-fi
+# Update the additional fluxcd manifests hash
+# This is idempotent and will run regardless of whether nix-update changes the package.nix version
+# note: tag format is assumed to be v${VERSION} which matches the fetchZip in package.nix
+MANIFESTS_SHA256=$(nix-prefetch-url --quiet --unpack "https://github.com/fluxcd/flux2/releases/download/v${VERSION}/manifests.tar.gz")
+MANIFESTS_HASH=$(nix --extra-experimental-features nix-command hash convert --hash-algo sha256 --to sri "$MANIFESTS_SHA256")
+sed -i "s|manifestsHash = \".*\"|manifestsHash = \"${MANIFESTS_HASH}\"|" "${SCRIPT_DIR}/package.nix"


### PR DESCRIPTION
This reimplements the fluxcd update script using nix-update.
The manifests hash logic is computed using the version info from the package.nix, similar to the fetchZip.
nix-update updates the file if possible.

The previous script's grep-based vendor hash extraction (`grep "got:" | cut -d: -f2`)
can fail (maybe the Nix error output format is not always reliable?)

Logs from r-ryantm, show this has prevented some automated PRs:
- [2026-03-01.log](https://r.ryantm.com/log/fluxcd/2026-03-01.log) — `Update failed. VENDOR_HASH is empty.`
- [Full log index](https://r.ryantm.com/log/fluxcd/)
- Last successful r-ryantm PR: [#450624](https://github.com/NixOS/nixpkgs/pull/450624) (Oct 2025)

some comparable update scripts are: adguardhome, helix, perses, and viddy

one improvement is that the old script used to log the GITHUB_TOKEN.
now the script doesn't touch it directly.