### PR TITLE
comfyui: init at 0.29.0; nixos/comfyui: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -854,6 +854,7 @@
   ./services/misc/cgminer.nix
   ./services/misc/clipcat.nix
   ./services/misc/clipmenu.nix
+  ./services/misc/comfyui.nix
   ./services/misc/confd.nix
   ./services/misc/conman.nix
   ./services/misc/cpuminer-cryptonight.nix

--- a/nixos/modules/services/misc/comfyui.nix
+++ b/nixos/modules/services/misc/comfyui.nix
@@ -1,0 +1,133 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.comfyui;
+in
+{
+  options = {
+    services.comfyui = {
+      enable = lib.mkEnableOption "ComfyUI";
+      package = lib.mkPackageOption pkgs "comfyui" { };
+
+      listen = lib.mkOption {
+        type = with lib.types; listOf str;
+        default = [
+          "127.0.0.1"
+          "::1"
+        ];
+        example = [
+          "0.0.0.0"
+          "::"
+        ];
+        description = ''
+          The host addresses on which ComfyUI should listen.
+        '';
+      };
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 8188;
+        example = 1234;
+        description = ''
+          The port on that ComfyUI will listen.
+        '';
+      };
+
+      extraArgs = lib.mkOption {
+        type = with lib.types; listOf str;
+        default = [ ];
+        example = [
+          "--enable-assets"
+          "--preview-method=auto"
+        ];
+        description = ''
+          Extra arguments to pass to the server. See `comfyui --help` for available args.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.comfyui.extraArgs = [
+      "--base-directory=/var/lib/comfyui"
+      "--database-url=sqlite:////var/lib/comfyui/user/comfyui.db"
+      "--listen=${lib.concatStringsSep "," cfg.listen}"
+      "--port=${toString cfg.port}"
+    ];
+
+    systemd.services.comfyui = {
+      description = "Powerful and modular diffusion model GUI, api and backend";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      preStart = ''
+        for d in custom_nodes input output models; do
+          if [[ ! -d /var/lib/comfyui/$d ]]; then
+            cp --no-preserve=all -r ${cfg.package}/share/comfyui/$d /var/lib/comfyui/
+          fi
+        done
+      '';
+
+      serviceConfig = {
+        ExecStart = "${lib.getExe cfg.package} ${lib.escapeShellArgs cfg.extraArgs}";
+        Group = "comfyui";
+        Restart = "always";
+        RestartSec = "5sec"; # don't crash loop immediately
+        StateDirectory = "comfyui";
+        Type = "simple";
+        User = "comfyui";
+
+        # required for Torch and GPU acceleration
+        BindReadOnlyPaths = [ "/proc/cpuinfo" ];
+        PrivateDevices = false;
+        ProcSubset = "all";
+
+        CapabilityBoundingSet = [ "" ];
+        DeviceAllow = null;
+        LockPersonality = true;
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = "tmpfs";
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        RuntimeDirectoryMode = "700";
+        StateDirectoryMode = "700";
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+        ];
+      };
+    };
+
+    users = {
+      groups.comfyui = { };
+      users.comfyui = {
+        group = "comfyui";
+        home = "/var/lib/comfyui";
+        isSystemUser = true;
+      };
+    };
+  };
+
+  meta.maintainers = pkgs.comfyui.meta.maintainers;
+}

--- a/pkgs/by-name/co/comfyui/package.nix
+++ b/pkgs/by-name/co/comfyui/package.nix
@@ -1,14 +1,13 @@
 {
   lib,
-  stdenvNoCC,
   fetchFromGitHub,
   makeBinaryWrapper,
   nix-update-script,
-  python3,
+  python3Packages,
 }:
 
 let
-  pythonEnv = python3.withPackages (
+  appDependencies =
     ps: with ps; [
       aiohttp
       alembic
@@ -46,12 +45,14 @@ let
       tqdm
       transformers
       yarl
-    ]
-  );
+    ];
+  pythonEnv = python3Packages.python.withPackages appDependencies;
 in
-stdenvNoCC.mkDerivation (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "comfyui";
   version = "0.20.1";
+
+  pyproject = false;
 
   strictDeps = true;
   __structuredAttrs = true;
@@ -65,37 +66,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ makeBinaryWrapper ];
 
-  postPatch = ''
-    substituteInPlace comfy/cli_args.py \
-      --replace-fail \
-        'parser.add_argument("--base-directory", type=str, default=None, help="Set the ComfyUI base directory for models, custom_nodes, input, output, temp, and user directories.")' \
-        'xdg_data_home = os.environ.get("XDG_DATA_HOME") or os.path.expanduser("~/.local/share")
-    comfyui_data_home = os.path.join(xdg_data_home, "comfyui")
-    parser.add_argument("--base-directory", type=str, default=comfyui_data_home, help="Set the ComfyUI base directory for models, custom_nodes, input, output, temp, and user directories.")' \
-      --replace-fail \
-        'database_default_path = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), "..", "user", "comfyui.db")
-    )' \
-        'database_default_path = os.path.join(comfyui_data_home, "user", "comfyui.db")'
+  patches = [ ./use-writable-runtime-paths.patch ];
 
-    substituteInPlace folder_paths.py \
-      --replace-fail \
-        'folder_names_and_paths["custom_nodes"] = ([os.path.join(base_path, "custom_nodes")], set())' \
-        'custom_nodes_directory = os.path.join(base_path, "custom_nodes")
-    folder_names_and_paths["custom_nodes"] = ([custom_nodes_directory], set())' \
-      --replace-fail \
-        'if not os.path.exists(input_directory):
-        try:
-            os.makedirs(input_directory)
-        except:
-            logging.error("Failed to create input directory")' \
-        'for default_directory in (input_directory, custom_nodes_directory):
-        if not os.path.exists(default_directory):
-            try:
-                os.makedirs(default_directory)
-            except:
-                logging.error(f"Failed to create {default_directory}")'
-  '';
+  dependencies = appDependencies python3Packages;
+
+  dontBuild = true;
+  dontWrapPythonPrograms = true;
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/co/comfyui/package.nix
+++ b/pkgs/by-name/co/comfyui/package.nix
@@ -18,6 +18,7 @@ let
       comfy-kitchen
       comfyui-embedded-docs
       comfyui-frontend-package
+      comfyui-manager
       comfyui-workflow-templates
       einops
       filelock

