### PR TITLE
texlivePackages: add meta.sourceProvenance to packages with JAR files

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/build-texlive-package.nix
+++ b/pkgs/tools/typesetting/tex/texlive/build-texlive-package.nix
@@ -82,6 +82,9 @@ let
   }
   // lib.optionalAttrs hasCatalogue {
     homepage = "https://ctan.org/pkg/${catalogue}";
+  }
+  // lib.optionalAttrs (lib.elem "jar" (args.scriptExts or [ ])) {
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
   };
 
   hasBinfiles = args ? binfiles && args.binfiles != [ ];

--- a/pkgs/tools/typesetting/tex/texlive/build-texlive-package.nix
+++ b/pkgs/tools/typesetting/tex/texlive/build-texlive-package.nix
@@ -54,6 +54,7 @@
   hasRunfiles ? (sha512 ? run),
   hasTlpkg ? false,
   hasCatalogue ? true,
+  hasJar ? false,
   catalogue ? pname,
   extraNativeBuildInputs ? [ ],
   ...
@@ -86,6 +87,9 @@ let
   }
   // lib.optionalAttrs (mainProgram != null) {
     inherit mainProgram;
+  }
+  // lib.optionalAttrs hasJar {
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
   };
 
   # if binfiles contains exactly one entry, use it as mainProgram, but allow overrides via args.mainProgram

--- a/pkgs/tools/typesetting/tex/texlive/tl2nix.sed
+++ b/pkgs/tools/typesetting/tex/texlive/tl2nix.sed
@@ -169,16 +169,16 @@ $a}
     }
 
     # extract script extensions
-    / texmf-dist\/scripts\/.*\.(jar|lua|py|rb|sno|tcl|texlua|tlu) /{
+    / texmf-dist\/scripts\/[^ ]*\.(jar|lua|py|rb|sno|tcl|texlua|tlu) /{
       i\  scriptExts = [
-        / texmf-dist\/scripts\/.*\.jar /i\    "jar"
-        / texmf-dist\/scripts\/.*\.lua /i\    "lua"
-        / texmf-dist\/scripts\/.*\.py /i\    "py"
-        / texmf-dist\/scripts\/.*\.rb /i\    "rb"
-        / texmf-dist\/scripts\/.*\.sno /i\    "sno"
-        / texmf-dist\/scripts\/.*\.tcl /i\    "tcl"
-        / texmf-dist\/scripts\/.*\.texlua /i\    "texlua"
-        / texmf-dist\/scripts\/.*\.tlu /i\    "tlu"
+        / texmf-dist\/scripts\/[^ ]*\.jar /i\    "jar"
+        / texmf-dist\/scripts\/[^ ]*\.lua /i\    "lua"
+        / texmf-dist\/scripts\/[^ ]*\.py /i\    "py"
+        / texmf-dist\/scripts\/[^ ]*\.rb /i\    "rb"
+        / texmf-dist\/scripts\/[^ ]*\.sno /i\    "sno"
+        / texmf-dist\/scripts\/[^ ]*\.tcl /i\    "tcl"
+        / texmf-dist\/scripts\/[^ ]*\.texlua /i\    "texlua"
+        / texmf-dist\/scripts\/[^ ]*\.tlu /i\    "tlu"
       i\  ];
     }
 

--- a/pkgs/tools/typesetting/tex/texlive/tl2nix.sed
+++ b/pkgs/tools/typesetting/tex/texlive/tl2nix.sed
@@ -167,6 +167,10 @@ $a}
       # flag existence of tlpkg files in hold space
       x ; s/$/\n  hasTlpkg = true;/ ; x
     }
+    / [^ ]*\.jar /{
+      # flag existence of java bytecode in hold space
+      x ; s/$/\n  hasJar = true;/ ; x
+    }
 
     # extract script extensions
     / texmf-dist\/scripts\/[^ ]*\.(jar|lua|py|rb|sno|tcl|texlua|tlu) /{

--- a/pkgs/tools/typesetting/tex/texlive/tlpdb.nix
+++ b/pkgs/tools/typesetting/tex/texlive/tlpdb.nix
@@ -703,6 +703,7 @@
     license = [ "bsd3" ];
     version = "0.5.1";
     sha512.run = "e43861305fb612100621b74079c43f554b85d2af958778ea47e2cdf01996d9e08f0ae2cbd576e14ef0dd90d5919571db537cea058200dd6b45e9165fcba8c9a1";
+    hasJar = true;
   };
   albatross.binfiles = [
     "albatross"
@@ -1600,6 +1601,7 @@
     license = [ "bsd3" ];
     version = "7.2.0";
     sha512.run = "340c6b8ff750e684955d07e167cfb77f4b60131166a38e6fcfa0d3498e9281ca51e954a492fdcafaf01ce103441d87cc0330b849d000a0a788812cee8d6bc365";
+    hasJar = true;
   };
   arara.binfiles = [
     "arara"
@@ -4155,6 +4157,7 @@
     license = [ "gpl3Plus" ];
     version = "4.7";
     sha512.run = "09c58acec980741552e643eff132be3f9b93408b5094c5ce40f7850ccb47cc6b4f1fdbd79ae7212b4df70bae68115328d118bd632eb8c55a1afac000c4bb9792";
+    hasJar = true;
   };
   bib2gls.binfiles = [
     "bib2gls"
@@ -28607,6 +28610,7 @@
     license = [ "gpl3Plus" ];
     version = "20191225.0";
     sha512.run = "da33a0bdc989fcb6f4521d23e5d44bae70d608ed8ac10f05d6962a252e99bbd80380afa2cbe9e02b9c652b044dfff79218f951144da6ce55f8a53033c11ff346";
+    hasJar = true;
   };
   ketcindy.binfiles = [
     "ketcindy"
@@ -29980,6 +29984,7 @@
     license = [ "gpl3Only" ];
     version = "1.1.3";
     sha512.run = "2824e5ac81f37b52b45686927add1c73d9e8a6b3972f144178c312cb6c11b0d40d356ce06153d620d64ca735ccac7f97adcec8e59fe31527d1cc1e53e1551fef";
+    hasJar = true;
   };
   latex2nemeth.binfiles = [
     "latex2nemeth"
@@ -38442,6 +38447,7 @@
       "gpl1Only"
     ];
     sha512.run = "71a2c105a7d593ca432a50a68fbcd16d876c8a28ce25be99326f323bcdba997b000158514328542378384f55a0ceadd9d34b71840980346b0b5c1c63843f7c1b";
