### PR TITLE
alerta: migrate to pyproject

### DIFF
--- a/pkgs/by-name/al/alerta/package.nix
+++ b/pkgs/by-name/al/alerta/package.nix
@@ -7,14 +7,16 @@
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "alerta";
   version = "8.5.3";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
     hash = "sha256-ePvT2icsgv+io5aDDUr1Zhfodm4wlqh/iqXtNkFhS10=";
   };
 
-  propagatedBuildInputs = with python3.pkgs; [
+  build-system = with python3.pkgs; [ setuptools ];
+
+  dependencies = with python3.pkgs; [
     six
     click
     requests

--- a/pkgs/by-name/al/alerta/package.nix
+++ b/pkgs/by-name/al/alerta/package.nix
@@ -24,7 +24,17 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     tabulate
   ];
 
-  doCheck = false;
+  doCheck = true;
+
+  pythonImportsCheck = [ "alertaclient" ];
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytestCheckHook
+    requests-mock
+  ];
+
+  # AlertTestCases attempt to connect to alerta api
+  disabledTests = [ "AlertTestCase" ];
 
   meta = {
     homepage = "https://alerta.io";

--- a/pkgs/by-name/al/alerta/package.nix
+++ b/pkgs/by-name/al/alerta/package.nix
@@ -17,7 +17,6 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   build-system = with python3.pkgs; [ setuptools ];
 
   dependencies = with python3.pkgs; [
-    six
     click
     requests
     requests-hawk


### PR DESCRIPTION
- #515974
- enable tests as there are provided in the wheel (only unittests)
- remove `six`:
	```
    install_requires=[
        'Click',
        'requests',
        'requests_hawk',
        'tabulate',
        'pytz'
    ],
	```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
