### PR TITLE
epoch: init at 0.2.3, maintainers: add sj14

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25436,6 +25436,11 @@
     githubId = 1328977;
     name = "Trent Small";
   };
+  sj14 = {
+    github = "sj14";
+    githubId = 6493966;
+    name = "Simon Jürgensmeyer";
+  };
   sjagoe = {
     email = "simon@simonjagoe.com";
     github = "sjagoe";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26678,6 +26678,11 @@
     githubId = 1328977;
     name = "Trent Small";
   };
+  sj14 = {
+    github = "sj14";
+    githubId = 6493966;
+    name = "Simon Jürgensmeyer";
+  };
   sjagoe = {
     email = "simon@simonjagoe.com";
     github = "sjagoe";

--- a/pkgs/by-name/ep/epoch/package.nix
+++ b/pkgs/by-name/ep/epoch/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGo126Module,
+  nix-update-script,
+}:
+
+buildGo126Module rec {
+  pname = "epoch";
+  version = "0.2.3";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "sj14";
+    repo = "epoch";
+    rev = "v${version}";
+    hash = "sha256-ENoHwWjFxIZj706o1jMZTBXhMOZnAUw3Owc485sxT88=";
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      git rev-parse HEAD > $out/COMMIT
+      git log -1 --pretty=%cd --date=format:'%Y-%m-%dT%H:%M:%SZ' > $out/SOURCE_DATE
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
+  };
+
+  subPackages = [ "cmd/epoch" ];
+
+  vendorHash = null;
+
+  env.CGO_ENABLED = 0;
+
+  # Otherwise, setting '__structuredAttrs = true' leads to:
+  #   error: output '/nix/store/jhs5w4qpahxgiflw29bg2cv9szvscpz3-epoch-0.2.3' is not allowed to refer to the following paths:
+  #          /nix/store/alxi5gr6vva9nk9ls68m4kvvcx5hvxfi-go-1.26.2
+  allowGoReference = true;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${version}"
+    "-X main.commit=$(cat COMMIT)"
+    "-X main.date=$(cat SOURCE_DATE)"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib; {
+    homepage = "https://github.com/sj14/epoch";
+    description = "Easily convert epoch timestamps to human readable formats and vice versa";
+    license = lib.licenses.mit;
+    maintainers = with maintainers; [ sj14 ];
+  };
+}

--- a/pkgs/by-name/ep/epoch/package.nix
+++ b/pkgs/by-name/ep/epoch/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  nix-update-script,
+  testers,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "epoch";
+  version = "0.2.3";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "sj14";
+    repo = "epoch";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-yrPN40FkF0EmrAoATMDTAShqVzDQc6mY9CyJdFhvTK4=";
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      git rev-parse HEAD > $out/COMMIT
+      git log -1 --pretty=%cd --date=format:'%Y-%m-%dT%H:%M:%SZ' > $out/SOURCE_DATE
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
+  };
+
+  subPackages = [ "cmd/epoch" ];
+
+  vendorHash = null;
+
+  env.CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  preBuild = ''
+    ldflags+=(
+      -X main.commit=$(cat COMMIT)
+      -X main.date=$(cat SOURCE_DATE)
+    )
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+    };
+  };
+
+  meta = {
+    homepage = "https://github.com/sj14/epoch";
+    description = "Easily convert epoch timestamps to human readable formats and vice versa";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sj14 ];
+  };
+})


### PR DESCRIPTION
Add package for https://github.com/sj14/epoch

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
