### PR TITLE
subtensor: init at 438

### DIFF
--- a/pkgs/by-name/su/subtensor/fix-vendor-path-deps.py
+++ b/pkgs/by-name/su/subtensor/fix-vendor-path-deps.py
@@ -1,0 +1,96 @@
+"""Fix intra-workspace path deps in vendored git-source crates.
+
+fetchCargoVendor copies crate dirs from git sources verbatim, without
+rewriting intra-workspace path deps the way `cargo vendor` would. Build
+tools such as substrate-wasm-builder spawn a fresh cargo with no lock file;
+that fresh resolution follows path deps literally and chokes on
+monorepo-relative paths that no longer exist in the flattened vendor layout.
+"""
+
+import os
+import sys
+import tomllib
+from pathlib import Path
+
+import tomli_w
+
+DEP_TABLES = ("dependencies", "dev-dependencies", "build-dependencies")
+
+
+def normalize(name):
+    return name.replace("_", "-")
+
+
+def iter_dep_tables(manifest):
+    roots = [
+        manifest,
+        *((manifest.get("target") or {}).values()),
+        manifest.get("workspace") or {},
+    ]
+    for root in roots:
+        if not isinstance(root, dict):
+            continue
+        for tbl in DEP_TABLES:
+            t = root.get(tbl)
+            if isinstance(t, dict):
+                yield t
+
+
+def build_crate_map(src_dir):
+    crate_map = {}
+    for d in src_dir.iterdir():
+        manifest_path = d / "Cargo.toml"
+        if not manifest_path.is_file():
+            continue
+        with manifest_path.open("rb") as fh:
+            manifest = tomllib.load(fh)
+        name = manifest.get("package", {}).get("name")
+        if name:
+            crate_map[normalize(name)] = d
+    return crate_map
+
+
+def fix_manifest(toml_path, crate_map):
+    with toml_path.open("rb") as fh:
+        manifest = tomllib.load(fh)
+
+    crate_dir = toml_path.parent
+    changed = False
+    for table in iter_dep_tables(manifest):
+        for alias, spec in table.items():
+            if not isinstance(spec, dict):
+                continue
+            path = spec.get("path")
+            if not path or (crate_dir / path).is_dir():
+                continue
+            package = spec.get("package", alias)
+            target = crate_map.get(normalize(package))
+            if target is None:
+                # cargo lazily resolves; deps that aren't pulled into the active
+                # build (dev-deps of transitive crates, optional/feature-gated,
+                # target-conditional, etc.) never get their Cargo.toml loaded,
+                # so a dangling path is harmless. Warn so it's visible.
+                print(f"{toml_path}: skipping unresolved {package!r} -> {path!r}", file=sys.stderr)
+                continue
+            new_path = os.path.relpath(target, crate_dir)
+            print(f"{toml_path}: {package} {path!r} -> {new_path!r}", file=sys.stderr)
+            spec["path"] = new_path
+            changed = True
+
+    if changed:
+        with toml_path.open("wb") as fh:
+            tomli_w.dump(manifest, fh)
+
+
+def main():
+    vendor_dir = Path(sys.argv[1])
+    for src_dir in sorted(vendor_dir.glob("source-git-*")):
+        if not src_dir.is_dir():
+            continue
+        crate_map = build_crate_map(src_dir)
+        for toml_path in sorted(src_dir.glob("*/Cargo.toml")):
+            fix_manifest(toml_path, crate_map)
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/by-name/su/subtensor/fix-vendor-path-deps.sh
+++ b/pkgs/by-name/su/subtensor/fix-vendor-path-deps.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Fix intra-workspace path deps in vendored git-source crates.
+#
+# fetchCargoVendor copies crate dirs from git sources verbatim, without
+# rewriting intra-workspace path deps the way `cargo vendor` would.  Build
+# tools such as substrate-wasm-builder spawn a fresh cargo with no lock file;
+# that fresh resolution follows path deps literally and chokes on
+# monorepo-relative paths that no longer exist in the flattened vendor layout.
+#
+# For each source-git-N dir: build a crate-name->dir map, then for each
+# vendored Cargo.toml redirect each broken path dep to the correct sibling
+# vendor dir.  Dep sections may list `package = "actual-name"` after `path =`,
+# so we buffer each section and resolve it only when we leave.
+set -euo pipefail
+
+vendor_dir="$1"
+
+flush_dep() {
+    local name="${dep_pkg:-$dep_alias}"
+    name=$(echo "$name" | tr _ -)
+    local name_u
+    name_u=$(echo "$name" | tr - _)
+    if [[ -n "$name" && -n "$dep_path" && ! -d "$crate_dir/$dep_path" ]]; then
+        local target="${crate_map[$name]:-${crate_map[$name_u]:-}}"
+        if [[ -n "$target" ]]; then
+            local rel
+            rel=$(realpath --relative-to="$crate_dir" "$target")
+            sed -i "s|path = \"$dep_path\"|path = \"$rel\"|g" "$toml"
+        fi
+    fi
+    dep_alias="" dep_pkg="" dep_path=""
+}
+
+for src_dir in "$vendor_dir"/source-git-*/; do
+    [[ -d "$src_dir" ]] || continue
+
+    declare -A crate_map=()
+    for d in "$src_dir"*/; do
+        name=$(awk '
+            /^\[package\]/ { in_pkg = 1 }
+            in_pkg && /^name[[:space:]]*=/ {
+                gsub(/.*=[[:space:]]*"|"[[:space:]]*$/, "")
+                print; exit
+            }
+        ' "$d/Cargo.toml" 2>/dev/null) || true
+        [[ -n "$name" ]] && crate_map["$name"]="${d%/}"
+    done
+
+    for toml in "$src_dir"*/Cargo.toml; do
+        dep_alias="" dep_pkg="" dep_path=""
+        crate_dir=$(dirname "$toml")
+        while IFS= read -r line; do
+            case "$line" in
+                \[*dependencies.*\])
+                    flush_dep
+                    dep_alias="${line##*dependencies.}"
+                    dep_alias="${dep_alias%%\]*}" ;;
+                package\ =\ *)
+                    dep_pkg="${line#*\"}"
+                    dep_pkg="${dep_pkg%\"*}" ;;
+                path\ =\ *)
+                    dep_path="${line#*\"}"
+                    dep_path="${dep_path%\"*}" ;;
+                \[*)
+                    flush_dep ;;
+            esac
+        done < "$toml"
+        flush_dep
+    done
+
+    unset crate_map
+done

