### PR TITLE
visualvm: 2.2 -> 2.2.1

### DIFF
--- a/pkgs/by-name/vi/visualvm/package.nix
+++ b/pkgs/by-name/vi/visualvm/package.nix
@@ -8,14 +8,14 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "2.2";
+  version = "2.2.1";
   pname = "visualvm";
 
   src = fetchzip {
     url = "https://github.com/visualvm/visualvm.src/releases/download/${finalAttrs.version}/visualvm_${
       builtins.replaceStrings [ "." ] [ "" ] finalAttrs.version
     }.zip";
-    sha256 = "sha256-xEqzSNM5Mkt9SQ+23Edb2NMN/o8koBjhQWTGuyZ/0m4=";
+    sha256 = "sha256-4Ub14FKOp2toMMuIaWJZ2pvE34UJ4m++Psoh8KdCe2M=";
   };
 
   desktopItem = makeDesktopItem {


### PR DESCRIPTION
Upstream release notes: https://visualvm.github.io/relnotes.html
GitHub release: https://github.com/oracle/visualvm/releases/tag/2.2.1

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is sandboxing enabled in `nix.conf`?
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change
- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review`
- [x] Tested basic functionality of binary (`./result/bin/visualvm --help` runs and reports usage; full GUI not tested on headless aarch64)
- [ ] Added release notes entry (not applicable — minor version bump, no breaking changes)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)

###### nixpkgs-review

Result of `nixpkgs-review wip` on `aarch64-linux`:

```
1 package built:
  visualvm

0 packages failed to build
```