### PR TITLE
nixos/tetrd: remove CAP_DAC_OVERRIDE

### DIFF
--- a/nixos/modules/services/networking/tetrd.nix
+++ b/nixos/modules/services/networking/tetrd.nix
@@ -89,17 +89,14 @@
 
           BindPaths = [
             "/etc/tetrd/resolv.conf:/etc/resolv.conf"
-            "/run"
-            "/var/log"
+            "/run/tetrd:/run"
           ];
 
           CapabilityBoundingSet = [
-            "CAP_DAC_OVERRIDE"
             "CAP_NET_ADMIN"
           ];
 
           AmbientCapabilities = [
-            "CAP_DAC_OVERRIDE"
             "CAP_NET_ADMIN"
           ];
         };


### PR DESCRIPTION
That's just a bonkers capability to hand out because a program uses stupid paths that it does not have permissions on.

cc @Madouura

Tested in a nixos test and behaves the same as before. Does not log anything into /var/log either. I'm not saying I'm correct about these changes, but this came up during a review and we're doing the best we can.

```nix
{
  name = "tetrd";

  sshBackdoor.enable = true;

  nodes.machine = {
    services.tetrd = {
      enable = true;
    };
  };

  testScript = ''
    machine.wait_for_unit("tetrd.service")
    machine.sleep(3600)
  '';
}
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
