### PR TITLE
nfft: fix build with gcc15

### DIFF
--- a/pkgs/by-name/nf/nfft/package.nix
+++ b/pkgs/by-name/nf/nfft/package.nix
@@ -3,6 +3,7 @@
   automake,
   cunit,
   fetchFromGitHub,
+  fetchpatch,
   fftw,
   lib,
   libtool,
@@ -21,6 +22,14 @@ stdenv.mkDerivation (finalAttrs: {
     rev = finalAttrs.version;
     hash = "sha256-HR8ME9PVC+RAv1GIgV2vK6eLU8Wk28+rSzbutThBv3w=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-gcc15.patch";
+      url = "https://github.com/NFFT/nfft/commit/b06d01be964be7490aed797468f9722e2de1dbfa.patch";
+      hash = "sha256-Ynhsyzf8ECVw4eBq50okd0oikiIfOCqFRHivuceg0KU=";
+    })
+  ];
 
   nativeBuildInputs = [
     autoconf


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/326835005

```
radon.c: In function 'Radon_trafo':
radon.c:150:3: error: too many arguments to function 'gridfcn'; expected 0, have 4
  150 |   gridfcn(T, S, x, w);
      |   ^~~~~~~ ~
radon.c: In function 'main':
radon.c:226:13: warning: assignment to 'int (*)(void)' from incompatible pointer type 'int (*)(int,  int,  NFFT_R *, NFFT_R *)' {aka 'int (*)(int,  int,  double *, double *)'} [-Wincompatible-pointer-types]
  226 |     gridfcn = polar_grid;
      |             ^
radon.c:56:12: note: 'polar_grid' declared here
   56 | static int polar_grid(int T, int S, NFFT_R *x, NFFT_R *w)
      |            ^~~~~~~~~~
radon.c:228:13: warning: assignment to 'int (*)(void)' from incompatible pointer type 'int (*)(int,  int,  NFFT_R *, NFFT_R *)' {aka 'int (*)(int,  int,  double *, double *)'} [-Wincompatible-pointer-types]
  228 |     gridfcn = linogram_grid;
      |             ^
radon.c:80:12: note: 'linogram_grid' declared here
   80 | static int linogram_grid(int T, int S, NFFT_R *x, NFFT_R *w)
      |            ^~~~~~~~~~~~~
radon.c:242:3: warning: ignoring return value of 'fread' declared with attribute 'warn_unused_result' [-Wunused-result]
  242 |   fread(f, sizeof(NFFT_R), (size_t)(N * N), fp);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Fetched an upstream commit to fix the compilation error.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
