### PR TITLE
legcord: fix app wmclass

### DIFF
--- a/pkgs/by-name/le/legcord/package.nix
+++ b/pkgs/by-name/le/legcord/package.nix
@@ -14,6 +14,7 @@
   pipewire,
   libpulseaudio,
   nix-update-script,
+  jq,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "legcord";
@@ -37,6 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     # legcord uses venmic, which is a shipped as a prebuilt node module
     # and needs to be patched
     autoPatchelfHook
+    jq
   ];
 
   buildInputs = [
@@ -54,6 +56,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildPhase = ''
     runHook preBuild
+
+    jq '.desktopName = "Legcord"' package.json > package.json.tmp
+    mv package.json.tmp package.json
 
     pnpm build
 

--- a/pkgs/by-name/le/legcord/package.nix
+++ b/pkgs/by-name/le/legcord/package.nix
@@ -14,6 +14,8 @@
   pipewire,
   libpulseaudio,
   nix-update-script,
+  jq,
+  moreutils,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "legcord";
@@ -37,6 +39,8 @@ stdenv.mkDerivation (finalAttrs: {
     # legcord uses venmic, which is a shipped as a prebuilt node module
     # and needs to be patched
     autoPatchelfHook
+    jq
+    moreutils
   ];
 
   buildInputs = [
@@ -55,6 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildPhase = ''
     runHook preBuild
 
+    jq '.desktopName = "Legcord"' package.json | sponge package.json
     pnpm build
 
     # Replicating the build step to copy venmic from the vendored node module manually,


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This change adds `desktopName` entry to the package. Legcord's startupwmclass will now properly appear as **Legcord** instead of the generic **electron**. This, in turn, will properly display app's icon and name (e.g., in overview or dock).
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
