### PR TITLE
h2: use finalAttrs instead of rec

### DIFF
--- a/pkgs/by-name/h2/h2/package.nix
+++ b/pkgs/by-name/h2/h2/package.nix
@@ -7,7 +7,7 @@
   nix-update-script,
 }:
 
-maven.buildMavenPackage rec {
+maven.buildMavenPackage (finalAttrs: {
   pname = "h2";
   version = "2.4.240";
 
@@ -19,7 +19,7 @@ maven.buildMavenPackage rec {
   src = fetchFromGitHub {
     owner = "h2database";
     repo = "h2database";
-    tag = "version-${version}";
+    tag = "version-${finalAttrs.version}";
     hash = "sha256-Cy6MoumJBhhcYT6dCHWeOfmhjGRkdNvSONdIiZaf6uU=";
   };
 
@@ -32,10 +32,10 @@ maven.buildMavenPackage rec {
 
   installPhase = ''
     mkdir -p $out/share/java
-    install -Dm644 h2/target/h2-${version}.jar $out/share/java
+    install -Dm644 h2/target/h2-${finalAttrs.version}.jar $out/share/java
 
     makeWrapper ${jre}/bin/java $out/bin/h2 \
-      --add-flags "-cp \"$out/share/java/h2-${version}.jar:\$H2DRIVERS:\$CLASSPATH\" org.h2.tools.Console"
+      --add-flags "-cp \"$out/share/java/h2-${finalAttrs.version}.jar:\$H2DRIVERS:\$CLASSPATH\" org.h2.tools.Console"
 
     mkdir -p $doc/share/doc/h2
     cp -r h2/src/docsrc/* $doc/share/doc/h2
@@ -60,4 +60,4 @@ maven.buildMavenPackage rec {
     ];
     mainProgram = "h2";
   };
-}
+})


### PR DESCRIPTION
This was enabled by #513696

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
