### PR TITLE
libretro.cap32: init at 4.5.4

### DIFF
--- a/pkgs/applications/emulators/libretro/cores/cap32.nix
+++ b/pkgs/applications/emulators/libretro/cores/cap32.nix
@@ -15,7 +15,7 @@ mkLibretroCore {
   };
 
   makefile = "Makefile";
-  
+
   meta = {
     description = "Caprice32 libretro port (Amstrad CPC emulator)";
     homepage = "https://github.com/libretro/libretro-cap32";

--- a/pkgs/applications/emulators/libretro/cores/cap32.nix
+++ b/pkgs/applications/emulators/libretro/cores/cap32.nix
@@ -1,0 +1,24 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkLibretroCore,
+}:
+mkLibretroCore {
+  core = "cap32";
+  version = "4.5.4";
+
+  src = fetchFromGitHub {
+    owner = "libretro";
+    repo = "libretro-cap32";
+    rev = "8e13eb69b46ad231f181391e5f7a775a635b3a63";
+    hash = "sha256-GTHnjLktb7ks9ZiuIQ0X89P5bpach/lfDsPUXgDejSA=";
+  };
+
+  makefile = "Makefile";
+  
+  meta = {
+    description = "Caprice32 libretro port (Amstrad CPC emulator)";
+    homepage = "https://github.com/libretro/libretro-cap32";
+    license = lib.licenses.gpl2Only;
+  };
+}

--- a/pkgs/applications/emulators/libretro/default.nix
+++ b/pkgs/applications/emulators/libretro/default.nix
@@ -48,6 +48,8 @@ lib.makeScope newScope (self: {
 
   bsnes-mercury-performance = self.bsnes-mercury.override { withProfile = "performance"; };
 
+  cap32 = self.callPackage ./cores/cap32.nix { };
+
   citra = self.callPackage ./cores/citra.nix { };
 
   desmume = self.callPackage ./cores/desmume.nix { };


### PR DESCRIPTION
Add `libretro.cap32`, a libretro core that ports [Caprice32](https://github.com/libretro/libretro-cap32), an Amstrad CPC emulator.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
