### PR TITLE
iscc: fix link issue

### DIFF
--- a/pkgs/by-name/is/iscc/package.nix
+++ b/pkgs/by-name/is/iscc/package.nix
@@ -65,7 +65,7 @@ stdenvNoCC.mkDerivation rec {
     homepage = "https://jrsoftware.org/isinfo.php";
     changelog = "https://jrsoftware.org/files/is6-whatsnew.htm";
     license = lib.licenses.unfreeRedistributable;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ liberodark ];
     mainProgram = "iscc";
     platforms = wineWow64Packages.stable.meta.platforms;
   };

--- a/pkgs/by-name/is/iscc/package.nix
+++ b/pkgs/by-name/is/iscc/package.nix
@@ -9,13 +9,13 @@
 
 let
   version = "6.4.1";
-  majorVersion = builtins.substring 0 1 version;
+  tagVersion = lib.replaceStrings [ "." ] [ "_" ] version;
 in
 stdenvNoCC.mkDerivation rec {
   pname = "iscc";
   inherit version;
   src = fetchurl {
-    url = "https://files.jrsoftware.org/is/${majorVersion}/innosetup-${version}.exe";
+    url = "https://github.com/jrsoftware/issrc/releases/download/is-${tagVersion}/innosetup-${version}.exe";
     hash = "sha256-9Bdg4fGuFdIIm7arFi4hcguSrnUG7XBmezkgAGPWjjQ=";
   };
   nativeBuildInputs = [
@@ -24,12 +24,15 @@ stdenvNoCC.mkDerivation rec {
   ];
   unpackPhase = ''
     runHook preUnpack
+
     innoextract $src
+
     runHook postUnpack
   '';
   dontBuild = true;
   installPhase = ''
     runHook preInstall
+
     mkdir -p "$out/bin"
     cp -r ./app/* "$out/bin"
 


### PR DESCRIPTION
jrsoftware no longer hosts the files; they are now on github.

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
