### PR TITLE
python3Packages.pkg-about: 2.0.12 -> 2.3.0

### DIFF
--- a/pkgs/development/python-modules/pkg-about/default.nix
+++ b/pkgs/development/python-modules/pkg-about/default.nix
@@ -1,10 +1,9 @@
 {
   lib,
   buildPythonPackage,
-  docutils,
   fetchPypi,
+  build,
   importlib-metadata,
-  importlib-resources,
   setuptools,
   packaging,
   typing-extensions,
@@ -14,19 +13,19 @@
 
 buildPythonPackage rec {
   pname = "pkg-about";
-  version = "2.0.12";
+  version = "2.3.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "pkg_about";
     inherit version;
-    hash = "sha256-WFhOMeBvAPaU/AIGoGlSziJ633TrGBgOcbfBxAm3H8E=";
+    hash = "sha256-g+RduU/aLD+UwZVexONXa8+rQznVmybC5G4ZnIugPqI=";
   };
 
-  # tox is listed in build requirements but not actually used to build
-  # keeping it as a requirement breaks the build unnecessarily
+  # Unnecessarily requires the newest versions available for these
   postPatch = ''
-    sed -i "/requires/s/, 'tox>=[^']*'//" pyproject.toml
+    sed -i 's/"setuptools>=[^"]*"/"setuptools>=${setuptools.version}"/' pyproject.toml
+    sed -i 's/"packaging>=[^"]*"/"packaging>=${packaging.version}"/' pyproject.toml
   '';
 
   build-system = [
@@ -35,11 +34,9 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
-    docutils
+    build
     importlib-metadata
-    importlib-resources
     packaging
-    setuptools
     typing-extensions
   ];
 
@@ -47,6 +44,9 @@ buildPythonPackage rec {
     appdirs
     pytestCheckHook
   ];
+
+  # Tries and fails to install itself via pip
+  disabledTests = [ "test_about_from_setup" ];
 
   pythonImportsCheck = [ "pkg_about" ];
 


### PR DESCRIPTION
Update pkg-about from yanked version 2.0.12 to latest 2.3.0

This yanked version was triggering a false-positive-ish in https://github.com/NixOS/nixpkgs/issues/514132

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
