### PR TITLE
python3Packages.funsor: 0.4.6 -> 0.4.7

### DIFF
--- a/pkgs/development/python-modules/funsor/default.nix
+++ b/pkgs/development/python-modules/funsor/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   fetchpatch,
@@ -14,7 +15,7 @@
   opt-einsum,
   typing-extensions,
 
-  # checks
+  # tests
   pyro-ppl,
   torch,
   pandas,
@@ -25,20 +26,19 @@
   requests,
   scipy,
   torchvision,
-
-  stdenv,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "funsor";
-  version = "0.4.6";
+  version = "0.4.7";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "pyro-ppl";
     repo = "funsor";
-    tag = version;
-    hash = "sha256-Prj1saT0yoPAP8rDE0ipBEpR3QMk4PS12VSJlxc22p8=";
+    tag = finalAttrs.version;
+    hash = "sha256-0STJv1OOliJaHdmYUXdnOnocH3hVXceH/Uw5nILvT+U=";
   };
 
   patches = [
@@ -48,13 +48,6 @@ buildPythonPackage rec {
       hash = "sha256-sTR+hbJtS0Th5sIqlvB2bReEC0wnEbnB7gAiZKiqjAQ=";
     })
   ];
-
-  # TypeError: clip() got an unexpected keyword argument 'a_max'
-  postPatch = ''
-    substituteInPlace funsor/jax/ops.py \
-      --replace-fail "a_max=" "max=" \
-      --replace-fail "a_min=" "min="
-  '';
 
   build-system = [ setuptools ];
 
@@ -96,15 +89,15 @@ buildPythonPackage rec {
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # Failures related to JIT
     # RuntimeError: required keyword attribute 'Subgraph' has the wrong type
-    "test_local_param_ok"
-    "test_plate_ok"
+    # "test_local_param_ok"
+    # "test_plate_ok"
   ];
 
   meta = {
     description = "Functional tensors for probabilistic programming";
     homepage = "https://funsor.pyro.ai";
-    changelog = "https://github.com/pyro-ppl/funsor/releases/tag/${version}";
+    changelog = "https://github.com/pyro-ppl/funsor/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ GaetanLepage ];
   };
-}
+})

--- a/pkgs/development/python-modules/funsor/default.nix
+++ b/pkgs/development/python-modules/funsor/default.nix
@@ -14,7 +14,7 @@
   opt-einsum,
   typing-extensions,
 
-  # checks
+  # tests
   pyro-ppl,
   torch,
   pandas,
@@ -25,20 +25,19 @@
   requests,
   scipy,
   torchvision,
-
-  stdenv,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "funsor";
-  version = "0.4.6";
+  version = "0.4.7";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "pyro-ppl";
     repo = "funsor";
-    tag = version;
-    hash = "sha256-Prj1saT0yoPAP8rDE0ipBEpR3QMk4PS12VSJlxc22p8=";
+    tag = finalAttrs.version;
+    hash = "sha256-0STJv1OOliJaHdmYUXdnOnocH3hVXceH/Uw5nILvT+U=";
   };
 
   patches = [
@@ -48,13 +47,6 @@ buildPythonPackage rec {
       hash = "sha256-sTR+hbJtS0Th5sIqlvB2bReEC0wnEbnB7gAiZKiqjAQ=";
     })
   ];
-
-  # TypeError: clip() got an unexpected keyword argument 'a_max'
-  postPatch = ''
-    substituteInPlace funsor/jax/ops.py \
-      --replace-fail "a_max=" "max=" \
-      --replace-fail "a_min=" "min="
-  '';
 
   build-system = [ setuptools ];
 
@@ -87,24 +79,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "funsor" ];
 
-  disabledTests = [
-    # `test_torch_save` got broken by the update of torch (2.3.1 -> 2.4.0):
-    # FutureWarning: You are using `torch.load` with `weights_only=False`...
-    # TODO: Try to re-enable this test at next release
-    "test_torch_save"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    # Failures related to JIT
-    # RuntimeError: required keyword attribute 'Subgraph' has the wrong type
-    "test_local_param_ok"
-    "test_plate_ok"
-  ];
-
   meta = {
     description = "Functional tensors for probabilistic programming";
     homepage = "https://funsor.pyro.ai";
-    changelog = "https://github.com/pyro-ppl/funsor/releases/tag/${version}";
+    changelog = "https://github.com/pyro-ppl/funsor/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ GaetanLepage ];
   };
-}
+})


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/pyro-ppl/funsor/compare/0.4.6...0.4.7
Changelog: https://github.com/pyro-ppl/funsor/releases/tag/0.4.7

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test