### PR TITLE
fulcrum: 1.12.0.1 -> 2.1.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -173,6 +173,8 @@
 
 - `services.home-assistant.config.lovelace.mode` has been renamed to `lovelace.dashboards` and `lovelace.resource_mode` to match the [configuration format](https://www.home-assistant.io/dashboards/dashboards/) required by Home Assistant 2026.8. Users who explicitly set `lovelace.mode` should remove it; the module generates the correct entries automatically.
 
+- `fulcrum` has been updated to 2.x. If run against an existing v1.x database without the `--db-upgrade` flag it refuses to start; the upgrade takes around an hour on Bitcoin mainnet.
+
 - `opentrack`, `slushload`, `synthesia`, `vtfedit`, `winbox`, `wineasio`, and `yabridge` use wineWow64Packages instead of wineWowPackages as wine versions >= 11.0 have deprecated wineWowPackages. As such, the prefixes for these packages are NOT backwards compatible and need to be regenerated with potential for data loss.
 
 - []{#sec-release-26.05-incompatibilities-profiles-hardened-removed} `profiles/hardened` has been removed, because:

--- a/pkgs/by-name/fu/fulcrum/package.nix
+++ b/pkgs/by-name/fu/fulcrum/package.nix
@@ -4,21 +4,22 @@
   fetchFromGitHub,
   pkg-config,
   python3,
-  rocksdb_7_10,
+  rocksdb_9_10,
   zeromq,
-  nix-update-script,
   libsForQt5,
+  nix-update-script,
+  testers,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fulcrum";
-  version = "1.12.0.1";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "cculianu";
     repo = "Fulcrum";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/RlvbZ6/f0Jxj6oCeHjGWqlktvtNUNczOXi2/wYw2LQ=";
+    hash = "sha256-5DsZcnmqO8ZuD3+H/1lkfBrKeGq7efAjji0JDXTPQ1M=";
   };
 
   nativeBuildInputs = [
@@ -29,13 +30,16 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     python3
     libsForQt5.qtbase
-    rocksdb_7_10
+    rocksdb_9_10
     zeromq
   ];
 
   dontWrapQtApps = true; # no GUI
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
+  };
 
   meta = {
     description = "Fast & nimble SPV server for Bitcoin Cash & Bitcoin BTC";
@@ -43,5 +47,6 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [ prusnak ];
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.unix;
+    mainProgram = "Fulcrum";
   };
 })


### PR DESCRIPTION
#### Things done

- Built on platform(s):
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] Package tests at `passthru.tests` (`tests.version` passes)
  - [x] Tested basic functionality of all binary files (`Fulcrum`, `FulcrumAdmin`) — verified against a live Bitcoin mainnet node: version string, block headers, script hash queries, and peer management all working correctly
- [ ] Ran `nixpkgs-review` on this PR — Fulcrum has no reverse dependencies in nixpkgs
- [x] Fits [`CONTRIBUTING.md`](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)

#### Description

Version update for Fulcrum.

Changes:
- `rocksdb_7_10` → `rocksdb_9_10`: Fulcrum 2.x uses `ReadOptions::auto_readahead_size`, a field added in RocksDB 8.x. The build fails against 7.10. `rocksdb_9_10` is the closest available pin to the 9.2.1 bundled in upstream's static builds.
- Add `passthru.tests.version` using `testers.testVersion`
- Add `mainProgram = "Fulcrum"` (upstream uses a capital-F binary name)