### PR TITLE
gnunet{-gtk,-messenger-cli}, libgnunetchat: fix 404 changelogs

### DIFF
--- a/pkgs/by-name/gn/gnunet-gtk/package.nix
+++ b/pkgs/by-name/gn/gnunet-gtk/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = gnunet.meta // {
     description = "GNUnet GTK User Interface";
-    homepage = "https://git.gnunet.org/gnunet-gtk.git";
+    homepage = "https://git-www.taler.net/gnunet-gtk.git";
     # https://www.gnunet.org/en/news/2025-09-0.25.0.html
     broken = true;
   };

--- a/pkgs/by-name/gn/gnunet-messenger-cli/package.nix
+++ b/pkgs/by-name/gn/gnunet-messenger-cli/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.3.1";
 
   src = fetchgit {
-    url = "https://git.gnunet.org/messenger-cli.git";
+    url = "https://git-www.taler.net/messenger-cli.git";
     tag = "v${finalAttrs.version}";
     hash = "sha256-8Iby3IZXEZJ1dqVV62xDzXx/qq7JKhVtn6ZLb697ZSw=";
   };
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Decentralized, privacy-preserving networking framework for secure peer-to-peer communication";
-    homepage = "https://git.gnunet.org/messenger-cli.git";
+    homepage = "https://git-www.taler.net/messenger-cli.git";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.all;
     teams = with lib.teams; [ ngi ];

--- a/pkgs/by-name/gn/gnunet/package.nix
+++ b/pkgs/by-name/gn/gnunet/package.nix
@@ -127,7 +127,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [ pstn ];
     teams = with lib.teams; [ ngi ];
     platforms = lib.platforms.unix;
-    changelog = "https://git.gnunet.org/gnunet.git/tree/ChangeLog?h=v${finalAttrs.version}";
+    changelog = "https://git-www.taler.net/gnunet.git/tree/NEWS/?h=v${finalAttrs.version}";
     # meson: "Can not run test applications in this cross environment." (for dane_verify_crt_raw)
     broken = !stdenv.buildPlatform.canExecute stdenv.hostPlatform;
   };

--- a/pkgs/by-name/li/libgnunetchat/package.nix
+++ b/pkgs/by-name/li/libgnunetchat/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.6.1";
 
   src = fetchgit {
-    url = "https://git.gnunet.org/libgnunetchat.git";
+    url = "https://git-www.taler.net/libgnunetchat.git";
     tag = "v${finalAttrs.version}";
     hash = "sha256-FKFoIuGGPcYVRBrsqn1rnodRVCLAjLKlgZOs9v4H+8w=";
   };
@@ -58,8 +58,8 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     pkgConfigModules = [ "gnunetchat" ];
     description = "Library for secure, decentralized chat using GNUnet network services";
-    homepage = "https://git.gnunet.org/libgnunetchat.git";
-    changelog = "https://git.gnunet.org/libgnunetchat.git/plain/ChangeLog?h=v${finalAttrs.version}";
+    homepage = "https://git-www.taler.net/libgnunetchat.git";
+    changelog = "https://git-www.taler.net/libgnunetchat.git/plain/ChangeLog?h=v${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.all;
     teams = with lib.teams; [ ngi ];


### PR DESCRIPTION
and switch to new repository, since the old one isn't a valid git repo anymore:

```
$ git clone https://git.gnunet.org/gnunet/libgnunetchat.git
Cloning into 'libgnunetchat'...
fatal: repository 'https://git.gnunet.org/gnunet/libgnunetchat.git/' not
found
```

Tracking: https://github.com/NixOS/nixpkgs/issues/514132

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
