### PR TITLE
openvpn-auth-ldap: fix build with gcc15

### DIFF
--- a/pkgs/tools/networking/openvpn/openvpn-auth-ldap.nix
+++ b/pkgs/tools/networking/openvpn/openvpn-auth-ldap.nix
@@ -29,6 +29,11 @@ stdenv.mkDerivation rec {
       url = "https://patch-diff.githubusercontent.com/raw/threerings/openvpn-auth-ldap/pull/92.patch";
       hash = "sha256-SXuo1D/WywKO5hCsmoeDdTsR7EelxFxJAKmlAQJ6vuE=";
     })
+    (fetchpatch2 {
+      name = "gcc-15-fix";
+      url = "https://sources.debian.org/data/main/o/openvpn-auth-ldap/2.0.4-5/debian/patches/gcc-15.patch";
+      hash = "sha256-VwUwRBBfxgxEO4PKC/97vEN4e6XcUG6esc0Khu+iDxM=";
+    })
   ];
 
   # clang > 17 dropped support for `-export-dynamic` but `-rdynamic` does the


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/326842990

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
