### PR TITLE
nxpmicro-mfgtools: 1.5.139 -> 1.5.243

### DIFF
--- a/pkgs/by-name/nx/nxpmicro-mfgtools/package.nix
+++ b/pkgs/by-name/nx/nxpmicro-mfgtools/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   pkg-config,
   bzip2,
@@ -10,27 +9,20 @@
   libusb1,
   libzip,
   openssl,
+  tinyxml-2,
   zstd,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nxpmicro-mfgtools";
-  version = "1.5.139";
+  version = "1.5.243";
 
   src = fetchFromGitHub {
     owner = "nxp-imx";
     repo = "mfgtools";
     rev = "uuu_${finalAttrs.version}";
-    sha256 = "sha256-t5usUGbcdLQlqPpZkNDeGncka9VfkpO7U933Kw/Sm7U=";
+    sha256 = "sha256-+m3r/QxOnTjemqIaZ/2cxDHtHlw7qxu9PbTsQYyMaEY=";
   };
-
-  patches = [
-    # build: support cmake 4.0
-    (fetchpatch {
-      url = "https://github.com/nxp-imx/mfgtools/commit/311ee9b3cca0275fbb5eb5228c56edbb518afd67.patch?full_index=1";
-      hash = "sha256-o4cPfXsPxk88zy5lARX8rcmQncsAkZegOxlAIyoFUpQ=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake
@@ -43,6 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
     libusb1
     libzip
     openssl
+    tinyxml-2
     zstd
   ];
 


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/326836480
- Changelog: https://github.com/nxp-imx/mfgtools/releases/tag/uuu_1.5.243
- Diff: https://github.com/nxp-imx/mfgtools/compare/uuu_1.5.139...uuu_1.5.243

```
In file included from /build/source/libuuu/sdps.cpp:32:
/build/source/libuuu/sdps.h:52:9: error: 'uint32_t' does not name a type
   52 |         uint32_t m_offset = 0;
      |         ^~~~~~~~
/build/source/libuuu/sdps.h:33:1: note: 'uint32_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
   32 | #include "cmd.h"
  +++ |+#include <cstdint>
   33 | 
/build/source/libuuu/sdps.h:53:9: error: 'uint64_t' does not name a type
   53 |         uint64_t m_scan_limited = UINT64_MAX;
      |         ^~~~~~~~
/build/source/libuuu/sdps.h:53:9: note: 'uint64_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
/build/source/libuuu/sdps.h: In constructor 'SDPSCmd::SDPSCmd(char*)':
/build/source/libuuu/sdps.h:41:47: error: 'm_offset' was not declared in this scope
   41 |                 insert_param_info("-offset", &m_offset, Param::Type::e_uint32);
      |                                               ^~~~~~~~
/build/source/libuuu/sdps.h:44:52: error: 'm_scan_limited' was not declared in this scope
   44 |                 insert_param_info("-scanlimited", &m_scan_limited, Param::Type::e_uint64);
      |                                                    ^~~~~~~~~~~~~~
/build/source/libuuu/sdps.cpp: In member function 'virtual int SDPSCmd::run(CmdCtx*)':
/build/source/libuuu/sdps.cpp:122:25: error: 'm_offset' was not declared in this scope; did you mean 'offset'?
  122 |         size_t offset = m_offset;
      |                         ^~~~~~~~
      |                         offset
/build/source/libuuu/sdps.cpp:128:41: error: 'm_scan_limited' was not declared in this scope
  128 |                 p = p1->request_data(0, m_scan_limited);
      |                                         ^~~~~~~~~~~~~~
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
