### PR TITLE
nix: fix withMimalloc

### DIFF
--- a/pkgs/tools/package-management/nix/modular/src/nix/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/nix/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   mkMesonExecutable,
+  stdenv,
 
   nix-store,
   nix-expr,
@@ -12,6 +13,11 @@
   # Configuration Options
 
   version,
+
+  # Whether to link against mimalloc for malloc override.
+  # Significantly improves evaluation performance on allocation-heavy
+  # workloads (~10-15% on large evaluations).
+  withMimalloc ? !stdenv.hostPlatform.isWindows,
 }:
 
 mkMesonExecutable (finalAttrs: {
@@ -25,10 +31,11 @@ mkMesonExecutable (finalAttrs: {
     nix-expr
     nix-main
     nix-cmd
-    mimalloc
-  ];
+  ]
+  ++ lib.optional ((lib.versionAtLeast version "2.35pre") && withMimalloc) mimalloc;
 
-  mesonFlags = [
+  mesonFlags = lib.optionals (lib.versionAtLeast version "2.35pre") [
+    (lib.mesonEnable "mimalloc" withMimalloc)
   ];
 
   meta = {


### PR DESCRIPTION
fixes https://github.com/NixOS/nixpkgs/commit/d22a182395ccfc06d84b1b13a6ea660b0aeddb47


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
