### PR TITLE
kicad: Workaround for #515658

### DIFF
--- a/pkgs/by-name/ki/kicad/base.nix
+++ b/pkgs/by-name/ki/kicad/base.nix
@@ -89,6 +89,8 @@ stdenv.mkDerivation (finalAttrs: {
     ./writable.patch
     # https://gitlab.com/kicad/code/kicad/-/issues/15687
     ./runtime_stock_data_path.patch
+    # https://github.com/NixOS/nixpkgs/issues/515658
+    ./default_lib_table_paths.patch
   ];
 
   # tagged releases don't have "unknown"

--- a/pkgs/by-name/ki/kicad/default_lib_table_paths.patch
+++ b/pkgs/by-name/ki/kicad/default_lib_table_paths.patch
@@ -1,0 +1,47 @@
+Workaround for https://github.com/NixOS/nixpkgs/issues/515658.
+
+KICAD_LIBRARY_DATA is baked in at compile time and points at the kicad
+base derivation, which on Nix does not contain the symbol or footprint
+template tables (those ship in separate derivations).  When KiCad runs
+its first-time setup it copies the URI from that nonexistent
+share/kicad/template/{sym,fp}-lib-table into the user's global library
+table, leaving the user with no built-in libraries.
+
+Point the default rows at the per-library env vars exposed by the
+wrapper (KICAD10_SYMBOL_DIR, KICAD10_FOOTPRINT_DIR) so the URIs resolve
+to the actual library locations.
+
+diff --git a/common/libraries/library_manager.cpp b/common/libraries/library_manager.cpp
+--- a/common/libraries/library_manager.cpp
++++ b/common/libraries/library_manager.cpp
+@@ -415,10 +415,28 @@ bool LIBRARY_MANAGER::CreateGlobalTable( LIBRARY_TABLE_TYPE aType, bool aPopulat
+     if( aPopulateDefaultLibraries )
+     {
+         LIBRARY_TABLE_ROW& chained = table.InsertRow();
+-        chained.SetType( LIBRARY_TABLE_ROW::TABLE_TYPE_NAME );
+         chained.SetNickname( wxT( "KiCad" ) );
+         chained.SetDescription( _( "KiCad Default Libraries" ) );
+-        chained.SetURI( defaultLib.GetFullPath() );
++
++        // Nixpkgs ships symbol/footprint libraries from separate derivations, so the
++        // compile-time KICAD_LIBRARY_DATA path is empty.  Point the default rows at
++        // the per-library env vars exposed by the wrapper instead.  See
++        // https://github.com/NixOS/nixpkgs/issues/515658
++        switch( aType )
++        {
++        case LIBRARY_TABLE_TYPE::SYMBOL:
++            chained.SetType( wxT( "KiCad" ) );
++            chained.SetURI( wxT( "${KICAD10_SYMBOL_DIR}" ) );
++            break;
++        case LIBRARY_TABLE_TYPE::FOOTPRINT:
++            chained.SetType( LIBRARY_TABLE_ROW::TABLE_TYPE_NAME );
++            chained.SetURI( wxT( "${KICAD10_FOOTPRINT_DIR}/../template/fp-lib-table" ) );
++            break;
++        default:
++            chained.SetType( LIBRARY_TABLE_ROW::TABLE_TYPE_NAME );
++            chained.SetURI( defaultLib.GetFullPath() );
++            break;
++        }
+     }
+
+     try


### PR DESCRIPTION
Fixes #515658, from the included patch:

> Workaround for https://github.com/NixOS/nixpkgs/issues/515658.
> 
> KICAD_LIBRARY_DATA is baked in at compile time and points at the kicad
> base derivation, which on Nix does not contain the symbol or footprint
> template tables (those ship in separate derivations).  When KiCad runs
> its first-time setup it copies the URI from that nonexistent
> share/kicad/template/{sym,fp}-lib-table into the user's global library
> table, leaving the user with no built-in libraries.
> 
> Point the default rows at the per-library env vars exposed by the
> wrapper (KICAD10_SYMBOL_DIR, KICAD10_FOOTPRINT_DIR) so the URIs resolve
> to the actual library locations.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
