### PR TITLE
qtcreator: Fix wrapper for Gnome environments

### DIFF
--- a/pkgs/by-name/qt/qtcreator/package.nix
+++ b/pkgs/by-name/qt/qtcreator/package.nix
@@ -18,6 +18,7 @@
   perf,
   callPackage,
   buildGoModule,
+  wrapGAppsHook3,
 }:
 let
   pname = "qtcreator";
@@ -48,6 +49,7 @@ stdenv'.mkDerivation {
     python3
     ninja
     go
+    wrapGAppsHook3
   ];
 
   buildInputs = [
@@ -98,6 +100,8 @@ stdenv'.mkDerivation {
     cp -r --reflink=auto ${goModules} src/libs/gocmdbridge/server/vendor
   '';
 
+  dontWrapGApps = true;
+
   qtWrapperArgs = [
     "--set-default PERFPROFILER_PARSER_FILEPATH ${lib.getBin perf}/bin"
   ];
@@ -107,6 +111,10 @@ stdenv'.mkDerivation {
     cmake . $cmakeFlags -DCMAKE_INSTALL_PREFIX="''${!outputDev}"
 
     cmake --install . --prefix "''${!outputDev}" --component Devel
+  '';
+
+  preFixup = ''
+    qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
   '';
 
   # Remove prefix from the QtC config to make sane output path for 3rd-party plug-ins.


### PR DESCRIPTION
On Gnome, QT Creator crashes with the following error:

(qtcreator:8838): GLib-GIO-ERROR **: 08:21:17.348: Settings schema 'org.gtk.Settings.FileChooser' is not installed.

Fix the wrapper hooks and include the Gnome wrapper args.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
