### PR TITLE
ffmpeg-normalize: 1.37.3 -> 1.37.6

### DIFF
--- a/pkgs/by-name/ff/ffmpeg-normalize/package.nix
+++ b/pkgs/by-name/ff/ffmpeg-normalize/package.nix
@@ -7,13 +7,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "ffmpeg-normalize";
-  version = "1.37.3";
+  version = "1.37.6";
   pyproject = true;
 
   src = fetchPypi {
     inherit version;
     pname = "ffmpeg_normalize";
-    hash = "sha256-mN4vmiST+LV5Bv/QZ9Pvo3qzhTaeD3MpDa8sLNqjeW0=";
+    hash = "sha256-zsfWqdGyEI8OT4/L0wTxkmdqcI6NEfr5SAc7+O7FYu4=";
   };
 
   build-system = with python3Packages; [ uv-build ];
@@ -29,9 +29,6 @@ python3Packages.buildPythonApplication rec {
 
   postPatch = with python3Packages; ''
     substituteInPlace pyproject.toml \
-      --replace-fail \
-      'requires = ["uv_build>=0.8.14,<0.9.0"]' \
-      'requires = ["uv_build==${uv-build.version}"]' \
       --replace-fail \
       'colorlog==6.7.0' \
       'colorlog==${colorlog.version}'


### PR DESCRIPTION
Diff: https://github.com/slhck/ffmpeg-normalize/compare/v1.37.3...v1.37.6
Changelogs:
> https://github.com/slhck/ffmpeg-normalize/releases/tag/v1.37.6
> https://github.com/slhck/ffmpeg-normalize/releases/tag/v1.37.5
> https://github.com/slhck/ffmpeg-normalize/releases/tag/v1.37.4


## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
