### PR TITLE
nixos/spire: make Workload API socket reachable by non-root workloads

### DIFF
--- a/nixos/modules/services/security/spire/agent.nix
+++ b/nixos/modules/services/security/spire/agent.nix
@@ -150,7 +150,7 @@ in
         Restart = "on-failure";
         StateDirectory = "spire/agent";
         StateDirectoryMode = "0700";
-        RuntimeDirectory = "spire/agent";
+        RuntimeDirectory = "spire/agent/public";
 
         # TODO: Switch to DynamicUser once https://github.com/NixOS/nixpkgs/issues/299476 lands
         # Without it, the systemd plugin can not talk to dbus

--- a/nixos/tests/spire.nix
+++ b/nixos/tests/spire.nix
@@ -45,6 +45,14 @@ let
         config.services.spire.agent.settings.agent.socket_path;
       virtualisation.credentials."spire.trust_bundle".source = "./trust_bundle";
       systemd.services.spire-agent.serviceConfig.ImportCredential = [ "spire.trust_bundle" ];
+
+      # A non-root, non-spire-agent user used to verify that arbitrary
+      # workloads can reach the Workload API socket.
+      users.users.workload = {
+        isNormalUser = true;
+        group = "workload";
+      };
+      users.groups.workload = { };
     };
 in
 {
@@ -180,25 +188,36 @@ in
         join_token = server.succeed("spire-server token generate -socketPath ${adminSocket}").split()[1]
         with open(agent.state_dir / "join_token", "w") as f:
           f.write(join_token)
-        parent_id = f"spiffe://${trustDomain}/spire/agent/join_token/{join_token}"
-        server.succeed(f"spire-server entry create -socketPath ${adminSocket} -selector 'systemd:id:backdoor.service' -parentID {parent_id} -spiffeID {spiffe_id}")
+        return f"spiffe://${trustDomain}/spire/agent/join_token/{join_token}"
 
 
       def provision_tpm(agent):
         agent.wait_for_unit("tpm2.target")
         ek_hash = agent.succeed("get_tpm_pubhash").strip()
-        parent_id = f"spiffe://${trustDomain}/spire/agent/tpm/{ek_hash}"
-        server.succeed(f"spire-server entry create -socketPath ${adminSocket} -selector 'systemd:id:backdoor.service' -parentID '{parent_id}' -spiffeID {spiffe_id}")
+        return f"spiffe://${trustDomain}/spire/agent/tpm/{ek_hash}"
+
+
+      def register_entry(parent_id, selector, spiffe_id):
+        server.succeed(f"spire-server entry create -socketPath ${adminSocket} -selector '{selector}' -parentID '{parent_id}' -spiffeID '{spiffe_id}'")
 
 
       def test_agent(name, agent_node, provision_fn):
         with subtest(f"Setup SPIRE agent with {name} attestation"):
           provision_trust_bundle(agent_node)
-          provision_fn(agent_node)
+          parent_id = provision_fn(agent_node)
+          register_entry(parent_id, "systemd:id:backdoor.service", spiffe_id)
+          register_entry(parent_id, "unix:user:workload", "spiffe://${trustDomain}/workload")
           agent_node.wait_for_unit("spire-agent.service")
           agent_node.wait_until_succeeds("spire-agent healthcheck -socketPath $SPIFFE_ENDPOINT_SOCKET", timeout=90)
         with subtest(f"Test certificate authentication from {name} agent"):
           agent_node.wait_until_succeeds("spire-agent api fetch x509 -socketPath $SPIFFE_ENDPOINT_SOCKET -write .")
+        with subtest(f"Workload running as non-root, non-spire-agent user can reach Workload API ({name})"):
+          # SPIRE's security model relies on workload attestation, not unix
+          # permissions on the socket. Verify an unrelated user can connect.
+          agent_node.wait_until_succeeds(
+            "su -s /bin/sh workload -c "
+            "'spire-agent api fetch x509 -socketPath \"$SPIFFE_ENDPOINT_SOCKET\"'"
+          )
         # TODO: Add something to communicate with
 
 


### PR DESCRIPTION
The unit's UMask=0027 was masking spire-agent's own os.MkdirAll("/run/spire/agent/public", 0755) down to mode 0750, so any process not in the spire-agent group got EACCES on connect() — defeating the point of workload attestation, which is supposed to identify arbitrary callers regardless of their unix identity.

Pre-create the directory via RuntimeDirectory so systemd applies RuntimeDirectoryMode (0755) independent of umask; spire-agent's MkdirAll then becomes a no-op.

Also exercises the path in the NixOS test by fetching an SVID as a normal user.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
