### PR TITLE
retrom,retrom-service: init at 0.8.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5417,6 +5417,12 @@
     githubId = 6487079;
     name = "Dane Rieber";
   };
+  concurac = {
+    email = "connor@scequ.com";
+    github = "ConcurAc";
+    githubId = 118907421;
+    name = "Connor Davis";
+  };
   conduktorbot = {
     email = "automation@conduktor.io";
     github = "conduktorbot";

--- a/pkgs/by-name/re/retrom-service/package.nix
+++ b/pkgs/by-name/re/retrom-service/package.nix
@@ -1,0 +1,98 @@
+{
+  lib,
+  pkg-config,
+  rustPlatform,
+  pnpmConfigHook,
+  pnpm_10, # used in upstream build toolchain
+  nodejs_24, # used in upstream build toolchain
+  faketty, # nx requires a TTY, see https://github.com/nrwl/nx/issues/22445
+  perl,
+  protobuf_29,
+  openssl,
+  makeWrapper,
+
+  retrom,
+  withEmbeddedDb ? false,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "retrom-service";
+
+  # client and service designed for matching version
+  inherit (retrom)
+    version
+    src
+    pnpmDeps
+    cargoDeps
+    ;
+
+  __structuredAttrs = true;
+
+  buildAndTestSubdir = "packages/service";
+
+  cargoBuildFeatures = lib.optional withEmbeddedDb "embedded_db";
+
+  nativeBuildInputs = [
+    pkg-config
+    pnpmConfigHook
+    pnpm_10
+    nodejs_24
+    faketty
+    perl
+    protobuf_29
+    makeWrapper
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  preBuild = ''
+    export CI=true
+    export NX_NO_CLOUD=true
+    export NX_DAEMON=false
+
+    export VITE_BASE_URL=/web
+
+    # See https://github.com/nrwl/nx/issues/22445
+    faketty pnpm nx build retrom-client-web
+
+    # Work around for https://github.com/pnpm/pnpm/issues/5315
+    mkdir -p web
+
+    cp -r packages/client-web/dist web
+
+    cp pnpm-workspace.yaml web
+    cp pnpm-lock.yaml web
+    cp package.json web
+    cp README.md web
+    cp packages/client-web/vite.config.ts web
+
+    pushd web
+    pnpm install --prod --offline --frozen-lockfile
+
+    rm -f pnpm-workspace.yaml pnpm-lock.yaml
+    popd
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share
+    cp -r web $out/share/retrom
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/retrom-service --set RETROM_WEB_DIR $out/share/retrom
+  '';
+
+  meta = with lib; {
+    description = "Server component of the Retrom game library management service";
+    homepage = "https://github.com/JMBeresford/retrom";
+    changelog = "https://github.com/JMBeresford/retrom/releases/tag/v${finalAttrs.version}";
+    license = licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      concurac
+    ];
+    # Upstream supports macOS and Windows but only Linux is tested in nixpkgs
+    platforms = platforms.linux;
+    mainProgram = "retrom-service";
+  };
+})

--- a/pkgs/by-name/re/retrom-service/package.nix
+++ b/pkgs/by-name/re/retrom-service/package.nix
@@ -3,9 +3,9 @@
   pkg-config,
   rustPlatform,
   pnpmConfigHook,
-  pnpm_10, # used in upstream build toolchain
-  nodejs_24, # used in upstream build toolchain
-  faketty, # nx requires a TTY, see https://github.com/nrwl/nx/issues/22445
+  pnpm_10,
+  nodejs_24,
+  faketty,
   perl,
   protobuf_29,
   openssl,

--- a/pkgs/by-name/re/retrom-service/package.nix
+++ b/pkgs/by-name/re/retrom-service/package.nix
@@ -83,16 +83,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
     wrapProgram $out/bin/retrom-service --set RETROM_WEB_DIR $out/share/retrom
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Server component of the Retrom game library management service";
     homepage = "https://github.com/JMBeresford/retrom";
     changelog = "https://github.com/JMBeresford/retrom/releases/tag/v${finalAttrs.version}";
-    license = licenses.gpl3Only;
+    license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
       concurac
     ];
-    # Upstream supports macOS and Windows but only Linux is tested in nixpkgs
-    platforms = platforms.linux;
+    # Upstream supports macOS and Windows but only Linux has so far been tested
+    platforms = lib.platforms.linux;
     mainProgram = "retrom-service";
   };
 })

