### PR TITLE
treewide: change `format = "pyproject"/"other";` to `pyproject = true/false;`

### DIFF
--- a/pkgs/by-name/de/devede/package.nix
+++ b/pkgs/by-name/de/devede/package.nix
@@ -11,7 +11,6 @@
   wrapGAppsHook3,
   gdk-pixbuf,
   gobject-introspection,
-  nix-update-script,
 }:
 
 let
@@ -28,7 +27,7 @@ in
 buildPythonApplication (finalAttrs: {
   pname = "devede";
   version = "4.21.3.1";
-  format = "pyproject";
+  pyproject = true;
   namePrefix = "";
 
   src = fetchFromGitLab {

--- a/pkgs/by-name/je/jello-lang/package.nix
+++ b/pkgs/by-name/je/jello-lang/package.nix
@@ -10,7 +10,7 @@
 python3Packages.buildPythonApplication {
   pname = "jello-lang";
   version = "0-unstable-2025-01-07";
-  format = "pyproject";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "codereport";

--- a/pkgs/by-name/je/jellyfish/package.nix
+++ b/pkgs/by-name/je/jellyfish/package.nix
@@ -8,7 +8,7 @@
 python3Packages.buildPythonApplication {
   pname = "jellyfish";
   version = "0-unstable-2024-05-27";
-  format = "pyproject";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "codereport";

--- a/pkgs/by-name/ne/neuron/package.nix
+++ b/pkgs/by-name/ne/neuron/package.nix
@@ -28,8 +28,8 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "neuron";
   version = "8.2.7";
 
-  # format is for pythonModule conversion
-  format = "other";
+  # pyproject is for pythonModule conversion
+  pyproject = false;
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/development/python-modules/aliyun-python-sdk-alimt/default.nix
+++ b/pkgs/development/python-modules/aliyun-python-sdk-alimt/default.nix
@@ -9,7 +9,7 @@
 buildPythonPackage rec {
   pname = "aliyun-python-sdk-alimt";
   version = "3.2.0";
-  format = "pyproject";
+  pyproject = true;
 
   # Upstream doesn't tag releases on Github
   # https://github.com/aliyun/aliyun-openapi-python-sdk/issues/551

--- a/pkgs/development/python-modules/flask-sqlalchemy/default.nix
+++ b/pkgs/development/python-modules/flask-sqlalchemy/default.nix
@@ -14,7 +14,7 @@
 buildPythonPackage rec {
   pname = "flask-sqlalchemy";
   version = "3.1.1";
-  format = "pyproject";
+  pyproject = true;
 
   src = fetchPypi {
     pname = "flask_sqlalchemy";

--- a/pkgs/development/python-modules/issubclass/default.nix
+++ b/pkgs/development/python-modules/issubclass/default.nix
@@ -8,7 +8,7 @@
 buildPythonPackage rec {
   pname = "issubclass";
   version = "0.1.2";
-  format = "pyproject";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "zmievsa";

--- a/pkgs/development/python-modules/retryhttp/default.nix
+++ b/pkgs/development/python-modules/retryhttp/default.nix
@@ -16,7 +16,7 @@
 buildPythonPackage rec {
   pname = "retryhttp";
   version = "1.3.1";
-  format = "pyproject";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "austind";

--- a/pkgs/development/python-modules/svcs/default.nix
+++ b/pkgs/development/python-modules/svcs/default.nix
@@ -23,7 +23,7 @@
 buildPythonPackage rec {
   pname = "svcs";
   version = "25.1.0";
-  format = "pyproject";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "hynek";


### PR DESCRIPTION
Baby sibling of #479499.

Part of #515974.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
