### PR TITLE
pi-coding-agent: remove vendored Linux binaries on Darwin

### DIFF
--- a/pkgs/by-name/pi/pi-coding-agent/package.nix
+++ b/pkgs/by-name/pi/pi-coding-agent/package.nix
@@ -10,16 +10,16 @@
 }:
 buildNpmPackage (finalAttrs: {
   pname = "pi-coding-agent";
-  version = "0.70.5";
+  version = "0.72.1";
 
   src = fetchFromGitHub {
     owner = "badlogic";
     repo = "pi-mono";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Jn+hvS/DIwbwAff+UovdIVnmrb4o8gsC4IR24MnwF1I=";
+    hash = "sha256-SqUxghc60P3HfmaFJGB/m23mvzw0cD7cDEUrNFOqo0Y=";
   };
 
-  npmDepsHash = "sha256-MZgcHJdGFGSNgQ26/24iA12FdmO7S5vWv4crSNFhHi0=";
+  npmDepsHash = "sha256-KUC1xQK6oJXtg962YeLOnO76uTdR10/VNa9iiCdT3VM=";
 
   npmWorkspace = "packages/coding-agent";
 

--- a/pkgs/by-name/pi/pi-coding-agent/package.nix
+++ b/pkgs/by-name/pi/pi-coding-agent/package.nix
@@ -7,6 +7,7 @@
   writableTmpDirAsHomeHook,
   ripgrep,
   makeBinaryWrapper,
+  stdenvNoCC,
 }:
 buildNpmPackage (finalAttrs: {
   pname = "pi-coding-agent";
@@ -65,7 +66,22 @@ buildNpmPackage (finalAttrs: {
 
     # Clean up now-dangling .bin symlinks
     find "$nm/.bin" -xtype l -delete
+
+  ''
+  + ''
+    # koffi vendors native addons for many platforms
+    # The non-Darwin ones are ELF files, which makes the Darwin
+    # audit-tmpdir hook try to inspect their RPATHs with patchelf (not
+    # available on Darwin)
+    find "$nm/koffi/build/koffi" -mindepth 1 -maxdepth 1 -type d \
+      ! -name '${
+        if stdenvNoCC.hostPlatform.isDarwin then
+          "darwin_*"
+        else
+          "${stdenvNoCC.hostPlatform.parsed.kernel.name}_*"
+      }' -exec rm -r {} +
   '';
+
   postFixup = "wrapProgram $out/bin/pi --prefix PATH : ${lib.makeBinPath [ ripgrep ]}";
 
   doInstallCheck = true;

--- a/pkgs/by-name/pi/pi-coding-agent/package.nix
+++ b/pkgs/by-name/pi/pi-coding-agent/package.nix
@@ -7,6 +7,7 @@
   writableTmpDirAsHomeHook,
   ripgrep,
   makeBinaryWrapper,
+  stdenvNoCC,
 }:
 buildNpmPackage (finalAttrs: {
   pname = "pi-coding-agent";
@@ -65,7 +66,17 @@ buildNpmPackage (finalAttrs: {
 
     # Clean up now-dangling .bin symlinks
     find "$nm/.bin" -xtype l -delete
+  ''
+  + lib.optionalString stdenvNoCC.hostPlatform.isDarwin ''
+    # Remove foreign Linux binaries that make audit-tmpdir try to inspect ELF
+    # RPATHs with patchelf
+    find "$nm/koffi/build/koffi" -mindepth 1 -maxdepth 1 -type d \
+      ! -name 'darwin_*' -exec rm -r {} +
+    rm -rf \
+      "$nm/@anthropic-ai/sandbox-runtime/dist/vendor/seccomp" \
+      "$nm/@anthropic-ai/sandbox-runtime/vendor/seccomp"
   '';
+
   postFixup = "wrapProgram $out/bin/pi --prefix PATH : ${lib.makeBinPath [ ripgrep ]}";
 
   doInstallCheck = true;


### PR DESCRIPTION
Changelog: https://github.com/badlogic/pi-mono/releases/tag/v0.72.1
Diff: https://github.com/badlogic/pi-mono/compare/v0.70.5...v0.72.1

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
