### PR TITLE
julec: 0.2.0 -> 0.2.1

### DIFF
--- a/pkgs/by-name/ju/julec/package.nix
+++ b/pkgs/by-name/ju/julec/package.nix
@@ -22,23 +22,23 @@ let
 in
 clangStdenv.mkDerivation (finalAttrs: {
   pname = "julec";
-  version = "0.2.0";
+  version = "0.2.1";
 
   src = fetchFromGitHub {
     owner = "julelang";
     repo = "jule";
     tag = "jule${finalAttrs.version}";
     name = "jule-${finalAttrs.version}";
-    hash = "sha256-fwltqCmpCzWkCFGxGrhozW7LQmDwGT8nR9NO5s0nMfI=";
+    hash = "sha256-zfFsWP1nFvyzIqtf/nG4itpKxy6ZZjb3gGC3LwLVGPk=";
   };
 
   irSrc = fetchFromGitHub {
     owner = "julelang";
     repo = "julec-ir";
     # revision determined by the upstream commit hash
-    rev = "e4134d89f34588e9fb5cc5698f27b0471918e057";
+    rev = "5de197f9041dbc61b1d97ed4e3b84c0f667014f8";
     name = "jule-ir-${finalAttrs.version}";
-    hash = "sha256-hdS/q2/V/N97fM0r6jrj2SEGWdx9pFivGE4K4l8iVag=";
+    hash = "sha256-PMAFXLXa3wS0+TWEU2bjlw5UzOmAx8ittQzuExhrWDM=";
   };
 
   dontConfigure = true;

--- a/pkgs/by-name/ju/juledoc/package.nix
+++ b/pkgs/by-name/ju/juledoc/package.nix
@@ -7,13 +7,13 @@
 
 clangStdenv.mkDerivation (finalAttrs: {
   pname = "juledoc";
-  version = "0.0.0-unstable-2026-02-02";
+  version = "0.0.0-unstable-2026-04-13";
 
   src = fetchFromGitHub {
     owner = "julelang";
     repo = "juledoc";
-    rev = "e01e200293d134064c674f705c9babf6d23775e8";
-    hash = "sha256-JzIwIEd9kuVrBVo2H5bv3ROqpVUndBqLAZVYmoGbYuQ=";
+    rev = "d6ba549aeb82ea224e2cf07e0f0f3a2448dbd9db";
+    hash = "sha256-3n9VOoXIFEI9V6fzSD75PdwkijXruC7qWClOUlWd52I=";
   };
 
   nativeBuildInputs = [ julec.hook ];

--- a/pkgs/by-name/ju/julefmt/package.nix
+++ b/pkgs/by-name/ju/julefmt/package.nix
@@ -7,13 +7,13 @@
 
 clangStdenv.mkDerivation (finalAttrs: {
   pname = "julefmt";
-  version = "0.0.0-unstable-2026-01-31";
+  version = "0.0.0-unstable-2026-05-02";
 
   src = fetchFromGitHub {
     owner = "julelang";
     repo = "julefmt";
-    rev = "85b4aaca42e958fb33d6769879ec0a375913206c";
-    hash = "sha256-1UR5hsG5squzb2ADPMmHMKFSL4/fePlYsSlfx70nPSU=";
+    rev = "6bd55e31ebba393c973017332502a548ea0f402c";
+    hash = "sha256-j8V5L4j4qaApJixsEo10Qv58IHcU54hnpL8uD+T0C0M=";
   };
 
   nativeBuildInputs = [ julec.hook ];


### PR DESCRIPTION
https://github.com/julelang/jule/releases/tag/jule0.2.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
