### PR TITLE
nixos/profiles/base: add explicit support for ext filesystems

### DIFF
--- a/nixos/modules/profiles/base.nix
+++ b/nixos/modules/profiles/base.nix
@@ -53,6 +53,9 @@
   # Include support for various filesystems and tools to create / manipulate them.
   boot.supportedFilesystems = lib.mkMerge [
     [
+      "ext2"
+      "ext3"
+      "ext4"
       "btrfs"
       "cifs"
       "f2fs"


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/515555

ext filesystems are only supported unconditionally if the systemd initrd is NOT used (see https://github.com/NixOS/nixpkgs/pull/169047/changes/160fb93fdc4155d7e6304f366384ad8afb00db1e and the follow-up https://github.com/NixOS/nixpkgs/pull/202132/changes/71c74bf1738d306fff289f8d48f82313e2c100f4). Since the systemd initrd was recently enabled by default, the default ISO image configuration is now missing support for ext filesystems, which means that one cannot e.g. boot into a live ISO image and run `fsck.ext4`.

This commit adds ext2, ext3 and ext4 as explicitly supported file systems in the base profile, which ensures that the associated tools are always available.

A diff between the old and new `system.path` confirms that `e2fsprogs` was the only missing package, so this should be enough.