### PR TITLE
cli53: 0.8.22 -> 0.9.0

### DIFF
--- a/pkgs/by-name/cl/cli53/package.nix
+++ b/pkgs/by-name/cl/cli53/package.nix
@@ -8,16 +8,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "cli53";
-  version = "0.8.22";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "barnybug";
     repo = "cli53";
-    rev = finalAttrs.version;
-    sha256 = "sha256-wfb3lK/WB/B8gd4BOqh+Ol10cNZdsoCoQ+hM33+goM8=";
+    tag = "v${finalAttrs.version}";
+    sha256 = "sha256-ojLqveOZ8IIJXNd6PdXbqWYcwXqAjjEpKiquqXwcZt8=";
   };
 
-  vendorHash = "sha256-LKJXoXZS866UfJ+Edwf6AkAZmTV2Q1OI1mZfbsxHb3s=";
+  vendorHash = "sha256-OpBeuIyyFOliVtN1z9Ll9ji2qNS41NvZBjL7vJvRe6E=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
Update to 0.9.0

That tag format changed from $version to v$version in the upstream repo.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
