### PR TITLE
filius: 2.9.4 -> 2.10.1

### DIFF
--- a/pkgs/by-name/fi/filius/package.nix
+++ b/pkgs/by-name/fi/filius/package.nix
@@ -10,17 +10,16 @@
 
 maven.buildMavenPackage rec {
   pname = "filius";
-  version = "2.9.4";
+  version = "2.10.1";
 
   src = fetchFromGitLab {
     owner = "filius1";
     repo = "filius";
-    # they seem to have stopped using the "v" prefix since 2.9.3
-    tag = version;
-    hash = "sha256-nQyDPLDQe5kFH3PhCmLqAt8kVnitPwX5K3xLnyntF5k=";
+    tag = "v${version}";
+    hash = "sha256-q6A+S50n09DgwayylAWbUFQ/sqfCVEkIoWCRtZT80M8=";
   };
 
-  mvnHash = "sha256-6Qq/7vgA9bWQK+k66qORNwvLKMR1U5yb95DJMWaDq/k=";
+  mvnHash = "sha256-R14EtImJJEC/DhKm7MKWzq9XEOqDGNPtLIaK3OKbyiQ=";
   mvnParameters = "-Plinux";
 
   # tests want to create an X11 window which isn't often feasible


### PR DESCRIPTION
changelog: https://gitlab.com/filius1/filius/-/blob/master/Changelog.md
diff: https://gitlab.com/filius1/filius/-/compare/2.9.4...v2.10.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
