### PR TITLE
vimPluginsUpdater: inherit license variables into global scope

### DIFF
--- a/pkgs/applications/editors/vim/plugins/utils/update.py
+++ b/pkgs/applications/editors/vim/plugins/utils/update.py
@@ -95,7 +95,10 @@ class VimEditor(nixpkgs_plugin_update.Editor):
                   fetchFromGitHub,
                   fetchgit,
                 }:
-
+                let
+                  inherit (lib.licenses) unfree;
+                  inherit (lib.meta) getLicenseFromSpdxId;
+                in
                 final: prev: {
                 """
                 )
@@ -128,9 +131,9 @@ class VimEditor(nixpkgs_plugin_update.Editor):
                 license_spdx_id, license_spdx_id
             )
         license_nix = (
-            f"    meta.license = lib.meta.getLicenseFromSpdxId {json.dumps(license_spdx_id)};\n"
+            f"    meta.license = getLicenseFromSpdxId {json.dumps(license_spdx_id)};\n"
             if license_spdx_id
-            else "    meta.license = lib.licenses.unfree;\n"
+            else "    meta.license = unfree;\n"
         )
         content += """{buildFn} {{
     pname = "{plugin.name}";


### PR DESCRIPTION
A million usages of the same variables in one file seems silly. Didn't run the generator - just putting this up for the next time it gets ran.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
