### PR TITLE
ollama: 0.21.1 -> 0.22.1

### DIFF
--- a/pkgs/by-name/ol/ollama/package.nix
+++ b/pkgs/by-name/ol/ollama/package.nix
@@ -141,13 +141,13 @@ let
 in
 goBuild (finalAttrs: {
   pname = "ollama";
-  version = "0.21.1";
+  version = "0.22.1";
 
   src = fetchFromGitHub {
     owner = "ollama";
     repo = "ollama";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-t/c2oba/y1IUh460+P3MQHGLnExrKcOcQpiMg0mFLBs=";
+    hash = "sha256-dCKGTu004PswCblMT86bEn6bJNipNFK+mG+0+hAP5LA=";
   };
 
   vendorHash = "sha256-Lc1Ktdqtv2VhJQssk8K1UOimeEjVNvDWePE9WkamCos=";
@@ -194,7 +194,10 @@ goBuild (finalAttrs: {
       --replace-fail 0.0.0 '${finalAttrs.version}'
     substituteInPlace cmd/launch/openclaw_test.go \
       --replace-fail '/bin/mkdir' '${coreutils}/bin/mkdir' \
-      --replace-fail '/bin/cat' '${coreutils}/bin/cat'
+      --replace-fail '/bin/cat' '${coreutils}/bin/cat' \
+      --replace-fail '/usr/bin/env' '${coreutils}/bin/env' \
+      --replace-fail '/usr/bin/sort' '${coreutils}/bin/sort' \
+      --replace-fail '/bin/chmod' '${coreutils}/bin/chmod'
     substituteInPlace cmd/launch/hermes_test.go \
       --replace-fail '/bin/mkdir' '${coreutils}/bin/mkdir' \
       --replace-fail '/bin/cat' '${coreutils}/bin/cat' \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Updated ollama to 0.22.1. It supposed to fix some bug in parsing in gemma4, but it doesn’t appear to work much better, so I’ll have to do some ollama debugging.

Still, works fine on my machine, and the nixos tests run (except the cuda variant, due to failing to build /nix/store/3sxpf7v3qk8lsaqviwxim6s9fwflyz53-cuda12.9-cuda_compat-12.9.40580548.drv. Still works fine on my machine with CUDA)

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`. (only tested the main binary, don’t know what the others are used for)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs. (as far as I know. Made some time I haven’t read them, and there is so many stuff to read for a simple package update)

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
