### PR TITLE
libfrida-core: 17.9.1 -> 17.15.3

### DIFF
--- a/pkgs/by-name/li/libfrida-core/package.nix
+++ b/pkgs/by-name/li/libfrida-core/package.nix
@@ -2,39 +2,18 @@
   lib,
   stdenvNoCC,
   fetchurl,
-  nix-update-script,
+  writeShellScript,
+  curl,
+  jq,
+  common-updater-scripts,
 }:
-let
-  inherit (stdenvNoCC.hostPlatform) system;
-  version = "17.9.5";
-  source =
-    {
-      x86_64-linux = {
-        url = "https://github.com/frida/frida/releases/download/${version}/frida-core-devkit-${version}-linux-x86_64.tar.xz";
-        hash = "sha256-6YgD9srSHEGhtn6qSVljlVr6tu166VoY3EhashiLsCE=";
-      };
-      aarch64-linux = {
-        url = "https://github.com/frida/frida/releases/download/${version}/frida-core-devkit-${version}-linux-arm64.tar.xz";
-        hash = "sha256-h4VPdfiz+a13mVIaL4YYTxhCsVJZh/u1t9fhGT95e7M=";
-      };
-      x86_64-darwin = {
-        url = "https://github.com/frida/frida/releases/download/${version}/frida-core-devkit-${version}-macos-x86_64.tar.xz";
-        hash = "sha256-y/IYH+qEtgiFgxdGZ1O9J01EYDOTGue2O3X7U5d8e8E=";
-      };
-      aarch64-darwin = {
-        url = "https://github.com/frida/frida/releases/download/${version}/frida-core-devkit-${version}-macos-arm64.tar.xz";
-        hash = "sha256-my5OQgYEx8mSnPfk3UtM20wc0Q5hnAuCkOohoRjOgu4=";
-      };
-    }
-    .${system} or (throw "Unsupported system: ${system}");
-in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "libfrida-core";
-  inherit version;
+  version = "17.9.5";
 
-  src = fetchurl {
-    inherit (source) url hash;
-  };
+  src =
+    finalAttrs.passthru.sources.${stdenvNoCC.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
   dontUnpack = true;
 
   installPhase = ''
@@ -46,7 +25,44 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    sources = {
+      x86_64-linux = fetchurl {
+        url = "https://github.com/frida/frida/releases/download/${finalAttrs.version}/frida-core-devkit-${finalAttrs.version}-linux-x86_64.tar.xz";
+        hash = "sha256-6YgD9srSHEGhtn6qSVljlVr6tu166VoY3EhashiLsCE=";
+      };
+      aarch64-linux = fetchurl {
+        url = "https://github.com/frida/frida/releases/download/${finalAttrs.version}/frida-core-devkit-${finalAttrs.version}-linux-arm64.tar.xz";
+        hash = "sha256-h4VPdfiz+a13mVIaL4YYTxhCsVJZh/u1t9fhGT95e7M=";
+      };
+      x86_64-darwin = fetchurl {
+        url = "https://github.com/frida/frida/releases/download/${finalAttrs.version}/frida-core-devkit-${finalAttrs.version}-macos-x86_64.tar.xz";
+        hash = "sha256-y/IYH+qEtgiFgxdGZ1O9J01EYDOTGue2O3X7U5d8e8E=";
+      };
+      aarch64-darwin = fetchurl {
+        url = "https://github.com/frida/frida/releases/download/${finalAttrs.version}/frida-core-devkit-${finalAttrs.version}-macos-arm64.tar.xz";
+        hash = "sha256-my5OQgYEx8mSnPfk3UtM20wc0Q5hnAuCkOohoRjOgu4=";
+      };
+    };
+    updateScript = writeShellScript "update-libfrida-core" ''
+      set -o errexit
+      export PATH="${
+        lib.makeBinPath [
+          curl
+          jq
+          common-updater-scripts
+        ]
+      }"
+      NEW_VERSION=$(curl --silent ''${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} https://api.github.com/repos/frida/frida/releases/latest | jq '.tag_name' --raw-output)
+      if [[ "${finalAttrs.version}" = "$NEW_VERSION" ]]; then
+        echo "The new version is the same as the old version."
+        exit 0
+      fi
+      for platform in ${lib.escapeShellArgs finalAttrs.meta.platforms}; do
+        update-source-version "libfrida-core" "$NEW_VERSION" --ignore-same-version --source-key="sources.$platform"
+      done
+    '';
+  };
 
   meta = {
     description = "Frida core library intended for static linking into bindings";
@@ -54,12 +70,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     changelog = "https://frida.re/news/";
     license = lib.licenses.wxWindowsException31;
     maintainers = with lib.maintainers; [ nilathedragon ];
-    platforms = [
-      "x86_64-linux"
-      "aarch64-linux"
-      "x86_64-darwin"
-      "aarch64-darwin"
-    ];
+    platforms = builtins.attrNames finalAttrs.passthru.sources;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
 })

