### PR TITLE
mrtg: fix build with gcc15

### DIFF
--- a/pkgs/by-name/mr/mrtg/package.nix
+++ b/pkgs/by-name/mr/mrtg/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   makeWrapper,
   fetchurl,
+  fetchpatch,
   perl,
   gd,
   rrdtool,
@@ -38,10 +39,18 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # gcc14 broke detection of printf format specifiers
     # building from master seems to be fixed upstream, so next release can (likely) drop the patch
-    # just keep the CFLAGS below
     ./configure-long-long-format-gcc14.patch
+    # fix gcc15 build, remove after next release
+    (fetchpatch {
+      name = "fix-gcc15.patch";
+      url = "https://github.com/oetiker/mrtg/commit/a64a83210643114b3a892e70ce07ded5bd5de054.patch";
+      hash = "sha256-9k16WrCAETuk5DJf5pmeXFHc4AZD9Acmtq/7P24tpwc=";
+      excludes = [ "CHANGES" ];
+      stripLen = 2;
+      extraPrefix = "";
+    })
   ];
-  env.NIX_CFLAGS_COMPILE = "-Werror";
+
   env.NIX_CFLAGS_LINK = "-lm";
 
   postInstall = ''


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/326833843

```
./src/rateup.c: In function 'image':
./src/rateup.c:264:1: error: old-style function definition [-Werror=old-style-definition]
  264 | image (file, maxvi, maxvo, maxx, maxy, xscale, yscale, growright, step, bits,
      | ^~~~~
./src/rateup.c: In function 'diff':
./src/rateup.c:1156:1: error: old-style function definition [-Werror=old-style-definition]
 1156 | diff (a, b)
      | ^~~~
./src/rateup.c: In function 'readhist':
./src/rateup.c:1228:1: error: old-style function definition [-Werror=old-style-definition]
 1228 | readhist (file)
      | ^~~~~~~~
./src/rateup.c: In function 'update':
./src/rateup.c:1380:1: error: old-style function definition [-Werror=old-style-definition]
 1380 | update (in, out, abs_max, absupdate)
      | ^~~~~~
./src/rateup.c: In function 'main':
./src/rateup.c:1824:1: error: old-style function definition [-Werror=old-style-definition]
 1824 | main (argc, argv)
      | ^~~~
```

Fetched an upstream patch to fix the issue.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
