### PR TITLE
gpu-burn: better cudaCapability selection

### DIFF
--- a/pkgs/by-name/gp/gpu-burn/package.nix
+++ b/pkgs/by-name/gp/gpu-burn/package.nix
@@ -18,6 +18,16 @@ let
     libcublas
     ;
   inherit (cudaPackages.flags) cudaCapabilities dropDots isJetsonBuild;
+  cudaCapability = lib.pipe cudaCapabilities [
+    # Filter out *a variants since gpu-burn doesn't use them
+    (builtins.filter (c: !lib.hasSuffix "a" c))
+
+    # 9.0 -> 90
+    (map dropDots)
+
+    # gpu-burn targets a single capability, so pick the last one in the list
+    last
+  ];
 in
 backendStdenv.mkDerivation {
   pname = "gpu-burn";
@@ -58,7 +68,7 @@ backendStdenv.mkDerivation {
   makeFlags = [
     # NOTE: CUDAPATH assumes cuda_cudart is a single output containing all of lib, dev, and stubs.
     "CUDAPATH=${cuda_cudart}"
-    "COMPUTE=${last (map dropDots cudaCapabilities)}"
+    "COMPUTE=${cudaCapability}"
     "IS_JETSON=${boolToString isJetsonBuild}"
   ];
 
@@ -70,8 +80,11 @@ backendStdenv.mkDerivation {
     runHook postInstall
   '';
 
-  passthru.updateScript = nix-update-script {
-    extraArgs = [ "--version=branch" ];
+  passthru = {
+    inherit cudaCapability;
+    updateScript = nix-update-script {
+      extraArgs = [ "--version=branch" ];
+    };
   };
 
   # NOTE: Certain packages may be missing from cudaPackages on non-Linux platforms. To avoid evaluation failure,

--- a/pkgs/by-name/gp/gpu-burn/package.nix
+++ b/pkgs/by-name/gp/gpu-burn/package.nix
@@ -1,13 +1,15 @@
 {
   lib,
   autoAddDriverRunpath,
-  config,
   cudaPackages,
   fetchFromGitHub,
   nix-update-script,
+
+  config,
+  cudaCapabilities ? cudaPackages.flags.cudaCapabilities,
 }:
 let
-  inherit (lib.lists) last map optionals;
+  inherit (lib.lists) head map optionals;
   inherit (lib.trivial) boolToString;
   inherit (config) cudaSupport;
   inherit (cudaPackages)
@@ -17,7 +19,17 @@ let
     cuda_nvcc
     libcublas
     ;
-  inherit (cudaPackages.flags) cudaCapabilities dropDots isJetsonBuild;
+  inherit (cudaPackages.flags) dropDots isJetsonBuild;
+  cudaCapability = lib.pipe cudaCapabilities [
+    # Filter out *a variants since gpu-burn doesn't use them
+    (builtins.filter (c: !lib.hasSuffix "a" c))
+
+    # 9.0 -> 90
+    (map dropDots)
+
+    # gpu-burn targets a single capability, so pick the first one in the list
+    head
+  ];
 in
 backendStdenv.mkDerivation {
   pname = "gpu-burn";
@@ -58,7 +70,7 @@ backendStdenv.mkDerivation {
   makeFlags = [
     # NOTE: CUDAPATH assumes cuda_cudart is a single output containing all of lib, dev, and stubs.
     "CUDAPATH=${cuda_cudart}"
-    "COMPUTE=${last (map dropDots cudaCapabilities)}"
+    "COMPUTE=${cudaCapability}"
     "IS_JETSON=${boolToString isJetsonBuild}"
   ];
 
@@ -70,8 +82,11 @@ backendStdenv.mkDerivation {
     runHook postInstall
   '';
 
-  passthru.updateScript = nix-update-script {
-    extraArgs = [ "--version=branch" ];
+  passthru = {
+    inherit cudaCapability;
+    updateScript = nix-update-script {
+      extraArgs = [ "--version=branch" ];
+    };
   };
 
   # NOTE: Certain packages may be missing from cudaPackages on non-Linux platforms. To avoid evaluation failure,


### PR DESCRIPTION
## Things done

Right now, when building with `cudaCapabilities = [ "9.0" "9.0a" ]`, gpu-burn is set to target `9.0a` which makes the resulting binary unnecessarily fragile.

The `*a` suffix denotes an architecture-specific target: it unlocks Hopper-exclusive instructions and, in exchange, gives up forward compatibility and tightens the coupling between the PTX produced and the host driver's JIT compiler.
Libraries like CUTLASS 3.x and FlashAttention-3 genuinely need `sm_90a`.
gpu-burn does not: it's a plain stress loop with no Hopper-specific intrinsics, so building it against `sm_90a` provides zero performance benefit while introducing real failure modes.

cc @NixOS/cuda-maintainers 

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