--- a/pkgs/by-name/li/libfrida-core/package.nix
+++ b/pkgs/by-name/li/libfrida-core/package.nix
@@ -6,24 +6,24 @@
 }:
 let
   inherit (stdenvNoCC.hostPlatform) system;
-  version = "17.9.1";
+  version = "17.9.5";
   source =
     {
       x86_64-linux = {
         url = "https://github.com/frida/frida/releases/download/${version}/frida-core-devkit-${version}-linux-x86_64.tar.xz";
-        hash = "sha256-94Zk7onepdNVEeDb+Vn4h680UoXCZPeZW+eGpaUrnwI=";
+        hash = "sha256-6YgD9srSHEGhtn6qSVljlVr6tu166VoY3EhashiLsCE=";
       };
       aarch64-linux = {
         url = "https://github.com/frida/frida/releases/download/${version}/frida-core-devkit-${version}-linux-arm64.tar.xz";
-        hash = "sha256-o9kJvxqHICzuFItPj6r76D8aEEF/8QsRwJvE4oxphfA=";
+        hash = "sha256-h4VPdfiz+a13mVIaL4YYTxhCsVJZh/u1t9fhGT95e7M=";
       };
       x86_64-darwin = {
         url = "https://github.com/frida/frida/releases/download/${version}/frida-core-devkit-${version}-macos-x86_64.tar.xz";
-        hash = "sha256-9W6o5giLSR/5bWsgRTMHI3GS7565Nkdb2kZCIm5V/cQ=";
+        hash = "sha256-y/IYH+qEtgiFgxdGZ1O9J01EYDOTGue2O3X7U5d8e8E=";
       };
       aarch64-darwin = {
         url = "https://github.com/frida/frida/releases/download/${version}/frida-core-devkit-${version}-macos-arm64.tar.xz";
-        hash = "sha256-bTxBvz+wpdNGUDHTFB1nN1UroMC3Bi2H/bzTVSCeMno=";
+        hash = "sha256-my5OQgYEx8mSnPfk3UtM20wc0Q5hnAuCkOohoRjOgu4=";
       };
     }
     .${system} or (throw "Unsupported system: ${system}");

--- a/pkgs/by-name/li/libfrida-core/package.nix
+++ b/pkgs/by-name/li/libfrida-core/package.nix
@@ -2,39 +2,18 @@
   lib,
   stdenvNoCC,
   fetchurl,
-  nix-update-script,
+  writeShellScript,
+  curl,
+  jq,
+  common-updater-scripts,
 }:
-let
-  inherit (stdenvNoCC.hostPlatform) system;
-  version = "17.15.3";
-  source =
-    {
-      x86_64-linux = {
-        url = "https://github.com/frida/frida/releases/download/${version}/frida-core-devkit-${version}-linux-x86_64.tar.xz";
-        hash = "sha256-cZKRmpJKv5I8Bjdi44vkRT424Lx8X71E8suHMJRKMVg=";
-      };
-      aarch64-linux = {
-        url = "https://github.com/frida/frida/releases/download/${version}/frida-core-devkit-${version}-linux-arm64.tar.xz";
-        hash = "sha256-av/exxhssyZgvLvlJsvxqTOymRLNu5eXl8zTv1rsLN0=";
-      };
-      x86_64-darwin = {
-        url = "https://github.com/frida/frida/releases/download/${version}/frida-core-devkit-${version}-macos-x86_64.tar.xz";
-        hash = "sha256-slmk8Zbk329pMscVWPXOi9G793wXquFuVBWLH2yuiYE=";
-      };
-      aarch64-darwin = {
-        url = "https://github.com/frida/frida/releases/download/${version}/frida-core-devkit-${version}-macos-arm64.tar.xz";
-        hash = "sha256-X65oBfz/yC92CHVIOg5ZAZwlAMgUQ/6MpBfi5uBLirg=";
-      };
-    }
-    .${system} or (throw "Unsupported system: ${system}");
-in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "libfrida-core";
-  inherit version;
+  version = "17.15.3";
 
