### PR TITLE
nixos/harmonia: fix for harmonia 3.1.0

### DIFF
--- a/nixos/modules/services/networking/harmonia.nix
+++ b/nixos/modules/services/networking/harmonia.nix
@@ -50,7 +50,7 @@ in
         signKeyPath = lib.mkOption {
           type = lib.types.nullOr lib.types.path;
           default = null;
-          description = "DEPRECATED: Use `services.harmonia-dev.cache.signKeyPaths` instead. Path to the signing key to use for signing the cache";
+          description = "DEPRECATED: Use `services.harmonia.cache.signKeyPaths` instead. Path to the signing key to use for signing the cache";
         };
 
         signKeyPaths = lib.mkOption {
@@ -109,31 +109,30 @@ in
         else
           [ ];
 
-      nix.settings.extra-allowed-users = [ "harmonia" ];
-      users.users.harmonia = {
-        isSystemUser = true;
-        group = "harmonia";
+      services.harmonia.cache.settings = builtins.mapAttrs (_: v: lib.mkDefault v) {
+        bind = "[::]:5000";
+        workers = 4;
+        max_connection_rate = 256;
+        priority = 50;
       };
-      users.groups.harmonia = { };
 
-      services.harmonia.cache.settings = builtins.mapAttrs (_: v: lib.mkDefault v) (
-        {
-          bind = "[::]:5000";
-          workers = 4;
-          max_connection_rate = 256;
-          priority = 50;
-        }
-        // lib.optionalAttrs daemonCfg.enable {
-          daemon_socket = daemonCfg.socketPath;
-        }
-      );
+      # Socket activation lets the service run with PrivateNetwork; the
+      # inherited fd keeps referring to the host netns.
+      systemd.sockets.harmonia = {
+        description = "harmonia binary cache socket";
+        wantedBy = [ "sockets.target" ];
+        socketConfig.ListenStream =
+          let
+            b = cacheCfg.settings.bind;
+          in
+          if lib.hasPrefix "unix:" b then lib.removePrefix "//" (lib.removePrefix "unix:" b) else b;
+      };
 
       systemd.services.harmonia = {
         description = "harmonia binary cache service";
 
-        requires = if daemonCfg.enable then [ "harmonia-daemon.service" ] else [ "nix-daemon.socket" ];
-        after = [ "network.target" ] ++ lib.optional daemonCfg.enable "harmonia-daemon.service";
-        wantedBy = [ "multi-user.target" ];
+        requires = [ "harmonia.socket" ];
+        after = [ "harmonia.socket" ];
 
         environment = {
           CONFIG_FILE = format.generate "harmonia.toml" cacheCfg.settings;
@@ -150,6 +149,9 @@ in
           ExecStart = lib.getExe cfg.package;
           User = "harmonia";
           Group = "harmonia";
+          DynamicUser = true;
+          Type = "notify";
+          WatchdogSec = 15;
           Restart = "on-failure";
           PrivateUsers = true;
           DeviceAllow = [ "" ];
@@ -174,7 +176,12 @@ in
           ProtectProc = "invisible";
           RestrictNamespaces = true;
           SystemCallArchitectures = "native";
-          PrivateNetwork = false;
+
+          # accept(2) on the inherited fd is exempt from both restrictions.
+          PrivateNetwork = true;
+          RestrictAddressFamilies = [ "AF_UNIX" ];
+          IPAddressDeny = "any";
+
           PrivateTmp = true;
           PrivateDevices = true;
           PrivateMounts = true;
@@ -182,7 +189,6 @@ in
           ProtectSystem = "strict";
           ProtectHome = true;
           LockPersonality = true;
-          RestrictAddressFamilies = "AF_UNIX AF_INET AF_INET6";
           LimitNOFILE = 65536;
         };
       };


### PR DESCRIPTION
this mostly just copies the upstream module at https://github.com/nix-community/harmonia/blob/harmonia-v3.1.0/nix/module.nix

tested and works for my instance of harmonia on https://cache.zitrone.net

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
