### PR TITLE
maintainers: remove antoinerg

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1955,12 +1955,6 @@
     githubId = 14838767;
     name = "Jacopo Scannella";
   };
-  antoinerg = {
-    email = "roygobeil.antoine@gmail.com";
-    github = "antoinerg";
-    githubId = 301546;
-    name = "Antoine Roy-Gobeil";
-  };
   anton-4 = {
     name = "Anton";
     github = "Anton-4";

--- a/pkgs/development/python-modules/dash-core-components/default.nix
+++ b/pkgs/development/python-modules/dash-core-components/default.nix
@@ -22,6 +22,6 @@ buildPythonPackage (finalAttrs: {
     description = "Dash component starter pack";
     homepage = "https://dash.plot.ly/dash-core-components";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.antoinerg ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/development/python-modules/dash-html-components/default.nix
+++ b/pkgs/development/python-modules/dash-html-components/default.nix
@@ -22,6 +22,6 @@ buildPythonPackage rec {
     description = "HTML components for Dash";
     homepage = "https://dash.plot.ly/dash-html-components";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.antoinerg ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/dash-table/default.nix
+++ b/pkgs/development/python-modules/dash-table/default.nix
@@ -22,6 +22,6 @@ buildPythonPackage rec {
     description = "First-Class Interactive DataTable for Dash";
     homepage = "https://dash.plot.ly/datatable";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.antoinerg ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/dash/default.nix
+++ b/pkgs/development/python-modules/dash/default.nix
@@ -138,9 +138,6 @@ buildPythonPackage (finalAttrs: {
     description = "Python framework for building analytical web applications";
     homepage = "https://dash.plot.ly/";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [
-      antoinerg
-      tomasajt
-    ];
+    maintainers = with lib.maintainers; [ tomasajt ];
   };
 })


### PR DESCRIPTION
## Reasons

- Last commented in [June 2022](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Aantoinerg)
- Hasn't created any PRs / Issues since [October 2021](https://github.com/NixOS/nixpkgs/issues?q=author%3Aantoinerg)
- About 69 [unanswered ](https://github.com/NixOS/nixpkgs/issues?q=involves%3Aantoinerg%20-commenter%3Aantoinerg%20-author%3Aantoinerg%20-reviewed-by%3Aantoinerg) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] python3Packages.dash-core-components
- [ ] python3Packages.dash-table
- [ ] python3Packages.dash-html-components