### PR TITLE
home-assistant-custom-components.ecoflow_ble: init at 0.8.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11504,6 +11504,13 @@
     name = "Noah Fontes";
     keys = [ { fingerprint = "F5B2 BE1B 9AAD 98FE 2916  5597 3665 FFF7 9D38 7BAA"; } ];
   };
+  implr = {
+    email = "bartoszstebel@gmail.com";
+    matrix = "@implr:hackerspace.pl";
+    github = "implr";
+    githubId = 2821175;
+    name = "Bartosz Stebel";
+  };
   imrying = {
     email = "philiprying@gmail.com";
     github = "imrying";

--- a/pkgs/servers/home-assistant/custom-components/ecoflow_ble/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/ecoflow_ble/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  bleak,
+  bleak-retry-connector,
+  crc,
+  ecdsa,
+  jsonpath-ng,
+  protobuf6,
+  pycryptodome,
+  pytestCheckHook,
+  pytest-asyncio,
+  pytest-mock,
+  nix-update-script,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "rabits";
+  domain = "ef_ble";
+  version = "0.8.5";
+
+  src = fetchFromGitHub {
+    owner = "rabits";
+    repo = "ha-ef-ble";
+    tag = "v${version}";
+    hash = "sha256-hqwsoG8BkB16zR5MX3NNltEQAZR0ZhVFNXSqDsvep+0=";
+  };
+
+  dependencies = [
+    bleak
+    bleak-retry-connector
+    ecdsa
+    crc
+    protobuf6
+    pycryptodome
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    pytest-mock
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/rabits/ha-ef-ble/releases/tag/v${version}";
+    description = "Home Assistant component for EcoFlow BLE devices (local)";
+    homepage = "https://github.com/rabits/ha-ef-ble";
+    maintainers = with lib.maintainers; [ implr ];
+    license = lib.licenses.asl20;
+  };
+}


### PR DESCRIPTION
New package for https://github.com/rabits/ha-ef-ble. Works offline as opposed to ecoflow_cloud which we already have.

Also add maintainer entry for myself.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
