### PR TITLE
 nixos/programs/kopia: init 

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -64,6 +64,8 @@
 
 - [Atuin](https://atuin.sh), magical shell history — sync, search and backup your terminal history. Available as [programs.atuin](#opt-programs.atuin.enable).
 
+- [kopia](https://kopia.io), a fast and secure open-source backup tool. Available as [programs.kopia](#opt-programs.kopia.enable).
+
 - [Meshtastic](https://meshtastic.org), an open-source, off-grid, decentralised mesh network
   designed to run on affordable, low-power devices. Available as [services.meshtasticd]
   (#opt-services.meshtasticd.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -253,6 +253,7 @@
   ./programs/kclock.nix
   ./programs/kde-pim.nix
   ./programs/kdeconnect.nix
+  ./programs/kopia.nix
   ./programs/kubeswitch.nix
   ./programs/ladybird.nix
   ./programs/lazygit.nix

--- a/nixos/modules/programs/kopia.nix
+++ b/nixos/modules/programs/kopia.nix
@@ -1,0 +1,96 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  options.programs.kopia = {
+    enable = lib.mkEnableOption "kopia, a fast and secure open-source backup/restore tool";
+
+    package = lib.mkPackageOption pkgs "kopia" { };
+
+    systemdProperties = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [
+        "Nice=10"
+        "IOSchedulingClass=idle"
+        "IOWeight=50"
+        "CPUWeight=50"
+      ];
+      description = ''
+        systemd service properties to apply to each kopia invocation, passed as
+        `--property=` flags to {manpage}`systemd-run(1)`. See
+        {manpage}`systemd.exec(5)` and {manpage}`systemd.resource-control(5)`
+        for available properties.
+
+        This requires systemd. Non-root invocations use the user manager
+        (present in standard desktop and SSH logins, absent in some containers);
+        root uses the system manager.
+      '';
+    };
+
+    ui = {
+      enable = lib.mkEnableOption "KopiaUI, the Electron-based GUI for kopia";
+
+      package = lib.mkPackageOption pkgs "kopia-ui" { };
+    };
+  };
+
+  config =
+    let
+      cfg = config.programs.kopia;
+      needsWrapper = cfg.systemdProperties != [ ];
+      kopiaFinal =
+        if !needsWrapper then
+          cfg.package
+        else
+          pkgs.symlinkJoin {
+            name = "kopia-wrapped";
+            meta.mainProgram = "kopia";
+            paths = [
+              (pkgs.writeShellScriptBin "kopia" ''
+                # --pty gives kopia a real tty (colours, progress bars); --pipe lets
+                # kopia detect non-interactive context when output is redirected.
+                _sd_tty=--pipe
+                [ -t 1 ] && _sd_tty=--pty
+
+                # Root has no user manager; use the system manager instead.
+                _sd_scope=--user
+                [ "$(${pkgs.coreutils}/bin/id -u)" = "0" ] && _sd_scope=
+
+                exec ${pkgs.systemd}/bin/systemd-run $_sd_scope --collect --quiet --same-dir --service-type=exec --wait "$_sd_tty" --unit="kopia-$$" \
+                  ${lib.concatStringsSep " \\\n  " (map (p: "--property=${p}") cfg.systemdProperties)} \
+                  -- ${lib.escapeShellArg "${cfg.package}/bin/kopia"} "$@"
+              '')
+              cfg.package # preserves completions, manpages, etc.
+            ];
+          };
+    in
+    lib.mkMerge [
+      (lib.mkIf cfg.enable {
+        environment.systemPackages = [ kopiaFinal ];
+      })
+      (lib.mkIf cfg.ui.enable {
+        environment.systemPackages = [
+          # Wrap rather than override kopia= to avoid rebuilding the electron app
+          # every time wrapper options change.
+          (
+            if !needsWrapper then
+              cfg.ui.package
+            else
+              pkgs.symlinkJoin {
+                name = "kopia-ui-wrapped";
+                nativeBuildInputs = [ pkgs.makeWrapper ];
+                paths = [ cfg.ui.package ];
+                postBuild = ''
+                  wrapProgram $out/bin/kopia-ui \
+                    --set-default KOPIA_EXECUTABLE ${lib.getExe kopiaFinal}
+                '';
+              }
+          )
+        ];
+      })
+    ];
+}

--- a/nixos/modules/programs/kopia.nix
+++ b/nixos/modules/programs/kopia.nix
@@ -1,0 +1,95 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.kopia;
+  needsWrapper = cfg.systemdProperties != [ ];
+  kopiaFinal =
+    if !needsWrapper then
+      cfg.package
+    else
+      pkgs.symlinkJoin {
+        name = "kopia-wrapped";
+        meta.mainProgram = "kopia";
+        paths = [
+          (pkgs.writeShellScriptBin "kopia" ''
+            # --pty gives kopia a real tty (colours, progress bars); --pipe lets
+            # kopia detect non-interactive context when output is redirected.
+            _sd_tty=--pipe
+            [ -t 1 ] && _sd_tty=--pty
+
+            # Root has no user manager; use the system manager instead.
+            _sd_scope=--user
+            [ "$(${pkgs.coreutils}/bin/id -u)" = "0" ] && _sd_scope=
+
+            exec ${config.systemd.package}/bin/systemd-run $_sd_scope --collect --quiet --same-dir --service-type=exec --wait "$_sd_tty" --unit="kopia-$$" \
+              ${lib.concatStringsSep " \\\n  " (map (p: "--property=${p}") cfg.systemdProperties)} \
+              -- ${lib.escapeShellArg "${lib.getExe cfg.package}"} "$@"
+          '')
+          cfg.package # preserves completions, manpages, etc.
+        ];
+      };
+in
+{
+  options.programs.kopia = {
+    enable = lib.mkEnableOption "kopia, a fast and secure open-source backup/restore tool";
+
+    package = lib.mkPackageOption pkgs "kopia" { };
+
+    systemdProperties = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [
+        "Nice=10"
+        "IOSchedulingClass=idle"
+        "IOWeight=50"
+        "CPUWeight=50"
+      ];
+      description = ''
+        systemd service properties to apply to each kopia invocation, passed as
+        `--property=` flags to {manpage}`systemd-run(1)`. See
+        {manpage}`systemd.exec(5)` and {manpage}`systemd.resource-control(5)`
+        for available properties.
+
+        This requires systemd. Non-root invocations use the user manager
+        (present in standard desktop and SSH logins, absent in some containers);
+        root uses the system manager.
+      '';
+    };
+
+    ui = {
+      enable = lib.mkEnableOption "KopiaUI, the Electron-based GUI for kopia";
+
+      package = lib.mkPackageOption pkgs "kopia-ui" { };
+    };
+  };
+
+  config = lib.mkMerge [
+    (lib.mkIf cfg.enable {
+      environment.systemPackages = [ kopiaFinal ];
+    })
+    (lib.mkIf cfg.ui.enable {
+      environment.systemPackages = [
+        # Wrap rather than override kopia= to avoid rebuilding the electron app
+        # every time wrapper options change.
+        (
+          if !needsWrapper then
+            cfg.ui.package
+          else
+            pkgs.symlinkJoin {
+              name = "kopia-ui-wrapped";
+              nativeBuildInputs = [ pkgs.makeWrapper ];
+              paths = [ cfg.ui.package ];
+              postBuild = ''
+                wrapProgram $out/bin/kopia-ui \
+                  --set-default KOPIA_EXECUTABLE ${lib.getExe kopiaFinal}
+              '';
+            }
+        )
+      ];
+    })
+  ];
+}

--- a/pkgs/by-name/ko/kopia-ui/fix-paths.patch
+++ b/pkgs/by-name/ko/kopia-ui/fix-paths.patch
@@ -57,7 +57,7 @@ index c5963e41..30f72965 100644
 -    win: path.join(process.resourcesPath, "server", "kopia.exe"),
 -    linux: path.join(process.resourcesPath, "server", "kopia"),
 -  }[osShortName];
