### PR TITLE
python3Packages.redisvl: init at 0.19.0

### DIFF
--- a/pkgs/development/python-modules/redisvl/default.nix
+++ b/pkgs/development/python-modules/redisvl/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  hatchling,
+  nix-update-script,
+  numpy,
+  pyyaml,
+  redis,
+  pydantic,
+  tenacity,
+  ml-dtypes,
+  python-ulid,
+  jsonpath-ng,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "redisvl";
+  version = "0.18.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "redis";
+    repo = "redis-vl-python";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2yByWnnHYUBsjUCqyEv70+S0GCFEb7y2BGw4kHbaC+0=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    numpy
+    pyyaml
+    redis
+    pydantic
+    tenacity
+    ml-dtypes
+    python-ulid
+    jsonpath-ng
+  ];
+
+  pythonImportsCheck = [ "redisvl" ];
+
+  # tests require a live Redis server with the search/vector module
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Python client library and CLI for using Redis as a vector database";
+    homepage = "https://github.com/redis/redis-vl-python";
+    changelog = "https://github.com/redis/redis-vl-python/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "rvl";
+    maintainers = with lib.maintainers; [ codgician ];
+  };
+})

--- a/pkgs/development/python-modules/redisvl/default.nix
+++ b/pkgs/development/python-modules/redisvl/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  numpy,
+  pyyaml,
+  redis,
+  pydantic,
+  tenacity,
+  ml-dtypes,
+  python-ulid,
+  jsonpath-ng,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "redisvl";
+  version = "0.19.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "redis";
+    repo = "redis-vl-python";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-x8HotooGv1u5uGls1Y9HiioVzpF+MT6oYspdmZUpgh0=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    numpy
+    pyyaml
+    redis
+    pydantic
+    tenacity
+    ml-dtypes
+    python-ulid
+    jsonpath-ng
+  ];
+
+  pythonImportsCheck = [ "redisvl" ];
+
+  # tests require a live Redis server with the search/vector module
+  doCheck = false;
+
+  meta = {
+    description = "Python client library and CLI for using Redis as a vector database";
+    homepage = " https://redisvl.com";
+    changelog = "https://github.com/redis/redis-vl-python/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "rvl";
+    maintainers = with lib.maintainers; [
+      codgician
+      hythera
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16699,6 +16699,8 @@ self: super: with self; {
 
   redis-om = callPackage ../development/python-modules/redis-om { };
 
+  redisvl = callPackage ../development/python-modules/redisvl { };
+
   redshift-connector = callPackage ../development/python-modules/redshift-connector { };
 
   reedsolo = callPackage ../development/python-modules/reedsolo { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16809,6 +16809,8 @@ self: super: with self; {
 
   redis-om = callPackage ../development/python-modules/redis-om { };
 
+  redisvl = callPackage ../development/python-modules/redisvl { };
+
   redshift-connector = callPackage ../development/python-modules/redshift-connector { };
 
   reedsolo = callPackage ../development/python-modules/reedsolo { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Init redisvl python package at 0.19.0: https://github.com/redis/redis-vl-python

The motivation for adding this is to ensure the redis stack for LiteLLM could work properly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

