### PR TITLE
ghui: init at 0.4.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14297,6 +14297,11 @@
     githubId = 148352;
     name = "Jim Fowler";
   };
+  kitlangton = {
+    github = "kitlangton";
+    githubId = 7587245;
+    name = "Kit Langton";
+  };
   kitsunoff = {
     github = "kitsunoff";
     githubId = 58953114;

--- a/pkgs/by-name/gh/ghui/package.nix
+++ b/pkgs/by-name/gh/ghui/package.nix
@@ -1,0 +1,142 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  bun,
+  gh,
+  git,
+  nodejs,
+  nix-update-script,
+  runtimeShell,
+  versionCheckHook,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "ghui";
+  version = "0.4.6";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "kitlangton";
+    repo = "ghui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jMi2Pc2VTpj0cZ2zXqtunG0FxcglCNEt9WzWnwxq+Js=";
+  };
+
+  npmDeps = fetchNpmDeps {
+    name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
+    inherit (finalAttrs) src;
+    fetcherVersion = finalAttrs.npmDepsFetcherVersion;
+    hash = "sha256-GYGegGw80M5T2wETreP95OrCn7F7XxlZcZWy9TjbCHY=";
+    nativeBuildInputs = [ nodejs ];
+    prePatch = ''
+      export HOME=$TMPDIR
+      npm pkg set 'dependencies.@ghui/keymap=file:packages/keymap'
+      npm pkg delete 'devDependencies.@ghui/keymap'
+      npm install --package-lock-only --ignore-scripts --no-audit --no-fund
+    '';
+  };
+
+  prePatch = ''
+    export HOME=$TMPDIR
+    # prefetch-npm-deps --map-cache reads npmDeps from the process environment.
+    export npmDeps
+    npm pkg set 'dependencies.@ghui/keymap=file:packages/keymap'
+    npm pkg delete 'devDependencies.@ghui/keymap'
+    cp ${finalAttrs.npmDeps}/package-lock.json package-lock.json
+  '';
+
+  nativeBuildInputs = [ bun ];
+
+  npmDepsFetcherVersion = 3;
+
+  npmFlags = [
+    "--no-audit"
+    "--no-fund"
+  ];
+
+  npmBuildScript = "build:cli";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  postInstallCheck = ''
+    cd $out/lib/ghui
+    ${lib.getExe bun} -e '
+      await import("@effect/atom-react")
+      await import("@ghui/keymap")
+      await import("@opentui/core")
+      await import("@opentui/react")
+      await import("effect")
+      await import("react")
+      await import("scheduler")
+    '
+  '';
+
+  # The bundled CLI runs on Bun and resolves runtime dependencies from the
+  # installed node_modules tree. gh is kept on PATH for GitHub API operations.
+  installPhase = ''
+    runHook preInstall
+
+    npm prune --omit=dev --no-save --no-audit --no-fund
+
+    mkdir -p $out/lib/ghui $out/bin
+    cp -r dist node_modules packages package.json README.md LICENSE .env.example $out/lib/ghui/
+    rm -f $out/lib/ghui/node_modules/.bin/ghui
+
+    cat > $out/bin/ghui <<'EOF'
+    #!@runtimeShell@
+    case "''${1-}" in
+      -v|--version|version)
+        echo @version@
+        exit 0
+        ;;
+      -h|--help|help)
+        printf '%s\n' \
+          "ghui @version@" \
+          "" \
+          "Terminal UI for GitHub pull requests." \
+          "" \
+          "Usage:" \
+          "  ghui              Start the TUI" \
+          "  ghui -v, --version" \
+          "                    Print the installed version" \
+          "  ghui -h, --help   Show this help message"
+        exit 0
+        ;;
+    esac
+
+    export PATH=@path@:$PATH
+    exec @bun@ "@out@/lib/ghui/dist/index.js" "$@"
+    EOF
+    substituteInPlace $out/bin/ghui \
+      --replace-fail @runtimeShell@ ${runtimeShell} \
+      --replace-fail @version@ ${finalAttrs.version} \
+      --replace-fail @path@ ${
+        lib.makeBinPath [
+          gh
+          git
+        ]
+      } \
+      --replace-fail @bun@ ${lib.getExe bun} \
+      --replace-fail @out@ $out
+    chmod +x $out/bin/ghui
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Terminal UI for GitHub pull requests";
+    homepage = "https://github.com/kitlangton/ghui";
+    changelog = "https://github.com/kitlangton/ghui/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kitlangton ];
+    mainProgram = "ghui";
+    platforms = bun.meta.platforms;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
Adds ghui, a terminal UI for GitHub pull requests.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

Tested with:

```sh
nix-build -E 'let pkgs = import <nixpkgs> {}; in pkgs.callPackage ./pkgs/by-name/gh/ghui/package.nix {}'
./result/bin/ghui --version
./result/bin/ghui --help
git diff --check
nixfmt --check pkgs/by-name/gh/ghui/package.nix maintainers/maintainer-list.nix
```

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test