### PR TITLE
nixos/spire: add http_challenge attestation

### DIFF
--- a/nixos/modules/services/security/spire/agent-http-challenge.nix
+++ b/nixos/modules/services/security/spire/agent-http-challenge.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  format = pkgs.formats.hcl1 { };
+  cfg = config.services.spire.agent;
+  http_challenge = cfg.settings.plugins.NodeAttestor.http_challenge;
+in
+{
+  options.services.spire.agent = {
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      description = ''
+        Whether to open the firewall for `services.spire.agent.settings.plugins.NodeAttestor.http_challenge.plugin_data.port`.
+      '';
+      default = false;
+    };
+
+    settings.plugins.NodeAttestor.http_challenge = lib.mkOption {
+      default = null;
+      description = ''
+        The `http_challenge` plugin handshakes via http to ensure the agent is
+        running on a valid dns name.
+
+        Must be used in conjunction with the server-side `http_challenge` plugin.
+        See [the plugin documentation](https://github.com/spiffe/spire/blob/main/doc/plugin_agent_nodeattestor_http_challenge.md).
+      '';
+      type = lib.types.nullOr (
+        lib.types.submodule {
+          freeformType = format.type;
+          options.plugin_data = lib.mkOption {
+            default = { };
+            description = "Plugin data for the http_challenge NodeAttestor.";
+            type = lib.types.submodule {
+              freeformType = format.type;
+              options = {
+                hostname = lib.mkOption {
+                  type = lib.types.nullOr lib.types.str;
+                  default = null;
+                  description = ''
+                    Hostname to use for handshaking. If unset, it will be automatically detected.
+                  '';
+                };
+                agentname = lib.mkOption {
+                  type = lib.types.str;
+                  default = "default";
+                  description = ''
+                    Name of this agent on the host. Useful if you have multiple agents bound to
+                    different spire servers on the same host and sharing the same port.
+                  '';
+                };
+                port = lib.mkOption {
+                  type = lib.types.nullOr lib.types.port;
+                  default = null;
+                  description = ''
+                    The port to listen on. If unspecified, a random value will be used.
+                  '';
+                };
+                advertised_port = lib.mkOption {
+                  type = lib.types.nullOr lib.types.port;
+                  default = null;
+                  description = ''
+                    The port to tell the server to call back on. Defaults to `port`.
+                  '';
+                };
+              };
+            };
+          };
+        }
+      );
+    };
+  };
+
+  config = lib.mkIf (cfg.enable && http_challenge != null) {
+    networking.firewall.allowedTCPPorts =
+      lib.mkIf (cfg.openFirewall && http_challenge.plugin_data.port != null)
+        [ http_challenge.plugin_data.port ];
+  };
+}

