### PR TITLE
librsvg: fix gdk-pixbuf-loader on Darwin

### DIFF
--- a/pkgs/by-name/li/librsvg/librsvg-libpixbufloader-install-names.patch
+++ b/pkgs/by-name/li/librsvg/librsvg-libpixbufloader-install-names.patch
@@ -1,0 +1,25 @@
+--- a/gdk-pixbuf-loader/meson_install.py
++++ b/gdk-pixbuf-loader/meson_install.py
+@@ -13,6 +13,22 @@ if __name__ == '__main__':
+     argparse.add_argument('--cache-file', type=Path, metavar="PATH", help="module cache file to write")
+     argparse.add_argument('--show-cross-message', action='store_true', help="tell the user to run query-loaders manually")
+     args = argparse.parse_args()
++    if sys.platform in ['darwin', 'ios']:
++        modulepath = Path(args.moduledir).resolve()
++        prefix = modulepath.parent.parent.parent
++        location = modulepath
++        if 'DESTDIR' in os.environ:
++            location = Path(os.environ['DESTDIR']) / modulepath.relative_to('/')
++        oldfilepath = location / 'libpixbufloader_svg.dylib'
++        newfilename = 'libpixbufloader-svg.so'
++        newfilepath = location / newfilename
++        installfilepath = modulepath / 'libpixbufloader-svg.so'
++        librsvgpath = prefix / 'librsvg-2.2.dylib'
++        os.rename(oldfilepath.as_posix(), newfilepath.as_posix())
++        subprocess.run(
++            ['install_name_tool', '-id', installfilepath.as_posix(), newfilepath.as_posix()])
++        subprocess.run(
++            ['install_name_tool', '-change', '@rpath/librsvg-2.2.dylib', librsvgpath.as_posix(), newfilepath.as_posix()])
+ 
+     if not(args.show_cross_message or (args.queryloaders and args.moduledir and args.cache_file)):
+         argparse.print_help()

--- a/pkgs/by-name/li/librsvg/package.nix
+++ b/pkgs/by-name/li/librsvg/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch2,
   pkg-config,
   meson,
   ninja,
@@ -64,6 +65,16 @@ stdenv.mkDerivation (finalAttrs: {
     url = "mirror://gnome/sources/librsvg/${lib.versions.majorMinor finalAttrs.version}/librsvg-${finalAttrs.version}.tar.xz";
     hash = "sha256-/KDqKNHyj5XIQH0lefRwLawIXnx1hkTayotA0eByygw=";
   };
+
+  # FIXME: This patch should be made unconditional the next time librsvg is
+  # updated.
+  patches = lib.optionals stdenv.hostPlatform.isDarwin [
+    # https://gitlab.gnome.org/GNOME/librsvg/-/work_items/1161
+    (fetchpatch2 {
+      url = "https://gitlab.gnome.org/GNOME/gtk-osx/-/raw/2c1492036ff92d1c87d7b7a4c3c5a7a3f042f825/patches/librsvg-libpixbufloader-install-names.patch";
+      hash = "sha256-kEoKwAUW56KtMQ1zShXSnt2gwA+Ik/i8U8k2Zy9V+Jw=";
+    })
+  ];
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;

--- a/pkgs/by-name/li/librsvg/package.nix
+++ b/pkgs/by-name/li/librsvg/package.nix
@@ -65,6 +65,14 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-frRJsnIqdoAhNW9m3+4yAsIptU7U5qcM5AwJDpf/FvI=";
   };
 
+  # FIXME: This patch should be made unconditional the next time librsvg is
+  # updated.
+  patches = lib.optionals stdenv.hostPlatform.isDarwin [
+    # Rebased copy of https://gitlab.gnome.org/GNOME/gtk-osx/-/blob/2c1492036ff92d1c87d7b7a4c3c5a7a3f042f825/patches/librsvg-libpixbufloader-install-names.patch.
+    # Fixes https://gitlab.gnome.org/GNOME/librsvg/-/work_items/1161.
+    ./librsvg-libpixbufloader-install-names.patch
+  ];
+
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
     name = "librsvg-deps-${finalAttrs.version}";


### PR DESCRIPTION
Previously, gdk-pixbuf-loader failed to load because it referred to librsvg as `@rpath/librsvg-2.2.dylib` with no RPATH set, and wouldn't be picked up by gdk-pixbuf because it assumes `.so` file extensions.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
