### PR TITLE
openrefine: 3.9.5 -> 3.10.1

### DIFF
--- a/pkgs/by-name/op/openrefine/package.nix
+++ b/pkgs/by-name/op/openrefine/package.nix
@@ -4,14 +4,13 @@
   fetchFromGitHub,
   buildNpmPackage,
   curl,
-  jdk17,
+  jdk,
   jq,
   makeWrapper,
   maven,
 }:
 
 let
-  jdk = jdk17;
   version = "3.10.1";
   src = fetchFromGitHub {
     owner = "openrefine";

--- a/pkgs/by-name/op/openrefine/package.nix
+++ b/pkgs/by-name/op/openrefine/package.nix
@@ -12,12 +12,12 @@
 
 let
   jdk = jdk17;
-  version = "3.9.5";
+  version = "3.10.1";
   src = fetchFromGitHub {
     owner = "openrefine";
     repo = "openrefine";
     rev = version;
-    hash = "sha256-548vOJf0mlk1AuuMjEXpsiVjft6UbJrUxh5mSca8Xbw=";
+    hash = "sha256-MyJlFTtdab9vpv135px/YskREXzQN5GA2ebAQGLnPu0=";
   };
 
   npmPkg = buildNpmPackage {
@@ -45,7 +45,7 @@ let
   };
 
 in
-maven.buildMavenPackage {
+maven.buildMavenPackage rec {
   inherit src version;
 
   pname = "openrefine";
@@ -56,7 +56,15 @@ maven.buildMavenPackage {
 
   mvnJdk = jdk;
   mvnParameters = "-pl !packaging";
-  mvnHash = "sha256-SV5nfyUeyRul/YfZZXor8O37ARdCtKkrHCLzQrmr96s=";
+  mvnHash = "sha256-BQnZkyftdqf3UoWddyve7wP3U3cDbATYqopJhwsP/gY=";
+  mvnFetchExtraArgs.env = {
+    inherit (env) SOURCE_DATE_EPOCH;
+  };
+
+  env = {
+    # fix for "date 1980-01-01T00:00:00Z is not within the valid range 1980-01-01T00:00:02Z to 2099-12-31T23:59:59Z"
+    SOURCE_DATE_EPOCH = "315532802"; # 1980-01-01T00:00:02Z
+  };
 
   nativeBuildInputs = [ makeWrapper ];
 


### PR DESCRIPTION
This required a `SOURCE_DATE_EPOCH` fix I cribbed from the `cryptomator` package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