--- a/nixos/modules/services/security/spire/agent-http-challenge.nix
+++ b/nixos/modules/services/security/spire/agent-http-challenge.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  format = pkgs.formats.hcl1 { };
+  cfg = config.services.spire.agent;
+  http_challenge = cfg.settings.plugins.NodeAttestor.http_challenge;
+in
+{
+  options.services.spire.agent = {
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      description = ''
+        Whether to open the firewall for `services.spire.agent.settings.plugins.NodeAttestor.http_challenge.plugin_data.port`.
+      '';
+      default = false;
+    };
+
+    settings.plugins.NodeAttestor.http_challenge = lib.mkOption {
+      default = null;
+      description = ''
+        The `http_challenge` plugin handshakes via http to ensure the agent is
+        running on a valid dns name.
+
+        Must be used in conjunction with the server-side `http_challenge` plugin.
+        See [the plugin documentation](https://github.com/spiffe/spire/blob/main/doc/plugin_agent_nodeattestor_http_challenge.md).
+      '';
+      type = lib.types.nullOr (
+        lib.types.submodule {
+          freeformType = format.type;
+          options.plugin_data = lib.mkOption {
+            default = { };
+            description = "Plugin data for the http_challenge NodeAttestor.";
+            type = lib.types.submodule {
+              freeformType = format.type;
+              options = {
+                hostname = lib.mkOption {
+                  type = lib.types.nullOr lib.types.str;
+                  default = null;
+                  description = ''
+                    Hostname to use for handshaking. If unset, it will be automatically detected.
+                  '';
+                };
+                agentname = lib.mkOption {
+                  type = lib.types.str;
+                  default = "default";
+                  description = ''
+                    Name of this agent on the host. Useful if you have multiple agents bound to
+                    different spire servers on the same host and sharing the same port.
+                  '';
+                };
+                port = lib.mkOption {
+                  type = lib.types.nullOr lib.types.port;
+                  default = null;
+                  description = ''
+                    The port to listen on. If unspecified, a random value will be used.
+                  '';
+                };
+                advertised_port = lib.mkOption {
+                  type = lib.types.nullOr lib.types.port;
+                  default = null;
+                  description = ''
+                    The port to tell the server to call back on. Defaults to `port`.
+                  '';
+                };
+              };
+            };
+          };
+        }
+      );
+    };
+  };
+
+  config = lib.mkIf (cfg.enable && http_challenge != null) {
+    networking.firewall.allowedTCPPorts = lib.mkIf (
+      cfg.openFirewall && http_challenge.plugin_data.port != null
+    ) [ http_challenge.plugin_data.port ];
+  };
+}

--- a/nixos/modules/services/security/spire/agent.nix
+++ b/nixos/modules/services/security/spire/agent.nix
@@ -125,7 +125,10 @@ in
     };
 
   };
-  imports = [ ./agent-tpm.nix ];
+  imports = [
+    ./agent-tpm.nix
+    ./agent-http-challenge.nix
+  ];
 
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];

--- a/nixos/modules/services/security/spire/server.nix
+++ b/nixos/modules/services/security/spire/server.nix
@@ -87,6 +87,61 @@ in
                       }
                     );
                   };
+                  options.http_challenge = lib.mkOption {
+                    default = null;
+                    description = ''
+                      The `http_challenge` plugin handshakes via http to ensure the agent is
+                      running on a valid dns name.
+
+                      See [the plugin documentation](https://github.com/spiffe/spire/blob/main/doc/plugin_server_nodeattestor_http_challenge.md).
+                    '';
+                    type = lib.types.nullOr (
+                      lib.types.submodule {
+                        freeformType = format.type;
+                        options.plugin_data = lib.mkOption {
+                          default = { };
+                          description = "Plugin data for the http_challenge NodeAttestor.";
+                          type = lib.types.submodule {
+                            freeformType = format.type;
+                            options = {
+                              allowed_dns_patterns = lib.mkOption {
+                                type = lib.types.listOf lib.types.str;
+                                default = [ ];
+                                example = [ ''p[0-9]\.example\.com'' ];
+                                description = ''
+                                  A list of regular expressions to match to the hostname being attested.
+                                  If none match, attestation will fail. If unset, all hostnames are allowed.
+                                '';
+                              };
+                              required_port = lib.mkOption {
+                                type = lib.types.nullOr lib.types.port;
+                                default = null;
+                                description = ''
+                                  Set to a port number to require clients to listen only on that port.
+                                  If unset, all port numbers are allowed.
+                                '';
+                              };
+                              allow_non_root_ports = lib.mkOption {
+                                type = lib.types.bool;
+                                default = true;
+                                description = ''
+                                  Set to true to allow ports >= 1024 to be used by the agents with the advertised_port.
+                                '';
+                              };
+                              tofu = lib.mkOption {
+                                type = lib.types.bool;
+                                default = true;
+                                description = ''
+                                  Trust on first use of the successful challenge. Can only be disabled
+                                  if allow_non_root_ports=false or required_port < 1024.
+                                '';
+                              };
+                            };
+                          };
+                        };
+                      }
+                    );
+                  };
                 };
               };
             };

