### PR TITLE
perlPackages.SessionToken: fix build with gcc15

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -30638,6 +30638,13 @@ with self;
         url = "https://github.com/hoytech/Session-Token/commit/cd64e7b69986054bb715755290811308159b7959.patch";
         hash = "sha256-nMQmdvVQW8cQYO0+bLJcdVfSOLVIsongk+71fQ7fQdU=";
       })
+      (fetchDebianPatch {
+        version = "1.503";
+        pname = "libsession-token-perl";
+        debianRevision = "3";
+        patch = "fix-gcc15-build.patch";
+        hash = "sha256-b6Yr5w++3lQcaI8JilthLykq4D4nEczz0h+r6LJ8hGI=";
+      })
     ];
     meta = {
       description = "Secure, efficient, simple random session token generation";


### PR DESCRIPTION
- #475479 
- #516381
- https://hydra.nixos.org/build/326851037

```
Token.xs: In function 'get_new_byte':
Token.xs:31:7: error: too many arguments to function 'isaac'; expected 0, have 1
   31 |       isaac(&ctx->isaac_ctx);
      |       ^~~~~ ~~~~~~~~~~~~~~~
In file included from Token.xs:6:
rand.h:41:6: note: declared here
   41 | void isaac(/*_ randctx *r _*/);
      |      ^~~~~
Token.xs: In function 'XS_Session__Token__new_context':
Token.xs:84:9: error: too many arguments to function 'randinit'; expected 0, have 2
   84 |         randinit(&ctx->isaac_ctx, TRUE);
      |         ^~~~~~~~ ~~~~~~~~~~~~~~~
rand.h:39:6: note: declared here
   39 | void randinit(/*_ randctx *r, word flag _*/);
      |      ^~~~~~~~
Token.xs:85:9: error: too many arguments to function 'isaac'; expected 0, have 1
   85 |         isaac(&ctx->isaac_ctx);
      |         ^~~~~ ~~~~~~~~~~~~~~~
rand.h:41:6: note: declared here
   41 | void isaac(/*_ randctx *r _*/);
      |      ^~~~~
```

Fetched debian patch: https://sources.debian.org/patches/libsession-token-perl/1.503-3/fix-gcc15-build.patch/

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
