### PR TITLE
prometheus-atlas-exporter: 1.0.4 -> 1.0.5, finalAttrs, tag naming change

### DIFF
--- a/pkgs/by-name/pr/prometheus-atlas-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-atlas-exporter/package.nix
@@ -4,18 +4,20 @@
   fetchFromGitHub,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "atlas-exporter";
-  version = "1.0.4";
+  version = "1.0.5";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "czerwonk";
     repo = "atlas_exporter";
-    rev = version;
-    sha256 = "sha256-vhUhWO7fQpUHT5nyxbT8AylgUqDNZRSb+EGRNGZJ14E=";
+    rev = "v${finalAttrs.version}";
+    sha256 = "sha256-GvjZhQsKR0qqSnfHarLct1z5BdusvODLnVxOtZCLAXo=";
   };
 
-  vendorHash = "sha256-tR+OHxj/97AixuAp0Kx9xQsKPAxpvF6hDha5BgMBha0=";
+  vendorHash = "sha256-Wq1rMkKfGiLG3qIL51VZoUWIsb3ANs1p81g94iYNJwE=";
 
   meta = {
     description = "Prometheus exporter for RIPE Atlas measurement results";
@@ -24,4 +26,4 @@ buildGoModule rec {
     license = lib.licenses.lgpl3;
     maintainers = with lib.maintainers; [ clerie ];
   };
-}
+})

--- a/pkgs/by-name/pr/prometheus-atlas-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-atlas-exporter/package.nix
@@ -4,24 +4,27 @@
   fetchFromGitHub,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "atlas-exporter";
-  version = "1.0.4";
+  version = "1.0.5";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "czerwonk";
     repo = "atlas_exporter";
-    rev = version;
-    sha256 = "sha256-vhUhWO7fQpUHT5nyxbT8AylgUqDNZRSb+EGRNGZJ14E=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-GvjZhQsKR0qqSnfHarLct1z5BdusvODLnVxOtZCLAXo=";
   };
 
-  vendorHash = "sha256-tR+OHxj/97AixuAp0Kx9xQsKPAxpvF6hDha5BgMBha0=";
+  vendorHash = "sha256-Wq1rMkKfGiLG3qIL51VZoUWIsb3ANs1p81g94iYNJwE=";
 
   meta = {
     description = "Prometheus exporter for RIPE Atlas measurement results";
     mainProgram = "atlas_exporter";
     homepage = "https://github.com/czerwonk/atlas_exporter";
+    changelog = "https://github.com/czerwonk/atlas_exporter/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.lgpl3;
     maintainers = with lib.maintainers; [ clerie ];
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/czerwonk/atlas_exporter/compare/1.0.4...v1.0.5
Changelog: https://github.com/czerwonk/atlas_exporter/releases/tag/v1.0.5

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
