### PR TITLE
clock-rs: 0.1.216 -> 0.2.0

### DIFF
--- a/pkgs/by-name/cl/clock-rs/package.nix
+++ b/pkgs/by-name/cl/clock-rs/package.nix
@@ -6,16 +6,18 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "clock-rs";
-  version = "0.1.216";
+  version = "0.2.0";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "Oughie";
     repo = "clock-rs";
-    tag = "v${finalAttrs.version}";
-    sha256 = "sha256-sSofMZThR025O2J4PnOMWVEuBt/+oZ01yDAQAijca0A=";
+    tag = finalAttrs.version;
+    hash = "sha256-mC7jZ0ZCSfjpF+p2TtNjt7oRowYkOujSkbuFzChYJ3U=";
   };
 
-  cargoHash = "sha256-7gpD7aAma9Ye7sxqm1wGekcovXxdd11XOMf7fKWZrcA=";
+  cargoHash = "sha256-K5AdTjRz1GEWmbqW/D/7faYABUo71tpiyyOrCjHd1GM=";
 
   meta = {
     description = "Modern, digital clock that effortlessly runs in your terminal";


### PR DESCRIPTION
Diff: https://github.com/Oughie/clock-rs/compare/v0.1.216...0.2.0

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
