### PR TITLE
maintainers: remove anhdle14

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1827,13 +1827,6 @@
     githubId = 102513;
     keys = [ { fingerprint = "B7B7 582E 564E 789B FCB8  71AB 0C6D FE2F B234 534A"; } ];
   };
-  anhdle14 = {
-    name = "Le Anh Duc";
-    email = "anhdle14@icloud.com";
-    github = "anhdle14";
-    githubId = 9645992;
-    keys = [ { fingerprint = "AA4B 8EC3 F971 D350 482E  4E20 0299 AFF9 ECBB 5169"; } ];
-  };
   anhduy = {
     email = "vo@anhduy.io";
     github = "voanhduy1512";

--- a/pkgs/by-name/ch/checkov/package.nix
+++ b/pkgs/by-name/ch/checkov/package.nix
@@ -204,9 +204,6 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     '';
     mainProgram = "checkov";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [
-      anhdle14
-      fab
-    ];
+    maintainers = with lib.maintainers; [ fab ];
   };
 })

--- a/pkgs/development/python-modules/bc-python-hcl2/default.nix
+++ b/pkgs/development/python-modules/bc-python-hcl2/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     '';
     homepage = "https://github.com/bridgecrewio/python-hcl2";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ anhdle14 ];
+    maintainers = [ ];
     mainProgram = "hcl2tojson";
   };
 }


### PR DESCRIPTION
## Reasons

- Last commented in [October 2023](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Aanhdle14)
- Hasn't created any PRs / Issues since [December 2020](https://github.com/NixOS/nixpkgs/issues?q=author%3Aanhdle14)
- About 450 [unanswered ](https://github.com/NixOS/nixpkgs/issues?q=involves%3Aanhdle14%20-commenter%3Aanhdle14%20-author%3Aanhdle14%20-reviewed-by%3Aanhdle14) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] python3Packages.bc-python-hcl2