### PR TITLE
stdenv/meta: Propagate nonTeamMaintainers if possible

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -571,8 +571,9 @@ let
       );
 
       # Needed for CI to be able to avoid requesting reviews from individual
-      # team members
-      nonTeamMaintainers = attrs.meta.maintainers or [ ];
+      # team members.
+      # Prefer nonTeamMaintainers in case meta is copied from another package
+      nonTeamMaintainers = attrs.meta.nonTeamMaintainers or attrs.meta.maintainers or [ ];
 
       identifiers =
         let


### PR DESCRIPTION
This fixes the problem where if `meta` for package A is inherited from package B, both team and non-team maintainers would end up in nonTeamMaintainers, because by default it would take the value from meta.maintainers, which when accessed also contains team maintainers for backwards compatibility reasons.

Noticed in https://github.com/NixOS/nixpkgs/pull/435641#event-25075587713, where both the security team and its members were requested for review, because the PR also triggered rebuilds for `gnupg1`, and `gnupg1.meta.nonTeamMaintainers` contained all team members individually, because it was inherited from `gnupg`: https://github.com/NixOS/nixpkgs/blob/510a31f5644e010379b51ed3955c4a72ba36d73b/pkgs/tools/security/gnupg/1compat.nix#L38

With this PR, `gnupg1.meta.nonTeamMaintainers` matches `gnupg.meta.nonTeamMaintainers`, therefore fixing the problem.

## Things done
- [x] Checked that `nonTeamMaintainers` now matches