--- a/nixos/tests/spire.nix
+++ b/nixos/tests/spire.nix
@@ -45,6 +45,23 @@ let
         config.services.spire.agent.settings.agent.socket_path;
       virtualisation.credentials."spire.trust_bundle".source = "./trust_bundle";
       systemd.services.spire-agent.serviceConfig.ImportCredential = [ "spire.trust_bundle" ];
+
+      services.spire.agent = {
+        enable = true;
+        settings = {
+          agent = {
+            trust_domain = trustDomain;
+            server_address = "server.${trustDomain}";
+            trust_bundle_format = "pem";
+            trust_bundle_path = "$CREDENTIALS_DIRECTORY/spire.trust_bundle";
+          };
+          plugins = {
+            KeyManager.memory.plugin_data = { };
+            WorkloadAttestor.systemd.plugin_data = { };
+            WorkloadAttestor.unix.plugin_data = { };
+          };
+        };
+      };
     };
 in
 {
@@ -80,23 +97,9 @@ in
       virtualisation.credentials."spire.join_token".source = "./join_token";
       systemd.services.spire-agent.serviceConfig.ImportCredential = [ "spire.join_token" ];
 
-      services.spire.agent = {
-        enable = true;
-        settings = {
-          agent = {
-            trust_domain = trustDomain;
-            server_address = "server.${trustDomain}";
-            join_token_file = "$CREDENTIALS_DIRECTORY/spire.join_token";
-            trust_bundle_format = "pem";
-            trust_bundle_path = "$CREDENTIALS_DIRECTORY/spire.trust_bundle";
-          };
-          plugins = {
-            KeyManager.memory.plugin_data = { };
-            NodeAttestor.join_token.plugin_data = { };
-            WorkloadAttestor.systemd.plugin_data = { };
-            WorkloadAttestor.unix.plugin_data = { };
-          };
-        };
+      services.spire.agent.settings = {
+        agent.join_token_file = "$CREDENTIALS_DIRECTORY/spire.join_token";
+        plugins.NodeAttestor.join_token.plugin_data = { };
       };
     };
 
@@ -141,23 +144,7 @@ in
 
         environment.systemPackages = [ pkgs.spire-tpm-plugin ];
 
-        services.spire.agent = {
-          enable = true;
-          settings = {
-            agent = {
-              trust_domain = trustDomain;
-              server_address = "server.${trustDomain}";
-              trust_bundle_format = "pem";
-              trust_bundle_path = "$CREDENTIALS_DIRECTORY/spire.trust_bundle";
-            };
-            plugins = {
-              KeyManager.memory.plugin_data = { };
-              NodeAttestor.tpm.plugin_data = { };
-              WorkloadAttestor.systemd.plugin_data = { };
-              WorkloadAttestor.unix.plugin_data = { };
-            };
-          };
-        };
+        services.spire.agent.settings.plugins.NodeAttestor.tpm.plugin_data = { };
       };
   };
 

--- a/nixos/tests/spire.nix
+++ b/nixos/tests/spire.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 let
   trustDomain = "example.com";
 
@@ -86,6 +86,10 @@ in
               };
               NodeAttestor.join_token.plugin_data = { };
               NodeAttestor.tpm.plugin_data.ca_path = "/etc/spire/server/certs";
+              NodeAttestor.http_challenge.plugin_data = {
+                required_port = 8080;
+                allowed_dns_patterns = [ ''^[a-zA-Z]+\.${lib.escapeRegex trustDomain}$'' ];
+              };
             };
           };
         };
@@ -146,6 +150,30 @@ in
 
         services.spire.agent.settings.plugins.NodeAttestor.tpm.plugin_data = { };
       };
