### PR TITLE
nixos/dnscache: Add option to put extra files into the chroot

### DIFF
--- a/nixos/modules/services/networking/dnscache.nix
+++ b/nixos/modules/services/networking/dnscache.nix
@@ -7,30 +7,40 @@
 let
   cfg = config.services.dnscache;
 
-  dnscache-root = pkgs.runCommand "dnscache-root" { preferLocalBuild = true; } ''
-    mkdir -p $out/{servers,ip}
+  dnscache-root =
+    pkgs.runCommand "dnscache-root"
+      {
+        preferLocalBuild = true;
+        inherit (cfg) extraRootFiles;
+      }
+      ''
+        mkdir -p $out/{servers,ip}
 
-    ${lib.concatMapStrings (ip: ''
-      touch "$out/ip/"${lib.escapeShellArg ip}
-    '') cfg.clientIps}
-
-    ${lib.concatStrings (
-      lib.mapAttrsToList (host: ips: ''
         ${lib.concatMapStrings (ip: ''
-          echo ${lib.escapeShellArg ip} >> "$out/servers/"${lib.escapeShellArg host}
-        '') ips}
-      '') cfg.domainServers
-    )}
+          touch "$out/ip/"${lib.escapeShellArg ip}
+        '') cfg.clientIps}
 
-    # if a list of root servers was not provided in config, copy it
-    # over. (this is also done by dnscache-conf, but we 'rm -rf
-    # /var/lib/dnscache/root' below & replace it wholesale with this,
-    # so we have to ensure servers/@ exists ourselves.)
-    if [ ! -e $out/servers/@ ]; then
-      # symlink does not work here, due chroot
-      cp ${pkgs.djbdns}/etc/dnsroots.global $out/servers/@;
-    fi
-  '';
+        ${lib.concatStrings (
+          lib.mapAttrsToList (host: ips: ''
+            ${lib.concatMapStrings (ip: ''
+              echo ${lib.escapeShellArg ip} >> "$out/servers/"${lib.escapeShellArg host}
+            '') ips}
+          '') cfg.domainServers
+        )}
+
+        # if a list of root servers was not provided in config, copy it
+        # over. (this is also done by dnscache-conf, but we 'rm -rf
+        # /var/lib/dnscache/root' below & replace it wholesale with this,
+        # so we have to ensure servers/@ exists ourselves.)
+        if [ ! -e $out/servers/@ ]; then
+          # symlink does not work here, due chroot
+          cp ${pkgs.djbdns}/etc/dnsroots.global $out/servers/@;
+        fi
+
+        if [ -n "$extraRootFiles" ] ; then
+           cp "$extraRootFiles"/* $out
+        fi
+      '';
 
 in
 {
@@ -74,6 +84,19 @@ in
             "@" = ["8.8.8.8" "8.8.4.4"];
             "example.com" = ["192.168.100.100"];
           }
+        '';
+
+      };
+
+      extraRootFiles = lib.mkOption {
+        default = null;
+        type = lib.types.nullOr lib.types.pathInStore;
+        description = ''
+          Directory with additional files to copy into the server chroot.
+
+          Vanilla dnscahe does not recognize any files other than those managed by other
+          options of this service, but that option might be necessary if additional
+          patches were applied to the "djbdns" package via nixpkgs overlay.
         '';
       };
 

--- a/nixos/modules/services/networking/dnscache.nix
+++ b/nixos/modules/services/networking/dnscache.nix
@@ -6,8 +6,12 @@
 }:
 let
   cfg = config.services.dnscache;
+  env = {
+    preferLocalBuild = true;
+    inherit (cfg) extraRootFiles;
+  };
 
-  dnscache-root = pkgs.runCommand "dnscache-root" { preferLocalBuild = true; } ''
+  dnscache-root = pkgs.runCommand "dnscache-root" env ''
     mkdir -p $out/{servers,ip}
 
     ${lib.concatMapStrings (ip: ''
@@ -29,6 +33,10 @@ let
     if [ ! -e $out/servers/@ ]; then
       # symlink does not work here, due chroot
       cp ${pkgs.djbdns}/etc/dnsroots.global $out/servers/@;
+    fi
+
+    if [ -n "$extraRootFiles" ] ; then
+       cp "$extraRootFiles"/* $out
     fi
   '';
 
@@ -74,6 +82,19 @@ in
             "@" = ["8.8.8.8" "8.8.4.4"];
             "example.com" = ["192.168.100.100"];
           }
+        '';
+
+      };
+
+      extraRootFiles = lib.mkOption {
+        default = null;
+        type = lib.types.nullOr lib.types.pathInStore;
+        description = ''
+          Directory with additional files to copy into the server chroot.
+
+          Vanilla dnscahe does not recognize any files other than those managed by other
+          options of this service, but that option might be necessary if additional
+          patches were applied to the "djbdns" package via nixpkgs overlay.
         '';
       };
 


### PR DESCRIPTION
Vanilla `dnscahe` does not recognize any files other than those managed by other options of this service, but that option might be necessary if additional patches were applied to the `djbdns` package via an overlay.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
