### PR TITLE
python3Packages.python-statemachine: init at 3.0.0

### DIFF
--- a/pkgs/development/python-modules/python-statemachine/default.nix
+++ b/pkgs/development/python-modules/python-statemachine/default.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchPypi,
+  hatchling,
+  pytestCheckHook,
+  pytest-asyncio,
+  pytest-benchmark,
+  pytest-mock,
+  pytest-timeout,
+  pytest-django,
+  pydot,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "python-statemachine";
+  version = "3.0.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    pname = "python_statemachine";
+    inherit (finalAttrs) version;
+    hash = "sha256-kVI/nq1zwdb+zJddXG4L/jY/v1N8XwvzCbzQ+U+UQbI=";
+  };
+
+  build-system = [ hatchling ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    pytest-benchmark
+    pytest-mock
+    pytest-timeout
+    pytest-django
+    pydot
+  ];
+
+  pytestFlags = [ "--benchmark-disable" ];
+
+  disabledTestPaths = [
+    # quite slow
+    "tests/test_weighted_transitions.py"
+    "tests/scxml/"
+  ];
+
+  disabledTests = [
+    # broken upstream
+    "statemachine.contrib.diagram.quickchart_write_svg"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # async state transitions appear broken on darwin
+    # TODO: investigate on an actual macOS machine
+    "test_timeout_fires_done_invoke"
+    "test_timeout_fires_before_slow_invoke"
+    "test_custom_event_fires"
+    "test_group_returns_ordered_results"
+    "test_group_error_cancels_remaining"
+  ];
+
+  pythonImportsCheck = [ "statemachine" ];
+
+  meta = {
+    description = "Expressive statecharts and FSMs for modern Python";
+
+    homepage = "https://github.com/fgmacedo/python-statemachine";
+    changelog = "https://github.com/fgmacedo/python-statemachine/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kilyanni ];
+  };
+})

--- a/pkgs/development/python-modules/python-statemachine/default.nix
+++ b/pkgs/development/python-modules/python-statemachine/default.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchPypi,
+  hatchling,
+  pytestCheckHook,
+  pytest-asyncio,
+  pytest-benchmark,
+  pytest-mock,
+  pytest-timeout,
+  pytest-django,
+  pydot,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "python-statemachine";
+  version = "3.0.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    pname = "python_statemachine";
+    inherit (finalAttrs) version;
+    hash = "sha256-kVI/nq1zwdb+zJddXG4L/jY/v1N8XwvzCbzQ+U+UQbI=";
+  };
+
+  build-system = [ hatchling ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    pytest-benchmark
+    pytest-mock
+    pytest-timeout
+    pytest-django
+    pydot
+  ];
+
+  pytestFlags = [ "--benchmark-disable" ];
+
+  disabledTestPaths = [
+    # quite slow
+    "tests/test_weighted_transitions.py"
+    "tests/scxml/"
+  ];
+
+  disabledTests = [
+    # broken upstream
+    "statemachine.contrib.diagram.quickchart_write_svg"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # async state transitions appear broken on darwin
+    # TODO: investigate on an actual macOS machine
+    "test_timeout_fires_done_invoke"
+    "test_timeout_fires_before_slow_invoke"
+    "test_custom_event_fires"
+
+    # flaky
+    "test_group_returns_ordered_results"
+    "test_group_error_cancels_remaining"
+    "test_group_with_file_io"
+    "test_group_cancel_on_exit"
+    "test_group_single_callable"
+    "test_each_sm_instance_gets_own_group"
+  ];
+
+  pythonImportsCheck = [ "statemachine" ];
+
+  meta = {
+    description = "Expressive statecharts and FSMs for modern Python";
+
+    homepage = "https://github.com/fgmacedo/python-statemachine";
+    changelog = "https://github.com/fgmacedo/python-statemachine/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kilyanni ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16005,6 +16005,8 @@ self: super: with self; {
 
   python-sql = callPackage ../development/python-modules/python-sql { };
 
+  python-statemachine = callPackage ../development/python-modules/python-statemachine { };
+
   python-status = callPackage ../development/python-modules/python-status { };
 
   python-stdnum = callPackage ../development/python-modules/python-stdnum { };


### PR DESCRIPTION
Adds [python-statemachine](https://github.com/fgmacedo/python-statemachine), a python library for expressive statecharts and FSMs for modern Python. 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
