### PR TITLE
ocamlPackages.seq: don't override meta

### DIFF
--- a/pkgs/development/ocaml-modules/seq/default.nix
+++ b/pkgs/development/ocaml-modules/seq/default.nix
@@ -7,18 +7,19 @@
   ocamlbuild,
 }:
 
+let
+  meta = {
+    license = lib.licenses.lgpl21;
+    maintainers = [ lib.maintainers.vbgl ];
+    homepage = "https://github.com/c-cube/seq";
+    inherit (ocaml.meta) platforms;
+  };
+
+in
 stdenv.mkDerivation (
   {
     version = "0.1";
     pname = "ocaml${ocaml.version}-seq";
-
-    meta = {
-      license = lib.licenses.lgpl21;
-      maintainers = [ lib.maintainers.vbgl ];
-      homepage = "https://github.com/c-cube/seq";
-      inherit (ocaml.meta) platforms;
-    };
-
   }
   // (
     if lib.versionOlder ocaml.version "4.07" then
@@ -40,7 +41,9 @@ stdenv.mkDerivation (
 
         createFindlibDestdir = true;
 
-        meta.description = "Compatibility package for OCaml’s standard iterator type starting from 4.07";
+        meta = meta // {
+          description = "Compatibility package for OCaml’s standard iterator type starting from 4.07";
+        };
 
       }
     else
@@ -55,7 +58,9 @@ stdenv.mkDerivation (
           cp META $out/lib/ocaml/${ocaml.version}/site-lib/seq
         '';
 
-        meta.description = "Dummy backward-compatibility package for iterators";
+        meta = {
+          description = "Dummy backward-compatibility package for iterators";
+        };
 
       }
   )


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
