### PR TITLE
dioxus-cli: 0.7.6 -> 0.7.7

### DIFF
--- a/pkgs/by-name/di/dioxus-cli/package.nix
+++ b/pkgs/by-name/di/dioxus-cli/package.nix
@@ -17,15 +17,20 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "dioxus-cli";
-  version = "0.7.6";
+  version = "0.7.7";
 
   src = fetchCrate {
     pname = "dioxus-cli";
     version = finalAttrs.version;
-    hash = "sha256-PKidohK85wv/ZN9WcNS+HTlVGgR5o07gWLshZhzyg5k=";
+    hash = "sha256-foKYD5mvx1CG4qYecmED0JGyKyjmodrgSGd2+x4IeR4=";
   };
 
-  cargoHash = "sha256-T6xLlu8XeJPm+ULgpTALTT93X55ExJhDMuhpal2QLhg=";
+  cargoHash = "sha256-qPxW3VzHUw+GBmHn9r77BcDw50AkCfAOa7JblpgYgls=";
+
+  patches = [
+    ./update-readme-for-0.7.patch
+  ];
+
   buildFeatures = [
     "no-downloads"
   ]

--- a/pkgs/by-name/di/dioxus-cli/update-readme-for-0.7.patch
+++ b/pkgs/by-name/di/dioxus-cli/update-readme-for-0.7.patch
@@ -1,0 +1,65 @@
+diff --git a/README.md b/README.md
+index 84e725c..18730f1 100644
+--- a/README.md
++++ b/README.md
+@@ -3,8 +3,10 @@
+   <p><strong>Tooling to supercharge Dioxus projects</strong></p>
+ </div>
+ 
+-The **dioxus-cli** (inspired by wasm-pack and webpack) is a tool for getting Dioxus projects up and running.
+-It handles building, bundling, development and publishing to simplify development.
++The **dioxus-cli** provides `dx`, the command line tool for creating, serving,
++building, and bundling Dioxus apps. It targets the Dioxus app model directly:
++web, desktop, mobile, and fullstack/server builds are selected through `dx`
++target flags instead of a separate frontend project or JavaScript framework.
+ 
+ ## Installation
+ 
+@@ -44,21 +46,32 @@ Alternatively, you can specify the template path:
+ dx new --template gh:dioxuslabs/dioxus-template
+ ```
+ 
+-Run `dx --help` for a list of all the available commands.
++Then serve or build the app for the target you need:
++
++```shell
++dx serve --web
++dx build --desktop
++dx build --android
++```
++
++Use `--fullstack`, `--server`, or the app's Dioxus features for fullstack and
++server builds. Run `dx --help` for a list of all the available commands.
+ Furthermore, you can run `dx <command> --help` to get help with a specific command.
+ 
+ ## Dioxus config file
+ 
+-You can use the `Dioxus.toml` file for further configuration.
+-Some fields are mandatory, but the CLI tool will tell you which ones are missing.
+-You can create a `Dioxus.toml` with all fields already set using `dx config init project-name`,
+-or you can use this bare-bones template (only mandatory fields) to get started:
++Dioxus apps can use a `Dioxus.toml` file for project configuration, including
++app metadata, static assets, development server settings, web metadata, and
++bundle metadata. Target selection is handled by `dx` flags such as `--web`,
++`--desktop`, `--ios`, `--android`, `--server`, or `--platform`.
++
++You can create a `Dioxus.toml` with `dx config init project-name`, or start
++from a small web app configuration:
+ 
+ ```toml
+ [application]
+ name = "project-name"
+-# Currently supported platforms: web, desktop
+-default_platform = "web"
++out_dir = "dist"
+ 
+ # Optional: enable copying from a static directory (e.g. "public")
+ public_dir = "public"
+@@ -66,5 +79,6 @@ public_dir = "public"
+ [web.app]
+ title = "Hello"
+ 
+-[web.resource.dev]
++[web.watcher]
++watch_path = ["src", "public"]
+ ```


### PR DESCRIPTION
dioxus-cli: 0.7.6 -> 0.7.7.

Changelog: https://github.com/DioxusLabs/dioxus/releases/tag/v0.7.7

Validation performed:
- Verified latest GitHub release is `v0.7.7`, published 2026-05-01.
- Verified crates.io reports `0.7.7` as the latest stable `dioxus-cli` version.
- Ran `nix eval --raw .#dioxus-cli.version` and got `0.7.7`.
- Prefetched the crates.io source hash with `nix store prefetch-file`.
- Reproduced the `cargoHash` from the packaged `Cargo.lock` vendor-staging tarballs.
- Ran `git diff --check -- pkgs/by-name/di/dioxus-cli/package.nix`.

Validation attempted but not completed:
- `nix build .#dioxus-cli --print-out-paths --print-build-logs` initially failed because the filesystem was full while unpacking a bootstrap dependency.
- Freed about 80 GiB with `nix-collect-garbage`, then retried the build.
- The retry progressed through local bootstrap dependencies but failed before building `dioxus-cli` itself, so I could not run the Nix-built `dx --version` output.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
