### PR TITLE
pulumi-bin: 3.232.0 -> 3.234.0

### DIFF
--- a/pkgs/by-name/pu/pulumi-bin/data.nix
+++ b/pkgs/by-name/pu/pulumi-bin/data.nix
@@ -1,12 +1,12 @@
 # DO NOT EDIT! This file is generated automatically by update.sh
 { }:
 {
-  version = "3.232.0";
+  version = "3.234.0";
   pulumiPkgs = {
     x86_64-linux = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.232.0-linux-x64.tar.gz";
-        sha256 = "08s4fbf7hvi2yyi3m7n5832cmjizpg8df1v9bkg0wlv6iffwcwlb";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.234.0-linux-x64.tar.gz";
+        sha256 = "10gzaiz1200fpm1jsha92pc03v8zjkjkiwckdybq7cryrdr7wy35";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aiven-v6.53.1-linux-amd64.tar.gz";
@@ -17,36 +17,36 @@
         sha256 = "139h210ixh4s46sa90p9ga9nl1bqb1m36hbr1ylcr80nx5hjh42p";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-alicloud-v3.100.0-linux-amd64.tar.gz";
-        sha256 = "0znqp5vd9kd02zdsqr6avvrdvvcc3fh370llyxwgif8x1kh8ri19";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-alicloud-v3.101.0-linux-amd64.tar.gz";
+        sha256 = "1bk4wswywss8i5isjrrlpnrkdplpp45sqq1yvdc0jwgzay36n8zl";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-artifactory-v8.10.4-linux-amd64.tar.gz";
         sha256 = "1j80sayzic63ahyv2x9k7kpisi7rvjml7cid1xzzcac8z7s2nhxq";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v3.40.0-linux-amd64.tar.gz";
-        sha256 = "00xz7zb8z64fy9fwbl6797ndj8q9xb3xnxpi6f5s4sbg3lzicp7j";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v3.41.0-linux-amd64.tar.gz";
+        sha256 = "1m11q8zm5112gh7wcqnb3k4jqv5yzsxzs4g319yxxh3b4jhi6mgv";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v7.27.0-linux-amd64.tar.gz";
-        sha256 = "1gzxca78x7k9r9z54hgqpg93sybcpkw6vcizjdvkiw55g621a8k6";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v7.28.0-linux-amd64.tar.gz";
+        sha256 = "1rcb1jkggyhvs7fmckwsvacf8ahn8wrz1n5gm2gsp75rg362ms79";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azuread-v6.9.0-linux-amd64.tar.gz";
         sha256 = "0w03d8r2dy4488wyjqj0q5259fwky6xxckq3dcyy69a2inakg762";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azuredevops-v3.14.0-linux-amd64.tar.gz";
-        sha256 = "14i18v6z68szdf1y1bg3m51kqn4i1fdv6jbi282f7rxr0fbzzmpl";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azuredevops-v3.14.1-linux-amd64.tar.gz";
+        sha256 = "0hvrq3b9al6sbx61dlqjs9rz5wd2ljr8ijd1x42ni76gazihix81";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azure-v6.35.0-linux-amd64.tar.gz";
         sha256 = "1wlfds1g2wx08dwi2vbzz79wlwyk78brxxirlq8xblp4hi8wv72d";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v6.14.0-linux-amd64.tar.gz";
-        sha256 = "0rx73m3mw0lkafcm6b82vdypzj4xfpff28i1n55z24pgn2s2vyli";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v6.15.0-linux-amd64.tar.gz";
+        sha256 = "1m7fkzr5cx9bb48bvqadyi38az403di4m1jyfr6ad05b6nqqiyww";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-consul-v3.14.1-linux-amd64.tar.gz";
@@ -57,8 +57,8 @@
         sha256 = "1af9y48rchnpryyy3j228d94iyvfrhphjw6m94r92y6carkpggg5";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.64.1-linux-amd64.tar.gz";
-        sha256 = "1jaf26rrhwf4b2bakvf5sidbvq8flqp5jgs8r7x5zgidr27p06b1";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.65.0-linux-amd64.tar.gz";
+        sha256 = "13rps07axi5v1v77bc37dspb6zr610h72pjslx3c9ky6hdapdpvv";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-docker-v5.0.0-linux-amd64.tar.gz";
@@ -73,12 +73,12 @@
         sha256 = "03w4kfws4zksmri961fs3lsvwg15mpj6nhc0a1zplqpw6rsjgcmr";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v9.21.0-linux-amd64.tar.gz";
-        sha256 = "0c9fgan0c1chx452lm05vfnvkzzrwwmzgxabv0cwc0b2sr9sv199";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v9.22.0-linux-amd64.tar.gz";
+        sha256 = "0jy0r3zlwfljqlg0sr8pc4y79wnnpa0wz55krdazww0znqzmiwv6";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v6.13.0-linux-amd64.tar.gz";
-        sha256 = "173gm48bs91f23zg3yds04zk70bwybr23cw3ljd28g5p3lzmxl33";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v6.13.1-linux-amd64.tar.gz";
+        sha256 = "1sblvkd800i30gy719g2sqajg3k5akblv7p5xa2j29lb46mxiaqf";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v9.11.0-linux-amd64.tar.gz";
@@ -89,8 +89,8 @@
         sha256 = "1zra1ck64gs4nwqf62ksfmpbx24lxw6vsgi47j4v8q051m89fgq3";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.33.0-linux-amd64.tar.gz";
-        sha256 = "179hhd656hyl7nvcxzsrj98gbs2rw2l700a2kz6252yr0gq07482";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.34.0-linux-amd64.tar.gz";
+        sha256 = "1pmp1cfhglx2cf0xpj1s1rrx6w9xzmcsvpzqgh2rzpy2rpbg5yfq";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v4.30.0-linux-amd64.tar.gz";
@@ -105,8 +105,8 @@
         sha256 = "1fl4pm2zlh0s2zv89b6m0qhphan9n0rcbaxid8gh24912h82xa5v";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v3.2.14-linux-amd64.tar.gz";
-        sha256 = "123m6fxv6zvmpxr3yva595wfda5ca1fkqjsrizgdl6br9jfqmvcl";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v3.2.15-linux-amd64.tar.gz";
+        sha256 = "1rk8sfbv99qrwzi1hfbr163aifs5v0bx2fqqzzymnj57br0i67yc";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-openstack-v5.4.2-linux-amd64.tar.gz";
@@ -145,8 +145,8 @@
         sha256 = "03pwdk0yjrnvr5hzd9fz4hvxa7cqfczd5148jvv5064vj214dk0w";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-venafi-v1.12.3-linux-amd64.tar.gz";
-        sha256 = "1bkvxk89j9pknmajkcx419zzizb9nk482j1j3lb9s66y20a3c0v6";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-venafi-v1.12.4-linux-amd64.tar.gz";
+        sha256 = "1r4g7czwknylpymi4v8zf771ri0dwl6ym9jd7ry7qsc84h9rx3by";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vsphere-v4.16.5-linux-amd64.tar.gz";
@@ -163,8 +163,8 @@
     ];
     x86_64-darwin = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.232.0-darwin-x64.tar.gz";
-        sha256 = "0ah734rb7g9s7211yx2xfg4jykj52l4amrxhvpsnxlblj42kmy6v";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.234.0-darwin-x64.tar.gz";
+        sha256 = "1vn74fm1bbgs8h726l0ma3ljsp4lzjim3h7vnnqa8608vqyvjl3y";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aiven-v6.53.1-darwin-amd64.tar.gz";
@@ -175,36 +175,36 @@
         sha256 = "1r1j115bii4hv22z5pwp1yvcbi41j4mdcvwbn04xjridvrpsp63b";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-alicloud-v3.100.0-darwin-amd64.tar.gz";
-        sha256 = "08fh378b7nv6cpdppiw9knnkr5nz7zvw4yikrbc607pinkby33qf";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-alicloud-v3.101.0-darwin-amd64.tar.gz";
+        sha256 = "1rhbpxi9g3pb11cj2yinil8iwsl2zb3ndz3h21grf94ss8h4395h";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-artifactory-v8.10.4-darwin-amd64.tar.gz";
         sha256 = "142ydaywi8xw3k8w2c2py0x88sxf55v9z26yjkjhn2izcr9yv3fg";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v3.40.0-darwin-amd64.tar.gz";
-        sha256 = "020sgrldrfj13y19n0vvblrc0jb7mssa1rx0izar0b93xdvywy0g";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v3.41.0-darwin-amd64.tar.gz";
+        sha256 = "0iq47qi17sxni3nq78pwc081mzi251mv2ffkb0kbijy0rix5miqd";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v7.27.0-darwin-amd64.tar.gz";
-        sha256 = "0a0vwb9vndi7s0arll0ppyp9w46n730rf2jd74qck05j2f3cmlbs";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v7.28.0-darwin-amd64.tar.gz";
+        sha256 = "1xi6k192f71idzari87a9lf37rc87wxbz5c4gqy2n8r2zd5lhybp";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azuread-v6.9.0-darwin-amd64.tar.gz";
         sha256 = "0y0qwk6vqpdaxzjl48dbgssl6bmyx4pc9167kbiir5q517bdf0zq";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azuredevops-v3.14.0-darwin-amd64.tar.gz";
-        sha256 = "1pvliacpzv58kfi3sq1xa8b16aa14gs23wh1gm12kb8lyrh9cvwf";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azuredevops-v3.14.1-darwin-amd64.tar.gz";
+        sha256 = "00jr2l7k9byw5wfsc9c764pblbisy8qhbdrb68vfhyf8xkiac4bv";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azure-v6.35.0-darwin-amd64.tar.gz";
         sha256 = "0c381vy7j2flvlcri2yadw3i983dgmi28y6xxz2x8psgy48ic7zd";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v6.14.0-darwin-amd64.tar.gz";
-        sha256 = "0f7xci6gkqx6j8xw4kmp6kj41c1xm04cj5vpwzdqi92k2bqm61v2";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v6.15.0-darwin-amd64.tar.gz";
+        sha256 = "1kb1csx83kbcx3gfjs7kq61klffi8pa83ah3i1zcp119w9lwswdz";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-consul-v3.14.1-darwin-amd64.tar.gz";
@@ -215,8 +215,8 @@
         sha256 = "1rc9pj5p4w9fszxdh8vs8lbajbmjljx08j8nlblm5dxiypm5w5bs";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.64.1-darwin-amd64.tar.gz";
-        sha256 = "1cn36p8qs1chnbwf78s56r1rbr1dvk15ahad3p5gr3q7kpxwa4cf";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.65.0-darwin-amd64.tar.gz";
+        sha256 = "0i9gnx79wikna2b83kg9qc1vfafyw5ibl2jlq4sk6ddqbhh283l8";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-docker-v5.0.0-darwin-amd64.tar.gz";
@@ -231,12 +231,12 @@
         sha256 = "1h8s1pc8bdpbhr2v8cfzn59mczpnwdi26x9dplkf95ck6r4s96gh";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v9.21.0-darwin-amd64.tar.gz";
-        sha256 = "17wlk03and5hw07cydlzpd5c8pxnfjd7drfgr41rjyq5gcrn1z6r";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v9.22.0-darwin-amd64.tar.gz";
+        sha256 = "1k5qd35w1389zmgr7h5ajnmq612jhq8yawqfali8vgrgppxfbl6w";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v6.13.0-darwin-amd64.tar.gz";
-        sha256 = "08lwfgna0xh3fmrgmzzsbm9wy2z36kvgqm0pqnh82cvhgrbrikpk";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v6.13.1-darwin-amd64.tar.gz";
+        sha256 = "0fdsnxgnv2w2q4xq4z653cbxmr2dknyzhvz70019naj5pa60k0sq";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v9.11.0-darwin-amd64.tar.gz";
@@ -247,8 +247,8 @@
         sha256 = "0ddd0pgpyywq291r9q8w6bn41r2px595017iihx4n2cnb1c4v6d5";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.33.0-darwin-amd64.tar.gz";
-        sha256 = "1l0n97dx3fdrjk5qrwfh72ib42c1kd5mj5zbsly8rc2l92bw63cq";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.34.0-darwin-amd64.tar.gz";
+        sha256 = "1n8dqpv67b1cj25cprv2sx8sz313xqcri7i31y114sjpcj36w50b";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v4.30.0-darwin-amd64.tar.gz";
@@ -263,8 +263,8 @@
         sha256 = "1ii8mgdiljh9xhk7c8dzzx24s9khdf5n3gwsglrkaf5m2hx24pvn";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v3.2.14-darwin-amd64.tar.gz";
-        sha256 = "0v48i2y4rk5b2mnnfhs8n4gbz7izvs0fmp2bipmmvd0cfki6ckzp";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v3.2.15-darwin-amd64.tar.gz";
+        sha256 = "1rqs0pplpzjh12598prq6md50bn12nh0zp9nnv8a5ng7r4c1r8ig";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-openstack-v5.4.2-darwin-amd64.tar.gz";
@@ -303,8 +303,8 @@
         sha256 = "1xirrbn9zh990j8vxrm8ggld79lbnrg26rw8xzlcypxvb0mkrv9k";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-venafi-v1.12.3-darwin-amd64.tar.gz";
-        sha256 = "0ckw8ilb4khvb2378rmw7zqagxbd0w8n29wf8byszvsgspzyj639";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-venafi-v1.12.4-darwin-amd64.tar.gz";
+        sha256 = "0lzz6jzbrlg64300n25d11xi4rrrnc9gspmcbirncsn94y0hyhqq";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vsphere-v4.16.5-darwin-amd64.tar.gz";
@@ -321,8 +321,8 @@
     ];
     aarch64-linux = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.232.0-linux-arm64.tar.gz";