--- a/pkgs/by-name/co/comfyui/package.nix
+++ b/pkgs/by-name/co/comfyui/package.nix
@@ -1,0 +1,119 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  nix-update-script,
+  python3,
+}:
+
+let
+  pythonEnv = python3.withPackages (
+    ps: with ps; [
+      aiohttp
+      alembic
+      av
+      blake3
+      comfy-aimdo
+      comfy-kitchen
+      comfyui-embedded-docs
+      comfyui-frontend-package
+      comfyui-workflow-templates
+      einops
+      filelock
+      glfw
+      kornia
+      numpy
+      pillow
+      psutil
+      pydantic
+      pydantic-settings
+      pyopengl
+      pyyaml
+      requests
+      safetensors
+      scipy
+      sentencepiece
+      simpleeval
+      spandrel
+      sqlalchemy
+      tokenizers
+      torch
+      torchaudio
+      torchsde
+      torchvision
+      tqdm
+      transformers
+      yarl
+    ]
+  );
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "comfyui";
+  version = "0.20.1";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Comfy-Org";
+    repo = "ComfyUI";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-CYrOLwfQvj4024WZ7OlGbJOxyj8qKHuwIfVluNVHIk4=";
+  };
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  postPatch = ''
+        substituteInPlace comfy/cli_args.py \
+          --replace-fail \
+            'parser.add_argument("--base-directory", type=str, default=None, help="Set the ComfyUI base directory for models, custom_nodes, input, output, temp, and user directories.")' \
+            'xdg_data_home = os.environ.get("XDG_DATA_HOME") or os.path.expanduser("~/.local/share")
+    comfyui_data_home = os.path.join(xdg_data_home, "comfyui")
+    parser.add_argument("--base-directory", type=str, default=comfyui_data_home, help="Set the ComfyUI base directory for models, custom_nodes, input, output, temp, and user directories.")' \
+          --replace-fail \
+            'database_default_path = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "user", "comfyui.db")
+    )' \
+            'database_default_path = os.path.join(comfyui_data_home, "user", "comfyui.db")'
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/comfyui $out/bin
+    cp -r . $out/share/comfyui
+
+    makeBinaryWrapper ${lib.getExe pythonEnv} $out/bin/comfyui \
+      --add-flag "$out/share/comfyui/main.py"
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    "$out"/bin/comfyui --help
+
+    runHook postInstallCheck
+  '';
+
+  passthru = {
+    inherit pythonEnv;
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Modular diffusion model GUI, API, and backend with graph and nodes interface";
+    homepage = "https://github.com/Comfy-Org/ComfyUI";
+    changelog = "https://github.com/Comfy-Org/ComfyUI/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "comfyui";
+    maintainers = with lib.maintainers; [
+      caniko
+      jk
+    ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/co/comfyui/package.nix
+++ b/pkgs/by-name/co/comfyui/package.nix
@@ -66,17 +66,35 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ makeBinaryWrapper ];
 
   postPatch = ''
-        substituteInPlace comfy/cli_args.py \
-          --replace-fail \
-            'parser.add_argument("--base-directory", type=str, default=None, help="Set the ComfyUI base directory for models, custom_nodes, input, output, temp, and user directories.")' \
-            'xdg_data_home = os.environ.get("XDG_DATA_HOME") or os.path.expanduser("~/.local/share")
+    substituteInPlace comfy/cli_args.py \
+      --replace-fail \
+        'parser.add_argument("--base-directory", type=str, default=None, help="Set the ComfyUI base directory for models, custom_nodes, input, output, temp, and user directories.")' \
+        'xdg_data_home = os.environ.get("XDG_DATA_HOME") or os.path.expanduser("~/.local/share")
     comfyui_data_home = os.path.join(xdg_data_home, "comfyui")
     parser.add_argument("--base-directory", type=str, default=comfyui_data_home, help="Set the ComfyUI base directory for models, custom_nodes, input, output, temp, and user directories.")' \
-          --replace-fail \
-            'database_default_path = os.path.abspath(
+      --replace-fail \
+        'database_default_path = os.path.abspath(
         os.path.join(os.path.dirname(__file__), "..", "user", "comfyui.db")
     )' \
-            'database_default_path = os.path.join(comfyui_data_home, "user", "comfyui.db")'
+        'database_default_path = os.path.join(comfyui_data_home, "user", "comfyui.db")'
+
+    substituteInPlace folder_paths.py \
+      --replace-fail \
+        'folder_names_and_paths["custom_nodes"] = ([os.path.join(base_path, "custom_nodes")], set())' \
+        'custom_nodes_directory = os.path.join(base_path, "custom_nodes")
+    folder_names_and_paths["custom_nodes"] = ([custom_nodes_directory], set())' \
+      --replace-fail \
+        'if not os.path.exists(input_directory):
+        try:
+            os.makedirs(input_directory)
+        except:
+            logging.error("Failed to create input directory")' \
+        'for default_directory in (input_directory, custom_nodes_directory):
+        if not os.path.exists(default_directory):
+            try:
+                os.makedirs(default_directory)
+            except:
+                logging.error(f"Failed to create {default_directory}")'
   '';
 
   installPhase = ''
@@ -96,6 +114,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook preInstallCheck
 
     "$out"/bin/comfyui --help
+    export XDG_DATA_HOME="$(mktemp -d)"
+    "$out"/bin/comfyui --cpu --quick-test-for-ci
 
     runHook postInstallCheck
   '';

--- a/pkgs/by-name/co/comfyui/package.nix
+++ b/pkgs/by-name/co/comfyui/package.nix
@@ -1,0 +1,140 @@
+{
+  lib,
+  callPackage,
+  cudaPackages_13,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  python3,
+  stdenvNoCC,
+  withManager ? false,
+}:
+
+let
+  # Using overrideScope does not work when using `withPackages appDependencies`
+  # and creates a an env without those overrides
+  python = python3.override {
+    self = python;
+    packageOverrides = final: prev: {
+      # older cudaPackages are not supported and actively disabled
+      # https://github.com/Comfy-Org/ComfyUI/blob/v0.27.0/comfy/quant_ops.py#L25
+      torch = prev.torch.override {
+        cudaPackages = cudaPackages_13;
+      };
+      triton = prev.triton.override {
+        cudaPackages = cudaPackages_13;
+      };
+    };
+  };
+
+  appDependencies =
+    ps:
+    with ps;
+    [
+      aiohttp
+      alembic
+      av
+      blake3
+      comfy-aimdo
+      comfy-angle
+      comfy-kitchen
+      comfyui-embedded-docs
+      comfyui-frontend-package
+      comfyui-workflow-templates
+      einops
+      filelock
+      kornia
+      numpy
+      pillow
+      psutil
+      pydantic
+      pydantic-settings
+      pyopengl
+      pyyaml
+      requests
+      safetensors
+      scipy
+      sentencepiece
+      simpleeval
+      spandrel
+      sqlalchemy
+      tokenizers
+      torch
+      torchaudio
+      torchsde
+      torchvision
+      tqdm
+      transformers
+      yarl
+    ]
+    ++ lib.optionals withManager [
+      ps.comfyui-manager
+    ];
+
+  pythonEnv = python.withPackages appDependencies;
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "comfyui";
+  version = "0.29.0";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Comfy-Org";
+    repo = "ComfyUI";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-sbIsVBHfs8aPPmNDklbrqPnz5ekQUguIPjGm2v2WTis=";
+  };
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  patches = [ ./use-writable-runtime-paths.patch ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/comfyui $out/bin
+    cp -r . $out/share/comfyui
+
+    makeBinaryWrapper ${lib.getExe pythonEnv} $out/bin/comfyui \
+      --add-flag "$out/share/comfyui/main.py" \
+      --unset NIX_PYTHONPATH \
+      --unset PYTHONPATH
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    PYTHONPATH=${pythonEnv}/${python.sitePackages} ${lib.getExe python.pkgs.pip} install --break-system-packages --dry-run --no-index -r requirements.txt
+    "$out"/bin/comfyui --help
+    export XDG_DATA_HOME="$(mktemp -d)"
+    "$out"/bin/comfyui --cpu --quick-test-for-ci
+
+    runHook postInstallCheck
+  '';
+
+  passthru = {
+    inherit python pythonEnv;
+  }
+  // lib.optionalAttrs (!withManager) {
+    tests.withManager = callPackage ./package.nix {
+      withManager = true;
+    };
+  };
+
+  meta = {
+    description = "Modular diffusion model GUI, API, and backend with graph and nodes interface";
+    homepage = "https://github.com/Comfy-Org/ComfyUI";
+    changelog = "https://github.com/Comfy-Org/ComfyUI/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "comfyui";
+    maintainers = with lib.maintainers; [
+      caniko
+      SuperSandro2000
+    ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/co/comfyui/use-writable-runtime-paths.patch
+++ b/pkgs/by-name/co/comfyui/use-writable-runtime-paths.patch
@@ -1,0 +1,58 @@
+diff --git a/comfy/cli_args.py b/comfy/cli_args.py
+index 810c90935..09d5bad61 100644
+--- a/comfy/cli_args.py
++++ b/comfy/cli_args.py
+@@ -42,7 +42,9 @@ parser.add_argument("--enable-cors-header", type=str, default=None, metavar="ORI
+ parser.add_argument("--enable-cors-header", type=str, default=None, metavar="ORIGIN", nargs="?", const="*", help="Enable CORS (Cross-Origin Resource Sharing) with optional origin or allow all with default '*'.")
+ parser.add_argument("--max-upload-size", type=float, default=100, help="Set the maximum upload size in MB.")
+ 
+-parser.add_argument("--base-directory", type=str, default=None, help="Set the ComfyUI base directory for models, custom_nodes, input, output, temp, and user directories.")
++xdg_data_home = os.environ.get("XDG_DATA_HOME") or os.path.expanduser("~/.local/share")
++comfyui_data_home = os.path.join(xdg_data_home, "comfyui")
++parser.add_argument("--base-directory", type=str, default=comfyui_data_home, help="Set the ComfyUI base directory for models, custom_nodes, input, output, temp, and user directories.")
+ parser.add_argument("--extra-model-paths-config", type=str, default=None, metavar="PATH", nargs='+', action='append', help="Load one or more extra_model_paths.yaml files.")
+ parser.add_argument("--output-directory", type=str, default=None, help="Set the ComfyUI output directory. Overrides --base-directory.")
+ parser.add_argument("--temp-directory", type=str, default=None, help="Set the ComfyUI temp directory (default is in the ComfyUI directory). Overrides --base-directory.")
+@@ -233,9 +235,7 @@ parser.add_argument(
+     help="Set the base URL for the ComfyUI API.  (default: https://api.comfy.org)",
+ )
+ 
+-database_default_path = os.path.abspath(
+-    os.path.join(os.path.dirname(__file__), "..", "user", "comfyui.db")
+-)
++database_default_path = os.path.join(comfyui_data_home, "user", "comfyui.db")
+ parser.add_argument("--database-url", type=str, default=f"sqlite:///{database_default_path}", help="Specify the database URL, e.g. for an in-memory database you can use 'sqlite:///:memory:'.")
+ parser.add_argument("--enable-assets", action="store_true", help="Enable the assets system (API routes, database synchronization, and background scanning).")
+ 
+diff --git a/folder_paths.py b/folder_paths.py
+index 2a7a7a996..8062cc1b6 100644
+--- a/folder_paths.py
++++ b/folder_paths.py
+@@ -40,7 +40,8 @@ folder_names_and_paths["upscale_models"] = ([os.path.join(models_dir, "upscale_
+ 
+ folder_names_and_paths["latent_upscale_models"] = ([os.path.join(models_dir, "latent_upscale_models")], supported_pt_extensions)
+ 
+-folder_names_and_paths["custom_nodes"] = ([os.path.join(base_path, "custom_nodes")], set())
++custom_nodes_directory = os.path.join(base_path, "custom_nodes")
++folder_names_and_paths["custom_nodes"] = ([custom_nodes_directory], set())
+ 
+ folder_names_and_paths["hypernetworks"] = ([os.path.join(models_dir, "hypernetworks")], supported_pt_extensions)
+ 
+@@ -101,11 +102,12 @@ def map_legacy(folder_name: str) -> str:
+               "clip": "text_encoders"}
+     return legacy.get(folder_name, folder_name)
+ 
+-if not os.path.exists(input_directory):
+-    try:
+-        os.makedirs(input_directory)
+-    except:
+-        logging.error("Failed to create input directory")
++for default_directory in (input_directory, custom_nodes_directory):
++    if not os.path.exists(default_directory):
++        try:
++            os.makedirs(default_directory)
++        except:
++            logging.error(f"Failed to create {default_directory}")
+ 
+ def set_output_directory(output_dir: str) -> None:
+     global output_directory

--- a/pkgs/by-name/co/comfyui/use-writable-runtime-paths.patch
+++ b/pkgs/by-name/co/comfyui/use-writable-runtime-paths.patch
@@ -1,0 +1,64 @@
+diff --git a/comfy/cli_args.py b/comfy/cli_args.py
+index 4bef096..30f8920 100644
+--- a/comfy/cli_args.py
++++ b/comfy/cli_args.py
+@@ -42,7 +42,15 @@ parser.add_argument("--tls-certfile", type=str, help="Path to TLS (SSL) certific
+ parser.add_argument("--enable-cors-header", type=str, default=None, metavar="ORIGIN", nargs="?", const="*", help="Enable CORS (Cross-Origin Resource Sharing) with optional origin or allow all with default '*'.")
+ parser.add_argument("--max-upload-size", type=float, default=100, help="Set the maximum upload size in MB.")
+ 
+-parser.add_argument("--base-directory", type=str, default=None, help="Set the ComfyUI base directory for models, custom_nodes, input, output, temp, and user directories.")
++xdg_data_home = os.environ.get("XDG_DATA_HOME")
++if xdg_data_home is None:
++    home = os.environ.get("HOME")
++    if home is None:
++        xdg_data_home = "/var/lib"
++    else:
++        xdg_data_home = os.path.join(home, ".local", "share")
++comfyui_data_home = os.path.join(xdg_data_home, "comfyui")
++parser.add_argument("--base-directory", type=str, default=comfyui_data_home, help="Set the ComfyUI base directory for models, custom_nodes, input, output, temp, and user directories.")
+ parser.add_argument("--extra-model-paths-config", type=str, default=None, metavar="PATH", nargs='+', action='append', help="Load one or more extra_model_paths.yaml files.")
+ parser.add_argument("--output-directory", type=str, default=None, help="Set the ComfyUI output directory. Overrides --base-directory.")
+ parser.add_argument("--temp-directory", type=str, default=None, help="Set the ComfyUI temp directory (default is in the ComfyUI directory). Overrides --base-directory.")
+@@ -235,9 +243,7 @@ parser.add_argument(
+     help="Set the base URL for the ComfyUI API.  (default: https://api.comfy.org)",
+ )
+ 
+-database_default_path = os.path.abspath(
+-    os.path.join(os.path.dirname(__file__), "..", "user", "comfyui.db")
+-)
++database_default_path = os.path.join(comfyui_data_home, "user", "comfyui.db")
+ parser.add_argument("--database-url", type=str, default=f"sqlite:///{database_default_path}", help="Specify the database URL, e.g. for an in-memory database you can use 'sqlite:///:memory:'.")
+ parser.add_argument("--enable-assets", action="store_true", help="Enable the assets system (API routes, database synchronization, and background scanning).")
+ parser.add_argument("--enable-asset-hashing", action="store_true", help="Compute blake3 content hashes when scanning assets. Hashing enables future asset-portability features (deduplication, cross-machine model resolution) but adds startup cost and per-output cost on large models directories. Off by default; enable to opt in.")
+diff --git a/folder_paths.py b/folder_paths.py
+index 7304e1b..32a66c9 100644
+--- a/folder_paths.py
++++ b/folder_paths.py
+@@ -38,7 +38,8 @@ folder_names_and_paths["upscale_models"] = ([os.path.join(models_dir, "upscale_m
+ 
+ folder_names_and_paths["latent_upscale_models"] = ([os.path.join(models_dir, "latent_upscale_models")], supported_pt_extensions)
+ 
+-folder_names_and_paths["custom_nodes"] = ([os.path.join(base_path, "custom_nodes")], set())
++custom_nodes_directory = os.path.join(base_path, "custom_nodes")
++folder_names_and_paths["custom_nodes"] = ([custom_nodes_directory], set())
+ 
+ folder_names_and_paths["hypernetworks"] = ([os.path.join(models_dir, "hypernetworks")], supported_pt_extensions)
+ 
+@@ -107,11 +108,12 @@ def map_legacy(folder_name: str) -> str:
+               "clip": "text_encoders"}
+     return legacy.get(folder_name, folder_name)
+ 
+-if not os.path.exists(input_directory):
+-    try:
+-        os.makedirs(input_directory)
+-    except:
+-        logging.error("Failed to create input directory")
++for default_directory in (input_directory, custom_nodes_directory):
++    if not os.path.exists(default_directory):
++        try:
++            os.makedirs(default_directory)
++        except:
++            logging.error(f"Failed to create {default_directory}")
+ 
+ def set_output_directory(output_dir: str) -> None:
+     global output_directory

--- a/pkgs/development/python-modules/comfy-aimdo/default.nix
+++ b/pkgs/development/python-modules/comfy-aimdo/default.nix
@@ -23,6 +23,9 @@ buildPythonPackage (finalAttrs: {
     setuptools-scm
   ];
 
+  # Upstream ships no test suite at this tag.
+  doCheck = false;
+
   pythonImportsCheck = [ "comfy_aimdo.control" ];
 
   meta = {

--- a/pkgs/development/python-modules/comfy-aimdo/default.nix
+++ b/pkgs/development/python-modules/comfy-aimdo/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  setuptools-scm,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "comfy-aimdo";
+  version = "0.2.14";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Comfy-Org";
+    repo = "comfy-aimdo";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jmBVUwQkd6ceLVx1ZSNiByx1vZF+Al7/jmgz0sy+B/E=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  pythonImportsCheck = [ "comfy_aimdo.control" ];
+
+  meta = {
+    description = "AI model dynamic offloader for ComfyUI";
+    homepage = "https://github.com/Comfy-Org/comfy-aimdo";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ caniko ];
+  };
+})

--- a/pkgs/development/python-modules/comfy-aimdo/default.nix
+++ b/pkgs/development/python-modules/comfy-aimdo/default.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  buildPythonPackage,
+  capstone,
+  cmake,
+  fetchFromGitHub,
+  setuptools,
+  setuptools-scm,
+  comfyui,
+}:
+
+let
+  funchookVersion = "1.1.3";
+  funchook = fetchFromGitHub {
+    owner = "kubo";
+    repo = "funchook";
+    tag = "v${funchookVersion}";
+    fetchSubmodules = true;
+    hash = "sha256-u/RXMNyKL6L7p5gEFnAQTErPXXGKXv74jbYlBbG0Wy4=";
+  };
+in
+buildPythonPackage (finalAttrs: {
+  pname = "comfy-aimdo";
+  version = "0.4.10";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Comfy-Org";
+    repo = "comfy-aimdo";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-57z8NrEabc0RrTJavbdbpOZSLkNarPA2D+hZ+WUS4r4=";
+  };
+
+  postPatch = ''
+    chmod +x scripts/*.sh
+    patchShebangs scripts/*.sh
+
+    substituteInPlace scripts/build-linux-aimdo.sh \
+      --replace-fail '-j"$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)"' '-j$NIX_BUILD_CORES'
+
+    mkdir build
+    cp -r ${funchook} build/funchook-${funchookVersion}
+
+    mkdir -p build/funchook-${funchookVersion}-capstone
+    cp -r ${capstone.src} build/funchook-${funchookVersion}-capstone/capstone-src
+
+    chmod -R +w build
+  '';
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  preBuild = ''
+    ./scripts/build-linux-aimdo.sh
+  '';
+
+  # Upstream ships no test suite at this tag.
+  doCheck = false;
+
+  pythonImportsCheck = [ "comfy_aimdo" ];
+
+  meta = {
+    description = "AI model dynamic offloader for ComfyUI";
+    homepage = "https://github.com/Comfy-Org/comfy-aimdo";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    inherit (comfyui.meta) maintainers;
+  };
+})

--- a/pkgs/development/python-modules/comfy-angle/default.nix
+++ b/pkgs/development/python-modules/comfy-angle/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  libGL,
+  setuptools,
+  stdenv,
+  comfyui,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "comfy-angle";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Comfy-Org";
+    repo = "comfy-angle";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-FnS2aQmPb5a3dO9m5McpO5Kfyy1aOaboc+oAtYqauQo=";
+  };
+
+  postPatch = ''
+    mkdir -p comfy_angle/libs
+    ln -s ${lib.getLib libGL}/lib/{libEGL,libGLESv2}${stdenv.hostPlatform.extensions.sharedLibrary} comfy_angle/libs/
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  # Repository has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "comfy_angle" ];
+
+  meta = {
+    description = "Redistributable ANGLE libraries";
+    homepage = "https://github.com/Comfy-Org/comfy-aimdo";
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.linux;
+    inherit (comfyui.meta) maintainers;
+  };
+})

--- a/pkgs/development/python-modules/comfy-kitchen/default.nix
+++ b/pkgs/development/python-modules/comfy-kitchen/default.nix
@@ -31,6 +31,11 @@ buildPythonPackage (finalAttrs: {
       --replace-fail "BUILD_NO_CUDA = False" "BUILD_NO_CUDA = True"
   '';
 
+  # Upstream tests exercise the CUDA/Triton kernel backends; this build
+  # uses BUILD_NO_CUDA = True so those backends are unavailable and the
+  # suite cannot run in the sandbox.
+  doCheck = false;
+
   pythonImportsCheck = [ "comfy_kitchen" ];
 
   meta = {

--- a/pkgs/development/python-modules/comfy-kitchen/default.nix
+++ b/pkgs/development/python-modules/comfy-kitchen/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nanobind,
+  setuptools,
+  torch,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "comfy-kitchen";
+  version = "0.2.8";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Comfy-Org";
+    repo = "comfy-kitchen";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-u83fTb65wALGzgBZO53UJMEFSm1w727IBhiS5XVEoc4=";
+  };
+
+  build-system = [
+    nanobind
+    setuptools
+  ];
+
+  dependencies = [ torch ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail "BUILD_NO_CUDA = False" "BUILD_NO_CUDA = True"
+  '';
+
+  pythonImportsCheck = [ "comfy_kitchen" ];
+
+  meta = {
+    description = "Fast kernel library for ComfyUI with multiple compute backends";
+    homepage = "https://github.com/Comfy-Org/comfy-kitchen";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ caniko ];
+  };
+})

--- a/pkgs/development/python-modules/comfy-kitchen/default.nix
+++ b/pkgs/development/python-modules/comfy-kitchen/default.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  buildPythonPackage,
+  cmake,
+  config,
+  cudaSupport ? config.cudaSupport,
+  fetchFromGitHub,
+  nanobind,
+  setuptools,
+  torch,
+  comfyui,
+}:
+
+let
+  inherit (torch) cudaPackages;
+in
+buildPythonPackage (finalAttrs: {
+  pname = "comfy-kitchen";
+  version = "0.2.22";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Comfy-Org";
+    repo = "comfy-kitchen";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-3neQWBLlB0bFQYbbkIy78eaBBwWQEdpUtDFIt0EIzb0=";
+  };
+
+  nativeBuildInputs = lib.optionals cudaSupport [
+    cmake
+  ];
+
+  buildInputs = lib.optionals cudaSupport (
+    with cudaPackages;
+    [
+      cuda_cudart
+      libcublas
+    ]
+  );
+
+  build-system = [
+    nanobind
+    setuptools
+  ];
+
+  dependencies = [ torch ];
+
+  dontUseCmakeConfigure = true;
+
+  pypaBuildFlags =
+    if cudaSupport then
+      [
+        ''--config-setting=--cuda-archs="${
+          lib.concatMapStringsSep ";" cudaPackages.flags.dropDots torch.cudaCapabilities
+        }"''
+      ]
+    else
+      [ "-C--global-option=--no-cuda" ];
+
+  env = lib.optionalAttrs cudaSupport {
+    CUDA_HOME = cudaPackages.cuda_nvcc;
+  };
+
+  # Upstream tests exercise the CUDA/Triton kernel backends; this build
+  # might use BUILD_NO_CUDA = True, so those backends would be unavailable
+  # and additionally the nix sandbox would prevent it.
+  doCheck = false;
+
+  pythonImportsCheck = [ "comfy_kitchen" ];
+
+  meta = {
+    description = "Fast kernel library for ComfyUI with multiple compute backends";
+    homepage = "https://github.com/Comfy-Org/comfy-kitchen";
+    license = lib.licenses.asl20;
+    inherit (comfyui.meta) maintainers;
+  };
+})

--- a/pkgs/development/python-modules/comfyui-embedded-docs/default.nix
+++ b/pkgs/development/python-modules/comfyui-embedded-docs/default.nix
@@ -18,6 +18,9 @@ buildPythonPackage (finalAttrs: {
 
   build-system = [ setuptools ];
 
+  # Package only ships static Markdown documentation; no tests.
+  doCheck = false;
+
   pythonImportsCheck = [ "comfyui_embedded_docs" ];
 
   meta = {

--- a/pkgs/development/python-modules/comfyui-embedded-docs/default.nix
+++ b/pkgs/development/python-modules/comfyui-embedded-docs/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "comfyui-embedded-docs";
+  version = "0.4.4";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "comfyui_embedded_docs";
+    inherit (finalAttrs) version;
+    hash = "sha256-+ZoRloCC+TQtszf8BpFkqN6UT2Op9efoMZ+8TQZhedk=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "comfyui_embedded_docs" ];
+
+  meta = {
+    description = "Embedded node documentation for ComfyUI";
+    homepage = "https://github.com/Comfy-Org/embedded-docs";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ caniko ];
+  };
+})

--- a/pkgs/development/python-modules/comfyui-embedded-docs/default.nix
+++ b/pkgs/development/python-modules/comfyui-embedded-docs/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  comfyui,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "comfyui-embedded-docs";
+  version = "0.5.9";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "comfyui_embedded_docs";
+    inherit (finalAttrs) version;
+    hash = "sha256-uz83lj91nLsqT4C/nHZdr1pfKI18FaFiU/dI2Dx9gZk=";
+  };
+
+  build-system = [ setuptools ];
+
+  # Package only ships static Markdown documentation; no tests.
+  doCheck = false;
+
+  pythonImportsCheck = [ "comfyui_embedded_docs" ];
+
+  meta = {
+    description = "Embedded node documentation for ComfyUI";
+    homepage = "https://github.com/Comfy-Org/embedded-docs";
+    license = lib.licenses.gpl3Only;
+    inherit (comfyui.meta) maintainers;
+  };
+})

--- a/pkgs/development/python-modules/comfyui-frontend-package/default.nix
+++ b/pkgs/development/python-modules/comfyui-frontend-package/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "comfyui-frontend-package";
+  version = "1.42.15";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "comfyui_frontend_package";
+    inherit (finalAttrs) version;
+    hash = "sha256-V1j+wiJSMyePkySd0PaNs99XLx3B4zT/tp7uV3AxuBQ=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "comfyui_frontend_package" ];
+
+  meta = {
+    description = "Frontend assets for ComfyUI";
+    homepage = "https://github.com/Comfy-Org/ComfyUI_frontend";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ caniko ];
+  };
+})

--- a/pkgs/development/python-modules/comfyui-frontend-package/default.nix
+++ b/pkgs/development/python-modules/comfyui-frontend-package/default.nix
@@ -18,6 +18,9 @@ buildPythonPackage (finalAttrs: {
 
   build-system = [ setuptools ];
 
+  # Package only ships the prebuilt frontend bundle; no tests.
+  doCheck = false;
+
   pythonImportsCheck = [ "comfyui_frontend_package" ];
 
   meta = {

--- a/pkgs/development/python-modules/comfyui-frontend-package/default.nix
+++ b/pkgs/development/python-modules/comfyui-frontend-package/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  comfyui,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "comfyui-frontend-package";
+  version = "1.47.10";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "comfyui_frontend_package";
+    inherit (finalAttrs) version;
+    hash = "sha256-+nGk04r/AtHsoc+Rgg/NOe7+ErFlOlmFCNfFao1QlGo=";
+  };
+
+  build-system = [ setuptools ];
+
+  env = {
+    COMFYUI_FRONTEND_VERSION = finalAttrs.version;
+  };
+
+  # Package only ships the prebuilt frontend bundle; no tests.
+  doCheck = false;
+
+  pythonImportsCheck = [ "comfyui_frontend_package" ];
+
+  meta = {
+    description = "Frontend assets for ComfyUI";
+    homepage = "https://github.com/Comfy-Org/ComfyUI_frontend";
+    license = lib.licenses.gpl3Only;
+    inherit (comfyui.meta) maintainers;
+    # The frontend is fetched as a prebuilt PyPI sdist. Building from source
+    # is tracked as a follow-up (see nixpkgs#441841).
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})

--- a/pkgs/development/python-modules/comfyui-manager/default.nix
+++ b/pkgs/development/python-modules/comfyui-manager/default.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  aiohttp,
+  chardet,
+  gitpython,
+  huggingface-hub,
+  packaging,
+  pydantic,
+  pygithub,
+  pyyaml,
+  requests,
+  rich,
+  toml,
+  tqdm,
+  transformers,
+  typer,
+  typing-extensions,
+  uv,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "comfyui-manager";
+  version = "4.2.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "comfyui_manager";
+    inherit (finalAttrs) version;
+    hash = "sha256-x3dH937Y0+gGAEQAYh0Rk3MktBnmHMFs95QbgAMkRvc=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    aiohttp
+    chardet
+    gitpython
+    huggingface-hub
+    packaging
+    pydantic
+    pygithub
+    pyyaml
+    requests
+    rich
+    toml
+    tqdm
+    transformers
+    typer
+    typing-extensions
+    uv
+  ];
+
+  # `comfyui_manager/__init__.py` imports `comfy.cli_args` at module-load
+  # time — that only resolves inside a running ComfyUI process, so a regular
+  # `import comfyui_manager` cannot succeed in isolation.
+  doCheck = false;
+  pythonImportsCheck = [ ];
+
+  meta = {
+    description = "Custom-node manager extension for ComfyUI";
+    homepage = "https://github.com/ltdrdata/ComfyUI-Manager";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "cm-cli";
+    maintainers = with lib.maintainers; [ caniko ];
+  };
+})

--- a/pkgs/development/python-modules/comfyui-manager/default.nix
+++ b/pkgs/development/python-modules/comfyui-manager/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  chardet,
+  gitpython,
+  huggingface-hub,
+  pygithub,
+  rich,
+  toml,
+  transformers,
+  typer,
+  typing-extensions,
+  uv,
+  comfyui,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "comfyui-manager";
+  version = "4.2.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "comfyui_manager";
+    inherit (finalAttrs) version;
+    hash = "sha256-7kjoOOetsHroQzLpu0+nvzZFVkNwxGz4qHBviNA0G8Y=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    chardet
+    gitpython
+    huggingface-hub
+    pygithub
+    rich
+    toml
+    transformers
+    typer
+    typing-extensions
+    uv
+  ];
+
+  # `comfyui_manager/__init__.py` imports `comfy.cli_args` at module-load
+  # time — that only resolves inside a running ComfyUI process, so a regular
+  # `import comfyui_manager` cannot succeed in isolation.
+  doCheck = false;
+
+  meta = {
+    description = "Custom-node manager extension for ComfyUI";
+    homepage = "https://github.com/ltdrdata/ComfyUI-Manager";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "cm-cli";
+    inherit (comfyui.meta) maintainers;
+  };
+})

--- a/pkgs/development/python-modules/comfyui-workflow-templates-core/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates-core/default.nix
@@ -18,6 +18,12 @@ buildPythonPackage (finalAttrs: {
 
   build-system = [ setuptools ];
 
+  # Upstream ships a `tests/` suite that resolves sibling packages by
+  # walking up to the source monorepo (`packages/{core,meta,media_*}/src`).
+  # That layout is not part of the published sdist, so the suite cannot
+  # run from a PyPI source checkout.
+  doCheck = false;
+
   pythonImportsCheck = [ "comfyui_workflow_templates_core" ];
 
   meta = {

--- a/pkgs/development/python-modules/comfyui-workflow-templates-core/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates-core/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "comfyui-workflow-templates-core";
+  version = "0.3.216";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "comfyui_workflow_templates_core";
+    inherit (finalAttrs) version;
+    hash = "sha256-oqmYJmO/rkTwUE0RHd+FqnSHEFYnXsxAL1pbgCmp8/Y=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "comfyui_workflow_templates_core" ];
+
+  meta = {
+    description = "Core loader for ComfyUI workflow templates";
+    homepage = "https://github.com/Comfy-Org/workflow_templates";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ caniko ];
+  };
+})

--- a/pkgs/development/python-modules/comfyui-workflow-templates-core/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates-core/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  comfyui,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "comfyui-workflow-templates-core";
+  version = "0.3.284";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "comfyui_workflow_templates_core";
+    inherit (finalAttrs) version;
+    hash = "sha256-KNw2OqMz3AhK+kVpTjABIqGz9jDwqimN3xjs0w2jCfI=";
+  };
+
+  build-system = [ setuptools ];
+
+  # Upstream ships a `tests/` suite that resolves sibling packages by
+  # walking up to the source monorepo (`packages/{core,meta,media_*}/src`).
+  # That layout is not part of the published sdist, so the suite cannot
+  # run from a PyPI source checkout.
+  doCheck = false;
+
+  pythonImportsCheck = [ "comfyui_workflow_templates_core" ];
+
+  meta = {
+    description = "Core loader for ComfyUI workflow templates";
+    homepage = "https://github.com/Comfy-Org/workflow_templates";
+    license = lib.licenses.mit;
+    inherit (comfyui.meta) maintainers;
+  };
+})

--- a/pkgs/development/python-modules/comfyui-workflow-templates-json/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates-json/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  comfyui,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "comfyui-workflow-templates-json";
+  version = "0.1.18";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "comfyui_workflow_templates_json";
+    inherit (finalAttrs) version;
+    hash = "sha256-ukfUq3sFMzjQxHzK7rXVHuEU2nKrEbHkr84R8C9DZW0=";
+  };
+
+  build-system = [ setuptools ];
+
+  # Package only ships static workflow JSON assets; no tests.
+  doCheck = false;
+
+  pythonImportsCheck = [ "comfyui_workflow_templates_json" ];
+
+  meta = {
+    description = "Workflow template JSON definitions for ComfyUI";
+    homepage = "https://github.com/Comfy-Org/workflow_templates";
+    license = lib.licenses.mit;
+    inherit (comfyui.meta) maintainers;
+  };
+})

--- a/pkgs/development/python-modules/comfyui-workflow-templates-media-api/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates-media-api/default.nix
@@ -18,6 +18,9 @@ buildPythonPackage (finalAttrs: {
 
   build-system = [ setuptools ];
 
+  # Package only ships static workflow JSON assets; no tests.
+  doCheck = false;
+
   pythonImportsCheck = [ "comfyui_workflow_templates_media_api" ];
 
   meta = {

--- a/pkgs/development/python-modules/comfyui-workflow-templates-media-api/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates-media-api/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "comfyui-workflow-templates-media-api";
+  version = "0.3.70";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "comfyui_workflow_templates_media_api";
+    inherit (finalAttrs) version;
+    hash = "sha256-yFcReKpkqdb0lqfh3krs+6V6IQMfWeoD6FbSQsE88tQ=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "comfyui_workflow_templates_media_api" ];
+
+  meta = {
+    description = "API workflow templates for ComfyUI";
+    homepage = "https://github.com/Comfy-Org/workflow_templates";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ caniko ];
+  };
+})

--- a/pkgs/development/python-modules/comfyui-workflow-templates-media-api/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates-media-api/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  comfyui,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "comfyui-workflow-templates-media-api";
+  version = "0.3.84";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "comfyui_workflow_templates_media_api";
+    inherit (finalAttrs) version;
+    hash = "sha256-a9XEluNo5eQN2H3+JfBm4k1X82AoiLo9+AATqI0GAlk=";
+  };
+
+  build-system = [ setuptools ];
+
+  # Package only ships static workflow JSON assets; no tests.
+  doCheck = false;
+
+  pythonImportsCheck = [ "comfyui_workflow_templates_media_api" ];
+
+  meta = {
+    description = "API workflow templates for ComfyUI";
+    homepage = "https://github.com/Comfy-Org/workflow_templates";
+    license = lib.licenses.mit;
+    inherit (comfyui.meta) maintainers;
+  };
+})

--- a/pkgs/development/python-modules/comfyui-workflow-templates-media-assets-01/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates-media-assets-01/default.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  comfyui,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "comfyui-workflow-templates-media-assets-01";
+  version = "0.1.12";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "comfyui_workflow_templates_media_assets_01";
+    inherit (finalAttrs) version;
+    hash = "sha256-tacQwHCXNgBbG3POe7bAER3asMZxVj2YVSzuRH1W92A=";
+  };
+
+  build-system = [ setuptools ];
+
+  doCheck = false;
+
+  pythonImportsCheck = [ "comfyui_workflow_templates_media_assets_01" ];
+
+  meta = {
+    description = "Media assets bundle 01 for ComfyUI workflow templates";
+    homepage = "https://github.com/Comfy-Org/workflow_templates";
+    license = lib.licenses.mit;
+    inherit (comfyui.meta) maintainers;
+  };
+})

--- a/pkgs/development/python-modules/comfyui-workflow-templates-media-image/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates-media-image/default.nix
@@ -18,6 +18,9 @@ buildPythonPackage (finalAttrs: {
 
   build-system = [ setuptools ];
 
+  # Package only ships static workflow JSON assets; no tests.
+  doCheck = false;
+
   pythonImportsCheck = [ "comfyui_workflow_templates_media_image" ];
 
   meta = {

--- a/pkgs/development/python-modules/comfyui-workflow-templates-media-image/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates-media-image/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "comfyui-workflow-templates-media-image";
+  version = "0.3.132";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "comfyui_workflow_templates_media_image";
+    inherit (finalAttrs) version;
+    hash = "sha256-fqQ6w7czSCuLUoi8qlw5in32AulCPzGpoMVXLKbCeHc=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "comfyui_workflow_templates_media_image" ];
+
+  meta = {
+    description = "Image workflow templates for ComfyUI";
+    homepage = "https://github.com/Comfy-Org/workflow_templates";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ caniko ];
+  };
+})

--- a/pkgs/development/python-modules/comfyui-workflow-templates-media-image/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates-media-image/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  comfyui,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "comfyui-workflow-templates-media-image";
+  version = "0.3.160";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "comfyui_workflow_templates_media_image";
+    inherit (finalAttrs) version;
+    hash = "sha256-iNz3STAsahL1uAPftGcktMiswx0RF87P9RZy2b2F6xg=";
+  };
+
+  build-system = [ setuptools ];
+
+  # Package only ships static workflow JSON assets; no tests.
+  doCheck = false;
+
+  pythonImportsCheck = [ "comfyui_workflow_templates_media_image" ];
+
+  meta = {
+    description = "Image workflow templates for ComfyUI";
+    homepage = "https://github.com/Comfy-Org/workflow_templates";
+    license = lib.licenses.mit;
+    inherit (comfyui.meta) maintainers;
+  };
+})

--- a/pkgs/development/python-modules/comfyui-workflow-templates-media-other/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates-media-other/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "comfyui-workflow-templates-media-other";
+  version = "0.3.182";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "comfyui_workflow_templates_media_other";
+    inherit (finalAttrs) version;
+    hash = "sha256-TZXVRhB+ROI7r9ClciCw/VDtkkkBMkQ+Kpkuc1rAs6M=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "comfyui_workflow_templates_media_other" ];
+
+  meta = {
+    description = "Additional workflow templates for ComfyUI";
+    homepage = "https://github.com/Comfy-Org/workflow_templates";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ caniko ];
+  };
+})

--- a/pkgs/development/python-modules/comfyui-workflow-templates-media-other/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates-media-other/default.nix
@@ -18,6 +18,9 @@ buildPythonPackage (finalAttrs: {
 
   build-system = [ setuptools ];
 
+  # Package only ships static workflow JSON assets; no tests.
+  doCheck = false;
+
   pythonImportsCheck = [ "comfyui_workflow_templates_media_other" ];
 
   meta = {

--- a/pkgs/development/python-modules/comfyui-workflow-templates-media-other/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates-media-other/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  comfyui,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "comfyui-workflow-templates-media-other";
+  version = "0.3.229";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "comfyui_workflow_templates_media_other";
+    inherit (finalAttrs) version;
+    hash = "sha256-bi2wdS8sfOlPaoudRBpfnceLv6dldF8PnqyuzLzmk4U=";
+  };
+
+  build-system = [ setuptools ];
+
+  # Package only ships static workflow JSON assets; no tests.
+  doCheck = false;
+
+  pythonImportsCheck = [ "comfyui_workflow_templates_media_other" ];
+
+  meta = {
+    description = "Additional workflow templates for ComfyUI";
+    homepage = "https://github.com/Comfy-Org/workflow_templates";
+    license = lib.licenses.mit;
+    inherit (comfyui.meta) maintainers;
+  };
+})

--- a/pkgs/development/python-modules/comfyui-workflow-templates-media-video/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates-media-video/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "comfyui-workflow-templates-media-video";
+  version = "0.3.81";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "comfyui_workflow_templates_media_video";
+    inherit (finalAttrs) version;
+    hash = "sha256-Bdlig7WooxMEs0Tss2D5ExEK5Y/lRsXvIQxmUiQkSHw=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "comfyui_workflow_templates_media_video" ];
+
+  meta = {
+    description = "Video workflow templates for ComfyUI";
+    homepage = "https://github.com/Comfy-Org/workflow_templates";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ caniko ];
+  };
+})

--- a/pkgs/development/python-modules/comfyui-workflow-templates-media-video/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates-media-video/default.nix
@@ -18,6 +18,9 @@ buildPythonPackage (finalAttrs: {
 
   build-system = [ setuptools ];
 
+  # Package only ships static workflow JSON assets; no tests.
+  doCheck = false;
+
   pythonImportsCheck = [ "comfyui_workflow_templates_media_video" ];
 
   meta = {

--- a/pkgs/development/python-modules/comfyui-workflow-templates-media-video/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates-media-video/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  comfyui,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "comfyui-workflow-templates-media-video";
+  version = "0.3.101";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "comfyui_workflow_templates_media_video";
+    inherit (finalAttrs) version;
+    hash = "sha256-dlLtmfubsAs52JBZGdyBUJIB4zXd4jqXNroTiRmQhHY=";
+  };
+
+  build-system = [ setuptools ];
+
+  # Package only ships static workflow JSON assets; no tests.
+  doCheck = false;
+
+  pythonImportsCheck = [ "comfyui_workflow_templates_media_video" ];
+
+  meta = {
+    description = "Video workflow templates for ComfyUI";
+    homepage = "https://github.com/Comfy-Org/workflow_templates";
+    license = lib.licenses.mit;
+    inherit (comfyui.meta) maintainers;
+  };
+})

--- a/pkgs/development/python-modules/comfyui-workflow-templates/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  comfyui-workflow-templates-core,
+  comfyui-workflow-templates-media-api,
+  comfyui-workflow-templates-media-video,
+  comfyui-workflow-templates-media-image,
+  comfyui-workflow-templates-media-other,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "comfyui-workflow-templates";
+  version = "0.9.63";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "comfyui_workflow_templates";
+    inherit (finalAttrs) version;
+    hash = "sha256-aadoH3Ccpbyi/K/CGaQVWmjHWxYNiGWFjXF8mH+S//c=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    comfyui-workflow-templates-core
+    comfyui-workflow-templates-media-api
+    comfyui-workflow-templates-media-video
+    comfyui-workflow-templates-media-image
+    comfyui-workflow-templates-media-other
+  ];
+
+  pythonImportsCheck = [ "comfyui_workflow_templates" ];
+
+  meta = {
+    description = "Workflow templates for ComfyUI";
+    homepage = "https://github.com/Comfy-Org/workflow_templates";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ caniko ];
+  };
+})

--- a/pkgs/development/python-modules/comfyui-workflow-templates/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates/default.nix
@@ -31,6 +31,9 @@ buildPythonPackage (finalAttrs: {
     comfyui-workflow-templates-media-other
   ];
 
+  # Package only ships static workflow JSON assets; no tests.
+  doCheck = false;
+
   pythonImportsCheck = [ "comfyui_workflow_templates" ];
 
   meta = {

--- a/pkgs/development/python-modules/comfyui-workflow-templates/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  comfyui,
+  comfyui-workflow-templates-core,
+  comfyui-workflow-templates-json,
+  comfyui-workflow-templates-media-api,
+  comfyui-workflow-templates-media-assets-01,
+  comfyui-workflow-templates-media-video,
+  comfyui-workflow-templates-media-image,
+  comfyui-workflow-templates-media-other,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "comfyui-workflow-templates";
+  version = "0.11.19";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "comfyui_workflow_templates";
+    inherit (finalAttrs) version;
+    hash = "sha256-m+CuTEisHzMDvceaVesYLA5cDuNxpwR/ftunKkv4uj8=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    comfyui-workflow-templates-core
+    comfyui-workflow-templates-json
+    comfyui-workflow-templates-media-api
+    comfyui-workflow-templates-media-assets-01
+    comfyui-workflow-templates-media-image
+    comfyui-workflow-templates-media-other
+    comfyui-workflow-templates-media-video
+  ];
+
+  # Package only ships static workflow JSON assets; no tests.
+  doCheck = false;
+
+  pythonImportsCheck = [ "comfyui_workflow_templates" ];
+
+  meta = {
+    description = "Workflow templates for ComfyUI";
+    homepage = "https://github.com/Comfy-Org/workflow_templates";
+    license = lib.licenses.mit;
+    inherit (comfyui.meta) maintainers;
+  };
+})

--- a/pkgs/development/python-modules/spandrel/default.nix
+++ b/pkgs/development/python-modules/spandrel/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  einops,
+  numpy,
+  safetensors,
+  torch,
+  torchvision,
+  typing-extensions,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "spandrel";
+  version = "0.4.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-/vpOqWbGpbdyHc8k8+IGKlqWo5XIvty1cPtVlx/cvMs=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    einops
+    numpy
+    safetensors
+    torch
+    torchvision
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [ "spandrel" ];
+
+  meta = {
+    description = "PyTorch architecture support for super-resolution, restoration, and inpainting models";
+    homepage = "https://github.com/chaiNNer-org/spandrel";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ caniko ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3090,6 +3090,38 @@ self: super: with self; {
 
   cometx = callPackage ../development/python-modules/cometx { };
 
+  comfy-aimdo = callPackage ../development/python-modules/comfy-aimdo { };
+
+  comfy-kitchen = callPackage ../development/python-modules/comfy-kitchen { };
+
+  comfyui-embedded-docs = callPackage ../development/python-modules/comfyui-embedded-docs { };
+
+  comfyui-frontend-package = callPackage ../development/python-modules/comfyui-frontend-package { };
+
+  comfyui-workflow-templates =
+    callPackage ../development/python-modules/comfyui-workflow-templates
+      { };
+
+  comfyui-workflow-templates-core =
+    callPackage ../development/python-modules/comfyui-workflow-templates-core
+      { };
+
+  comfyui-workflow-templates-media-api =
+    callPackage ../development/python-modules/comfyui-workflow-templates-media-api
+      { };
+
+  comfyui-workflow-templates-media-image =
+    callPackage ../development/python-modules/comfyui-workflow-templates-media-image
+      { };
+
+  comfyui-workflow-templates-media-other =
+    callPackage ../development/python-modules/comfyui-workflow-templates-media-other
+      { };
+
+  comfyui-workflow-templates-media-video =
+    callPackage ../development/python-modules/comfyui-workflow-templates-media-video
+      { };
+
   comicapi = callPackage ../development/python-modules/comicapi { };
 
   comicon = callPackage ../development/python-modules/comicon { };
@@ -18174,6 +18206,8 @@ self: super: with self; {
   spacy-transformers = callPackage ../development/python-modules/spacy-transformers { };
 
   spake2 = callPackage ../development/python-modules/spake2 { };
+
+  spandrel = callPackage ../development/python-modules/spandrel { };
 
   spark-parser = callPackage ../development/python-modules/spark-parser { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3098,6 +3098,8 @@ self: super: with self; {
 
   comfyui-frontend-package = callPackage ../development/python-modules/comfyui-frontend-package { };
 
+  comfyui-manager = callPackage ../development/python-modules/comfyui-manager { };
+
   comfyui-workflow-templates =
     callPackage ../development/python-modules/comfyui-workflow-templates
       { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3483,6 +3483,10 @@ self: super: with self; {
     callPackage ../development/python-modules/comfyui-workflow-templates-media-assets-01
       { };
 
+  comfyui-workflow-templates-media-image =
+    callPackage ../development/python-modules/comfyui-workflow-templates-media-image
+      { };
+
   comicapi = callPackage ../development/python-modules/comicapi { };
 
   comicon = callPackage ../development/python-modules/comicon { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3467,6 +3467,8 @@ self: super: with self; {
 
   comfyui-frontend-package = callPackage ../development/python-modules/comfyui-frontend-package { };
 
+  comfyui-manager = callPackage ../development/python-modules/comfyui-manager { };
+
   comfyui-workflow-templates =
     callPackage ../development/python-modules/comfyui-workflow-templates
       { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3467,6 +3467,10 @@ self: super: with self; {
 
   comfyui-frontend-package = callPackage ../development/python-modules/comfyui-frontend-package { };
 
+  comfyui-workflow-templates =
+    callPackage ../development/python-modules/comfyui-workflow-templates
+      { };
+
   comfyui-workflow-templates-core =
     callPackage ../development/python-modules/comfyui-workflow-templates-core
       { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3491,6 +3491,10 @@ self: super: with self; {
     callPackage ../development/python-modules/comfyui-workflow-templates-media-other
       { };
 
+  comfyui-workflow-templates-media-video =
+    callPackage ../development/python-modules/comfyui-workflow-templates-media-video
+      { };
+
   comicapi = callPackage ../development/python-modules/comicapi { };
 
   comicon = callPackage ../development/python-modules/comicon { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3465,6 +3465,8 @@ self: super: with self; {
 
   comfyui-embedded-docs = callPackage ../development/python-modules/comfyui-embedded-docs { };
 
+  comfyui-frontend-package = callPackage ../development/python-modules/comfyui-frontend-package { };
+
   comicapi = callPackage ../development/python-modules/comicapi { };
 
   comicon = callPackage ../development/python-modules/comicon { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3459,6 +3459,8 @@ self: super: with self; {
 
   comfy-aimdo = callPackage ../development/python-modules/comfy-aimdo { };
 
+  comfy-angle = callPackage ../development/python-modules/comfy-angle { };
+
   comicapi = callPackage ../development/python-modules/comicapi { };
 
   comicon = callPackage ../development/python-modules/comicon { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3487,6 +3487,10 @@ self: super: with self; {
     callPackage ../development/python-modules/comfyui-workflow-templates-media-image
       { };
 
+  comfyui-workflow-templates-media-other =
+    callPackage ../development/python-modules/comfyui-workflow-templates-media-other
+      { };
+
   comicapi = callPackage ../development/python-modules/comicapi { };
 
   comicon = callPackage ../development/python-modules/comicon { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3463,6 +3463,8 @@ self: super: with self; {
 
   comfy-kitchen = callPackage ../development/python-modules/comfy-kitchen { };
 
+  comfyui-embedded-docs = callPackage ../development/python-modules/comfyui-embedded-docs { };
+
   comicapi = callPackage ../development/python-modules/comicapi { };
 
   comicon = callPackage ../development/python-modules/comicon { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3475,6 +3475,10 @@ self: super: with self; {
     callPackage ../development/python-modules/comfyui-workflow-templates-json
       { };
 
+  comfyui-workflow-templates-media-api =
+    callPackage ../development/python-modules/comfyui-workflow-templates-media-api
+      { };
+
   comicapi = callPackage ../development/python-modules/comicapi { };
 
   comicon = callPackage ../development/python-modules/comicon { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3457,6 +3457,8 @@ self: super: with self; {
 
   cometx = callPackage ../development/python-modules/cometx { };
 
+  comfy-aimdo = callPackage ../development/python-modules/comfy-aimdo { };
+
   comicapi = callPackage ../development/python-modules/comicapi { };
 
   comicon = callPackage ../development/python-modules/comicon { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3479,6 +3479,10 @@ self: super: with self; {
     callPackage ../development/python-modules/comfyui-workflow-templates-media-api
       { };
 
+  comfyui-workflow-templates-media-assets-01 =
+    callPackage ../development/python-modules/comfyui-workflow-templates-media-assets-01
+      { };
+
   comicapi = callPackage ../development/python-modules/comicapi { };
 
   comicon = callPackage ../development/python-modules/comicon { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3461,6 +3461,8 @@ self: super: with self; {
 
   comfy-angle = callPackage ../development/python-modules/comfy-angle { };
 
+  comfy-kitchen = callPackage ../development/python-modules/comfy-kitchen { };
+
   comicapi = callPackage ../development/python-modules/comicapi { };
 
   comicon = callPackage ../development/python-modules/comicon { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3467,6 +3467,10 @@ self: super: with self; {
 
   comfyui-frontend-package = callPackage ../development/python-modules/comfyui-frontend-package { };
 
+  comfyui-workflow-templates-core =
+    callPackage ../development/python-modules/comfyui-workflow-templates-core
+      { };
+
   comicapi = callPackage ../development/python-modules/comicapi { };
 
   comicon = callPackage ../development/python-modules/comicon { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3471,6 +3471,10 @@ self: super: with self; {
     callPackage ../development/python-modules/comfyui-workflow-templates-core
       { };
 
+  comfyui-workflow-templates-json =
+    callPackage ../development/python-modules/comfyui-workflow-templates-json
+      { };
+
   comicapi = callPackage ../development/python-modules/comicapi { };
 
   comicon = callPackage ../development/python-modules/comicon { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19028,6 +19028,8 @@ self: super: with self; {
 
   spake2 = callPackage ../development/python-modules/spake2 { };
 
+  spandrel = callPackage ../development/python-modules/spandrel { };
+
   spark-parser = callPackage ../development/python-modules/spark-parser { };
 
   sparklines = callPackage ../development/python-modules/sparklines { };


### PR DESCRIPTION
Adds ComfyUI 0.20.1 (a modular diffusion model GUI/API/backend with a graph and nodes interface) and ComfyUI-Manager 4.2.1, plus the Comfy-specific Python helpers required by both.

`comfyui` builds without ComfyUI-Manager by default, so the base package stays suitable for Nix-managed custom nodes and does not include Manager's arbitrary project fetching surface. Users who want Manager can opt in with:

```nix
comfyui.override { withManager = true; }
```

The Manager-enabled variant is also covered by `comfyui.tests.withManager`.

Related: #441841 is an earlier draft ComfyUI init by @06kellyjac with useful work around writable runtime paths, custom-node packaging, ComfyUI-GGUF, ComfyUI-Manager caveats, and CUDA/ROCm ergonomics. This PR is a narrower current-version package init; it intentionally leaves the NixOS module and custom-node ecosystem as follow-up/coordination work rather than duplicating that larger scope.

`comfy-kitchen` is built in its source-supported no-CUDA variant; GPU support for ComfyUI comes from the selected `torch` package set.

## Upstream patch

ComfyUI-Manager's prestartup hook unconditionally calls `pip`/`uv` to "self-heal" the Python env (PIPFixer auto-rollback, the unified dependency resolver, per-node `pip install -r requirements.txt`). On Nix that is a read-only store, so `--enable-manager` startup still emits a noisy `error: The interpreter [...] is externally managed` chain before Manager continues loading.

I sent an opt-out switch upstream so distros can disable the auto-install paths without forking: https://github.com/Comfy-Org/ComfyUI-Manager/pull/2851. Once that lands and ships in a release, this package can set `dependency_management = off` (or export `COMFYUI_MANAGER_DEPENDENCY_MANAGEMENT=off`) to make `--enable-manager` clean by default. Until then, users opting in to the manager will see the install errors but Manager itself still loads.

## Local validation

- `nix fmt pkgs/by-name/co/comfyui/package.nix`
- `nix build -L --impure --expr 'let pkgs = import ./. {}; in pkgs.comfyui'`
- `nix build -L --impure --expr 'let pkgs = import ./. {}; in pkgs.comfyui.override { withManager = true; }'`
- `nix build -L --impure --expr 'let pkgs = import ./. {}; in pkgs.comfyui.tests.withManager'`
- `nix path-info -r /nix/store/yp9dhkvf84kmzjsym08qpqzssrnqpvd2-comfyui-0.20.1 | rg 'comfyui-manager' || true` produced no output for the default build closure.
- `nix eval --impure --expr 'let pkgs = import ./. {}; in pkgs.comfyui.passthru.tests.withManager.pname + "-" + pkgs.comfyui.passthru.tests.withManager.version'`
- `nix eval --impure --expr 'let pkgs = import ./. { config.allowUnfree = true; }; in pkgs.comfyui.updateScript'`
- `nix-shell maintainers/scripts/update.nix --argstr package comfyui --argstr skip-prompt true`

`nixpkgs-review-gha` is running for the current PR head: https://github.com/caniko/nixpkgs-review-gha/actions/runs/25518071431

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
