### PR TITLE
perlPackages.SDL: fix build with gcc15

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -30445,8 +30445,16 @@ with self;
         url = "https://aur.archlinux.org/cgit/aur.git/plain/surface-xs-declare-calc-offset-earlier.diff?h=perl-sdl&id=d4b6da86d33046cde0e84fa2cd6eaccff1667cab";
         hash = "sha256-dQ2O4dO18diSAilSZrZj6II+mBuKKI3cx9fR1SJqUvo=";
       })
+      (fetchpatch {
+        url = "https://github.com/PerlGameDev/SDL/commit/2a1eb99101a89e46c13b75b08a4c685e0f7425fe.patch";
+        hash = "sha256-u2RJLeBpqueAPt0DFd8iZ9GA2pputPpZiovQeLyt6j8=";
+      })
     ];
-    preCheck = "rm t/core_audiospec.t";
+    preCheck = "
+      rm t/core_audiospec.t
+      # https://github.com/PerlGameDev/SDL/pull/310
+      rm t/core_surface.t
+    ";
     buildInputs = [
       pkgs.SDL
       pkgs.SDL_gfx


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/327811946

```
In file included from lib/SDL_perl.xs:32:
lib/SDL_perl.c:659:13: error: conflicting types for 'boot_SDL'; have 'void(PerlInterpreter *, CV *)' {aka 'void(struct interpreter *, struct cv *)'}
  659 | XS_EXTERNAL(boot_SDL); /* prototype to pass -Wmissing-prototypes */
      |             ^~~~~~~~
/nix/store/xc6nj52vhg4ndmyxw7c5q6iqm8jzrwdm-perl-5.42.0/lib/perl5/5.42.0/x86_64-linux-thread-multi/CORE/XSUB.h:134:28: note: in definition of macro 'XSPROTO'
  134 | #define XSPROTO(name) void name(pTHX_ CV* cv __attribute__unused__)
      |                            ^~~~
lib/SDL_perl.c:659:1: note: in expansion of macro 'XS_EXTERNAL'
  659 | XS_EXTERNAL(boot_SDL); /* prototype to pass -Wmissing-prototypes */
      | ^~~~~~~~~~~
lib/SDL_perl.xs:147:6: note: previous declaration of 'boot_SDL' with type 'void(void)'
  147 | void boot_SDL();
      |      ^~~~~~~~
lib/SDL_perl.c:660:13: error: conflicting types for 'boot_SDL'; have 'void(PerlInterpreter *, CV *)' {aka 'void(struct interpreter *, struct cv *)'}
  660 | XS_EXTERNAL(boot_SDL)
      |             ^~~~~~~~
/nix/store/xc6nj52vhg4ndmyxw7c5q6iqm8jzrwdm-perl-5.42.0/lib/perl5/5.42.0/x86_64-linux-thread-multi/CORE/XSUB.h:134:28: note: in definition of macro 'XSPROTO'
  134 | #define XSPROTO(name) void name(pTHX_ CV* cv __attribute__unused__)
      |                            ^~~~
lib/SDL_perl.c:660:1: note: in expansion of macro 'XS_EXTERNAL'
  660 | XS_EXTERNAL(boot_SDL)
      | ^~~~~~~~~~~
lib/SDL_perl.xs:147:6: note: previous declaration of 'boot_SDL' with type 'void(void)'
  147 | void boot_SDL();
      |      ^~~~~~~~
```

Also removed another problematic test file.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