-        sha256 = "1l87s3g3yz75xwp0l43psa5ngb9cwv8kmimlybn87drnj6klkih2";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.234.0-linux-arm64.tar.gz";
+        sha256 = "1qdwmzy1v3msnhyb97xfnj56vl7mnarc2dmbrvp94lpl79mdah58";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aiven-v6.53.1-linux-arm64.tar.gz";
@@ -333,36 +333,36 @@
         sha256 = "0v84z83y56lnvrgsmla4qnig8cs57ynilib4ah29wb0dwkxvzamf";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-alicloud-v3.100.0-linux-arm64.tar.gz";
-        sha256 = "0n455bfxf6r4ffrg773rhr57m230ldap58dpxm1dnrx640vc7wdd";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-alicloud-v3.101.0-linux-arm64.tar.gz";
+        sha256 = "0dg2brhn72i5wd7nfqs6dhl99fcpfkdr4nd98ll8k12x4g2qjfim";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-artifactory-v8.10.4-linux-arm64.tar.gz";
         sha256 = "0xfa9p3dhnmlq5vpdwgsb73mcp8ckkw17pkgjmlsb54nfayj687d";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v3.40.0-linux-arm64.tar.gz";
-        sha256 = "0cn81fmbgkx1c8cdlsmkxncfq7xfxb08lpkw9419p0kzrvqkgd3l";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v3.41.0-linux-arm64.tar.gz";
+        sha256 = "0p7vknr3j8bfgrh3mlm5nfxnwim0nj8ahc9aqbvsd3ncqlk257vw";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v7.27.0-linux-arm64.tar.gz";
-        sha256 = "1vbi2yap9z5rr9b5yybyfr9y6h8a2910gs8kwh8yxp6ipn94dwa3";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v7.28.0-linux-arm64.tar.gz";
+        sha256 = "0akg4h6i6a81xi9z6brid7g2s6zv2fcm1z7987hbbfnja1z9d1wl";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azuread-v6.9.0-linux-arm64.tar.gz";
         sha256 = "0z4mhhj3hhz1jf1bz3sbny7xn7m158xmg3zs7jxqna4vvmk22afm";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azuredevops-v3.14.0-linux-arm64.tar.gz";
