### PR TITLE
nixos/timesyncd: migrate to RFC 42-style settings

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -23,6 +23,8 @@
   no longer sets `programs.pqos-wrapper.enable = true`
   as the corresponding module has been deleted.
 
+- `services.timesyncd.extraConfig` has been removed in favor of the structured [](#opt-services.timesyncd.settings.Time) option. Use `services.timesyncd.settings.Time` to set any `timesyncd.conf(5)` option directly. For example, replace `services.timesyncd.extraConfig = "PollIntervalMaxSec=180";` with `services.timesyncd.settings.Time.PollIntervalMaxSec = 180;`.
+
 ## Other Notable Changes {#sec-release-26.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/system/boot/timesyncd.nix
+++ b/nixos/modules/system/boot/timesyncd.nix
@@ -1,9 +1,22 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  utils,
+  ...
+}:
 
 let
   cfg = config.services.timesyncd;
 in
 {
+
+  imports = [
+    (lib.mkRemovedOptionModule [
+      "services"
+      "timesyncd"
+      "extraConfig"
+    ] "Use services.timesyncd.settings.Time instead.")
+  ];
 
   options = {
 
@@ -43,15 +56,17 @@ in
           See {manpage}`timesyncd.conf(5)` for details.
         '';
       };
-      extraConfig = lib.mkOption {
-        default = "";
-        type = lib.types.lines;
-        example = ''
-          PollIntervalMaxSec=180
-        '';
+      settings.Time = lib.mkOption {
+        default = { };
+        type = lib.types.submodule {
+          freeformType = lib.types.attrsOf utils.systemdUtils.unitOptions.unitOption;
+        };
+        example = {
+          PollIntervalMaxSec = 180;
+        };
         description = ''
-          Extra config options for systemd-timesyncd. See
-          {manpage}`timesyncd.conf(5)` for available options.
+          Settings for systemd-timesyncd. See {manpage}`timesyncd.conf(5)` for
+          available options.
         '';
       };
     };
@@ -74,16 +89,17 @@ in
       environment.LD_LIBRARY_PATH = config.system.nssModules.path;
     };
 
