### PR TITLE
olive-editor: fix build with qt-6.10.1+

### DIFF
--- a/pkgs/by-name/ol/olive-editor/olive-editor-fix-qstring-arg-scoped-enum.patch
+++ b/pkgs/by-name/ol/olive-editor/olive-editor-fix-qstring-arg-scoped-enum.patch
@@ -1,0 +1,26 @@
+diff --git a/app/render/videoparams.cpp b/app/render/videoparams.cpp
+index 742e01227..7cac394b3 100644
+--- a/app/render/videoparams.cpp
++++ b/app/render/videoparams.cpp
+@@ -226,7 +226,7 @@ QString VideoParams::GetFormatName(PixelFormat format)
+     break;
+   }
+ 
+-  return QCoreApplication::translate("VideoParams", "Unknown (0x%1)").arg(format, 0, 16);
++  return QCoreApplication::translate("VideoParams", "Unknown (0x%1)").arg(static_cast<int>(format), 0, 16);
+ }
+ 
+ int VideoParams::GetDividerForTargetResolution(int src_width, int src_height, int dst_width, int dst_height)
+diff --git a/app/ui/humanstrings.cpp b/app/ui/humanstrings.cpp
+index 6a52a9ccb..96e5c3fb3 100644
+--- a/app/ui/humanstrings.cpp
++++ b/app/ui/humanstrings.cpp
+@@ -60,7 +60,7 @@ QString HumanStrings::FormatToString(const SampleFormat &f)
+     break;
+   }
+ 
+-  return QCoreApplication::translate("AudioParams", "Unknown (0x%1)").arg(f, 1, 16);
++  return QCoreApplication::translate("AudioParams", "Unknown (0x%1)").arg(static_cast<int>(f), 1, 16);
+ }
+ 
+ }

--- a/pkgs/by-name/ol/olive-editor/package.nix
+++ b/pkgs/by-name/ol/olive-editor/package.nix
@@ -62,6 +62,10 @@ stdenv.mkDerivation {
     # https://github.com/KDAB/KDDockWidgets/pull/615
     # https://github.com/KDAB/KDDockWidgets/commit/f2b50fff29bd4b49acdfed3ed8fc42eb0a502032
     ./olive-editor-kddockwidgets-fix-build-with-qt-6_10.patch
+
+    # Fix QString::arg() with scope enums for qt-6.10.1+
+    # https://github.com/olive-editor/olive/pull/2401
+    ./olive-editor-fix-qstring-arg-scoped-enum.patch
   ];
 
   # https://github.com/olive-editor/olive/issues/2200


### PR DESCRIPTION
- https://hydra.nixos.org/build/326842183
- #516381
- Fixes #465896
- Closes #523100

```
app/render/videoparams.cpp: In static member function 'static QString olive::VideoParams::GetFormatName(olive::core::PixelFormat)':
app/render/videoparams.cpp:229:74: error: no matching function for call to 'QString::arg(olive::core::PixelFormat&, int, int)'
  229 |   return QCoreApplication::translate("VideoParams", "Unknown (0x%1)").arg(format, 0, 16);
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~

app/ui/humanstrings.cpp: In static member function 'static QString olive::HumanStrings::FormatToString(const olive::core::SampleFormat&)':
app/ui/humanstrings.cpp:63:74: error: no matching function for call to 'QString::arg(const olive::core::SampleFormat&, int, int)'
   63 |   return QCoreApplication::translate("AudioParams", "Unknown (0x%1)").arg(f, 1, 16);
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