--- a/pkgs/by-name/re/retrom/package.nix
+++ b/pkgs/by-name/re/retrom/package.nix
@@ -1,0 +1,112 @@
+{
+  lib,
+  pkg-config,
+  rustPlatform,
+  cargo-tauri,
+  pnpmConfigHook,
+  fetchPnpmDeps,
+  pnpm_10, # used in upstream build toolchain
+  nodejs_24, # used in upstream build toolchain
+  faketty, # nx requires a TTY, see https://github.com/nrwl/nx/issues/22445
+  perl,
+  protobuf_29,
+  webkitgtk_4_1,
+  openssl,
+  glib-networking,
+  gst_all_1,
+  postgresql,
+  wrapGAppsHook3,
+  fetchFromGitHub,
+
+  embeddedDbOpts ? { },
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "retrom";
+  version = "0.8.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "JMBeresford";
+    repo = "retrom";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-sXduy81+C9yy33yw2u/FEGOTkrok2LcjGn710/EzIFY=";
+  };
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    fetcherVersion = 3;
+    hash = "sha256-MmWCpe7NzzT8W/Ic9y1VzGAp4rk0vxoOxbz5sRRlQs0=";
+  };
+
+  # Cargo.lock has git dependencies
+  cargoHash = "sha256-13VHe4LU3R8NKhcDedhUcnnF9fQd95C3E+moh2jPnis=";
+
+  buildAndTestSubdir = "packages/client";
+
+  nativeBuildInputs = [
+    pkg-config
+    pnpmConfigHook
+    pnpm_10
+    nodejs_24
+    faketty
+    perl
+    protobuf_29
+    cargo-tauri.hook
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    openssl
+    webkitgtk_4_1
+    glib-networking
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+  ];
+
+  # Patch source to use system postgres install
+  postPatch =
+    let
+      opts = lib.concatMapAttrsStringSep "&" (name: value: "${name}=${value}") (
+        {
+          installation_dir = postgresql;
+          trust_installation_dir = "true";
+          "configuration.unix_socket_directories" = "/tmp";
+        }
+        // embeddedDbOpts
+      );
+    in
+    ''
+      substituteInPlace plugins/retrom-plugin-standalone/src/desktop.rs \
+        --replace-fail \
+          "?data_dir={}&password_file={}" \
+          "?data_dir={}&password_file={}&${opts}"
+    '';
+
+  preBuild = ''
+    export CI=true
+    export NX_NO_CLOUD=true
+    export NX_DAEMON=false
+
+    # See https://github.com/nrwl/nx/issues/22445
+    faketty pnpm nx build:desktop retrom-client-web
+  '';
+
+  passthru.updateScript = {
+    command = [ ./update.sh ];
+    supportedFeatures = [ "commit" ];
+  };
+
+  meta = with lib; {
+    description = "Desktop client for the Retrom game library management service";
+    homepage = "https://github.com/JMBeresford/retrom";
+    changelog = "https://github.com/JMBeresford/retrom/releases/tag/v${finalAttrs.version}";
+    license = licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      concurac
+    ];
+    # Upstream supports macOS and Windows but only Linux is tested in nixpkgs
+    platforms = platforms.linux;
+    mainProgram = "Retrom";
+  };
+})

--- a/pkgs/by-name/re/retrom/package.nix
+++ b/pkgs/by-name/re/retrom/package.nix
@@ -5,9 +5,9 @@
   cargo-tauri,
   pnpmConfigHook,
   fetchPnpmDeps,
-  pnpm_10, # used in upstream build toolchain
-  nodejs_24, # used in upstream build toolchain
-  faketty, # nx requires a TTY, see https://github.com/nrwl/nx/issues/22445
+  pnpm_10,
+  nodejs_24,
+  faketty,
   perl,
   protobuf_29,
   webkitgtk_4_1,
@@ -39,7 +39,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-MmWCpe7NzzT8W/Ic9y1VzGAp4rk0vxoOxbz5sRRlQs0=";
   };
 
-  # Cargo.lock has git dependencies
   cargoHash = "sha256-13VHe4LU3R8NKhcDedhUcnnF9fQd95C3E+moh2jPnis=";
 
   buildAndTestSubdir = "packages/client";

--- a/pkgs/by-name/re/retrom/package.nix
+++ b/pkgs/by-name/re/retrom/package.nix
@@ -29,7 +29,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "JMBeresford";
     repo = "retrom";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
+
     hash = "sha256-sXduy81+C9yy33yw2u/FEGOTkrok2LcjGn710/EzIFY=";
   };
 
@@ -96,16 +97,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
     supportedFeatures = [ "commit" ];
   };
 
