### PR TITLE
dmarc-metrics-exporter: 1.2.0 -> 1.3.0

### DIFF
--- a/pkgs/by-name/dm/dmarc-metrics-exporter/package.nix
+++ b/pkgs/by-name/dm/dmarc-metrics-exporter/package.nix
@@ -12,7 +12,7 @@ in
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "dmarc-metrics-exporter";
-  version = "1.2.0";
+  version = "1.3.0";
 
   pyproject = true;
 
@@ -20,7 +20,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     owner = "jgosmann";
     repo = "dmarc-metrics-exporter";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-cIsI4TNYuLK0fpUg9lnbl5KSBtzQoT/pTByI9hiy/7o=";
+    hash = "sha256-B2a/F0Ebz6zpe4apVRl7+lX0IS099EmuWOatW2HZdVM=";
   };
 
   pythonRelaxDeps = true;
@@ -35,6 +35,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
       bite-parser
       dataclasses-serialization
       prometheus-client
+      pydantic
       structlog
       uvicorn
       xsdata


### PR DESCRIPTION
ChangeLog: https://github.com/jgosmann/dmarc-metrics-exporter/releases/tag/v1.3.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
