### PR TITLE
ocamlPackages.seq: cleanup

### DIFF
--- a/pkgs/development/ocaml-modules/seq/default.nix
+++ b/pkgs/development/ocaml-modules/seq/default.nix
@@ -1,62 +1,28 @@
 {
   stdenv,
   lib,
-  fetchFromGitHub,
   ocaml,
-  findlib,
-  ocamlbuild,
 }:
 
-stdenv.mkDerivation (
-  {
-    version = "0.1";
-    pname = "ocaml${ocaml.version}-seq";
+stdenv.mkDerivation {
+  version = "0.1";
+  pname = "ocaml${ocaml.version}-seq";
 
-    meta = {
-      license = lib.licenses.lgpl21;
-      maintainers = [ lib.maintainers.vbgl ];
-      homepage = "https://github.com/c-cube/seq";
-      inherit (ocaml.meta) platforms;
-    };
+  meta = {
+    license = lib.licenses.lgpl21;
+    maintainers = [ lib.maintainers.vbgl ];
+    homepage = "https://github.com/c-cube/seq";
+    description = "Dummy backward-compatibility package for iterators";
+    inherit (ocaml.meta) platforms;
+  };
 
-  }
-  // (
-    if lib.versionOlder ocaml.version "4.07" then
-      {
+  src = ./src-base;
 
-        src = fetchFromGitHub {
-          owner = "c-cube";
-          repo = "seq";
-          rev = "0.1";
-          sha256 = "1cjpsc7q76yfgq9iyvswxgic4kfq2vcqdlmxjdjgd4lx87zvcwrv";
-        };
+  dontBuild = true;
 
-        nativeBuildInputs = [
-          ocaml
-          findlib
-          ocamlbuild
-        ];
-        strictDeps = true;
+  installPhase = ''
+    mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/seq
+    cp META $out/lib/ocaml/${ocaml.version}/site-lib/seq
+  '';
 
-        createFindlibDestdir = true;
-
-        meta.description = "Compatibility package for OCaml’s standard iterator type starting from 4.07";
-
-      }
-    else
-      {
-
-        src = ./src-base;
-
-        dontBuild = true;
-
-        installPhase = ''
-          mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/seq
-          cp META $out/lib/ocaml/${ocaml.version}/site-lib/seq
-        '';
-
-        meta.description = "Dummy backward-compatibility package for iterators";
-
-      }
-  )
-)
+}


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
