### PR TITLE
buildkite-agent: 3.121.0 -> 3.124.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4579,6 +4579,12 @@
     githubId = 9086315;
     name = "Connor Brewster";
   };
+  cbrxyz = {
+    email = "me@cbrxyz.com";
+    github = "cbrxyz";
+    githubId = 52760912;
+    name = "Cameron Brown";
+  };
   ccellado = {
     email = "annplague@gmail.com";
     github = "ccellado";

--- a/pkgs/by-name/bu/buildkite-agent/package.nix
+++ b/pkgs/by-name/bu/buildkite-agent/package.nix
@@ -14,16 +14,16 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "buildkite-agent";
-  version = "3.121.0";
+  version = "3.124.0";
 
   src = fetchFromGitHub {
     owner = "buildkite";
     repo = "agent";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-QlslPoLpqzuX05bp58xz/3Vhj0imEqCleO1hhe1PPXM=";
+    hash = "sha256-HdTMsCBvd3vN/OkpBpiJ7dXq50PXx165NWmKGGpikUQ=";
   };
 
-  vendorHash = "sha256-rv5CqNpjmXhGcZ3KQBX0Z2428upWBUVkdRjEG4QWEoY=";
+  vendorHash = "sha256-VE7YEBIrkDG1ERGXnib0LPjBWcrepGAqwY5yKzSQ6wg=";
 
   postPatch = ''
     substituteInPlace clicommand/agent_start.go --replace /bin/bash ${bash}/bin/bash

--- a/pkgs/by-name/bu/buildkite-agent/package.nix
+++ b/pkgs/by-name/bu/buildkite-agent/package.nix
@@ -80,6 +80,7 @@ buildGoModule (finalAttrs: {
       zimbatm
       jsoo1
       techknowlogick
+      cbrxyz
     ];
     platforms = with lib.platforms; unix ++ darwin;
   };

--- a/pkgs/by-name/bu/buildkite-agent/package.nix
+++ b/pkgs/by-name/bu/buildkite-agent/package.nix
@@ -59,9 +59,6 @@ buildGoModule (finalAttrs: {
 
   passthru = {
     tests.smoke-test = nixosTests.buildkite-agents;
-    updateScript = gitUpdater {
-      rev-prefix = "v";
-    };
   };
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Release: https://github.com/buildkite/agent/releases/tag/v3.124.0
Diff: https://github.com/buildkite/agent/compare/v3.121.1...v3.124.0

This PR also adds me as a maintainer so I can better help with supporting this package (previous update to this package was made by me: #505717)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

---

## `nixpkgs-review` result for [#515983](https://github.com/NixOS/nixpkgs/pull/515983)

Generated using [`nixpkgs-review-gha`](https://github.com/Defelo/nixpkgs-review-gha)

Command: `nixpkgs-review pr 515983`
Commit: [`a49877d00fb070260cd0f6962fbe6175c218834e`](https://github.com/NixOS/nixpkgs/commit/a49877d00fb070260cd0f6962fbe6175c218834e) ([subsequent changes](https://github.com/NixOS/nixpkgs/compare/a49877d00fb070260cd0f6962fbe6175c218834e..pull/515983/head))
Merge: [`0f164a9c96fe3738523dae313e5b9ac74059e59a`](https://github.com/NixOS/nixpkgs/commit/0f164a9c96fe3738523dae313e5b9ac74059e59a)

Logs: https://github.com/cbrxyz/nixpkgs-review-gha/actions/runs/25263692465


---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>buildkite-agent</li>
  </ul>
</details>

---
### `aarch64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>buildkite-agent</li>
  </ul>
</details>

---
### `x86_64-darwin` (sandbox = relaxed)
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>buildkite-agent</li>
  </ul>
</details>

---
### `aarch64-darwin` (sandbox = relaxed)
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>buildkite-agent</li>
  </ul>
</details>


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
