### PR TITLE
cjdns: 22.1 -> 22.3

### DIFF
--- a/pkgs/by-name/cj/cjdns/package.nix
+++ b/pkgs/by-name/cj/cjdns/package.nix
@@ -15,36 +15,22 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cjdns";
-  version = "22.1";
+  version = "22.3";
 
   src = fetchFromGitHub {
     owner = "cjdelisle";
     repo = "cjdns";
     tag = "cjdns-v${finalAttrs.version}";
-    hash = "sha256-0imQrkcvIA+2Eq/zlC65USMR7T3OUKwQxrB1KtVexyU=";
+    hash = "sha256-A5KPcjFrCIYhT/6W+J4Nvb1y23cAgv9M6PWcyN43st4=";
   };
 
   patches = [
     (replaceVars ./system-libsodium.patch {
       libsodium_include_dir = "${libsodium.dev}/include";
     })
-    # Remove mkpasswd since it is failing the build
-    (fetchpatch {
-      url = "https://github.com/cjdelisle/cjdns/commit/6391dba3f5fdab45df4b4b6b71dbe9620286ce32.patch";
-      hash = "sha256-XVA4tdTVMLrV6zuGoBCkOgQq6NXh0x7u8HgmaxFeoRI=";
-    })
-    (fetchpatch {
-      url = "https://github.com/cjdelisle/cjdns/commit/436d9a9784bae85734992c2561c778fbd2f5ac32.patch";
-      hash = "sha256-THcYNGVbMx/xf3/5UIxEhz3OlODE0qiYgDBOlHunhj8=";
-    })
-    # Fix build failure with Rust 1.89.0 (https://github.com/cjdelisle/cjdns/pull/1271)
-    (fetchpatch {
-      url = "https://github.com/cjdelisle/cjdns/commit/68b786aca5bfa427e5f58c029e4d9cc74969ef87.patch";
-      hash = "sha256-FmrooDzrIWUIAnzwZTVDXI+Cl8pMngPqxsJjUHVhry8=";
-    })
   ];
 
-  cargoHash = "sha256-f96y6ZW0HxC+73ts5re8GIo2aigQgK3gXyF7fMrcJ0o=";
+  cargoHash = "sha256-tob45/99svE0R1Kk7G1+H7waBWYmI9VKC8ffl3ZmdcU=";
 
   nativeBuildInputs = [
     which


### PR DESCRIPTION
update to 22.3

remove outdated patches

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
