### PR TITLE
xpra: 6.3.6 -> 6.4.3

### DIFF
--- a/pkgs/by-name/xp/xpra/fix-122159.patch
+++ b/pkgs/by-name/xp/xpra/fix-122159.patch
@@ -1,10 +1,8 @@
-diff --git a/xpra/scripts/main.py b/xpra/scripts/main.py
-index 7806612e05..4c7a0ec2dd 100755
 --- a/xpra/scripts/main.py
 +++ b/xpra/scripts/main.py
-@@ -444,13 +444,7 @@ def run_mode(script_file: str, cmdline, error_cb, options, args, full_mode: str,
-             "seamless", "desktop", "shadow", "shadow-screen", "expand",
+@@ -536,13 +536,7 @@
              "upgrade", "upgrade-seamless", "upgrade-desktop",
+             "encoder", "runner",
      ) and not display_is_remote and options.daemon and use_systemd_run(options.systemd_run):
 -        # make sure we run via the same interpreter,
 -        # inject it into the command line if we have to:

--- a/pkgs/by-name/xp/xpra/fix-41106.patch
+++ b/pkgs/by-name/xp/xpra/fix-41106.patch
@@ -1,8 +1,6 @@
-diff --git a/xpra/server/util.py b/xpra/server/util.py
-index 401a9fb959..678e2ce745 100644
---- a/xpra/server/util.py
-+++ b/xpra/server/util.py
-@@ -175,6 +175,10 @@ def xpra_env_shell_script(socket_dir: str, env: dict[str, str]) -> str:
+--- a/xpra/server/runner_script.py
++++ b/xpra/server/runner_script.py
+@@ -74,6 +74,10 @@
  
  
  def xpra_runner_shell_script(xpra_file: str, starting_dir: str) -> str:

--- a/pkgs/by-name/xp/xpra/package.nix
+++ b/pkgs/by-name/xp/xpra/package.nix
@@ -104,14 +104,14 @@ let
 in
 effectiveBuildPythonApplication rec {
   pname = "xpra";
-  version = "6.3.6";
+  version = "6.4.3";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "Xpra-org";
     repo = "xpra";
     tag = "v${version}";
-    hash = "sha256-kXe/Pyjzf6CxYtsYP15hgYnj+qricrlXGqi/G3uQMFM=";
+    hash = "sha256-TmhMjO1WTF4fT/G0EyRzORI/Q/cd3IipQn0eRwkWYRE=";
   };
 
   patches = [
@@ -135,6 +135,7 @@ effectiveBuildPythonApplication rec {
 
   nativeBuildInputs = [
     clang
+    cython
     gobject-introspection
     pkg-config
     wrapGAppsHook3
@@ -168,7 +169,6 @@ effectiveBuildPythonApplication rec {
   ++ [
     atk.out
     cairo
-    cython
     ffmpeg
     gdk-pixbuf
     glib


### PR DESCRIPTION
Update version to 6.4.3
Updated patches to fix build
Moved cython from buildInputs to nativeBuildInputs to resolve a build failure

xpraWithNvenc is broken but it was broken on master before that update.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
