### PR TITLE
tinygltf: 2.9.7 -> 3.0.0

### DIFF
--- a/pkgs/by-name/ti/tinygltf/package.nix
+++ b/pkgs/by-name/ti/tinygltf/package.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tinygltf";
-  version = "2.9.7";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "syoyo";
     repo = "tinygltf";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-tG9hrR2rsfgS8zCBNdcplig2vyiIcNspSVKop03Zx9A=";
+    hash = "sha256-qs/7O/nPXpMbn31smMfdd3V9zRbyhAnDyjZwlduseKU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ti/tinygltf/package.nix
+++ b/pkgs/by-name/ti/tinygltf/package.nix
@@ -3,6 +3,7 @@
 
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   nix-update-script,
 
   # nativeBuildInputs
@@ -23,6 +24,15 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-qs/7O/nPXpMbn31smMfdd3V9zRbyhAnDyjZwlduseKU=";
   };
+
+  patches = [
+    # ref. https://github.com/syoyo/tinygltf/pull/552
+    (fetchpatch2 {
+      name = "cmake-export-nlohmann_json-dependency.patch";
+      url = "https://github.com/nim65s/tinygltf/commit/12aec65d78b6b135b2bbd17290a99f608bf5ebd5.patch?full_index=1";
+      hash = "sha256-jN/P6FIlOiOx+UIWcpNbPIUILtKCFm7QSU8r5XcEFy4=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/ti/tinygltf/package.nix
+++ b/pkgs/by-name/ti/tinygltf/package.nix
@@ -35,11 +35,16 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "TINYGLTF_INSTALL_VENDOR" false)
+    (lib.cmakeBool "TINYGLTF_USE_CUSTOM_JSON" false) # faster but vibe-coded
+    (lib.cmakeBool "TINYGLTF_BUILD_TESTS" finalAttrs.doCheck)
   ];
+
+  doCheck = true;
 
   passthru.updateScript = nix-update-script { };
 
   meta = {
+    changelog = "https://github.com/syoyo/tinygltf/releases/tag/${finalAttrs.src.tag}";
     description = "Header only C++11 tiny glTF 2.0 library";
     homepage = "https://github.com/syoyo/tinygltf";
     license = lib.licenses.mit;


### PR DESCRIPTION
supersede #https://github.com/NixOS/nixpkgs/pull/504743

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
