### PR TITLE
fluxcd: build with CGO_ENABLED=0 to match upstream

### DIFF
--- a/pkgs/by-name/fl/fluxcd/package.nix
+++ b/pkgs/by-name/fl/fluxcd/package.nix
@@ -39,6 +39,8 @@ buildGoModule rec {
     rm source/cmd/flux/create_secret_git_test.go
   '';
 
+  env.CGO_ENABLED = 0;
+
   ldflags = [
     "-s"
     "-w"


### PR DESCRIPTION
Flux's upstream Makefile and goreleaser config both build with
CGO_ENABLED=0. This produces a fully static binary and ensures
consistent behavior (ex. pure-Go DNS resolver) across all
platforms.

Confirmed the resulting binary is statically linked (patchelf reports
no .dynamic section). local checks/tests still pass.

Also confirmed old binaries were using cgo.