-  meta = with lib; {
+  meta = {
     description = "Desktop client for the Retrom game library management service";
     homepage = "https://github.com/JMBeresford/retrom";
     changelog = "https://github.com/JMBeresford/retrom/releases/tag/v${finalAttrs.version}";
-    license = licenses.gpl3Only;
+    license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
       concurac
     ];
-    # Upstream supports macOS and Windows but only Linux is tested in nixpkgs
-    platforms = platforms.linux;
+    # Upstream supports macOS and Windows but only Linux has so far been tested
+    platforms = lib.platforms.linux;
     mainProgram = "Retrom";
   };
 })

--- a/pkgs/by-name/re/retrom/update.sh
+++ b/pkgs/by-name/re/retrom/update.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash curl jq common-updater-scripts
+
+set -eux
+
+nixpkgs="$PWD"
+
+attrPath="retrom"
+file="pkgs/by-name/${attrPath:0:2}/$attrPath/package.nix"
+
+retromReleaseUrl="https://api.github.com/repos/JMBeresford/retrom/releases/latest"
+retromRelease=$(curl --silent ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} $retromReleaseUrl)
+
+latestVersion=$(echo "$retromRelease" | jq -r ".tag_name")
+latestVersion="${latestVersion:1}" # remove first char 'v'
+
+oldVersion=$(nix eval --raw -f "$nixpkgs" $attrPath.version)
+
+if [[ "$oldVersion" == "$latestVersion" ]]; then
+    echo "[]"
+    exit 0
+fi
+
+update-source-version $attrPath "$latestVersion"
+
+nix_get_hash() {
+  (nix build --no-link -f "$nixpkgs" "$@" 2>&1 || true) | awk '/got:/{ print $2 }'
+}
+
+nix_eval() {
+  nix eval --raw -f "$nixpkgs" "$@"
+}
+
+escape_sed() {
+  printf '%s' "$1" | sed 's/\//\\\//g'
+}
+
+update_hash() {
+  local attr="$1"
+  local buildAttr="$2"
+
+  local fakeHash="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+  local oldHash
+  oldHash=$(escape_sed "$(nix_eval "$attr")")
+
+  sed -i "s/$oldHash/$fakeHash/" "$file"
+
+  local newHash
+  newHash=$(escape_sed "$(nix_get_hash "$buildAttr")")
+
+  if [[ -z "$newHash" ]]; then
+    echo "no $buildAttr found" >&2
+    exit 1
+  fi
+
+  sed -i "s/$fakeHash/$newHash/" "$file"
+}
+
+update_hash $attrPath.pnpmDeps.outputHash $attrPath.pnpmDeps
+update_hash $attrPath.cargoHash $attrPath.cargoDeps
+
+jq -n \
+  --arg attrPath "$attrPath" \
+  --arg oldVersion "$oldVersion" \
+  --arg newVersion "$latestVersion" \
+  --arg file "$nixpkgs/$file" \
+  '[{
+    attrPath: $attrPath,
+    oldVersion: $oldVersion,
+    newVersion: $newVersion,
+    files: [$file]
+  }]'

--- a/pkgs/by-name/re/retrom/update.sh
+++ b/pkgs/by-name/re/retrom/update.sh
@@ -8,8 +8,7 @@ nixpkgs="$PWD"
 attrPath="retrom"
 file="pkgs/by-name/${attrPath:0:2}/$attrPath/package.nix"
 
-retromReleaseUrl="https://api.github.com/repos/JMBeresford/retrom/releases/latest"
-retromRelease=$(curl --silent ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} $retromReleaseUrl)
+retromRelease=$(curl --silent ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} https://api.github.com/repos/JMBeresford/retrom/releases/latest)
 
 latestVersion=$(echo "$retromRelease" | jq -r ".tag_name")
 latestVersion="${latestVersion:1}" # remove first char 'v'


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- [Add Retrom game library management service as a package](https://github.com/JMBeresford/retrom/issues/474) https://github.com/JMBeresford/retrom.
- Includes separate packages for the client (retrom) and service (retrom-service) components.
- Accommodates client standalone operation (built-in service) integrated with nixpkgs postgres install.
- Added custom update script.
- Added myself (@concurac) as maintainer for the package.

## Notes

- I am down-streaming a rewrite of the packages in the Retrom flake, which has already been available for some weeks.
- I chose to opt for replacing cargoHash, as opposed to specifying the Cargo.lock due to git dependencies for correctness as they would require manual updates.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
