### PR TITLE
popa3d: fix build with gcc15

### DIFF
--- a/pkgs/by-name/po/popa3d/fix-gcc15.patch
+++ b/pkgs/by-name/po/popa3d/fix-gcc15.patch
@@ -1,0 +1,22 @@
+diff --git a/standalone.c b/standalone.c
+index 216d937..2bce0e8 100644
+--- a/standalone.c
++++ b/standalone.c
+@@ -108,7 +108,7 @@ int do_standalone(void)
+ int main(void)
+ #endif
+ {
+-	int true = 1;
++	int opt = 1;
+ 	int sock, new;
+ 	struct sockaddr_in addr;
+ 	socklen_t addrlen;
+@@ -123,7 +123,7 @@ int main(void)
+ 		return log_error("socket");
+ 
+ 	if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR,
+-	    (void *)&true, sizeof(true)))
++	    (void *)&opt, sizeof(opt)))
+ 		return log_error("setsockopt");
+ 
+ 	memset(&addr, 0, sizeof(addr));

--- a/pkgs/by-name/po/popa3d/package.nix
+++ b/pkgs/by-name/po/popa3d/package.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
     ./use-openssl.patch
     ./use-glibc-crypt.patch
     ./enable-standalone-mode.patch
+    ./fix-gcc15.patch
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
- #475479
- https://hydra.nixos.org/build/326855298

```
standalone.c: In function 'do_standalone':
standalone.c:111:13: error: expected identifier or '(' before 'true'
  111 |         int true = 1;
      |             ^~~~
standalone.c:126:21: error: lvalue required as unary '&' operand
  126 |             (void *)&true, sizeof(true)))
      |                     ^
standalone.c:139:9: warning: ignoring return value of 'chdir' declared with attribute 'warn_unused_result' [-Wunused-result]
  139 |         chdir("/");
      |         ^~~~~~~~~~
```

Only verified compilation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
