### PR TITLE
grafana-alloy: 1.15.1 -> 1.16.0

### DIFF
--- a/pkgs/by-name/gr/grafana-alloy/package.nix
+++ b/pkgs/by-name/gr/grafana-alloy/package.nix
@@ -15,23 +15,23 @@
 }:
 
 let
-  beylaVersion = "v3.6.0";
+  beylaVersion = "v3.9.5";
 in
 
 buildGoModule (finalAttrs: {
   pname = "grafana-alloy";
-  version = "1.15.1";
+  version = "1.16.0";
 
   src = fetchFromGitHub {
     owner = "grafana";
     repo = "alloy";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-dAWBmvrthnsji6WuM2itRdfV4ONKDjsCzUJkUSmb1XI=";
+    hash = "sha256-q5R2noxBZ3OPyZqmB+bx3iJKWFxC2WIprcgh9RwjLzk=";
   };
 
   npmDeps = fetchNpmDeps {
     src = "${finalAttrs.src}/internal/web/ui";
-    hash = "sha256-YUCft67WskKubZu8qEIUoH5NHwSfD5o0tWzyply90Zg=";
+    hash = "sha256-vResNUT4auDsK9ngnJYfMUUOYr/ikPhrvakqCjGq2Q8=";
   };
 
   frontend = buildNpmPackage {
@@ -65,7 +65,7 @@ buildGoModule (finalAttrs: {
   modRoot = "collector";
 
   proxyVendor = true;
-  vendorHash = "sha256-PbaqxDJHXB1MT5KtiEIkl+gP0DolzlC5JRItGC5VCpQ=";
+  vendorHash = "sha256-uTIdurwLfxh27fb1CPCHbHmENk3S6VYNBaGT/5yh3Sc=";
 
   subPackages = [ "." ];
 
@@ -82,6 +82,7 @@ buildGoModule (finalAttrs: {
 
   tags = [
     "embedalloyui"
+    "gore2regex"
     "netgo"
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [


### PR DESCRIPTION
https://github.com/grafana/alloy/releases/tag/v1.16.0
https://github.com/grafana/alloy/compare/v1.15.1...v1.16.0

`gore2regex` tag was introduced here: https://github.com/grafana/alloy/commit/c16a660b912a948badc4e69de4eeab6edc1b3364
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
