### PR TITLE
spooftooph: fix build with gcc15

### DIFF
--- a/pkgs/by-name/sp/spooftooph/package.nix
+++ b/pkgs/by-name/sp/spooftooph/package.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation (finalAttrs: {
     ncurses
   ];
 
+  env.NIX_CFLAGS_COMPILE = "-Wno-incompatible-pointer-types";
+
   makeFlags = [ "BIN=$(out)/bin" ];
 
   preInstall = ''


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/326907086

```
spooftooph.c: In function 'main':
spooftooph.c:1033:72: error: passing argument 3 of 'pthread_create' from incompatible pointer type [-Wincompatible-pointer-types]
 1033 |                                 if( (rc=pthread_create( &thread, NULL, &run_thread, NULL)) )
      |                                                                        ^~~~~~~~~~~
      |                                                                        |
      |                                                                        void * (*)(void)
In file included from spooftooph.c:39:
/nix/store/fbbw928argckfii0j322346ihmllg7a7-glibc-2.42-61-dev/include/pthread.h:204:36: note: expected 'void * (*)(void *)' but argument is of type 'void * (*)(void)'
  204 |                            void *(*__start_routine) (void *),
      |                            ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
spooftooph.c:712:7: note: 'run_thread' declared here
  712 | void *run_thread()
      |       ^~~~~~~~~~
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
