### PR TITLE
maintainers: drop sbruder

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24431,12 +24431,6 @@
     githubId = 2320433;
     name = "Sam Boosalis";
   };
-  sbruder = {
-    email = "nixos@sbruder.de";
-    github = "sbruder";
-    githubId = 15986681;
-    name = "Simon Bruder";
-  };
   scandiravian = {
     email = "nixos@scandiravian.com";
     github = "scandiravian";

--- a/nixos/tests/invidious.nix
+++ b/nixos/tests/invidious.nix
@@ -2,8 +2,8 @@
 {
   name = "invidious";
 
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ sbruder ];
+  meta = {
+    maintainers = [ ];
   };
 
   nodes = {

--- a/pkgs/by-name/fc/fceux/package.nix
+++ b/pkgs/by-name/fc/fceux/package.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/TASEmulators/fceux/blob/${finalAttrs.src.rev}/changelog.txt";
     license = with lib.licenses; [ gpl2Plus ];
     mainProgram = "fceux";
-    maintainers = with lib.maintainers; [ sbruder ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ht/httpdirfs/package.nix
+++ b/pkgs/by-name/ht/httpdirfs/package.nix
@@ -61,7 +61,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Only;
     mainProgram = "httpdirfs";
     maintainers = with lib.maintainers; [
-      sbruder
       schnusch
       anthonyroussel
     ];

--- a/pkgs/by-name/in/invidious/package.nix
+++ b/pkgs/by-name/in/invidious/package.nix
@@ -141,7 +141,6 @@ crystal.buildCrystalPackage rec {
     maintainers = with lib.maintainers; [
       _999eagle
       GaetanLepage
-      sbruder
     ];
   };
 }

--- a/pkgs/by-name/li/libusbsio/package.nix
+++ b/pkgs/by-name/li/libusbsio/package.nix
@@ -54,7 +54,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
       frogamic
-      sbruder
     ];
   };
 })

--- a/pkgs/by-name/pr/prometheus-fritzbox-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-fritzbox-exporter/package.nix
@@ -30,7 +30,6 @@ buildGoModule {
     maintainers = with lib.maintainers; [
       bachp
       flokli
-      sbruder
     ];
   };
 }

--- a/pkgs/by-name/va/vapoursynth/package.nix
+++ b/pkgs/by-name/va/vapoursynth/package.nix
@@ -113,7 +113,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [
       rnhmjoj
-      sbruder
       snaki
     ];
     mainProgram = "vspipe";

--- a/pkgs/development/python-modules/argparse-addons/default.nix
+++ b/pkgs/development/python-modules/argparse-addons/default.nix
@@ -23,7 +23,6 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       frogamic
-      sbruder
     ];
   };
 }

--- a/pkgs/development/python-modules/bincopy/default.nix
+++ b/pkgs/development/python-modules/bincopy/default.nix
@@ -32,7 +32,6 @@ buildPythonPackage (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       frogamic
-      sbruder
     ];
   };
 })

--- a/pkgs/development/python-modules/cmsis-pack-manager/default.nix
+++ b/pkgs/development/python-modules/cmsis-pack-manager/default.nix
@@ -69,7 +69,6 @@ buildPythonPackage rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       frogamic
-      sbruder
     ];
   };
 }

--- a/pkgs/development/python-modules/hexdump/default.nix
+++ b/pkgs/development/python-modules/hexdump/default.nix
@@ -35,7 +35,6 @@ buildPythonPackage rec {
     license = lib.licenses.publicDomain;
     maintainers = with lib.maintainers; [
       frogamic
-      sbruder
     ];
   };
 }

--- a/pkgs/development/python-modules/libusbsio/default.nix
+++ b/pkgs/development/python-modules/libusbsio/default.nix
@@ -37,7 +37,6 @@ buildPythonPackage rec {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
       frogamic
-      sbruder
     ];
   };
 }

--- a/pkgs/development/python-modules/pyocd/default.nix
+++ b/pkgs/development/python-modules/pyocd/default.nix
@@ -83,7 +83,6 @@ buildPythonPackage rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       frogamic
-      sbruder
     ];
   };
 }

--- a/pkgs/development/python-modules/pypemicro/default.nix
+++ b/pkgs/development/python-modules/pypemicro/default.nix
@@ -29,7 +29,6 @@ buildPythonPackage rec {
     ]; # it includes shared libraries for which no license is available (https://github.com/NXPmicro/pypemicro/issues/10)
     maintainers = with lib.maintainers; [
       frogamic
-      sbruder
     ];
   };
 }

--- a/pkgs/development/python-modules/python-flirt/default.nix
+++ b/pkgs/development/python-modules/python-flirt/default.nix
@@ -45,6 +45,6 @@ buildPythonPackage rec {
     description = "Python library for parsing, compiling, and matching Fast Library Identification and Recognition Technology (FLIRT) signatures";
     homepage = "https://github.com/williballenthin/lancelot/tree/master/pyflirt";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ sbruder ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/spsdk/default.nix
+++ b/pkgs/development/python-modules/spsdk/default.nix
@@ -148,7 +148,6 @@ buildPythonPackage rec {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
       frogamic
-      sbruder
     ];
     mainProgram = "spsdk";
   };

--- a/pkgs/development/python-modules/univers/default.nix
+++ b/pkgs/development/python-modules/univers/default.nix
@@ -64,7 +64,6 @@ buildPythonPackage rec {
     ];
     maintainers = with lib.maintainers; [
       armijnhemel
-      sbruder
     ];
   };
 }

--- a/pkgs/tools/misc/antimicrox/default.nix
+++ b/pkgs/tools/misc/antimicrox/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "GUI for mapping keyboard and mouse controls to a gamepad";
     inherit (src.meta) homepage;
-    maintainers = with lib.maintainers; [ sbruder ];
+    maintainers = [ ];
     license = lib.licenses.gpl3Plus;
     platforms = with lib.platforms; linux;
     mainProgram = "antimicrox";


### PR DESCRIPTION
No [comments](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+commenter%3Asbruder) since September 2024 despite over 50 [review requests](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+created%3A%3E%3D2024-10-01+user-review-requested%3Asbruder). Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/33954594ec46166510795930ba8ebf0856249d4e/maintainers/README.md#losing-maintainer-status).

@sbruder if you object to being dropped please respond saying so within a week. Even if you don't make it, you are of course welcome back whenever you would like!




## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
