### PR TITLE
moon: 1.41.8 -> 2.2.3

### DIFF
--- a/pkgs/by-name/mo/moon/package.nix
+++ b/pkgs/by-name/mo/moon/package.nix
@@ -4,6 +4,7 @@
   rustPlatform,
   fetchFromGitHub,
   openssl,
+  protobuf,
   pkg-config,
   versionCheckHook,
   nix-update-script,
@@ -14,24 +15,26 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "moon";
-  version = "1.41.8";
+  version = "2.2.3";
 
   src = fetchFromGitHub {
     owner = "moonrepo";
     repo = "moon";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-KPK1XE18A8vh5FlGIPizxWmEVPkJHcy6fvtFsOQlhok=";
+    hash = "sha256-DLZ4JNz3NlcZtlEn6kHYRym85lxLQ7TsQAhisrjqk98=";
   };
 
-  cargoHash = "sha256-U3Hq5zy1dvG/sJA08bBi2mwMbTP2E5LLIpx0rMq2U1A=";
+  cargoHash = "sha256-vWsUThZUzDD+K83DIou4xIsiSVp9FRm6dl8QrYD26Oc=";
 
   env = {
     RUSTFLAGS = "-C strip=symbols";
     OPENSSL_NO_VENDOR = 1;
+    PROTOC = lib.getExe protobuf;
   };
 
   buildInputs = [ openssl ];
   nativeBuildInputs = [
+    protobuf
     pkg-config
     installShellFiles
     writableTmpDirAsHomeHook


### PR DESCRIPTION
Changelog: https://github.com/moonrepo/moon/releases/tag/v2.2.3
Diff: https://github.com/moonrepo/moon/compare/v1.41.8...v2.2.3

ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327045213)](https://hydra.nixos.org/build/327045213)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
