### PR TITLE
python3Packages.orjson: fix cross compilation patch

### DIFF
--- a/pkgs/development/python-modules/orjson/cross-arch-compat.patch
+++ b/pkgs/development/python-modules/orjson/cross-arch-compat.patch
@@ -12,33 +12,37 @@ riscv64, leading to compilation errors.
 Now uses CARGO_CFG_TARGET_ARCH environment variable to correctly
 detect the target architecture during cross-compilation.
 ---
- build.rs | 10 ++++++----
- 1 file changed, 6 insertions(+), 4 deletions(-)
+ build.rs | 7 ++++++--
+ 1 file changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/build.rs b/build.rs
-index 42788623..28e006a9 100644
+index 49a9a9a4..0a99698d 100644
 --- a/build.rs
 +++ b/build.rs
-@@ -38,8 +38,11 @@ fn main() {
+@@ -11,6 +11,9 @@ fn main() {
      #[allow(unused_variables)]
      let is_64_bit_python = matches!(python_config.pointer_width, Some(64));
 
--    #[cfg(all(target_arch = "x86_64", not(target_os = "macos")))]
--    if version_check::is_min_version("1.89.0").unwrap_or(false) && is_64_bit_python {
-+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
-+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
++    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
++    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
 +
-+    if target_arch == "x86_64" && target_os != "macos"
-+        && version_check::is_min_version("1.89.0").unwrap_or(false) && is_64_bit_python {
-         println!("cargo:rustc-cfg=feature=\"avx512\"");
-     }
+     match python_config.implementation {
+         pyo3_build_config::PythonImplementation::CPython => {
+             println!("cargo:rustc-cfg=CPython");
+@@ -18,7 +21,7 @@ fn main() {
+             println!("cargo:rustc-cfg=CPython");
+             #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+-            if is_64_bit_python {
++            if (target_arch == "x86_64" || target_arch == "aarch64") && is_64_bit_python {
+                 println!("cargo:rustc-cfg=feature=\"inline_int\"");
+                 #[cfg(target_endian = "little")]
+                 println!("cargo:rustc-cfg=feature=\"inline_str\"");
+             }
+@@ -50,7 +53,7 @@ fn main() {
+     println!("cargo:rustc-check-cfg=cfg(PyPy)");
 
-@@ -51,8 +54,7 @@ fn main() {
-         println!("cargo:rustc-cfg=feature=\"optimize\"");
-     }
-
--    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+     #[cfg(all(target_arch = "x86_64", not(target_os = "macos")))]
 -    if is_64_bit_python {
-+    if (target_arch == "x86_64" || target_arch == "aarch64") && is_64_bit_python {
-         println!("cargo:rustc-cfg=feature=\"inline_int\"");
++    if target_arch == "x86_64" && target_os != "macos" && is_64_bit_python {
+         println!("cargo:rustc-cfg=feature=\"avx512\"");
      }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

# Description
The cross compile patch was outdated and did not apply cleanly anymore.
I just adapted it to upstream changes, logic remains unchanged.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Cross compiled to platform:
  - [x] aarch64-linux
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

@misuzu
