### PR TITLE
archiveopteryx: re-init at package

### DIFF
--- a/pkgs/by-name/ar/archiveopteryx/package.nix
+++ b/pkgs/by-name/ar/archiveopteryx/package.nix
@@ -1,0 +1,98 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  openssl,
+  perl,
+  zlib,
+  jam,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "archiveopteryx";
+  version = "3.2.0-unstable-2026-04-29";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "aox";
+    repo = "aox";
+    rev = "1f9a987ab63808c72dd9e400ddcdc3c1601a157a";
+    hash = "sha256-LEILJARkRlEkV7g7JIemB00a7HIiYoKMcugRZOpmtGk=";
+  };
+
+  nativeBuildInputs = [
+    jam
+    perl
+  ];
+
+  buildInputs = [
+    openssl
+    zlib
+  ];
+
+  env = {
+    INSTALLROOT = placeholder "out";
+  };
+
+  postPatch = ''
+    substituteInPlace server/tlsthread.cpp \
+      --replace-fail 'SSLv23_server_method()' 'TLS_server_method()'
+
+    substituteInPlace Jamsettings \
+      --replace-fail 'BINDIR = $(PREFIX)/bin' 'BINDIR = '"$out"'/bin' \
+      --replace-fail 'SBINDIR = $(PREFIX)/sbin' 'SBINDIR = '"$out"'/bin' \
+      --replace-fail 'LIBDIR = $(PREFIX)/lib' 'LIBDIR = '"$out"'/lib' \
+      --replace-fail 'PIDFILEDIR ?= $(PREFIX)/lib/pidfiles' 'PIDFILEDIR ?= /run/archiveopteryx' \
+      --replace-fail 'JAILDIR = $(PREFIX)/jail' 'JAILDIR = /var/lib/archiveopteryx/jail' \
+      --replace-fail 'MESSAGEDIR = $(JAILDIR)/messages' 'MESSAGEDIR = /var/lib/archiveopteryx/jail/messages' \
+      --replace-fail 'CONFIGDIR = $(PREFIX)' 'CONFIGDIR = /etc/archiveopteryx' \
+      --replace-fail 'MANDIR = $(PREFIX)/man' 'MANDIR = '"$out"'/share/man' \
+      --replace-fail 'READMEDIR = $(PREFIX)' 'READMEDIR = '"$out"'/share/doc/archiveopteryx'
+  '';
+
+  # c++17+ fails; newer GCCs also promote a few legacy warnings to errors.
+  env.NIX_CFLAGS_COMPILE = toString (
+    [
+      "-std=c++11"
+      "-Wno-error=builtin-declaration-mismatch"
+      "-Wno-error=deprecated-copy"
+      "-Wno-error=implicit-fallthrough"
+      "-Wno-error=nonnull"
+    ]
+    ++ lib.optionals (stdenv.cc.isGNU && lib.versionAtLeast stdenv.cc.version "11") [
+      "-Wno-error=mismatched-new-delete"
+    ]
+  );
+
+  buildPhase = ''
+    runHook preBuild
+
+    jam "-j$NIX_BUILD_CORES"
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    jam install
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Advanced PostgreSQL-based IMAP and POP server";
+    longDescription = ''
+      Archiveopteryx is a mail server with IMAP, POP, LMTP, and related
+      administration tooling built around a PostgreSQL-backed message store.
+    '';
+    changelog = "https://github.com/aox/aox/commit/${finalAttrs.src.rev}";
+    homepage = "http://archiveopteryx.org/";
+    license = lib.licenses.postgresql;
+    mainProgram = "aox";
+    maintainers = [ lib.maintainers.philocalyst ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Reverts #270449


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

The return of archiopteryx! 
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
