### PR TITLE
nixos/networking: add tor transparent proxy option

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6410,6 +6410,12 @@
     github = "deadbaed";
     githubId = 8809909;
   };
+  deade1e = {
+    name = "Francesco Pompo'";
+    email = "nix@francesco.cc";
+    github = "deade1e";
+    githubId = 6452799;
+  };
   dearrude = {
     name = "Ebrahim Nejati";
     email = "dearrude@tfwno.gf";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1429,6 +1429,7 @@
   ./services/networking/tinydns.nix
   ./services/networking/tinyproxy.nix
   ./services/networking/tmate-ssh-server.nix
+  ./services/networking/tor.nix
   ./services/networking/tox-bootstrapd.nix
   ./services/networking/tox-node.nix
   ./services/networking/toxvpn.nix

--- a/nixos/modules/services/networking/tor.nix
+++ b/nixos/modules/services/networking/tor.nix
@@ -1,0 +1,308 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  # List of subnets that aren't routable on the public internet.
+  # https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
+  reservedSubnets = [
+    "0.0.0.0/8"
+    "10.0.0.0/8"
+    "100.64.0.0/10"
+    "127.0.0.0/8"
+    "169.254.0.0/16"
+    "172.16.0.0/12"
+    "192.0.0.0/24"
+    "192.0.2.0/24"
+    "192.88.99.0/24"
+    "192.168.0.0/16"
+    "198.18.0.0/15"
+    "198.51.100.0/24"
+    "203.0.113.0/24"
+    "224.0.0.0/4" # https://www.iana.org/assignments/multicast-addresses/multicast-addresses.xhtml
+    "240.0.0.0/4"
+  ];
+
+  # Helper to build a nftables set.
+  buildSet = type: flags: name: elements: ''
+    set ${name} {
+      type ${type}
+      ${lib.optionalString (flags != [ ]) "flags ${lib.concatStringsSep "," flags}"}
+      ${lib.optionalString (elements != [ ]) "elements = { ${lib.concatStringsSep "," elements} }"}
+    }
+  '';
+
+  buildSubnetsSet = buildSet "ipv4_addr" [ "interval" ];
+
+  cfg = config.networking.tor;
+in
+{
+
+  meta.maintainers = with lib.maintainers; [ deade1e ];
+
+  options = {
+
+    networking.tor = {
+
+      virtualAddrNetworkIPv4 = lib.mkOption {
+        type = lib.types.str;
+        default = "10.64.0.0/10";
+        description = "The virtual address space used by Tor.";
+      };
+
+      transPort = lib.mkOption {
+        type = lib.types.int;
+        default = 9040;
+        example = 10040;
+        description = "The TransPort setting of Tor";
+      };
+
+      dnsPort = lib.mkOption {
+        type = lib.types.int;
+        default = 9053;
+        example = 10053;
+        description = "The DNSPort setting of Tor";
+      };
+
+      natPriority = lib.mkOption {
+        type = lib.types.int;
+        default = -100;
+        description = "nftables NAT handling priority.";
+      };
+
+      filterPriority = lib.mkOption {
+        type = lib.types.int;
+        default = 0;
+        description = "nftables filter handling priority.";
+      };
+
+      client = {
+        enable = lib.mkEnableOption "the routing of all traffic of the current machine through Tor. Does not act as a router for other machines. IPv6 traffic is not routed and it is dropped.";
+
+        clearnetProxy = {
+          enable = lib.mkEnableOption "a squid instance that can perform requests without being routed through Tor.";
+
+          port = lib.mkOption {
+            type = lib.types.int;
+            default = 3128;
+            example = 8080;
+            description = "Port used for the squid proxy.";
+          };
+
+        };
+
+        excludedDestinations = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          example = [ "104.16.0.0/13" ];
+          description = "Excluded destination addresses that will not be routed through Tor.";
+        };
+
+        excludedInterfaces = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          description = "List of excluded interfaces. The packets that are destined to these interfaces will not be routed through Tor.";
+          example = [ "wg0" ];
+        };
+
+        excludedFwMarks = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          description = "List of excluded fwMarks. The packets marked with these fwMarks will not be routed through Tor.";
+          example = [ "0x100" ];
+        };
+
+      };
+
+      router = {
+        enable = lib.mkEnableOption "the routing of all received traffic through Tor. Does not act as a router for the current machine. IPv6 traffic is not routed and it is dropped.";
+
+        excludedDestinations = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          example = [ "104.16.0.0/13" ];
+          description = "Excluded destination addresses that will not be routed through Tor.";
+        };
+
+        excludedSources = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          example = [ "192.168.1.0/24" ];
+          description = "Excluded source addresses that will not be routed through Tor.";
+        };
+
+      };
+
+    };
+  };
+
+  config = lib.mkIf (cfg.client.enable || cfg.router.enable) {
+
+    services.tor = {
+      enable = true;
+      client.enable = true;
+
+      settings = {
+        DNSPort = [
+          (lib.mkIf cfg.client.enable {
+            addr = "127.0.0.1";
+            port = cfg.dnsPort;
+          })
+
+          (lib.mkIf cfg.router.enable {
+            addr = "0.0.0.0";
+            port = cfg.dnsPort;
+          })
+        ];
+
+        AutomapHostOnResolve = true;
+
+        TransPort = [
+          {
+            addr = if cfg.router.enable then "0.0.0.0" else "127.0.0.1";
+            port = cfg.transPort;
+          }
+        ];
+
+        VirtualAddrNetworkIPv4 = cfg.virtualAddrNetworkIPv4;
+      };
+
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.router.enable [ cfg.transPort ];
+
+    networking.firewall.allowedUDPPorts = lib.mkIf cfg.router.enable [ cfg.dnsPort ];
+
+    # Enable squid with shutdown_lifetime set to 0, as it instead would delay service stopping.
+    services.squid = lib.mkIf cfg.client.clearnetProxy.enable {
+      enable = true;
+      proxyAddress = "127.0.0.1";
+      proxyPort = cfg.client.clearnetProxy.port;
+      extraConfig = ''
+        shutdown_lifetime 0 seconds;
+      '';
+    };
+
+    # Wait for network so that squid picks up the right DNS information
+    systemd.services.squid.after = lib.mkIf cfg.client.clearnetProxy.enable [
+      "network-online.target"
+    ];
+
+    systemd.services.squid.wants = lib.mkIf cfg.client.clearnetProxy.enable [
+      "network-online.target"
+    ];
+
+    networking.nftables.enable = true;
+
+    # Patch rules before checking them as they would simply fail as both "tor"
+    # and "squid" users aren't available during build.
+    networking.nftables.preCheckRuleset = ''
+      ${lib.getExe pkgs.gnused} --in-place 's/skuid tor/skuid 1/' ruleset.conf
+      ${lib.getExe pkgs.gnused} --in-place 's/skuid squid/skuid 2/' ruleset.conf
+    '';
+
+    # Here are the nftables for the routing operations. As you may notice the
+    # family is "inet" so it handles both IPv4 and IPv6, but there are no rules
+    # regarding IPv6 traffic, so it gets simply dropped at the end of filter
+    # chains. That's on purpose as IPv6 has not been tested.
+    networking.nftables.tables = {
+      tor = lib.mkIf cfg.client.enable {
+        enable = true;
+        family = "inet";
+        content = ''
+
+          ${buildSubnetsSet "reserved_subnets" reservedSubnets}
+
+          ${buildSubnetsSet "excluded_destinations" cfg.client.excludedDestinations}
+
+          ${buildSet "ifname" [ ] "excluded_ifs" cfg.client.excludedInterfaces}
+
+          ${buildSet "mark" [ ] "excluded_marks" cfg.client.excludedFwMarks}
+
+          chain tor_nat_output {
+            type nat hook output priority ${toString cfg.natPriority}
+
+            oifname lo return
+            ip daddr 127.0.0.0/8 return
+            ip6 daddr ::1/128 return
+
+            oifname @excluded_ifs return # Do not modify any packet destined to excluded intfs
+            meta mark @excluded_marks return # Do not modify any packet marked with excluded marks
+
+            skuid tor return # Do not modify any tor packets
+
+            # Do not modify any squid packets
+            ${lib.optionalString (cfg.client.clearnetProxy.enable) "skuid squid counter return"}
+
+            # Here we prioritize excludedDestinations over DNS redirection,
+            # but we redirect DNS requests before allowing local addresses, as
+            # most network configurations have local IP addresses as DNS servers.
+            ip daddr @excluded_destinations return
+            ip protocol udp udp dport 53 counter dnat to 127.0.0.1:${toString cfg.dnsPort} # route dns before allowing local addresses
+            ip daddr @reserved_subnets ip daddr != ${cfg.virtualAddrNetworkIPv4} return
+
+            ip protocol tcp counter dnat to 127.0.0.1:${toString cfg.transPort} # this rewrites the dest addr but not the interface!
+          }
+
+          chain tor_filter_output {
+            # Set filterPriority and drop everything by default.
+            type filter hook output priority ${toString cfg.filterPriority}; policy drop;
+
+            ct state established,related accept
+
+            oifname lo accept # For processes that connect to interface IPs, like 192.186.1.150 and are routed through lo
+            ip daddr 127.0.0.0/8 accept # DNATed packets have ethernet intf but local addresses
+
+            oifname @excluded_ifs accept
+            meta mark @excluded_marks accept
+
+            skuid tor accept
+
+            ${lib.optionalString (cfg.client.clearnetProxy.enable) "skuid squid accept"}
+
+            ip daddr @reserved_subnets accept
+            ip daddr @excluded_destinations accept
+          }
+        '';
+      };
+
+      tor-router = lib.mkIf cfg.router.enable {
+        enable = true;
+        family = "inet";
+        content = ''
+
+          ${buildSubnetsSet "reserved_subnets" reservedSubnets}
+          ${buildSubnetsSet "excluded_destinations" cfg.router.excludedDestinations}
+
+          ${buildSubnetsSet "excluded_sources" cfg.router.excludedSources}
+
+          chain tor_nat_prerouting {
+            type nat hook prerouting priority ${toString cfg.natPriority}
+
+            ip daddr @reserved_subnets ip daddr != ${cfg.virtualAddrNetworkIPv4} return
+            ip saddr @excluded_sources return
+            ip daddr @excluded_destinations return
+
+            ip protocol udp udp dport 53 counter redirect to :${toString cfg.dnsPort}
+            ip protocol tcp tcp flags syn counter redirect to :${toString cfg.transPort}
+          }
+
+          chain tor_filter_forward {
+            type filter hook forward priority ${toString cfg.filterPriority}; policy drop
+
+            ct state established,related accept
+
+            ip daddr @reserved_subnets accept
+            ip saddr @excluded_sources accept
+            ip daddr @excluded_destinations accept
+          }
+        '';
+      };
+
+    };
+
+  };
+
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1075,6 +1075,7 @@ in
   networking.networkd = handleTest ./networking/networkd-and-scripted.nix { networkd = true; };
   networking.networkmanager = handleTest ./networking/networkmanager.nix { };
   networking.scripted = handleTest ./networking/networkd-and-scripted.nix { networkd = false; };
+  networking.tor = runTest ./networking/tor.nix;
   # TODO: put in networking.nix after the test becomes more complete
   networkingProxy = runTest ./networking-proxy.nix;
   nextcloud = handleTest ./nextcloud { };

--- a/nixos/tests/networking/tor.nix
+++ b/nixos/tests/networking/tor.nix
@@ -1,0 +1,159 @@
+{ lib, pkgs, ... }:
+let
+  clientTransPort = 8040;
+  clientDnsPort = 8053;
+  clientProxyPort = 3128;
+  routerTransPort = 7040;
+  routerDnsPort = 7053;
+in
+{
+  name = "networking-tor";
+  meta.maintainers = with lib.maintainers; [ deade1e ];
+
+  nodes = {
+    client =
+      { ... }:
+      {
+        networking.tor = {
+          transPort = clientTransPort;
+          dnsPort = clientDnsPort;
+          client = {
+            enable = true;
+            clearnetProxy = {
+              enable = true;
+              port = clientProxyPort;
+            };
+          };
+        };
+
+        environment.systemPackages = with pkgs; [ dnsutils ];
+      };
+
+    clearclient =
+      { nodes, ... }:
+      {
+        environment.systemPackages = with pkgs; [ dnsutils ];
+        # Set the router node as the gateway.
+        networking.defaultGateway = nodes.router.networking.primaryIPAddress;
+      };
+
+    router =
+      { ... }:
+      {
+        networking.tor = {
+          transPort = routerTransPort;
+          dnsPort = routerDnsPort;
+          router.enable = true;
+        };
+      };
+  };
+
+  testScript = ''
+    import re
+
+    # Return packet counters found in Tor's output chain.
+    def get_output_pkts(node, trans_port, dns_port):
+      proxy_user = int(node.succeed("id -u squid"))
+      proxy_re = rf'meta skuid {proxy_user} counter packets (\d+) bytes \d+ return'
+      tcp_re = rf'ip protocol tcp counter packets (\d+) bytes \d+ dnat ip to 127.0.0.1:{trans_port}'
+      dns_re = rf'ip protocol udp udp dport 53 counter packets (\d+) bytes \d+ dnat ip to 127.0.0.1:{dns_port}'
+      ruleset = node.succeed("nft list chain inet tor tor_nat_output")
+      proxy = int(re.search(proxy_re, ruleset).group(1))
+      tcp = int(re.search(tcp_re, ruleset).group(1))
+      dns = int(re.search(dns_re, ruleset).group(1))
+      return proxy, tcp, dns
+
+    # Return packet counters found in Tor's prerouting chain.
+    def get_prerouting_pkts(node, trans_port, dns_port):
+      tcp_re = rf'ip protocol tcp tcp flags syn counter packets (\d+) bytes \d+ redirect to :{trans_port}'
+      dns_re = rf'ip protocol udp udp dport 53 counter packets (\d+) bytes \d+ redirect to :{dns_port}'
+      ruleset = node.succeed("nft list chain inet tor-router tor_nat_prerouting")
+      tcp = int(re.search(tcp_re, ruleset).group(1))
+      dns = int(re.search(dns_re, ruleset).group(1))
+      return tcp, dns
+
+    CLIENT_TRANS_PORT = ${toString clientTransPort}
+    CLIENT_DNS_PORT = ${toString clientDnsPort}
+    CLIENT_PROXY_PORT = ${toString clientProxyPort}
+    ROUTER_TRANS_PORT = ${toString routerTransPort}
+    ROUTER_DNS_PORT = ${toString routerDnsPort}
+
+    router.wait_for_unit("tor.service")
+    router.succeed("nft list ruleset | grep tor_nat_prerouting")
+    router.succeed("nft list ruleset | grep tor_filter_forward")
+    router.succeed(f"ss -tlpn | grep -F '0.0.0.0:{ROUTER_TRANS_PORT}'")
+    router.succeed(f"ss -ulpn | grep -F '0.0.0.0:{ROUTER_DNS_PORT}'")
+
+    tcp, dns = get_prerouting_pkts(router, ROUTER_TRANS_PORT, ROUTER_DNS_PORT)
+    assert tcp == 0 and dns == 0
+
+    clearclient.wait_for_unit("multi-user.target")
+
+    # If routed through a Tor gateway, the Tor daemon always replies with a
+    # SYN-ACK, no matter its network state.
+    clearclient.succeed("nc -vz 1.1.1.1 80")
+
+    # At this point we should have TCP packets but no DNS packets.
+    tcp, dns = get_prerouting_pkts(router, ROUTER_TRANS_PORT, ROUTER_DNS_PORT)
+    assert tcp > 0 and dns == 0
+
+    # This should fail as without connectivity the Tor daemon cannot to resolve domains.
+    clearclient.fail("nslookup -timeout=1 www.google.com 8.8.8.8")
+    tcp, dns = get_prerouting_pkts(router, ROUTER_TRANS_PORT, ROUTER_DNS_PORT)
+    assert tcp > 0 and dns > 0
+
+    # Trying to resolve a .onion address instead should always succeed as the
+    # Tor daemon optimistically replies with a IP within VirtualAddrNetworkIPv4
+    # even without connectivity.
+    clearclient.succeed("nslookup -timeout=1 duckduckgogg42xjoc72x3sjasowoarfbgcmvfimaftt6twagswzczad.onion 8.8.8.8 | grep -F 'Address: 10.'")
+
+    client.wait_for_unit("tor.service")
+    client.succeed("nft list ruleset | grep tor_nat_output")
+    client.succeed("nft list ruleset | grep tor_filter_output")
+    client.succeed(f"ss -tlpn | grep -F '127.0.0.1:{CLIENT_TRANS_PORT}'")
+    client.succeed(f"ss -ulpn | grep -F '127.0.0.1:{CLIENT_DNS_PORT}'")
+
+    # This must fail as the dummy intf is not yet available
+    client.fail("nc -vz 1.1.1.1 80")
+
+    # Create a dummy interface and set a fake gateway to trick the OS into
+    # trying to route packets.
+    client.succeed("ip link add dummy0 type dummy")
+    client.succeed("ip addr add 10.88.99.2/24 dev dummy0")
+    client.succeed("ip link set dummy0 up")
+    client.succeed("ip route add default via 10.88.99.1 dev dummy0")
+
+    # Trigger network-online.target and wait for Squid.
+    client.succeed("systemctl start network-online.target")
+    client.wait_for_unit("squid.service")
+
+    # Verify that there are zero TCP and zero DNS packets forwarded to Tor and
+    # zero allowed proxy packets.
+    proxy, tcp, dns = get_output_pkts(client, CLIENT_TRANS_PORT, CLIENT_DNS_PORT)
+    assert proxy == 0 and tcp == 0 and dns == 0
+
+    client.fail(f"curl --proxy http://127.0.0.1:{CLIENT_PROXY_PORT} --max-time 1 http://1.1.1.1")
+    proxy, tcp, dns = get_output_pkts(client, CLIENT_TRANS_PORT, CLIENT_DNS_PORT)
+    assert proxy > 0 and tcp == 0 and dns == 0
+
+    # Send one DNS request somewhere.
+    client.fail("nslookup -timeout=1 www.google.com 8.8.8.8")
+
+    # Ensure there are more than zero DNS packets and exactly zero TCP packets
+    # being forwarded to the Tor daemon.
+    _, tcp, dns = get_output_pkts(client, CLIENT_TRANS_PORT, CLIENT_DNS_PORT)
+    assert tcp == 0 and dns > 0
+
+    # This should succeed even though there is no internet, as the packet
+    # should be routed to the Tor daemon and it should always reply with a
+    # SYN-ACK.
+    client.succeed("nc -vz 1.1.1.1 80")
+
+    # And then verify that this packet did go exactly through our TCP DNAT rule.
+    _, tcp, dns = get_output_pkts(client, CLIENT_TRANS_PORT, CLIENT_DNS_PORT)
+    assert tcp > 0 and dns > 0
+
+    # Try to resolve a .onion because why not.
+    client.succeed("nslookup -timeout=1 duckduckgogg42xjoc72x3sjasowoarfbgcmvfimaftt6twagswzczad.onion 8.8.8.8 | grep -F 'Address: 10.'")
+  '';
+}


### PR DESCRIPTION
Adds the `networking.tor` option to transparently route traffic through
Tor's transparent proxy feature using nftables.

There are two modes:
Client mode `networking.tor.client.enable` routes all outbound traffic
of the local machine through Tor.

Router mode `networking.tor.router.enable` routes forwarded traffic
through Tor, turning the machine into a Tor gateway for other devices.
Also accepts excludedSources/excludedDestinations to exempt
specific subnets from being routed.

There are other options to ignore traffic with certain fwMark or interface.

Both `router` and `client` modes can be enabled simultaneously.

Notes:
`networking.nftables.enable` is set automatically.
Router mode opens TCP port 9040 and UDP port 9053 in the firewall
(ports can be changed).
DNS is redirected through Tor to prevent leaks.
Traffic from the `tor` and optionally `squid` system users is always
exempted to prevent routing loops.

Adds a test that verifies that once the two modes are enabled, the
respective nftables get applied and the Tor daemon is bound accordingly.
The test also makes sure the packets are routed properly through the
nftables rules, by counting packets.

## Things done

- Add `networking.tor` option that enables routing of all traffic through Tor
- Add a test for this option
- Add myself as maintainer


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
