### PR TITLE
nixos/tinyauth: add enableUnixSocket option

### DIFF
--- a/nixos/modules/services/security/tinyauth.nix
+++ b/nixos/modules/services/security/tinyauth.nix
@@ -149,6 +149,11 @@ in
       default = "tinyauth";
       description = "Group account under which Tinyauth runs.";
     };
+
+    enableUnixSocket = mkEnableOption ''
+      Whether to enable a UNIX domain socket at `/run/tinyauth/tinyauth.sock`
+      instead of listening on an IP address and port.
+    '';
   };
 
   config = mkIf cfg.enable {
@@ -174,6 +179,7 @@ in
         GIN_MODE = "release";
         TINYAUTH_DATABASE_PATH = "${cfg.dataDir}/tinyauth.db";
         TINYAUTH_RESOURCES_PATH = "${cfg.dataDir}/resources";
+        TINYAUTH_SERVER_SOCKETPATH = mkIf cfg.enableUnixSocket "%t/tinyauth/tinyauth.sock";
       };
 
       serviceConfig = {
@@ -181,6 +187,8 @@ in
         User = cfg.user;
         Group = cfg.group;
         WorkingDirectory = cfg.dataDir;
+        RuntimeDirectory = mkIf cfg.enableUnixSocket "tinyauth";
+        RuntimeDirectoryMode = mkIf cfg.enableUnixSocket "750";
         ExecStart = getExe cfg.package;
         Restart = "always";
 
@@ -224,7 +232,7 @@ in
           "~@privileged"
           "~@resources"
         ];
-        UMask = "0077";
+        UMask = if cfg.enableUnixSocket then "0007" else "0077";
       };
     };
 

--- a/nixos/modules/services/security/tinyauth.nix
+++ b/nixos/modules/services/security/tinyauth.nix
@@ -149,6 +149,11 @@ in
       default = "tinyauth";
       description = "Group account under which Tinyauth runs.";
     };
+
+    enableUnixSocket = mkEnableOption (
+      "a UNIX domain socket at `/run/tinyauth/tinyauth.sock`"
+      + " instead of listening on an IP address and port."
+    );
   };
 
   config = mkIf cfg.enable {
@@ -174,6 +179,7 @@ in
         GIN_MODE = "release";
         TINYAUTH_DATABASE_PATH = "${cfg.dataDir}/tinyauth.db";
         TINYAUTH_RESOURCES_PATH = "${cfg.dataDir}/resources";
+        TINYAUTH_SERVER_SOCKETPATH = mkIf cfg.enableUnixSocket "%t/tinyauth/tinyauth.sock";
       };
 
       serviceConfig = {
@@ -181,6 +187,8 @@ in
         User = cfg.user;
         Group = cfg.group;
         WorkingDirectory = cfg.dataDir;
+        RuntimeDirectory = mkIf cfg.enableUnixSocket "tinyauth";
+        RuntimeDirectoryMode = mkIf cfg.enableUnixSocket "750";
         ExecStart = getExe cfg.package;
         Restart = "always";
 
@@ -224,7 +232,7 @@ in
           "~@privileged"
           "~@resources"
         ];
-        UMask = "0077";
+        UMask = if cfg.enableUnixSocket then "0007" else "0077";
       };
     };
 


### PR DESCRIPTION
To let other processes access this UNIX socket, umask 0007 is required. This way the socket will have permission 770 (u=rwx,g=rwx,o=).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
