### PR TITLE
graphite: update branding in updateScript

### DIFF
--- a/pkgs/by-name/gr/graphite/package.nix
+++ b/pkgs/by-name/gr/graphite/package.nix
@@ -27,7 +27,6 @@
   libxcursor,
   libx11,
   libxcb,
-  nix-update-script,
 }:
 
 let
@@ -173,12 +172,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   disallowedReferences = [ rustc ];
 
-  passthru.updateScript = nix-update-script {
-    extraArgs = [
-      "--version=branch"
-      "--version-regex=(0-unstable-.*)"
-    ];
-  };
+  passthru.updateScript = ./update.nu;
 
   meta = {
     description = "Open source vector graphics editor and procedural design engine";

--- a/pkgs/by-name/gr/graphite/update.nu
+++ b/pkgs/by-name/gr/graphite/update.nu
@@ -1,0 +1,14 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i nu -p nushell nix-update curl common-updater-scripts nix
+
+^nix-update graphite --version=branch --version-regex '(0-unstable-.*)'
+
+let pkg = "./pkgs/by-name/gr/graphite/package.nix"
+let rev = (open $pkg | lines | where ($it | str contains 'rev = "') | first | str trim | parse 'rev = "{rev}";' | get 0.rev)
+let meta = (http get $"https://raw.githubusercontent.com/GraphiteEditor/Graphite/($rev)/.branding" | lines)
+let branding_rev = ($meta | get 0 | path basename | str replace ".tar.gz" "")
+let branding_hash = (^nix hash convert --to sri --hash-algo sha256 ($meta | get 1) | str trim)
+open $pkg
+| str replace --regex 'brandingRev = "[^"]*"' $'brandingRev = "($branding_rev)"'
+| str replace --regex 'brandingHash = "[^"]*"' $'brandingHash = "($branding_hash)"'
+| save --force $pkg


### PR DESCRIPTION
We also need to update branding automatically.
URL and Hash from `.branding` file in the repo. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
