### PR TITLE
python3Packages.mkPythonEditablePackage: use structuredAttrs instead of passAsFile

### DIFF
--- a/pkgs/development/interpreters/python/editable.nix
+++ b/pkgs/development/interpreters/python/editable.nix
@@ -81,7 +81,7 @@ buildPythonPackage (
     pyproject = true;
 
     unpackPhase = ''
-      python -c "import json, tomli_w; print(tomli_w.dumps(json.load(open('$pyprojectContentsPath'))))" > pyproject.toml
+      printf "%s" "$pyprojectContents" | python -c "import json, sys, tomli_w; print(tomli_w.dumps(json.load(sys.stdin)))" > pyproject.toml
       echo 'import os.path, sys; sys.path.insert(0, os.path.expandvars("${root}"))' > _${pname}.pth
     '';
 
@@ -93,7 +93,7 @@ buildPythonPackage (
     # We inline the same functionality for better UX.
     nativeBuildInputs = (derivationArgs.nativeBuildInputs or [ ]) ++ [ tomli-w ];
     pyprojectContents = builtins.toJSON pyproject;
-    passAsFile = [ "pyprojectContents" ];
     preferLocalBuild = true;
+    __structuredAttrs = true;
   }
 )

--- a/pkgs/development/interpreters/python/editable.nix
+++ b/pkgs/development/interpreters/python/editable.nix
@@ -39,7 +39,7 @@ let
   # In editable mode build-system's are considered to be runtime dependencies.
   dependencies' = dependencies ++ build-system;
 
-  pyproject = {
+  pyprojectContents = {
     # PEP-621 project table
     project = {
       name = pname;
@@ -81,7 +81,7 @@ buildPythonPackage (
     pyproject = true;
 
     unpackPhase = ''
-      printf "%s" "$pyprojectContents" | python -c "import json, sys, tomli_w; print(tomli_w.dumps(json.load(sys.stdin)))" > pyproject.toml
+      python -c "import json, os, tomli_w; attrs = json.load(open(os.environ['NIX_ATTRS_JSON_FILE'], 'r')); print(tomli_w.dumps(attrs['pyprojectContents']))" > pyproject.toml
       echo 'import os.path, sys; sys.path.insert(0, os.path.expandvars("${root}"))' > _${pname}.pth
     '';
 
@@ -92,7 +92,7 @@ buildPythonPackage (
     # Note: Using formats.toml generates another intermediary derivation that needs to be built.
     # We inline the same functionality for better UX.
     nativeBuildInputs = (derivationArgs.nativeBuildInputs or [ ]) ++ [ tomli-w ];
-    pyprojectContents = builtins.toJSON pyproject;
+    inherit pyprojectContents;
     preferLocalBuild = true;
     __structuredAttrs = true;
   }


### PR DESCRIPTION
Tested via `nix-build -A python3.tests.editable-script`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
