### PR TITLE
mini-httpd: fix build with boost 1.89

### DIFF
--- a/pkgs/by-name/mi/mini-httpd/package.nix
+++ b/pkgs/by-name/mi/mini-httpd/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  autoreconfHook,
   boost,
 }:
 
@@ -13,6 +14,12 @@ stdenv.mkDerivation (finalAttrs: {
     url = "https://download-mirror.savannah.gnu.org/releases/mini-httpd/mini-httpd-${finalAttrs.version}.tar.gz";
     sha256 = "0jggmlaywjfbdljzv5hyiz49plnxh0har2bnc9dq4xmj1pmjgs49";
   };
+
+  patches = [
+    ./remove-boost-system.patch
+  ];
+
+  nativeBuildInputs = [ autoreconfHook ];
 
   buildInputs = [ boost ];
 

--- a/pkgs/by-name/mi/mini-httpd/remove-boost-system.patch
+++ b/pkgs/by-name/mi/mini-httpd/remove-boost-system.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index fd06d1a..337178c 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -14,8 +14,6 @@ AC_PROG_RANLIB
+ AC_LANG([C++])
+ AC_CHECK_HEADER(boost/spirit.hpp, :,
+     AC_MSG_ERROR([Cannot find the Boost library headers! See the README for details.]))
+-AC_CHECK_LIB([boost_system], [main], [LIBS="-lboost_system"],
+-    [AC_MSG_ERROR([cannot link required boost.system library])])
+ gl_INIT
+ AC_SYS_LARGEFILE
+ 


### PR DESCRIPTION
- #485826 
- #516381
- https://hydra.nixos.org/build/326832743

```
configure: error: cannot link required boost.system library
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
