### PR TITLE
librelane: 3.0.2 -> 3.0.3

### DIFF
--- a/pkgs/by-name/li/librelane/package.nix
+++ b/pkgs/by-name/li/librelane/package.nix
@@ -23,14 +23,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "librelane";
-  version = "3.0.2";
+  version = "3.0.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "librelane";
     repo = "librelane";
     tag = finalAttrs.version;
-    hash = "sha256-JxWuaOBhkjjw4sp7l++QF+0EzGIhPAOaJcKwwmdTg+w=";
+    hash = "sha256-SA0y5ooqfDaoVlXzsHStG3uhBuyu9t9T2ej+49csizw=";
   };
 
   build-system = [
@@ -93,7 +93,12 @@ python3Packages.buildPythonApplication (finalAttrs: {
   '';
 
   passthru = {
-    updateScript = nix-update-script { };
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version-regex"
+        "^([0-9.]+)$"
+      ];
+    };
   };
 
   meta = {


### PR DESCRIPTION
https://github.com/librelane/librelane/compare/3.0.2...3.0.3


R.RyanTM suggested 3.1.0.dev1 which we don't want hence the passthru update.

- Built on platform:
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
