### PR TITLE
nixos/h2o: upgrade Mozilla’s TLS recommendations (drops “old”)

### DIFF
--- a/nixos/modules/services/web-servers/h2o/common.nix
+++ b/nixos/modules/services/web-servers/h2o/common.nix
@@ -5,7 +5,6 @@
       lib.types.enum [
         "modern"
         "intermediate"
-        "old"
       ]
     );
     default = null;
@@ -27,10 +26,6 @@
       intermediate
       : General-purpose servers with a variety of clients, recommended for
         almost all systems
-
-      old
-      : Compatible with a number of very old clients, & should be used only as
-        a last resort
 
       The default for all virtual hosts can be set with
       services.h2o.defaultTLSRecommendations, but this value can be overridden

--- a/nixos/modules/services/web-servers/h2o/default.nix
+++ b/nixos/modules/services/web-servers/h2o/default.nix
@@ -84,8 +84,8 @@ let
         # other settings with the tests @
         # `nixos/tests/web-servers/h2o/tls-recommendations.nix`
         # & run with `nix-build -A nixosTests.h2o.tls-recommendations`
-        version = "5.7";
-        git_tag = "v5.7.1";
+        version = "6.0";
+        git_tag = "v6.0";
         guidelinesJSON =
           lib.pipe
             {
@@ -93,7 +93,7 @@ let
                 "https://ssl-config.mozilla.org/guidelines/${version}.json"
                 "https://raw.githubusercontent.com/mozilla/ssl-config-generator/refs/tags/${git_tag}/src/static/guidelines/${version}.json"
               ];
-              sha256 = "sha256:1mj2pcb1hg7q2wpgdq3ac8pc2q64wvwvwlkb9xjmdd9jm4hiyny7";
+              sha256 = "sha256-aHdzLNPo4c6jlbS+Fg3R0X5VcdPKtUky0oX5Q7Y94SQ=";
             }
             [
               pkgs.fetchurl

--- a/nixos/tests/web-servers/h2o/tls-recommendations.nix
+++ b/nixos/tests/web-servers/h2o/tls-recommendations.nix
@@ -25,7 +25,6 @@ let
           lib.optionalAttrs
             (builtins.elem recommendations [
               "intermediate"
-              "old"
             ])
             {
               openssl = pkgs.openssl_legacy;
@@ -83,24 +82,20 @@ in
   nodes = {
     server_modern = mkH2OServer "modern";
     server_intermediate = mkH2OServer "intermediate";
-    server_old = mkH2OServer "old";
   };
 
   testScript =
     { nodes, ... }:
     let
-      inherit (nodes) server_modern server_intermediate server_old;
+      inherit (nodes) server_modern server_intermediate;
       modernPortStr = toString server_modern.services.h2o.hosts.${domain}.tls.port;
       intermediatePortStr = toString server_intermediate.services.h2o.hosts.${domain}.tls.port;
-      oldPortStr = toString server_old.services.h2o.hosts.${domain}.tls.port;
     in
-    # python
-    ''
+    /* python */ ''
       curl_basic = "curl -v --tlsv1.3 --http2 'https://${domain}:{port}/'"
       curl_head = "curl -v --head 'https://${domain}:{port}/'"
       curl_max_tls1_2 ="curl -v --tlsv1.0 --tls-max 1.2 'https://${domain}:{port}/'"
       curl_max_tls1_2_intermediate_cipher ="curl -v --tlsv1.0 --tls-max 1.2 --ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256' 'https://${domain}:{port}/'"
-      curl_max_tls1_2_old_cipher ="curl -v --tlsv1.0 --tls-max 1.2 --ciphers 'ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA256' 'https://${domain}:{port}/'"
 
       start_all()
 
@@ -120,16 +115,5 @@ in
       assert "strict-transport-security" in intermediate_head
       server_intermediate.succeed(curl_max_tls1_2.format(port="${intermediatePortStr}"))
       server_intermediate.succeed(curl_max_tls1_2_intermediate_cipher.format(port="${intermediatePortStr}"))
-      server_intermediate.fail(curl_max_tls1_2_old_cipher.format(port="${intermediatePortStr}"))
-
-      server_old.wait_for_unit("h2o.service")
-      server_old.wait_for_open_port(${oldPortStr})
-      old_response = server_old.succeed(curl_basic.format(port="${oldPortStr}"))
-      assert "Hello, old!" in old_response
-      old_head = server_modern.succeed(curl_head.format(port="${oldPortStr}"))
-      assert "strict-transport-security" in old_head
-      server_old.succeed(curl_max_tls1_2.format(port="${oldPortStr}"))
-      server_old.succeed(curl_max_tls1_2_intermediate_cipher.format(port="${oldPortStr}"))
-      server_old.succeed(curl_max_tls1_2_old_cipher.format(port="${oldPortStr}"))
     '';
 }


### PR DESCRIPTION
<!--
^ Please summarize the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Upgrade removed the “old” value

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.