### PR TITLE
s2png: 0.7.2 -> 1.0.0, adopt

### DIFF
--- a/pkgs/by-name/s2/s2png/package.nix
+++ b/pkgs/by-name/s2/s2png/package.nix
@@ -1,38 +1,32 @@
 {
   lib,
-  stdenv,
+  rustPlatform,
   fetchFromGitHub,
-  diffutils,
-  gd,
-  pkg-config,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "s2png";
-  version = "0.7.2";
+  version = "1.0.0";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "dbohdan";
     repo = "s2png";
     rev = "v${finalAttrs.version}";
-    sha256 = "0y3crfm0jqprgxamlly713cka2x1bp6z63p1lw9wh4wc37kpira6";
+    sha256 = "sha256-BRVubGy5GpP0zhJ26DXBwlqflfZTnLVfhQk5qFj29x4=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [
-    diffutils
-    gd
-  ];
-  installFlags = [
-    "prefix="
-    "DESTDIR=$(out)"
-  ];
+  cargoHash = "sha256-aka4q3Wh0s1iaIUJkPuL/2FnJH5KdbpOOWLIAWirBFk=";
 
   meta = {
     homepage = "https://github.com/dbohdan/s2png/";
     description = "Store any data in PNG images";
     license = lib.licenses.gpl2Plus;
-    maintainers = [ lib.maintainers.dbohdan ];
+    maintainers = with lib.maintainers; [
+      dbohdan
+      kybe236
+    ];
     platforms = lib.platforms.unix;
     mainProgram = "s2png";
   };


### PR DESCRIPTION
Diff: https://github.com/dbohdan/s2png/compare/v0.7.2...v1.0.0
Changelogs:
> https://github.com/dbohdan/s2png/releases/tag/v1.0.0
> https://github.com/dbohdan/s2png/releases/tag/v0.11.1
> https://github.com/dbohdan/s2png/releases/tag/v0.11.0
> https://github.com/dbohdan/s2png/releases/tag/v0.10.0
> https://github.com/dbohdan/s2png/releases/tag/v0.9.0
> https://github.com/dbohdan/s2png/releases/tag/v0.8.0
> https://github.com/dbohdan/s2png/releases/tag/v0.7.3

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
