### PR TITLE
sonic-lineup: fix build with gcc15; fix qt wrapping

### DIFF
--- a/pkgs/by-name/so/sonic-lineup/package.nix
+++ b/pkgs/by-name/so/sonic-lineup/package.nix
@@ -10,6 +10,7 @@
   fftwFloat,
   libfishsound,
   libid3tag,
+  libjack2,
   liblo,
   libmad,
   liboggz,
@@ -23,9 +24,8 @@
   serd,
   sord,
   capnproto,
-  pkg-config,
-  libjack2,
   libsForQt5,
+  pkg-config,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -39,10 +39,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     (fetchpatch2 {
-      url = "https://github.com/sonic-visualiser/svcore/commit/5a7b517e43b7f0b3f03b7fc3145102cf4e5b0ffc.patch";
+      url = "https://github.com/sonic-visualiser/svcore/commit/5a7b517e43b7f0b3f03b7fc3145102cf4e5b0ffc.patch?full_index=1";
       stripLen = 1;
       extraPrefix = "svcore/";
-      sha256 = "sha256-DOCdQqCihkR0g/6m90DbJxw00QTpyVmFzCxagrVWKiI=";
+      hash = "sha256-ReFOGRyM7IXKOUuzNoGIVX+C+zMz3/fftQN7k5BHp0k=";
     })
     ./match-vamp.patch
     (fetchpatch2 {
@@ -57,10 +57,12 @@ stdenv.mkDerivation (finalAttrs: {
     alsa-lib
     boost
     bzip2
+    capnproto
     fftw
     fftwFloat
     libfishsound
     libid3tag
+    libjack2
     liblo
     libmad
     liboggz
@@ -73,14 +75,12 @@ stdenv.mkDerivation (finalAttrs: {
     rubberband
     serd
     sord
-    capnproto
-    libjack2
   ];
 
   nativeBuildInputs = [
     capnproto # capnp
-    pkg-config
     libsForQt5.wrapQtAppsHook
+    pkg-config
   ];
 
   strictDeps = true;

--- a/pkgs/by-name/so/sonic-lineup/package.nix
+++ b/pkgs/by-name/so/sonic-lineup/package.nix
@@ -63,6 +63,8 @@ stdenv.mkDerivation (finalAttrs: {
     libfishsound
     libid3tag
     libjack2
+    libsForQt5.qtbase
+    libsForQt5.qtsvg
     liblo
     libmad
     liboggz

--- a/pkgs/by-name/so/sonic-lineup/package.nix
+++ b/pkgs/by-name/so/sonic-lineup/package.nix
@@ -45,6 +45,12 @@ stdenv.mkDerivation (finalAttrs: {
       sha256 = "sha256-DOCdQqCihkR0g/6m90DbJxw00QTpyVmFzCxagrVWKiI=";
     })
     ./match-vamp.patch
+    (fetchpatch2 {
+      url = "https://github.com/piper-audio/piper-vamp-cpp/commit/6f16a09b78b995b3cf2844f00033bde90e5e0936.patch?full_index=1";
+      stripLen = 1;
+      extraPrefix = "piper-vamp-cpp/";
+      hash = "sha256-G9O9t1Niesffj4bDFO0q8KMgygTdYJUVHkq/7nkGSRk=";
+    })
   ];
 
   buildInputs = [


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/327601810

```
piper-vamp-cpp/ext/json11/json11.cpp: In function 'void json11::dump(const std::string&, std::string&)':
piper-vamp-cpp/ext/json11/json11.cpp:95:32: error: 'uint8_t' does not name a type
   95 |         } else if (static_cast<uint8_t>(ch) <= 0x1f) {
      |                                ^~~~~~~
piper-vamp-cpp/ext/json11/json11.cpp:28:1: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
   27 | #include <limits>
  +++ |+#include <cstdint>
   28 | 
piper-vamp-cpp/ext/json11/json11.cpp:99:32: error: 'uint8_t' does not name a type
   99 |         } else if (static_cast<uint8_t>(ch) == 0xe2 && static_cast<uint8_t>(value[i+1]) == 0x80
      |                                ^~~~~~~
piper-vamp-cpp/ext/json11/json11.cpp:99:32: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
piper-vamp-cpp/ext/json11/json11.cpp:99:68: error: 'uint8_t' does not name a type
   99 |         } else if (static_cast<uint8_t>(ch) == 0xe2 && static_cast<uint8_t>(value[i+1]) == 0x80
      |                                                                    ^~~~~~~
piper-vamp-cpp/ext/json11/json11.cpp:99:68: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
piper-vamp-cpp/ext/json11/json11.cpp:100:35: error: 'uint8_t' does not name a type
  100 |                    && static_cast<uint8_t>(value[i+2]) == 0xa8) {
      |                                   ^~~~~~~
piper-vamp-cpp/ext/json11/json11.cpp:100:35: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
piper-vamp-cpp/ext/json11/json11.cpp:103:32: error: 'uint8_t' does not name a type
  103 |         } else if (static_cast<uint8_t>(ch) == 0xe2 && static_cast<uint8_t>(value[i+1]) == 0x80
      |                                ^~~~~~~
piper-vamp-cpp/ext/json11/json11.cpp:103:32: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
piper-vamp-cpp/ext/json11/json11.cpp:103:68: error: 'uint8_t' does not name a type
  103 |         } else if (static_cast<uint8_t>(ch) == 0xe2 && static_cast<uint8_t>(value[i+1]) == 0x80
      |                                                                    ^~~~~~~
piper-vamp-cpp/ext/json11/json11.cpp:103:68: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
piper-vamp-cpp/ext/json11/json11.cpp:104:35: error: 'uint8_t' does not name a type
  104 |                    && static_cast<uint8_t>(value[i+2]) == 0xa9) {
      |                                   ^~~~~~~
piper-vamp-cpp/ext/json11/json11.cpp:104:35: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
...
```

Also cleaned up a bit. This does not load before due to incorrect qt wrapping.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
