### PR TITLE
scsh: fix build with gcc15

### DIFF
--- a/pkgs/by-name/sc/scsh/gcc-15.patch
+++ b/pkgs/by-name/sc/scsh/gcc-15.patch
@@ -1,0 +1,13 @@
+diff --git a/c/syscalls.c b/c/syscalls.c
+index 2be25a8..311f02b 100644
+--- a/c/syscalls.c
++++ b/c/syscalls.c
+@@ -670,7 +670,7 @@ s48_ref_t scm_gethostname(s48_call_t call)
+ {
+    char hostname[MAXHOSTNAMELEN+1];
+     /* different OS's declare differently, so punt the prototype. */
+-    int gethostname();
++    int gethostname(char *name, size_t size);
+     int retval = gethostname(hostname, MAXHOSTNAMELEN);
+     if (retval == -1) s48_os_error_2(call, "scm_gethostname", errno, 0);
+     return s48_enter_byte_string_2(call, hostname);

--- a/pkgs/by-name/sc/scsh/package.nix
+++ b/pkgs/by-name/sc/scsh/package.nix
@@ -26,6 +26,9 @@ stdenv.mkDerivation {
     # Fix the build against gcc-14:
     # https://github.com/scheme/scsh/pull/51
     ./gcc-14-p2.patch
+    # Fix the build against gcc-15:
+    # https://github.com/scheme/scsh/pull/52
+    ./gcc-15.patch
   ];
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/326905217

```
c/syscalls.c: In function 'scm_gethostname':
c/syscalls.c:673:9: error: conflicting types for 'gethostname'; have 'int(void)'
  673 |     int gethostname();
      |         ^~~~~~~~~~~
In file included from /nix/store/fbbw928argckfii0j322346ihmllg7a7-glibc-2.42-61-dev/include/features.h:524,
                 from /nix/store/fbbw928argckfii0j322346ihmllg7a7-glibc-2.42-61-dev/include/bits/libc-header-start.h:33,
                 from /nix/store/fbbw928argckfii0j322346ihmllg7a7-glibc-2.42-61-dev/include/stdio.h:28,
                 from c/syscalls.c:6:
/nix/store/fbbw928argckfii0j322346ihmllg7a7-glibc-2.42-61-dev/include/bits/unistd.h:189:1: note: previous definition of 'gethostname' with type 'int(char *, long unsigned int)'
  189 | __NTH (gethostname (__fortify_clang_overload_arg (char *, ,__buf),
      | ^~~~~
c/syscalls.c:674:18: error: too many arguments to function 'gethostname'; expected 0, have 2
  674 |     int retval = gethostname(hostname, MAXHOSTNAMELEN);
      |                  ^~~~~~~~~~~ ~~~~~~~~
c/syscalls.c:673:9: note: declared here
  673 |     int gethostname();
      |         ^~~~~~~~~~~
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
