### PR TITLE
python3Packages.pysdl3: allow update script to update docfiles

### DIFF
--- a/pkgs/development/python-modules/pysdl3/default.nix
+++ b/pkgs/development/python-modules/pysdl3/default.nix
@@ -27,10 +27,11 @@ let
     else
       throw "PySDL3 does not support ${stdenv.hostPlatform.uname.system}";
   lib_ext = stdenv.hostPlatform.extensions.sharedLibrary;
-in
-buildPythonPackage rec {
-  pname = "pysdl3";
   version = "0.9.11b0";
+in
+buildPythonPackage {
+  pname = "pysdl3";
+  inherit version;
   pyproject = true;
 
   pythonImportsCheck = [ "sdl3" ];

--- a/pkgs/development/python-modules/pysdl3/default.nix
+++ b/pkgs/development/python-modules/pysdl3/default.nix
@@ -16,7 +16,6 @@
   sdl3-image,
 }:
 let
-  lib_ext = stdenv.hostPlatform.extensions.sharedLibrary;
   version = "0.9.11b0";
 
   # Arranging these as normal derivations allows the updater to function while still allowing easy access to the fod via the `src` attribute.
@@ -56,12 +55,16 @@ buildPythonPackage {
     cp ${docfile} source/sdl3/__doc__.py
   '';
 
-  postInstall = ''
-    mkdir $out/${python.sitePackages}/sdl3/bin
-    ln -s ${sdl3}/lib/libSDL3${lib_ext} -t $out/${python.sitePackages}/sdl3/bin
-    ln -s ${sdl3-ttf}/lib/libSDL3_ttf${lib_ext} -t $out/${python.sitePackages}/sdl3/bin
-    ln -s ${sdl3-image}/lib/libSDL3_image${lib_ext} -t $out/${python.sitePackages}/sdl3/bin
-  '';
+  postInstall =
+    let
+      lib_ext = stdenv.hostPlatform.extensions.sharedLibrary;
+    in
+    ''
+      mkdir $out/${python.sitePackages}/sdl3/bin
+      ln -s ${sdl3}/lib/libSDL3${lib_ext} -t $out/${python.sitePackages}/sdl3/bin
+      ln -s ${sdl3-ttf}/lib/libSDL3_ttf${lib_ext} -t $out/${python.sitePackages}/sdl3/bin
+      ln -s ${sdl3-image}/lib/libSDL3_image${lib_ext} -t $out/${python.sitePackages}/sdl3/bin
+    '';
 
   build-system = [
     setuptools-scm

--- a/pkgs/development/python-modules/pysdl3/default.nix
+++ b/pkgs/development/python-modules/pysdl3/default.nix
@@ -96,7 +96,10 @@ buildPythonPackage rec {
     description = "Pure Python wrapper for SDL3";
     homepage = "https://github.com/Aermoss/PySDL3";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ jansol ];
+    maintainers = with lib.maintainers; [
+      jansol
+      alfarel
+    ];
     platforms = [
       "aarch64-linux"
       "x86_64-linux"

--- a/pkgs/development/python-modules/pysdl3/default.nix
+++ b/pkgs/development/python-modules/pysdl3/default.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchurl,
+  callPackage,
   fetchFromGitHub,
   python,
   buildPythonPackage,
@@ -15,19 +15,26 @@
   sdl3-ttf,
   sdl3-image,
 }:
-
 let
-  dochash =
-    if stdenv.hostPlatform.isLinux then
-      "sha256-ldx6r0KKNl1mkohTkaEG4rawf4VjHeJvNUdPkmrAkYA="
-    else if stdenv.hostPlatform.isDarwin then
-      "sha256-ga0ebb9zIPI5+Qza8APs0kbCxUIxqCmXRO/R8uWASOg="
-    else if stdenv.hostPlatform.isWindows then
-      "sha256-bBwETA9/ph0zXVNad9zMkQvfq1MmFJ08tCV+mUPwlXQ="
-    else
-      throw "PySDL3 does not support ${stdenv.hostPlatform.uname.system}";
   lib_ext = stdenv.hostPlatform.extensions.sharedLibrary;
   version = "0.9.11b0";
+
+  # Arranging these as normal derivations allows the updater to function while still allowing easy access to the fod via the `src` attribute.
+  # They are placed in separate files since the update script will replace all instances of the old version string
+  # in the file where the derivation is defined, and can only do one hash per version update.
+  # They must be derivations with `version`, `pname`, and `src` since `gitUpdater` will error out if they do not have a `name`,
+  # and will only update the `src` attribute's `hash` (and any other instances of the hash).
+  docfiles = {
+    Linux = callPackage ./docfiles/linux.nix { };
+    Darwin = callPackage ./docfiles/darwin.nix { };
+    Windows = callPackage ./docfiles/windows.nix { };
+  };
+
+  docfile =
+    let
+      uname-system = stdenv.hostPlatform.uname.system;
+    in
+    docfiles.${uname-system}.src or (throw "PySDL3 does not support ${uname-system}");
 in
 buildPythonPackage {
   pname = "pysdl3";
@@ -43,10 +50,7 @@ buildPythonPackage {
     hash = "sha256-lUnQ5YDM6HXarZUSy+x95lStBXDQlvG5JL6hFdHg6z0=";
   };
 
-  docfile = fetchurl {
-    url = "https://github.com/Aermoss/PySDL3/releases/download/v${version}/${stdenv.hostPlatform.uname.system}-Docs.py";
-    hash = dochash;
-  };
+  passthru = { inherit docfile; };
 
   postUnpack = ''
     cp ${docfile} source/sdl3/__doc__.py

--- a/pkgs/development/python-modules/pysdl3/default.nix
+++ b/pkgs/development/python-modules/pysdl3/default.nix
@@ -27,10 +27,11 @@ let
     else
       throw "PySDL3 does not support ${stdenv.hostPlatform.uname.system}";
   lib_ext = stdenv.hostPlatform.extensions.sharedLibrary;
-in
-buildPythonPackage rec {
-  pname = "pysdl3";
   version = "0.9.11b1";
+in
+buildPythonPackage {
+  pname = "pysdl3";
+  inherit version;
   pyproject = true;
 
   pythonImportsCheck = [ "sdl3" ];

--- a/pkgs/development/python-modules/pysdl3/default.nix
+++ b/pkgs/development/python-modules/pysdl3/default.nix
@@ -16,7 +16,6 @@
   sdl3-image,
 }:
 let
-  lib_ext = stdenv.hostPlatform.extensions.sharedLibrary;
   version = "0.9.11b1";
 
   # Arranging these as normal derivations allows the updater to function while still allowing easy access to the fod via the `src` attribute.
@@ -56,12 +55,16 @@ buildPythonPackage {
     cp ${docfile} source/sdl3/__doc__.py
   '';
 
-  postInstall = ''
-    mkdir $out/${python.sitePackages}/sdl3/bin
-    ln -s ${sdl3}/lib/libSDL3${lib_ext} -t $out/${python.sitePackages}/sdl3/bin
-    ln -s ${sdl3-ttf}/lib/libSDL3_ttf${lib_ext} -t $out/${python.sitePackages}/sdl3/bin
-    ln -s ${sdl3-image}/lib/libSDL3_image${lib_ext} -t $out/${python.sitePackages}/sdl3/bin
-  '';
+  postInstall =
+    let
+      lib_ext = stdenv.hostPlatform.extensions.sharedLibrary;
+    in
+    ''
+      mkdir $out/${python.sitePackages}/sdl3/bin
+      ln -s ${sdl3}/lib/libSDL3${lib_ext} -t $out/${python.sitePackages}/sdl3/bin
+      ln -s ${sdl3-ttf}/lib/libSDL3_ttf${lib_ext} -t $out/${python.sitePackages}/sdl3/bin
+      ln -s ${sdl3-image}/lib/libSDL3_image${lib_ext} -t $out/${python.sitePackages}/sdl3/bin
+    '';
 
   build-system = [
     setuptools-scm

--- a/pkgs/development/python-modules/pysdl3/default.nix
+++ b/pkgs/development/python-modules/pysdl3/default.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchurl,
+  callPackage,
   fetchFromGitHub,
   python,
   buildPythonPackage,
@@ -15,19 +15,26 @@
   sdl3-ttf,
   sdl3-image,
 }:
-
 let
-  dochash =
-    if stdenv.hostPlatform.isLinux then
-      "sha256-ldx6r0KKNl1mkohTkaEG4rawf4VjHeJvNUdPkmrAkYA="
-    else if stdenv.hostPlatform.isDarwin then
-      "sha256-ga0ebb9zIPI5+Qza8APs0kbCxUIxqCmXRO/R8uWASOg="
-    else if stdenv.hostPlatform.isWindows then
-      "sha256-bBwETA9/ph0zXVNad9zMkQvfq1MmFJ08tCV+mUPwlXQ="
-    else
-      throw "PySDL3 does not support ${stdenv.hostPlatform.uname.system}";
   lib_ext = stdenv.hostPlatform.extensions.sharedLibrary;
   version = "0.9.11b1";
+
+  # Arranging these as normal derivations allows the updater to function while still allowing easy access to the fod via the `src` attribute.
+  # They are placed in separate files since the update script will replace all instances of the old version string
+  # in the file where the derivation is defined, and can only do one hash per version update.
+  # They must be derivations with `version`, `pname`, and `src` since `gitUpdater` will error out if they do not have a `name`,
+  # and will only update the `src` attribute's `hash` (and any other instances of the hash).
+  docfiles = {
+    Linux = callPackage ./docfiles/linux.nix { };
+    Darwin = callPackage ./docfiles/darwin.nix { };
+    Windows = callPackage ./docfiles/windows.nix { };
+  };
+
+  docfile =
+    let
+      uname-system = stdenv.hostPlatform.uname.system;
+    in
+    docfiles.${uname-system}.src or (throw "PySDL3 does not support ${uname-system}");
 in
 buildPythonPackage {
   pname = "pysdl3";
@@ -43,10 +50,7 @@ buildPythonPackage {
     hash = "sha256-fATBYZ4DYpOYYr09SwfODaWqEwQtig0smqI2Pjnv9uo=";
   };
 
-  docfile = fetchurl {
-    url = "https://github.com/Aermoss/PySDL3/releases/download/v${version}/${stdenv.hostPlatform.uname.system}-Docs.py";
-    hash = dochash;
-  };
+  passthru = { inherit docfile docfiles; };
 
   postUnpack = ''
     cp ${docfile} source/sdl3/__doc__.py

--- a/pkgs/development/python-modules/pysdl3/docfiles/darwin.nix
+++ b/pkgs/development/python-modules/pysdl3/docfiles/darwin.nix
@@ -1,0 +1,12 @@
+{ stdenv, fetchurl }:
+let
+  version = "0.9.11b0";
+in
+stdenv.mkDerivation {
+  pname = "Darwin-Docs.py";
+  inherit version;
+  src = fetchurl {
+    url = "https://github.com/Aermoss/PySDL3/releases/download/v${version}/Darwin-Docs.py";
+    hash = "sha256-ga0ebb9zIPI5+Qza8APs0kbCxUIxqCmXRO/R8uWASOg=";
+  };
+}

--- a/pkgs/development/python-modules/pysdl3/docfiles/darwin.nix
+++ b/pkgs/development/python-modules/pysdl3/docfiles/darwin.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl }:
 let
-  version = "0.9.11b0";
+  version = "0.9.11b1";
 in
 stdenv.mkDerivation {
   pname = "Darwin-Docs.py";
   inherit version;
   src = fetchurl {
     url = "https://github.com/Aermoss/PySDL3/releases/download/v${version}/Darwin-Docs.py";
-    hash = "sha256-ga0ebb9zIPI5+Qza8APs0kbCxUIxqCmXRO/R8uWASOg=";
+    hash = "sha256-gumVIn/st/mgdPpQA/BLZD0sI5qLf1EJRQ90rKLXjvQ=";
   };
 }

--- a/pkgs/development/python-modules/pysdl3/docfiles/linux.nix
+++ b/pkgs/development/python-modules/pysdl3/docfiles/linux.nix
@@ -1,0 +1,12 @@
+{ stdenv, fetchurl }:
+let
+  version = "0.9.11b0";
+in
+stdenv.mkDerivation {
+  pname = "Linux-Docs.py";
+  inherit version;
+  src = fetchurl {
+    url = "https://github.com/Aermoss/PySDL3/releases/download/v${version}/Linux-Docs.py";
+    hash = "sha256-ldx6r0KKNl1mkohTkaEG4rawf4VjHeJvNUdPkmrAkYA=";
+  };
+}

--- a/pkgs/development/python-modules/pysdl3/docfiles/linux.nix
+++ b/pkgs/development/python-modules/pysdl3/docfiles/linux.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl }:
 let
-  version = "0.9.11b0";
+  version = "0.9.11b1";
 in
 stdenv.mkDerivation {
   pname = "Linux-Docs.py";
   inherit version;
   src = fetchurl {
     url = "https://github.com/Aermoss/PySDL3/releases/download/v${version}/Linux-Docs.py";
-    hash = "sha256-ldx6r0KKNl1mkohTkaEG4rawf4VjHeJvNUdPkmrAkYA=";
+    hash = "sha256-7Uc1kfbfizpRmAr5h3rpTX565wvbZfbbbYcJh9s96DY=";
   };
 }

--- a/pkgs/development/python-modules/pysdl3/docfiles/windows.nix
+++ b/pkgs/development/python-modules/pysdl3/docfiles/windows.nix
@@ -1,0 +1,12 @@
+{ stdenv, fetchurl }:
+let
+  version = "0.9.11b0";
+in
+stdenv.mkDerivation {
+  pname = "Windows-Docs.py";
+  inherit version;
+  src = fetchurl {
+    url = "https://github.com/Aermoss/PySDL3/releases/download/v${version}/Windows-Docs.py";
+    hash = "sha256-bBwETA9/ph0zXVNad9zMkQvfq1MmFJ08tCV+mUPwlXQ=";
+  };
+}

--- a/pkgs/development/python-modules/pysdl3/docfiles/windows.nix
+++ b/pkgs/development/python-modules/pysdl3/docfiles/windows.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl }:
 let
-  version = "0.9.11b0";
+  version = "0.9.11b1";
 in
 stdenv.mkDerivation {
   pname = "Windows-Docs.py";
   inherit version;
   src = fetchurl {
     url = "https://github.com/Aermoss/PySDL3/releases/download/v${version}/Windows-Docs.py";
-    hash = "sha256-bBwETA9/ph0zXVNad9zMkQvfq1MmFJ08tCV+mUPwlXQ=";
+    hash = "sha256-55Ti6HUzlptSf9ozaz0kmYMz+6EAcOcnZ0R64rZYISY=";
   };
 }


### PR DESCRIPTION
This rearranges the definitions for the different docfiles so that the default `updateScript`(s) can correctly update their hashes, without conflicting with any of the others or with the main derivation.

I had to split them into separate files and wrap each in `mkDerivation` to make them the shape `gitUpdater` expects, see the commit description for more detail.

I added myself as a maintainer and made a couple small stylistic changes in separate commits, which can be removed as desired.
Feel free to just look at the individual commits.

As of now, I have only tested manual updates with `nix-update python3Packages.pysdl3.docfiles.Linux --use-update-script`, etc. for `Darwin` and `Windows`, as well as ensuring the base derivation one still works and that they don't conflict with each other in any way.

Previous conversation: #511947

## Remaining Work

- [ ] I don't (yet) know how to make sure that the `nixpkgs-review` bot will actually find them and update them automatically, but this is an improvement to the workflow either way.
   - [ ] make sure that if it can find them, it updates correctly (with manual bot runs)

- [ ] Maybe the `pysdl3` derivation should check that the `docfile` has the same version as it in some way, and either throw an error or warning or something?
   That would only be useful if the nixpkgs-review bot doesn't catch the updates.

- [x] Looking at the diff I also included all of the docfiles as attributes in all of the builds.
   These should probably go in `passthru`, and should maybe only be the docs for the platform being built.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
