### PR TITLE
rpm-ostree: 2024.8 -> 2026.1

### DIFF
--- a/pkgs/by-name/rp/rpm-ostree/package.nix
+++ b/pkgs/by-name/rp/rpm-ostree/package.nix
@@ -42,7 +42,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rpm-ostree";
-  version = "2024.8";
+  version = "2026.1";
 
   outputs = [
     "out"
@@ -53,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://github.com/coreos/rpm-ostree/releases/download/v${finalAttrs.version}/rpm-ostree-${finalAttrs.version}.tar.xz";
-    hash = "sha256-6aCGP3SJ0DegmhiQkiqBr733C5vuDGTjLMaxNtai3G0=";
+    hash = "sha256-/dgF4jN4Sq7pRFmSMWXmG21y0PlkPPOMf8QhP8CB+yA=";
   };
 
   nativeBuildInputs = [
@@ -103,7 +103,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   configureFlags = [
     "--enable-gtk-doc"
-    "--with-bubblewrap=${bubblewrap}/bin/bwrap"
   ];
 
   dontUseCmakeConfigure = true;
@@ -115,6 +114,10 @@ stdenv.mkDerivation (finalAttrs: {
     # Let's not hardcode the rpm-gpg path...
     substituteInPlace libdnf/libdnf/dnf-keyring.cpp \
       --replace '"/etc/pki/rpm-gpg"' 'getenv("LIBDNF_RPM_GPG_PATH_OVERRIDE") ? getenv("LIBDNF_RPM_GPG_PATH_OVERRIDE") : "/etc/pki/rpm-gpg"'
+
+    # Do not try to install in global /usr/lib
+    substituteInPlace Makefile-rpm-ostree.am \
+      --replace '/usr/lib/kernel/install.d' '$(libdir)/kernel/install.d'
   '';
 
   preConfigure = ''


### PR DESCRIPTION
Found this broken build on https://zh.fail/failed/by-maintainer/_.html (see also: [the ZHF campaign](https://github.com/NixOS/nixpkgs/issues/516381)), thought it would be nice to get fixed before the release.

Changelogs:
- https://github.com/coreos/rpm-ostree/releases/tag/v2024.9
- https://github.com/coreos/rpm-ostree/releases/tag/v2025.1
- https://github.com/coreos/rpm-ostree/releases/tag/v2025.2
- https://github.com/coreos/rpm-ostree/releases/tag/v2025.3
- https://github.com/coreos/rpm-ostree/releases/tag/v2025.4
- https://github.com/coreos/rpm-ostree/releases/tag/v2025.5
- https://github.com/coreos/rpm-ostree/releases/tag/v2025.6
- https://github.com/coreos/rpm-ostree/releases/tag/v2025.7
- https://github.com/coreos/rpm-ostree/releases/tag/v2025.8
- https://github.com/coreos/rpm-ostree/releases/tag/v2025.9
- https://github.com/coreos/rpm-ostree/releases/tag/v2025.10
- https://github.com/coreos/rpm-ostree/releases/tag/v2025.11
- https://github.com/coreos/rpm-ostree/releases/tag/v2025.12
- https://github.com/coreos/rpm-ostree/releases/tag/v2026.1

Hydra job: https://hydra.nixos.org/build/326900030

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
