### PR TITLE
prisma-engine_7: fix `meta.mainProgram`

### DIFF
--- a/pkgs/by-name/pr/prisma-engines_7/package.nix
+++ b/pkgs/by-name/pr/prisma-engines_7/package.nix
@@ -54,7 +54,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://www.prisma.io/";
     license = lib.licenses.asl20;
     platforms = lib.platforms.unix;
-    mainProgram = "prisma";
+    mainProgram = "schema-engine";
     maintainers = with lib.maintainers; [
       aqrln
     ];


### PR DESCRIPTION
the attribute meta.mainProgram was set to `prisma`, while the derivation only builds a single binary `schema-engine`.

```sh
$ nix eval --impure --expr 'with import ./. {}; lib.getExe prisma-engines_7'
"/nix/store/aq4pd0qb4hg030309mi356h060mjnqj9-prisma-engines_7-7.8.0/bin/prisma"
                                                                      # ^ ??

$ nix run nixpkgs#tree /nix/store/aq4pd0qb4hg030309mi356h060mjnqj9-prisma-engines_7-7.8.0/
/nix/store/aq4pd0qb4hg030309mi356h060mjnqj9-prisma-engines_7-7.8.0/
├── bin
│   └── schema-engine # <-- real main program
└── nix-support
    └── setup-hook

3 directories, 2 files
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
