### PR TITLE
llama-cpp: support openVINO backend

### DIFF
--- a/pkgs/by-name/ll/llama-cpp-openvino/package.nix
+++ b/pkgs/by-name/ll/llama-cpp-openvino/package.nix
@@ -1,0 +1,5 @@
+{ llama-cpp }:
+
+llama-cpp.override {
+  openVINOSupport = true;
+}

--- a/pkgs/by-name/ll/llama-cpp/package.nix
+++ b/pkgs/by-name/ll/llama-cpp/package.nix
@@ -35,11 +35,19 @@
   metalSupport ? stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64 && !openclSupport,
   vulkanSupport ? false,
   rpcSupport ? false,
+  openVINOSupport ? false,
   openssl,
   llama-cpp,
   shaderc,
   vulkan-headers,
   vulkan-loader,
+  openvino,
+  intel-compute-runtime,
+  opencl-headers,
+  khronos-ocl-icd-loader,
+  onetbb,
+  opencl-clhpp,
+  autoPatchelfHook,
   ninja,
 }:
 
@@ -75,6 +83,15 @@ let
     vulkan-headers
     vulkan-loader
   ];
+
+  openVINOBuildInputs = [
+    openvino
+    onetbb.dev
+    intel-compute-runtime
+    opencl-headers
+    khronos-ocl-icd-loader
+    opencl-clhpp
+  ];
 in
 effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "llama-cpp";
@@ -98,6 +115,8 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [ ];
+  strictDeps = true;
+  __structuredAttrs = true;
 
   nativeBuildInputs = [
     cmake
@@ -110,6 +129,10 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   ++ optionals cudaSupport [
     cudaPackages.cuda_nvcc
     autoAddDriverRunpath
+  ]
+  ++ optionals openVINOSupport [
+    openvino
+    autoPatchelfHook
   ];
 
   buildInputs =
@@ -118,6 +141,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     ++ optionals rocmSupport rocmBuildInputs
     ++ optionals blasSupport [ blas ]
     ++ optionals vulkanSupport vulkanBuildInputs
+    ++ optionals openVINOSupport openVINOBuildInputs
     ++ [ openssl ];
 
   npmRoot = "tools/server/webui";
@@ -130,6 +154,15 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     '';
     hash = finalAttrs.npmDepsHash;
   };
+
+  preBuild = optionals openVINOSupport ''
+    addAutoPatchelfSearchPath ${openvino}/runtime/lib/
+  '';
+
+  prePatch = optionals openVINOSupport ''
+    substituteInPlace ggml/src/ggml-openvino/CMakeLists.txt \
+      --replace-fail '${"\${OpenVINO_DIR}"}/../3rdparty/tbb/lib/cmake/TBB/' "${onetbb.dev}/lib/cmake/TBB/"
+  '';
 
   preConfigure = ''
     prependToVar cmakeFlags "-DLLAMA_BUILD_COMMIT:STRING=$(cat COMMIT)"
@@ -153,6 +186,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     (cmakeBool "GGML_METAL" metalSupport)
     (cmakeBool "GGML_RPC" rpcSupport)
     (cmakeBool "GGML_VULKAN" vulkanSupport)
+    (cmakeBool "GGML_OPENVINO" openVINOSupport)
     (cmakeFeature "LLAMA_BUILD_NUMBER" finalAttrs.version)
   ]
   ++ optionals cudaSupport [
@@ -170,6 +204,9 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     # This is done so we can move rpc-server out of bin because llama.cpp doesn't
     # install rpc-server in their install target.
     (cmakeBool "CMAKE_SKIP_BUILD_RPATH" true)
+  ]
+  ++ optionals openVINOSupport [
+    (cmakeFeature "OpenVINO_DIR" "${openvino}/runtime/cmake")
   ];
 
   # upstream plans on adding targets at the cmakelevel, remove those
@@ -182,7 +219,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     cp $src/include/llama.h $out/include/
 
   ''
-  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform && !openVINOSupport) ''
     installShellCompletion --cmd llama-server --bash <($out/bin/llama-server --completion-bash)
   ''
   + optionalString rpcSupport "cp bin/rpc-server $out/bin/llama-rpc-server";


### PR DESCRIPTION
This adds support for the new openVINO backend for llama-cpp. I can verify that this does build and produce binaries that at least don't immediately bail looking for openvino.so, however i learned only after doing this work that my hardware was not supported, so I can't do any actually testing to see if the backend is working anywhere close to advertised. Since it does build, I figured I'd at least make draft a PR in the event someone in the future is looking for the same support.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
