### PR TITLE
nixos/networking: add tor transparent proxy option

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6410,6 +6410,12 @@
     github = "deadbaed";
     githubId = 8809909;
   };
+  deade1e = {
+    name = "Francesco Pompo'";
+    email = "nix@francesco.cc";
+    github = "deade1e";
+    githubId = 6452799;
+  };
   dearrude = {
     name = "Ebrahim Nejati";
     email = "dearrude@tfwno.gf";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1429,6 +1429,7 @@
   ./services/networking/tinydns.nix
   ./services/networking/tinyproxy.nix
   ./services/networking/tmate-ssh-server.nix
+  ./services/networking/tor.nix
   ./services/networking/tox-bootstrapd.nix
   ./services/networking/tox-node.nix
   ./services/networking/toxvpn.nix

--- a/nixos/modules/services/networking/tor.nix
+++ b/nixos/modules/services/networking/tor.nix
@@ -31,6 +31,7 @@ let
 
   buildSubnetsSet = buildSet "ipv4_addr" [ "interval" ];
 
+  cfg = config.networking.tor;
 in
 {
 
@@ -120,69 +121,65 @@ in
 
   config = {
 
-    services.tor =
-      lib.mkIf (config.networking.tor.client.enable || config.networking.tor.router.enable)
-        {
-          enable = true;
+    services.tor = lib.mkIf (cfg.client.enable || cfg.router.enable) {
+      enable = true;
 
-          client = {
-            enable = true;
-            transparentProxy.enable = true;
-            dns.enable = true;
-          };
+      client = {
+        enable = true;
+        transparentProxy.enable = true;
+        dns.enable = true;
+      };
 
-          settings = {
+      settings = {
 
-            # If router option is enabled then bind to 0.0.0.0 instead of 127.0.0.1.
-            DNSPort = lib.mkIf config.networking.tor.router.enable [
-              {
-                addr = "0.0.0.0";
-                port = 9053;
-              }
-            ];
+        # If router option is enabled then bind to 0.0.0.0 instead of 127.0.0.1.
+        DNSPort = lib.mkIf cfg.router.enable [
+          {
+            addr = "0.0.0.0";
+            port = 9053;
+          }
+        ];
 
-            # Without mkForce it sets addr to 127.0.0.1 and later it cannot bind again as 0.0.0.0.
-            TransPort = lib.mkIf config.networking.tor.router.enable (
-              lib.mkForce [
-                {
-                  addr = "0.0.0.0";
-                  port = 9040;
-                }
-              ]
-            );
+        # Without mkForce it sets addr to 127.0.0.1 and later it cannot bind again as 0.0.0.0.
+        TransPort = lib.mkIf cfg.router.enable (
+          lib.mkForce [
+            {
+              addr = "0.0.0.0";
+              port = 9040;
+            }
+          ]
+        );
 
-            VirtualAddrNetworkIPv4 = config.networking.tor.virtualAddrNetworkIPv4;
-          };
+        VirtualAddrNetworkIPv4 = cfg.virtualAddrNetworkIPv4;
+      };
 
-        };
+    };
 
     # Open ports on firewall.
-    networking.firewall.allowedTCPPorts = lib.mkIf config.networking.tor.router.enable [ 9040 ];
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.router.enable [ 9040 ];
 
-    networking.firewall.allowedUDPPorts = lib.mkIf config.networking.tor.router.enable [ 9053 ];
+    networking.firewall.allowedUDPPorts = lib.mkIf cfg.router.enable [ 9053 ];
 
     # Enable squid with shutdown_lifetime set to 0, as it instead would delay service stopping.
-    services.squid = lib.mkIf config.networking.tor.client.enable {
-      enable = config.networking.tor.client.clearnetProxy.enable;
+    services.squid = lib.mkIf cfg.client.enable {
+      enable = cfg.client.clearnetProxy.enable;
       proxyAddress = "127.0.0.1";
-      proxyPort = config.networking.tor.client.clearnetProxy.port;
+      proxyPort = cfg.client.clearnetProxy.port;
       extraConfig = ''
         shutdown_lifetime 0 seconds;
       '';
     };
 
     # Sometimes squid would refuse to start if no network is available.
-    systemd.services.squid.after = lib.mkIf config.networking.tor.client.enable [
+    systemd.services.squid.after = lib.mkIf cfg.client.enable [
       "network-online.target"
     ];
 
-    systemd.services.squid.wants = lib.mkIf config.networking.tor.client.enable [
+    systemd.services.squid.wants = lib.mkIf cfg.client.enable [
       "network-online.target"
     ];
 
-    networking.nftables.enable = lib.mkIf (
-      config.networking.tor.client.enable || config.networking.tor.router.enable
-    ) true;
+    networking.nftables.enable = lib.mkIf (cfg.client.enable || cfg.router.enable) true;
 
     # Patch rules before checking them as they would simply fail as both "tor"
     # and "squid" users aren't available during build.
@@ -196,21 +193,21 @@ in
     # regarding IPv6 traffic, so it gets simply dropped at the end of filter
     # chains. That's on purpose as IPv6 has not been tested.
     networking.nftables.tables = {
-      tor = lib.mkIf config.networking.tor.client.enable {
+      tor = lib.mkIf cfg.client.enable {
         enable = true;
         family = "inet";
         content = ''
 
           ${buildSubnetsSet "reserved_subnets" reservedSubnets}
 
-          ${buildSubnetsSet "excluded_destinations" config.networking.tor.client.excludedDestinations}
+          ${buildSubnetsSet "excluded_destinations" cfg.client.excludedDestinations}
 
-          ${buildSet "ifname" null "excluded_ifs" config.networking.tor.client.excludedInterfaces}
+          ${buildSet "ifname" null "excluded_ifs" cfg.client.excludedInterfaces}
 
-          ${buildSet "mark" null "excluded_marks" config.networking.tor.client.excludedFwMarks}
+          ${buildSet "mark" null "excluded_marks" cfg.client.excludedFwMarks}
 
           chain tor_nat_output {
-            type nat hook output priority ${toString config.networking.tor.natPriority}
+            type nat hook output priority ${toString cfg.natPriority}
 
             oifname lo return
             ip daddr 127.0.0.0/8 return
@@ -222,7 +219,7 @@ in
             skuid tor return # Do not modify any tor packets
 
             # Do not modify any squid packets
-            ${lib.optionalString (config.networking.tor.client.clearnetProxy.enable)
+            ${lib.optionalString (cfg.client.clearnetProxy.enable)
 
               "skuid squid return"
             }
@@ -232,14 +229,14 @@ in
             # most network configurations have local IP addresses as DNS servers.
             ip daddr @excluded_destinations return
             ip protocol udp udp dport 53 dnat to 127.0.0.1:9053 # route dns before allowing local addresses
-            ip daddr @reserved_subnets ip daddr != ${config.networking.tor.virtualAddrNetworkIPv4} return
+            ip daddr @reserved_subnets ip daddr != ${cfg.virtualAddrNetworkIPv4} return
 
             ip protocol tcp dnat to 127.0.0.1:9040 # this rewrites the dest addr but not the interface!
           }
 
           chain tor_filter_output {
             # Set filterPriority and drop everything by default.
-            type filter hook output priority ${toString config.networking.tor.filterPriority}; policy drop;
+            type filter hook output priority ${toString cfg.filterPriority}; policy drop;
 
             ct state established,related accept
 
@@ -251,7 +248,7 @@ in
 
             skuid tor accept
 
-            ${lib.optionalString (config.networking.tor.client.clearnetProxy.enable)
+            ${lib.optionalString (cfg.client.clearnetProxy.enable)
 
               "skuid squid accept"
             }
@@ -262,20 +259,20 @@ in
         '';
       };
 
-      tor-router = lib.mkIf config.networking.tor.router.enable {
+      tor-router = lib.mkIf cfg.router.enable {
         enable = true;
         family = "inet";
         content = ''
 
           ${buildSubnetsSet "reserved_subnets" reservedSubnets}
-          ${buildSubnetsSet "excluded_destinations" config.networking.tor.router.excludedDestinations}
+          ${buildSubnetsSet "excluded_destinations" cfg.router.excludedDestinations}
 
-          ${buildSubnetsSet "excluded_sources" config.networking.tor.router.excludedSources}
+          ${buildSubnetsSet "excluded_sources" cfg.router.excludedSources}
 
           chain tor_nat_prerouting {
-            type nat hook prerouting priority ${toString config.networking.tor.natPriority}
+            type nat hook prerouting priority ${toString cfg.natPriority}
 
-            ip daddr @reserved_subnets ip daddr != ${config.networking.tor.virtualAddrNetworkIPv4} return
+            ip daddr @reserved_subnets ip daddr != ${cfg.virtualAddrNetworkIPv4} return
             ip saddr @excluded_sources return
             ip daddr @excluded_destinations return
 
@@ -284,7 +281,7 @@ in
           }
 
           chain tor_filter_forward {
-            type filter hook forward priority ${toString config.networking.tor.filterPriority}; policy drop
+            type filter hook forward priority ${toString cfg.filterPriority}; policy drop
 
             ct state established,related accept
 
@@ -297,9 +294,7 @@ in
 
     };
 
-    boot.kernel.sysctl."net.ipv4.ip_forward" = lib.mkIf config.networking.tor.router.enable (
-      lib.mkDefault 1
-    );
+    boot.kernel.sysctl."net.ipv4.ip_forward" = lib.mkIf cfg.router.enable (lib.mkDefault 1);
 
   };
 

--- a/nixos/modules/services/networking/tor.nix
+++ b/nixos/modules/services/networking/tor.nix
@@ -40,7 +40,7 @@ in
 
     networking.tor = {
 
-      VirtualAddrNetworkIPv4 = lib.mkOption {
+      virtualAddrNetworkIPv4 = lib.mkOption {
         type = lib.types.str;
         default = "10.64.0.0/10";
         description = "The virtual address space used by Tor.";
@@ -151,7 +151,7 @@ in
               ]
             );
 
-            VirtualAddrNetworkIPv4 = config.networking.tor.VirtualAddrNetworkIPv4;
+            VirtualAddrNetworkIPv4 = config.networking.tor.virtualAddrNetworkIPv4;
           };
 
         };
@@ -232,7 +232,7 @@ in
             # most network configurations have local IP addresses as DNS servers.
             ip daddr @excluded_destinations return
             ip protocol udp udp dport 53 dnat to 127.0.0.1:9053 # route dns before allowing local addresses
-            ip daddr @reserved_subnets ip daddr != ${config.networking.tor.VirtualAddrNetworkIPv4} return
+            ip daddr @reserved_subnets ip daddr != ${config.networking.tor.virtualAddrNetworkIPv4} return
 
             ip protocol tcp dnat to 127.0.0.1:9040 # this rewrites the dest addr but not the interface!
           }
@@ -275,7 +275,7 @@ in
           chain tor_nat_prerouting {
             type nat hook prerouting priority ${toString config.networking.tor.natPriority}
 
-            ip daddr @reserved_subnets ip daddr != ${config.networking.tor.VirtualAddrNetworkIPv4} return
+            ip daddr @reserved_subnets ip daddr != ${config.networking.tor.virtualAddrNetworkIPv4} return
             ip saddr @excluded_sources return
             ip daddr @excluded_destinations return
 

--- a/nixos/modules/services/networking/tor.nix
+++ b/nixos/modules/services/networking/tor.nix
@@ -59,7 +59,7 @@ in
       };
 
       client = {
-        enable = lib.mkEnableOption "the routing of all traffic of the current machine through Tor. Does not act as a router for other machines.";
+        enable = lib.mkEnableOption "the routing of all traffic of the current machine through Tor. Does not act as a router for other machines. IPv6 traffic is not routed and it is dropped.";
 
         clearnetProxy = {
           enable = lib.mkEnableOption "a squid instance that can perform requests without being routed through Tor.";
@@ -97,7 +97,7 @@ in
       };
 
       router = {
-        enable = lib.mkEnableOption "the routing of all received traffic through Tor. Does not act as a router for the current machine.";
+        enable = lib.mkEnableOption "the routing of all received traffic through Tor. Does not act as a router for the current machine. IPv6 traffic is not routed and it is dropped.";
 
         allowedDestinations = lib.mkOption {
           type = lib.types.listOf lib.types.str;

--- a/nixos/modules/services/networking/tor.nix
+++ b/nixos/modules/services/networking/tor.nix
@@ -73,24 +73,24 @@ in
 
         };
 
-        allowedDestinations = lib.mkOption {
+        excludedDestinations = lib.mkOption {
           type = lib.types.listOf lib.types.str;
           default = [ ];
           example = [ "104.16.0.0/13" ];
-          description = "Allowed destination addresses that will not be routed through Tor.";
+          description = "Excluded destination addresses that will not be routed through Tor.";
         };
 
-        allowedInterfaces = lib.mkOption {
+        excludedInterfaces = lib.mkOption {
           type = lib.types.listOf lib.types.str;
           default = [ ];
-          description = "List of allowed interfaces. The packets that are destined to these interfaces will not be routed through Tor.";
+          description = "List of excluded interfaces. The packets that are destined to these interfaces will not be routed through Tor.";
           example = [ "wg0" ];
         };
 
-        allowedFwMarks = lib.mkOption {
+        excludedFwMarks = lib.mkOption {
           type = lib.types.listOf lib.types.str;
           default = [ ];
-          description = "List of allowed fwMarks. The packets marked with these fwMarks will not be routed through Tor.";
+          description = "List of excluded fwMarks. The packets marked with these fwMarks will not be routed through Tor.";
           example = [ "0x100" ];
         };
 
@@ -99,18 +99,18 @@ in
       router = {
         enable = lib.mkEnableOption "the routing of all received traffic through Tor. Does not act as a router for the current machine. IPv6 traffic is not routed and it is dropped.";
 
-        allowedDestinations = lib.mkOption {
+        excludedDestinations = lib.mkOption {
           type = lib.types.listOf lib.types.str;
           default = [ ];
           example = [ "104.16.0.0/13" ];
-          description = "Allowed destination addresses that will not be routed through Tor.";
+          description = "Excluded destination addresses that will not be routed through Tor.";
         };
 
-        allowedSources = lib.mkOption {
+        excludedSources = lib.mkOption {
           type = lib.types.listOf lib.types.str;
           default = [ ];
           example = [ "192.168.1.0/24" ];
-          description = "Allowed source addresses that will not be routed through Tor.";
+          description = "Excluded source addresses that will not be routed through Tor.";
         };
 
       };
@@ -203,11 +203,11 @@ in
 
           ${buildSubnetsSet "reserved_subnets" reservedSubnets}
 
-          ${buildSubnetsSet "allowed_destinations" config.networking.tor.client.allowedDestinations}
+          ${buildSubnetsSet "excluded_destinations" config.networking.tor.client.excludedDestinations}
 
-          ${buildSet "ifname" null "allowed_ifs" config.networking.tor.client.allowedInterfaces}
+          ${buildSet "ifname" null "excluded_ifs" config.networking.tor.client.excludedInterfaces}
 
-          ${buildSet "mark" null "allowed_marks" config.networking.tor.client.allowedFwMarks}
+          ${buildSet "mark" null "excluded_marks" config.networking.tor.client.excludedFwMarks}
 
           chain tor_nat_output {
             type nat hook output priority ${toString config.networking.tor.natPriority}
@@ -216,8 +216,8 @@ in
             ip daddr 127.0.0.0/8 return
             ip6 daddr ::1/128 return
 
-            oifname @allowed_ifs return # Do not modify any packet destined to allowed intfs
-            meta mark @allowed_marks return # Do not modify any packet marked with allowed marks
+            oifname @excluded_ifs return # Do not modify any packet destined to excluded intfs
+            meta mark @excluded_marks return # Do not modify any packet marked with excluded marks
 
             skuid tor return # Do not modify any tor packets
 
@@ -227,10 +227,10 @@ in
               "skuid squid return"
             }
 
-            # Here we prioritize allowedDestinations over DNS redirection,
+            # Here we prioritize excludedDestinations over DNS redirection,
             # but we redirect DNS requests before allowing local addresses, as
             # most network configurations have local IP addresses as DNS servers.
-            ip daddr @allowed_destinations return
+            ip daddr @excluded_destinations return
             ip protocol udp udp dport 53 dnat to 127.0.0.1:9053 # route dns before allowing local addresses
             ip daddr @reserved_subnets ip daddr != ${config.networking.tor.VirtualAddrNetworkIPv4} return
 
@@ -246,8 +246,8 @@ in
             oifname lo accept # For processes that connect to interface IPs, like 192.186.1.150 and are routed through lo
             ip daddr 127.0.0.0/8 accept # DNATed packets have ethernet intf but local addresses
 
-            oifname @allowed_ifs accept
-            meta mark @allowed_marks accept
+            oifname @excluded_ifs accept
+            meta mark @excluded_marks accept
 
             skuid tor accept
 
@@ -257,7 +257,7 @@ in
             }
 
             ip daddr @reserved_subnets accept
-            ip daddr @allowed_destinations accept
+            ip daddr @excluded_destinations accept
           }
         '';
       };
@@ -268,16 +268,16 @@ in
         content = ''
 
           ${buildSubnetsSet "reserved_subnets" reservedSubnets}
-          ${buildSubnetsSet "allowed_destinations" config.networking.tor.router.allowedDestinations}
+          ${buildSubnetsSet "excluded_destinations" config.networking.tor.router.excludedDestinations}
 
-          ${buildSubnetsSet "allowed_sources" config.networking.tor.router.allowedSources}
+          ${buildSubnetsSet "excluded_sources" config.networking.tor.router.excludedSources}
 
           chain tor_nat_prerouting {
             type nat hook prerouting priority ${toString config.networking.tor.natPriority}
 
             ip daddr @reserved_subnets ip daddr != ${config.networking.tor.VirtualAddrNetworkIPv4} return
-            ip saddr @allowed_sources return
-            ip daddr @allowed_destinations return
+            ip saddr @excluded_sources return
+            ip daddr @excluded_destinations return
 
             ip protocol udp udp dport 53 redirect to :9053
             ip protocol tcp tcp flags syn redirect to :9040
@@ -289,8 +289,8 @@ in
             ct state established,related accept
 
             ip daddr @reserved_subnets accept
-            ip saddr @allowed_sources accept
-            ip daddr @allowed_destinations accept
+            ip saddr @excluded_sources accept
+            ip daddr @excluded_destinations accept
           }
         '';
       };

--- a/nixos/modules/services/networking/tor.nix
+++ b/nixos/modules/services/networking/tor.nix
@@ -1,0 +1,309 @@
+{ lib, config, ... }:
+let
+  # List of subnets that will never be routed through Tor under any circumstance.
+  reservedSubnets = [
+    "0.0.0.0/8"
+    "10.0.0.0/8"
+    "100.64.0.0/10"
+    "127.0.0.0/8"
+    "169.254.0.0/16"
+    "172.16.0.0/12"
+    "192.0.0.0/24"
+    "192.0.2.0/24"
+    "192.88.99.0/24"
+    "192.168.0.0/16"
+    "198.18.0.0/15"
+    "198.51.100.0/24"
+    "203.0.113.0/24"
+    "224.0.0.0/4"
+    "240.0.0.0/4"
+  ];
+
+  # Helper to build a nftables set.
+  buildSet = type: flags: name: elements: ''
+    set ${name} {
+      type ${type}
+      ${if flags != null then "flags ${flags}" else ""}
+
+      ${lib.optionalString (elements != [ ])
+
+        "elements = { ${lib.concatStringsSep "," elements} }"
+      }
+    }
+  '';
+
+  buildSubnetsSet = buildSet "ipv4_addr" "interval";
+
+in
+{
+
+  meta.maintainers = with lib.maintainers; [ deade1e ];
+
+  options = {
+
+    networking.tor = {
+
+      VirtualAddrNetworkIPv4 = lib.mkOption {
+        type = lib.types.str;
+        default = "10.64.0.0/10";
+        description = "The virtual address space used by Tor.";
+      };
+
+      natPriority = lib.mkOption {
+        type = lib.types.int;
+        default = -100;
+        description = "nftables NAT handling priority.";
+      };
+
+      filterPriority = lib.mkOption {
+        type = lib.types.int;
+        default = 0;
+        description = "nftables filter handling priority.";
+      };
+
+      client = {
+        enable = lib.mkEnableOption "the routing of all traffic of the current machine through Tor. Does not act as a router for other machines.";
+
+        clearnetProxy = {
+          enable = lib.mkEnableOption "a squid instance that can perform requests without being routed through Tor.";
+
+          port = lib.mkOption {
+            type = lib.types.int;
+            default = 3128;
+            example = 8080;
+            description = "Port used for the squid proxy.";
+          };
+
+        };
+
+        allowedDestinations = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          example = [ "104.16.0.0/13" ];
+          description = "Allowed destination addresses that will not be routed through Tor.";
+        };
+
+        allowedInterfaces = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          description = "List of allowed interfaces. The packets that are destined to these interfaces will not be routed through Tor.";
+          example = [ "wg0" ];
+        };
+
+        allowedFwMarks = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          description = "List of allowed fwMarks. The packets marked with these fwMarks will not be routed through Tor.";
+          example = [ "0x100" ];
+        };
+
+      };
+
+      router = {
+        enable = lib.mkEnableOption "the routing of all received traffic through Tor. Does not act as a router for the current machine.";
+
+        allowedDestinations = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          example = [ "104.16.0.0/13" ];
+          description = "Allowed destination addresses that will not be routed through Tor.";
+        };
+
+        allowedSources = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          example = [ "192.168.1.0/24" ];
+          description = "Allowed source addresses that will not be routed through Tor.";
+        };
+
+      };
+
+    };
+  };
+
+  config = {
+
+    services.tor =
+      lib.mkIf (config.networking.tor.client.enable || config.networking.tor.router.enable)
+        {
+          enable = true;
+
+          client = {
+            enable = true;
+            transparentProxy.enable = true;
+            dns.enable = true;
+          };
+
+          settings = {
+
+            # If router option is enabled then bind to 0.0.0.0 instead of 127.0.0.1.
+            DNSPort = lib.mkIf config.networking.tor.router.enable [
+              {
+                addr = "0.0.0.0";
+                port = 9053;
+              }
+            ];
+
+            # Without mkForce it sets addr to 127.0.0.1 and later it cannot bind again as 0.0.0.0.
+            TransPort = lib.mkIf config.networking.tor.router.enable (
+              lib.mkForce [
+                {
+                  addr = "0.0.0.0";
+                  port = 9040;
+                }
+              ]
+            );
+
+            VirtualAddrNetworkIPv4 = config.networking.tor.VirtualAddrNetworkIPv4;
+          };
+
+        };
+
+    # Open ports on firewall.
+    networking.firewall.allowedTCPPorts = lib.mkIf config.networking.tor.router.enable [ 9040 ];
+
+    networking.firewall.allowedUDPPorts = lib.mkIf config.networking.tor.router.enable [ 9053 ];
+
+    # Enable squid with shutdown_lifetime set to 0, as it instead would delay service stopping.
+    services.squid = lib.mkIf config.networking.tor.client.enable {
+      enable = config.networking.tor.client.clearnetProxy.enable;
+      proxyAddress = "127.0.0.1";
+      proxyPort = config.networking.tor.client.clearnetProxy.port;
+      extraConfig = ''
+        shutdown_lifetime 0 seconds;
+      '';
+    };
+
+    # Sometimes squid would refuse to start if no network is available.
+    systemd.services.squid.after = lib.mkIf config.networking.tor.client.enable [
+      "network-online.target"
+    ];
+
+    systemd.services.squid.wants = lib.mkIf config.networking.tor.client.enable [
+      "network-online.target"
+    ];
+
+    networking.nftables.enable = lib.mkIf (
+      config.networking.tor.client.enable || config.networking.tor.router.enable
+    ) true;
+
+    # Patch rules before checking them as they would simply fail as both "tor"
+    # and "squid" users aren't available during build.
+    networking.nftables.preCheckRuleset = ''
+      sed -i 's/skuid tor/skuid 1/' ruleset.conf
+      sed -i 's/skuid squid/skuid 2/' ruleset.conf
+    '';
+
+    # Here are the nftables for the routing operations. As you may notice the
+    # family is "inet" so it handles both IPv4 and IPv6, but there are no rules
+    # regarding IPv6 traffic, so it gets simply dropped at the end of filter
+    # chains. That's on purpose as IPv6 has not been tested.
+    networking.nftables.tables = {
+      tor = {
+        enable = config.networking.tor.client.enable;
+        family = "inet";
+        content = ''
+
+          ${buildSubnetsSet "reserved_subnets" reservedSubnets}
+
+          ${buildSubnetsSet "allowed_destinations" config.networking.tor.client.allowedDestinations}
+
+          ${buildSet "ifname" null "allowed_ifs" config.networking.tor.client.allowedInterfaces}
+
+          ${buildSet "mark" null "allowed_marks" config.networking.tor.client.allowedFwMarks}
+
+          chain tor_nat_output {
+            type nat hook output priority ${toString config.networking.tor.natPriority}
+
+            oifname lo return
+            ip daddr 127.0.0.0/8 return
+            ip6 daddr ::1/128 return
+
+            oifname @allowed_ifs return # Do not modify any packet destined to allowed intfs
+            meta mark @allowed_marks return # Do not modify any packet marked with allowed marks
+
+            skuid tor return # Do not modify any tor packets
+
+            # Do not modify any squid packets
+            ${lib.optionalString (config.networking.tor.client.clearnetProxy.enable)
+
+              "skuid squid return"
+            }
+
+            # Here we prioritize allowedDestinations over DNS redirection,
+            # but we redirect DNS requests before allowing local addresses, as
+            # most network configurations have local IP addresses as DNS servers.
+            ip daddr @allowed_destinations return
+            ip protocol udp udp dport 53 dnat to 127.0.0.1:9053 # route dns before allowing local addresses
+            ip daddr @reserved_subnets ip daddr != ${config.networking.tor.VirtualAddrNetworkIPv4} return
+
+            ip protocol tcp dnat to 127.0.0.1:9040 # this rewrites the dest addr but not the interface!
+          }
+
+          chain tor_filter_output {
+            # Set filterPriority and drop everything by default.
+            type filter hook output priority ${toString config.networking.tor.filterPriority}; policy drop;
+
+            ct state established,related accept
+
+            oifname lo accept # For processes that connect to interface IPs, like 192.186.1.150 and are routed through lo
+            ip daddr 127.0.0.0/8 accept # DNATed packets have ethernet intf but local addresses
+
+            oifname @allowed_ifs accept
+            meta mark @allowed_marks accept
+
+            skuid tor accept
+
+            ${lib.optionalString (config.networking.tor.client.clearnetProxy.enable)
+
+              "skuid squid accept"
+            }
+
+            ip daddr @reserved_subnets accept
+            ip daddr @allowed_destinations accept
+          }
+        '';
+      };
+
+      tor-router = {
+        enable = config.networking.tor.router.enable;
+        family = "inet";
+        content = ''
+
+          ${buildSubnetsSet "reserved_subnets" reservedSubnets}
+          ${buildSubnetsSet "allowed_destinations" config.networking.tor.router.allowedDestinations}
+
+          ${buildSubnetsSet "allowed_sources" config.networking.tor.router.allowedSources}
+
+          chain tor_nat_prerouting {
+            type nat hook prerouting priority ${toString config.networking.tor.natPriority}
+
+            ip daddr @reserved_subnets ip daddr != ${config.networking.tor.VirtualAddrNetworkIPv4} return
+            ip saddr @allowed_sources return
+            ip daddr @allowed_destinations return
+
+            ip protocol udp udp dport 53 redirect to :9053
+            ip protocol tcp tcp flags syn redirect to :9040
+          }
+
+          chain tor_filter_forward {
+            type filter hook forward priority ${toString config.networking.tor.filterPriority}; policy drop
+
+            ct state established,related accept
+
+            ip daddr @reserved_subnets accept
+            ip saddr @allowed_sources accept
+            ip daddr @allowed_destinations accept
+          }
+        '';
+      };
+
+    };
+
+    boot.kernel.sysctl."net.ipv4.ip_forward" = lib.mkIf config.networking.tor.router.enable (
+      lib.mkDefault 1
+    );
+
+  };
+
+}

--- a/nixos/modules/services/networking/tor.nix
+++ b/nixos/modules/services/networking/tor.nix
@@ -24,16 +24,12 @@ let
   buildSet = type: flags: name: elements: ''
     set ${name} {
       type ${type}
-      ${if flags != null then "flags ${flags}" else ""}
-
-      ${lib.optionalString (elements != [ ])
-
-        "elements = { ${lib.concatStringsSep "," elements} }"
-      }
+      ${lib.optionalString (flags != [ ]) "flags ${lib.concatStringsSep "," flags}"}
+      ${lib.optionalString (elements != [ ]) "elements = { ${lib.concatStringsSep "," elements} }"}
     }
   '';
 
-  buildSubnetsSet = buildSet "ipv4_addr" "interval";
+  buildSubnetsSet = buildSet "ipv4_addr" [ "interval" ];
 
 in
 {

--- a/nixos/modules/services/networking/tor.nix
+++ b/nixos/modules/services/networking/tor.nix
@@ -24,7 +24,7 @@ let
   buildSet = type: flags: name: elements: ''
     set ${name} {
       type ${type}
-      ${lib.optionalString (flags != [ ]) "flags ${lib.concatStringsSep "," flags}"}
+      ${lib.optionalString (flags != null && flags != [ ]) "flags ${lib.concatStringsSep "," flags}"}
       ${lib.optionalString (elements != [ ]) "elements = { ${lib.concatStringsSep "," elements} }"}
     }
   '';

--- a/nixos/modules/services/networking/tor.nix
+++ b/nixos/modules/services/networking/tor.nix
@@ -1,6 +1,7 @@
 { lib, config, ... }:
 let
-  # List of subnets that will never be routed through Tor under any circumstance.
+  # List of subnets that aren't routable on the public internet.
+  # https://en.wikipedia.org/wiki/List_of_reserved_IP_addresses
   reservedSubnets = [
     "0.0.0.0/8"
     "10.0.0.0/8"

--- a/nixos/modules/services/networking/tor.nix
+++ b/nixos/modules/services/networking/tor.nix
@@ -196,8 +196,8 @@ in
     # regarding IPv6 traffic, so it gets simply dropped at the end of filter
     # chains. That's on purpose as IPv6 has not been tested.
     networking.nftables.tables = {
-      tor = {
-        enable = config.networking.tor.client.enable;
+      tor = lib.mkIf config.networking.tor.client.enable {
+        enable = true;
         family = "inet";
         content = ''
 
@@ -262,8 +262,8 @@ in
         '';
       };
 
-      tor-router = {
-        enable = config.networking.tor.router.enable;
+      tor-router = lib.mkIf config.networking.tor.router.enable {
+        enable = true;
         family = "inet";
         content = ''
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1075,6 +1075,7 @@ in
   networking.networkd = handleTest ./networking/networkd-and-scripted.nix { networkd = true; };
   networking.networkmanager = handleTest ./networking/networkmanager.nix { };
   networking.scripted = handleTest ./networking/networkd-and-scripted.nix { networkd = false; };
+  networking.tor = runTest ./networking/tor.nix;
   # TODO: put in networking.nix after the test becomes more complete
   networkingProxy = runTest ./networking-proxy.nix;
   nextcloud = handleTest ./nextcloud { };

--- a/nixos/tests/networking/tor.nix
+++ b/nixos/tests/networking/tor.nix
@@ -1,0 +1,35 @@
+{ lib, ... }:
+{
+  name = "networking-tor";
+  meta.maintainers = with lib.maintainers; [ deade1e ];
+
+  nodes = {
+    client =
+      { ... }:
+      {
+        networking.tor.client.enable = true;
+      };
+
+    router =
+      { ... }:
+      {
+        networking.tor.router.enable = true;
+      };
+  };
+
+  testScript = ''
+    client.wait_for_unit("tor.service")
+    client.succeed("nft list ruleset | grep tor_nat_output")
+    client.succeed("nft list ruleset | grep tor_filter_output")
+    client.succeed("ss -tlpn | grep -F '127.0.0.1:9040'")
+    client.succeed("ss -ulpn | grep -F '127.0.0.1:9053'")
+    client.succeed("cat /proc/sys/net/ipv4/ip_forward | grep 0")
+
+    router.wait_for_unit("tor.service")
+    router.succeed("nft list ruleset | grep tor_nat_prerouting")
+    router.succeed("nft list ruleset | grep tor_filter_forward")
+    router.succeed("ss -tlpn | grep -F '0.0.0.0:9040'")
+    router.succeed("ss -ulpn | grep -F '0.0.0.0:9053'")
+    router.succeed("cat /proc/sys/net/ipv4/ip_forward | grep 1")
+  '';
+}


### PR DESCRIPTION
Adds the `networking.tor` option to transparently route traffic through
Tor's transparent proxy feature using nftables.

There are two modes:
Client mode `networking.tor.client.enable` routes all outbound traffic
of the local machine through Tor.

Router mode `networking.tor.router.enable` routes forwarded traffic
through Tor, turning the machine into a Tor gateway for other devices.
Also accepts allowedSources to exempt specific source subnets.

Both modes can be enabled simultaneously.

Notes:
`networking.nftables.enable` is set automatically.
Router mode enables `net.ipv4.ip_forward` automatically.
Router mode opens TCP port 9040 and UDP port 9053 in the firewall.
DNS is redirected through Tor to prevent leaks.
Traffic from the `tor` and `squid` system users is always exempted to
prevent routing loops.

Adds a test that verifies that once the two modes are enabled, the
respective nftables get applied and the Tor daemon is bound accordingly.

## Things done
- Add `networking.tor` option that enables routing of all traffic through Tor
- Add a test for this option
- Add myself as maintainer

- Built on platform:
  - [ x ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ x ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ x ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ x ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
