### PR TITLE
nixfmt-rs: init at 0.1.4

### DIFF
--- a/pkgs/by-name/ni/nixfmt-rs/package.nix
+++ b/pkgs/by-name/ni/nixfmt-rs/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+  nixfmt,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "nixfmt-rs";
+  version = "0.1.4";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "Mic92";
+    repo = "nixfmt-rs";
+    tag = finalAttrs.version;
+    hash = "sha256-lfT+cFys0iJGkOgLO8LR7lnKMG7ZKJTVvOCm6dSBf8w=";
+  };
+
+  cargoHash = "sha256-TmZi99xxTlSTpqr6k29CsnTK8qfj5gjs1AGkx1hcXCg=";
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  nativeCheckInputs = [ nixfmt ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/Mic92/nixfmt-rs/releases/tag/${finalAttrs.version}";
+    description = "Rust reimplementation of nixfmt that produces byte-identical output to the Haskell original";
+    homepage = "https://github.com/Mic92/nixfmt-rs";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [
+      drupol
+      mic92
+    ];
+    mainProgram = "nixfmt";
+  };
+})

--- a/pkgs/by-name/ni/nixfmt-rs/package.nix
+++ b/pkgs/by-name/ni/nixfmt-rs/package.nix
@@ -3,6 +3,7 @@
   rustPlatform,
   fetchFromGitHub,
   installShellFiles,
+  scdoc,
   versionCheckHook,
   nix-update-script,
   nixfmt,
@@ -25,10 +26,17 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-fadjOtfB8bFuhTN9mAmi2A526boW7Aje39IBjdxszok=";
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [
+    installShellFiles
+    scdoc
+  ];
+
+  postBuild = ''
+    scdoc < docs/nixfmt.1.scd > nixfmt.1
+  '';
 
   postInstall = ''
-    installManPage docs/*
+    installManPage nixfmt.1
   '';
 
   doInstallCheck = true;

--- a/pkgs/by-name/ni/nixfmt-rs/package.nix
+++ b/pkgs/by-name/ni/nixfmt-rs/package.nix
@@ -2,14 +2,16 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  installShellFiles,
   versionCheckHook,
   nix-update-script,
   nixfmt,
+  gitMinimal,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nixfmt-rs";
-  version = "0.1.4";
+  version = "0.2.0";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -18,15 +20,24 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "Mic92";
     repo = "nixfmt-rs";
     tag = finalAttrs.version;
-    hash = "sha256-lfT+cFys0iJGkOgLO8LR7lnKMG7ZKJTVvOCm6dSBf8w=";
+    hash = "sha256-eBVi22+EGMYWv2t/seoPqou8PuABxVcsWTFcrNYP6So=";
   };
 
-  cargoHash = "sha256-TmZi99xxTlSTpqr6k29CsnTK8qfj5gjs1AGkx1hcXCg=";
+  cargoHash = "sha256-fadjOtfB8bFuhTN9mAmi2A526boW7Aje39IBjdxszok=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installManPage docs/*
+  '';
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
 
-  nativeCheckInputs = [ nixfmt ];
+  nativeCheckInputs = [
+    gitMinimal
+    nixfmt
+  ];
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
Context: https://discourse.nixos.org/t/nixfmt-rs-towards-nicer-parser-error-messages/77377

@mic92: Let me know if this is OK to add you as maintainer

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
