### PR TITLE
plankc: init at 0.1.1

### DIFF
--- a/pkgs/by-name/pl/plankc/package.nix
+++ b/pkgs/by-name/pl/plankc/package.nix
@@ -1,0 +1,73 @@
+{
+  fetchFromGitHub,
+  lib,
+  mdbook,
+  makeWrapper,
+  nix-update-script,
+  rustPlatform,
+  stdenvNoCC,
+}:
+let
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "plankevm";
+    repo = "plank-monorepo";
+    tag = "v${version}";
+    hash = "sha256-B2UmV5i2ELlmzyrR8iFIOQcSpHeRQl4I6lxakMskolg=";
+  };
+
+  plank-docs = stdenvNoCC.mkDerivation {
+    pname = "plank-docs";
+    inherit version src;
+    __structuredAttrs = true;
+    strictDeps = true;
+
+    sourceRoot = "${src.name}/plank-doc";
+
+    nativeBuildInputs = [ mdbook ];
+
+    buildPhase = ''
+      mdbook build
+    '';
+
+    installPhase = ''
+      mkdir -p $out/share/doc
+      cp -r book/. $out/share/doc/
+      cp -r src $out/share/doc/src
+    '';
+  };
+in
+rustPlatform.buildRustPackage {
+  pname = "plankc";
+  inherit version src;
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  sourceRoot = "${src.name}/plankc";
+  cargoHash = "sha256-KLqTTywM6sObPO+0DzjkNqrfuKPVGKiv52HlXfR/UI0=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    mkdir -p $out/share/doc $out/stdlib
+    cp -r ${plank-docs}/share/doc/. $out/share/doc/
+    cp -r ${src}/std/. $out/stdlib/
+    wrapProgram $out/bin/plank \
+      --set PLANK_DIR $out
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/plankevm/plank-monorepo/releases/tag/v${version}";
+    description = "Compiler for Plank, an EVM-Native smart contract language";
+    homepage = "https://plankevm.org";
+    license = lib.licenses.mit;
+    mainProgram = "plank";
+    maintainers = with lib.maintainers; [
+      _0xferrous
+      hythera
+    ];
+  };
+}

--- a/pkgs/by-name/pl/plankc/package.nix
+++ b/pkgs/by-name/pl/plankc/package.nix
@@ -1,0 +1,72 @@
+{
+  fetchFromGitHub,
+  lib,
+  mdbook,
+  makeWrapper,
+  rustPlatform,
+  stdenvNoCC,
+}:
+let
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "plankevm";
+    repo = "plank-monorepo";
+    tag = "v${version}";
+    hash = "sha256-4r/hYPlVIKzq1/50mivs6CJjObAS5Iq1inwRe1bFlzE=";
+  };
+
+  plank-docs = stdenvNoCC.mkDerivation {
+    pname = "plank-docs";
+    inherit version src;
+    __structuredAttrs = true;
+    strictDeps = true;
+
+    sourceRoot = "${src.name}/plank-doc";
+
+    nativeBuildInputs = [ mdbook ];
+
+    buildPhase = ''
+      mdbook build
+    '';
+
+    installPhase = ''
+      mkdir -p $out/share/doc
+      cp -r book/. $out/share/doc/
+      cp -r src $out/share/doc/src
+    '';
+  };
+in
+rustPlatform.buildRustPackage {
+  pname = "plankc";
+  inherit version src;
+  __structuredAttrs = true;
+
+  sourceRoot = "${src.name}/plankc";
+  cargoHash = "sha256-BPHkNQGlAqUVvQs8Sx5w0SNyglg0pSETIFjuc0XQXzk=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # Let plank know about its actual version.
+  env.PLANK_VERSION = version;
+
+  postInstall = ''
+    mkdir -p $out/share/doc $out/stdlib
+    cp -r ${plank-docs}/share/doc/. $out/share/doc/
+    cp -r ${src}/std/. $out/stdlib/
+    wrapProgram $out/bin/plank \
+      --set PLANK_DIR $out
+  '';
+
+  meta = {
+    changelog = "https://github.com/plankevm/plank-monorepo/releases/tag/v${version}";
+    description = "Compiler for Plank, an EVM-Native smart contract language";
+    homepage = "https://plankevm.org";
+    license = lib.licenses.mit;
+    mainProgram = "plank";
+    maintainers = with lib.maintainers; [
+      _0xferrous
+      hythera
+    ];
+  };
+}


### PR DESCRIPTION
Adds the compiler of the [plank language](https://github.com/plankevm/plank-monorepo) to `nixpkgs`. Inspired by the [plankevm-flake](https://github.com/0xferrous/plankevm-flake).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