+
+    httpChallengeAllowedAgent =
+      { config, ... }:
+      {
+        imports = [ agent ];
+        networking.domain = trustDomain;
+        services.spire.agent.openFirewall = true;
+        services.spire.agent.settings.plugins.NodeAttestor.http_challenge.plugin_data = {
+          port = 8080;
+          hostname = config.networking.fqdn;
+        };
+      };
+
+    httpChallengeRejectedAgent =
+      { config, ... }:
+      {
+        imports = [ agent ];
+        networking.domain = "invalid";
+        services.spire.agent.openFirewall = true;
+        services.spire.agent.settings.plugins.NodeAttestor.http_challenge.plugin_data = {
+          port = 8080;
+          hostname = config.networking.fqdn;
+        };
+      };
   };
 
   testScript =
@@ -178,6 +206,12 @@ in
         server.succeed(f"spire-server entry create -socketPath ${adminSocket} -selector 'systemd:id:backdoor.service' -parentID '{parent_id}' -spiffeID {spiffe_id}")
 
 
+      def provision_http_challenge(agent):
+        hostname = agent.succeed("hostname --fqdn").strip()
+        parent_id = f"spiffe://${trustDomain}/spire/agent/http_challenge/{hostname}"
+        server.succeed(f"spire-server entry create -socketPath ${adminSocket} -selector 'systemd:id:backdoor.service' -parentID '{parent_id}' -spiffeID {spiffe_id}")
+
+
       def test_agent(name, agent_node, provision_fn):
         with subtest(f"Setup SPIRE agent with {name} attestation"):
           provision_trust_bundle(agent_node)
@@ -196,6 +230,13 @@ in
 
       test_agent("join_token", agent, provision_join_token)
       test_agent("tpm", tpmAgent, provision_tpm)
+      test_agent("http_challenge_allowed", httpChallengeAllowedAgent, provision_http_challenge)
+
+      with subtest("http_challenge: agent with hostname not matching allowed_dns_patterns is rejected"):
+        provision_trust_bundle(httpChallengeRejectedAgent)
+        httpChallengeRejectedAgent.wait_for_unit("spire-agent.service")
+        httpChallengeRejectedAgent.wait_for_console_text("the requested hostname is not allowed to connect")
+        httpChallengeRejectedAgent.fail("spire-agent healthcheck -socketPath $SPIFFE_ENDPOINT_SOCKET")
 
     '';
 }

--- a/nixos/tests/spire.nix
+++ b/nixos/tests/spire.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 let
   trustDomain = "example.com";
 
@@ -94,6 +94,10 @@ in
               };
               NodeAttestor.join_token.plugin_data = { };
               NodeAttestor.tpm.plugin_data.ca_path = "/etc/spire/server/certs";
+              NodeAttestor.http_challenge.plugin_data = {
+                required_port = 8080;
+                allowed_dns_patterns = [ ''^[a-zA-Z]+\.${lib.escapeRegex trustDomain}$'' ];
+              };
             };
           };
         };
@@ -154,6 +158,30 @@ in
 
         services.spire.agent.settings.plugins.NodeAttestor.tpm.plugin_data = { };
       };
+
+    httpChallengeAllowedAgent =
+      { config, ... }:
+      {
+        imports = [ agent ];
+        networking.domain = trustDomain;
+        services.spire.agent.openFirewall = true;
+        services.spire.agent.settings.plugins.NodeAttestor.http_challenge.plugin_data = {
+          port = 8080;
+          hostname = config.networking.fqdn;
+        };
+      };
+
+    httpChallengeRejectedAgent =
+      { config, ... }:
+      {
+        imports = [ agent ];
+        networking.domain = "invalid";
+        services.spire.agent.openFirewall = true;
+        services.spire.agent.settings.plugins.NodeAttestor.http_challenge.plugin_data = {
+          port = 8080;
+          hostname = config.networking.fqdn;
+        };
+      };
   };
 
   testScript =
@@ -188,6 +216,12 @@ in
         server.succeed(f"spire-server entry create -socketPath ${adminSocket} -selector '{selector}' -parentID '{parent_id}' -spiffeID '{spiffe_id}'")
 
 
