### PR TITLE
frp: 0.66.0 -> 0.69.1

### DIFF
--- a/pkgs/by-name/fr/frp/dashboard.nix
+++ b/pkgs/by-name/fr/frp/dashboard.nix
@@ -1,0 +1,34 @@
+{
+  buildNpmPackage,
+  src,
+  version,
+}:
+let
+  builder =
+    name:
+    buildNpmPackage {
+      pname = "${name}-dashboard";
+      inherit version src;
+
+      sourceRoot = "source/web";
+
+      buildPhase = ''
+        runHook preBuild
+        cd ${name}
+        npm run build
+        runHook postBuild
+      '';
+
+      installPhase = ''
+        runHook preInstall
+        cp -r dist $out
+        runHook postInstall
+      '';
+
+      npmDepsHash = "sha256-ZScKHx3WhXb/BzGsm4vrWjxeL/K8zfBmectBr66iKFQ=";
+    };
+in
+{
+  frpc = builder "frpc";
+  frps = builder "frps";
+}

--- a/pkgs/by-name/fr/frp/dashboard.nix
+++ b/pkgs/by-name/fr/frp/dashboard.nix
@@ -1,0 +1,34 @@
+{
+  buildNpmPackage,
+  frp,
+}:
+let
+  builder =
+    name:
+    buildNpmPackage {
+      pname = "${name}-dashboard";
+      inherit (frp) version src;
+
+      sourceRoot = "source/web";
+
+      preBuild = ''
+        pushd ${name}
+      '';
+
+      installPhase = ''
+        runHook preInstall
+        cp -r dist $out
+        runHook postInstall
+      '';
+
+      npmDepsHash = "sha256-XuqQPfywzK81anAD1pAl1TMQqb1+hH2QxLwuTn7zCPU=";
+
+      meta = frp.meta // {
+        description = "Dashboard for frp";
+      };
+    };
+in
+{
+  frpc = builder "frpc";
+  frps = builder "frps";
+}

--- a/pkgs/by-name/fr/frp/package.nix
+++ b/pkgs/by-name/fr/frp/package.nix
@@ -1,22 +1,26 @@
 {
   buildGoModule,
+  callPackage,
   lib,
   fetchFromGitHub,
   nixosTests,
 }:
-
-buildGoModule (finalAttrs: {
-  pname = "frp";
-  version = "0.66.0";
+let
+  version = "0.68.1";
 
   src = fetchFromGitHub {
     owner = "fatedier";
     repo = "frp";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-GFvXdhX7kA43kppWWdL7KhummUCqpa1cQ7V2d9ISGfo=";
+    tag = "v${version}";
+    hash = "sha256-AF0SrJFqWzwYJZSRm36fl+nR3TO6GldUMko18AkhjLI=";
   };
+  web = callPackage ./dashboard.nix { inherit version src; };
+in
+buildGoModule (finalAttrs: {
+  pname = "frp";
+  inherit version src;
 
-  vendorHash = "sha256-m5ECF0cgp2LfsTKey02MHz5TfqfzOCT5cU5trUfrOjY=";
+  vendorHash = "sha256-Tolhk0si85L/ZRs5k+xt5H6bZceZaW7xMPvcunHufSU=";
 
   doCheck = false;
 
@@ -24,6 +28,11 @@ buildGoModule (finalAttrs: {
     "cmd/frpc"
     "cmd/frps"
   ];
+
+  preBuild = ''
+    cp -r ${web.frpc} web/frpc/dist
+    cp -r ${web.frps} web/frps/dist
+  '';
 
   passthru.tests = {
     frp = nixosTests.frp;

--- a/pkgs/by-name/fr/frp/package.nix
+++ b/pkgs/by-name/fr/frp/package.nix
@@ -1,22 +1,24 @@
 {
   buildGoModule,
+  callPackage,
   lib,
   fetchFromGitHub,
   nixosTests,
 }:
-
+let
+  web = callPackage ./dashboard.nix { };
+in
 buildGoModule (finalAttrs: {
   pname = "frp";
-  version = "0.66.0";
-
+  version = "0.69.1";
   src = fetchFromGitHub {
     owner = "fatedier";
     repo = "frp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-GFvXdhX7kA43kppWWdL7KhummUCqpa1cQ7V2d9ISGfo=";
+    hash = "sha256-3tOOgnzZZ05En5NMLbp4UFNazX950Jbosvszmjf947c=";
   };
 
-  vendorHash = "sha256-m5ECF0cgp2LfsTKey02MHz5TfqfzOCT5cU5trUfrOjY=";
+  vendorHash = "sha256-JrkIztnmhEYAogr4pDWrPu9/j+C0VLpEyNbh2UK5UcY=";
 
   doCheck = false;
 
@@ -25,8 +27,14 @@ buildGoModule (finalAttrs: {
     "cmd/frps"
   ];
 
-  passthru.tests = {
-    frp = nixosTests.frp;
+  preBuild = ''
+    cp -r ${web.frpc} web/frpc/dist
+    cp -r ${web.frps} web/frps/dist
+  '';
+
+  passthru = {
+    tests.frp = nixosTests.frp;
+    inherit web;
   };
 
   meta = {

--- a/pkgs/by-name/fr/frp/package.nix
+++ b/pkgs/by-name/fr/frp/package.nix
@@ -47,5 +47,6 @@ buildGoModule (finalAttrs: {
     '';
     homepage = "https://github.com/fatedier/frp";
     license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ epireyn ];
   };
 })


### PR DESCRIPTION
This update refactors the packaging of the dashboard (now compiled using npm). It is therefore built in the dashboard.nix file and used in the package's preBuild phase.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I tested the server dashboard, and it is showing correctly.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
