### PR TITLE
freesmlauncher: init at 2.2.0

### DIFF
--- a/pkgs/by-name/fr/freesmlauncher-backup/package.nix
+++ b/pkgs/by-name/fr/freesmlauncher-backup/package.nix
@@ -1,0 +1,135 @@
+{
+  addDriverRunpath,
+  alsa-lib,
+  flite,
+  gamemode,
+  glfw3-minecraft,
+  jdk17,
+  jdk21,
+  jdk25,
+  jdk8,
+  kdePackages,
+  lib,
+  libGL,
+  libx11,
+  libXcursor,
+  libXext,
+  libXrandr,
+  libXxf86vm,
+  libjack2,
+  libpulseaudio,
+  libusb1,
+  mesa-demos,
+  openal,
+  pciutils,
+  pipewire,
+  freesmlauncher-unwrapped,
+  clangStdenv,
+  stdenv ? clangStdenv,
+  symlinkJoin,
+  udev,
+  vulkan-loader,
+  xrandr,
+  additionalLibs ? [ ],
+  additionalPrograms ? [ ],
+  controllerSupport ? stdenv.hostPlatform.isLinux,
+  gamemodeSupport ? stdenv.hostPlatform.isLinux,
+  jdks ? [
+    jdk25
+    jdk21
+    jdk17
+    jdk8
+  ],
+  msaClientID ? null,
+  textToSpeechSupport ? stdenv.hostPlatform.isLinux,
+}:
+
+assert lib.assertMsg (
+  controllerSupport -> stdenv.hostPlatform.isLinux
+) "controllerSupport only has an effect on Linux.";
+assert lib.assertMsg (
+  textToSpeechSupport -> stdenv.hostPlatform.isLinux
+) "textToSpeechSupport only has an effect on Linux.";
+let
+  freesmlauncher' = freesmlauncher-unwrapped.override { inherit msaClientID gamemodeSupport; };
+in
+symlinkJoin {
+  pname = "freesmlauncher";
+  inherit (freesmlauncher') version;
+
+  paths = [ freesmlauncher' ];
+
+  nativeBuildInputs = [ kdePackages.wrapQtAppsHook ];
+
+  buildInputs = [
+    kdePackages.qtbase
+    kdePackages.qtsvg
+  ]
+  ++ lib.optional (
+    lib.versionAtLeast kdePackages.qtbase.version "6" && stdenv.hostPlatform.isLinux
+  ) kdePackages.qtwayland;
+  # __structuredAttrs seems to break when using symlinkJoin
+  #__structuredAttrs = true;
+  strictDeps = true;
+  postBuild = ''
+    wrapQtAppsHook
+  '';
+
+  qtWrapperArgs =
+    let
+      runtimeLibs = [
+        stdenv.cc.cc.lib
+        # native versions
+        glfw3-minecraft
+        openal
+
+        ## openal
+        alsa-lib
+        libjack2
+        libpulseaudio
+        pipewire
+
+        ## glfw
+        libGL
+        libx11
+        libXcursor
+        libXext
+        libXrandr
+        libXxf86vm
+
+        udev # oshi
+
+        vulkan-loader # VulkanMod's lwjgl
+      ]
+      ++ lib.optional textToSpeechSupport flite
+      ++ lib.optional gamemodeSupport gamemode.lib
+      ++ lib.optional controllerSupport libusb1
+      ++ additionalLibs;
+
+      runtimePrograms = [
+        mesa-demos
+        pciutils # need lspci
+        xrandr # needed for LWJGL [2.9.2, 3)
+      ]
+      ++ additionalPrograms;
+
+    in
+    [ "--prefix PRISMLAUNCHER_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}" ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      "--set LD_LIBRARY_PATH ${addDriverRunpath.driverLink}/lib:${lib.makeLibraryPath runtimeLibs}"
+      "--prefix PATH : ${lib.makeBinPath runtimePrograms}"
+    ];
+
+  meta = {
+    inherit (freesmlauncher'.meta)
+      description
+      longDescription
+      homepage
+      changelog
+      license
+      maintainers
+      mainProgram
+      platforms
+      ;
+  };
+}

--- a/pkgs/by-name/fr/freesmlauncher-unwrapped-backup/package.nix
+++ b/pkgs/by-name/fr/freesmlauncher-unwrapped-backup/package.nix
@@ -1,0 +1,107 @@
+{
+  lib,
+  zlib,
+  fetchFromGitHub,
+  stdenv ? clangStdenv,
+  darwin,
+  kdePackages,
+  tomlplusplus,
+  ghc_filesystem,
+  stripJavaArchivesHook,
+  cmake,
+  ninja,
+  jdk17,
+  cmark,
+  qrencode,
+  clangStdenv,
+  gamemode,
+  libarchive,
+  extra-cmake-modules,
+  msaClientID ? null,
+  gamemodeSupport ? stdenv.hostPlatform.isLinux,
+}:
+assert lib.assertMsg (
+  gamemodeSupport -> stdenv.hostPlatform.isLinux
+) "gamemodeSupport is only available on Linux.";
+
+let
+  libnbtplusplus = fetchFromGitHub {
+    owner = "PrismLauncher";
+    repo = "libnbtplusplus";
+    rev = "3538933614059f0f44388a2b16f3db25ce42285b";
+    hash = "sha256-6/8clF2yNhfonV16cfIkxVIzuB9i9ThxoLMxAo/fDuY=";
+  };
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "freesmlauncher-unwrapped";
+  version = "2.2.0";
+  src = fetchFromGitHub {
+    owner = "FreesmTeam";
+    repo = "FreesmLauncher";
+    tag = finalAttrs.version;
+    hash = "sha256-eBr7koLRQHqljzKXHIfwgHXTtbQ7M6UadDVFql5H8gk=";
+  };
+
+  postUnpack = ''
+    rm -rf source/libraries/libnbtplusplus
+    ln -s ${libnbtplusplus} source/libraries/libnbtplusplus
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    extra-cmake-modules
+    jdk17
+    stripJavaArchivesHook
+  ];
+
+  buildInputs = [
+    cmark
+    ghc_filesystem
+    kdePackages.qtbase
+    kdePackages.qtnetworkauth
+    kdePackages.quazip
+    libarchive
+    tomlplusplus
+    qrencode
+    zlib
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    darwin.apple_sdk.frameworks.Cocoa
+  ]
+  ++ lib.optional gamemodeSupport gamemode;
+
+  cmakeFlags = [
+    (lib.cmakeFeature "Launcher_BUILD_PLATFORM" "nixpkgs")
+  ]
+  ++ lib.optionals (msaClientID != null) [
+    (lib.cmakeFeature "Launcher_MSA_CLIENT_ID" (toString msaClientID))
+  ]
+  ++ lib.optionals (lib.versionOlder kdePackages.qtbase.version "6") [
+    (lib.cmakeFeature "Launcher_QT_VERSION_MAJOR" "5")
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    (lib.cmakeFeature "INSTALL_BUNDLE" "nodeps")
+    (lib.cmakeFeature "MACOSX_SPARKLE_UPDATE_FEED_URL" "''")
+    (lib.cmakeFeature "CMAKE_INSTALL_PREFIX" "${placeholder "out"}/Applications/")
+  ];
+
+  doCheck = true;
+
+  dontWrapQtApps = true;
+
+  meta = {
+    description = "Prism Launcher fork aimed to provide a free way to play Minecraft";
+    homepage = "https://freesmlauncher.org/";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    mainProgram = "freesmlauncher";
+    license = lib.licenses.gpl3Only;
+    longDescription = ''
+      Freesm Launcher is a custom launcher for Minecraft that allows you
+      to easily manage multiple installations of Minecraft at once and login
+      with offline account without any restrictions.
+    '';
+    maintainers = with lib.maintainers; [ andreborge ];
+  };
+})


### PR DESCRIPTION
[FreesmLauncher](https://freesmlauncher.org/) is a Prism-based Minecraft launcher with support for offline accounts
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
