### PR TITLE
nixos/ntsync: new module for improved wine/proton sync compat, enabled by default with Steam

### DIFF
--- a/nixos/modules/hardware/ntsync.nix
+++ b/nixos/modules/hardware/ntsync.nix
@@ -1,0 +1,23 @@
+{ config, lib, ... }:
+{
+  options.hardware.ntsync.enable = lib.mkEnableOption ''
+    ntsync, a Linux kernel driver that emulates Windows NT
+    synchronization primitives via /dev/ntsync. Used by Wine/Proton
+    (>= Proton 11) for better performance and compatibility than the
+    userspace esync/fsync alternatives.
+
+    Requires Linux kernel 6.14 or newer
+  '';
+
+  config = lib.mkIf config.hardware.ntsync.enable {
+    assertions = [
+      {
+        assertion = lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.14";
+        message = "hardware.ntsync requires kernel >= 6.14";
+      }
+    ];
+    boot.kernelModules = [ "ntsync" ];
+  };
+
+  meta.maintainers = with lib.maintainers; [ mitchmindtree ];
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -98,6 +98,7 @@
   ./hardware/new-lg4ff.nix
   ./hardware/nfc-nci.nix
   ./hardware/nitrokey.nix
+  ./hardware/ntsync.nix
   ./hardware/onlykey/default.nix
   ./hardware/openrazer.nix
   ./hardware/opentabletdriver.nix

--- a/nixos/modules/programs/steam.nix
+++ b/nixos/modules/programs/steam.nix
@@ -241,6 +241,11 @@ in
 
     hardware.steam-hardware.enable = true;
 
+    # ntsync is enabled by default if the module is available in Proton 11 onwards.
+    hardware.ntsync.enable = lib.mkDefault (
+      lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.14"
+    );
+
     environment.systemPackages = [
       cfg.package
       cfg.package.run


### PR DESCRIPTION
Provides a module for enabling `ntsync`, a Linux kernel driver that emulates Windows NT synchronization primitives via `/dev/ntsync`. Used by Wine/Proton (>= Proton 11) for better performance and compatibility than the userspace esync/fsync alternatives.

Enables the module by default for Steam now that Proton 11 onwards defaults to ntsync when the module is available. This improves compatibility by default for some games. For me personally, this specifically [fixes a frequent deadlock bug in a game called "The Finals"](https://github.com/ValveSoftware/Proton/issues/7317#issuecomment-4366647094) after a week of debugging.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
