### PR TITLE
algol68g: 3.11.3 -> 3.12.0

### DIFF
--- a/pkgs/by-name/al/algol68g/package.nix
+++ b/pkgs/by-name/al/algol68g/package.nix
@@ -15,12 +15,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "algol68g";
-  version = "3.11.3";
+  version = "3.12.0";
 
   src = fetchurl {
     # Uses archive.org because the original site removes older versions.
-    url = "https://web.archive.org/web/20260419212716/https://jmvdveer.home.xs4all.nl/algol68g-3.11.3.tar.gz";
-    hash = "sha256-P8hKm5lFG3P8+OigX2mFPzL1bN30bblAvijajJzTcxA=";
+    url = "https://web.archive.org/web/20260503173638/https://algol68genie.nl/algol68g-3.12.0.tar.gz";
+    hash = "sha256-fYjuivr6AKRK4Nn45Q+oglpTMnp+PhO6KOkGZjwVKn0=";
   };
 
   outputs = [
@@ -48,8 +48,8 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall =
     let
       pdfdoc = fetchurl {
-        url = "https://jmvdveer.home.xs4all.nl/learning-algol-68-genie.pdf";
-        hash = "sha256-QCwn1e/lVfTYTeolCFErvfMhvwCgsBnASqq2K+NYmlU=";
+        url = "https://web.archive.org/web/20260503174213/https://algol68genie.nl/learning-algol-68-genie.pdf";
+        hash = "sha256-eLMRf3XcAkr/Dmk7ieRe62x76VcCj+2QltHH7YtL15s=";
       };
     in
     lib.optionalString withPDFDoc ''
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
 
   meta = {
-    homepage = "https://jmvdveer.home.xs4all.nl/en.algol-68-genie.html";
+    homepage = "https://algol68genie.nl/en/algol-68-genie/";
     description = "Algol 68 Genie compiler-interpreter";
     longDescription = ''
       Algol 68 Genie (a68g) is a recent checkout hybrid compiler-interpreter,


### PR DESCRIPTION
Update to 3.12.0

Update homepage. Statement on old page: 
```
The domain home.xs4all.nl will go offline on July 1, 2026.

This page has already been migrated to the new URL

https://algol68genie.nl/en/algol-68-genie/
```


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
