### PR TITLE
moshi: use system oniguruma

### DIFF
--- a/pkgs/by-name/mo/moshi/package.nix
+++ b/pkgs/by-name/mo/moshi/package.nix
@@ -12,6 +12,7 @@
 
   # buildInputs
   libopus,
+  oniguruma,
   openssl,
   sentencepiece,
   alsa-lib,
@@ -74,6 +75,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   buildInputs = [
     libopus
+    oniguruma
     openssl
     sentencepiece
   ]
@@ -92,7 +94,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     lib.optionals stdenv.hostPlatform.isDarwin [ "metal" ]
     ++ lib.optionals config.cudaSupport [ "cuda" ];
 
-  env = lib.optionalAttrs config.cudaSupport {
+  env = {
+    # use system oniguruma
+    RUSTONIG_SYSTEM_LIBONIG = true;
+  }
+  // lib.optionalAttrs config.cudaSupport {
     CUDA_COMPUTE_CAP = cudaCapability';
 
     # We already list CUDA dependencies in buildInputs


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/326833496

```
warning: onig_sys@69.8.1: oniguruma/src/regparse.c: In function 'onig_st_init_strend_table_with_size':
warning: onig_sys@69.8.1: oniguruma/src/regparse.c:588:5: error: initialization of 'int (*)(void)' from incompatible pointer type 'int (*)(st_str_end_key *, st_str_end_key *)' [-Wincompatible-pointer-types]
warning: onig_sys@69.8.1:   588 |     str_end_cmp,
warning: onig_sys@69.8.1:       |     ^~~~~~~~~~~
warning: onig_sys@69.8.1: oniguruma/src/regparse.c:588:5: note: (near initialization for 'hashType.compare')
warning: onig_sys@69.8.1: oniguruma/src/regparse.c:550:1: note: 'str_end_cmp' declared here
warning: onig_sys@69.8.1:   550 | str_end_cmp(st_str_end_key* x, st_str_end_key* y)
warning: onig_sys@69.8.1:       | ^~~~~~~~~~~
...
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
