### PR TITLE
taler-wallet-core: 1.3.1 -> 1.5.10

### DIFF
--- a/pkgs/by-name/ta/taler-wallet-core/package.nix
+++ b/pkgs/by-name/ta/taler-wallet-core/package.nix
@@ -7,7 +7,7 @@
   fetchgit,
   srcOnly,
   removeReferencesTo,
-  nodejs_20,
+  nodejs_24,
   pnpm_9,
   fetchPnpmDeps,
   pnpmConfigHook,
@@ -17,8 +17,8 @@
   zip,
 }:
 let
-  nodeSources = srcOnly nodejs_20;
-  pnpm' = pnpm_9.override { nodejs = nodejs_20; };
+  nodeSources = srcOnly nodejs_24;
+  pnpm' = pnpm_9.override { nodejs = nodejs_24; };
   esbuild' = esbuild.override {
     buildGoModule =
       args:
@@ -40,17 +40,28 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "taler-wallet-core";
-  version = "1.3.1";
+  version = "1.5.10";
 
+  # NOTE: we have to use the tag's commit, else:
+  # > fatal: Not a valid object name
+  # > Unrecognized git object type:
+  # > Unable to checkout refs/tags/v1.5.10 from https://git-www.taler.net/taler-typescript-core.git.
   src = fetchgit {
-    url = "https://git.taler.net/taler-typescript-core.git";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-YTFS4s8GuC3SQ/b4JJ5DbEbzc8hrywYaf6rtSKGiSpE=";
+    url = "https://git-www.taler.net/taler-typescript-core.git";
+    rev = "3816d089724c513299b62b20bdb88d94d5be67f5";
+    hash = "sha256-/KxB4uBbJbnFUPAc6a++bfTwl2CM1ZYjxPTDYwRh21Q=";
+  };
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm';
+    fetcherVersion = 3;
+    hash = "sha256-W5C2JVFbEccf4b+ppeEJ68au/2Tqfsry7ri6Qi1M50k=";
   };
 
   nativeBuildInputs = [
     customPython
-    nodejs_20
+    nodejs_24
     pnpmConfigHook
     pnpm'
     gitMinimal
@@ -58,14 +69,9 @@ stdenv.mkDerivation (finalAttrs: {
     zip
   ];
 
-  pnpmDeps = fetchPnpmDeps {
-    inherit (finalAttrs) pname version src;
-    pnpm = pnpm';
-    fetcherVersion = 3;
-    hash = "sha256-a1ym/UpUufUPTGL3dozZ9Jb0eX1XVB7Hahek25eLvc4=";
-  };
-
-  buildInputs = [ nodejs_20 ];
+  buildInputs = [
+    nodejs_24
+  ];
 
   # Make a fake git repo with a commit.
   # Without this, the package does not build.
@@ -108,7 +114,7 @@ stdenv.mkDerivation (finalAttrs: {
   env.ESBUILD_BINARY_PATH = lib.getExe esbuild';
 
   meta = {
-    homepage = "https://git.taler.net/wallet-core.git/";
+    homepage = "https://git-www.taler.net/taler-typescript-core.git";
     description = "CLI wallet for GNU Taler written in TypeScript and Anastasis Web UI";
     license = lib.licenses.gpl3Plus;
     teams = [ lib.teams.ngi ];


### PR DESCRIPTION
Diff: https://git-www.taler.net/taler-typescript-core.git/diff/?h=v1.5.10&id=3816d089724c513299b62b20bdb88d94d5be67f5&id2=e02109a31627919a7e01c8e0965099f6467c6174

Ran the [basic Taler test](https://github.com/NixOS/nixpkgs/blob/7911ee5c8ba4ad014ef2ded216773cb650f499c5/nixos/tests/taler/tests/basic.nix) which uses this package as a client and that passes.

**PS:** this also updates nodejs from EOL 20 to 24 (tracking https://github.com/NixOS/nixpkgs/issues/515284)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
