### PR TITLE
speech-tools: fix build with gcc15; fix unrunnable scripts

### DIFF
--- a/pkgs/by-name/sp/speech-tools/fix-c23.patch
+++ b/pkgs/by-name/sp/speech-tools/fix-c23.patch
@@ -1,0 +1,46 @@
+diff --git a/siod/editline.c b/siod/editline.c
+index 6a1b847..964fe5e 100644
+--- a/siod/editline.c
++++ b/siod/editline.c
+@@ -176,7 +176,7 @@ STATIC STATUS h_next();
+ STATIC STATUS h_prev();
+ STATIC STATUS h_first();
+ STATIC STATUS h_last();
+-STATIC int substrcmp(char *text, char *pat, int len);
++STATIC int substrcmp(const char *text, const char *pat, size_t len);
+ STATIC ECHAR *search_hist(ECHAR *search, ECHAR *(*move)());
+ STATIC STATUS h_search();
+ STATIC STATUS fd_char();
+@@ -224,10 +224,10 @@ int		rl_meta_chars = 0;
+ */
+ STATIC ECHAR	*editinput();
+ #if	defined(USE_TERMCAP)
+-extern char	*getenv();
+-extern char	*tgetstr();
+-extern int	tgetent();
+-extern int	tgetnum();
++extern char	*getenv(const char *);
++extern char	*tgetstr(char *, char **);
++extern int	tgetent(char *, const char *);
++extern int	tgetnum(char *);
+ #endif	/* defined(USE_TERMCAP) */
+
+ /*
+@@ -806,7 +806,7 @@ STATIC STATUS h_last()
+ /*
+ **  Return zero if pat appears as a substring in text.
+ */
+-STATIC int substrcmp(char *text, char *pat, int len)
++STATIC int substrcmp(const char *text, const char *pat, size_t len)
+ {
+     ECHAR	c;
+
+@@ -823,7 +823,7 @@ STATIC ECHAR *search_hist(ECHAR *search, ECHAR *(*move)())
+     static ECHAR	*old_search;
+     int		len;
+     int		pos;
+-    int		(*match)();
++    int		(*match)(const char *, const char *, size_t);
+     char	*pat;
+
+     /* Save or get remembered search pattern. */

--- a/pkgs/by-name/sp/speech-tools/fix-unbonded-variable.patch
+++ b/pkgs/by-name/sp/speech-tools/fix-unbonded-variable.patch
@@ -1,0 +1,39 @@
+diff --git a/scripts/est_examples.sh b/scripts/est_examples.sh
+index 5e6f38c..b931fda 100755
+--- a/scripts/est_examples.sh
++++ b/scripts/est_examples.sh
+@@ -64,7 +64,7 @@ EOF
+ prepend() {
+ 	var="$1"
+ 	extra="$2"
+-	eval "val=\$$var"
++	eval "val=\${$var:-}"
+ 	
+ 	if [ -n "$val" ]
+ 		then
+diff --git a/scripts/shared_script b/scripts/shared_script
+index b159134..2732699 100644
+--- a/scripts/shared_script
++++ b/scripts/shared_script
+@@ -5,7 +5,7 @@
+ extend() {
+ 	var="$1"
+ 	extra="$2"
+-	eval "val=\$$var"
++	eval "val=\${$var:-}"
+ 	
+ 	if [ -n "$val" ]
+ 		then
+diff --git a/scripts/shared_setup_sh b/scripts/shared_setup_sh
+index 64f0ba9..e0488f4 100644
+--- a/scripts/shared_setup_sh
++++ b/scripts/shared_setup_sh
+@@ -4,7 +4,7 @@
+ extend() {
+ 	var="$1"
+ 	extra="$2"
+-	eval "val=\$$var"
++	eval "val=\${$var:-}"
+ 	
+ 	if [ -n "$val" ]
+ 		then

--- a/pkgs/by-name/sp/speech-tools/package.nix
+++ b/pkgs/by-name/sp/speech-tools/package.nix
@@ -5,6 +5,7 @@
   fetchpatch,
   ncurses,
   alsa-lib,
+  perl,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -24,10 +25,13 @@ stdenv.mkDerivation (finalAttrs: {
     })
     # Fix C23 compatibility: https://github.com/festvox/speech_tools/pull/58
     ./fix-c23.patch
+    # Fix "unbonded variable" error in some scripts
+    ./fix-unbonded-variable.patch
   ];
 
   buildInputs = [
     ncurses
+    perl
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     alsa-lib
@@ -50,11 +54,16 @@ stdenv.mkDerivation (finalAttrs: {
     # c99 makes isnan valid for float and double
     substituteInPlace include/EST_math.h \
       --replace '__isnanf(X)' 'isnan(X)'
+
+    # fix script referenced paths
+    substituteInPlace config/rules/script_process.awk \
+      --replace-fail "topdir" "\"$out\"" \
+      --replace-fail "est" "\"$out\""
   '';
 
   installPhase = ''
-    mkdir -p "$out"/{bin,lib}
-    for d in bin lib; do
+    mkdir -p "$out"/{bin,include,lib}
+    for d in bin include lib; do
       for i in ./$d/*; do
         test "$(basename "$i")" = "Makefile" ||
           cp -r "$(readlink -f $i)" "$out/$d"

--- a/pkgs/by-name/sp/speech-tools/package.nix
+++ b/pkgs/by-name/sp/speech-tools/package.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/festvox/speech_tools/commit/06141f69d21bf507a9becb5405265dc362edb0df.patch";
       hash = "sha256-tRestCBuRhak+2ccsB6mvDxGm/TIYX4eZ3oppCOEP9s=";
     })
+    # Fix C23 compatibility: https://github.com/festvox/speech_tools/pull/58
+    ./fix-c23.patch
   ];
 
   buildInputs = [

--- a/pkgs/by-name/sp/speech-tools/package.nix
+++ b/pkgs/by-name/sp/speech-tools/package.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation (finalAttrs: {
     ./fix-c23.patch
     # Fix "unbonded variable" error in some scripts
     ./fix-unbonded-variable.patch
+    # Fix "ISO C++17 does not allow 'register' storage class specifier
+    ./remove-register-specifier.patch
   ];
 
   buildInputs = [

--- a/pkgs/by-name/sp/speech-tools/remove-register-specifier.patch
+++ b/pkgs/by-name/sp/speech-tools/remove-register-specifier.patch
@@ -1,0 +1,56 @@
+diff --git a/base_class/string/EST_strcasecmp.c b/base_class/string/EST_strcasecmp.c
+index 72a9b7c..e196c3a 100755
+--- a/base_class/string/EST_strcasecmp.c
++++ b/base_class/string/EST_strcasecmp.c
+@@ -86,7 +86,7 @@ static const unsigned char def_charmap[] = {
+ int
+ EST_strcasecmp(const char *s1, const char *s2, const unsigned char *charmap)
+ {
+-	register const unsigned char *cm = charmap?charmap:def_charmap,
++	const unsigned char *cm = charmap?charmap:def_charmap,
+ 			*us1 = (const unsigned char *)s1,
+ 			*us2 = (const unsigned char *)s2;
+ 	int r;
+@@ -102,7 +102,7 @@ int
+ EST_strncasecmp(const char *s1, const char *s2, size_t n, const unsigned char *charmap)
+ {
+ 	if (n != 0) {
+-		register const unsigned char *cm = charmap?charmap:def_charmap,
++		const unsigned char *cm = charmap?charmap:def_charmap,
+ 				*us1 = (const unsigned char *)s1,
+ 				*us2 = (const unsigned char *)s2;
+ 
+diff --git a/base_class/string/regexp.cc b/base_class/string/regexp.cc
+index 8b8f15f..c6211fa 100644
+--- a/base_class/string/regexp.cc
++++ b/base_class/string/regexp.cc
+@@ -175,7 +175,7 @@ STATIC char *regbranch(int *flagp);
+ STATIC char *regpiece(int *flagp);
+ STATIC char *regatom(int *flagp);
+ STATIC char *regnode(char op);
+-STATIC char *regnext(register char *p);
++STATIC char *regnext(char *p);
+ STATIC void regc(char b);
+ STATIC void reginsert(char op, char *opnd);
+ STATIC void regtail(char *p, char *val);
+diff --git a/base_class/string/regsub.c b/base_class/string/regsub.c
+index 017cea2..ed7cc9b 100644
+--- a/base_class/string/regsub.c
++++ b/base_class/string/regsub.c
+@@ -38,11 +38,11 @@ const hs_regexp *prog;
+ const char *source;
+ char *dest;
+ {
+-	register char *src;
+-	register char *dst;
+-	register char c;
+-	register int no;
+-	register int len;
++	char *src;
++	char *dst;
++	char c;
++	int no;
++	int len;
+ 
+ 	if (prog == NULL || source == NULL || dest == NULL) {
+ 		hs_regerror("NULL parm to regsub");


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/326906945
- Fixes #484513

```
editline.c:227:18: error: conflicting types for 'getenv'; have 'char *(void)'
  227 | extern char     *getenv();
      |                  ^~~~~~
In file included from editline.h:69,
                 from editline.c:55:
/nix/store/fbbw928argckfii0j322346ihmllg7a7-glibc-2.42-61-dev/include/stdlib.h:773:14: note: previous declaration of 'getenv' with type 'char *(const char *)'
  773 | extern char *getenv (const char *__name) __THROW __nonnull ((1)) __wur;
      |              ^~~~~~
...
```

Aside from the compilation issue, many installed scripts are having shebang/path issues which prevent them to be used at all. This problem is also present in release-25.11.

With this patch most should work out of the box.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
