### PR TITLE
nbench: fix build with gcc15

### DIFF
--- a/pkgs/by-name/nb/nbench/package.nix
+++ b/pkgs/by-name/nb/nbench/package.nix
@@ -14,11 +14,12 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   prePatch = ''
-    substituteInPlace nbench1.h --replace '"NNET.DAT"' "\"$out/NNET.DAT\""
-    substituteInPlace sysspec.h --replace "malloc.h" "stdlib.h"
+    substituteInPlace nbench1.h --replace-fail '"NNET.DAT"' "\"$out/NNET.DAT\"" \
+      --replace-fail 'static void adjust_mid_wts();' 'static void adjust_mid_wts(int);'
+    substituteInPlace sysspec.h --replace-fail "malloc.h" "stdlib.h"
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    substituteInPlace Makefile --replace "-static" ""
+    substituteInPlace Makefile --replace-fail "-static" ""
   '';
 
   buildInputs = lib.optionals stdenv.hostPlatform.isGnu [


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/326834417

```
nbench1.c: At top level:
nbench1.c:3520:13: error: conflicting types for 'adjust_mid_wts'; have 'void(int)'
 3520 | static void adjust_mid_wts(int patt)
      |             ^~~~~~~~~~~~~~
nbench1.h:373:13: note: previous declaration of 'adjust_mid_wts' with type 'void(void)'
  373 | static void adjust_mid_wts();
      |             ^~~~~~~~~~~~~~
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
