### PR TITLE
python3Packages.yamllint: 1.37.1 -> 1.38.0

### DIFF
--- a/pkgs/development/python-modules/yamllint/default.nix
+++ b/pkgs/development/python-modules/yamllint/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "yamllint";
-  version = "1.37.1";
+  version = "1.38.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "adrienverge";
     repo = "yamllint";
     tag = "v${version}";
-    hash = "sha256-CohqiBoQcgvGVP0Bt6U768BY1aIwh59YRsgzJfaDmP0=";
+    hash = "sha256-4H8tbn2TRzTGIXmP9Hnmc93rGSLsWh5A5R9KAIz0mKM=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Release: https://github.com/adrienverge/yamllint/releases/tag/v1.38.0
Diff: https://github.com/adrienverge/yamllint/compare/v1.37.1...v1.38.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 49 packages built:</summary>
  <ul>
    <li>ansible (python313Packages.ansible-core)</li>
    <li>ansible-doctor</li>
    <li>ansible-lint</li>
    <li>ansible-navigator</li>
    <li>bbot</li>
    <li>chart-testing</li>
    <li>fdroidserver</li>
    <li>molecule (python313Packages.molecule)</li>
    <li>napalm</li>
    <li>peering-manager</li>
    <li>pyinfra (python313Packages.pyinfra)</li>
    <li>python313Packages.ansible</li>
    <li>python313Packages.ansible-compat</li>
    <li>python313Packages.ansible-kernel</li>
    <li>python313Packages.ansible-runner</li>
    <li>python313Packages.ansible-vault-rw</li>
    <li>python313Packages.dynaconf</li>
    <li>python313Packages.junos-eznc</li>
    <li>python313Packages.napalm</li>
    <li>python313Packages.napalm-hp-procurve</li>
    <li>python313Packages.napalm-ros</li>
    <li>python313Packages.netbox-napalm-plugin</li>
    <li>python313Packages.netmiko</li>
    <li>python313Packages.ntc-templates</li>
    <li>python313Packages.pytest-ansible</li>
    <li>python313Packages.pytest-testinfra</li>
    <li>ttp (python313Packages.ttp)</li>
    <li>yamllint (python313Packages.yamllint)</li>
    <li>python314Packages.ansible</li>
    <li>python314Packages.ansible-compat</li>
    <li>python314Packages.ansible-core</li>
    <li>python314Packages.ansible-kernel</li>
    <li>python314Packages.ansible-runner</li>
    <li>python314Packages.ansible-vault-rw</li>
    <li>python314Packages.dynaconf</li>
    <li>python314Packages.junos-eznc</li>
    <li>python314Packages.molecule</li>
    <li>python314Packages.napalm</li>
    <li>python314Packages.napalm-hp-procurve</li>
    <li>python314Packages.napalm-ros</li>
    <li>python314Packages.netmiko</li>
    <li>python314Packages.ntc-templates</li>
    <li>python314Packages.pyinfra</li>
    <li>python314Packages.pytest-ansible</li>
    <li>python314Packages.pytest-testinfra</li>
    <li>python314Packages.ttp</li>
    <li>python314Packages.yamllint</li>
    <li>scap-security-guide</li>
    <li>ubootPythonTools.binman</li>
  </ul>
</details>


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
