### PR TITLE
bleamd: init at 0.1.0

### DIFF
--- a/pkgs/by-name/bl/bleamd/package.nix
+++ b/pkgs/by-name/bl/bleamd/package.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "bleamd";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "guttermonk";
+    repo = "bleamd";
+    rev = "v${version}";
+    hash = "sha256-uWh8GaYiLNNmich+/Ir7xTRXBokzKf0HaRHzoQVUccc=";
+  };
+
+  vendorHash = "sha256-s7SEUAt9SJEDm8+1N5cb5+mM9M6H7tAfSzZKczu/60s=";
+
+  meta = {
+    description = "Fast, interactive markdown viewer with search, theming, and clickable links for the terminal";
+    homepage = "https://github.com/guttermonk/bleamd";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ guttermonk ];
+    mainProgram = "bleamd";
+  };
+}


### PR DESCRIPTION
Adds `bleamd`, a fast, interactive terminal Markdown viewer with full-text search, clickable hyperlinks, customizable keybindings, and a rich theming system. It is a fork of [mdr](https://github.com/MichaelMure/mdr) with significant enhancements. MIT licensed, written in Go.

https://github.com/guttermonk/bleamd

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test