### PR TITLE
zulip-term: fix meta.changelog.url

### DIFF
--- a/pkgs/by-name/zu/zulip-term/package.nix
+++ b/pkgs/by-name/zu/zulip-term/package.nix
@@ -27,7 +27,7 @@ let
 in
 with py.pkgs;
 
-buildPythonApplication rec {
+buildPythonApplication {
   pname = "zulip-term";
   version = "0.7.0-unstable-2026-02-10";
   pyproject = true;
@@ -97,7 +97,7 @@ buildPythonApplication rec {
   meta = {
     description = "Zulip's official terminal client";
     homepage = "https://github.com/zulip/zulip-terminal";
-    changelog = "https://github.com/zulip/zulip-terminal/releases/tag/${version}";
+    changelog = "https://github.com/zulip/zulip-terminal/releases/tag/0.7.0";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       dotlambda


### PR DESCRIPTION
Fixes the CHANGELOG url in meta.

Upstream has been stuck on 0.7.0 for 4 years so I just hardcoded the changelog to version 0.7.0 instead of trying to do anything too clever. This makes me question the value of this field for this particular package but c'est la vie. I have reached out on their zulip channel about cutting a new release so we'll see what happens with that.

See #514132


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
