### PR TITLE
anytype-cli: init at 0.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28453,6 +28453,14 @@
     github = "wamserma";
     githubId = 60148;
   };
+  wanderer = {
+    name = "Martin Becze";
+    email = "martin@becze.org";
+    matrix = "@null_radix:matrix.org";
+    github = "wanderer";
+    githubId = 158211;
+    keys = [ { fingerprint = "82CB 91F4 F3E4 04A5 DAB2  78E8 8B99 1293 8FF2 1020"; } ];
+  };
   wariuccio = {
     name = "Wariuccio";
     github = "wariuccio";

--- a/pkgs/by-name/an/anytype-cli/package.nix
+++ b/pkgs/by-name/an/anytype-cli/package.nix
@@ -7,7 +7,7 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "anytype-cli";
-  version = "0.1.14";
+  version = "0.2.3";
 
   src = fetchFromGitHub {
     owner = "anyproto";

--- a/pkgs/by-name/an/anytype-cli/package.nix
+++ b/pkgs/by-name/an/anytype-cli/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  tantivy-go,
+}:
+buildGoModule (finalAttrs: {
+  pname = "anytype-cli";
+  version = "0.1.14";
+
+  src = fetchFromGitHub {
+    owner = "anyproto";
+    repo = "anytype-cli";
+    rev = "187c066c080c0ef4d535aeb7ec23370f15ed17e3";
+    hash = "sha256-xbukPdGXtITO3GtQz+7zz1o/k5rjtVqy42yINANPKUk=";
+  };
+
+  vendorHash = "sha256-PxD+2flqelGFMCrpRU6iOEasMf24YKkoPd0gUSowQwA=";
+  proxyVendor = true;
+
+  env.CGO_ENABLED = 1;
+  env.CGO_LDFLAGS = "-L${tantivy-go}/lib";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/anyproto/anytype-cli/core.Version=v${finalAttrs.version}"
+  ];
+
+  doCheck = false;
+
+  postInstall = ''
+    ln -s $out/bin/anytype-cli $out/bin/anytype
+    ln -s $out/bin/anytype-cli $out/bin/any
+  '';
+
+  meta = with lib; {
+    description = "Command-line interface for interacting with Anytype";
+    homepage = "https://github.com/anyproto/anytype-cli";
+    license = licenses.mit;
+    mainProgram = "anytype";
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+})

--- a/pkgs/by-name/an/anytype-cli/package.nix
+++ b/pkgs/by-name/an/anytype-cli/package.nix
@@ -28,18 +28,11 @@ buildGoModule (finalAttrs: {
     "-X github.com/anyproto/anytype-cli/core.Version=v${finalAttrs.version}"
   ];
 
-  doCheck = false;
-
-  postInstall = ''
-    ln -s $out/bin/anytype-cli $out/bin/anytype
-    ln -s $out/bin/anytype-cli $out/bin/any
-  '';
-
   meta = with lib; {
     description = "Command-line interface for interacting with Anytype";
     homepage = "https://github.com/anyproto/anytype-cli";
     license = licenses.mit;
-    mainProgram = "anytype";
+    mainProgram = "anytype-cli";
     platforms = platforms.linux ++ platforms.darwin;
   };
 })

--- a/pkgs/by-name/an/anytype-cli/package.nix
+++ b/pkgs/by-name/an/anytype-cli/package.nix
@@ -6,6 +6,8 @@
   tantivy-go,
 }:
 buildGoModule (finalAttrs: {
+  __structuredAttrs = true;
+
   pname = "anytype-cli";
   version = "0.2.3";
 

--- a/pkgs/by-name/an/anytype-cli/package.nix
+++ b/pkgs/by-name/an/anytype-cli/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  tantivy-go,
+}:
+buildGoModule (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "anytype-cli";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "anyproto";
+    repo = "anytype-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9jJ4FV4ASUrhUvW/lI4qs7AmK06OkPfnD0+okl5blrs=";
+  };
+
+  vendorHash = "sha256-7J/nW4Jn2vdAs8sN+rV3wg6nV3JhtQrnLwlxNI0uja0=";
+  proxyVendor = true;
+
+  env.CGO_ENABLED = 1;
+  env.CGO_LDFLAGS = "-L${tantivy-go}/lib";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/anyproto/anytype-cli/core.Version=v${finalAttrs.version}"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Command-line interface for interacting with Anytype";
+    homepage = "https://github.com/anyproto/anytype-cli";
+    changelog = "https://github.com/anyproto/anytype-cli/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    mainProgram = "anytype-cli";
+    maintainers = with lib.maintainers; [
+      adda
+      wanderer
+    ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
## Summary

Add `anytype-cli`, a command-line interface for interacting with Anytype.

https://github.com/anyproto/anytype-cli

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.