### PR TITLE
mew: 1.0-unstable-2025-06-20 -> 1.0-unstable-2026-03-18; fix build

### DIFF
--- a/pkgs/by-name/me/mew/package.nix
+++ b/pkgs/by-name/me/mew/package.nix
@@ -43,6 +43,8 @@ stdenv.mkDerivation {
     "PREFIX=$(out)"
   ];
 
+  patches = [ ./typed-wayland-listeners.patch ];
+
   postFixup = ''
     substituteInPlace $out/bin/mew-run \
       --replace-fail \

--- a/pkgs/by-name/me/mew/package.nix
+++ b/pkgs/by-name/me/mew/package.nix
@@ -16,13 +16,13 @@
 }:
 stdenv.mkDerivation {
   pname = "mew";
-  version = "1.0-unstable-2025-06-20";
+  version = "1.0-unstable-2026-03-18";
 
   src = fetchFromCodeberg {
     owner = "sewn";
     repo = "mew";
-    rev = "af6440da8fe6683cf0b873e0a98c293bf02c3447";
-    hash = "sha256-NbpYITHO81fnaDY0dtolaUBdRqQNKwHQz/lBQMOHM5c=";
+    rev = "98dea211e634ccc2f75b4dae09fc2705666c6322";
+    hash = "sha256-u0TBWPBOdXNYwuwn9U1xqJsUShyOz9MIP1CNozcxbzg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/me/mew/typed-wayland-listeners.patch
+++ b/pkgs/by-name/me/mew/typed-wayland-listeners.patch
@@ -1,0 +1,70 @@
+--- a/mew.c
++++ b/mew.c
+@@ -768,7 +768,7 @@
+ 
+ static const struct wl_keyboard_listener keyboard_listener = {
+ 	.keymap = keyboard_handle_keymap,
+-	.enter = noop,
++	.enter = NULL,
+ 	.leave = keyboard_handle_leave,
+ 	.key = keyboard_handle_key,
+ 	.modifiers = keyboard_handle_modifiers,
+@@ -816,10 +816,10 @@
+ }
+ 
+ static const struct wl_surface_listener surface_listener = {
+-	.enter = noop,
+-	.leave = noop,
++	.enter = NULL,
++	.leave = NULL,
+ 	.preferred_buffer_scale = surface_handle_preferred_scale,
+-	.preferred_buffer_transform = noop,
++	.preferred_buffer_transform = NULL,
+ };
+ 
+ static void
+@@ -833,7 +833,7 @@
+ }
+ 
+ static const struct wl_data_device_listener data_device_listener = {
+-	.data_offer = noop,
++	.data_offer = NULL,
+ 	.selection = data_device_handle_selection,
+ };
+ 
+@@ -847,12 +847,12 @@
+ }
+ 
+ static const struct wl_output_listener output_listener = {
+-	.geometry = noop,
+-	.mode = noop,
+-	.done = noop,
+-	.scale = noop,
++	.geometry = NULL,
++	.mode = NULL,
++	.done = NULL,
++	.scale = NULL,
+ 	.name = output_handle_name,
+-	.description = noop,
++	.description = NULL,
+ };
+ 
+ static void
+@@ -871,7 +871,7 @@
+ 
+ static const struct wl_seat_listener seat_listener = {
+ 	.capabilities = seat_handle_capabilities,
+-	.name = noop,
++	.name = NULL,
+ };
+ 
+ static void
+@@ -902,7 +902,7 @@
+ 
+ static const struct wl_registry_listener registry_listener = {
+ 	.global = registry_handle_global,
+-	.global_remove = noop,
++	.global_remove = NULL,
+ };
+ 
+ static void


### PR DESCRIPTION
Diff: https://codeberg.org/sewn/mew/compare/af6440da8fe6683cf0b873e0a98c293bf02c3447...98dea211e634ccc2f75b4dae09fc2705666c6322
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327043956)](https://hydra.nixos.org/build/327043956)

Closes: #515581
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