-        sha256 = "027nbrks3n634nsmlwis1qwklj615ixknr6k5jg0q4wd1mwxhsjm";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azuredevops-v3.14.1-linux-arm64.tar.gz";
+        sha256 = "0ahx69c0cl2yhrac0x4041b5mw23s77kl6pp7ryvicdr51r9l3vv";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azure-v6.35.0-linux-arm64.tar.gz";
         sha256 = "0hrn1bw7hr15j29ghw7c18nkpkwmfkqjh62vxmnrs26r9qawzyl5";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v6.14.0-linux-arm64.tar.gz";
-        sha256 = "1x7az4dgd3mw2wi4f6c3pq8k0wbcajjwx927wlg7r5j6scwmcmr3";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v6.15.0-linux-arm64.tar.gz";
+        sha256 = "0msc1ncq5g03ikjg5f9hxzx0xfh3y1lpd369zgyjhwknc628ggfx";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-consul-v3.14.1-linux-arm64.tar.gz";
@@ -373,8 +373,8 @@
         sha256 = "0fah19z4iiq76pyam7m0gzfhlpd6cl4sbb6gz2gn51vnklgs5blz";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.64.1-linux-arm64.tar.gz";
-        sha256 = "0kliiasvaxxhbgaw00686rmb1sx9ml4njm6vxxs90bz77vq4y6kh";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.65.0-linux-arm64.tar.gz";
+        sha256 = "1midgzvrijrcqbphdlkrhh8hv7vzvvkp6zqdk6r7iarwbj7bpigf";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-docker-v5.0.0-linux-arm64.tar.gz";
@@ -389,12 +389,12 @@
         sha256 = "1zagad13q8xgpicqz2d0qgrj4qxg9iqvmmw6di8n2nqhy4hczv8f";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v9.21.0-linux-arm64.tar.gz";
