### PR TITLE
rt: fix "Wide character in subroutine entry" crash on every request

### DIFF
--- a/pkgs/by-name/rt/rt/package.nix
+++ b/pkgs/by-name/rt/rt/package.nix
@@ -4,6 +4,7 @@
   autoreconfHook,
   buildEnv,
   fetchFromGitHub,
+  fetchpatch,
   perl,
   perlPackages,
   makeWrapper,
@@ -25,6 +26,12 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     ./dont-check-users_groups.patch # needed for "make testdeps" to work in the build
     ./override-generated.patch
+    # Fix "Wide character in subroutine entry" crash on every request
+    # merged upstream
+    (fetchpatch {
+      url = "https://github.com/bestpractical/rt/commit/f8f03dd6e69dfbf4eb71e3ded0f793af4721a06d.patch";
+      hash = "sha256-Mk8ve8n5tgyyHT7RAt2o+QnUlcYNOu95lNjku6VgXS0=";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes recent web request crashes:
```
[1454831] Wide character in subroutine entry at /nix/store/0j8rr63sfnpfkfbjwmbix0qn2gvj562n-rt-5.0.8/bin/../lib/RT/Squish.pm line 85.
                                         
                                         Stack:
                                           [/nix/store/0j8rr63sfnpfkfbjwmbix0qn2gvj562n-rt-5.0.8/bin/../lib/RT/Squish.pm:85]
                                           [/nix/store/0j8rr63sfnpfkfbjwmbix0qn2gvj562n-rt-5.0.8/bin/../lib/RT/Interface/Web.pm:113]
                                           [/nix/store/0j8rr63sfnpfkfbjwmbix0qn2gvj562n-rt-5.0.8/share/html/Elements/HeaderJavascript:72]
                                           [/nix/store/0j8rr63sfnpfkfbjwmbix0qn2gvj562n-rt-5.0.8/share/html/Elements/Header:95]
                                           [/nix/store/0j8rr63sfnpfkfbjwmbix0qn2gvj562n-rt-5.0.8/share/html/Elements/Login:49]
                                           [/nix/store/0j8rr63sfnpfkfbjwmbix0qn2gvj562n-rt-5.0.8/share/html/NoAuth/Login.html:56]
                                           [/nix/store/0j8rr63sfnpfkfbjwmbix0qn2gvj562n-rt-5.0.8/bin/../lib/RT/Interface/Web.pm:701]
                                           [/nix/store/0j8rr63sfnpfkfbjwmbix0qn2gvj562n-rt-5.0.8/bin/../lib/RT/Interface/Web.pm:410]
                                           [/nix/store/0j8rr63sfnpfkfbjwmbix0qn2gvj562n-rt-5.0.8/share/html/autohandler:53]
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
