### PR TITLE
lib.systems.architectures: add rocketlake

### DIFF
--- a/lib/systems/architectures.nix
+++ b/lib/systems/architectures.nix
@@ -137,6 +137,17 @@ rec {
       "avx512"
       "fma"
     ];
+    rocketlake = [
+      "sse3"
+      "ssse3"
+      "sse4_1"
+      "sse4_2"
+      "aes"
+      "avx"
+      "avx2"
+      "avx512"
+      "fma"
+    ];
     cascadelake = [
       "sse3"
       "ssse3"
@@ -419,6 +430,7 @@ rec {
       sapphirerapids = [ "tigerlake" ] ++ inferiors.tigerlake;
       emeraldrapids = [ "sapphirerapids" ] ++ inferiors.sapphirerapids;
 
+      rocketlake = [ "x86-64-v4" ] ++ inferiors.x86-64-v4;
       alderlake = [ "skylake" ] ++ inferiors.skylake;
       sierraforest = [ "alderlake" ] ++ inferiors.alderlake;
 

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -195,6 +195,7 @@ let
         cooperlake = versionAtLeast ccVersion "10.0";
         tigerlake = versionAtLeast ccVersion "10.0";
         knm = versionAtLeast ccVersion "8.0";
+        rocketlake = versionAtLeast ccVersion "11.0";
         alderlake = versionAtLeast ccVersion "12.0";
         sapphirerapids = versionAtLeast ccVersion "11.0";
         emeraldrapids = versionAtLeast ccVersion "13.0";
@@ -228,6 +229,7 @@ let
         icelake-client = versionAtLeast ccVersion "7.0";
         icelake-server = versionAtLeast ccVersion "7.0";
         knm = versionAtLeast ccVersion "7.0";
+        rocketlake = versionAtLeast ccVersion "13.0";
         alderlake = versionAtLeast ccVersion "16.0";
         sapphirerapids = versionAtLeast ccVersion "12.0";
         emeraldrapids = versionAtLeast ccVersion "16.0";


### PR DESCRIPTION
This shouldn't cause any rebuilds except for configurations where `gcc.arch = "rocketlake"` has been set. In those cases, the platform feature flags and inferiors will be automatically set now.

Since Rocket Lake doesn't support SGX, I think the next inferior down is `x86-64-v4`. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux: `(import ./. { localSystem = { system = "x86_64-linux"; gcc.arch = "rocketlake"; }; }).stdenv` builds
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
