### PR TITLE
statix: use molybdenumsoftware fork

### DIFF
--- a/pkgs/applications/editors/vim/plugins/non-generated/statix/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/statix/default.nix
@@ -2,14 +2,15 @@
   vimUtils,
   statix,
 }:
-vimUtils.buildVimPlugin rec {
-  inherit (statix) pname src meta;
-  version = "0.1.0";
-  postPatch = ''
-    # check that version is up to date
-    grep 'pname = "statix-vim"' -A 1 flake.nix \
-      | grep -F 'version = "${version}"'
+vimUtils.buildVimPlugin {
+  inherit (statix)
+    pname
+    src
+    meta
+    version
+    ;
 
+  postPatch = ''
     cd vim-plugin
     substituteInPlace ftplugin/nix.vim --replace-fail statix ${statix}/bin/statix
     substituteInPlace plugin/statix.vim --replace-fail statix ${statix}/bin/statix

--- a/pkgs/by-name/st/statix/package.nix
+++ b/pkgs/by-name/st/statix/package.nix
@@ -3,41 +3,31 @@
   rustPlatform,
   fetchFromGitHub,
   withJson ? true,
-  stdenv,
-  versionCheckHook,
   nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "statix";
-  # also update version of the vim plugin in
-  # pkgs/applications/editors/vim/plugins/overrides.nix
-  # the version can be found in flake.nix of the source code
-  version = "0.5.8";
+  version = "0-unstable-2026-05-03";
 
   src = fetchFromGitHub {
-    owner = "oppiliappan";
+    owner = "molybdenumsoftware";
     repo = "statix";
-    tag = "v${finalAttrs.version}";
-    sha256 = "sha256-bMs3XMiGP6sXCqdjna4xoV6CANOIWuISSzCaL5LYY4c=";
+    rev = "91e28aa76179b5769e8eff7ff4b09464d0913f27";
+    hash = "sha256-JDCJ8fgIs5ZdYygQxlR63H/V4VyfmVMR4FleWwAl+AM=";
   };
 
-  cargoHash = "sha256-Pi1q2qNLjQYr3Wla7rqrktNm0StszB2klcfzwAnF3tE=";
+  cargoHash = "sha256-lODAnIGw8MncMT5xicWORSbCChn2HQXENsOStJYHepQ=";
 
   buildFeatures = lib.optional withJson "json";
 
-  # tests are failing on darwin
-  doCheck = !stdenv.hostPlatform.isDarwin;
-
-  doInstallCheck = true;
-  nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
-
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script {
+    version = "branch";
+  };
 
   meta = {
     description = "Lints and suggestions for the nix programming language";
-    homepage = "https://github.com/oppiliappan/statix";
+    homepage = "https://github.com/molybdenumsoftware/statix";
     license = lib.licenses.mit;
     mainProgram = "statix";
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/st/statix/package.nix
+++ b/pkgs/by-name/st/statix/package.nix
@@ -31,6 +31,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.mit;
     mainProgram = "statix";
     maintainers = with lib.maintainers; [
+      mightyiam
       nerdypepper
       progrm_jarvis
     ];


### PR DESCRIPTION
My fork of statix under the molybdenumsoftware mob programming org has been receiving maintenance and fixes from me and others while the original has been stale.

I do hope to unfork, but until then, users should enjoy the benefits.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
