### PR TITLE
python3Packages.insteon-frontend-home-assistant: 0.6.1 -> 0.6.2

### DIFF
--- a/pkgs/development/python-modules/insteon-frontend-home-assistant/default.nix
+++ b/pkgs/development/python-modules/insteon-frontend-home-assistant/default.nix
@@ -7,13 +7,13 @@
 
 buildPythonPackage rec {
   pname = "insteon-frontend-home-assistant";
-  version = "0.6.1";
+  version = "0.6.2";
   pyproject = true;
 
   src = fetchPypi {
     pname = "insteon_frontend_home_assistant";
     inherit version;
-    hash = "sha256-r6xXEZFAGgXByl+urpXfzhuCedBPjqkwT8Q0sEHQA2w=";
+    hash = "sha256-p5hL8LE8h/4ytHft/v23uzv7YwR9UBDVru8n7WeY99Q=";
   };
 
   nativeBuildInputs = [ setuptools ];


### PR DESCRIPTION
Changelog: https://github.com/pyinsteon/insteon-panel/releases/tag/0.6.2

<details>
<summary>
I tried to build from source as suggested in #471179 but the build hung forever.
cc @mweinelt
</summary>

```diff
diff --git a/pkgs/development/python-modules/insteon-frontend-home-assistant/default.nix b/pkgs/development/python-modules/insteon-frontend-home-assistant/default.nix
index c466b2a2ee58..d4e299598e9b 100644
--- a/pkgs/development/python-modules/insteon-frontend-home-assistant/default.nix
+++ b/pkgs/development/python-modules/insteon-frontend-home-assistant/default.nix
@@ -1,8 +1,10 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
+  nodejs,
   setuptools,
+  yarn-berry_4,
 }:
 
 buildPythonPackage rec {
@@ -10,13 +12,27 @@ buildPythonPackage rec {
   version = "0.6.1";
   pyproject = true;
 
-  src = fetchPypi {
-    pname = "insteon_frontend_home_assistant";
-    inherit version;
-    hash = "sha256-r6xXEZFAGgXByl+urpXfzhuCedBPjqkwT8Q0sEHQA2w=";
+  src = fetchFromGitHub {
+    owner = "pyinsteon";
+    repo = "insteon-panel";
+    tag = version;
+    fetchSubmodules = true;
+    hash = "sha256-F3Srs3Xx533ck3OaFLsWypkVHaBInrZPXYlYFInBulE=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  missingHashes = ./missing-hashes.json;
+
+  yarnOfflineCache = yarn-berry_4.fetchYarnBerryDeps {
+    inherit src missingHashes;
+    hash = "sha256-d/Agq5ZRF9h61iwcjxVMggForaIdMqpC54nSwrErkrU=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    yarn-berry_4.yarnBerryConfigHook
+  ];
+
+  build-system = [ setuptools ];
 
   # upstream has no tests
   doCheck = false;
diff --git a/pkgs/development/python-modules/insteon-frontend-home-assistant/missing-hashes.json b/pkgs/development/python-modules/insteon-frontend-home-assistant/missing-hashes.json
new file mode 100644
index 000000000000..2254dd650c51
--- /dev/null
+++ b/pkgs/development/python-modules/insteon-frontend-home-assistant/missing-hashes.json
@@ -0,0 +1,60 @@
+{
+  "@esbuild/aix-ppc64@npm:0.27.2": "9c18cc2e4a03339a55013aac05b4a3fc4b77e75715dc252d034aa3d43b754abc053a7601b95e31249f4b6e69b68db2f5e6cb04b0ed619f825f2f70daff1a78d7",
+  "@esbuild/android-arm64@npm:0.27.2": "a318fc9ffcdad7fda8bb521af8b17f73d93d9a94b4cca9301fbf72cf3f5a6e945edd589a47388de70f3e9582655dcf5b5bb928a11e306368fae4a9106d5143d2",
+  "@esbuild/android-arm@npm:0.27.2": "01114275e096b9177ad2496730087ee081d6e65a75bc087457b527c5baac5a8ccb362435f45232532bf6f97de95e1790dbce127d55abd5e4152c7214682bf4d3",
+  "@esbuild/android-x64@npm:0.27.2": "e92c5b6919081a14c8882f1167cf90b4e4bba745ad6e9a23428f85a1cd5e79dfa3f1d2fc943686b237e4cd09fac52ad3b3791deab6a0419ee10859284d3834aa",
+  "@esbuild/darwin-arm64@npm:0.27.2": "5e99db5037167bad4a095fc445b94a2ce02357870ed58b79e13ae6bc09b5cb33d7e03f925492df940f9e0ad685a889f02beec1431d8fbf4c7ced55b2f48f5659",
+  "@esbuild/darwin-x64@npm:0.27.2": "87f2fbc4cf11724ef805b17cbdc7b0a9498332bc4b61d55e110ecc3b09bc488b88c0bd140ea48924e9c97a2063cf7e440fef13dd56e415c46799619d61086910",
+  "@esbuild/freebsd-arm64@npm:0.27.2": "1ffa23243b913e377a5b09fd97ad9f089be3695aafdd893b60bb7f9be479256d8b7546f0bc96c4e61133fe7aeeaf95a8e941e82a65d99008ff82c99bdec85eee",
+  "@esbuild/freebsd-x64@npm:0.27.2": "44f744b289cf9e115b0adfac1905818d756dfced14213bf144d9016d96f67575ef2a55526f76e29ee775fcfec7274ba3a5e6833f35ed79a4592d3f5eac278267",
+  "@esbuild/linux-arm64@npm:0.27.2": "2b037d74eaff4e9b5a6076760ede873320707636a3495939687cdd0c2c7150883111273bc0a8663fa305c42f439f4748b5ad7f15a1a1ea9fa7db575d9faf2d1b",
+  "@esbuild/linux-arm@npm:0.27.2": "28cfc3a9ca11fc899649e7a706fb4b2ee57999bd92e86c23726b3ed0f832732411dd0aa3e2bcdb4105759f83bc4e5adc98dc195aaafce736c910db4e43694702",
+  "@esbuild/linux-ia32@npm:0.27.2": "ac6cc92b9be2ec6d9d483c53fc973e6381765b784a2e1b71fa93ea0cf976344c2e3e0bfda0140b0829b3ec4304d9b886692b2891e68c17d2121066d06e67f0ac",
+  "@esbuild/linux-loong64@npm:0.27.2": "625f5b6c2218a3acb2cff8f7f02a53ca89d13925f8932260ddad01595c6907beda4a79e4b767b1101f5971049f88d3ec6ab29cf565b4d61d9b0d7277e2cb578d",
+  "@esbuild/linux-mips64el@npm:0.27.2": "0c62692cb3a297b37212dfde52a861861843a716f6b3bdb73da49ba249a4c001b989ea61dc4540c430fac59ce2f8fc45035cdfac80172c5ddaf1b9df8471aecf",
+  "@esbuild/linux-ppc64@npm:0.27.2": "b804d2dd0a6a85fe1c731828c725731a55ab120d2cc16941d560b2e9af5c2ec51586914ce26a84a326a9d46fa61eb8bb1f843953fe29ddd43b3f3099c491b5ff",
+  "@esbuild/linux-riscv64@npm:0.27.2": "03e67e7207a83801363e3637f9a35fb6224ed4dc23bbf6eca41904fc42f5a6806e1e591666bf48dbf62eba97d41ff4355413b14dcb2339007b22c693374c49f6",
+  "@esbuild/linux-s390x@npm:0.27.2": "eb24b9c0a4a1492e4ff34a87933f6a3b348739c12f864b408144efdf949871c1fbb02a1cca741bfa11fd08aebe585d046fd3311b462ce4c795e3064ba3912469",
+  "@esbuild/linux-x64@npm:0.27.2": "ed1542f203329521fb1f308696c76ba59ed4a4616a24e21bf4820685362bba209d5c44c2f4e66c88dc7b7399df9ace625454d4829ee529d076ccaf61566e11cf",
+  "@esbuild/netbsd-arm64@npm:0.27.2": "576dd082047077b9cc41fbeffd728821a4f3b80969c1d2d6c274301122c6de2050f484fd4e946777527b8a15bd2a5ac54f85ca7ab95ea72b5345177e6a888687",
+  "@esbuild/netbsd-x64@npm:0.27.2": "f8994af3e2ff3c9a91e874e58698b66e6f8d4e72dbc0aaf749b74a79420954146ed053359b0a4c213918582cee187d8a371737a33cfb93e624b4d091e5a6c240",
+  "@esbuild/openbsd-arm64@npm:0.27.2": "f710da24beeb747ef3a11b9d99085a14f5c929f942fd9d9a05b7806d5ff1b85631bfa506eb7a6aed9fd01ec99bf91f24736f9f0e0eb6b7c0019fe0dddd2e615c",
+  "@esbuild/openbsd-x64@npm:0.27.2": "62670fbe1f609c5362df7b45968ded512a0860e2ad8a4715a89993abfa2f9f08a28f1294c7857d80e6d3f713639a71d291c06a961b331de67ad350032d1b8e96",
+  "@esbuild/openharmony-arm64@npm:0.27.2": "e279efdc18301add96ea791ba9ef117cae05346688cd521fd225a60ad166add4bc995af985058e3b6ab9e65a7c49a79108a294d6aa26a1d1685ad0db194e2c56",
+  "@esbuild/sunos-x64@npm:0.27.2": "7234302321d36576b5a9f027915417cddc195a67b19cdfb50e69c337ee0dd63a88be6b72d7ef299cd569d1af62e54774303d52d3d6b5e5858db975241ae467d6",
+  "@esbuild/win32-arm64@npm:0.27.2": "36620fddf79da3e8e527ef8331436929fa7a0b23c9b591af8f8573d80ed9c4ef45b24c6fa0abbb01d187dec497efa6c9d9d397d575afc1f28477e9ca16a48d73",
+  "@esbuild/win32-ia32@npm:0.27.2": "96e8c1fa0ec2b5529ead2ba703e5da7644c138b2f9b6e285c05513f0455e99b2b0dcf399f01779fb384e22810e82f892491e44402772c62d3fe094b025bbdc0f",
+  "@esbuild/win32-x64@npm:0.27.2": "1ed08bebd916c16003f3784276ae683ab41d34951a0c272f6e072b8067a2b4bacd6f6f75a8dcea375b8545e15891d305425cf7c8dd31f7deab56ef22cde4a1e2",
+  "@rollup/rollup-android-arm-eabi@npm:4.52.3": "f0d0db95d55c655e1fbb995130b37c6c6d882fc993d9c9cc6129245164c7ddb9128a8d301415421600fb2885c285abee140d67253b1df6dc8c4d2665bad165b5",
+  "@rollup/rollup-android-arm64@npm:4.52.3": "240e99e6cf7f156ec8432c611c6b208fa19fad3c3774bc100c87ebad1a6439158f495bc2413b92ac8229bd2ab3535ddc7dcb428f4e883b9ce98196e6add3619c",
+  "@rollup/rollup-darwin-arm64@npm:4.52.3": "96b89a37746837ca62679844464247c91c29cc2a2da7ce1f1d5af5fbaeb3e5ae4a8fb7d54d64a83deb8a235b0e50303add5fa010bb5e7af675e17e2f8268ff6d",
+  "@rollup/rollup-darwin-x64@npm:4.52.3": "b5846633e535590718a0e11cfa6f5bb5d6c7532469f84c0dd323bb175dc115dffa9a5064c0b3598670dd25b72a930d52a50ad598e8494ba79069b9f34b31174b",
+  "@rollup/rollup-freebsd-arm64@npm:4.52.3": "b8fb013278fbc155a47fe878c9351499a5df4630da5cf52b6d183d32b74fed38b14eb6adebabdd9ec60ca16574f974307d2cff6ad7db89d7383bf6f418540a72",
+  "@rollup/rollup-freebsd-x64@npm:4.52.3": "384a263192a68a534bb91b88d65e5f64f2ca5e7b5064be2f0f8bbb7959832d78dfa003e657c429a0a6d2641db9d0321396c27d5db884a137556caadcff90b642",
+  "@rollup/rollup-linux-arm-gnueabihf@npm:4.52.3": "aafda5bc3df250030f5e6727b2d61d6bf589a1383f45d1906317b5ec39563a36dda20bc96a5ceda2ae88372f4c45d52f4eee976f675a88f94825c1516c2e2493",
+  "@rollup/rollup-linux-arm-musleabihf@npm:4.52.3": "122368b9e3184d78d12ff671545fa519f7ccb8b6b93137e107fe837c65e3204974418e007b90136499f8d2a067bd07744c84d6eb8bfcdb99ef698e7ad1e28d41",
+  "@rollup/rollup-linux-arm64-gnu@npm:4.52.3": "8439dae60c2da444a5a37764da5cd611da9acbc7ce23d96d68ede7d6c94a080430c698b8c24c2ce22c137917ac9db0d76478e3e711bc1bd0dae859730320bd3f",
+  "@rollup/rollup-linux-arm64-musl@npm:4.52.3": "e651512d6d689a7b487786ac0abfe58a6ad5c56a429c4c2ed01d3fb6211ed1d8c51eb384ba67fbf77acf19d580e0feec685a784f39447a21e5051d2525102b45",
+  "@rollup/rollup-linux-loong64-gnu@npm:4.52.3": "5e41b00328453212f5c63a3324e2b46eb76ccddffb9a23bf5950d314fd1ff7618a065bd912fb1992cbe8109afa81eff8c2d81e19a09fe72da6866350f0b3c96c",
+  "@rollup/rollup-linux-ppc64-gnu@npm:4.52.3": "5c8909719bc66e5ecabf20916ad7a4573a8942ec2e574eb413842f107a510bac633f61bd90e4c0b1d475b6426caaca60aac5a26d0656189b7f17a053eeb3a037",
+  "@rollup/rollup-linux-riscv64-gnu@npm:4.52.3": "d42ae7ff36e05e596212565f36423bd095cdd2f88502b606a3c9d31b309424ece1d2b6186098205c9b53dc8e58c9c83a2dd25166b9af7c6055c2061d1de5848f",
+  "@rollup/rollup-linux-riscv64-musl@npm:4.52.3": "1c99e576cb025952f43defdeea53e84114beab4dec68c4c53879b17c2209d196a080fba951823fa6b3350553bd72cd2a7f0f567d70bb46a8f2efafdd0493615d",
+  "@rollup/rollup-linux-s390x-gnu@npm:4.52.3": "2df10aeeb9771b5153a88ceefa4d1585489152825d8c8cc9e42cbf03fc51c4fc7424c6d9c2289609337ce19c4b9e63eb2bc84cb7415fb2ee35a4fe474ff73f40",
+  "@rollup/rollup-linux-x64-gnu@npm:4.52.3": "20e30b2c697b1a2a9dd22df2d48c8bb04108049f0594ebf72b56c650f2deeb9a1c2c254b94a73e2a48b80ed8a78ce10ad551731444d3a58f75de2fc0c97ee0c5",
+  "@rollup/rollup-linux-x64-musl@npm:4.52.3": "c9bb76b6928ed67b909fa0d2a6c8a630d3a2467533dec36f074926d598c679d05ae60aa31f0623586308b586ec7416d2e2e148697c259c10ee4d6f687a39d55c",
+  "@rollup/rollup-openharmony-arm64@npm:4.52.3": "189bbc62a733a585885bd099efb45799c4962750a89aa4491e33205c3d0013a1d5ed1a03cd8a97cb9c3c8aa59259aea2f3ab9f48b37d6e451d7182d5adc916f0",
+  "@rollup/rollup-win32-arm64-msvc@npm:4.52.3": "2f78ce0be008e6ae572fc92ec03671f095caed89c658b3849eeb4a21e9acbba6d818a22d626eb3c0a15c3621cd7a6bb22f227e8bf6cdd607c3d99725ecddf39b",
+  "@rollup/rollup-win32-ia32-msvc@npm:4.52.3": "43d638f552a2302ab0ed004884887d117f474e2b8e5b23e55dadbc49eeb68739111a0e1f98d8f895d280f26e581c6de109ee371b8e258506900691ed768f686e",
+  "@rollup/rollup-win32-x64-gnu@npm:4.52.3": "06f664b200330d25d3380d6c8b7f920e7a8da4c8614011c1474d51cfb76b14b25e6b62fb3c645188e283c3ab1ef4d1843950c3760ea5c1e1e647f397ee05cef5",
+  "@rollup/rollup-win32-x64-msvc@npm:4.52.3": "a50854481d03b4d4914e544bd4c2dbdc6931ca7acc491522a3eff5b2884c2db61f8309eaf5fefe50f391b0f072eeef0fbc3c2fa20e8b609aead9fc586ddc75c5",
+  "@rspack/binding-darwin-arm64@npm:1.6.4": "193222dc2c221cb50e8aed3c21594787c0cdfac9c3290ed20c43ededfd9fa960ba9f9f1d9d8956a9722757108e8a37a6d032b8b76e5fc0c549dbecbc4b283d4d",
+  "@rspack/binding-darwin-x64@npm:1.6.4": "41e38a58e183470e2bfb761284e59f57d1d005aa6ba14b86d75ea345bce73e45fc93047d736dc65e028050469a059560633a55f2f18a1505dc1b1b09eb6bf30c",
+  "@rspack/binding-linux-arm64-gnu@npm:1.6.4": "dc60f5a226e3244aa93fa8dd9eb69058850ba83d5b9024d147744a06670e19e81872b70301734e44f3dc1fdb61238e9ba9fb2c94e8cb63c5e715e7e8a873f0fb",
+  "@rspack/binding-linux-arm64-musl@npm:1.6.4": "b9a5219dcf9fc2a9d0b422627f0bfb780c856cefa93ae185ee94bf683585ec7e690b8f483dcb00ff61b812bb59b1b5816b6ea21ffa94ad6586040f5589f46dea",
+  "@rspack/binding-linux-x64-gnu@npm:1.6.4": "c2433dea78a0438b66d33ec830a290ba39d35848ea98b97d662e6fd54048a72e8783c923f71014bcd731d826e62dc3287f91789f9ac1e93bb7816a6274790082",
+  "@rspack/binding-linux-x64-musl@npm:1.6.4": "f7e9b238b7527e0c002ccec5ae6c23dbc3cf8418f3a7e4143ac09c4ca6fc2ce34a113c8f14ab33cd5936959dd5668381f8befe1acadbcadc612d0cde11caf6a1",
+  "@rspack/binding-wasm32-wasi@npm:1.6.4": "267ccc109079a44ee4f5b8dfea9ba32309b020e71e6528c0817597b1261d2f081de5f2828776cb5cfc02ab0753947ab60a76591b462ad8e59076291a23e32bfa",
+  "@rspack/binding-win32-arm64-msvc@npm:1.6.4": "2e2749ee9500c0f6e2ad1c0a8601dc9e12cef2636c5b0069a4d2fcc67c30831422350ba33952e8e448abae33f8964eafdfaeb75cc6e45b7b9b63c425a6ff723b",
+  "@rspack/binding-win32-ia32-msvc@npm:1.6.4": "02e5a5b15acc6703513e27348fbf6c69130a583fa93b40bafbf03e6a5a632b643eb699386e7ba46ddf8959aeccd8636937a6bf1cc9a459ebacb29796c423c00d",
+  "@rspack/binding-win32-x64-msvc@npm:1.6.4": "62c6dc8cd42c808ac0f9cce6194ea7ec3eb82e4f843a8a24eda77cc5ffff0b5a66a5f969c2dec9fcad209dfc27f114b5e519570f4244762676b491992b74aa28"
+}
```
</details>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
