### PR TITLE
buf: 1.68.4 -> 1.69.0

### DIFF
--- a/pkgs/by-name/bu/buf/package.nix
+++ b/pkgs/by-name/bu/buf/package.nix
@@ -10,16 +10,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "buf";
-  version = "1.68.4";
+  version = "1.69.0";
 
   src = fetchFromGitHub {
     owner = "bufbuild";
     repo = "buf";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-qxTRUYt2JKBE5WvfXlMsdXMJtrD9MLnMjy6+3PMkpvo=";
+    hash = "sha256-x8Dj4xl67Jq0ViWu+Tz+3lAnfIpE926dIr+oe4ul0gI=";
   };
 
-  vendorHash = "sha256-aQ4yWdHUmb0LaJ33T2vuVDS1UhYmBUYcwkbnkN7DOqQ=";
+  vendorHash = "sha256-zhXpWpYd/bim5f4EQJujVm072LPgBusjCFGYAwK10HE=";
 
   patches = [
     # Skip a test that requires networking to be available to work.

--- a/pkgs/by-name/bu/buf/skip_broken_tests.patch
+++ b/pkgs/by-name/bu/buf/skip_broken_tests.patch
@@ -1,15 +1,15 @@
 diff --git a/private/buf/buftesting/buftesting.go b/private/buf/buftesting/buftesting.go
-index 1c650077..5422f703 100644
+index 1b5557d..cec5736 100644
 --- a/private/buf/buftesting/buftesting.go
 +++ b/private/buf/buftesting/buftesting.go
-@@ -106,6 +106,10 @@ func RunActualProtoc(
+@@ -100,6 +100,10 @@ func RunActualProtoc(
  
  // GetGoogleapisDirPath gets the path to a clone of googleapis.
- func GetGoogleapisDirPath(t *testing.T, buftestingDirPath string) string {
+ func GetGoogleapisDirPath(tb testing.TB, buftestingDirPath string) string {
 +	// Requires network access, which is not available during
 +	// the nixpkgs sandboxed build
-+	t.Skip()
++	tb.Skip()
 +
  	googleapisDirPath := filepath.Join(buftestingDirPath, testGoogleapisDirPath)
  	require.NoError(
- 		t,
+ 		tb,


### PR DESCRIPTION
changelog: https://github.com/bufbuild/buf/releases/tag/v1.69.0
diff: https://github.com/bufbuild/buf/compare/v1.68.4...v1.69.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
