### PR TITLE
otpw: fix build with gcc15

### DIFF
--- a/pkgs/by-name/ot/otpw/package.nix
+++ b/pkgs/by-name/ot/otpw/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   coreutils,
+  fetchDebianPatch,
   fetchurl,
   libxcrypt,
   pam,
@@ -20,7 +21,17 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-mKyjimHHcTZ3uW8kQmynBTSAwP0HfZGx6ZvJ+SzLgyo=";
   };
 
-  patchPhase = ''
+  patches = [
+    (fetchDebianPatch {
+      pname = "otpw";
+      version = "1.5";
+      debianRevision = "6";
+      patch = "gcc15.patch";
+      hash = "sha256-lR/FZannn9YVCTj+DWZvIyu99lmkaUxG48TGzckyolU=";
+    })
+  ];
+
+  postPatch = ''
     sed -i 's/^CFLAGS.*/CFLAGS=-O2 -fPIC/' Makefile
     substituteInPlace otpw-gen.c \
       --replace "head -c 20 /dev/urandom 2>&1" "${coreutils}/bin/head -c 20 /dev/urandom 2>&1" \


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/326843261

```
otpw.c:119:5: error: conflicting types for 'otpw_set_pseudouser'; have 'int(struct otpw_pwdbuf **)'
  119 | int otpw_set_pseudouser(struct otpw_pwdbuf **pseudouser)
      |     ^~~~~~~~~~~~~~~~~~~
In file included from otpw.c:19:
otpw.h:101:5: note: previous declaration of 'otpw_set_pseudouser' with type 'int(void)'
  101 | int otpw_set_pseudouser();
      |     ^~~~~~~~~~~~~~~~~~~
```

Applied debian patch: https://sources.debian.org/src/otpw/1.5-6/debian/patches/gcc15.patch

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
