### PR TITLE
python3Packages.msgpack-numpy-opentensor: init at 0.5.0

### DIFF
--- a/pkgs/development/python-modules/msgpack-numpy-opentensor/default.nix
+++ b/pkgs/development/python-modules/msgpack-numpy-opentensor/default.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  msgpack,
+  numpy,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "msgpack-numpy-opentensor";
+  version = "0.5.0";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-ITIywg4u/VKOyKmIK2Beith8/DW1ffz+/gXTOqqr5XQ=";
+  };
+
+  propagatedBuildInputs = [
+    msgpack
+    numpy
+  ];
+
+  pythonImportsCheck = [ "msgpack_numpy" ];
+
+  meta = {
+    description = "Numpy data serialization using msgpack (opentensor fork)";
+    homepage = "https://pypi.org/project/msgpack-numpy-opentensor";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ kilyanni ];
+  };
+})

--- a/pkgs/development/python-modules/msgpack-numpy-opentensor/default.nix
+++ b/pkgs/development/python-modules/msgpack-numpy-opentensor/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  msgpack,
+  numpy,
+  python,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "msgpack-numpy-opentensor";
+  version = "0.5.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-ITIywg4u/VKOyKmIK2Beith8/DW1ffz+/gXTOqqr5XQ=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    msgpack
+    numpy
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    ${python.interpreter} tests.py
+
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "Numpy data serialization using msgpack (opentensor fork)";
+    homepage = "https://github.com/opentensor/msgpack-numpy";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ kilyanni ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10326,6 +10326,8 @@ self: super: with self; {
 
   msgpack-numpy = callPackage ../development/python-modules/msgpack-numpy { };
 
+  msgpack-numpy-opentensor = callPackage ../development/python-modules/msgpack-numpy-opentensor { };
+
   msgraph-core = callPackage ../development/python-modules/msgraph-core { };
 
   msgraph-sdk = callPackage ../development/python-modules/msgraph-sdk { };


### PR DESCRIPTION
Adds `msgpack-numpy-opentensor`, OpenTensor's fork of `msgpack-numpy`, a small python library for serializing numpy tensors via msgpack.

Dependency of Bittensor SDK

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
