### PR TITLE
hof: fix build with Go 1.26

### DIFF
--- a/pkgs/by-name/ho/hof/go-testdeps-modulepath.patch
+++ b/pkgs/by-name/ho/hof/go-testdeps-modulepath.patch
@@ -1,0 +1,14 @@
+diff --git a/script/runtime/exe.go b/script/runtime/exe.go
+index d15bf50f..66f784a4 100644
+--- a/script/runtime/exe.go
++++ b/script/runtime/exe.go
+@@ -140,6 +140,9 @@ func (nopTestDeps) WriteProfileTo(name string, w io.Writer, debug int) error {
+ func (nopTestDeps) ImportPath() string {
+ 	return ""
+ }
++func (nopTestDeps) ModulePath() string {
++	return ""
++}
+ func (nopTestDeps) StartTestLog(w io.Writer) {}
+ 
+ func (nopTestDeps) StopTestLog() error {

--- a/pkgs/by-name/ho/hof/package.nix
+++ b/pkgs/by-name/ho/hof/package.nix
@@ -17,6 +17,11 @@ buildGoModule (finalAttrs: {
     hash = "sha256-okc11mXqB/PaXd0vsRuIIL70qWSFprvsZJtE6PvCaIg=";
   };
 
+  patches = [
+    # https://github.com/hofstadter-io/hof/pull/411
+    ./go-testdeps-modulepath.patch
+  ];
+
   nativeBuildInputs = [ installShellFiles ];
 
   vendorHash = "sha256-mLOWnHzKw/B+jFNuswejEnYbPxFkk95I/BWeHRTH55I=";


### PR DESCRIPTION
Hydra Failure (Click the banner to go to Hydra build report):

[![](https://hydra-banner.harinn.dev/build/327015796)](https://hydra.nixos.org/build/327015796)

ZHF: #516381 (Part of)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
