### PR TITLE
gammu: 1.42.0 -> 1.43.2

### DIFF
--- a/pkgs/by-name/ga/gammu/bashcomp-dir.patch
+++ b/pkgs/by-name/ga/gammu/bashcomp-dir.patch
@@ -1,6 +1,8 @@
+diff --git a/contrib/CMakeLists.txt b/contrib/CMakeLists.txt
+index 1120c0309..62e6177ab 100644
 --- a/contrib/CMakeLists.txt
 +++ b/contrib/CMakeLists.txt
-@@ -85,7 +85,7 @@ endif (INSTALL_PHP_EXAMPLES)
+@@ -87,7 +87,7 @@ endif (INSTALL_PHP_EXAMPLES)
  if (INSTALL_BASH_COMPLETION)
      macro_optional_find_package (BashCompletion)
      if (NOT BASH_COMPLETION_FOUND)

--- a/pkgs/by-name/ga/gammu/gammu-config-dialog.patch
+++ b/pkgs/by-name/ga/gammu/gammu-config-dialog.patch
@@ -1,14 +1,16 @@
+diff --git a/utils/gammu-config b/utils/gammu-config
+index abf278ada..fc12493cd 100755
 --- a/utils/gammu-config
 +++ b/utils/gammu-config
-@@ -59,16 +59,7 @@
+@@ -59,16 +59,7 @@ while [ "$#" -ge 1 ] ; do
      shift
  done
  
--if type dialog > /dev/null 2>&1 ; then
+-if command -v dialog > /dev/null 2>&1 ; then
 -    DIALOG=dialog
--elif type cdialog > /dev/null 2>&1 ; then
+-elif command -v cdialog > /dev/null 2>&1 ; then
 -    DIALOG=cdialog
--elif type whiptail > /dev/null 2>&1 ; then
+-elif command -v whiptail > /dev/null 2>&1 ; then
 -    DIALOG=whiptail
 -else
 -    echo "You need dialog, cdialog or whiptail installed to make this work"

--- a/pkgs/by-name/ga/gammu/package.nix
+++ b/pkgs/by-name/ga/gammu/package.nix
@@ -22,13 +22,15 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gammu";
-  version = "1.42.0";
+  version = "1.43.2";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "gammu";
     repo = "gammu";
     rev = finalAttrs.version;
-    sha256 = "sha256-aeaGHVxOMiXRU6RHws+oAnzdO9RY1jw/X/xuGfSt76I=";
+    sha256 = "sha256-+mZBELwFUEL4S3IUIIa83TaNIYQxjQE1TvWhXTcIfYc=";
   };
 
   patches = [


### PR DESCRIPTION
Diff: https://github.com/gammu/gammu/compare/1.42.0...1.43.2
Changelogs:
> https://github.com/gammu/gammu/releases/tag/1.43.2
> https://github.com/gammu/gammu/releases/tag/1.43.1
> https://github.com/gammu/gammu/releases/tag/1.43.0

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
