### PR TITLE
musly: fix build with gcc15

### DIFF
--- a/pkgs/by-name/mu/musly/0005-Fix-minilog-get.patch
+++ b/pkgs/by-name/mu/musly/0005-Fix-minilog-get.patch
@@ -1,0 +1,13 @@
+diff --git a/include/minilog.h b/include/minilog.h
+index b1c387e..9390a6e 100644
+--- a/include/minilog.h
++++ b/include/minilog.h
+@@ -198,7 +198,7 @@ Log<T>::from_string(
+     else if (level == "NONE")
+         return logNONE;
+     else {
+-        Log<T>().Get(logWARNING) << "Unknown logging level '" << level
++        Log<T>().get(logWARNING) << "Unknown logging level '" << level
+                 << "'. Using INFO level as default.";
+         return logINFO;
+     }

--- a/pkgs/by-name/mu/musly/package.nix
+++ b/pkgs/by-name/mu/musly/package.nix
@@ -37,6 +37,10 @@ stdenv.mkDerivation {
     ./0002-Fix-build-with-C-17.patch
     ./0003-Modernize-CMake-build-system.patch
     ./0004-Use-pkg-config-to-find-libresample-and-kissfft.patch
+    # Fix build with gcc15: minilog.h uses Get() instead of get() in unused
+    # template code
+    # https://github.com/dominikschnitzer/musly/pull/55
+    ./0005-Fix-minilog-get.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/326834094

```
/build/source/include/minilog.h: In static member function 'static minilog_level Log<T>::from_string(const std::string&)':
/build/source/include/minilog.h:201:18: error: 'class Log<T>' has no member named 'Get'; did you mean 'get'? [-Wtemplate-body]
  201 |         Log<T>().Get(logWARNING) << "Unknown logging level '" << level
      |                  ^~~
      |                  get
```

Only verified compilation.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
