### PR TITLE
maintainers: drop HaoZeke

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10437,13 +10437,6 @@
     githubId = 9850776;
     name = "Hans-Jörg Schurr";
   };
-  HaoZeke = {
-    email = "r95g10@gmail.com";
-    github = "HaoZeke";
-    githubId = 4336207;
-    name = "Rohit Goswami";
-    keys = [ { fingerprint = "74B1 F67D 8E43 A94A 7554  0768 9CCC E364 02CB 49A6"; } ];
-  };
   happy-river = {
     email = "happyriver93@runbox.com";
     github = "happy-river";

--- a/pkgs/by-name/co/conan/package.nix
+++ b/pkgs/by-name/co/conan/package.nix
@@ -133,7 +133,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     homepage = "https://conan.io";
     changelog = "https://github.com/conan-io/conan/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ HaoZeke ];
+    maintainers = [ ];
     mainProgram = "conan";
   };
 })

--- a/pkgs/by-name/d-/d-seams/package.nix
+++ b/pkgs/by-name/d-/d-seams/package.nix
@@ -71,6 +71,6 @@ clangStdenv.mkDerivation rec {
     homepage = "https://dseams.info";
     license = lib.licenses.gpl3Plus;
     platforms = [ "x86_64-linux" ];
-    maintainers = [ lib.maintainers.HaoZeke ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ra/rang/package.nix
+++ b/pkgs/by-name/ra/rang/package.nix
@@ -27,6 +27,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Minimal, Header only Modern c++ library for terminal goodies";
     homepage = "https://agauniyal.github.io/rang/";
     license = lib.licenses.unlicense;
-    maintainers = [ lib.maintainers.HaoZeke ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/development/python-modules/patch-ng/default.nix
+++ b/pkgs/development/python-modules/patch-ng/default.nix
@@ -18,6 +18,6 @@ buildPythonPackage rec {
     description = "Library to parse and apply unified diffs";
     homepage = "https://github.com/conan-io/python-patch";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ HaoZeke ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
No [comments](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+commenter%3AHaoZeke) since April 2025 despite 10 [review requests](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+created%3A%3E%3D2025-05-01+user-review-requested%3AHaoZeke). Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/33954594ec46166510795930ba8ebf0856249d4e/maintainers/README.md#losing-maintainer-status).

@HaoZeke if you object to being dropped please respond saying so within a week. Even if you don't make it, you are of course welcome back whenever you would like!


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
