### PR TITLE
pe-parse: 2.1.1 -> 2.1.1-unstable-2026-01-08

### DIFF
--- a/pkgs/by-name/pe/pe-parse/package.nix
+++ b/pkgs/by-name/pe/pe-parse/package.nix
@@ -3,26 +3,22 @@
   stdenv,
   fetchFromGitHub,
   cmake,
+  icu,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pe-parse";
-  version = "2.1.1";
+  version = "2.1.1-unstable-2026-01-12";
 
   src = fetchFromGitHub {
     owner = "trailofbits";
     repo = "pe-parse";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-XegSZWRoQg6NEWuTSFI1RMvN3GbpLDrZrloPU2XdK2M=";
+    rev = "b0dabd3fdcccd8f53bab500a45e92f37c6fec936";
+    hash = "sha256-j1QJ12hEy1c7SRIJSiFwQwJhhDKGbUrquFXDZbNNEDk=";
   };
 
   nativeBuildInputs = [ cmake ];
-
-  env.NIX_CFLAGS_COMPILE = toString (
-    lib.optionals stdenv.cc.isClang [
-      "-Wno-error=deprecated-declarations"
-    ]
-  );
+  buildInputs = [ icu ];
 
   doInstallCheck = true;
   installCheckPhase = ''

--- a/pkgs/by-name/pe/pe-parse/package.nix
+++ b/pkgs/by-name/pe/pe-parse/package.nix
@@ -3,26 +3,22 @@
   stdenv,
   fetchFromGitHub,
   cmake,
+  icu,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pe-parse";
-  version = "2.1.1";
+  version = "2.1.1-unstable-2026-01-12";
 
   src = fetchFromGitHub {
     owner = "trailofbits";
     repo = "pe-parse";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-XegSZWRoQg6NEWuTSFI1RMvN3GbpLDrZrloPU2XdK2M=";
+    rev = "b0dabd3fdcccd8f53bab500a45e92f37c6fec936";
+    hash = "sha256-j1QJ12hEy1c7SRIJSiFwQwJhhDKGbUrquFXDZbNNEDk=";
   };
 
   nativeBuildInputs = [ cmake ];
-
-  env.NIX_CFLAGS_COMPILE = toString (
-    lib.optionals stdenv.cc.isClang [
-      "-Wno-error=deprecated-declarations"
-    ]
-  );
+  buildInputs = [ icu ];
 
   doInstallCheck = true;
   installCheckPhase = ''
@@ -32,7 +28,8 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Principled, lightweight parser for Windows portable executable files";
     homepage = "https://github.com/trailofbits/pe-parse";
-    changelog = "https://github.com/trailofbits/pe-parse/releases/tag/v${finalAttrs.version}";
+    ${if lib.hasInfix "unstable" finalAttrs.version then null else "changelog"} =
+      "https://github.com/trailofbits/pe-parse/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ arturcygan ];
     mainProgram = "dump-pe";


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/326844263
- Diff: https://github.com/trailofbits/pe-parse/compare/v2.1.1...b0dabd3fdcccd8f53bab500a45e92f37c6fec936

```
/build/source/pe-parser-library/src/unicode_codecvt.cpp: In function 'std::string peparse::from_utf16(const UCharString&)':
/build/source/pe-parser-library/src/unicode_codecvt.cpp:33:8: error: 'template<class _Codecvt, class _Elem, class _Wide_alloc, class _Byte_alloc> class std::__cxx11::wstring_convert' is deprecated [-Werror=deprecated-declarations]
   33 |   std::wstring_convert<std::codecvt_utf8<char16_t>, char16_t> convert;
      |        ^~~~~~~~~~~~~~~
In file included from /nix/store/sanx9fg8mry8mq92zhlm5qvb83qlxrlx-gcc-15.2.0/include/c++/15.2.0/locale:47,
                 from /build/source/pe-parser-library/src/unicode_codecvt.cpp:26:
/nix/store/sanx9fg8mry8mq92zhlm5qvb83qlxrlx-gcc-15.2.0/include/c++/15.2.0/bits/locale_conv.h:262:33: note: declared here
  262 |     class _GLIBCXX17_DEPRECATED wstring_convert
      |                                 ^~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```

Most significant change is migration from codecvt to icu which fixed this compilation error.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
