### PR TITLE
libeufin, taldir, taler-*: switch to new git repository

### DIFF
--- a/pkgs/by-name/li/libeufin/package.nix
+++ b/pkgs/by-name/li/libeufin/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.3.0";
 
   src = fetchgit {
-    url = "https://git.taler.net/libeufin.git/";
+    url = "https://git-www.taler.net/libeufin.git/";
     tag = "v${finalAttrs.version}";
     hash = "sha256-bt1NBoiN52CX2Itg8lQ/b0V/MZulBTaD8luNlH4Mwss=";
     fetchSubmodules = true;
@@ -116,7 +116,7 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = false;
 
   meta = {
-    homepage = "https://git.taler.net/libeufin.git/";
+    homepage = "https://git-www.taler.net/libeufin.git";
     description = "Integration and sandbox testing for FinTech APIs and data formats";
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [ atemu ];

--- a/pkgs/by-name/ta/taldir/package.nix
+++ b/pkgs/by-name/ta/taldir/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "1.0.5";
 
   src = fetchgit {
-    url = "https://git.taler.net/taldir.git";
+    url = "https://git-www.taler.net/taldir.git";
     tag = "v${finalAttrs.version}";
     hash = "sha256-ZKNkMV0IV6E+yCQeabGXpIQclx1S4YEgFn4whGXTaks=";
   };
@@ -40,7 +40,7 @@ buildGoModule (finalAttrs: {
   doCheck = false;
 
   meta = {
-    homepage = "https://git.taler.net/taldir.git";
+    homepage = "https://git-www.taler.net/taldir.git";
     description = "Directory service to resolve wallet mailboxes by messenger addresses";
     teams = with lib.teams; [ ngi ];
     # themadbit will maintain after being added to maintainers

--- a/pkgs/by-name/ta/taler-challenger/package.nix
+++ b/pkgs/by-name/ta/taler-challenger/package.nix
@@ -24,12 +24,12 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.3.0";
 
   src = fetchgit {
-    url = "https://git.taler.net/challenger.git";
+    url = "https://git-www.taler.net/challenger.git";
     tag = "v${finalAttrs.version}";
     hash = "sha256-oomrqpA/V2sNTRzFbHS7rnZdTIs8w+SRYsa9AYDFn5o=";
   };
 
-  # https://git.taler.net/challenger.git/tree/bootstrap
+  # https://git-www.taler.net/challenger.git/tree/bootstrap
   preAutoreconf = ''
     # Generate Makefile.am in contrib/
     pushd contrib
@@ -73,7 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "OAuth 2.0-based authentication service that validates user can receive messages at a certain address";
-    homepage = "https://git.taler.net/challenger.git";
+    homepage = "https://git-www.taler.net/challenger.git";
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [ wegank ];
     teams = with lib.teams; [ ngi ];

--- a/pkgs/by-name/ta/taler-depolymerization/package.nix
+++ b/pkgs/by-name/ta/taler-depolymerization/package.nix
@@ -8,7 +8,7 @@ rustPlatform.buildRustPackage {
   version = "0-unstable-2024-06-17";
 
   src = fetchgit {
-    url = "https://git.taler.net/depolymerization.git/";
+    url = "https://git-www.taler.net/depolymerization.git";
     rev = "a0d27ac3bba22d4934ca9f7b244b0d9e45bb484f";
     hash = "sha256-HmQ/DPq/O6aODWms/bSsCVgBF7z246xxfYxiHrAkgYw=";
   };
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage {
 
   meta = {
     description = "Wire gateway for Bitcoin/Ethereum";
-    homepage = "https://git.taler.net/depolymerization.git/";
+    homepage = "https://git-www.taler.net/depolymerization.git/";
     license = lib.licenses.agpl3Only;
     teams = [ lib.teams.ngi ];
   };

--- a/pkgs/by-name/ta/taler-exchange/package.nix
+++ b/pkgs/by-name/ta/taler-exchange/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.3.0";
 
   src = fetchgit {
-    url = "https://git.taler.net/exchange.git";
+    url = "https://git-www.taler.net/exchange.git";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-FePuJUEa01E2jlAOdHryzkFwXqNcU+AkMKs1pamNJn8=";
@@ -133,7 +133,7 @@ stdenv.mkDerivation (finalAttrs: {
       payment system.
     '';
     homepage = "https://taler.net/";
-    changelog = "https://git.taler.net/exchange.git/tree/ChangeLog";
+    changelog = "https://git-www.taler.net/exchange.git/tree/ChangeLog?h=v${finalAttrs.version}";
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [ astro ];
     teams = with lib.teams; [ ngi ];

--- a/pkgs/by-name/ta/taler-mdb/package.nix
+++ b/pkgs/by-name/ta/taler-mdb/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.3.0";
 
   src = fetchgit {
-    url = "https://git.taler.net/taler-mdb.git";
+    url = "https://git-www.taler.net/taler-mdb.git";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-bslsC/m75kt8JoIQPp53u64SxghwZloOHehctphpNwI=";
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
 
   meta = {
-    homepage = "https://git.taler.net/taler-mdb.git";
+    homepage = "https://git-www.taler.net/taler-mdb.git";
     description = "Sales integration with the Multi-Drop-Bus of Snack machines, NFC readers and QR code display";
     license = lib.licenses.agpl3Plus;
     teams = with lib.teams; [ ngi ];

--- a/pkgs/by-name/ta/taler-merchant/package.nix
+++ b/pkgs/by-name/ta/taler-merchant/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.3.0";
 
   src = fetchgit {
-    url = "https://git.taler.net/merchant.git";
+    url = "https://git-www.taler.net/merchant.git";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-nrXokwZ0IFXAH3B12/FDAhhyE6JAiiJ59cuWLwLM684=";
@@ -113,7 +113,7 @@ stdenv.mkDerivation (finalAttrs: {
       to know the customer's physical address.
     '';
     homepage = "https://taler.net/";
-    changelog = "https://git.taler.net/merchant.git/tree/ChangeLog";
+    changelog = "https://git-www.taler.net/merchant.git/tree/ChangeLog?h=v${finalAttrs.version}";
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [ astro ];
     teams = with lib.teams; [ ngi ];

--- a/pkgs/by-name/ta/taler-sync/package.nix
+++ b/pkgs/by-name/ta/taler-sync/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.3.0";
 
   src = fetchgit {
-    url = "https://git.taler.net/sync.git";
+    url = "https://git-www.taler.net/sync.git";
     tag = "v${finalAttrs.version}";
     hash = "sha256-1m26ORKsN0GHJWQ/5gtMO3x1ng+GsZK9Y80413vF5pI=";
   };
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Backup and synchronization service";
-    homepage = "https://git.taler.net/sync.git";
+    homepage = "https://git-www.taler.net/sync.git";
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [ wegank ];
     teams = with lib.teams; [ ngi ];

--- a/pkgs/by-name/ta/taler-twister/package.nix
+++ b/pkgs/by-name/ta/taler-twister/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.0.0";
 
   src = fetchgit {
-    url = "https://git.taler.net/twister.git";
+    url = "https://git-www.taler.net/twister.git";
     tag = "v${finalAttrs.version}";
     hash = "sha256-ir+kU9bCWwhqR88hmNHB5cm1DXOQowI5y6GdhWpX/L0=";
   };
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   doInstallCheck = true;
 
   meta = {
-    homepage = "https://git.taler.net/twister.git";
+    homepage = "https://git-www.taler.net/twister.git";
     description = "Fault injector for HTTP traffic";
     teams = with lib.teams; [ ngi ];
     maintainers = [ ];


### PR DESCRIPTION
since the old one isn't valid anymore.

**PS:** this also fixes the invalid changelogs (tracking https://github.com/NixOS/nixpkgs/issues/514132)
**PPS:** `taler-wallet-core`'s repo URL is fixed in https://github.com/NixOS/nixpkgs/pull/515750, that's why it wasn't included here.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
