### PR TITLE
nabi: 1.0.1 -> 1.0.2; fix build

### DIFF
--- a/pkgs/by-name/na/nabi/package.nix
+++ b/pkgs/by-name/na/nabi/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nabi";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchFromGitHub {
     owner = "libhangul";
     repo = "nabi";
     tag = "nabi-${finalAttrs.version}";
-    hash = "sha256-C6K8sXVCGf45VZtGSCB5emFzZPV21kG9JxAwBHRiFsY=";
+    hash = "sha256-U3W8G7cJ+lIqso6gSixmenX1cWnKuJO6dumUz4SUWi0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/na/nabi/package.nix
+++ b/pkgs/by-name/na/nabi/package.nix
@@ -7,6 +7,7 @@
   libhangul,
   autoconf,
   automake,
+  gettext,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -24,6 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     autoconf
     automake
+    gettext
   ];
 
   buildInputs = [
@@ -33,6 +35,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     patchShebangs ./autogen.sh
+    substituteInPlace ./autogen.sh --replace-fail "autopoint" "autopoint --force"
+    substituteInPlace ./autogen.sh --replace-fail "aclocal" "aclocal -I m4"
   '';
 
   preConfigure = ''


### PR DESCRIPTION
Release: https://github.com/libhangul/nabi/releases/tag/nabi-1.0.2
Diff: https://github.com/libhangul/nabi/compare/nabi-1.0.1...nabi-1.0.2

ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327046775)](https://hydra.nixos.org/build/327046775)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
