### PR TITLE
openldap: skip flaky test017-syncreplication-refresh

### DIFF
--- a/pkgs/by-name/op/openldap/package.nix
+++ b/pkgs/by-name/op/openldap/package.nix
@@ -122,6 +122,10 @@ stdenv.mkDerivation (finalAttrs: {
     # https://bugs.openldap.org/show_bug.cgi?id=8623
     rm -f tests/scripts/test022-ppolicy
 
+    # syncreplication timing-sensitive test, fails on slow/sandboxed builders
+    # https://github.com/NixOS/nixpkgs/issues/516392
+    rm -f tests/scripts/test017-syncreplication-refresh
+
     rm -f tests/scripts/test063-delta-multiprovider
 
     # https://bugs.openldap.org/show_bug.cgi?id=10009


### PR DESCRIPTION
# Description

`test017-syncreplication-refresh` is a timing-sensitive test that fails non-deterministically on slow or sandboxed build hosts. It causes a cascade of failures for packages that depend on openldap, most notably `lutris`, `bottles`, and wine-related FHS envs — all critical for gaming on NixOS.

The existing `preCheck` already skips other known flaky tests (`test022-ppolicy`, `test063-delta-multiprovider`, `test076-authid-rewrite`). This adds `test017` to that list.

The test failure:
```
test failed - provider and consumer databases differ
>>>>> Failed   test017-syncreplication-refresh for mdb after 38 seconds
```

Fixes: https://github.com/NixOS/nixpkgs/issues/516392

# Checklist

- [x] Tested the build: `nix build .#openldap` (skipping test produces a successful build)
- [x] Referenced upstream issue in comment