### PR TITLE
maintainers: remove trino

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28061,12 +28061,6 @@
     githubId = 16036882;
     name = "Thibault Gagnaux";
   };
-  trino = {
-    email = "muehlhans.hubert@ekodia.de";
-    github = "hmuehlhans";
-    githubId = 9870613;
-    name = "Hubert Mühlhans";
-  };
   tris203 = {
     email = "admin@snappeh.com";
     github = "tris203";


### PR DESCRIPTION
## Reasons

- Last commented in [March 2015](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Ahmuehlhans)
- Hasn't created any PRs / Issues since [March 2015](https://github.com/NixOS/nixpkgs/issues?q=author%3Ahmuehlhans)
- About 0 [unanswered ](https://github.com/NixOS/nixpkgs/issues?q=involves%3Ahmuehlhans%20-commenter%3Ahmuehlhans%20-author%3Ahmuehlhans%20-reviewed-by%3Ahmuehlhans) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.