### PR TITLE
nixos/sunshine: new documentation links

### DIFF
--- a/nixos/modules/services/networking/sunshine.nix
+++ b/nixos/modules/services/networking/sunshine.nix
@@ -20,7 +20,7 @@ let
   inherit (utils) escapeSystemdExecArgs;
   cfg = config.services.sunshine;
 
-  # ports used are offset from a single base port, see https://docs.lizardbyte.dev/projects/sunshine/en/latest/about/advanced_usage.html#port
+  # ports used are offset from a single base port, see https://docs.lizardbyte.dev/projects/sunshine/latest/md_docs_2configuration.html#port
   generatePorts = port: offsets: map (offset: port + offset) offsets;
   defaultPort = 47989;
 
@@ -60,7 +60,7 @@ in
       description = ''
         Settings to be rendered into the configuration file. If this is set, no configuration is possible from the web UI.
 
-        See <https://docs.lizardbyte.dev/projects/sunshine/en/latest/about/advanced_usage.html#configuration for syntax>.
+        See <https://docs.lizardbyte.dev/projects/sunshine/latest/md_docs_2configuration.html> for syntax.
       '';
       example = literalExpression ''
         {
@@ -73,7 +73,7 @@ in
           type = port;
           default = defaultPort;
           description = ''
-            Base port -- others used are offset from this one, see <https://docs.lizardbyte.dev/projects/sunshine/en/latest/about/advanced_usage.html#port> for details.
+            Base port -- others used are offset from this one, see <https://docs.lizardbyte.dev/projects/sunshine/latest/md_docs_2configuration.html#port> for details.
           '';
         };
       });


### PR DESCRIPTION
Sunshine seems to have changed config documentation locations
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
