### PR TITLE
ophcrack: fix build

### DIFF
--- a/pkgs/by-name/op/ophcrack/package.nix
+++ b/pkgs/by-name/op/ophcrack/package.nix
@@ -50,6 +50,11 @@ stdenv.mkDerivation (finalAttrs: {
       [ "--disable-gui" ]
   );
 
+  installPhase = lib.optional (stdenv.hostPlatform.isDarwin && enableGui) ''
+    mkdir -p $out/Applications
+    cp -R src/ophcrack.app $out/Applications/ophcrack.app
+  '';
+
   meta = {
     description = "Free Windows password cracker based on rainbow tables";
     homepage = "https://ophcrack.sourceforge.io";

--- a/pkgs/by-name/op/ophcrack/package.nix
+++ b/pkgs/by-name/op/ophcrack/package.nix
@@ -33,9 +33,9 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ pkg-config ] ++ lib.optional enableGui libsForQt5.wrapQtAppsHook;
   buildInputs = [
     openssl
+    expat
   ]
-  ++ (if enableGui then [ libsForQt5.qtcharts ] else [ expat ])
-  ++ lib.optional stdenv.hostPlatform.isDarwin expat;
+  ++ lib.optional enableGui libsForQt5.qtcharts;
 
   configureFlags = [
     "--with-libssl"
@@ -49,11 +49,6 @@ stdenv.mkDerivation (finalAttrs: {
     else
       [ "--disable-gui" ]
   );
-
-  installPhase = lib.optional stdenv.hostPlatform.isDarwin ''
-    mkdir -p $out/bin
-    cp -R src/ophcrack $out/bin
-  '';
 
   meta = {
     description = "Free Windows password cracker based on rainbow tables";


### PR DESCRIPTION
- #516381
- https://hydra.nixos.org/build/326843020

```
configure: error: ophcrack requires libexpat.
```

Added `expat` to buildInputs unconditionally.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
