### PR TITLE
mtail: 3.2.26 -> 3.2.48

### DIFF
--- a/pkgs/by-name/mt/mtail/package.nix
+++ b/pkgs/by-name/mt/mtail/package.nix
@@ -8,16 +8,17 @@
 
 buildGoModule (finalAttrs: {
   pname = "mtail";
-  version = "3.2.26";
+  version = "3.2.48";
 
   src = fetchFromGitHub {
     owner = "jaqx0r";
     repo = "mtail";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-L+kRRAP74n8OJVQhbDjDGNc8IYp/11a6sKbGa1/UdNY=";
+    hash = "sha256-dZ0fjBpQ1hS1AxuD5A3gSTmimhP6PbiyxGs8XaYdo64=";
   };
 
-  vendorHash = "sha256-kdPj9XjjvDMNCP8K8RBFoHCd1G2NqVq6UR1XykZEdkQ=";
+  proxyVendor = true;
+  vendorHash = "sha256-ZZcVtZBG0Erh/NmYbw0aOVCg2AGZeHMFRfRbwNFTCks=";
 
   nativeBuildInputs = [
     gotools # goyacc


### PR DESCRIPTION
This update the mtail package from `3.2.26` to `3.2.48`, but I was having a weird `go mod vendor` error, and even when trying to update the `vendorHash` it was still failling until I added the `proxyVensor = true` attribute (thanks @isabelroses  for the suggestion).

The error I was getting:

```
go: inconsistent vendoring in /build/source:
        contrib.go.opencensus.io/exporter/jaeger@v0.2.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/bazelbuild/rules_go@v0.59.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/golang/glog@v1.2.5: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/golang/groupcache@v0.0.0-20241129210726-2c02b8208cf8: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/google/go-cmp@v0.7.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/pkg/errors@v0.9.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/prometheus/client_golang@v1.23.2: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/prometheus/common@v0.67.5: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        go.opencensus.io@v0.24.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        go.opentelemetry.io/otel@v1.40.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc@v1.40.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        go.opentelemetry.io/otel/sdk@v1.40.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        go.opentelemetry.io/otel/sdk/metric@v1.40.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        golang.org/x/sys@v0.40.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        golang.org/x/tools@v0.41.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/beorn7/perks@v1.0.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/cenkalti/backoff/v5@v5.0.3: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/cespare/xxhash/v2@v2.3.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/go-logr/logr@v1.4.3: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/go-logr/stdr@v1.2.2: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/google/uuid@v1.6.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/grpc-ecosystem/grpc-gateway/v2@v2.27.7: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/kylelemons/godebug@v1.1.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/prometheus/client_model@v0.6.2: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/prometheus/procfs@v0.16.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/uber/jaeger-client-go@v2.25.0+incompatible: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        go.opentelemetry.io/auto/sdk@v1.2.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        go.opentelemetry.io/otel/metric@v1.40.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        go.opentelemetry.io/otel/trace@v1.40.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        go.opentelemetry.io/proto/otlp@v1.9.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        go.yaml.in/yaml/v2@v2.4.3: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        golang.org/x/net@v0.49.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        golang.org/x/sync@v0.19.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        golang.org/x/text@v0.33.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        google.golang.org/api@v0.105.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        google.golang.org/genproto/googleapis/api@v0.0.0-20260128011058-8636f8732409: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        google.golang.org/genproto/googleapis/rpc@v0.0.0-20260128011058-8636f8732409: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        google.golang.org/grpc@v1.78.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        google.golang.org/protobuf@v1.36.11: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt

        To ignore the vendor directory, use -mod=readonly or -mod=mod.
        To sync the vendor directory, run:
                go mod vendor
error: builder for '/nix/store/d2d1q8r50mb64f20xqf362scw8azfk7l-mtail-3.2.37-go-modules.drv' failed with exit code 1;
       last 25 log lines:
       >        github.com/go-logr/stdr@v1.2.2: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
       >     github.com/google/uuid@v1.6.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
       >      github.com/grpc-ecosystem/grpc-gateway/v2@v2.27.7: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
       >  github.com/kylelemons/godebug@v1.1.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
       >       github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
       >    github.com/prometheus/client_model@v0.6.2: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
       >  github.com/prometheus/procfs@v0.16.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
       >       github.com/uber/jaeger-client-go@v2.25.0+incompatible: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
       >      go.opentelemetry.io/auto/sdk@v1.2.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
       >        go.opentelemetry.io/otel/metric@v1.40.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
       >    go.opentelemetry.io/otel/trace@v1.40.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
       >     go.opentelemetry.io/proto/otlp@v1.9.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
       >      go.yaml.in/yaml/v2@v2.4.3: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
       >  golang.org/x/net@v0.49.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
       >   golang.org/x/sync@v0.19.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
       >  golang.org/x/text@v0.33.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
       >  google.golang.org/api@v0.105.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
       >     google.golang.org/genproto/googleapis/api@v0.0.0-20260128011058-8636f8732409: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
       >       google.golang.org/genproto/googleapis/rpc@v0.0.0-20260128011058-8636f8732409: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
       >       google.golang.org/grpc@v1.78.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
       >     google.golang.org/protobuf@v1.36.11: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
       >
       >       To ignore the vendor directory, use -mod=readonly or -mod=mod.
       >         To sync the vendor directory, run:
       >             go mod vendor
       For full logs, run:
               nix log /nix/store/d2d1q8r50mb64f20xqf362scw8azfk7l-mtail-3.2.37-go-modules.drv
error: 1 dependencies of derivation '/nix/store/ns6lyw3zmapsx7fh0ghhwrq199vpa911-mtail-3.2.37.drv' failed to build
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
