### PR TITLE
lib.makeDerivation: build less temporary lists

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -13,6 +13,7 @@ stdenv:
 let
   # Lib attributes are inherited to the lexical scope for performance reasons.
   inherit (lib)
+    all
     assertMsg
     attrNames
     concatLists
@@ -398,17 +399,16 @@ let
           actualValue;
       outputs' = outputs ++ optional separateDebugInfo' "debug";
 
-      noNonNativeDeps =
-        (
-          depsBuildTarget
-          ++ depsBuildTargetPropagated
-          ++ depsHostHost
-          ++ depsHostHostPropagated
-          ++ buildInputs
-          ++ propagatedBuildInputs
-          ++ depsTargetTarget
-          ++ depsTargetTargetPropagated
-        ) == [ ];
+      noNonNativeDeps = all (list: list == [ ]) [
+        depsBuildTarget
+        depsBuildTargetPropagated
+        depsHostHost
+        depsHostHostPropagated
+        buildInputs
+        propagatedBuildInputs
+        depsTargetTarget
+        depsTargetTargetPropagated
+      ];
       dontAddHostSuffix = attrs ? outputHash && !noNonNativeDeps || !stdenvHasCC;
 
       concretizeFlagImplications =
@@ -466,14 +466,18 @@ let
       let
         doCheck = doCheck';
         doInstallCheck = doInstallCheck';
-        buildInputs' =
-          buildInputs ++ optionals doCheck checkInputs ++ optionals doInstallCheck installCheckInputs;
-        nativeBuildInputs' =
+        buildInputs' = concatLists [
+          buildInputs
+          (optionals doCheck checkInputs)
+          (optionals doInstallCheck installCheckInputs)
+        ];
+        nativeBuildInputs' = concatLists [
           nativeBuildInputs
-          ++ optional separateDebugInfo' ../../build-support/setup-hooks/separate-debug-info.sh
-          ++ optional isWindows ../../build-support/setup-hooks/win-dll-link.sh
-          ++ optionals doCheck nativeCheckInputs
-          ++ optionals doInstallCheck nativeInstallCheckInputs;
+          (optional separateDebugInfo' ../../build-support/setup-hooks/separate-debug-info.sh)
+          (optional isWindows ../../build-support/setup-hooks/win-dll-link.sh)
+          (optionals doCheck nativeCheckInputs)
+          (optionals doInstallCheck nativeInstallCheckInputs)
+        ];
 
         outputs = outputs';
 
@@ -649,14 +653,16 @@ let
               computedPropagatedSandboxProfile = concatMap (
                 input: input.__propagatedSandboxProfile or [ ]
               ) allPropagatedDependencies;
-              profiles = [
-                extraSandboxProfile
-              ]
-              ++ computedSandboxProfile
-              ++ computedPropagatedSandboxProfile
-              ++ [
-                propagatedSandboxProfile
-                sandboxProfile
+              profiles = concatLists [
+                [
+                  extraSandboxProfile
+                ]
+                computedSandboxProfile
+                computedPropagatedSandboxProfile
+                [
+                  propagatedSandboxProfile
+                  sandboxProfile
+                ]
               ];
             in
             # TODO: remove `unique` once nix has a list canonicalization primitive
@@ -679,16 +685,18 @@ let
                 concatMap (input: input.__propagatedImpureHostDeps or [ ]) allPropagatedDependencies
               );
             in
-            computedImpureHostDeps
-            ++ computedPropagatedImpureHostDeps
-            ++ __propagatedImpureHostDeps
-            ++ __impureHostDeps
-            ++ __extraImpureHostDeps
-            ++ [
-              "/dev/zero"
-              "/dev/random"
-              "/dev/urandom"
-              "/bin/sh"
+            concatLists [
+              computedImpureHostDeps
+              computedPropagatedImpureHostDeps
+              __propagatedImpureHostDeps
+              __impureHostDeps
+              __extraImpureHostDeps
+              [
+                "/dev/zero"
+                "/dev/random"
+                "/dev/urandom"
+                "/bin/sh"
+              ]
             ];
           ${if buildIsDarwin then "__propagatedImpureHostDeps" else null} =
             let
@@ -826,11 +834,12 @@ let
 
       meta = checkMeta.commonMeta {
         inherit validity attrs pos;
-        references =
-          attrs.nativeBuildInputs or [ ]
-          ++ attrs.buildInputs or [ ]
-          ++ attrs.propagatedNativeBuildInputs or [ ]
-          ++ attrs.propagatedBuildInputs or [ ];
+        references = concatLists [
+          (attrs.nativeBuildInputs or [ ])
+          (attrs.buildInputs or [ ])
+          (attrs.propagatedNativeBuildInputs or [ ])
+          (attrs.propagatedBuildInputs or [ ])
+        ];
       };
       validity = checkMeta.assertValidity { inherit meta attrs; };
 


### PR DESCRIPTION
Remove chained usage of the list concatenation operator because this creates unnecessary temporary lists.
- `noNonNativeDeps` evaluation time is constant now.
- further optimization of #515116

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