-        sha256 = "0ab5m34s7cbyf7gsb6gb1kgsyb09l33wb4bn62x9l21pk11ra9w7";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v9.22.0-linux-arm64.tar.gz";
+        sha256 = "1gzf8r1zd9ydbxz9ai289j3r35ayzf3lac79ap82cdhh3qag8f6p";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v6.13.0-linux-arm64.tar.gz";
-        sha256 = "1p5r5mgyknvsxpcr0blplj654s0wdzpaap22ia21k34krzjf41ii";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v6.13.1-linux-arm64.tar.gz";
+        sha256 = "0j5krb0aa1ajrr1n0vgdj00jzr6099yasvwv7dssby83zjl44s6k";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v9.11.0-linux-arm64.tar.gz";
@@ -405,8 +405,8 @@
         sha256 = "0d8m2krbzxjhfm82dgf8p4vm3kk9gk98l798q4ayjrddqqb4mxq4";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.33.0-linux-arm64.tar.gz";
-        sha256 = "04spc869y5pl9fdrs75sand1345hx25r21fv2xvglmifgjk2b93j";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.34.0-linux-arm64.tar.gz";
+        sha256 = "1fgg006xljrzjnwbifbih55imgvas26mq6n11nkcgj1njpb77ylf";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v4.30.0-linux-arm64.tar.gz";
@@ -421,8 +421,8 @@
         sha256 = "1k6hl98i33w0cfcr7jxjlah3ssmxk9w8319p2ycwrpmcmjnmra7z";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v3.2.14-linux-arm64.tar.gz";
