### PR TITLE
form: 4.3.1 -> 5.0.0

### DIFF
--- a/pkgs/by-name/fo/form/package.nix
+++ b/pkgs/by-name/fo/form/package.nix
@@ -4,18 +4,31 @@
   fetchFromGitHub,
   autoreconfHook,
   gmp,
+  zstd,
+  mpfr,
   zlib,
+  flint,
 }:
-
+let
+  zstd_src = fetchFromGitHub {
+    owner = "facebook";
+    repo = "zstd";
+    # latest commit on dev (only branch that has that folder) that changed zlibWrapper (https://github.com/facebook/zstd/commits/dev/zlibWrapper)
+    rev = "0b96e6d42a9b22eb472a050fcd2cc4be3ffb8e2b";
+    hash = "sha256-EPsLRjCCj0ruQ+z7eBzr/ACF0wh5LzUmdpbw/w5moWU=";
+  };
+in
 stdenv.mkDerivation (finalAttrs: {
-  version = "4.3.1";
   pname = "form";
+  version = "5.0.0";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "form-dev";
     repo = "form";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ZWpfPeTekHEALqXVF/nLkcNsrkt17AKm2B/uydUBfvo=";
+    hash = "sha256-cYO8B5uDJQ9eUc4w5Le47su3JS/jGYwUFtHFunuQaJc=";
   };
 
   nativeBuildInputs = [
@@ -24,8 +37,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     gmp
+    mpfr
+    zstd
     zlib
+    flint
   ];
+
+  postUnpack = ''
+    mkdir -p source/extern/zstd
+    cp -r ${zstd_src}/zlibWrapper source/extern/zstd/
+    chmod -R +w source
+  '';
 
   meta = {
     description = "Symbolic manipulation of very big expressions";


### PR DESCRIPTION
Diff: https://github.com/form-dev/form/compare/v4.3.1...v5.0.0
Changelog: https://github.com/form-dev/form/wiki/Release-Notes-FORM-5.0.0

the `zstd_src` is required to fix [`configure: error: ./extern/zstd/zlibWrapper does not exist. Copy the zlibWrapper directory from upstream (https://github.com/facebook/zstd)`](https://nixpkgs-update-logs.nix-community.org/form/2026-05-03.log)

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
