### PR TITLE
coroot: 1.17.9 -> 1.19.7

### DIFF
--- a/pkgs/by-name/co/coroot/package.nix
+++ b/pkgs/by-name/co/coroot/package.nix
@@ -11,19 +11,19 @@
 
 buildGoModule (finalAttrs: {
   pname = "coroot";
-  version = "1.17.9";
+  version = "1.19.7";
 
   src = fetchFromGitHub {
     owner = "coroot";
     repo = "coroot";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-hr1t3WaYEOYnj3Cam2NGgiGD49Vr9HBkz4JmOlJxzQQ=";
+    hash = "sha256-eMN0n+kXN49o7oCjWAa3kPDAEksvGroRLrfFEVdPORE=";
   };
 
   vendorHash = "sha256-DCdrE8UYkuUN+rUuxVSGbAnAeLivZ2Xp8xjM+56ZF+A=";
   npmDeps = fetchNpmDeps {
     src = "${finalAttrs.src}/front";
-    hash = "sha256-6a8eOPgAdpZpdXmrHVw/twfikjjWHSy/BdYdlyRQkjc=";
+    hash = "sha256-5N4dmtKdZgwulqxFHYKhnHOYAg0gnb/rzVVcmzjYFUg=";
   };
 
   nativeBuildInputs = [
@@ -42,6 +42,9 @@ buildGoModule (finalAttrs: {
   preBuild = ''
     npm --prefix="$npmRoot" run build-prod
   '';
+
+  # required for tests
+  __darwinAllowLocalNetworking = true;
 
   meta = {
     description = "Open-source APM & Observability tool";


### PR DESCRIPTION
Update to 1.19.7

Simple hash update that failed in r-ryantm because of npm hash.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
