### PR TITLE
pkgs-lib/formats: revert to remarshal for toml

### DIFF
--- a/pkgs/build-support/writers/test.nix
+++ b/pkgs/build-support/writers/test.nix
@@ -471,7 +471,7 @@ recurseIntoAttrs {
     toml = expectDataEqual {
       file = writeTOML "data.toml" { hello = "world"; };
       expected = ''
-        hello = 'world'
+        hello = "world"
       '';
     };
 

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -461,18 +461,16 @@ optionalAttrs allowAliases aliases
       generate =
         name: value:
         pkgs.callPackage (
-          { runCommand, go-toml }:
+          { runCommand, remarshal }:
           runCommand name
             {
-              nativeBuildInputs = [ go-toml ];
+              nativeBuildInputs = [ remarshal ];
               value = builtins.toJSON value;
               passAsFile = [ "value" ];
               preferLocalBuild = true;
             }
-            # -use-json-number: preserve JSON ints as TOML ints
-            # (Go's json.Decoder defaults to float64 for all numbers)
             ''
-              jsontoml -use-json-number < "$valuePath" > "$out"
+              json2toml "$valuePath" "$out"
             ''
         ) { };
 

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -695,16 +695,14 @@ runBuildTests {
       float = 3.141
       int = 10
       list = [1, 2]
-      str = 'foo'
+      str = "foo"
       true = true
 
       [attrs]
-      foo = 'foo'
+      foo = "foo"
 
-      [level1]
-      [level1.level2]
       [level1.level2.level3]
-      level4 = 'deep'
+      level4 = "deep"
     '';
   };
 
@@ -725,7 +723,7 @@ runBuildTests {
       ];
     };
     expected = ''
-      language-server = ['bash-language-server', {except-features = ['diagnostics'], name = 'typescript-language-server'}]
+      language-server = ["bash-language-server", {except-features = ["diagnostics"], name = "typescript-language-server"}]
     '';
   };
 
@@ -739,7 +737,7 @@ runBuildTests {
       "stack(x,n)" = "foobar";
     };
     expected = ''
-      'stack(x,n)' = 'foobar'
+      "stack(x,n)" = "foobar"
     '';
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

fixes #513610

alternative to #513796 before the branch off

this is not a series of revert commits since there were simply too many commits, and there are changes like 32c7a5e0469e220b716188d4cc16aff7f143a7d1 that required changes but didn't need to be reverted

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
