### PR TITLE
gscan2pdf: disable a failing test

### DIFF
--- a/pkgs/by-name/gs/gscan2pdf/package.nix
+++ b/pkgs/by-name/gs/gscan2pdf/package.nix
@@ -123,14 +123,14 @@ perlPackages.buildPerlPackage rec {
   ]);
 
   checkPhase = ''
-    # Temporarily disable a test failing because of a behavioural change in ImageMagick7
-    # t/04_Page.t ................................... 1/12
-    #   Failed test 'undefined'
-    #   at t/04_Page.t line 114.
-    #          got: '72'
-    #     expected: '300'
-    # Looks like you failed 1 test of 12.
+    # Skip a failing test, due to a change in ImageMagick:
+    # https://sourceforge.net/p/gscan2pdf/bugs/439/
     rm t/04_Page.t
+
+    # Skip a failing test, due to a breaking change in ImageMagick:
+    # https://sourceforge.net/p/gscan2pdf/bugs/442/
+    # https://github.com/ImageMagick/ImageMagick/issues/8714
+    rm t/113_save_pdf_with_downsample.t
 
     export XDG_CACHE_HOME="$(mktemp -d)"
     xvfb-run -s '-screen 0 800x600x24' \


### PR DESCRIPTION
This is due to a breaking change in ImageMagick. I reported the issue to
both gscan2pdf and ImageMagick:

- https://sourceforge.net/p/gscan2pdf/bugs/442/
- https://github.com/ImageMagick/ImageMagick/issues/8714


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
