### PR TITLE
libkrun-efi: 1.17.4 -> 1.18.0

### DIFF
--- a/pkgs/by-name/li/libkrun-efi/package.nix
+++ b/pkgs/by-name/li/libkrun-efi/package.nix
@@ -20,13 +20,13 @@
   withGpu ? true,
 }:
 let
-  version = "1.17.4";
+  version = "1.18.0";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = "libkrun";
     tag = "v${version}";
-    hash = "sha256-Th4vCg3xHb6lbo26IDZES7tLOUAJTebQK2+h3xSYX7U=";
+    hash = "sha256-R7q52ZwiL9JsGofLPhXVTk/eH6bEob3DoZe21PHSBrU=";
   };
 
   virglrenderer = stdenv.mkDerivation (finalAttrs: {
@@ -78,7 +78,7 @@ let
     buildPhase = ''
       runHook preBuild
       cd init
-      $CC -O2 -static -Wall -o init init.c
+      $CC -O2 -static -Wall -o init init.c dhcp.c
       runHook postBuild
     '';
 
@@ -100,7 +100,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
-    hash = "sha256-0xpAyNe1jF1OMtc7FXMsejqIv0xKc1ktEvm3rj/mVFU=";
+    hash = "sha256-3IAEWF+XGeKnb61SUpuVHMPiX6q0FgQFN4/eOBCH80c=";
   };
 
   nativeBuildInputs = [
@@ -124,8 +124,12 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optional withGpu "GPU=1";
 
-  preBuild = ''
-    cp ${initBinary}/init init/init
+  env.KRUN_INIT_BINARY_PATH = "${initBinary}/init";
+
+  postPatch = ''
+    substituteInPlace Makefile --replace-fail \
+      '$(LIBRARY_RELEASE_$(OS)): $(SYSROOT_TARGET) $(INIT_BINARY_BSD)' \
+      '$(LIBRARY_RELEASE_$(OS)):'
   '';
 
   passthru = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- bump libkrun-efi to v1.18.0
- patch Makefile to skip building debian sysroot for cross-compilation
- remove `preBuild` step that copies the init binary into `init/init`, instead add `env.KRUN_INIT_BINARY_PATH` pointing to `${initBinary}/init`. This is because [upstream moved the init binary build logic to `src/devices/build.rs`](https://github.com/containers/libkrun/commit/53920d2d7999c9d509da8fcf23678b0b1fc1d82c).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
