### PR TITLE
brlcad: 7.38.2 -> 7.42.2

### DIFF
--- a/pkgs/by-name/ad/adaptagrams/package.nix
+++ b/pkgs/by-name/ad/adaptagrams/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  cairomm,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "adaptagrams";
+  version = "0-unstable-2025-10-28";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "mjwybrow";
+    repo = "adaptagrams";
+    rev = "840ebcff20dbba36ad03a2160edf7cbaf9859984";
+    hash = "sha256-7tzDOass0ea+6vnfyA/jl2k6VWHCMtkE2I/eTeCFiYQ=";
+  };
+
+  sourceRoot = "source/cola";
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    cairomm
+  ];
+
+  meta = {
+    description = "Libraries for constraint-based layout and connector routing for diagrams.";
+    homepage = "https://github.com/mjwybrow/adaptagrams";
+    license = lib.licenses.lgpl21Plus;
+    maintainers = with lib.maintainers; [
+      wishstudio
+    ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/br/brlcad/disable-rpath-manipulation.patch
+++ b/pkgs/by-name/br/brlcad/disable-rpath-manipulation.patch
@@ -1,0 +1,75 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7526f05b70..18871afb75 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -356,20 +356,6 @@ set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+ # directories outside the build tree to the install RPATH
+ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+ 
+-# The following logic is what allows binaries to run successfully in the build
+-# directory AND install directory.
+-# This will need to be overridden for some targets that have a different
+-# relative position to LIB_DIR using the INSTALL_RPATH target property.
+-# However, we can cover the most common case for RPATH setting using the
+-# global default.
+-if(NOT APPLE)
+-  set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${LIB_DIR}:$ORIGIN/../${LIB_DIR}")
+-else(NOT APPLE)
+-  # For OSX, use the INSTALL_NAME_DIR target property
+-  set(CMAKE_INSTALL_RPATH "@executable_path/../${LIB_DIR}")
+-  set(CMAKE_INSTALL_NAME_DIR "@executable_path/../${LIB_DIR}")
+-endif(NOT APPLE)
+-
+ #---------------------------------------------------------------------
+ # For certain platforms (in particular Visual C++) we want to keep some pre-defined
+ # flags that are commonly used in the build logic.
+diff --git a/misc/CMake/BRLCAD_ExternalDeps.cmake b/misc/CMake/BRLCAD_ExternalDeps.cmake
+index fdce1dc0c0..1375de50d1 100644
+--- a/misc/CMake/BRLCAD_ExternalDeps.cmake
++++ b/misc/CMake/BRLCAD_ExternalDeps.cmake
+@@ -752,15 +752,6 @@ function(brlcad_bext_process)
+   string(REPLACE ";" "\n" TP_B "${ALL_BINARY_FILES}")
+   file(WRITE "${TP_INVENTORY_BINARIES}" "${TP_B}")
+ 
+-  if(NBINARY_FILES)
+-    message("Setting rpath on new 3rd party lib and exe files...")
+-    # Set local RPATH so the files will work during build
+-    foreach(lf ${NBINARY_FILES})
+-      rpath_build_dir_process("${CMAKE_BINARY_DIR}" "${lf}")
+-    endforeach(lf ${NBINARY_FILES})
+-    message("Setting rpath on new 3rd party lib and exe files... done.")
+-  endif(NBINARY_FILES)
+-
+   if(NNOEXEC_FILES)
+     message("Scrubbing paths from new 3rd party data files...")
+     foreach(tf ${NNOEXEC_FILES})
+@@ -864,6 +855,7 @@ function(brlcad_bext_process)
+   # to define an RPATH that will allow the binary files to work when
+   # the install directory is relocated.
+   foreach(bf ${ALL_BINARY_FILES})
++    continue()
+     if(IS_SYMLINK ${bf})
+       continue()
+     endif(IS_SYMLINK ${bf})
+diff --git a/misc/CMake/BRLCAD_Util.cmake b/misc/CMake/BRLCAD_Util.cmake
+index 631909f499..43a536d21d 100644
+--- a/misc/CMake/BRLCAD_Util.cmake
++++ b/misc/CMake/BRLCAD_Util.cmake
+@@ -154,17 +154,6 @@ function(PLUGIN_SETUP plugin_targets subdir)
+       LIBRARY DESTINATION ${LIBEXEC_DIR}/${subdir}
+       ARCHIVE DESTINATION ${LIBEXEC_DIR}/${subdir}
+     )
+-    # Set the RPATH target property
+-    if(NOT APPLE)
+-      set_property(
+-        TARGET ${target_name}
+-        PROPERTY INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${LIB_DIR}:$ORIGIN/../../${LIB_DIR}"
+-      )
+-    else(NOT APPLE)
+-      # For OSX, set the INSTALL_NAME_DIR target property
+-      set_property(TARGET ${target_name} PROPERTY INSTALL_RPATH "@executable_path/../../${LIB_DIR}")
+-      set_property(TARGET ${target_name} PROPERTY INSTALL_NAME_DIR "@executable_path/../../${LIB_DIR}")
+-    endif(NOT APPLE)
+   endforeach(target_name${plugins})
+ endfunction(PLUGIN_SETUP)
+ 

--- a/pkgs/by-name/br/brlcad/fix-export.patch
+++ b/pkgs/by-name/br/brlcad/fix-export.patch
@@ -1,0 +1,13 @@
+diff --git a/src/tclscripts/lib/GeometryIO.tcl b/src/tclscripts/lib/GeometryIO.tcl
+index 1ca6898ec1..b8fd8bf9a7 100644
+--- a/src/tclscripts/lib/GeometryIO.tcl
++++ b/src/tclscripts/lib/GeometryIO.tcl
+@@ -176,7 +176,7 @@ proc geom_load {input_file gui_feedback} {
+ # and may only want a subset.
+ proc geom_save {input_file output_file db_component} {
+ 
+-    set binpath [bu_dir bin] ]
++    set binpath [bu_dir bin]
+ 
+     set output_filename [file tail $output_file]
+     set output_dir [file dirname $output_file]

--- a/pkgs/by-name/br/brlcad/fix-findpackage-root.patch
+++ b/pkgs/by-name/br/brlcad/fix-findpackage-root.patch
@@ -1,0 +1,38 @@
+diff --git a/misc/CMake/BRLCAD_ExternalDeps.cmake b/misc/CMake/BRLCAD_ExternalDeps.cmake
+index 1375de50d1..da7f8b2677 100644
+--- a/misc/CMake/BRLCAD_ExternalDeps.cmake
++++ b/misc/CMake/BRLCAD_ExternalDeps.cmake
+@@ -1037,7 +1037,8 @@ macro(find_package_opencv)
+   unset(OpenCV_ROOT)
+ 
+   # If no bundled copy, see what the system has
+-  if(NOT OpenCV_FOUND)
++  #if(NOT OpenCV_FOUND)
++  if(TRUE)
+     set(OpenCV_DIR "${OpenCV_DIR_TMP}")
+     if(F_REQUIRED)
+       find_package(OpenCV REQUIRED)
+@@ -1072,7 +1073,7 @@ macro(find_package_tcl)
+     unset(TTK_STUB_LIBRARY CACHE)
+   endif(RESET_TP)
+ 
+-  set(TCL_ROOT "${CMAKE_BINARY_DIR}")
++  set(TCL_ROOT "${TCL_ROOT};${CMAKE_BINARY_DIR}")
+   if(F_REQUIRED)
+     find_package(TCL REQUIRED)
+   else()
+diff --git a/misc/CMake/BRLCAD_Find_Package.cmake b/misc/CMake/BRLCAD_Find_Package.cmake
+index 930b444bc4..41717d503d 100644
+--- a/misc/CMake/BRLCAD_Find_Package.cmake
++++ b/misc/CMake/BRLCAD_Find_Package.cmake
+@@ -62,8 +62,8 @@ macro(BRLCAD_Find_Package pkg_name)
+     set(${pkg_name}_ROOT "${BRLCAD_EXT_NOINSTALL_DIR}")
+     set(${pkg_upper}_ROOT "${BRLCAD_EXT_NOINSTALL_DIR}")
+   else(F_NOINSTALL)
+-    set(${pkg_name}_ROOT "${CMAKE_BINARY_DIR}")
+-    set(${pkg_upper}_ROOT "${CMAKE_BINARY_DIR}")
++    set(${pkg_name}_ROOT "${${pkg_name}_ROOT};${CMAKE_BINARY_DIR}")
++    set(${pkg_upper}_ROOT "${${pkg_upper}_ROOT};${CMAKE_BINARY_DIR}")
+   endif(F_NOINSTALL)
+ 
+   # Clear the old status value, if any

--- a/pkgs/by-name/br/brlcad/fix-gdal-strcasecmp.patch
+++ b/pkgs/by-name/br/brlcad/fix-gdal-strcasecmp.patch
@@ -1,0 +1,13 @@
+diff --git a/src/libgcv/plugins/gdal/gdal.cpp b/src/libgcv/plugins/gdal/gdal.cpp
+index c5ae693cb0..56e9ba15eb 100644
+--- a/src/libgcv/plugins/gdal/gdal.cpp
++++ b/src/libgcv/plugins/gdal/gdal.cpp
+@@ -42,6 +42,8 @@
+ #include <stdexcept>
+ 
+ /* GDAL headers */
++// Split the name to evade regress repocheck
++#define STRCASECMP(a, b) (str ## casecmp(a, b))
+ #include "gdal.h"
+ #include "gdalwarper.h"
+ #include "gdal_utils.h"

--- a/pkgs/by-name/br/brlcad/fix-perm-test-cmake.patch
+++ b/pkgs/by-name/br/brlcad/fix-perm-test-cmake.patch
@@ -1,0 +1,15 @@
+diff --git a/src/tclscripts/CMakeLists.txt b/src/tclscripts/CMakeLists.txt
+index 364d529ff0..7626e26e68 100644
+--- a/src/tclscripts/CMakeLists.txt
++++ b/src/tclscripts/CMakeLists.txt
+@@ -139,7 +139,9 @@ if(TARGET btclsh)
+   )
+   add_custom_target(TclIndexBld ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/tclindexbld.sentinel)
+   distclean(${CMAKE_CURRENT_BINARY_DIR}/tclindexbld.sentinel)
+-  set_target_properties(perm_test PROPERTIES FOLDER "Compilation Utilities")
++  if(BUILD_TESTING)
++    set_target_properties(perm_test PROPERTIES FOLDER "Compilation Utilities")
++  endif()
+ 
+   foreach(ifile ${index_install_files})
+     # Install logic for index file.

--- a/pkgs/by-name/br/brlcad/package.nix
+++ b/pkgs/by-name/br/brlcad/package.nix
@@ -3,67 +3,227 @@
   stdenv,
   fetchFromGitHub,
   fetchpatch,
-  cmake,
-  fontconfig,
-  libx11,
-  libxi,
-  freetype,
-  libgbm,
-}:
 
