### PR TITLE
osmo: fix build with gcc15

### DIFF
--- a/pkgs/by-name/os/osmo/package.nix
+++ b/pkgs/by-name/os/osmo/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchDebianPatch,
   pkg-config,
   gtk3,
   libxml2,
@@ -23,6 +24,16 @@ stdenv.mkDerivation (finalAttrs: {
     url = "mirror://sourceforge/osmo-pim/osmo-${finalAttrs.version}.tar.gz";
     sha256 = "19h3dnjgqbawnvgnycyp4n5b6mjsp5zghn3b69b6f3xa3fyi32qy";
   };
+
+  patches = [
+    (fetchDebianPatch {
+      pname = "osmo";
+      version = "0.4.4";
+      debianRevision = "3";
+      patch = "gcc-15.patch";
+      hash = "sha256-2T34wYczOTc57tjt3w91q8TDtQZqLpwYOsr8JKpYs0c=";
+    })
+  ];
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/326843174

```
calendar_notes.c: In function 'cal_notes_foreach':
calendar_notes.c:79:30: error: too many arguments to function 'cnfunc'; expected 0, have 2
   79 |                         if ((*cnfunc)(n, appGUI) == TRUE)
      |                             ~^~~~~~~~ ~
```

Fetched debian patch: https://sources.debian.org/patches/osmo/0.4.4-3/gcc-15.patch/

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
