### PR TITLE
gappa: 1.6.1 -> 1.8.0

### DIFF
--- a/pkgs/by-name/ga/gappa/package.nix
+++ b/pkgs/by-name/ga/gappa/package.nix
@@ -5,26 +5,39 @@
   gmp,
   mpfr,
   boost,
+  flex,
+  bison,
   versionCheckHook,
   nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gappa";
-  version = "1.6.1";
+  version = "1.8.0";
 
   src = fetchurl {
     url = "https://gappa.gitlabpages.inria.fr/releases/gappa-${finalAttrs.version}.tar.gz";
-    hash = "sha256-1ux5ImKR8edXyvL21w3jY2o4/fATEjO2SMzS8B0o8Ok=";
+    hash = "sha256-dA1gOwRkW7lEo04bMldFHX0Chs8gMbd0Yl4/HhYK4qo";
   };
 
   strictDeps = true;
+
+  nativeBuildInputs = [
+    flex
+    bison
+  ];
 
   buildInputs = [
     gmp
     mpfr
     boost.dev
   ];
+
+  # For darwin sandboxed builds
+  postPatch = ''
+    substituteInPlace remake.cpp \
+      --replace 'tempnam(NULL, "rmk-")' 'tempnam(".", "rmk-")'
+  '';
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/by-name/ga/gappa/package.nix
+++ b/pkgs/by-name/ga/gappa/package.nix
@@ -11,11 +11,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gappa";
-  version = "1.6.1";
+  version = "1.7.0";
 
   src = fetchurl {
     url = "https://gappa.gitlabpages.inria.fr/releases/gappa-${finalAttrs.version}.tar.gz";
-    hash = "sha256-1ux5ImKR8edXyvL21w3jY2o4/fATEjO2SMzS8B0o8Ok=";
+    hash = "sha256-NAEaQcS5NsbfH6MoL+THTJYZyeAJ4VQyp1kiFXeV0cU=";
   };
 
   strictDeps = true;
@@ -41,6 +41,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  __darwinAllowLocalNetworking = true;
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];


### PR DESCRIPTION
Update to 1.8.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