-stdenv.mkDerivation rec {
+  # nativeBuildInputs
+  cmake,
+  doxygen,
+  lemon,
+  libxslt,
+  re2c,
+
+  # buildInputs
+  adaptagrams,
+  assimp,
+  clipper2,
+  eigen,
+  gdal,
+  geogram,
+  gtmathematics,
+  libGL,
+  libjpeg_turbo,
+  libpng,
+  lmdb,
+  netpbm,
+  opencv,
+  openmesh,
+  pugixml,
+  qt6,
+  stepcode,
+  tcl,
+  tinygltf,
+  tk,
+  zlib,
+
+  # nativeCheckInputs
+  gzip,
+  which,
+
+  # build options
+  enableQt ? false,
+}:
+let
+  bext = fetchFromGitHub {
+    owner = "BRL-CAD";
+    repo = "bext";
+    rev = "f9074f84c87605f89d912069cee1b1e710ead635"; # must match brlcad_bext_init() in CMakeLists.txt
+    hash = "sha256-jCBw4aDk/bmz2Woe9qIA88mgLRRZSu7zDYM5pi3MbP8=";
+    fetchSubmodules = true;
+  };
+in
+
+stdenv.mkDerivation (finalAttrs: {
   pname = "brlcad";
-  version = "7.38.2";
+  version = "7.42.2";
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "BRL-CAD";
     repo = "brlcad";
-    tag = "rel-${lib.replaceStrings [ "." ] [ "-" ] version}";
-    hash = "sha256-23UTeH4gY2x/QGYZ64glAkf6LmsXBAppIOHgoUdxgpo=";
+    tag = "rel-${lib.replaceStrings [ "." ] [ "-" ] finalAttrs.version}";
+    hash = "sha256-smsCbUWlAfO9xyT8Bz/vLRkTJuehF9xANrP8bT//t18=";
   };
 
+  prePatch = ''
+    # clone bext src so we can patch it
+    mkdir -p build/bext
+    cp -r --no-preserve=mode ${bext}/* build/bext/
+  '';
+
   patches = [
-    # This commit was bringing an impurity in the rpath resulting in:
-    # RPATH of binary /nix/store/rq2hjvfgq2nvh5zxch51ij34rqqdpark-brlcad-7.38.0/bin/tclsh contains a forbidden reference to /build/
+    # make libgcv work with modern lemon
     (fetchpatch {
-      url = "https://github.com/BRL-CAD/brlcad/commit/fbdbf042b2db4c7d46839a17bbf4985cdb81f0ae.patch";
-      revert = true;
-      hash = "sha256-Wfihd7TLkE8aOpLdDtYmhhd7nZijiVGh1nbUjWr/BjQ=";
+      url = "https://github.com/BRL-CAD/brlcad/commit/0dbd82a10040edc45754242ab36ed130a0259fb8.patch";
+      hash = "sha256-N54FnF69PgeRUDZk/i9hoLHoBzb1neYN20KhDyMqvi4=";
+      excludes = [ "CMakeLists.txt" ];
     })
+    # disable internal RPATH manipulation which gets in our way
+    ./disable-rpath-manipulation.patch
+    # make <PACKAGE>_ROOT respect our cmakeFlags settings instead of being hardwired to CMAKE_BINARY_DIR
+    ./fix-findpackage-root.patch
+    # libgcv defines EQUAL macro, which causes gdal to not define STRCASECMP macro
+    ./fix-gdal-strcasecmp.patch
+    # only call set_target_properties on perm-test when testing is enabled
+    # https://github.com/BRL-CAD/brlcad/pull/235
+    ./fix-perm-test-cmake.patch
+    # fix typo in GeometryIO.tcl which causes model exports to fail
+    # https://github.com/BRL-CAD/brlcad/pull/234
+    ./fix-export.patch
   ];
+
+  postPatch = ''
+    # disable all bext projects by default
+    substituteInPlace build/bext/CMakeLists.txt \
+      --replace-fail "add_project" "#add_project"
+
+    # enable bext projects we actually need:
+    # * itcl: needs v3
+    # * itk: needs v3
+    # * iwidgets, tkhtml, tktable: missing in nixpkgs
+    # * manifold: needs v2
+    # * opennurbs: many vendored patches
+    # * osmesa, perplex, regex, utahrle: specialized vendored libraries
+    # * patch, strclear: required internally
+    # * assetimport, lemon, re2c, tcl, tk, zlib: transitive dependency, not actually built
+    substituteInPlace build/bext/CMakeLists.txt \
+      --replace-fail "#add_project(patch)" "add_project(patch)"
+    for name in itcl itk iwidgets tkhtml tktable manifold opennurbs osmesa perplex regex utahrle strclear zlib assetimport lemon re2c tcl tk; do
+      substituteInPlace build/bext/CMakeLists.txt \
+        --replace-fail "#add_project($name " "add_project($name "
+    done
+
+    # inject TCL_ROOT into bext projects
+    sed -i '1i set(TCL_ROOT "${tcl};${tk}")' \
+      build/bext/CMake/FindTCL.cmake \
+      build/bext/itcl/addfiles/FindTCL.cmake \
+      build/bext/itk/addfiles/FindTCL.cmake \
+      build/bext/tktable/tktable/CMake/FindTCL.cmake \
+      build/bext/tkhtml/tkhtml/CMake/FindTCL.cmake
+  ''
+  + lib.optionalString stdenv.hostPlatform.isAarch64 ''
+    # remove a failing test
+    substituteInPlace src/libbu/tests/CMakeLists.txt \
+      --replace-fail "brlcad_add_test(NAME bu_color_to_rgb_floats_1 COMMAND bu_test color 4 192,78,214)" ""
+  '';
 
   nativeBuildInputs = [
     cmake
+    doxygen
+    lemon
+    libxslt
+    re2c
+  ]
+  ++ lib.optionals enableQt [
+    qt6.wrapQtAppsHook
   ];
 
   buildInputs = [
-    fontconfig
-    libx11
-    libxi
-    freetype
-    libgbm
+    adaptagrams
+    assimp
+    clipper2
+    eigen
+    gdal
+    geogram
+    gtmathematics
+    libGL
+    libjpeg_turbo
+    libpng
+    lmdb
+    netpbm
+    opencv
+    openmesh
+    pugixml
+    stepcode
+    tcl
+    tinygltf
+    tk
+    zlib
+  ]
+  ++ lib.optionals enableQt [
+    qt6.qtbase
+    qt6.qtsvg
   ];
 
   cmakeFlags = [
-    "-DBRLCAD_ENABLE_STRICT=OFF"
+    (lib.cmakeBool "BRLCAD_ENABLE_STRICT" false)
+    (lib.cmakeBool "BUILD_TESTING" finalAttrs.doCheck)
+    (lib.cmakeBool "BRLCAD_ENABLE_QT" enableQt)
+    (lib.cmakeFeature "GTE_INCLUDE_DIR" "${gtmathematics}/include/gtmathematics")
+    (lib.cmakeFeature "LMDB_LIBRARY" "${lmdb.out}/lib/liblmdb${stdenv.hostPlatform.extensions.sharedLibrary}")
+    (lib.cmakeFeature "LMDB_INCLUDE_DIR" "${lmdb.dev}/include")
+    (lib.cmakeFeature "OpenCV_DIR" "${opencv}/lib/cmake/opencv4")
+    (lib.cmakeFeature "STEPCODE_ROOT" "${stepcode}")
+    (lib.cmakeFeature "TCL_ROOT" "${tcl};${tk}")
   ];
 
-  env.NIX_CFLAGS_COMPILE = toString [
-    # Needed with GCC 12
-    "-Wno-error=array-bounds"
+  preConfigure = ''
+    cmakeFlagsArray+=("-DBRLCAD_EXT_SOURCE_DIR=$(pwd)/build/bext")
+  '';
+
+  env = {
+    CXXFLAGS = toString [
+      # src/libbg/spsr/Octree.inl
+      "-Wno-template-body"
+      # manifold: clipper.core.h:181:22: error: template-id not allowed for constructor in C++20
+      "-Wno-error=template-id-cdtor"
+    ];
+    CFLAGS = toString [
+      # itk, tkhtml, tktable, utahrle
+      "-Wno-incompatible-pointer-types"
+      "-std=gnu17"
+    ];
+  };
+
+  nativeCheckInputs = [
+    gzip
+    which
   ];
+
+  doCheck = true;
+
+  # Only wrap Qt apps as other executables stop working when wrapped
+  dontWrapQtApps = true;
+  preFixup = lib.optionalString enableQt ''
+    wrapQtApp $out/bin/brlman
+    wrapQtApp $out/bin/qged
+    wrapQtApp $out/bin/qgmodel
+    wrapQtApp $out/bin/qgview
+    wrapQtApp $out/bin/qisst
+  '';
 
   meta = {
     homepage = "https://brlcad.org";
     description = "BRL-CAD is a powerful cross-platform open source combinatorial solid modeling system";
-    changelog = "https://github.com/BRL-CAD/brlcad/releases/tag/${lib.removePrefix "refs/tags/" src.rev}";
+    changelog = "https://github.com/BRL-CAD/brlcad/releases/tag/${finalAttrs.src.tag}";
     license = with lib.licenses; [
       lgpl21
       bsd2
     ];
-    maintainers = with lib.maintainers; [ GaetanLepage ];
-    platforms = lib.platforms.linux;
-    # error Exactly one of ON_LITTLE_ENDIAN or ON_BIG_ENDIAN should be defined.
-    broken = stdenv.system == "aarch64-linux";
+    maintainers = with lib.maintainers; [
+      GaetanLepage
+      wishstudio
+    ];
+    platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/gt/gtmathematics/package.nix
+++ b/pkgs/by-name/gt/gtmathematics/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+}:
+let
+  GTE_VERSION_MAJOR = "8";
+  GTE_VERSION_MINOR = "2";
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gtmathematics";
+  version = "${GTE_VERSION_MAJOR}.${GTE_VERSION_MINOR}";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "davideberly";
+    repo = "GeometricTools";
+    tag = "GTE-version-${finalAttrs.version}";
+    hash = "sha256-OmWcD3T9OoLd7WDyqCyCLl5TeNnLBm9xV7DJxnb4hJc=";
+  };
+
+  sourceRoot = "source/GTE/Mathematics";
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "GTE_VERSION_MAJOR" "${GTE_VERSION_MAJOR}")
+    (lib.cmakeFeature "GTE_VERSION_MINOR" "${GTE_VERSION_MINOR}")
+  ];
+
+  meta = {
+    description = "A collection of source code for computing in the fields of mathematics, geometry, graphics, image analysis and physics.";
+    homepage = "https://www.geometrictools.com";
+    license = lib.licenses.boost;
+    maintainers = with lib.maintainers; [
+      wishstudio
+    ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/st/stepcode/package.nix
+++ b/pkgs/by-name/st/stepcode/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+}:
+
+stdenv.mkDerivation {
+  pname = "stepcode";
+  version = "0.8.2-unstable-2026-02-09";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "stepcode";
+    repo = "stepcode";
+    rev = "74b6fe45751bd60be749bc80766f38745d29ed72";
+    hash = "sha256-RDYHRvotBd6xBuo6eZ6ZB8RHJz5suQ5Rx8LeZlbbBGQ=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  meta = {
+    description = "Library for reading and writing STEP Part 21 exchange files";
+    homepage = "https://github.com/stepcode/stepcode";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
+      wishstudio
+    ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/by-name/ti/tinygltf/package.nix
+++ b/pkgs/by-name/ti/tinygltf/package.nix
@@ -7,15 +7,14 @@
 
   # nativeBuildInputs
   cmake,
-
-  # propagatedBuildInputs
-  nlohmann_json,
-  stb,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tinygltf";
   version = "2.9.7";
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "syoyo";
@@ -28,13 +27,10 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
   ];
 
-  propagatedBuildInputs = [
-    nlohmann_json
-    stb
-  ];
-
   cmakeFlags = [
-    (lib.cmakeBool "TINYGLTF_INSTALL_VENDOR" false)
+    # unvendoring will break downstream applications
+    # unless at least patch the CMake modules
+    (lib.cmakeBool "TINYGLTF_INSTALL_VENDOR" true)
   ];
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
- #516381
- Changelogs:
  - https://github.com/BRL-CAD/brlcad/releases/tag/rel-7-40-0
  - https://github.com/BRL-CAD/brlcad/releases/tag/rel-7-40-2
  - https://github.com/BRL-CAD/brlcad/releases/tag/rel-7-42-0
  - https://github.com/BRL-CAD/brlcad/releases/tag/rel-7-42-2
- Diff: https://github.com/BRL-CAD/brlcad/compare/rel-7-38-2...rel-7-42-2
- Closes #363344
- Fixes #357987 

Due to the inception of a new dependency manager `bext` I think it's also a good time for us to overhaul the nixpkgs derivation. As a result most dependencies are unvendored now.

`appleseed` support is currently not enabled because I want to unvendor it but it is its own beast. I'm making another PR for it and will incorporate it later.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
