### PR TITLE
various: fix missing webfont outputs

### DIFF
--- a/pkgs/by-name/al/alcarin-tengwar/package.nix
+++ b/pkgs/by-name/al/alcarin-tengwar/package.nix
@@ -9,6 +9,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "alcarin-tengwar";
   version = "0.83";
 
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
   src = fetchFromGitHub {
     owner = "Tosche";
     repo = "Alcarin-Tengwar";

--- a/pkgs/by-name/al/aleo-fonts/package.nix
+++ b/pkgs/by-name/al/aleo-fonts/package.nix
@@ -16,7 +16,14 @@ stdenvNoCC.mkDerivation {
     hash = "sha256-HSxP5/sLHQTujBVt1u93625EXEc42lxpt8W1//6ngWM=";
   };
 
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
   nativeBuildInputs = [ installFonts ];
+
+  preInstall = "rm -r fonts/old";
 
   meta = {
     description = "Slab serif typeface designed by Alessio Laiso";

--- a/pkgs/by-name/at/atkinson-hyperlegible-mono/package.nix
+++ b/pkgs/by-name/at/atkinson-hyperlegible-mono/package.nix
@@ -9,6 +9,11 @@ stdenvNoCC.mkDerivation {
   pname = "atkinson-hyperlegible-mono";
   version = "2.001-unstable-2024-11-20";
 
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
   src = fetchFromGitHub {
     owner = "googlefonts";
     repo = "atkinson-hyperlegible-next-mono";

--- a/pkgs/by-name/at/atkinson-hyperlegible-next/package.nix
+++ b/pkgs/by-name/at/atkinson-hyperlegible-next/package.nix
@@ -9,6 +9,11 @@ stdenvNoCC.mkDerivation {
   pname = "atkinson-hyperlegible-next";
   version = "2.001-unstable-2025-02-21";
 
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
   src = fetchFromGitHub {
     owner = "googlefonts";
     repo = "atkinson-hyperlegible-next";

--- a/pkgs/by-name/be/beedii/package.nix
+++ b/pkgs/by-name/be/beedii/package.nix
@@ -10,6 +10,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "beedii";
   version = "1.0.0";
 
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
   src = fetchzip {
     url = "https://github.com/webkul/beedii/releases/download/v${finalAttrs.version}/beedii.zip";
     hash = "sha256-MefkmWl7LdhQiePpixKcatoIeOTlrRaO3QA9xWAxJ4Q=";

--- a/pkgs/by-name/be/behdad-fonts/package.nix
+++ b/pkgs/by-name/be/behdad-fonts/package.nix
@@ -9,6 +9,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "behdad-fonts";
   version = "0.0.3";
 
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
   src = fetchFromGitHub {
     owner = "font-store";
     repo = "BehdadFont";

--- a/pkgs/by-name/be/besley/package.nix
+++ b/pkgs/by-name/be/besley/package.nix
@@ -8,6 +8,11 @@ stdenvNoCC.mkDerivation {
   pname = "besley";
   version = "4.0-unstable-2023-01-09";
 
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
   src = fetchFromGitHub {
     owner = "indestructible-type";
     repo = "Besley";

--- a/pkgs/by-name/bl/blackout/package.nix
+++ b/pkgs/by-name/bl/blackout/package.nix
@@ -9,6 +9,11 @@ stdenvNoCC.mkDerivation {
   pname = "blackout";
   version = "2014-07-29";
 
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
   src = fetchFromGitHub {
     owner = "theleagueof";
     repo = "blackout";

--- a/pkgs/by-name/bo/bodoni-moda/package.nix
+++ b/pkgs/by-name/bo/bodoni-moda/package.nix
@@ -8,6 +8,11 @@ stdenvNoCC.mkDerivation {
   pname = "bodoni-moda";
   version = "2.4-unstable-2024-02-18";
 
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
   src = fetchFromGitHub {
     owner = "indestructible-type";
     repo = "Bodoni";

--- a/pkgs/by-name/co/cooper/package.nix
+++ b/pkgs/by-name/co/cooper/package.nix
@@ -8,6 +8,11 @@ stdenvNoCC.mkDerivation {
   pname = "cooper";
   version = "1.01-unstable-2025-05-25";
 
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
   src = fetchFromGitHub {
     owner = "indestructible-type";
     repo = "Cooper";

--- a/pkgs/by-name/hu/hubot-sans/package.nix
+++ b/pkgs/by-name/hu/hubot-sans/package.nix
@@ -9,6 +9,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "hubot-sans";
   version = "1.0.1";
 
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
   src = fetchzip {
     url = "https://github.com/github/hubot-sans/releases/download/v${finalAttrs.version}/Hubot-Sans.zip";
     hash = "sha256-EWTyoGNqyZcqlF1H1Tdcodc8muHIo8C9gbSPAjiogRk=";

--- a/pkgs/by-name/li/linden-hill/package.nix
+++ b/pkgs/by-name/li/linden-hill/package.nix
@@ -9,6 +9,11 @@ stdenvNoCC.mkDerivation {
   pname = "linden-hill";
   version = "2011-05-25";
 
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
   src = fetchFromGitHub {
     owner = "theleagueof";
     repo = "linden-hill";

--- a/pkgs/by-name/li/literata/package.nix
+++ b/pkgs/by-name/li/literata/package.nix
@@ -8,6 +8,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "literata";
   version = "3.103";
 
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
   src = fetchzip {
     url = "https://github.com/googlefonts/literata/releases/download/${finalAttrs.version}/${finalAttrs.version}.zip";
     hash = "sha256-XwwvyzwO2uhi1Bay9HtB75j1QfAJR4TMETgy/zyvwZ0=";

--- a/pkgs/by-name/lo/lora/package.nix
+++ b/pkgs/by-name/lo/lora/package.nix
@@ -10,6 +10,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "lora";
   version = "3.021";
 
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
   src = fetchFromGitHub {
     owner = "cyrealtype";
     repo = "lora";

--- a/pkgs/by-name/mo/mona-sans/package.nix
+++ b/pkgs/by-name/mo/mona-sans/package.nix
@@ -9,6 +9,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "mona-sans";
   version = "2.0.23";
 
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
   src = fetchFromGitHub {
     rev = finalAttrs.version;
     owner = "github";

--- a/pkgs/by-name/ro/route159/package.nix
+++ b/pkgs/by-name/ro/route159/package.nix
@@ -13,6 +13,11 @@ stdenvNoCC.mkDerivation {
   pname = "route159";
   version = "${majorVersion}.${minorVersion}";
 
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
   src = fetchzip {
     url = "https://dotcolon.net/files/fonts/route159_${majorVersion}${minorVersion}.zip";
     hash = "sha256-1InyBW1LGbp/IU/ql9mvT14W3MTxJdWThFwRH6VHpTU=";

--- a/pkgs/by-name/st/stix-two/package.nix
+++ b/pkgs/by-name/st/stix-two/package.nix
@@ -9,6 +9,11 @@ stdenvNoCC.mkDerivation rec {
   pname = "stix-two";
   version = "2.13";
 
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
   src = fetchzip {
     url = "https://github.com/stipub/stixfonts/raw/v${version}/zipfiles/STIX${
       builtins.replaceStrings [ "." ] [ "_" ] version

--- a/pkgs/by-name/st/stix-two/package.nix
+++ b/pkgs/by-name/st/stix-two/package.nix
@@ -14,6 +14,8 @@ stdenvNoCC.mkDerivation rec {
     "webfont"
   ];
 
+  preInstall = "rm -r static_ttf_woff2/";
+
   src = fetchzip {
     url = "https://github.com/stipub/stixfonts/raw/v${version}/zipfiles/STIX${
       builtins.replaceStrings [ "." ] [ "_" ] version

--- a/pkgs/by-name/su/sudo-font/package.nix
+++ b/pkgs/by-name/su/sudo-font/package.nix
@@ -9,6 +9,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "sudo-font";
   version = "3.4";
 
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
   src = fetchzip {
     url = "https://github.com/jenskutilek/sudo-font/releases/download/v${finalAttrs.version}/sudo.zip";
     hash = "sha256-sSLY94wY9+AYAqWDq+Xy+KctUfJVS0jeS3baF8mLO9I=";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Based on nixpkgs-review results in #504978. 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
