### PR TITLE
elmPackages.elm: unpin nodejs

### DIFF
--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -2,7 +2,7 @@
   pkgs,
   lib,
   makeWrapper,
-  nodejs ? pkgs.nodejs_20,
+  nodejs,
   config,
 }:
 


### PR DESCRIPTION
Removes the `nodejs_20` pin so elm uses the default `nodejs` (currently `nodejs_24`) which it used previously anyway

Tracking: #515284 

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.