-        sha256 = "10b1vgmc9n4vdbm3q7d15a3q2x0hgbgyb3mfgi0gpbvvargljm1g";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v3.2.15-linux-arm64.tar.gz";
+        sha256 = "0gyqx6cs4sd8lr1vb9f1w0i6kaw3vajg0fx4jz2ssqv62xcmwj3z";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-openstack-v5.4.2-linux-arm64.tar.gz";
@@ -461,8 +461,8 @@
         sha256 = "1fraas5hwplzfll5ck2q3vq4jqrxl06q04namjy4rbb195159s0l";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-venafi-v1.12.3-linux-arm64.tar.gz";
-        sha256 = "0ki9yg2vqy7w3rbijdv2bhjxhz0lz72xh4cn1x33wp1nri7n4px1";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-venafi-v1.12.4-linux-arm64.tar.gz";
+        sha256 = "0bafyvvmprfrr30nmrccydci73zz3rrrxf4qa3w3hg1c04qsagg6";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vsphere-v4.16.5-linux-arm64.tar.gz";
@@ -479,8 +479,8 @@
     ];
     aarch64-darwin = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.232.0-darwin-arm64.tar.gz";
-        sha256 = "1v2h6a6qb2i94nx43rxilxc04nmzcpmh75bm4ha0nyg1x6q9g6mj";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.234.0-darwin-arm64.tar.gz";
+        sha256 = "1v7sbyjyyz69hdwqf0h1sfg2g551ys5aqgc970ns06vc70pkjgq0";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aiven-v6.53.1-darwin-arm64.tar.gz";
@@ -491,36 +491,36 @@
         sha256 = "0zsa46x3fqmbicfm6lg10k9ghj40pjq0v889ksqpws2d4jlhbwp7";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-alicloud-v3.100.0-darwin-arm64.tar.gz";
