### PR TITLE
numdiff: fix build with gcc15

### DIFF
--- a/pkgs/by-name/nu/numdiff/package.nix
+++ b/pkgs/by-name/nu/numdiff/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchDebianPatch,
   libintl,
 }:
 
@@ -13,6 +14,16 @@ stdenv.mkDerivation (finalAttrs: {
     url = "mirror://savannah/numdiff/numdiff-${finalAttrs.version}.tar.gz";
     sha256 = "1vzmjh8mhwwysn4x4m2vif7q2k8i19x8azq7pzmkwwj4g48lla47";
   };
+
+  patches = [
+    (fetchDebianPatch {
+      pname = "numdiff";
+      version = "5.9.0";
+      debianRevision = "2";
+      patch = "0005-gcc-15.patch";
+      hash = "sha256-+8pNiEfGuh/03LRCY6kuoIcPZ4fQOhNrD93ZW/mXxJw=";
+    })
+  ];
 
   buildInputs = [ libintl ];
 


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/326836269

```
setmode.c:29:15: error: cannot use keyword 'false' as enumeration constant
   29 | typedef enum {false = 0, true = 1} bool;
      |               ^~~~~
setmode.c:29:15: note: 'false' is a keyword with '-std=c23' onwards
setmode.c:29:36: error: expected ';', identifier or '(' before 'bool'
   29 | typedef enum {false = 0, true = 1} bool;
      |                                    ^~~~
setmode.c:29:36: warning: useless type name in empty declaration
```

Fetched debian patch: https://sources.debian.org/data/main/n/numdiff/5.9.0-2/debian/patches/0005-gcc-15.patch

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