-+  return "KOPIA";
++  return process.env.KOPIA_EXECUTABLE;
  }
  export function selectByOS(x) {
    return x[osShortName];

--- a/pkgs/by-name/ko/kopia-ui/package.nix
+++ b/pkgs/by-name/ko/kopia-ui/package.nix
@@ -38,10 +38,6 @@ buildNpmPackage {
 
   patches = [ ./fix-paths.patch ];
 
-  postPatch = ''
-    substituteInPlace public/utils.js --replace-fail KOPIA ${lib.getExe kopia}
-  '';
-
   buildPhase = ''
     runHook preBuild
     cp -r ${electron.dist} electron-dist
@@ -60,7 +56,7 @@ buildNpmPackage {
     cp -r ../dist/kopia-ui/*-unpacked/{locales,resources{,.pak}} $out/share/kopia
     install -Dm644 $src/icons/kopia.svg $out/share/icons/hicolor/scalable/apps/kopia.svg
     makeWrapper ${lib.getExe electron} $out/bin/kopia-ui \
-      --prefix PATH : ${lib.makeBinPath [ kopia ]} \
+      --set-default KOPIA_EXECUTABLE ${lib.getExe kopia} \
       --add-flags $out/share/kopia/resources/app.asar \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --inherit-argv0


### PR DESCRIPTION
Adds a `programs.kopia` module that installs [kopia](https://github.com/kopia/kopia) and optionally wraps each invocation in a transient systemd service, allowing resource limits to be applied.

Backups can saturate IO and CPU; running them at lower priority keeps the system responsive. The wrapper applies to both CLI invocations and subprocesses spawned by kopia-ui              
(`programs.kopia.ui.enable`), which is commonly added to the desktop environment's autostart to let kopia manage its own backup schedule.

Limits are applied via `programs.kopia.systemdProperties` (any `Property=Value` accepted by
`systemd-run --property=`, e.g. `Nice=10`, `IOWeight=50`, `CPUWeight=50`).

To make the wrapper apply to `kopia-ui` too, the module needs to redirect which `kopia` binary it spawns. Previously this path was baked in at build time, so any change would trigger a full electron rebuild. This PR switches `kopia-ui` to read the path from an environment variable instead, letting the module point it at the wrapper without rebuilds.

To verify it's working, launch `kopia-ui` with `systemdProperties` set, then inspect the transient unit: `systemctl --user show -p Nice kopia-<pid>.service` (substituting whichever property you set). You can find the unit name with `systemctl --user list-units 'kopia-*'`.

For backups scheduled by systemd rather than kopia itself, see #494870

Note for reviewers; I am maintainer of `kopia` and `kopia-ui`

cc @nadir-ishiguro

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
