### PR TITLE
subxt: 0.44.2 -> 0.50.0

### DIFF
--- a/pkgs/by-name/su/subxt/package.nix
+++ b/pkgs/by-name/su/subxt/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "paritytech";
     repo = "subxt";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-3yTX2H4T0nnA0Kh1Lx1/blK/Edd1ZOHQVEXiiOLxino=";
   };
 

--- a/pkgs/by-name/su/subxt/package.nix
+++ b/pkgs/by-name/su/subxt/package.nix
@@ -2,7 +2,6 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
-  cmake,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -23,9 +22,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--bin"
     "subxt"
   ];
-
-  # Needed by wabt-sys
-  nativeBuildInputs = [ cmake ];
 
   # Requires a running substrate node
   doCheck = false;

--- a/pkgs/by-name/su/subxt/package.nix
+++ b/pkgs/by-name/su/subxt/package.nix
@@ -32,12 +32,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     homepage = "https://github.com/paritytech/subxt";
-    description = "Submit transactions to a substrate node via RPC";
+    description = "Subxt is a CLI tool for interacting with chains in the Polkadot network";
+    changelog = "https://github.com/paritytech/subxt/releases/tag/${finalAttrs.src.tag}";
     mainProgram = "subxt";
     license = with lib.licenses; [
       gpl3Plus
       asl20
     ];
-    maintainers = [ lib.maintainers.FlorianFranzen ];
+    maintainers = with lib.maintainers; [
+      FlorianFranzen
+      kilyanni
+    ];
   };
 })

--- a/pkgs/by-name/su/subxt/package.nix
+++ b/pkgs/by-name/su/subxt/package.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "subxt";
-  version = "0.44.2";
+  version = "0.50.0";
 
   src = fetchFromGitHub {
     owner = "paritytech";
     repo = "subxt";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-3yTX2H4T0nnA0Kh1Lx1/blK/Edd1ZOHQVEXiiOLxino=";
+    hash = "sha256-nMal78+TYZ1f9X/YZhsqOsEIrjxhi9fEcevnQW8u97o=";
   };
 
-  cargoHash = "sha256-zJpzsPHK9Mq0KF0WvbBINxSQVr0m4Z5+M6/nFD8jiMg=";
+  cargoHash = "sha256-sqspcTwODoRzaaUSXT+2yPUTzUqcW1gNu0c1Lv9D1u0=";
 
   # Only build the command line client
   cargoBuildFlags = [


### PR DESCRIPTION
Updates the package, drops a now-outdated dependency and slightly improves `meta` section (changelog, description)

Since the maintainer seems inactive (hasn't responded to update bot PR in over a month), I adopted the package

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