-        sha256 = "1v73xq38hnr8lh6z2ma7sks6a7z2awb388pfcifa2wna13i36dy1";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-alicloud-v3.101.0-darwin-arm64.tar.gz";
+        sha256 = "1crcyyilsj4zsba7mwhqzirikp0ff8x6r3mw4sbm2czi9bba1mv9";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-artifactory-v8.10.4-darwin-arm64.tar.gz";
         sha256 = "14dwhd8d6683babl6399yqn6dwihxmjs7fa2p40d071ibmpsx307";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v3.40.0-darwin-arm64.tar.gz";
-        sha256 = "13cmpgxyg8qcpdrv6qf5ik401khf76h04qrphy8avggzzsqb2vfs";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v3.41.0-darwin-arm64.tar.gz";
+        sha256 = "0q71v1skm0k26rapggsam7ds9k3454qdn3wrpmsinjdmvdlbm7m0";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v7.27.0-darwin-arm64.tar.gz";
-        sha256 = "0l1msjdcibyg7h33zfsbgrc0cz4alzy914dh2ck8l2amd1x1r1s4";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v7.28.0-darwin-arm64.tar.gz";
+        sha256 = "1n9dmfiwr16gnrb90irsm46dnqlkhsiyjgb5vvi6zc7qx5qqsc93";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azuread-v6.9.0-darwin-arm64.tar.gz";
         sha256 = "15fnai1jw1mfgk4n6ka952y3iw0825g9xib9h08j6v8r6c06a4by";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azuredevops-v3.14.0-darwin-arm64.tar.gz";
-        sha256 = "0bgv7zbszr2x175x6qm124giplb6a182kabd34kxlp3rddikcyl1";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azuredevops-v3.14.1-darwin-arm64.tar.gz";
+        sha256 = "12vvxl1x9drn91dvnjsa0ff59civlj9ps00ggrbvdn4y43cdlxc1";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azure-v6.35.0-darwin-arm64.tar.gz";
         sha256 = "1g076zzz792s9ywc81xwm7y6r6nfwglwxapcyl0jnlc873mdf842";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v6.14.0-darwin-arm64.tar.gz";
