### PR TITLE
maven_4: init at 4.0.0-rc5

### DIFF
--- a/doc/languages-frameworks/maven.section.md
+++ b/doc/languages-frameworks/maven.section.md
@@ -174,6 +174,59 @@ To make sure that your package does not add extra manual effort when upgrading M
 </plugin>
 ```
 
+## Maven 4 {#maven-4}
+
+Alongside the default `maven` package (the latest Maven 3 release), nixpkgs ships `maven_4`, which packages the [Maven 4](https://maven.apache.org/whatsnewinmaven4.html) release line.
+
+`maven_4` is a standalone derivation and can be used as a drop-in replacement wherever `maven` is used, for example to build a project with the latest Maven 4:
+
+```nix
+{
+  lib,
+  fetchFromGitHub,
+  jre,
+  makeWrapper,
+  maven_4,
+}:
+
+maven_4.buildMavenPackage (finalAttrs: {
+  pname = "jd-cli";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "intoolswetrust";
+    repo = "jd-cli";
+    tag = "jd-cli-${finalAttrs.version}";
+    hash = "sha256-rRttA5H0A0c44loBzbKH7Waoted3IsOgxGCD2VM0U/Q=";
+  };
+
+  mvnHash = "";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/jd-cli
+    install -Dm644 jd-cli/target/jd-cli.jar $out/share/jd-cli
+
+    makeWrapper ${jre}/bin/java $out/bin/jd-cli \
+      --add-flags "-jar $out/share/jd-cli/jd-cli.jar"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Simple command line wrapper around JD Core Java Decompiler project";
+    homepage = "https://github.com/intoolswetrust/jd-cli";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ majiir ];
+  };
+})
+```
+
+`maven_4` exposes the same `buildMavenPackage` helper as `maven` (see [](#maven-buildmavenpackage)), so all of the patterns documented above apply equally. Note that the Maven dependencies resolved by Maven 4 differ from those resolved by Maven 3, so `mvnHash` must be recomputed when switching between the two.
+
 ## Manually using `mvn2nix` {#maven-mvn2nix}
 ::: {.warning}
 This way is no longer recommended; see [](#maven-buildmavenpackage) for the simpler and preferred way.

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -3942,6 +3942,9 @@
   "maven": [
     "index.html#maven"
   ],
+  "maven-4": [
+    "index.html#maven-4"
+  ],
   "maven-buildmavenpackage": [
     "index.html#maven-buildmavenpackage"
   ],

--- a/pkgs/by-name/ma/maven/build-maven-package.nix
+++ b/pkgs/by-name/ma/maven/build-maven-package.nix
@@ -112,6 +112,7 @@ let
               -o -name resolver-status.properties \
               -o -name _remote.repositories \) \
               -delete
+            rm -rf $out/.m2/.meta
 
             runHook postInstall
           '';

--- a/pkgs/by-name/ma/maven/package.nix
+++ b/pkgs/by-name/ma/maven/package.nix
@@ -47,17 +47,26 @@ stdenvNoCC.mkDerivation (finalAttrs: {
         // {
           overrideMavenAttrs = newArgs: makeOverridableMavenPackage mavenRecipe (overrideWith newArgs);
         };
+
+      # Exposed so other Maven versions (e.g. maven_4) can reuse the builder
+      # without duplicating build-maven-package.nix.
+      mkBuildMavenPackage =
+        maven:
+        makeOverridableMavenPackage (
+          callPackage ./build-maven-package.nix {
+            inherit maven;
+          }
+        );
     in
     {
       buildMaven = callPackage ./build-maven.nix {
         maven = finalAttrs.finalPackage;
       };
 
-      buildMavenPackage = makeOverridableMavenPackage (
-        callPackage ./build-maven-package.nix {
-          maven = finalAttrs.finalPackage;
-        }
-      );
+      inherit mkBuildMavenPackage;
+
+      buildMavenPackage = mkBuildMavenPackage finalAttrs.finalPackage;
+
       tests = {
         version = testers.testVersion {
           package = finalAttrs.finalPackage;

--- a/pkgs/by-name/ma/maven_4/package.nix
+++ b/pkgs/by-name/ma/maven_4/package.nix
@@ -1,0 +1,15 @@
+{
+  fetchurl,
+  maven,
+}:
+maven.overrideAttrs (
+  final: _prev: {
+    version = "4.0.0-rc-5";
+    src = fetchurl {
+      url = "mirror://apache/maven/maven-4/${final.version}/binaries/apache-maven-${final.version}-bin.tar.gz";
+      hash = "sha256-7OalyZ09BBx25/7RgU656jogoSC8s8I1pz0sTo2xbKE=";
+    };
+    strictDeps = true;
+    __structuredAttrs = true;
+  }
+)

--- a/pkgs/by-name/ma/maven_4/package.nix
+++ b/pkgs/by-name/ma/maven_4/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  fetchurl,
+  jdk25_headless,
+  makeWrapper,
+  maven,
+  stdenvNoCC,
+  testers,
+}:
+let
+  # Maven 4 defaults to the latest LTS JDK. Bump this binding to change it.
+  jdk_headless = jdk25_headless;
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "maven";
+  version = "4.0.0-rc-5";
+
+  src = fetchurl {
+    url = "mirror://apache/maven/maven-4/${finalAttrs.version}/binaries/apache-maven-${finalAttrs.version}-bin.tar.gz";
+    hash = "sha256-7OalyZ09BBx25/7RgU656jogoSC8s8I1pz0sTo2xbKE=";
+  };
+
+  sourceRoot = ".";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/maven
+    cp -r apache-maven-${finalAttrs.version}/* $out/maven
+
+    makeWrapper $out/maven/bin/mvn $out/bin/mvn \
+      --set-default JAVA_HOME "${jdk_headless}"
+    makeWrapper $out/maven/bin/mvnDebug $out/bin/mvnDebug \
+      --set-default JAVA_HOME "${jdk_headless}"
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    # Reuse maven's builder so build-maven-package.nix is not duplicated.
+    buildMavenPackage = maven.mkBuildMavenPackage finalAttrs.finalPackage;
+
+    tests = {
+      version = testers.testVersion {
+        package = finalAttrs.finalPackage;
+        command = ''
+          env MAVEN_OPTS="-Dmaven.repo.local=$TMPDIR/m2" \
+            mvn --version
+        '';
+      };
+    };
+  };
+
+  meta = {
+    homepage = "https://maven.apache.org/";
+    description = "Build automation tool (used primarily for Java projects)";
+    longDescription = ''
+      Apache Maven is a software project management and comprehension
+      tool. Based on the concept of a project object model (POM), Maven can
+      manage a project's build, reporting and documentation from a central piece
+      of information.
+    '';
+    changelog = "https://maven.apache.org/docs/${finalAttrs.version}/release-notes.html";
+    sourceProvenance = with lib.sourceTypes; [
+      binaryBytecode
+      binaryNativeCode
+    ];
+    license = lib.licenses.asl20;
+    mainProgram = "mvn";
+    maintainers = with lib.maintainers; [
+      tricktron
+      britter
+    ];
+    teams = [ lib.teams.java ];
+    inherit (jdk_headless.meta) platforms;
+  };
+})


### PR DESCRIPTION
Adds a new package called maven_4 which builds maven 4.0.0-rc5. The packages is based on the existing maven package, and copies most of it. `maven_4` provides a `buildMavenPackage` hook that works the same way as `maven.buildMavenPackage` but uses `maven_4` for building. `maven_4` does not provide `buildMaven` since it is semi deprecated.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