-    environment.etc."systemd/timesyncd.conf".text = ''
-      [Time]
-    ''
-    + lib.optionalString (cfg.servers != null) ''
-      NTP=${lib.concatStringsSep " " cfg.servers}
-    ''
-    + lib.optionalString (cfg.fallbackServers != null) ''
-      FallbackNTP=${lib.concatStringsSep " " cfg.fallbackServers}
-    ''
-    + cfg.extraConfig;
+    services.timesyncd.settings.Time = lib.mkMerge [
+      (lib.mkIf (cfg.servers != null) {
+        NTP = lib.mkDefault (lib.concatStringsSep " " cfg.servers);
+      })
+      (lib.mkIf (cfg.fallbackServers != null) {
+        FallbackNTP = lib.mkDefault (lib.concatStringsSep " " cfg.fallbackServers);
+      })
+    ];
+
+    environment.etc."systemd/timesyncd.conf".text =
+      utils.systemdUtils.lib.settingsToSections cfg.settings;
 
     users.users.systemd-timesync = {
       uid = config.ids.uids.systemd-timesync;

--- a/nixos/modules/system/boot/timesyncd.nix
+++ b/nixos/modules/system/boot/timesyncd.nix
@@ -1,7 +1,5 @@
 { config, lib, ... }:
 
-with lib;
-
 let
   cfg = config.services.timesyncd;
 in
@@ -9,18 +7,18 @@ in
 
   options = {
 
-    services.timesyncd = with types; {
-      enable = mkOption {
+    services.timesyncd = {
+      enable = lib.mkOption {
         default = !config.boot.isContainer;
-        defaultText = literalExpression "!config.boot.isContainer";
-        type = bool;
+        defaultText = lib.literalExpression "!config.boot.isContainer";
+        type = lib.types.bool;
         description = ''
           Enables the systemd NTP client daemon.
         '';
       };
-      servers = mkOption {
+      servers = lib.mkOption {
         default = null;
-        type = nullOr (listOf str);
+        type = lib.types.nullOr (lib.types.listOf lib.types.str);
         description = ''
           The set of NTP servers from which to synchronise.
 
@@ -31,10 +29,10 @@ in
           See {manpage}`timesyncd.conf(5)` for details.
         '';
       };
-      fallbackServers = mkOption {
+      fallbackServers = lib.mkOption {
         default = config.networking.timeServers;
-        defaultText = literalExpression "config.networking.timeServers";
-        type = nullOr (listOf str);
+        defaultText = lib.literalExpression "config.networking.timeServers";
+        type = lib.types.nullOr (lib.types.listOf lib.types.str);
         description = ''
           The set of fallback NTP servers from which to synchronise.
 
@@ -45,9 +43,9 @@ in
           See {manpage}`timesyncd.conf(5)` for details.
         '';
       };
-      extraConfig = mkOption {
+      extraConfig = lib.mkOption {
         default = "";
-        type = lines;
+        type = lib.types.lines;
         example = ''
           PollIntervalMaxSec=180
         '';
@@ -59,7 +57,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     systemd.additionalUpstreamSystemUnits = [ "systemd-timesyncd.service" ];
 
@@ -79,11 +77,11 @@ in
     environment.etc."systemd/timesyncd.conf".text = ''
       [Time]
     ''
-    + optionalString (cfg.servers != null) ''
-      NTP=${concatStringsSep " " cfg.servers}
+    + lib.optionalString (cfg.servers != null) ''
+      NTP=${lib.concatStringsSep " " cfg.servers}
     ''
-    + optionalString (cfg.fallbackServers != null) ''
-      FallbackNTP=${concatStringsSep " " cfg.fallbackServers}
+    + lib.optionalString (cfg.fallbackServers != null) ''
+      FallbackNTP=${lib.concatStringsSep " " cfg.fallbackServers}
     ''
     + cfg.extraConfig;
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1653,6 +1653,7 @@ in
   systemd-sysusers-immutable = runTest ./systemd-sysusers-immutable.nix;
   systemd-sysusers-mutable = runTest ./systemd-sysusers-mutable.nix;
   systemd-sysusers-password-option-override-ordering = runTest ./systemd-sysusers-password-option-override-ordering.nix;
+  systemd-timesyncd = runTest ./systemd-timesyncd.nix;
   systemd-timesyncd-nscd-dnssec = runTest ./systemd-timesyncd-nscd-dnssec.nix;
   systemd-user-linger = runTest ./systemd-user-linger.nix;
   systemd-user-linger-purge = runTest ./systemd-user-linger-purge.nix;

--- a/nixos/tests/systemd-timesyncd-nscd-dnssec.nix
+++ b/nixos/tests/systemd-timesyncd-nscd-dnssec.nix
@@ -50,9 +50,7 @@ in
       # Configure systemd-timesyncd to use our NTP hostname
       services.timesyncd.enable = lib.mkForce true;
       services.timesyncd.servers = [ ntpHostname ];
-      services.timesyncd.extraConfig = ''
-        FallbackNTP=${ntpHostname}
-      '';
+      services.timesyncd.settings.Time.FallbackNTP = ntpHostname;
 
       # The debug output is necessary to determine whether systemd-timesyncd successfully resolves our NTP hostname or not
       systemd.services.systemd-timesyncd.environment.SYSTEMD_LOG_LEVEL = "debug";

--- a/nixos/tests/systemd-timesyncd-nscd-dnssec.nix
+++ b/nixos/tests/systemd-timesyncd-nscd-dnssec.nix
@@ -20,7 +20,7 @@ let
   ntpIP = "192.0.2.1";
 in
 {
-  name = "systemd-timesyncd";
+  name = "systemd-timesyncd-nscd-dnssec";
   nodes.machine =
     {
       pkgs,

--- a/nixos/tests/systemd-timesyncd.nix
+++ b/nixos/tests/systemd-timesyncd.nix
@@ -1,0 +1,31 @@
+{
+  name = "systemd-timesyncd";
+  meta = {
+    maintainers = [ ];
+  };
+
+  nodes.machine =
+    { lib, ... }:
+    {
+      services.timesyncd = {
+        enable = lib.mkForce true;
+        servers = [ "ntp.example.com" ];
+        fallbackServers = [ "fallback.example.com" ];
+        settings.Time = {
+          PollIntervalMaxSec = "180";
+          RootDistanceMaxSec = "5";
+        };
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+
+    with subtest("settings.Time renders timesyncd.conf"):
+      machine.succeed("grep -F '[Time]' /etc/systemd/timesyncd.conf")
+      machine.succeed("grep -F 'NTP=ntp.example.com' /etc/systemd/timesyncd.conf")
+      machine.succeed("grep -F 'FallbackNTP=fallback.example.com' /etc/systemd/timesyncd.conf")
+      machine.succeed("grep -F 'PollIntervalMaxSec=180' /etc/systemd/timesyncd.conf")
+      machine.succeed("grep -F 'RootDistanceMaxSec=5' /etc/systemd/timesyncd.conf")
+  '';
+}


### PR DESCRIPTION
Same RFC 42 treatment that `coredump`, `oomd`, `logind` etc. already got.

- `services.timesyncd.extraConfig` is gone (`mkRemovedOptionModule` points at `services.timesyncd.settings.Time`).
- `servers` / `fallbackServers` stay; they're now wired into `settings.Time.NTP` / `FallbackNTP` via `mkDefault`, so existing configs aren't disturbed.
- First commit just drops `with lib;` so the migration diff is easier to read.
- New `nixos/tests/systemd-timesyncd` asserts the rendered `timesyncd.conf`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
