### PR TITLE
various: switch from deprecated --replace #2

### DIFF
--- a/pkgs/by-name/al/alacritty/package.nix
+++ b/pkgs/by-name/al/alacritty/package.nix
@@ -94,7 +94,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
     substituteInPlace alacritty/src/config/ui_config.rs \
-      --replace xdg-open ${xdg-utils}/bin/xdg-open
+      --replace-fail xdg-open ${xdg-utils}/bin/xdg-open
   '';
 
   checkFlags = [ "--skip=term::test::mock_term" ]; # broken on aarch64

--- a/pkgs/by-name/al/alice-tools/package.nix
+++ b/pkgs/by-name/al/alice-tools/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = lib.optionalString (withGUI && withQt6) ''
     # Use Meson's Qt6 module
     substituteInPlace src/meson.build \
-      --replace qt5 qt6
+      --replace-fail qt5 qt6
 
     # For some reason Meson uses QMake instead of pkg-config detection method for Qt6 on Darwin, which gives wrong search paths for tools
     export PATH=${qt.qtbase.dev}/libexec:$PATH

--- a/pkgs/by-name/al/alps/package.nix
+++ b/pkgs/by-name/al/alps/package.nix
@@ -35,7 +35,7 @@ buildGoModule {
   ];
 
   postPatch = ''
-    substituteInPlace plugin.go --replace "const PluginDir" "var PluginDir"
+    substituteInPlace plugin.go --replace-fail "const PluginDir" "var PluginDir"
   '';
 
   postInstall = ''

--- a/pkgs/by-name/am/amd-libflame/package.nix
+++ b/pkgs/by-name/am/amd-libflame/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs build
 
     # Enforce reproducible build compiler flags
-    substituteInPlace CMakeLists.txt --replace '-mtune=native' ""
+    substituteInPlace CMakeLists.txt --replace-fail '-mtune=native' ""
   '';
 
   env.NIX_CFLAGS_COMPILE = "-Wno-implicit-function-declaration";