-        sha256 = "092pls9brh7sx8jxs14dkw1djnvk7kpn0skj09bdh7m6rg004h53";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v6.15.0-darwin-arm64.tar.gz";
+        sha256 = "03pjmknlf16i20bs92fiw3kzsvns6jj4szzngcahfwalm6ycg3kz";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-consul-v3.14.1-darwin-arm64.tar.gz";
@@ -531,8 +531,8 @@
         sha256 = "1rnp6l80fbgc1dzc643y4xrgcgj6niaq0hrnb4zq257ksjcm6wmx";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.64.1-darwin-arm64.tar.gz";
-        sha256 = "1y9sl873la0k3fkkl8y7rfzzq5sl9qayks7zvpasacpykpr5fi7x";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.65.0-darwin-arm64.tar.gz";
+        sha256 = "0p338qlfsxrxmd7f4kv2aiaxn7rnjh843nl01iv15i47pbq6512v";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-docker-v5.0.0-darwin-arm64.tar.gz";
@@ -547,12 +547,12 @@
         sha256 = "13lgi9zy9cxs6zwc1whw3qhq6hk1kgi72p4yvhdavdc3j4nf241p";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v9.21.0-darwin-arm64.tar.gz";
-        sha256 = "1h9fnc878f3r1nyd0a6rbzmanxsv5ymc1k63kqvc0lcny4k8w6m9";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v9.22.0-darwin-arm64.tar.gz";
+        sha256 = "03vd2x27h5givqcjgs6c5qhnb975hd2rw3zzc9m897hgr0vj1p0y";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v6.13.0-darwin-arm64.tar.gz";
-        sha256 = "1kmapqwa3vdi7caf1ir9r2ypx7g062lgn8xqdda5rq5yclkv3jqi";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v6.13.1-darwin-arm64.tar.gz";
+        sha256 = "1fyz5ciiq6cxl9wmnsysnn0afx5fcs1cpz92zzjlbk62g66kx2a4";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v9.11.0-darwin-arm64.tar.gz";
@@ -563,8 +563,8 @@
         sha256 = "0caz4kgnnrmdr7n571xc7yqscac9jnjwwpjzbnvx4ib6a91wvsdn";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.33.0-darwin-arm64.tar.gz";
-        sha256 = "17507yg6izmnwaw029wvg5r0xnnsh4fcjczd61ajbhs7vqysrvx2";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.34.0-darwin-arm64.tar.gz";
+        sha256 = "07wzz9a3ch000bvf77m32wkclvzdqq6chc6qcb98m6lc8m3m2h07";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v4.30.0-darwin-arm64.tar.gz";
@@ -579,8 +579,8 @@
         sha256 = "0pni3rikp7vai89jix54mc1k1niawxb0kajwwqis9k34f1nf8yir";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v3.2.14-darwin-arm64.tar.gz";
-        sha256 = "0f31jv8akf96lx310s79siqas29lymlx20di49i8h1mydnqm0fix";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v3.2.15-darwin-arm64.tar.gz";
+        sha256 = "056l532pqhff0ib5yp2p6jh7hyn3bs6vw7wamgkhnwvl8amqgbmn";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-openstack-v5.4.2-darwin-arm64.tar.gz";
@@ -619,8 +619,8 @@
         sha256 = "1cdz7s9hij9xmpkmlzszj78b9wand55sivwnk49halbwdrfrjd8x";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-venafi-v1.12.3-darwin-arm64.tar.gz";
-        sha256 = "02zachw7b5qq0axf8l54rlyrxg0i8xhb9af4jy8r755rhnz890nc";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-venafi-v1.12.4-darwin-arm64.tar.gz";
+        sha256 = "0njj75j9b5gq2fwk09i5bnsvph8gvjqm4m4b5jrhmxj34j1325ig";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vsphere-v4.16.5-darwin-arm64.tar.gz";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/pulumi/pulumi/releases/tag/v3.234.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
