### PR TITLE
porxie: 0.1.2 -> 0.2.0, nixos/porxie: update options

### DIFF
--- a/nixos/modules/services/networking/porxie.nix
+++ b/nixos/modules/services/networking/porxie.nix
@@ -18,7 +18,7 @@ in
       default = [ ];
       description = ''
         Files to load environment variables from. Use for secrets such as
-        {env}`PORXIE_SERVER_AUTH_TOKEN` and {env}`PORXIE_POLICY_REQUEST_HEADERS`.
+        {env}`PORXIE_SERVER_ADMIN_PASSWORD` and {env}`PORXIE_POLICY_REQUEST_HEADERS`.
       '';
     };
 
@@ -29,7 +29,7 @@ in
         [README](https://codeberg.org/Blooym/porxie/src/branch/main/README.md)
         for detailed information about application configuration.
 
-        Secrets such as {option}`settings.PORXIE_SERVER_AUTH_TOKEN` should be set via
+        Secrets such as {option}`settings.PORXIE_SERVER_ADMIN_PASSWORD` should be set via
         {option}`environmentFiles` rather than here, as values set here will
         be readable in the Nix store.
       '';
@@ -56,13 +56,15 @@ in
               systems, the `unix:` prefix for a UNIX socket path (e.g. `unix:/run/porxie/porxie.sock`).
             '';
           };
-          PORXIE_SERVER_AUTH_TOKEN = lib.mkOption {
+          PORXIE_SERVER_ADMIN_PASSWORD = lib.mkOption {
             type = lib.types.nullOr lib.types.str;
             default = null;
             description = ''
-              Bearer token for authenticating admin requests.
+              Admin password for authenticating privileged requests.
 
               When unset, all authenticated endpoints will reject requests with HTTP 401.
+
+              Authenticated requests always expect the username `admin` as per specification.
 
               Should be set via {option}`environmentFiles` rather than directly.
             '';
@@ -88,9 +90,8 @@ in
             description = ''
               Maximum blob size that can be fetched and served.
 
-              Blobs that exceed this limit will return HTTP 413. Setting this too high can
-              exhaust process or system memory. The minimum value is 512kb and the maximum is
-              the system's total memory.
+              Blobs that exceed this limit will return HTTP 413. The minimum value is 512kb
+              and the maximum is the system's total memory.
             '';
           };
           PORXIE_BLOB_CACHE_HEADER = lib.mkOption {
@@ -162,8 +163,7 @@ in
               For production deployments, a CDN or caching layer in front of this server is
               recommended for lower latency and better global availability.
 
-              Setting this too high can exhaust process or system memory. The minimum value is
-              8mb and the maximum is the system's total memory.
+              The minimum value is 8mb and the maximum is the system's total memory.
             '';
           };
           PORXIE_CACHE_BLOB_TTI = lib.mkOption {
@@ -194,8 +194,7 @@ in
             description = ''
               Policy service URL that DID+CID pairs will be checked against.
 
-              Requests are sent as HTTP GET `<url>/<did>/<cid>`. The service is expected to
-              return HTTP 200 (OK) if permitted or HTTP 410 (GONE) if restricted.
+              Requests are sent via XRPC to `<url>/xrpc/dev.blooym.porxie.getBlobPolicy?did=<did>&cid=<cid>`.
             '';
           };
           PORXIE_POLICY_REQUEST_HEADERS = lib.mkOption {
@@ -206,6 +205,8 @@ in
               Headers sent alongside all requests to the policy service.
               Each header must be in the format `Name: value`.
 
+              As pipes are used as a delimiter, they cannot be contained in header values.
+
               Should be set via {option}`environmentFiles` for sensitive values such as API keys.
             '';
           };
@@ -214,8 +215,7 @@ in
             default = null;
             apply = v: if v != null then lib.boolToString v else null;
             description = ''
-              Allow requests to proceed if the policy service is unavailable or returns an
-              unexpected status code.
+              Allow requests to proceed if the policy service is unavailable.
 
               Warning: enabling this means restricted blobs may be served when the policy
               service is unreachable.

--- a/pkgs/by-name/po/porxie/package.nix
+++ b/pkgs/by-name/po/porxie/package.nix
@@ -11,15 +11,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
   __structuredAttrs = true;
 
   pname = "porxie";
-  version = "0.1.2";
+  version = "0.2.0";
 
   src = fetchFromCodeberg {
     owner = "Blooym";
     repo = "porxie";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-dnBHgNSk0i6bokBXQlZMOwePusiplAN2hIna08Y68fA=";
+    hash = "sha256-BLlsvzmAQj/N1pmw+ZMBmC48O4SPvvLWDD198ihXR+k=";
   };
-  cargoHash = "sha256-fl6mv8qHdVQtXc6B6cVu9vG9gJQruAJU2tklChziOBo=";
+  cargoHash = "sha256-4gRC7ZXok9oshUCkDBhxtbnxma224smaL4GcCgdCkSc=";
 
   buildInputs = [ rust-jemalloc-sys ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
