### PR TITLE
isso: 0.13.0 -> 0.14.0

### DIFF
--- a/pkgs/by-name/is/isso/package.nix
+++ b/pkgs/by-name/is/isso/package.nix
@@ -4,25 +4,25 @@
   fetchFromGitHub,
   nixosTests,
   fetchNpmDeps,
-  nodejs_20,
+  nodejs,
   npmHooks,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "isso";
-  version = "0.13.0";
+  version = "0.14.0";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "posativ";
     repo = "isso";
     tag = finalAttrs.version;
-    hash = "sha256-kZNf7Rlb1DZtQe4dK1B283OkzQQcCX+pbvZzfL65gsA=";
+    hash = "sha256-8kXqqiMXxF0wCJ+AzYT8j0rjuhlXO3F6UJbump672b4=";
   };
 
   npmDeps = fetchNpmDeps {
     inherit (finalAttrs) src;
-    hash = "sha256-RBpuhFI0hdi8bB48Pks9Ac/UdcQ/DJw+WFnNj5f7IYE=";
+    hash = "sha256-e3r5iZLmXlf5YBPGgeNBDkdgfbNcIZIXbRLyyoyJiTU=";
   };
 
   outputs = [
@@ -40,6 +40,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     itsdangerous
     jinja2
     misaka
+    mistune
     html5lib
     werkzeug
     bleach
@@ -50,7 +51,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     python3Packages.cffi
     python3Packages.sphinxHook
     python3Packages.sphinx
-    nodejs_20
+    nodejs
     npmHooks.npmConfigHook
   ];
 


### PR DESCRIPTION
Fixes the NixOS test.
Removes EOL node version (#515284).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