-  src = fetchurl {
-    inherit (source) url hash;
-  };
+  src =
+    finalAttrs.passthru.sources.${stdenvNoCC.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
   dontUnpack = true;
 
   installPhase = ''
@@ -46,7 +25,44 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    sources = {
+      x86_64-linux = fetchurl {
+        url = "https://github.com/frida/frida/releases/download/${finalAttrs.version}/frida-core-devkit-${finalAttrs.version}-linux-x86_64.tar.xz";
+        hash = "sha256-cZKRmpJKv5I8Bjdi44vkRT424Lx8X71E8suHMJRKMVg=";
+      };
+      aarch64-linux = fetchurl {
+        url = "https://github.com/frida/frida/releases/download/${finalAttrs.version}/frida-core-devkit-${finalAttrs.version}-linux-arm64.tar.xz";
+        hash = "sha256-av/exxhssyZgvLvlJsvxqTOymRLNu5eXl8zTv1rsLN0=";
+      };
+      x86_64-darwin = fetchurl {
+        url = "https://github.com/frida/frida/releases/download/${finalAttrs.version}/frida-core-devkit-${finalAttrs.version}-macos-x86_64.tar.xz";
+        hash = "sha256-slmk8Zbk329pMscVWPXOi9G793wXquFuVBWLH2yuiYE=";
+      };
+      aarch64-darwin = fetchurl {
+        url = "https://github.com/frida/frida/releases/download/${finalAttrs.version}/frida-core-devkit-${finalAttrs.version}-macos-arm64.tar.xz";
+        hash = "sha256-X65oBfz/yC92CHVIOg5ZAZwlAMgUQ/6MpBfi5uBLirg=";
+      };
+    };
+    updateScript = writeShellScript "update-libfrida-core" ''
+      set -o errexit
+      export PATH="${
+        lib.makeBinPath [
+          curl
+          jq
+          common-updater-scripts
+        ]
+      }"
+      NEW_VERSION=$(curl --silent ''${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} https://api.github.com/repos/frida/frida/releases/latest | jq '.tag_name' --raw-output)
+      if [[ "${finalAttrs.version}" = "$NEW_VERSION" ]]; then
+        echo "The new version is the same as the old version."
+        exit 0
+      fi
+      for platform in ${lib.escapeShellArgs finalAttrs.meta.platforms}; do
+        update-source-version "libfrida-core" "$NEW_VERSION" --ignore-same-version --source-key="sources.$platform"
+      done
+    '';
+  };
 
   meta = {
     description = "Frida core library intended for static linking into bindings";
@@ -54,12 +70,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     changelog = "https://frida.re/news/";
     license = lib.licenses.wxWindowsException31;
     maintainers = with lib.maintainers; [ nilathedragon ];
-    platforms = [
-      "x86_64-linux"
-      "aarch64-linux"
-      "x86_64-darwin"
-      "aarch64-darwin"
-    ];
+    platforms = builtins.attrNames finalAttrs.passthru.sources;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
 })

--- a/pkgs/by-name/li/libfrida-core/package.nix
+++ b/pkgs/by-name/li/libfrida-core/package.nix
@@ -6,24 +6,24 @@
 }:
 let
   inherit (stdenvNoCC.hostPlatform) system;
-  version = "17.9.1";
+  version = "17.15.3";
   source =
     {
       x86_64-linux = {
         url = "https://github.com/frida/frida/releases/download/${version}/frida-core-devkit-${version}-linux-x86_64.tar.xz";
-        hash = "sha256-94Zk7onepdNVEeDb+Vn4h680UoXCZPeZW+eGpaUrnwI=";
+        hash = "sha256-cZKRmpJKv5I8Bjdi44vkRT424Lx8X71E8suHMJRKMVg=";
       };
       aarch64-linux = {
         url = "https://github.com/frida/frida/releases/download/${version}/frida-core-devkit-${version}-linux-arm64.tar.xz";
-        hash = "sha256-o9kJvxqHICzuFItPj6r76D8aEEF/8QsRwJvE4oxphfA=";
+        hash = "sha256-av/exxhssyZgvLvlJsvxqTOymRLNu5eXl8zTv1rsLN0=";
       };
       x86_64-darwin = {
         url = "https://github.com/frida/frida/releases/download/${version}/frida-core-devkit-${version}-macos-x86_64.tar.xz";
-        hash = "sha256-9W6o5giLSR/5bWsgRTMHI3GS7565Nkdb2kZCIm5V/cQ=";
+        hash = "sha256-slmk8Zbk329pMscVWPXOi9G793wXquFuVBWLH2yuiYE=";
       };
       aarch64-darwin = {
         url = "https://github.com/frida/frida/releases/download/${version}/frida-core-devkit-${version}-macos-arm64.tar.xz";
-        hash = "sha256-bTxBvz+wpdNGUDHTFB1nN1UroMC3Bi2H/bzTVSCeMno=";
+        hash = "sha256-X65oBfz/yC92CHVIOg5ZAZwlAMgUQ/6MpBfi5uBLirg=";
       };
     }
     .${system} or (throw "Unsupported system: ${system}");


### PR DESCRIPTION
## Things done
Changelog: https://frida.re/news/2026/06/22/frida-17-15-3-released/

This PR has two parts to it:
1. Update the hashes for the update
2. Refactoring the update script so [r-ryantm](https://github.com/r-ryantm) can correctly update the hashes for all platforms in the future (It tried to only update one in this PR here #515277)

For the refactor I took inspiration from the bun package.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
