### PR TITLE
earlybird: 4.0.0 -> 4.6.0

### DIFF
--- a/pkgs/by-name/ea/earlybird/package.nix
+++ b/pkgs/by-name/ea/earlybird/package.nix
@@ -2,25 +2,54 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  gitMinimal,
+  poppler-utils,
+  wv,
+  unrtf,
+  html-tidy,
+  makeWrapper,
+  # TODO add justext when github.com/JalfResi/justext becomes available
+  # justext
 }:
 
 buildGoModule (finalAttrs: {
   pname = "earlybird";
-  version = "4.0.0";
+  version = "4.6.0";
 
   src = fetchFromGitHub {
     owner = "americanexpress";
     repo = "earlybird";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-guSm/ha4ICaOcoynvAwFeojE6ikaCykMcdfskD/ehTw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-P8kA9MJA+2jtVOYLBu0oG9xTUTGCtiX4R+4ecmXDAAw=";
   };
 
-  vendorHash = "sha256-39jXqCXAwg/C+9gEXiS1X58OD61nMNQifnhgVGEF6ck=";
+  vendorHash = "sha256-pQ8gSDHsdDT/cgvRB0OSqnMZz2W5vAzFBzph0xksC2o=";
 
   ldflags = [
     "-s"
     "-w"
   ];
+
+  nativeBuildInputs = [
+    makeWrapper
+    gitMinimal
+  ];
+
+  checkFlags = [
+    "--skip=Test_parseGitFiles"
+  ];
+
+  postFixup = ''
+    wrapProgram $out/bin/earlybird \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          poppler-utils
+          wv
+          unrtf
+          html-tidy
+        ]
+      }
+  '';
 
   meta = {
     description = "Sensitive data detection tool capable of scanning source code repositories for passwords, key files, and more";
@@ -28,6 +57,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/americanexpress/earlybird";
     changelog = "https://github.com/americanexpress/earlybird/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ tbutter ];
   };
 })


### PR DESCRIPTION
Update to 4.6.0

Add the necessary binaries for document conversion to the dependencies / wrapper.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
