### PR TITLE
sshp: init at 1.1.4

### DIFF
--- a/pkgs/by-name/ss/sshp/package.nix
+++ b/pkgs/by-name/ss/sshp/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sshp";
+  version = "1.1.3";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "bahamas10";
+    repo = "sshp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-E7nt+t1CS51YG16371LEPtQxHTJ54Ak+r0LP0erC9Mk=";
+  };
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp sshp $out/bin/
+
+    mkdir -p $man/share/man/man1
+    cp man/sshp.1 $man/share/man/man1/
+  '';
+
+  meta = {
+    description = "Parallel SSH Executor";
+    mainProgram = "sshp";
+    longDescription = ''
+      sshp manages multiple ssh processes and handles coalescing the output to the terminal.
+      By default, sshp will read a file of newline-separated hostnames or IPs and fork ssh
+      subprocesses for them, redirecting the stdout and stderr streams of the child
+      line-by-line to stdout of sshp itself.
+    '';
+    homepage = "https://github.com/bahamas10/sshp";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ theCapypara ];
+  };
+})

--- a/pkgs/by-name/ss/sshp/package.nix
+++ b/pkgs/by-name/ss/sshp/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  installShellFiles,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sshp";
+  version = "1.1.4";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "bahamas10";
+    repo = "sshp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-4DrNGQQ1ETKuLiB3N+3KnRxx4BEhrCOgskpowbF/KWc=";
+  };
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D sshp "$out/bin/sshp"
+    installManPage man/sshp.1
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Parallel SSH Executor";
+    mainProgram = "sshp";
+    longDescription = ''
+      sshp manages multiple ssh processes and handles coalescing the output to the terminal.
+      By default, sshp will read a file of newline-separated hostnames or IPs and fork ssh
+      subprocesses for them, redirecting the stdout and stderr streams of the child
+      line-by-line to stdout of sshp itself.
+    '';
+    homepage = "https://github.com/bahamas10/sshp";
+    license = lib.licenses.mit;
+    platforms = with lib.platforms; linux ++ darwin ++ freebsd;
+    maintainers = with lib.maintainers; [ theCapypara ];
+  };
+})


### PR DESCRIPTION
This adds https://github.com/bahamas10/sshp

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
