### PR TITLE
petidomo: fix build with gcc15

### DIFF
--- a/pkgs/by-name/pe/petidomo/fix-gcc15.patch
+++ b/pkgs/by-name/pe/petidomo/fix-gcc15.patch
@@ -1,0 +1,68 @@
+diff --git a/liblists/lists.h b/liblists/lists.h
+index 6643552..982c8bc 100644
+--- a/liblists/lists.h
++++ b/liblists/lists.h
+@@ -32,7 +32,7 @@
+ #ifndef __cplusplus
+ #ifndef PETIDOMO_HAS_DEFINED_BOOL
+ #  define PETIDOMO_HAS_DEFINED_BOOL 1
+-typedef int bool;
++#include <stdbool.h>
+ #endif
+ #ifndef FALSE
+ #  define FALSE (0==1)
+diff --git a/libtext/text.h b/libtext/text.h
+index a258c79..1fd5274 100644
+--- a/libtext/text.h
++++ b/libtext/text.h
+@@ -36,7 +36,7 @@ extern "C" {
+ #ifndef __cplusplus
+ #ifndef PETIDOMO_HAS_DEFINED_BOOL
+ #  define PETIDOMO_HAS_DEFINED_BOOL 1
+-typedef int bool;
++#include <stdbool.h>
+ #endif
+ 
+ #ifndef FALSE
+diff --git a/petidomo.h b/petidomo.h
+index d503de0..a0c1308 100644
+--- a/petidomo.h
++++ b/petidomo.h
+@@ -26,7 +26,7 @@
+ 
+ #ifndef PETIDOMO_HAS_DEFINED_BOOL
+ #    define PETIDOMO_HAS_DEFINED_BOOL 1
+-     typedef int bool;
++#include <stdbool.h>
+ #endif
+ 
+ #ifndef DEBUG_DMALLOC
+@@ -135,7 +135,7 @@ struct Mail
+     };
+ 
+ void RemoveCarrigeReturns(char *buffer);
+-int isRFC822Address(const char *buffer);
++bool isRFC822Address(const char *buffer);
+ int ParseAddressLine(char *buffer);
+ int ParseReplyToLine(char *buffer);
+ int ParseFromLine(char *buffer);
+@@ -157,8 +157,8 @@ int ArchiveMail(const struct Mail *MailStruct, const char *listname);
+ /********** authen.c **********/
+ 
+ int FindBodyPassword(struct Mail *MailStruct);
+-int isValidAdminPassword(const char *password, const char *listname);
+-int isValidPostingPassword(const char *password, const char *listname);
++bool isValidAdminPassword(const char *password, const char *listname);
++bool isValidPostingPassword(const char *password, const char *listname);
+ 
+ /********** filter.c **********/
+ 
+@@ -226,7 +226,7 @@ const char *getPassword(void  );
+ /********** tool.c **********/
+ 
+ char *buildFuzzyMatchAddress(const char *);
+-int isValidListName(const char *);
++bool isValidListName(const char *);
+ bool isSubscribed(const char *, const char *, char **, char **, bool);
+ 
+ /********** unsubscribe.c **********/

--- a/pkgs/by-name/pe/petidomo/package.nix
+++ b/pkgs/by-name/pe/petidomo/package.nix
@@ -17,6 +17,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-ddNw0fq2MQLJd6YCmIkf9lvq9/Xscl94Ds8xR1hfjXQ=";
   };
 
+  patches = [
+    # https://github.com/peti/petidomo/pull/1
+    ./fix-gcc15.patch
+  ];
+
   buildInputs = [
     flex
     bison
@@ -38,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://petidomo.sourceforge.net/";
     description = "Simple and easy to administer mailing list server";
     license = lib.licenses.gpl3Plus;
-
+    mainProgram = "petidomo";
     platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.peti ];
   };


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/326852030

```
In file included from easy_pattern_match.c:23:
text.h:39:13: error: 'bool' cannot be defined via 'typedef'
   39 | typedef int bool;
      |             ^~~~
text.h:39:13: note: 'bool' is a keyword with '-std=c23' onwards
text.h:39:1: warning: useless type name in empty declaration
   39 | typedef int bool;
      | ^~~~~~~
In file included from find_next_line.c:21:
text.h:39:13: error: 'bool' cannot be defined via 'typedef'
   39 | typedef int bool;
      |             ^~~~
text.h:39:13: note: 'bool' is a keyword with '-std=c23' onwards
text.h:39:1: warning: useless type name in empty declaration
   39 | typedef int bool;
      | ^~~~~~~
```

Only verified compilation.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
