### PR TITLE
nixos/modemmanager: new systemd-networkd integration

### DIFF
--- a/nixos/modules/services/networking/modemmanager.nix
+++ b/nixos/modules/services/networking/modemmanager.nix
@@ -73,6 +73,7 @@ in
       ];
 
       wantedBy = [ "network.target" ];
+      serviceConfig.KillMode = "mixed";
     };
 
     /*

--- a/nixos/modules/services/networking/modemmanager.nix
+++ b/nixos/modules/services/networking/modemmanager.nix
@@ -71,6 +71,8 @@ in
         pkgs.libqmi
         pkgs.libmbim
       ];
+
+      wantedBy = [ "network.target" ];
     };
 
     /*

--- a/nixos/modules/services/networking/modemmanager.nix
+++ b/nixos/modules/services/networking/modemmanager.nix
@@ -6,6 +6,9 @@
 }:
 let
   cfg = config.networking.modemmanager;
+
+  useNetworkManager = config.networking.networkmanager.enable;
+  useNetworkd = config.systemd.network.enable;
 in
 {
   meta = {
@@ -79,15 +82,26 @@ in
       ResultActive=yes
     */
     security.polkit.enable = true;
-    security.polkit.extraConfig = ''
-      polkit.addRule(function(action, subject) {
-        if (
-          subject.isInGroup("networkmanager")
-          && action.id.indexOf("org.freedesktop.ModemManager") == 0
-          )
-            { return polkit.Result.YES; }
-      });
-    '';
+    security.polkit.extraConfig = lib.concatStrings [
+      (lib.optionalString useNetworkManager ''
+        polkit.addRule(function(action, subject) {
+          if (
+            subject.isInGroup("networkmanager")
+            && action.id.indexOf("org.freedesktop.ModemManager") == 0
+            )
+              { return polkit.Result.YES; }
+        });
+      '')
+      (lib.optionalString useNetworkd ''
+        polkit.addRule(function(action, subject) {
+          if (
+            subject.isInGroup("systemd-network")
+            && action.id.indexOf("org.freedesktop.ModemManager") == 0
+            )
+              { return polkit.Result.YES; }
+        });
+      '')
+    ];
 
     environment.systemPackages = [ cfg.package ];
     systemd.packages = [ cfg.package ];

--- a/nixos/modules/services/networking/modemmanager.nix
+++ b/nixos/modules/services/networking/modemmanager.nix
@@ -85,8 +85,8 @@ in
       ResultActive=yes
     */
     security.polkit.enable = true;
-    security.polkit.extraConfig = lib.concatStrings [
-      (lib.optionalString useNetworkManager ''
+    security.polkit.extraConfig = lib.mkMerge [
+      (lib.mkIf useNetworkManager ''
         polkit.addRule(function(action, subject) {
           if (
             subject.isInGroup("networkmanager")
@@ -95,7 +95,7 @@ in
               { return polkit.Result.YES; }
         });
       '')
-      (lib.optionalString useNetworkd ''
+      (lib.mkIf useNetworkd ''
         polkit.addRule(function(action, subject) {
           if (
             subject.isInGroup("systemd-network")


### PR DESCRIPTION
The systemd v260 release has a new ModemManager integration for systemd-networkd. I've had a PR (https://github.com/NixOS/nixpkgs/pull/513521) merged for configuring the networkd side of things but found the following are needed in the `nixos/modemmanager` module:

1. a new Polkit rule to allow systemd-networkd to communicate with ModemManager
2. a way to start `ModemManager.service` automatically
   + (see also: https://github.com/NixOS/nixpkgs/issues/270809)

In testing this I've also found that the ModemManager.service does not stop cleanly and that changing the service `KillMode=mixed` fixes this (see [`man systemd.kill`](https://www.freedesktop.org/software/systemd/man/latest/systemd.kill.html)).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## NixOS test results

- `nixosTests.networking.networkd` fails with `AssertionError: fou1 exists`

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 516073`
Commit: `cabcc3873e5ac62ad64a0c82dff1630d9143440c`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 2 packages blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
    <li>tests.nixos-functions.nixos-test</li>
  </ul>
</details>