### PR TITLE
python3Packages.wfuzz: fix Python 3.13 plugin breakage and add netaddr runtime dep

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2913,6 +2913,12 @@
     githubId = 1017537;
     name = "Bruno Bieth";
   };
+  bad3r = {
+    name = "Bad3r";
+    email = "github@unsigned.sh";
+    github = "Bad3r";
+    githubId = 25513724;
+  };
   badele = {
     name = "Bruno Adelé";
     email = "brunoadele@gmail.com";

--- a/pkgs/development/python-modules/wfuzz/default.nix
+++ b/pkgs/development/python-modules/wfuzz/default.nix
@@ -35,6 +35,9 @@ buildPythonPackage (finalAttrs: {
       url = "https://github.com/xmendez/wfuzz/commit/f4c028b9ada4c36dabf3bc752f69f6ddc110920f.patch?full_index=1";
       hash = "sha256-t7pUMcdFmwAsGUNBRdZr+Jje/yR0yzeGIgeYNEq4hFE=";
     })
+    # replace removed `pipes` stdlib module with `shlex` for Python >= 3.13
+    # https://github.com/xmendez/wfuzz/issues/380
+    ./python-313-shlex.patch
   ];
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/wfuzz/default.nix
+++ b/pkgs/development/python-modules/wfuzz/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage (finalAttrs: {
   };
 
   patches = [
-    # replace use of imp module for Python 3.12
+    # replace use of imp module for Python >= 3.12
     # https://github.com/xmendez/wfuzz/pull/365
     (fetchpatch2 {
       url = "https://github.com/xmendez/wfuzz/commit/f4c028b9ada4c36dabf3bc752f69f6ddc110920f.patch?full_index=1";
@@ -48,9 +48,9 @@ buildPythonPackage (finalAttrs: {
     legacy-cgi
     netaddr # src/wfuzz/plugins/payloads/{iprange,ipnet}.py
     pycurl
-    six
-    setuptools
     pyparsing
+    setuptools
+    six
   ]
   ++ lib.optionals stdenv.hostPlatform.isWindows [ colorama ];
 

--- a/pkgs/development/python-modules/wfuzz/default.nix
+++ b/pkgs/development/python-modules/wfuzz/default.nix
@@ -46,6 +46,7 @@ buildPythonPackage (finalAttrs: {
     chardet
     distutils # src/wfuzz/plugin_api/base.py
     legacy-cgi
+    netaddr # src/wfuzz/plugins/payloads/{iprange,ipnet}.py
     pycurl
     six
     setuptools

--- a/pkgs/development/python-modules/wfuzz/default.nix
+++ b/pkgs/development/python-modules/wfuzz/default.nix
@@ -85,5 +85,6 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://wfuzz.readthedocs.io";
     license = with lib.licenses; [ gpl2Only ];
     maintainers = with lib.maintainers; [ pamplemousse ];
+    mainProgram = "wfuzz";
   };
 })

--- a/pkgs/development/python-modules/wfuzz/default.nix
+++ b/pkgs/development/python-modules/wfuzz/default.nix
@@ -88,7 +88,10 @@ buildPythonPackage (finalAttrs: {
     '';
     homepage = "https://wfuzz.readthedocs.io";
     license = with lib.licenses; [ gpl2Only ];
-    maintainers = with lib.maintainers; [ pamplemousse ];
+    maintainers = with lib.maintainers; [
+      bad3r
+      pamplemousse
+    ];
     mainProgram = "wfuzz";
   };
 })

--- a/pkgs/development/python-modules/wfuzz/python-313-shlex.patch
+++ b/pkgs/development/python-modules/wfuzz/python-313-shlex.patch
@@ -1,0 +1,29 @@
+Replace removed `pipes` stdlib module with `shlex` in screenshot plugin.
+
+`pipes` was deprecated in Python 3.11 (PEP 594) and removed in 3.13;
+`shlex.quote` is the documented stdlib replacement and behaves identically
+for the single argument used here.
+
+Reported upstream: https://github.com/xmendez/wfuzz/issues/380
+
+diff --git a/src/wfuzz/plugins/scripts/screenshot.py b/src/wfuzz/plugins/scripts/screenshot.py
+--- a/src/wfuzz/plugins/scripts/screenshot.py
++++ b/src/wfuzz/plugins/scripts/screenshot.py
+@@ -3,7 +3,7 @@ from wfuzz.externals.moduleman.plugin import moduleman_plugin
+
+ import subprocess
+ import tempfile
+-import pipes
++import shlex
+ import os
+ import re
+
+@@ -42,7 +42,7 @@ class screenshot(BasePlugin):
+         subprocess.call(
+             [
+                 "cutycapt",
+-                "--url=%s" % pipes.quote(fuzzresult.url),
++                "--url=%s" % shlex.quote(fuzzresult.url),
+                 "--out=%s" % filename,
+                 "--insecure",
+                 "--print-backgrounds=on",


### PR DESCRIPTION
Four commits fixing/hardening `python3Packages.wfuzz` against Python >= 3.13 breakage and inconsistent metadata.

1. **`python3Packages.wfuzz: set meta.mainProgram`** - the package installs four console scripts (`wfuzz`, `wfpayload`, `wfencode`, `wxfuzz`) and is exposed at the top level via `toPythonApplication`, so `lib.getExe` and `nix run` need an explicit primary binary to avoid the default-pname fallback warning.
2. **`python3Packages.wfuzz: fix screenshot plugin on Python 3.13`** - `src/wfuzz/plugins/scripts/screenshot.py` imports the removed `pipes` stdlib module. Without the patch, `wfuzz`'s plugin loader silently drops `screenshot` (loader catches the `ImportError` and logs a CRITICAL message); after the patch it appears in `wfuzz -e scripts`. The patch swaps `pipes` → `shlex` (`shlex.quote` is the documented stdlib replacement). Filed upstream as https://github.com/xmendez/wfuzz/issues/380; remove this patch once a release ships with the fix.
3. **`python3Packages.wfuzz: add netaddr to runtime dependencies`** - `src/wfuzz/plugins/payloads/{iprange,ipnet}.py` lazily import `netaddr`; on `ImportError` they raise `FuzzExceptBadInstall("...requires netaddr module. Please install it using pip.")`. On a Nix-built wfuzz without this dep, `wfuzz -z iprange,...` and `-z ipnet,...` show that misleading pip-install message. `netaddr` is kept in `nativeCheckInputs` because `tests/api/test_payload.py` exercises the ipranges payload.
4. **`python3Packages.wfuzz: tidy style nits`** - alphabetize `dependencies`, widen the imp/importlib patch comment to "Python >= 3.12" (still required on 3.13+), and use the canonical `v\${finalAttrs.version}` form for the changelog URL instead of `\${finalAttrs.src.tag}`.

A separate setuptools 81 / `pkg_resources` removal time-bomb is documented upstream at https://github.com/xmendez/wfuzz/issues/381 - `src/wfuzz/helpers/file_func.py` still uses `pkg_resources.resource_filename`. nixpkgs setuptools is currently 80.10.1 so this works today; once setuptools >= 81 lands, `get_filter_help_file()` will raise `ModuleNotFoundError` and need either an upstream `importlib.resources` migration or a third nixpkgs-side patch. Tracking via the upstream issue rather than carrying a workaround here.

> [!NOTE] 
> All these changes/fixes will also be upstreamed and deprecated in the future.

Changelog: https://github.com/xmendez/wfuzz/releases/tag/v3.1.1 (no upstream release for these specific fixes; the screenshot/netaddr breakage is on the v3.1.1 tag itself).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at \`passthru.tests\`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
    - Existing \`pytestCheckHook\` suite: 168 passed
- [x] Ran \`nixpkgs-review\` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in \`./result/bin/\`.
  - \`wfuzz --help\`, \`wfpayload -z iprange,10.0.0.1-10.0.0.2 FUZZ\`, \`wfpayload -z ipnet,192.168.1.0/30 FUZZ\`, \`wfuzz -e scripts\` (verified \`screenshot\` plugin loads)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test