--- a/pkgs/by-name/su/subtensor/package.nix
+++ b/pkgs/by-name/su/subtensor/package.nix
@@ -1,0 +1,80 @@
+{
+  clang,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  openssl,
+  pkg-config,
+  protobuf,
+  rocksdb,
+  rustPlatform,
+  rustc,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "subtensor";
+  version = "3.3.14-401";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "opentensor";
+    repo = "subtensor";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-btuV2YQ/TCRiYucpdcXOuM2E4CgR7WsFWoHXqbVjhYk=";
+  };
+
+  cargoHash = "sha256-bksIPV6wYl9FGa7D4qXs0pvgn9CF8tvE3MY2CkvNU+Q=";
+
+  postPatch = ''
+    # cargoSetupHook substitutes @vendor@ into a temp copy appended to the
+    # source .cargo/config.toml, but leaves the vendor dir's own config.toml
+    # unsubstituted. wasm-builder's child cargo reads that file directly,
+    # so we need to manually do the substitution there
+    substituteInPlace "$cargoDepsCopy/.cargo/config.toml" \
+      --subst-var-by vendor "$cargoDepsCopy"
+
+    # fetchCargoVendor does not rewrite intra-workspace path deps in vendored
+    # git-source crates (unlike `cargo vendor`). Fix them so that
+    # substrate-wasm-builder's fresh cargo invocation can resolve its deps
+    bash ${./fix-vendor-path-deps.sh} "$cargoDepsCopy"
+  '';
+
+  cargoBuildFlags = [
+    "-p"
+    "node-subtensor"
+  ];
+
+  nativeBuildInputs = [
+    clang
+    pkg-config
+    protobuf
+    rustPlatform.bindgenHook
+    rustc.llvmPackages.lld
+  ];
+
+  buildInputs = [
+    openssl
+    rocksdb
+  ];
+
+  env = {
+    OPENSSL_NO_VENDOR = "1";
+    PROTOC = "${protobuf}/bin/protoc";
+    ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+  };
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex=v(.*)" ];
+  };
+
+  meta = {
+    description = "Bittensor blockchain layer (Subtensor node)";
+    homepage = "https://github.com/opentensor/subtensor";
+    changelog = "https://github.com/opentensor/subtensor/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.unlicense;
+    maintainers = with lib.maintainers; [ kilyanni ];
+    mainProgram = "node-subtensor";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/su/subtensor/package.nix
+++ b/pkgs/by-name/su/subtensor/package.nix
@@ -1,0 +1,99 @@
+{
+  clang,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  openssl,
+  pkg-config,
+  protobuf,
+  python3,
+  rocksdb,
+  rustPlatform,
+  rustc,
+}:
+
+let
+  python = python3.withPackages (ps: [ ps.tomli-w ]);
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "subtensor";
+  version = "438";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "RaoFoundation";
+    repo = "subtensor";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ZQxI3aBK1oHO6DAf0SePfLYy6AM+ADNC7wWXBMPFTSg=";
+  };
+
+  cargoHash = "sha256-qpheM5oLcLOexjnlZCpgJKbpb3OjUvu4Z/QHq27CkFU=";
+
+  postPatch = ''
+    # cargoSetupHook substitutes @vendor@ into a temp copy appended to the
+    # source .cargo/config.toml, but leaves the vendor dir's own config.toml
+    # unsubstituted. wasm-builder's child cargo reads that file directly,
+    # so we need to manually do the substitution there
+    substituteInPlace "$cargoDepsCopy/.cargo/config.toml" \
+      --subst-var-by vendor "$cargoDepsCopy"
+
+    # fetchCargoVendor does not rewrite intra-workspace path deps in vendored
+    # git-source crates (unlike `cargo vendor`). Fix them so that
+    # substrate-wasm-builder's fresh cargo invocation can resolve its deps
+    ${python.interpreter} ${./fix-vendor-path-deps.py} "$cargoDepsCopy"
+  '';
+
+  cargoBuildFlags = [
+    "-p"
+    "node-subtensor"
+  ];
+
+  nativeBuildInputs = [
+    clang
+    pkg-config
+    protobuf
+    rustPlatform.bindgenHook
+    rustc.llvmPackages.lld
+  ];
+
+  buildInputs = [
+    openssl
+    rocksdb
+  ];
+
+  env =
+    let
+      inherit (rustc.llvmPackages) clang-unwrapped libclang;
+      majorVersion = lib.versions.major clang-unwrapped.version;
+      resourceDir = "${lib.getLib clang-unwrapped}/lib/clang/${majorVersion}";
+      includeDir = "${lib.getLib libclang}/lib/clang/${majorVersion}/include";
+    in
+    {
+      OPENSSL_NO_VENDOR = "1";
+      PROTOC = "${protobuf}/bin/protoc";
+      ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+
+      # wasm-builder compiles the runtime blob for wasm32v1-none, but cc-rs
+      # inherits the nix-wrapped host gcc from $CC, which rejects wasm-only
+      # flags such as -mmutable-globals. Point that target at an unwrapped
+      # clang, which can target wasm
+      CC_wasm32v1_none = lib.getExe clang-unwrapped;
+      CFLAGS_wasm32v1_none = "-isystem ${includeDir} -resource-dir ${resourceDir}";
+      WASM_BUILD_RUSTFLAGS = "-C link-arg=--allow-undefined";
+    };
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex=v(\\d+)" ];
+  };
+
+  meta = {
+    description = "Bittensor blockchain layer (Subtensor node)";
+    homepage = "https://github.com/RaoFoundation/subtensor";
+    changelog = "https://github.com/RaoFoundation/subtensor/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kilyanni ];
+    mainProgram = "node-subtensor";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
https://github.com/opentensor/subtensor is the blockchain layer of https://bittensor.com, a decentralised network for machine learning.

This packages the node-subtensor binary needed to run a full node or validator.

The derivation implements a slightly contrived workaround for an issue with `fetchCargoVendor`;
The package internally spawns a second `cargo` invocation, which tries to resolve the vendored deps without the lock file containing all the overrides by `fetchCargoVendor`.
(Note we can't just copy the lock file, as the path it'll spawn in is not constant (`$CARGO_TARGET_DIR/<triple>/release/build/<pkg>-<hash>/out/wbuild/`))
It ends up looking up relative paths of vendored crates, but the vendoring breaks the original intended relative paths.
To deal with this, a small python script rewrites the relative paths in the `Cargo.toml` files to point to the vendored paths.

I'm not entirely sure whether this is something `fetchCargoVendor` should be doing. Unless reviewers notice something I'm missing here, I'll file a bug report after

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
