### PR TITLE
claude-agent-acp: 0.31.4 -> 0.32.0

### DIFF
--- a/pkgs/by-name/cl/claude-agent-acp/package.nix
+++ b/pkgs/by-name/cl/claude-agent-acp/package.nix
@@ -11,7 +11,7 @@ buildNpmPackage (finalAttrs: {
   version = "0.31.4";
 
   src = fetchFromGitHub {
-    owner = "zed-industries";
+    owner = "agentclientprotocol";
     repo = "claude-agent-acp";
     tag = "v${finalAttrs.version}";
     hash = "sha256-cXTtDekC0+n1NCgTzIyGSqHEgpgdHP6EVI23L4nCbWE=";
@@ -28,7 +28,7 @@ buildNpmPackage (finalAttrs: {
 
   meta = {
     description = "ACP-compatible coding agent powered by the Claude Agent SDK";
-    homepage = "https://github.com/zed-industries/claude-agent-acp";
+    homepage = "https://github.com/agentclientprotocol/claude-agent-acp";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       amadejkastelic

--- a/pkgs/by-name/cl/claude-agent-acp/package.nix
+++ b/pkgs/by-name/cl/claude-agent-acp/package.nix
@@ -2,20 +2,29 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
+  makeWrapper,
+  claude-code,
 }:
 
 buildNpmPackage (finalAttrs: {
   pname = "claude-agent-acp";
-  version = "0.21.0";
+  version = "0.31.4";
 
   src = fetchFromGitHub {
     owner = "zed-industries";
     repo = "claude-agent-acp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-6c6bHuso3diW5ZfHiM2xcxGDTNG0LIL0TZd0MFVpW/E=";
+    hash = "sha256-cXTtDekC0+n1NCgTzIyGSqHEgpgdHP6EVI23L4nCbWE=";
   };
 
-  npmDepsHash = "sha256-UtiIcjgNCYMFrRpO5AlUbOyutJ3ipwIbcpMi2BqawEk=";
+  npmDepsHash = "sha256-PmcE99h303iOH5OJ4wCwxgR+0zVJM8O5A3ZyBgPxJeM=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/claude-agent-acp \
+      --prefix CLAUDE_CODE_EXECUTABLE ${lib.getExe claude-code}
+  '';
 
   meta = {
     description = "ACP-compatible coding agent powered by the Claude Agent SDK";

--- a/pkgs/by-name/cl/claude-agent-acp/package.nix
+++ b/pkgs/by-name/cl/claude-agent-acp/package.nix
@@ -30,7 +30,10 @@ buildNpmPackage (finalAttrs: {
     description = "ACP-compatible coding agent powered by the Claude Agent SDK";
     homepage = "https://github.com/zed-industries/claude-agent-acp";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ storopoli ];
+    maintainers = with lib.maintainers; [
+      amadejkastelic
+      storopoli
+    ];
     mainProgram = "claude-agent-acp";
   };
 })

--- a/pkgs/by-name/cl/claude-agent-acp/package.nix
+++ b/pkgs/by-name/cl/claude-agent-acp/package.nix
@@ -3,21 +3,22 @@
   buildNpmPackage,
   fetchFromGitHub,
   makeWrapper,
+  nix-update-script,
   claude-code,
 }:
 
 buildNpmPackage (finalAttrs: {
   pname = "claude-agent-acp";
-  version = "0.31.4";
+  version = "0.32.0";
 
   src = fetchFromGitHub {
     owner = "agentclientprotocol";
     repo = "claude-agent-acp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-cXTtDekC0+n1NCgTzIyGSqHEgpgdHP6EVI23L4nCbWE=";
+    hash = "sha256-egYGwkN8iexw42EIhUgKb+QuAKfH4lKts0lftzfHAiY=";
   };
 
-  npmDepsHash = "sha256-PmcE99h303iOH5OJ4wCwxgR+0zVJM8O5A3ZyBgPxJeM=";
+  npmDepsHash = "sha256-sUB/S3EycM3FGibAaZMA1T7tCyDu2XfkSg86qcABmYk=";
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -26,12 +27,15 @@ buildNpmPackage (finalAttrs: {
       --prefix CLAUDE_CODE_EXECUTABLE ${lib.getExe claude-code}
   '';
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "ACP-compatible coding agent powered by the Claude Agent SDK";
     homepage = "https://github.com/agentclientprotocol/claude-agent-acp";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       amadejkastelic
+      caniko
       storopoli
     ];
     mainProgram = "claude-agent-acp";


### PR DESCRIPTION
Builds on top of #515145 (currently 0.31.4). Bumps to the latest release 0.32.0, adds `passthru.updateScript = nix-update-script { }` so future bumps can be automated, and adds @caniko as a co-maintainer.

Changelog: https://github.com/agentclientprotocol/claude-agent-acp/blob/main/CHANGELOG.md
Supersedes: #515145
Resolves: #510435

`nixpkgs-review-gha` run: https://github.com/caniko/nixpkgs-review-gha/actions/runs/25302165042

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test