### PR TITLE
osdlyrics: 0.5.15 -> 0.5.16

### DIFF
--- a/pkgs/by-name/os/osdlyrics/package.nix
+++ b/pkgs/by-name/os/osdlyrics/package.nix
@@ -20,13 +20,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "osdlyrics";
-  version = "0.5.15";
+  version = "0.5.16";
 
   src = fetchFromGitHub {
     owner = "osdlyrics";
     repo = "osdlyrics";
     rev = finalAttrs.version;
-    hash = "sha256-4jEF1LdMwaLNF6zvzAuGW8Iu4dzhrFLutX69LwSjTAI=";
+    hash = "sha256-GvvFtpiuWuHh1dxd7Hd9F9M0WyVOtN0LxZJzGGB0mVA=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/324269266

```
ol_keybindings.c: In function 'ol_keybinding_init':
ol_keybindings.c:54:40: error: passing argument 2 of 'ol_keybinder_bind' from incompatible pointer type [-Wincompatible-pointer-types]
   54 |   ol_keybinder_bind ("<Ctrl><Shift>H", ol_osd_switch_display, NULL);
      |                                        ^~~~~~~~~~~~~~~~~~~~~
      |                                        |
      |                                        void (*)(void)
In file included from ol_keybindings.c:21:
ol_keybinder.h:36:45: note: expected 'OlBindkeyHandler' {aka 'void (*)(char *, void *)'} but argument is of type 'void (*)(void)'
   36 |                           OlBindkeyHandler  handler,
      |                           ~~~~~~~~~~~~~~~~~~^~~~~~~
In file included from ol_keybindings.c:22:
ol_commands.h:42:6: note: 'ol_osd_switch_display' declared here
   42 | void ol_osd_switch_display ();
      |      ^~~~~~~~~~~~~~~~~~~~~
ol_keybinder.h:31:17: note: 'OlBindkeyHandler' declared here
   31 | typedef void (* OlBindkeyHandler) (char *keystring, gpointer user_data);
      |                 ^~~~~~~~~~~~~~~~
ol_keybindings.c:55:40: error: passing argument 2 of 'ol_keybinder_bind' from incompatible pointer type [-Wincompatible-pointer-types]
   55 |   ol_keybinder_bind ("<Ctrl><Shift>L", ol_osd_lock_unlock, NULL);
      |                                        ^~~~~~~~~~~~~~~~~~
      |                                        |
      |                                        void (*)(void)
ol_keybinder.h:36:45: note: expected 'OlBindkeyHandler' {aka 'void (*)(char *, void *)'} but argument is of type 'void (*)(void)'
   36 |                           OlBindkeyHandler  handler,
      |                           ~~~~~~~~~~~~~~~~~~^~~~~~~
ol_commands.h:36:6: note: 'ol_osd_lock_unlock' declared here
   36 | void ol_osd_lock_unlock ();
      |      ^~~~~~~~~~~~~~~~~~
ol_keybinder.h:31:17: note: 'OlBindkeyHandler' declared here
   31 | typedef void (* OlBindkeyHandler) (char *keystring, gpointer user_data);
      |                 ^~~~~~~~~~~~~~~~
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
