### PR TITLE
reitti: init at 4.0.5

### DIFF
--- a/pkgs/by-name/re/reitti/package.nix
+++ b/pkgs/by-name/re/reitti/package.nix
@@ -8,6 +8,8 @@
   makeWrapper,
 }:
 maven.buildMavenPackage {
+  __structuredAttrs = true;
+
   pname = "reitti";
   version = "3.4.1";
 

--- a/pkgs/by-name/re/reitti/package.nix
+++ b/pkgs/by-name/re/reitti/package.nix
@@ -7,18 +7,18 @@
   jq,
   makeWrapper,
 }:
-maven.buildMavenPackage {
+maven.buildMavenPackage rec {
   __structuredAttrs = true;
   strictDeps = true;
 
   pname = "reitti";
-  version = "3.4.1";
+  version = "4.0.4";
 
   src = fetchFromGitHub {
     owner = "dedicatedcode";
     repo = "reitti";
-    rev = "54291e7d71dc9cc256f22a3c08176974c314d315";
-    hash = "sha256-ybRArA9MzQRwF/WuC0PLr5n4pfte2kw1hluwezSR3os=";
+    tag = "v${version}";
+    hash = "sha256-2Fx6j/88jhfiv1PHGCSM80i/F00JzIrDkJ37DEEEfHA=";
   };
 
   mvnHash = "sha256-AeQVaj438m/ydXe+H+IZ7ZcOkXaokng5WiBsjrOCdFo=";
@@ -65,11 +65,11 @@ maven.buildMavenPackage {
     runHook postInstall
   '';
 
-  meta = with lib; {
-    description = "A personal transit tracking application";
+  meta = {
+    description = "Personal transit tracking application";
     homepage = "https://github.com/dedicatedcode/reitti";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     mainProgram = "reitti";
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/re/reitti/package.nix
+++ b/pkgs/by-name/re/reitti/package.nix
@@ -2,6 +2,7 @@
   lib,
   maven,
   openjdk25,
+  openjdk25_headless,
   fetchFromGitHub,
   xmlstarlet,
   jq,
@@ -59,7 +60,7 @@ maven.buildMavenPackage rec {
     cp target/*.jar $out/share/java/reitti.jar
 
     mkdir -p $out/bin
-    makeWrapper ${openjdk25}/bin/java $out/bin/reitti \
+    makeWrapper ${openjdk25_headless}/bin/java $out/bin/reitti \
       --add-flags "-jar $out/share/java/reitti.jar"
 
     runHook postInstall

--- a/pkgs/by-name/re/reitti/package.nix
+++ b/pkgs/by-name/re/reitti/package.nix
@@ -2,18 +2,37 @@
   lib,
   maven,
   openjdk25,
-  openjdk25_headless,
+  jre25_minimal,
   fetchFromGitHub,
   xmlstarlet,
   jq,
   makeWrapper,
 }:
+let
+  jre = jre25_minimal.override {
+    modules = [
+      "java.base"
+      "java.compiler"
+      "java.desktop"
+      "java.instrument"
+      "java.net.http"
+      "java.prefs"
+      "java.rmi"
+      "java.scripting"
+      "java.security.jgss"
+      "java.sql.rowset"
+      "jdk.jfr"
+      "jdk.management"
+      "jdk.net"
+      "jdk.unsupported"
+    ];
+  };
+in
 maven.buildMavenPackage rec {
-  __structuredAttrs = true;
-  strictDeps = true;
-
   pname = "reitti";
   version = "4.0.4";
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "dedicatedcode";
@@ -60,7 +79,7 @@ maven.buildMavenPackage rec {
     cp target/*.jar $out/share/java/reitti.jar
 
     mkdir -p $out/bin
-    makeWrapper ${openjdk25_headless}/bin/java $out/bin/reitti \
+    makeWrapper ${jre}/bin/java $out/bin/reitti \
       --add-flags "-jar $out/share/java/reitti.jar"
 
     runHook postInstall

--- a/pkgs/by-name/re/reitti/package.nix
+++ b/pkgs/by-name/re/reitti/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  maven,
+  openjdk25,
+  fetchFromGitHub,
+  xmlstarlet,
+  jq,
+  makeWrapper,
+}:
+maven.buildMavenPackage {
+  pname = "reitti";
+  version = "3.4.1";
+
+  src = fetchFromGitHub {
+    owner = "dedicatedcode";
+    repo = "reitti";
+    rev = "54291e7d71dc9cc256f22a3c08176974c314d315";
+    hash = "sha256-ybRArA9MzQRwF/WuC0PLr5n4pfte2kw1hluwezSR3os=";
+  };
+
+  mvnHash = "sha256-AeQVaj438m/ydXe+H+IZ7ZcOkXaokng5WiBsjrOCdFo=";
+  mvnJdk = openjdk25;
+
+  mvnFlags = "-Dmaven.test.skip=true -DskipTests -Dmaven.gitcommitid.skip=true";
+
+  nativeBuildInputs = [
+    xmlstarlet
+    jq
+    makeWrapper
+  ];
+
+  postPatch = ''
+    NS="http://maven.apache.org/POM/4.0.0"
+
+    xmlstarlet ed -L -N x="$NS" \
+      -d "//x:plugin[x:artifactId='git-commit-id-maven-plugin']" \
+      -d "//x:plugin[x:artifactId='maven-surefire-plugin']" \
+      -d "//x:plugin[x:artifactId='jacoco-maven-plugin']" \
+      pom.xml
+
+    rm -rf src/test
+
+    cat > src/main/resources/git.properties <<EOF
+    git.commit.id.abbrev=nix
+    git.commit.time=unknown
+    git.build.time=unknown
+    git.tags=nix-build
+    EOF
+
+    echo '{"contributors": []}' > src/main/resources/contributors.json
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/java
+    cp target/*.jar $out/share/java/reitti.jar
+
+    mkdir -p $out/bin
+    makeWrapper ${openjdk25}/bin/java $out/bin/reitti \
+      --add-flags "-jar $out/share/java/reitti.jar"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A personal transit tracking application";
+    homepage = "https://github.com/dedicatedcode/reitti";
+    license = licenses.mit;
+    mainProgram = "reitti";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/by-name/re/reitti/package.nix
+++ b/pkgs/by-name/re/reitti/package.nix
@@ -9,6 +9,7 @@
 }:
 maven.buildMavenPackage {
   __structuredAttrs = true;
+  strictDeps = true;
 
   pname = "reitti";
   version = "3.4.1";

--- a/pkgs/by-name/re/reitti/package.nix
+++ b/pkgs/by-name/re/reitti/package.nix
@@ -1,0 +1,101 @@
+{
+  lib,
+  maven,
+  openjdk25,
+  jre25_minimal,
+  fetchFromGitHub,
+  xmlstarlet,
+  jq,
+  makeWrapper,
+  nix-update-script,
+}:
+let
+  jre = jre25_minimal.override {
+    modules = [
+      "java.base"
+      "java.compiler"
+      "java.desktop"
+      "java.instrument"
+      "java.net.http"
+      "java.prefs"
+      "java.rmi"
+      "java.scripting"
+      "java.security.jgss"
+      "java.sql.rowset"
+      "jdk.jfr"
+      "jdk.management"
+      "jdk.net"
+      "jdk.unsupported"
+    ];
+  };
+in
+maven.buildMavenPackage rec {
+  pname = "reitti";
+  version = "5.0.1";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "dedicatedcode";
+    repo = "reitti";
+    tag = "v${version}";
+    hash = "sha256-+4J9us+8JhIAkE0bWQvo3X3PHVw6wq6h4Jewjrce/Zc=";
+  };
+
+  mvnHash = "sha256-OZ0bDfWRHsZzB0IEmORb48frFBKNpoiT5/HDARXj8iQ=";
+  mvnJdk = openjdk25;
+
+  mvnFlags = "-Dmaven.test.skip=true -DskipTests -Dmaven.gitcommitid.skip=true";
+
+  nativeBuildInputs = [
+    xmlstarlet
+    jq
+    makeWrapper
+  ];
+
+  postPatch = ''
+    NS="http://maven.apache.org/POM/4.0.0"
+
+    xmlstarlet ed -L -N x="$NS" \
+      -d "//x:plugin[x:artifactId='git-commit-id-maven-plugin']" \
+      -d "//x:plugin[x:artifactId='maven-surefire-plugin']" \
+      -d "//x:plugin[x:artifactId='jacoco-maven-plugin']" \
+      pom.xml
+
+    rm -rf src/test
+
+    cat > src/main/resources/git.properties <<EOF
+    git.commit.id.abbrev=nix
+    git.commit.time=unknown
+    git.build.time=unknown
+    git.tags=nix-build
+    EOF
+
+    echo '{"contributors": []}' > src/main/resources/contributors.json
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/java
+    cp target/*.jar $out/share/java/reitti.jar
+
+    mkdir -p $out/bin
+    makeWrapper ${jre}/bin/java $out/bin/reitti \
+      --add-flags "-jar $out/share/java/reitti.jar"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Personal transit tracking application";
+    homepage = "https://github.com/dedicatedcode/reitti";
+    license = lib.licenses.agpl3Only;
+    mainProgram = "reitti";
+    maintainers = with lib.maintainers; [
+      wanderer
+    ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Summary

Add `reitti`, a personal transit tracking application.

https://github.com/dedicatedcode/reitti

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.