+      def provision_http_challenge(agent):
+        hostname = agent.succeed("hostname --fqdn").strip()
+        parent_id = f"spiffe://${trustDomain}/spire/agent/http_challenge/{hostname}"
+        server.succeed(f"spire-server entry create -socketPath ${adminSocket} -selector 'systemd:id:backdoor.service' -parentID '{parent_id}' -spiffeID {spiffe_id}")
+
+
       def test_agent(name, agent_node, provision_fn):
         with subtest(f"Setup SPIRE agent with {name} attestation"):
           provision_trust_bundle(agent_node)
@@ -215,6 +249,13 @@ in
 
       test_agent("join_token", agent, provision_join_token)
       test_agent("tpm", tpmAgent, provision_tpm)
+      test_agent("http_challenge_allowed", httpChallengeAllowedAgent, provision_http_challenge)
+
+      with subtest("http_challenge: agent with hostname not matching allowed_dns_patterns is rejected"):
+        provision_trust_bundle(httpChallengeRejectedAgent)
+        httpChallengeRejectedAgent.wait_for_unit("spire-agent.service")
+        httpChallengeRejectedAgent.wait_for_console_text("the requested hostname is not allowed to connect")
+        httpChallengeRejectedAgent.fail("spire-agent healthcheck -socketPath $SPIFFE_ENDPOINT_SOCKET")
 
     '';
 }

--- a/nixos/tests/spire.nix
+++ b/nixos/tests/spire.nix
@@ -53,6 +53,23 @@ let
         group = "workload";
       };
       users.groups.workload = { };
+
+      services.spire.agent = {
+        enable = true;
+        settings = {
+          agent = {
+            trust_domain = trustDomain;
+            server_address = "server.${trustDomain}";
+            trust_bundle_format = "pem";
+            trust_bundle_path = "$CREDENTIALS_DIRECTORY/spire.trust_bundle";
+          };
+          plugins = {
+            KeyManager.memory.plugin_data = { };
+            WorkloadAttestor.systemd.plugin_data = { };
+            WorkloadAttestor.unix.plugin_data = { };
+          };
+        };
+      };
     };
 in
 {
@@ -88,23 +105,9 @@ in
       virtualisation.credentials."spire.join_token".source = "./join_token";
       systemd.services.spire-agent.serviceConfig.ImportCredential = [ "spire.join_token" ];
 
-      services.spire.agent = {
-        enable = true;
-        settings = {
-          agent = {
-            trust_domain = trustDomain;
-            server_address = "server.${trustDomain}";
-            join_token_file = "$CREDENTIALS_DIRECTORY/spire.join_token";
-            trust_bundle_format = "pem";
-            trust_bundle_path = "$CREDENTIALS_DIRECTORY/spire.trust_bundle";
-          };
-          plugins = {
-            KeyManager.memory.plugin_data = { };
-            NodeAttestor.join_token.plugin_data = { };
-            WorkloadAttestor.systemd.plugin_data = { };
-            WorkloadAttestor.unix.plugin_data = { };
-          };
-        };
+      services.spire.agent.settings = {
+        agent.join_token_file = "$CREDENTIALS_DIRECTORY/spire.join_token";
+        plugins.NodeAttestor.join_token.plugin_data = { };
       };
     };
 
@@ -149,23 +152,7 @@ in
 
         environment.systemPackages = [ pkgs.spire-tpm-plugin ];
 
-        services.spire.agent = {
-          enable = true;
-          settings = {
-            agent = {
-              trust_domain = trustDomain;
-              server_address = "server.${trustDomain}";
-              trust_bundle_format = "pem";
-              trust_bundle_path = "$CREDENTIALS_DIRECTORY/spire.trust_bundle";
-            };
-            plugins = {
-              KeyManager.memory.plugin_data = { };
-              NodeAttestor.tpm.plugin_data = { };
-              WorkloadAttestor.systemd.plugin_data = { };
-              WorkloadAttestor.unix.plugin_data = { };
-            };
-          };
-        };
+        services.spire.agent.settings.plugins.NodeAttestor.tpm.plugin_data = { };
       };
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
