### PR TITLE
ndn-cxx: fix build with gcc15

### DIFF
--- a/pkgs/by-name/nd/ndn-cxx/package.nix
+++ b/pkgs/by-name/nd/ndn-cxx/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   doxygen,
   pkg-config,
   python3,
@@ -22,6 +23,14 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "ndn-cxx-${finalAttrs.version}";
     sha256 = "sha256-u9+QxqdCET1f5B54HF+Jk/YuQvhcYWsPNIVHi5l0XTM=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-gcc15.patch";
+      url = "https://github.com/named-data/ndn-cxx/commit/0ba3d3a9d9701be4baa3969fe50e97e89d11249b.patch";
+      hash = "sha256-ikVIJ8Jza17k/sa/wtu2EUGLEhUMloMOkBrMN9W9BPY=";
+    })
+  ];
 
   nativeBuildInputs = [
     doxygen


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/326834491

```
In file included from ../ndn-cxx/interest.hpp:25,
                 from ../ndn-cxx/security/key-chain.hpp:25,
                 from ./../tools/ndnsec/util.hpp:25,
                 from ./../tools/ndnsec/ndnsec-pch.hpp:25,
                 from <command-line>:
../ndn-cxx/detail/packet-base.hpp:36:3: error: ‘uint64_t’ does not name a type
   36 |   uint64_t
      |   ^~~~~~~~
../ndn-cxx/detail/packet-base.hpp:26:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
   25 | #include "ndn-cxx/detail/tag-host.hpp"
  +++ |+#include <cstdint>
   26 | 
../ndn-cxx/detail/packet-base.hpp:42:21: error: ‘uint64_t’ has not been declared
   42 |   setCongestionMark(uint64_t mark);
      |                     ^~~~~~~~
../ndn-cxx/detail/packet-base.hpp:42:21: note: ‘uint64_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
```

Only verified compilation.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
