### PR TITLE
turn-rs: 4.0.1 -> 4.1.2

### DIFF
--- a/nixos/tests/turn-rs.nix
+++ b/nixos/tests/turn-rs.nix
@@ -23,23 +23,23 @@
           USER_1_CREDS="foobar"
         '';
         settings = {
-          turn = {
+          server = {
             realm = "localhost";
             interfaces = [
               {
                 transport = "udp";
-                bind = "127.0.0.1:3478";
+                listen = "127.0.0.1:3478";
                 external = "127.0.0.1:3478";
               }
               {
                 transport = "tcp";
-                bind = "127.0.0.1:3478";
+                listen = "127.0.0.1:3478";
                 external = "127.0.0.1:3478";
               }
             ];
           };
 
-          auth.static_credentials.user1 = "$USER_1_CREDS";
+          auth."static-credentials".user1 = "$USER_1_CREDS";
         };
       };
     };
@@ -47,15 +47,20 @@
 
   testScript = # python
     ''
-      import json
-
       start_all()
       server.wait_for_unit('turn-rs.service')
-      server.wait_for_open_port(3000, "127.0.0.1")
+      server.wait_for_open_port(3478, "127.0.0.1")
 
-      info = server.succeed('curl http://localhost:3000/info')
-      jsonInfo = json.loads(info)
-      assert len(jsonInfo['interfaces']) == 2, f'Interfaces doesn\'t contain two entries:\n{json.dumps(jsonInfo, indent=2)}'
+      base = (
+          "${pkgs.coturn}/bin/turnutils_uclient"
+          " -L 127.0.0.1 -e 127.0.0.1 -u user1 -w foobar -X -y -t"
+      )
+      for extra in ["", "-s", "-t", "-t -s"]:
+          out = server.succeed(f"{base} {extra} 127.0.0.1")
+          assert "ERROR" not in out, f"turnutils_uclient errors:\n{out}"
+          assert "Total lost packets 0 (0.000000%)" in out, (
+              f"turnutils_uclient reported packet loss or did not finish:\n{out}"
+          )
 
       config = server.succeed('cat /run/turn-rs/config.toml')
       assert 'foobar' in config, f'Secrets are not properly injected:\n{config}'

--- a/pkgs/by-name/tu/turn-rs/package.nix
+++ b/pkgs/by-name/tu/turn-rs/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   # Dependencies
   protobuf,
+  coturn,
   # Tests
   versionCheckHook,
   nix-update-script,
@@ -12,16 +13,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "turn-rs";
-  version = "4.0.1";
+  version = "4.1.2";
 
   src = fetchFromGitHub {
     owner = "mycrl";
     repo = "turn-rs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-CtDlkHHOkU0mwNiyP9PNw/40szBNKeGYvVep9Z/aoDg=";
+    hash = "sha256-YZPKcLePLX+Mdu4J31VNofiX/qCLjcxydc4iVhonhkU=";
   };
 
-  cargoHash = "sha256-x45GDuhxqoB/DZvccdzxBoS/7nnFvHtjkRgfM/LOOE8=";
+  cargoHash = "sha256-vvhj0B/KYdOeddALh38MvAwrg8sIAIlEzTj0yFNEjFk=";
 
   # By default, no features are enabled
   # https://github.com/mycrl/turn-rs?tab=readme-ov-file#features-1
@@ -30,6 +31,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeBuildInputs = [
     protobuf
   ];
+
+  # Fix coturn needed
+  nativeCheckInputs = [ coturn ];
+  env.COTURN_UCLIENT_PATH = lib.getExe' coturn "turnutils_uclient";
 
   nativeInstallCheckInputs = [
     versionCheckHook


### PR DESCRIPTION
Diff : https://github.com/mycrl/turn-rs/compare/v4.0.1...v4.1.2
Changelog : https://github.com/mycrl/turn-rs/releases/tag/v4.1.2
Related to : https://github.com/NixOS/nixpkgs/issues/516381
Hydra : https://hydra.nixos.org/build/327803702

Fix nixosTests.turn-rs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
