### PR TITLE
libgcc: replace usage of libgcc.lib with libgcc

### DIFF
--- a/pkgs/by-name/ai/airtame/package.nix
+++ b/pkgs/by-name/ai/airtame/package.nix
@@ -44,7 +44,7 @@ let
   ];
 
   deps = [
-    libgcc.lib
+    libgcc
     glib
     nss
     nspr

--- a/pkgs/by-name/pl/plasticscm-client-core/package.nix
+++ b/pkgs/by-name/pl/plasticscm-client-core/package.nix
@@ -25,7 +25,7 @@ buildFHSEnv {
     [
       # Dependencies from the Debian package
       glibc.out
-      libgcc.lib
+      libgcc
       libz
       krb5.lib
       lttng-ust.out

--- a/pkgs/by-name/pl/plasticscm-client-gui/package.nix
+++ b/pkgs/by-name/pl/plasticscm-client-gui/package.nix
@@ -33,7 +33,7 @@ buildFHSEnv {
     [
       # Dependencies from the Debian package
       glibc.out
-      libgcc.lib
+      libgcc
       krb5.lib
       lttng-ust.out
       openssl_3.out

--- a/pkgs/development/libraries/intel-oneapi/default.nix
+++ b/pkgs/development/libraries/intel-oneapi/default.nix
@@ -84,7 +84,7 @@
           mkdir -p "$out"
 
           # Required for the installer to find libstdc++
-          export LD_LIBRARY_PATH="${lib.makeLibraryPath [ libgcc.lib ]}"
+          export LD_LIBRARY_PATH="${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}"
 
           # The installer is an insane four-stage rube goldberg machine:
           # 1. Our $src (bash script) unpacks install.sh (bash script)

--- a/pkgs/development/web/playwright/chromium-headless-shell.nix
+++ b/pkgs/development/web/playwright/chromium-headless-shell.nix
@@ -57,7 +57,7 @@ let
       libxfixes
       libxrandr
       libgbm
-      libgcc.lib
+      libgcc
       libxkbcommon
       nspr
       nss

--- a/pkgs/development/web/playwright/webkit.nix
+++ b/pkgs/development/web/playwright/webkit.nix
@@ -150,7 +150,7 @@ let
       libdrm
       libepoxy
       libevent
-      libgcc.lib
+      libgcc
       libgcrypt
       libgpg-error
       libjpeg8

--- a/pkgs/development/web/playwright/webkit.nix
+++ b/pkgs/development/web/playwright/webkit.nix
@@ -152,7 +152,7 @@ let
       libdrm
       libepoxy
       libevent
-      libgcc.lib
+      libgcc
       libgcrypt
       libgpg-error
       libjpeg8


### PR DESCRIPTION
fixes: #515906
`authentik` in the build failure is already failing in master (see [hydra build](https://hydra.nixos.org/build/327804195)).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
