### PR TITLE
motion: fix cross compilation, use headless ffmpeg to reduce closure size

### DIFF
--- a/pkgs/by-name/mo/motion/fix-cross.diff
+++ b/pkgs/by-name/mo/motion/fix-cross.diff
@@ -1,0 +1,31 @@
+diff --git a/configure.ac b/configure.ac
+index ef7cb3e..135a082 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -64,9 +64,9 @@ CFLAGS="$HOLD_CFLAGS"
+ ##############################################################################
+ ###  Check libmicrohttpd - Required.  Needed for stream/webcontrol
+ ##############################################################################
+-AS_IF([pkg-config libmicrohttpd ], [
+-    TEMP_CFLAGS="$TEMP_CFLAGS "`pkg-config --cflags libmicrohttpd`
+-    TEMP_LIBS="$TEMP_LIBS "`pkg-config --libs libmicrohttpd`
++PKG_CHECK_MODULES([MICROHTTPD], [libmicrohttpd], [
++    TEMP_CPPFLAGS="$TEMP_CPPFLAGS $MICROHTTPD_CFLAGS"
++    TEMP_LIBS="$TEMP_LIBS $MICROHTTPD_LIBS"
+   ],[
+     AC_MSG_ERROR([Required package libmicrohttpd-dev not found, please check motion_guide.html and install necessary dependencies])
+   ]
+@@ -226,10 +226,10 @@ AS_IF([test "${FFMPEG}" = "no"], [
+ 
+     FFMPEG_DEPS="libavutil libavformat libavcodec libswscale libavdevice"
+     AC_MSG_CHECKING(for FFmpeg)
+-    AS_IF([pkg-config $FFMPEG_DEPS], [
++    PKG_CHECK_MODULES([TEMP_FFMPEG], [$FFMPEG_DEPS], [
+         FFMPEG_VER=`pkg-config --modversion libavformat`
+-        TEMP_CFLAGS="$TEMP_CFLAGS "`pkg-config --cflags $FFMPEG_DEPS`
+-        TEMP_LIBS="$TEMP_LIBS "`pkg-config --libs $FFMPEG_DEPS`
++        TEMP_CFLAGS="$TEMP_CFLAGS $TEMP_FFMPEG_CFLAGS"
++        TEMP_LIBS="$TEMP_LIBS $TEMP_FFMPEG_LIBS"
+         AC_DEFINE([HAVE_FFMPEG], [1], [Define to 1 if FFMPEG is around])
+         AC_MSG_RESULT(yes)
+       ],[

--- a/pkgs/by-name/mo/motion/package.nix
+++ b/pkgs/by-name/mo/motion/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   autoreconfHook,
   pkg-config,
-  ffmpeg,
+  ffmpeg-headless,
   libjpeg,
   libmicrohttpd,
 }:
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    ffmpeg
+    ffmpeg-headless
     libjpeg
     libmicrohttpd
   ];

--- a/pkgs/by-name/mo/motion/package.nix
+++ b/pkgs/by-name/mo/motion/package.nix
@@ -20,6 +20,13 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-NAzVFWWbys+jYYOifCOOoucAKfa19njIzXBQbtgGX9M=";
   };
 
+  patches = [
+    # https://github.com/Motion-Project/motion/pull/1959
+    ./fix-cross.diff
+  ];
+
+  depsBuildBuild = [ pkg-config ];
+
   nativeBuildInputs = [
     autoreconfHook
     pkg-config


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
