### PR TITLE
picard: fix eval & build on Darwin with avoiding unsupported dependencies

### DIFF
--- a/pkgs/by-name/pi/picard/package.nix
+++ b/pkgs/by-name/pi/picard/package.nix
@@ -9,6 +9,8 @@
 
   enablePlayback ? true,
   gst_all_1,
+
+  writableTmpDirAsHomeHook,
 }:
 
 let
@@ -68,10 +70,8 @@ pythonPackages.buildPythonApplication (finalAttrs: {
 
   nativeCheckInputs = [
     pythonPackages.pytestCheckHook
+    writableTmpDirAsHomeHook
   ];
-  preCheck = ''
-    export HOME=$(mktemp -d)
-  '';
   doCheck = true;
 
   # In order to spare double wrapping, we use:

--- a/pkgs/by-name/pi/picard/package.nix
+++ b/pkgs/by-name/pi/picard/package.nix
@@ -22,6 +22,7 @@ pythonPackages.buildPythonApplication (finalAttrs: {
   # nix-update --commit picard --version-regex 'release-(.*)'
   version = "2.13.3";
   pyproject = true;
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "metabrainz";
@@ -34,13 +35,6 @@ pythonPackages.buildPythonApplication (finalAttrs: {
     gettext
     qt5.wrapQtAppsHook
     pythonPackages.setuptools
-  ]
-  ++ lib.optionals (pyqt5.multimediaEnabled) [
-    gst_all_1.gst-libav
-    gst_all_1.gst-plugins-base
-    gst_all_1.gst-plugins-good
-    gst_all_1.gst-vaapi
-    gst_all_1.gstreamer
   ];
 
   buildInputs = [
@@ -49,6 +43,10 @@ pythonPackages.buildPythonApplication (finalAttrs: {
   ]
   ++ lib.optionals (pyqt5.multimediaEnabled) [
     qt5.qtmultimedia.bin
+    gst_all_1.gst-libav
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-vaapi
   ];
 
   propagatedBuildInputs = with pythonPackages; [

--- a/pkgs/by-name/pi/picard/package.nix
+++ b/pkgs/by-name/pi/picard/package.nix
@@ -31,7 +31,6 @@ pythonPackages.buildPythonApplication (finalAttrs: {
   nativeBuildInputs = [
     gettext
     qt5.wrapQtAppsHook
-    pythonPackages.pytestCheckHook
   ]
   ++ lib.optionals (pyqt5.multimediaEnabled) [
     gst_all_1.gst-libav
@@ -67,6 +66,9 @@ pythonPackages.buildPythonApplication (finalAttrs: {
     "--localedir=${placeholder "out"}/share/locale"
   ];
 
+  nativeCheckInputs = [
+    pythonPackages.pytestCheckHook
+  ];
   preCheck = ''
     export HOME=$(mktemp -d)
   '';

--- a/pkgs/by-name/pi/picard/package.nix
+++ b/pkgs/by-name/pi/picard/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   python312Packages,
   fetchFromGitHub,
 
@@ -40,27 +41,55 @@ pythonPackages.buildPythonApplication (finalAttrs: {
 
   buildInputs = [
     qt5.qtbase
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform qt5.qtwayland) [
     qt5.qtwayland
   ]
-  ++ lib.optionals (pyqt5.multimediaEnabled) [
-    qt5.qtmultimedia.bin
-    gst_all_1.gst-libav
-    gst_all_1.gst-plugins-base
-    gst_all_1.gst-plugins-good
-    gst_all_1.gst-vaapi
+  ++ lib.optionals (pyqt5.multimediaEnabled) (
+    [
+      qt5.qtmultimedia.bin
+      gst_all_1.gst-libav
+      gst_all_1.gst-plugins-base
+      gst_all_1.gst-plugins-good
+    ]
+    ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform gst_all_1.gst-vaapi) [
+      gst_all_1.gst-vaapi
+    ]
+  );
+
+  pythonRelaxDeps = lib.optionals stdenv.hostPlatform.isDarwin [
+    # Should be resolved in the next version
+    "pyobjc-core"
+    "pyobjc-framework-Cocoa"
   ];
 
-  propagatedBuildInputs = with pythonPackages; [
-    charset-normalizer
-    chromaprint
-    discid
-    fasteners
-    markdown
-    mutagen
-    pyjwt
-    pyqt5
-    python-dateutil
-    pyyaml
+  propagatedBuildInputs =
+    with pythonPackages;
+    [
+      charset-normalizer
+      chromaprint
+      discid
+      fasteners
+      markdown
+      mutagen
+      pyjwt
+      pyqt5
+      python-dateutil
+      pyyaml
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      pyobjc-core
+      pyobjc-framework-Cocoa
+    ];
+
+  # Not reporting any of these issues because the next upstream version will
+  # include many breaking changes and this might not be relevant.
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
+    "test/test_const_appdirs.py::AppPathsTest::test_cache_folder_macos" # - AssertionError: '/nix/var/nix/builds/nix-54642-966088698/.h[33 chars]card' ...
+    "test/test_const_appdirs.py::AppPathsTest::test_config_folder_macos" # - AssertionError: '/nix/var/nix/builds/nix-54642-966088698/.h[38 chars]card' ...
+    "test/test_const_appdirs.py::AppPathsTest::test_plugin_folder_macos" # - AssertionError: '/nix/var/nix/builds/nix-54642-966088698/.h[46 chars]gins' ...
+    "test/test_plugins.py" # Various PermissionError for /var/empty/Library - hopefully will be resolved in the next release.
+    "test/test_utils.py::HiddenFileTest::test_macos" # - FileNotFoundError: [Errno 2] No such file or directory: 'SetFile'
   ];
 
   setupPyGlobalFlags = [

--- a/pkgs/by-name/pi/picard/package.nix
+++ b/pkgs/by-name/pi/picard/package.nix
@@ -21,7 +21,7 @@ pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "picard";
   # nix-update --commit picard --version-regex 'release-(.*)'
   version = "2.13.3";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "metabrainz";
@@ -33,6 +33,7 @@ pythonPackages.buildPythonApplication (finalAttrs: {
   nativeBuildInputs = [
     gettext
     qt5.wrapQtAppsHook
+    pythonPackages.setuptools
   ]
   ++ lib.optionals (pyqt5.multimediaEnabled) [
     gst_all_1.gst-libav
@@ -51,6 +52,7 @@ pythonPackages.buildPythonApplication (finalAttrs: {
   ];
 
   propagatedBuildInputs = with pythonPackages; [
+    charset-normalizer
     chromaprint
     discid
     fasteners

--- a/pkgs/by-name/pi/picard/package.nix
+++ b/pkgs/by-name/pi/picard/package.nix
@@ -23,6 +23,7 @@ pythonPackages.buildPythonApplication (finalAttrs: {
   version = "2.13.3";
   pyproject = true;
   strictDeps = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "metabrainz";


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test