### PR TITLE
process-viewer: 0.5.8 -> 0.5.11, adopt, `__structuredAttrs`

### DIFF
--- a/pkgs/by-name/pr/process-viewer/package.nix
+++ b/pkgs/by-name/pr/process-viewer/package.nix
@@ -8,14 +8,17 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "process-viewer";
-  version = "0.5.8";
+  version = "0.5.11";
+
+  __structuredAttrs = true;
 
   src = fetchCrate {
-    inherit (finalAttrs) pname version;
-    hash = "sha256-mEmtLCtHlrCurjKKJ3vEtEkLBik4LwuUED5UeQ1QLws=";
+    inherit (finalAttrs) version;
+    pname = "process_viewer";
+    hash = "sha256-d2qEcb9iPnhNnRFbzbktk36hyL16opcDgE9xOnmlJGg=";
   };
 
-  cargoHash = "sha256-vmNqay/tYGASSez+VqyCQVMW+JGqfBvjwSKx0AG/LeY=";
+  cargoHash = "sha256-UD0eTRfHimp6ZGStvrP1upUe3yO3Mw96Sq3OG4Y7zn0=";
 
   nativeBuildInputs = [ pkg-config ];
 
@@ -31,7 +34,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "Process viewer GUI in rust";
     homepage = "https://github.com/guillaumegomez/process-viewer";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.matthiasbeyer ];
+    maintainers = with lib.maintainers; [
+      matthiasbeyer
+      kybe236
+    ];
     mainProgram = "process_viewer";
   };
 })


### PR DESCRIPTION
## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
