### PR TITLE
home-assistant-custom-components.{openplantbook,thewatchman}: use ignoreVersionRequirement

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/openplantbook/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/openplantbook/package.nix
@@ -20,10 +20,10 @@ buildHomeAssistantComponent rec {
     hash = "sha256-Ym7bt+0s7eqlL3oDtppIGenoW1XvrSjKkV2flE0TzUo=";
   };
 
-  postPatch = ''
-    substituteInPlace custom_components/openplantbook/manifest.json \
-      --replace-fail "==" ">="
-  '';
+  ignoreVersionRequirement = [
+    "json-timeseries"
+    "openplantbook-sdk"
+  ];
 
   dependencies = [
     json-timeseries

--- a/pkgs/servers/home-assistant/custom-components/thewatchman/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/thewatchman/package.nix
@@ -20,10 +20,9 @@ buildHomeAssistantComponent rec {
     hash = "sha256-5BXIKh8uPKuxsLbxu0fUbuCR2LYOXk1HpOvrqehg0u0=";
   };
 
-  postPatch = ''
-    substituteInPlace custom_components/watchman/manifest.json \
-      --replace-fail "prettytable==3.12.0" "prettytable"
-  '';
+  ignoreVersionRequirement = [
+    "prettytable"
+  ];
 
   dontBuild = true;
 


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