+    hasJar = true;
   };
   pax.binfiles = [
     "pdfannotextractor"
@@ -48448,6 +48454,7 @@
     sha512.source = "a2a6022a828a7b55a78ca72514e681951731e4ab451b54e0683e0daad6f07d243b52b056e376a6a0fa3b91652396598e819a8a8d14fdfcef65f5a8cd93e30a0f";
     license = [ "lppl13c" ];
     sha512.run = "760a199f6fde826739c94eee51bbb6424df4b4b8bc67e2f225884d7d42985d2a64560bca9623e5d71724caff484cd9a68854de80d8a6632efb5b81e645200d57";
+    hasJar = true;
   };
   tex4ht.binfiles = [
     "ht"
@@ -48937,6 +48944,7 @@
     license = [ "lppl13c" ];
     version = "1.7";
     sha512.run = "fbd239be879748a38a7fe3544081b2e5ef230176e7f3a6513f1d2a11fb9d537a8c882d6af36f4226776faf84a23fea6c040246f1c7403fa018d2c6da801b5654";
+    hasJar = true;
   };
   texosquery.binfiles = [
     "texosquery"
@@ -48954,6 +48962,7 @@
     license = [ "bsd3" ];
     version = "1.0.6";
     sha512.run = "c70f7e8e637a72c18b74e2c5e1832c911a32e7ac4f9b2fa538fb11b85c9c026c62373e0af52b6114180cbaed2d2c6222923ff400a0beff2db1adc16b499a64cd";
+    hasJar = true;
   };
   texplate.binfiles = [
     "texplate"
@@ -50544,6 +50553,7 @@
     license = [ "gpl3Plus" ];
     version = "1.2";
     sha512.run = "50817d4c68d4e302cf0f4075ff9321bde2fd26336923efd2fb39bf097090b617a2a67ce75d1a14d562939514acb17b2a356bc388f72049dbe52a868ff3d63ffd";
+    hasJar = true;
   };
   tlcockpit.binfiles = [
     "tlcockpit"

--- a/pkgs/tools/typesetting/tex/texlive/tlpdb.nix
+++ b/pkgs/tools/typesetting/tex/texlive/tlpdb.nix
@@ -23530,9 +23530,6 @@
     shortdesc = "Engraving Gregorian Chant scores";
     sha512.doc = "acfa4975c8936132f6cfb0f1af75c35fddfc030e74f01bcf88cededf66d67b6840477847d332db66c4a1645c4ac2b152070496786b4f2232a8d2392c31e8754a";
     sha512.source = "2bd9d16ac9b11b8ecdcaf0864f007ce10be9ae29662edbca81611fa0d3b7697fe12eea871a1e016880172dd629ae08774e9a6722aea564519ebb4919bd7d3238";
-    scriptExts = [
-      "lua"
-    ];
     license = [ "gpl3Only" ];
     version = "6.1.0";
     sha512.run = "0d15d49278efb0b4dcc6ff714bd7e5c97407a567c0a7f6f189d328839b727e4d3f6f6f8769c5f9ece3227a14d38b52875a2139484f5ddd3f8962f611e96c7d5a";
@@ -48449,10 +48446,6 @@
     shortdesc = "Convert (La)TeX to HTML/XML";
     sha512.doc = "3a932fda55762263ae1ae1ab3695dbcef2a7e6d4995028bfcc0a9ca15de04998aefbad56110b7853489fe038eddeb1f2057a65ea28d2b78caea30ae1b69a7e1a";
     sha512.source = "a2a6022a828a7b55a78ca72514e681951731e4ab451b54e0683e0daad6f07d243b52b056e376a6a0fa3b91652396598e819a8a8d14fdfcef65f5a8cd93e30a0f";
-    scriptExts = [
-      "jar"
-      "lua"
-    ];
     license = [ "lppl13c" ];
     sha512.run = "760a199f6fde826739c94eee51bbb6424df4b4b8bc67e2f225884d7d42985d2a64560bca9623e5d71724caff484cd9a68854de80d8a6632efb5b81e645200d57";
   };
@@ -48764,7 +48757,6 @@
     hasManpages = true;
     scriptExts = [
       "lua"
-      "tcl"
     ];
     hasCatalogue = false;
     sha512.run = "7b3365e054384d1acd91eb50d34c43dbd7d7ea7bcc98eee91ccc62c6ede11b32c1bdebfa34593eda672b13918059e895e3aa969948d988b578a1482e2712efbb";


### PR DESCRIPTION
Fix #516092. This affects `texliveSmall`, because tex4ht contains a .jar file. If this becomes a problem, I think I have figured how to compile the .jar file (it's a painful bootstrap exercise, though, because you need tex4ht to compile tex4ht.jar...).

## Things done

There's no evaluation change.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
