### PR TITLE
prometheus-bird-exporter: 1.4.3 -> 1.4.5

### DIFF
--- a/pkgs/by-name/pr/prometheus-bird-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-bird-exporter/package.nix
@@ -5,18 +5,20 @@
   nixosTests,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "bird-exporter";
-  version = "1.4.3";
+  version = "1.4.5";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "czerwonk";
     repo = "bird_exporter";
-    rev = version;
-    sha256 = "sha256-aClwJ+J83iuZbfNP+Y1vKEjBULD5wh/R3TMceCccacc=";
+    tag = "v${finalAttrs.version}";
+    sha256 = "sha256-uR3/2ktVxzEZOy57eFopLFsAuiw03e9WZn2QC4/GNVc=";
   };
 
-  vendorHash = "sha256-0EXRpehdpOYpq6H9udmNnQ24EucvAcPUKOlFSAAewbE=";
+  vendorHash = "sha256-seTykqpdYQiWp8CoTAJ62rzxDaLFqjWe8y5YMu8Ypm8=";
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) bird; };
 
@@ -27,4 +29,4 @@ buildGoModule rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ lukegb ];
   };
-}
+})

--- a/pkgs/by-name/pr/prometheus-bird-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-bird-exporter/package.nix
@@ -5,26 +5,29 @@
   nixosTests,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "bird-exporter";
-  version = "1.4.3";
+  version = "1.4.5";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "czerwonk";
     repo = "bird_exporter";
-    rev = version;
-    sha256 = "sha256-aClwJ+J83iuZbfNP+Y1vKEjBULD5wh/R3TMceCccacc=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-uR3/2ktVxzEZOy57eFopLFsAuiw03e9WZn2QC4/GNVc=";
   };
 
-  vendorHash = "sha256-0EXRpehdpOYpq6H9udmNnQ24EucvAcPUKOlFSAAewbE=";
+  vendorHash = "sha256-seTykqpdYQiWp8CoTAJ62rzxDaLFqjWe8y5YMu8Ypm8=";
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) bird; };
 
   meta = {
     description = "Prometheus exporter for the bird routing daemon";
-    mainProgram = "bird_exporter";
     homepage = "https://github.com/czerwonk/bird_exporter";
+    changelog = "https://github.com/czerwonk/bird_exporter/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ lukegb ];
+    mainProgram = "bird_exporter";
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/czerwonk/bird_exporter/compare/1.4.3...v1.4.5
Changelogs:
> https://github.com/czerwonk/bird_exporter/releases/tag/v1.4.5
> https://github.com/czerwonk/bird_exporter/releases/tag/v1.4.4

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
