### PR TITLE
dc3dd: fix for `gcc-15`

### DIFF
--- a/pkgs/by-name/dc/dc3dd/package.nix
+++ b/pkgs/by-name/dc/dc3dd/package.nix
@@ -25,6 +25,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ perlPackages.LocaleGettext ];
 
+  # Remove once upstream ports to c23: https://sourceforge.net/p/dc3dd/bugs/24/
+  env.NIX_CFLAGS_COMPILE = "-std=gnu17";
+
   makeFlags = [
     "PREFIX=$out"
     "CC=${stdenv.cc.targetPrefix}cc"


### PR DESCRIPTION
Without the chnage the build fails as https://hydra.nixos.org/build/326967790:

```
In file included from argmatch.c:22:
argmatch.c: In function '__argmatch_die':
./config.h:8:22: error: too many arguments to function 'usage'; expected 0, have 1
    8 | #define ARGMATCH_DIE usage (1)
      |                      ^~~~~  ~
```

Work it around by falling back to pre-c23 standard.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
