### PR TITLE
rust-parallel: 1.21.0 -> 1.22.0, fix tests, use `__structuredAttrs`

### DIFF
--- a/pkgs/by-name/ru/rust-parallel/package.nix
+++ b/pkgs/by-name/ru/rust-parallel/package.nix
@@ -1,38 +1,35 @@
 {
-  bash,
-  fetchFromGitHub,
   lib,
   rustPlatform,
+  fetchFromGitHub,
   versionCheckHook,
   nix-update-script,
+  bashNonInteractive,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rust-parallel";
-  version = "1.21.0";
+  version = "1.22.0";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "aaronriekenberg";
     repo = "rust-parallel";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-86CUFtq6XpTYL7zpDBBfbSXlPYhWofwMjJSK698lclI=";
+    hash = "sha256-6SDWYIJDoDKANYZvYM2hdFzXTyqbfRA2uKQDFn+6erg=";
   };
 
-  cargoHash = "sha256-g2R3dEvDv3uzZVXBFvsCoX/M0XuHhoE/mMHni6qEN1g=";
+  cargoHash = "sha256-uFx0Sli6uwmhHKQoT1aX0S5NwuWLu3M6g5pQYYpAsEI=";
 
-  postPatch = ''
-    substituteInPlace tests/dummy_shell.sh \
-      --replace-fail "/bin/bash" "${bash}/bin/bash"
+  checkInputs = [ bashNonInteractive ];
+
+  # Some test require the output of tracing which for some reason hides info if RUST_LOG is set to "" which it is by default
+  logLevel = "info";
+
+  preCheck = ''
+    patchShebangs ./tests/dummy_shell.sh
   '';
-
-  checkFlags = [
-    "--skip=runs_echo_commands_dry_run"
-    "--skip=test_keep_order_with_sleep"
-
-    "--skip=runs_regex_command_with_dollar_signs"
-    "--skip=runs_regex_from_command_line_args_nomatch_1"
-    "--skip=runs_regex_from_input_file_badline_j1"
-  ];
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;

--- a/pkgs/by-name/ru/rust-parallel/package.nix
+++ b/pkgs/by-name/ru/rust-parallel/package.nix
@@ -1,38 +1,35 @@
 {
-  bash,
-  fetchFromGitHub,
   lib,
+  bash,
   rustPlatform,
+  fetchFromGitHub,
   versionCheckHook,
   nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rust-parallel";
-  version = "1.21.0";
+  version = "1.22.0";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "aaronriekenberg";
     repo = "rust-parallel";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-86CUFtq6XpTYL7zpDBBfbSXlPYhWofwMjJSK698lclI=";
+    hash = "sha256-6SDWYIJDoDKANYZvYM2hdFzXTyqbfRA2uKQDFn+6erg=";
   };
 
-  cargoHash = "sha256-g2R3dEvDv3uzZVXBFvsCoX/M0XuHhoE/mMHni6qEN1g=";
+  cargoHash = "sha256-uFx0Sli6uwmhHKQoT1aX0S5NwuWLu3M6g5pQYYpAsEI=";
 
-  postPatch = ''
-    substituteInPlace tests/dummy_shell.sh \
-      --replace-fail "/bin/bash" "${bash}/bin/bash"
+  checkInputs = [ bash ];
+
+  # Some test require the output of tracing which for some reason hides info if RUST_LOG is set to "" which it is by default
+  logLevel = "info";
+
+  preCheck = ''
+    patchShebangs ./tests/dummy_shell.sh
   '';
-
-  checkFlags = [
-    "--skip=runs_echo_commands_dry_run"
-    "--skip=test_keep_order_with_sleep"
-
-    "--skip=runs_regex_command_with_dollar_signs"
-    "--skip=runs_regex_from_command_line_args_nomatch_1"
-    "--skip=runs_regex_from_input_file_badline_j1"
-  ];
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;


### PR DESCRIPTION
Diff: https://github.com/aaronriekenberg/rust-parallel/compare/v1.21.0...v1.22.0
Changelog: https://github.com/aaronriekenberg/rust-parallel/releases/tag/v1.22.0

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
