### PR TITLE
motus: init at 0.4.0

### DIFF
--- a/pkgs/by-name/mo/motus/package.nix
+++ b/pkgs/by-name/mo/motus/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  rustPlatform,
+  stdenv,
+  libxcb,
+  versionCheckHook,
+  withClipboard ? true,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "motus";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "oleiade";
+    repo = "motus";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-lMNXg6YYTxAycxOiVtBGrSHpccLwerIQcY25K/NkqMo=";
+  };
+
+  cargoHash = "sha256-6MKEHnB2MJVB4cNvz3JYlhuzxhzsA+Pq5OkpLNoAEyU=";
+
+  buildAndTestSubdir = "crates/motus-cli";
+
+  # The CLI crate version was not bumped to match the v0.4.0 release tag:
+  # https://github.com/oleiade/motus/issues/58
+  postPatch = ''
+    substituteInPlace crates/motus-cli/src/main.rs \
+      --replace-fail '#[command(version = "0.3.1")]' '#[command(version = "${finalAttrs.version}")]'
+  '';
+
+  buildNoDefaultFeatures = !withClipboard;
+
+  buildInputs = lib.optionals (withClipboard && stdenv.hostPlatform.isLinux) [ libxcb ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Dead simple password generator";
+    homepage = "https://github.com/oleiade/motus";
+    changelog = "https://github.com/oleiade/motus/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ britter ];
+    mainProgram = "motus";
+  };
+})


### PR DESCRIPTION
Adds [motus](https://github.com/oleiade/motus), a dead simple password generator inspired by 1Password's password generator. It supports generating memorable passphrases, random passwords, and PIN codes, with optional clipboard integration.

Note: there is a version mismatch between the `v0.4.0` release tag and the CLI crate version (`0.3.1`). This is a known upstream issue tracked at https://github.com/oleiade/motus/issues/58.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test