### PR TITLE
slsnif: fix build with gcc15

### DIFF
--- a/pkgs/by-name/sl/slsnif/fix-gcc15.patch
+++ b/pkgs/by-name/sl/slsnif/fix-gcc15.patch
@@ -1,0 +1,26 @@
+diff --git a/src/rcfile.h b/src/rcfile.h
+index 0fcb4d8..84f77f2 100644
+--- a/src/rcfile.h
++++ b/src/rcfile.h
+@@ -24,7 +24,7 @@
+ 
+ typedef struct _rc_struct {
+     char *name;
+-    void (*fn)();
++    void (*fn)(tty_struct *, char *);
+ } rc_struct;
+ 
+ /* external functions */
+diff --git a/src/slsnif.c b/src/slsnif.c
+index 1341f59..e17f288 100644
+--- a/src/slsnif.c
++++ b/src/slsnif.c
+@@ -549,7 +549,7 @@ int main(int argc, char *argv[]) {
+         close(tty_data.portpipefd[1]);
+         signal(SIGINT, sigintC);
+         signal(SIGHUP, sighupC);
+-        pipeReader(&tty_data);
++        pipeReader();
+         break;
+     case -1:
+         /* fork() failed */

--- a/pkgs/by-name/sl/slsnif/package.nix
+++ b/pkgs/by-name/sl/slsnif/package.nix
@@ -13,6 +13,14 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "0gn8c5hj8m3sywpwdgn6w5xl4rzsvg0z7d2w8dxi6p152j5b0pii";
   };
 
+  patches = [
+    ./fix-gcc15.patch
+  ];
+
+  configureFlags = [
+    "ac_cv_type_signal=void"
+  ];
+
   meta = {
     description = "Serial line sniffer";
     homepage = "http://slsnif.sourceforge.net/";


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/326906326

Only verified compilation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
