### PR TITLE
copacetic: 0.11.1 -> 0.13.0

### DIFF
--- a/pkgs/by-name/co/copacetic/package.nix
+++ b/pkgs/by-name/co/copacetic/package.nix
@@ -12,16 +12,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "copacetic";
-  version = "0.11.1";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "project-copacetic";
     repo = "copacetic";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-kgFT+IK6zCGoGK8L/lwXyiUXCWYG7ElziPs0Q1cq+fw=";
+    hash = "sha256-FTldgBYOmJt3VIC3vwp415oPNRCAiR1cxEF8lJr5TSU=";
   };
 
-  vendorHash = "sha256-qe2VJHXSYtZJlMd5R2J1NXWcXb8+cbTiDBQeN20fbEE=";
+  vendorHash = "sha256-nkVAHqe61AR0GBK5upsk650kl8UDp1ppFWhyi3erpr4=";
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -41,6 +41,8 @@ buildGoModule (finalAttrs: {
     "-X=main.version=${finalAttrs.version}"
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   checkFlags =
     let
       # Skip tests that require network access and container services
@@ -52,6 +54,16 @@ buildGoModule (finalAttrs: {
         "TestPushToRegistry"
         "TestMultiPlatformPluginPatch"
         "TestPodmanLoader_Load_Success"
+        "TestMultiArchBulkPatching"
+        "TestComprehensiveBulkPatching"
+        "TestTrivyParserParseWithNodeJS/OS_and_Node.js_packages"
+        "TestLocalImageDescriptor"
+        "TestGetImageDescriptor"
+        "TestDotNetSDKImagePatching"
+        "TestGenerateWithoutReport"
+        "TestGenerateToStdout"
+        "TestCustomBuildPatching"
+        "TestNodeJSPatching"
       ];
     in
     [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
@@ -78,6 +90,6 @@ buildGoModule (finalAttrs: {
     changelog = "https://github.com/project-copacetic/copacetic/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     mainProgram = "copa";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ tbutter ];
   };
 })


### PR DESCRIPTION
Update 0.13.0

Disables a few new checks that require network or docker.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
