### PR TITLE
phrasendrescher: fix build with gcc15

### DIFF
--- a/pkgs/by-name/ph/phrasendrescher/fix-prototypes.patch
+++ b/pkgs/by-name/ph/phrasendrescher/fix-prototypes.patch
@@ -1,0 +1,26 @@
+diff --git a/src/rewriter.c b/src/rewriter.c
+index f8c72bf..9c95e7e 100644
+--- a/src/rewriter.c
++++ b/src/rewriter.c
+@@ -64,7 +64,7 @@ int rewriter_get(char *word)
+     	
+ 	if (word == '\0') {
+ 		*original_word = '\0';
+-		rewriter_reset(rule_set);
++		rewriter_reset();
+ 		return 0;
+ 	}
+ 	
+diff --git a/src/utils.h b/src/utils.h
+index c20ac5c..b8fe00a 100644
+--- a/src/utils.h
++++ b/src/utils.h
+@@ -33,7 +33,7 @@
+ 
+ void	prepare_tty();
+ void	reset_tty();
+-void	handle_user_input();
++void	handle_user_input(int worker_num);
+ void	set_verbose();
+ 
+ void	verbose_printf(const char *fmt, ...);

--- a/pkgs/by-name/ph/phrasendrescher/package.nix
+++ b/pkgs/by-name/ph/phrasendrescher/package.nix
@@ -16,6 +16,11 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "18vg6h294219v14x5zqm8ddmq5amxlbz7pw81lcmpz8v678kwyph";
   };
 
+  patches = [
+    # gcc15
+    ./fix-prototypes.patch
+  ];
+
   postPatch = ''
     substituteInPlace configure \
       --replace 'SSL_LIB="ssl"' 'SSL_LIB="crypto"'

--- a/pkgs/by-name/ph/phrasendrescher/package.nix
+++ b/pkgs/by-name/ph/phrasendrescher/package.nix
@@ -5,6 +5,7 @@
   openssl,
   libssh2,
   gpgme,
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -33,6 +34,10 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   configureFlags = [ "--with-plugins" ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "-h";
+  doInstallCheck = true;
 
   meta = {
     description = "Modular and multi processing pass phrase cracking tool";


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/326853417

```
../utils.c:70:1: error: conflicting types for 'handle_user_input'; have 'void(int)'
   70 | handle_user_input(int worker_num)
      | ^~~~~~~~~~~~~~~~~
In file included from ../utils.c:34:
../utils.h:36:9: note: previous declaration of 'handle_user_input' with type 'void(void)'
   36 | void    handle_user_input();
      |         ^~~~~~~~~~~~~~~~~
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