--- a/pkgs/by-name/am/amoco/package.nix
+++ b/pkgs/by-name/am/amoco/package.nix
@@ -47,7 +47,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'pytest-runner'," ""
+      --replace-fail "'pytest-runner'," ""
   '';
 
   pythonRelaxDeps = [

--- a/pkgs/by-name/an/ananicy/package.nix
+++ b/pkgs/by-name/an/ananicy/package.nix
@@ -53,8 +53,8 @@ stdenv.mkDerivation {
       }
 
     substituteInPlace $out/lib/systemd/system/ananicy.service \
-      --replace "/sbin/sysctl" "${sysctl}/bin/sysctl" \
-      --replace "/usr/bin/ananicy" "$out/bin/ananicy"
+      --replace-fail "/sbin/sysctl" "${sysctl}/bin/sysctl" \
+      --replace-fail "/usr/bin/ananicy" "$out/bin/ananicy"
   '';
 
   meta = {

--- a/pkgs/by-name/an/anarchism/package.nix
+++ b/pkgs/by-name/an/anarchism/package.nix
@@ -19,9 +19,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     substituteInPlace debian/anarchism.desktop \
-      --replace "/usr/bin/xdg-open" "${xdg-utils}/bin/xdg-open"
+      --replace-fail "/usr/bin/xdg-open" "${xdg-utils}/bin/xdg-open"
     substituteInPlace debian/anarchism.desktop \
-      --replace "file:///usr" "file://$out"
+      --replace-fail "file:///usr" "file://$out"
   '';
 
   installPhase = ''

--- a/pkgs/by-name/an/anilibria-winmaclinux/package.nix
+++ b/pkgs/by-name/an/anilibria-winmaclinux/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   preConfigure = ''
     substituteInPlace AniLibria.pro \
-      --replace "\$\$PREFIX" '${placeholder "out"}'
+      --replace-fail "\$\$PREFIX" '${placeholder "out"}'
   '';
 
   qtWrapperArgs = [

--- a/pkgs/by-name/an/antiword/package.nix
+++ b/pkgs/by-name/an/antiword/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   prePatch = ''
     sed -i -e "s|/usr/local/bin|$out/bin|g" -e "s|/usr/share|$out/share|g" Makefile antiword.h
-    substituteInPlace Makefile --replace "gcc" '$(CC)'
+    substituteInPlace Makefile --replace-fail "gcc" '$(CC)'
   '';
 
   patches = [ ./10_fix_buffer_overflow_wordole_c_CVE-2014-8123.patch ];

--- a/pkgs/by-name/an/antora-lunr-extension/package.nix
+++ b/pkgs/by-name/an/antora-lunr-extension/package.nix
@@ -20,7 +20,7 @@ buildNpmPackage rec {
 
   # Prevent tests from failing because they are fetching data at runtime.
   postPatch = ''
-    substituteInPlace package.json --replace '"_mocha"' '""'
+    substituteInPlace package.json --replace-fail '"_mocha"' '""'
   '';
 
   # Pointing $out to $out/lib/node_modules/@antora/lunr-extension simplifies

--- a/pkgs/by-name/ap/apache-flex-sdk/package.nix
+++ b/pkgs/by-name/ap/apache-flex-sdk/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     shopt -s extglob
     for i in bin/!(aasdoc|acompc|amxmlc); do
-      substituteInPlace $i --replace "java " "${jre}/bin/java "
+      substituteInPlace $i --replace-fail "java " "${jre}/bin/java "
     done
   '';
 

--- a/pkgs/by-name/ap/apbs/package.nix
+++ b/pkgs/by-name/ap/apbs/package.nix
@@ -67,12 +67,12 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     # ImportFETK.cmake downloads source and builds fetk
     substituteInPlace CMakeLists.txt \
-      --replace "include(ImportFETK)" "" \
-      --replace 'import_fetk(''${FETK_VERSION})' ""
+      --replace-fail "include(ImportFETK)" "" \
+      --replace-fail 'import_fetk(''${FETK_VERSION})' ""
 
     # U was removed in python 3.11 because it had no effect
     substituteInPlace tools/manip/inputgen.py \
-      --replace '"rU"' '"r"'
+      --replace-fail '"rU"' '"r"'
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ap/apfs-fuse/package.nix
+++ b/pkgs/by-name/ap/apfs-fuse/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
 
   postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace CMakeLists.txt \
-      --replace "/usr/local/lib/libosxfuse.dylib" "fuse"
+      --replace-fail "/usr/local/lib/libosxfuse.dylib" "fuse"
   '';
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/ap/apkid/package.nix
+++ b/pkgs/by-name/ap/apkid/package.nix
@@ -19,7 +19,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   postPatch = ''
     # We have dex support enabled in yara-python
     substituteInPlace setup.py \
-      --replace "yara-python-dex>=1.0.1" "yara-python"
+      --replace-fail "yara-python-dex>=1.0.1" "yara-python"
   '';
 
   build-system = with python3.pkgs; [ setuptools ];

--- a/pkgs/by-name/ap/appgate-sdp/package.nix
+++ b/pkgs/by-name/ap/appgate-sdp/package.nix
@@ -130,21 +130,20 @@ stdenv.mkDerivation rec {
     cp -r $out/usr/share $out/share
 
     substituteInPlace $out/lib/systemd/system/appgate-dumb-resolver.service \
-        --replace "/opt/" "$out/opt/"
+        --replace-fail "/opt/" "$out/opt/"
 
     substituteInPlace $out/lib/systemd/system/appgatedriver.service \
-        --replace "/opt/" "$out/opt/" \
-        --replace "InaccessiblePaths=/mnt /srv /boot /media" "InaccessiblePaths=-/mnt -/srv -/boot -/media"
+        --replace-fail "/opt/" "$out/opt/" \
 
     substituteInPlace $out/lib/systemd/system/appgate-resolver.service \
-        --replace "/usr/sbin/dnsmasq" "${dnsmasq}/bin/dnsmasq" \
-        --replace "/opt/" "$out/opt/"
+        --replace-fail "/usr/sbin/dnsmasq" "${dnsmasq}/bin/dnsmasq" \
+        --replace-fail "/opt/" "$out/opt/"
 
     substituteInPlace $out/opt/appgate/linux/nm.py \
-        --replace "/usr/sbin/dnsmasq" "${dnsmasq}/bin/dnsmasq"
+        --replace-fail "/usr/sbin/dnsmasq" "${dnsmasq}/bin/dnsmasq"
 
     substituteInPlace $out/opt/appgate/linux/set_dns \
-        --replace "/etc/appgate.conf" "$out/etc/appgate.conf"
+        --replace-fail "/etc/appgate.conf" "$out/etc/appgate.conf"
 
     wrapProgram $out/opt/appgate/service/createdump \
         --set LD_LIBRARY_PATH "${lib.makeLibraryPath [ stdenv.cc.cc ]}"

--- a/pkgs/by-name/ap/aprutil/package.nix
+++ b/pkgs/by-name/ap/aprutil/package.nix
@@ -87,9 +87,9 @@ stdenv.mkDerivation (finalAttrs: {
     # Always replacing the link flag with a generic link flag seems to help though, so let's do that for now.
     lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
       substituteInPlace Makefile \
-        --replace "-ldb-6.9" "-ldb"
+        --replace-fail "-ldb-6.9" "-ldb"
       substituteInPlace apu-1-config \
-        --replace "-ldb-6.9" "-ldb"
+        --replace-fail "-ldb-6.9" "-ldb"
     '';
 
   propagatedBuildInputs = [
@@ -106,9 +106,9 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     for f in $out/lib/*.la $out/lib/apr-util-1/*.la $dev/bin/apu-1-config; do
       substituteInPlace $f \
-        --replace "${expat.dev}/lib" "${expat.out}/lib" \
-        --replace "${db.dev}/lib" "${db.out}/lib" \
-        --replace "${openssl.dev}/lib" "${lib.getLib openssl}/lib"
+        --replace-fail "${expat.dev}/lib" "${expat.out}/lib" \
+        --replace-fail "${db.dev}/lib" "${db.out}/lib" \
+        --replace-fail "${openssl.dev}/lib" "${lib.getLib openssl}/lib"
     done
 
     # Give apr1 access to sed for runtime invocations.

--- a/pkgs/by-name/ar/arachne-pnr/package.nix
+++ b/pkgs/by-name/ar/arachne-pnr/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace ./Makefile \
-      --replace 'echo UNKNOWN' 'echo ${lib.substring 0 10 src.rev}'
+      --replace-fail 'echo UNKNOWN' 'echo ${lib.substring 0 10 src.rev}'
   '';
 
   meta = {

--- a/pkgs/by-name/ar/arduino-ci/package.nix
+++ b/pkgs/by-name/ar/arduino-ci/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   fixupPhase = ''
-    substituteInPlace $out/bin/arduino-ci --replace "/usr/bin/env nix-shell" "${ruby}/bin/ruby"
+    substituteInPlace $out/bin/arduino-ci --replace-fail "/usr/bin/env nix-shell" "${ruby}/bin/ruby"
     wrapProgram $out/bin/arduino-ci --prefix PATH ":" "${runtimePath}"
   '';
 

--- a/pkgs/by-name/ar/argbash/package.nix
+++ b/pkgs/by-name/ar/argbash/package.nix
@@ -21,8 +21,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     patchShebangs .
-    substituteInPlace resources/Makefile \
-      --replace '/bin/bash' "${runtimeShell}"
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ar/argparse/package.nix
+++ b/pkgs/by-name/ar/argparse/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace CMakeLists.txt \
       --replace '$'{CMAKE_INSTALL_LIBDIR_ARCHIND} '$'{CMAKE_INSTALL_LIBDIR}
     substituteInPlace packaging/pkgconfig.pc.in \
-      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+      --replace-fail '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ar/argus/package.nix
+++ b/pkgs/by-name/ar/argus/package.nix
@@ -47,13 +47,13 @@ stdenv.mkDerivation (finalAttrs: {
      substituteInPlace events/argus-extip.pl \
        --subst-var-by PERLBIN ${perl}/bin/perl
     substituteInPlace events/argus-lsof.pl \
-      --replace "\`which lsof\`" "\"${lsof}/bin/lsof\"" \
+      --replace-fail "\`which lsof\`" "\"${lsof}/bin/lsof\"" \
       --subst-var-by PERLBIN ${perl}/bin/perl
     substituteInPlace events/argus-vmstat.sh \
-      --replace vm_stat ${procps}/bin/vmstat
+      --replace-fail vm_stat ${procps}/bin/vmstat
     substituteInPlace events/argus-snmp.sh \
-      --replace /usr/bin/snmpget ${lib.getBin net-snmp}/bin/snmpget \
-      --replace /usr/bin/snmpwalk ${lib.getBin net-snmp}/bin/snmpwalk
+      --replace-fail /usr/bin/snmpget ${lib.getBin net-snmp}/bin/snmpget \
+      --replace-fail /usr/bin/snmpwalk ${lib.getBin net-snmp}/bin/snmpwalk
   '';
 
   meta = {

--- a/pkgs/by-name/ar/argyllcms/package.nix
+++ b/pkgs/by-name/ar/argyllcms/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
 
   postPatch = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
     substituteInPlace Jambase \
-      --replace "-m64" ""
+      --replace-fail "-m64" ""
   '';
 
   preConfigure =
@@ -125,7 +125,7 @@ stdenv.mkDerivation rec {
     in
     ''
       cp ${jamTop} Jamtop
-      substituteInPlace Makefile --replace "-j 3" "-j $NIX_BUILD_CORES"
+      substituteInPlace Makefile --replace-fail "-j 3" "-j $NIX_BUILD_CORES"
       # Remove tiff, jpg and png to be sure the nixpkgs-provided ones are used
       rm -rf tiff jpg png
 

--- a/pkgs/by-name/ar/arpoison/package.nix
+++ b/pkgs/by-name/ar/arpoison/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "0krhszx3s0qwfg4rma5a51ak71nnd9xfs2ibggc3hwiz506s2x37";
   };
 
-  postPatch = "substituteInPlace Makefile --replace gcc cc";
+  postPatch = "substituteInPlace Makefile --replace-fail gcc cc";
 
   installPhase = ''
     mkdir -p $out/bin $out/share/man/man8

--- a/pkgs/by-name/as/asciidoc/package.nix
+++ b/pkgs/by-name/as/asciidoc/package.nix
@@ -287,14 +287,14 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   + ''
     # Fix tests
     for f in $(grep -R --files-with-matches "2002-11-25") ; do
-      substituteInPlace $f --replace "2002-11-25" "1980-01-02"
-      substituteInPlace $f --replace "00:37:42" "00:00:00"
+      substituteInPlace $f --replace-fail "2002-11-25" "1980-01-02"
+      substituteInPlace $f --replace-warn "00:37:42" "00:00:00"
     done
   ''
   + lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
     # We want to use asciidoc from the build platform to build the documentation.
     substituteInPlace Makefile.in \
-      --replace "python3 -m asciidoc.a2x" "${buildPackages.asciidoc}/bin/a2x"
+      --replace-fail "python3 -m asciidoc.a2x" "${buildPackages.asciidoc}/bin/a2x"
   '';
 
   build-system = with python3.pythonOnBuildForHost.pkgs; [ setuptools ];

--- a/pkgs/by-name/as/asl/package.nix
+++ b/pkgs/by-name/as/asl/package.nix
@@ -30,10 +30,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch =
     lib.optionalString (!buildDocs) ''
-      substituteInPlace Makefile --replace "all: binaries docs" "all: binaries"
+      substituteInPlace Makefile --replace-fail "all: binaries docs" "all: binaries"
     ''
     + lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) ''
-      substituteInPlace sysdefs.h --replace "x86_64" "aarch64"
+      substituteInPlace sysdefs.h --replace-fail "x86_64" "aarch64"
     '';
 
   dontConfigure = true;

--- a/pkgs/by-name/as/aspino/package.nix
+++ b/pkgs/by-name/as/aspino/package.nix
@@ -32,11 +32,11 @@ stdenv.mkDerivation {
 
   postPatch = ''
     substituteInPlace Makefile \
-      --replace "GCC = g++" "GCC = c++"
+      --replace-fail "GCC = g++" "GCC = c++"
     substituteInPlace src/main.cc \
-      --replace "defined(__linux__)" "defined(__linux__) && defined(__x86_64__)"
+      --replace-fail "defined(__linux__)" "defined(__linux__) && defined(__x86_64__)"
     substituteInPlace src/MaxSatSolver.cc \
-      --replace "occ[i][sign(softLiterals[j])] > 0" "occ[i][sign(softLiterals[j])] != 0"
+      --replace-fail "occ[i][sign(softLiterals[j])] > 0" "occ[i][sign(softLiterals[j])] != 0"
   '';
 
   preBuild = ''

--- a/pkgs/by-name/as/astc-encoder/package.nix
+++ b/pkgs/by-name/as/astc-encoder/package.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
   # Set a fixed build year to display within help output (otherwise, it would be 1980)
   postPatch = ''
     substituteInPlace Source/cmake_core.cmake \
-      --replace 'string(TIMESTAMP astcencoder_YEAR "%Y")' 'set(astcencoder_YEAR "2023")'
+      --replace-fail 'string(TIMESTAMP astcencoder_YEAR "%Y")' 'set(astcencoder_YEAR "2023")'
   '';
 
   # Provide 'astcenc' link to main executable

--- a/pkgs/by-name/as/astrolog/package.nix
+++ b/pkgs/by-name/as/astrolog/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
 
   patchPhase = ''
     sed -i "s:~/astrolog:$out/astrolog:g" astrolog.h
-    substituteInPlace Makefile --replace cc "$CC" --replace strip "$STRIP"
+    substituteInPlace Makefile --replace-fail cc "$CC" --replace-fail strip "$STRIP"
   '';
 
   buildInputs = [ libx11 ];

--- a/pkgs/by-name/at/at/package.nix
+++ b/pkgs/by-name/at/at/package.nix
@@ -32,17 +32,17 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     # Remove chown commands and setuid bit
     substituteInPlace Makefile.in \
-      --replace ' -o root ' ' ' \
-      --replace ' -g root ' ' ' \
-      --replace ' -o $(DAEMON_USERNAME) ' ' ' \
-      --replace ' -o $(DAEMON_GROUPNAME) ' ' ' \
-      --replace ' -g $(DAEMON_GROUPNAME) ' ' ' \
-      --replace '$(DESTDIR)$(etcdir)' "$out/etc" \
-      --replace '$(DESTDIR)$(ATJOB_DIR)' "$out/var/spool/atjobs" \
-      --replace '$(DESTDIR)$(ATSPOOL_DIR)' "$out/var/spool/atspool" \
-      --replace '$(DESTDIR)$(LFILE)' "$out/var/spool/atjobs/.SEQ" \
-      --replace 'chown' '# skip chown' \
-      --replace '6755' '0755'
+      --replace-fail ' -o root ' ' ' \
+      --replace-fail ' -g root ' ' ' \
+      --replace-fail ' -o $(DAEMON_USERNAME) ' ' ' \
+      --replace-fail ' -o $(DAEMON_GROUPNAME) ' ' ' \
+      --replace-fail ' -g $(DAEMON_GROUPNAME) ' ' ' \
+      --replace-fail '$(DESTDIR)$(etcdir)' "$out/etc" \
+      --replace-fail '$(DESTDIR)$(ATJOB_DIR)' "$out/var/spool/atjobs" \
+      --replace-fail '$(DESTDIR)$(ATSPOOL_DIR)' "$out/var/spool/atspool" \
+      --replace-fail '$(DESTDIR)$(LFILE)' "$out/var/spool/atjobs/.SEQ" \
+      --replace-fail 'chown' '# skip chown' \
+      --replace-fail '6755' '0755'
   '';
 
   nativeBuildInputs = [
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     export SENDMAIL=${sendmailPath}
     # Purity: force atd.pid to be placed in /var/run regardless of
     # whether it exists now.
-    substituteInPlace ./configure --replace "test -d /var/run" "true"
+    substituteInPlace ./configure --replace-fail "test -d /var/run" "true"
   '';
 
   configureFlags = [

--- a/pkgs/by-name/at/atop/package.nix
+++ b/pkgs/by-name/at/atop/package.nix
@@ -67,8 +67,8 @@ stdenv.mkDerivation (finalAttrs: {
       findutils=${findutils} systemd=${systemd} substituteAllInPlace "$f"
     done
 
-    substituteInPlace Makefile --replace 'chown' 'true'
-    substituteInPlace Makefile --replace 'chmod 04711' 'chmod 0711'
+    substituteInPlace Makefile --replace-fail 'chown' 'true'
+    substituteInPlace Makefile --replace-fail 'chmod 04711' 'chmod 0711'
   '';
 
   preInstall = ''

--- a/pkgs/by-name/at/ats-acc/package.nix
+++ b/pkgs/by-name/at/ats-acc/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
 
   postPatch = ''
     substituteInPlace Makefile \
-      --replace "mv acc \''$(PATSHOME)/bin/" "install -Dm755 acc ${placeholder "out"}/bin/"
+      --replace-fail "mv acc \''$(PATSHOME)/bin/" "install -Dm755 acc ${placeholder "out"}/bin/"
   '';
 
   nativeBuildInputs = [ ats2 ];


### PR DESCRIPTION
This pull request updates multiple Nix package expressions to use the `--replace-fail` flag instead of `--replace` in `substituteInPlace` commands. This change ensures that substitutions will fail the build if the target string is not found, making builds more robust and preventing silent errors.

Key changes by theme:

**Build robustness improvements:**

* Replaced all uses of `--replace` with `--replace-fail` in `substituteInPlace` calls across numerous package files, ensuring that missing substitution targets will cause the build to fail rather than silently succeeding.

**Minor code cleanup:**

* Removed an unnecessary `substituteInPlace` command from `pkgs/by-name/ar/argbash/package.nix` that replaced `/bin/bash` with `${runtimeShell}` in the `resources/Makefile`.

These changes increase the reliability of the build process by ensuring that all substitutions are explicit and verifiable.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
