### PR TITLE
nexusd: init at 3.3.0

### DIFF
--- a/pkgs/by-name/ne/nexusd/package.nix
+++ b/pkgs/by-name/ne/nexusd/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "nexusd";
+  version = "3.3.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "gammazero";
+    repo = "nexus";
+    rev = "v${finalAttrs.version}";
+    sha256 = "sha256-c9y1NplODCIz+IZlZAyzm3G75D1wawTwbB6SZXZqjXc=";
+  };
+
+  vendorHash = "sha256-1sZDoDcX/9upTZ8bL7l+ldsouBZVT+61RFSRaeB6Dm8=";
+
+  subPackages = [ "nexusd" ];
+
+  meta = {
+    description = "Full-feature WAMP v2 router written in Go";
+    homepage = "https://github.com/gammazero/nexus";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kiara ];
+    mainProgram = "nexusd";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/ne/nexusd/package.nix
+++ b/pkgs/by-name/ne/nexusd/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule rec {
+  pname = "nexusd";
+  version = "3.3.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "gammazero";
+    repo = "nexus";
+    rev = "v${version}";
+    sha256 = "sha256-c9y1NplODCIz+IZlZAyzm3G75D1wawTwbB6SZXZqjXc=";
+  };
+
+  vendorHash = "sha256-1sZDoDcX/9upTZ8bL7l+ldsouBZVT+61RFSRaeB6Dm8=";
+
+  subPackages = [ "nexusd" ];
+
+  meta = {
+    description = "Full-feature WAMP v2 router written in Go";
+    homepage = "https://github.com/gammazero/nexus";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kiara ];
+    mainProgram = "nexusd";
+  };
+}


### PR DESCRIPTION
Add [nexusd](https://github.com/gammazero/nexus), a WAMP v2 router written in Go.
Note that while the upstream repo also offers a (client) library, this package is scoped to just the router daemon.

disclaimer i used a coding agent in the creation of this patch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
