### PR TITLE
dotnet: april 2026 releases part 2

### DIFF
--- a/pkgs/development/compilers/dotnet/10.0/2xx/release-info.json
+++ b/pkgs/development/compilers/dotnet/10.0/2xx/release-info.json
@@ -1,5 +1,5 @@
 {
-  "tarballHash": "sha256-ra5VfQDOBfoejYdHwPr5Wjj++Tp6T9i8aeOJReN0MhE=",
+  "tarballHash": "sha256-GFAmNiWnVqJyX0Qk17h+nULV7oxPp+mDjEeRO5oaEOs=",
   "artifactsUrl": "https://builds.dotnet.microsoft.com/dotnet/source-build/Private.SourceBuilt.Artifacts.10.0.201-servicing.26153.122-1.centos.10-x64.tar.gz",
   "artifactsHash": "sha256-w7BmwpQQZNrjUOVQdeyVINSu6wX8GUWy6KLWVnYLXqU="
 }

--- a/pkgs/development/compilers/dotnet/10.0/2xx/release.json
+++ b/pkgs/development/compilers/dotnet/10.0/2xx/release.json
@@ -1,11 +1,11 @@
 {
-  "release": "10.0.6",
+  "release": "10.0.7",
   "channel": "10.0",
-  "tag": "v10.0.202",
-  "sdkVersion": "10.0.202",
-  "runtimeVersion": "10.0.6",
-  "aspNetCoreVersion": "10.0.6",
+  "tag": "v10.0.203",
+  "sdkVersion": "10.0.203",
+  "runtimeVersion": "10.0.7",
+  "aspNetCoreVersion": "10.0.7",
   "sourceRepository": "https://github.com/dotnet/dotnet",
-  "sourceVersion": "1e7d5a8ae309af8fad1826a5e968aae30719a281",
-  "officialBuildId": "20260330.18"
+  "sourceVersion": "c23858a6d860abe3ca94f9ac630c3e61b2625664",
+  "officialBuildId": "20260419.5"
 }

--- a/pkgs/development/compilers/dotnet/10.0/release-info.json
+++ b/pkgs/development/compilers/dotnet/10.0/release-info.json
@@ -1,5 +1,5 @@
 {
-  "tarballHash": "sha256-BKKWmei16tFgpjPDdtgVKAzNenjgPIDyV+MpwL/f53E=",
+  "tarballHash": "sha256-rRF03sQ1onwlKIibroCDjO14SiloADYI7K/ePiodrd0=",
   "artifactsUrl": "https://builds.dotnet.microsoft.com/dotnet/source-build/Private.SourceBuilt.Artifacts.10.0.105-servicing.26153.111.centos.10-x64.tar.gz",
   "artifactsHash": "sha256-s94GxZMpLHFg9ZDyMwPMfCqkVKCRHh14KgXeAVlThsY="
 }

--- a/pkgs/development/compilers/dotnet/10.0/release.json
+++ b/pkgs/development/compilers/dotnet/10.0/release.json
@@ -1,11 +1,11 @@
 {
-  "release": "10.0.6",
+  "release": "10.0.7",
   "channel": "10.0",
-  "tag": "v10.0.106",
-  "sdkVersion": "10.0.106",
-  "runtimeVersion": "10.0.6",
-  "aspNetCoreVersion": "10.0.6",
+  "tag": "v10.0.107",
+  "sdkVersion": "10.0.107",
+  "runtimeVersion": "10.0.7",
+  "aspNetCoreVersion": "10.0.7",
   "sourceRepository": "https://github.com/dotnet/dotnet",
-  "sourceVersion": "47fb725acf5d7094af51aebbb5b7e5c44a3b2a77",
-  "officialBuildId": "20260326.1"
+  "sourceVersion": "b16286c2284fecf303dbc12a0bb152476d662e44",
+  "officialBuildId": "20260417.8"
 }

--- a/pkgs/development/compilers/dotnet/10.0/releases.nix
+++ b/pkgs/development/compilers/dotnet/10.0/releases.nix
@@ -11,33 +11,33 @@ let
   commonPackages = [
     (fetchNupkg {
       pname = "Microsoft.AspNetCore.App.Ref";
-      version = "10.0.6";
-      hash = "sha512-cQ75/6hc+zGl+uQ8lNNEkC0Oc/3T4mjVpeWJFlXlPlSwDcNU5tVl/fjRlieOLhzMF6cTU9lL72yI1dLEMyDP9Q==";
+      version = "10.0.7";
+      hash = "sha512-Gf7BPLQGekD+oXoub+UqQdZTSk+Y7oe7+s8Z6R3EyJnk/JcJDCXVfyoWDYjY4RWNw6DztEHxqdw4HCLheeZpHQ==";
     })
     (fetchNupkg {
       pname = "Microsoft.AspNetCore.App.Internal.Assets";
-      version = "10.0.6";
-      hash = "sha512-5jQimhzuPNV6TE6aj52TaYupFZq4IUTFgQrWIwPzzMnolOaXUr6D4RBLhb3IGi3Uv2BU1k4oQTxZVd4xWDiv5g==";
+      version = "10.0.7";
+      hash = "sha512-ax/0xF5bAuwsDwyO1hUr8FoESqEkw58JgqVnrF9gX7wMI+w/49lSFGLT5rEKABg2oCd1k4+rAnA4o7d6nHF/mg==";
     })
     (fetchNupkg {
       pname = "Microsoft.NETCore.DotNetAppHost";
-      version = "10.0.6";
-      hash = "sha512-1s5oBp6JvoZqZuDgjni+sYxPlhi0nkCqURE07eJQ9jdw1a1r134Yx7lg6bsSQLijqjnGLI5DPN7lU37uWB4+TQ==";
+      version = "10.0.7";
+      hash = "sha512-H2wX26dSDJNjseyuKnD4BttAz3+pFY7r5QUC+165DV6Fy5zl4vkhQCzW/CuDpZjvgJ7d/h/o5FpJC51S8BBOmg==";
     })
     (fetchNupkg {
       pname = "Microsoft.NETCore.App.Ref";
-      version = "10.0.6";
-      hash = "sha512-xS5ooHpkeKXXZmPXheJuK7Pv+8+xBupMFAgWobcOGCWpw5TSVaDzuM1FEfiaSyHDQt2KKyZix8m0csTBbblRKg==";
+      version = "10.0.7";
+      hash = "sha512-kLouD8cOoStNwIroAqsTOtKyLrHOGkoJKWit6VBMqnHG+JyKe/LIAoHFFm9RXlymIdD47ANutlmfUptqIMgLuA==";
     })
     (fetchNupkg {
       pname = "Microsoft.DotNet.ILCompiler";
-      version = "10.0.6";
-      hash = "sha512-eunvfUh0wuKo11dAwnisa3udCtguCDsKnY/RhFRy8FC1b5H77n0T+2NpUCgyldOjKZSI+giQiWKdqXE/8dEfdg==";
+      version = "10.0.7";
+      hash = "sha512-wpu6ojmbre4W8Z3L5UlTCCZ8XWD7KBqivC23bt3dhcDhGiefk2b0SkqPPc2hDWVJR6u6bNtOO3PJuX6mKT4BFg==";
     })
     (fetchNupkg {
       pname = "Microsoft.NET.ILLink.Tasks";
-      version = "10.0.6";
-      hash = "sha512-Iv8IFWPnBsNIwA8V554YOAOumiojGwUsu9NSBINNUkFoENjHdwS5wpdAI47mGJWCCDFIM71Zv3jkD57DwqBpJg==";
+      version = "10.0.7";
+      hash = "sha512-eqf4OnhoDCh9ecBVgRjfbLtx8gFU2Am8YFn4vG9fJS+bwtmDgH0/o2q5KjDYhnCcODoHtDGFDz+rjx+6wKgf+w==";
     })
   ];
 
@@ -45,118 +45,118 @@ let
     linux-arm = [
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Crossgen2.linux-arm";
-        version = "10.0.6";
-        hash = "sha512-MVWSx6oeaOJ60FoMlsAL8gpkGoSsMg2CcM/o3hsY6CcKbkR3HGHhsw8gIcQlQHXfWTLJwrbkrGlZ97Z6BR5F9Q==";
+        version = "10.0.7";
+        hash = "sha512-fiHBwcC0h66rHu+bHcSweipcnd3QHQ9PkMBo/HXCqPb6cDK/58pV6ZwFSX9+H5omldLa80jKHxWrfaSaEdmt1Q==";
       })
     ];
     linux-arm64 = [
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Crossgen2.linux-arm64";
-        version = "10.0.6";
-        hash = "sha512-Xh8ftU1G45mh4t55yIF+inyHrQFXbffYZ/h0QvSjWhs2TIw+WN95wJ+4g8mqUvRu9fuvB17PXNF5e8UPdevtqg==";
+        version = "10.0.7";
+        hash = "sha512-V+7DGnggco8KCXGdsNsBk6FXpKrumk6P9gg3U4Bq/NCMXRQnw1lK1P/CRVGxnhSpU4ZPRAPiwJ19wYZUpfoSqQ==";
       })
       (fetchNupkg {
         pname = "runtime.linux-arm64.Microsoft.DotNet.ILCompiler";
-        version = "10.0.6";
-        hash = "sha512-O9BWotDFn8yOGM/tMckBSyZq9pldL4ObSaOhpX8xPQ22t+PJ4hbEGmCuk5NG+EepBRPBUdLForuDU72Pa2gddw==";
+        version = "10.0.7";
+        hash = "sha512-w2KQmyqmJPhv2ad7D3zVMOEv4Tp4WvDOGpUYHRSiLLidxdLmG1FMxmST46FkctOCczVropUBoYLJ1aZ8AKyHJw==";
       })
     ];
     linux-x64 = [
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Crossgen2.linux-x64";
-        version = "10.0.6";
-        hash = "sha512-8glLSqD3bXhg8RC24eKa8f1z7J2Sz0mibzk8Cz7MLHvwFyZH1BaEdgn4criEN4T72sk76kT0q5qytxnG04drDg==";
+        version = "10.0.7";
+        hash = "sha512-f94tNt9buVP9R1WSdiip3knUTPhRDnF/PcMsvCO+31vKp0zRza31Z6zz0HhgEsqZWUq5+7rF4FiQHo1h4osNbA==";
       })
       (fetchNupkg {
         pname = "runtime.linux-x64.Microsoft.DotNet.ILCompiler";
-        version = "10.0.6";
-        hash = "sha512-2Mvrr2NE2jX+sXtOygszYRRrp/RwIlaMO4bbAU2wRuAzd9YBH/WsYai30/6iFbwHcsqTUoVwC7PCtKBYHrvfTw==";
+        version = "10.0.7";
+        hash = "sha512-iEOqzzRNCCpMGkj86R21xl5DerN6sJV0OGht/u6KYK3/jjhxNh5hBkS1xW0Ot7ePG0Q59sNuYTrpeLvj149YMQ==";
       })
     ];
     linux-musl-arm = [
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Crossgen2.linux-musl-arm";
-        version = "10.0.6";
-        hash = "sha512-W1r+mbgbyu8mIy3sZr6XslDnTTZ8zhizC1oF2ik01kX/0mQGe/p1qiK/AVkPBN5Wk25uCNJECYdUHXBOkS5oaQ==";
+        version = "10.0.7";
+        hash = "sha512-6Qgktj6xoboOywSjjkAGQ4FewF87cGFc18zp56E8z4kyBSOk0wM79KCPQrOe5MKVeHaEPQEvbvwVhIZkwqwqAg==";
       })
     ];
     linux-musl-arm64 = [
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Crossgen2.linux-musl-arm64";
-        version = "10.0.6";
-        hash = "sha512-yvAnLNsSoUWLZqxXtcm106ZB7RWWteWyBSo3rMhtB8+7KtdjaEkTogI0d/7SNGUabGJ4Zro/nqpKuEdNlRxIBw==";
+        version = "10.0.7";
+        hash = "sha512-ZGLQLyhKxXuPyNsG6330/6Bt48zZiqUzWVDYaiMme7thodpy11OkMdtSCJLWJWzH9cLukJe8YuebOlLdTsKVOg==";
       })
       (fetchNupkg {
         pname = "runtime.linux-musl-arm64.Microsoft.DotNet.ILCompiler";
-        version = "10.0.6";
-        hash = "sha512-5EMADmMNPGqm++7UlF+9D3R01a1ANVeBUQC4UhGyfktS2aMYBahNiwnlYMEj/dCWQ9FqJ/gnrmYSFdoGsBaAHQ==";
+        version = "10.0.7";
+        hash = "sha512-yl7Ya0xaRRvCyoiyKiYYQXOG2DAVZVGG9biUpW1zSVWKOQg5iL7BQYaZg7WhcDVVeRPDTyC5VPf9gln+yJMM8w==";
       })
     ];
     linux-musl-x64 = [
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Crossgen2.linux-musl-x64";
-        version = "10.0.6";
-        hash = "sha512-Y0eBYjBqz1chbRKgGKdsv1ubAZy1EhYFE5KH5XdsIB0xZ7o0t1ruw1Yph7P84HZzNeGI5k4lv3brVrukZ9K48g==";
+        version = "10.0.7";
+        hash = "sha512-p5eA4ycxZp0DOStJGO6OBQGdJLqFkTpPBv8pZginrAN8lqWTC/DQmPP9yQFRVXecTZ5RgbUDSjO/fOBVHPDf1A==";
       })
       (fetchNupkg {
         pname = "runtime.linux-musl-x64.Microsoft.DotNet.ILCompiler";
-        version = "10.0.6";
-        hash = "sha512-MUnbdeOpMQCgW+eWwL2PJEMBcgWjuDEa9DM+0xP+pZ+qTaasnLrNJ4xEAe+i9Vq94F+vZ9uA0u0nhmF79cYLJg==";
+        version = "10.0.7";
+        hash = "sha512-QEaPTnKFte+SoB5+J7ySGHvOYgM1KB8cR7F74NxA9D4lOwJxDSSUgKjTkKY5BxOwqlrzLzyl1LLPeCT1M9AEWw==";
       })
     ];
     osx-arm64 = [
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Crossgen2.osx-arm64";
-        version = "10.0.6";
-        hash = "sha512-VjfFLidwSMXiecKYR4H4TwzgL1x5+jbwhRrr9PxFBEmwEtP/LWokBN22YLCFWmJiSQZqx0n2gGYMrKE2dOvBng==";
+        version = "10.0.7";
+        hash = "sha512-Udp1ZVPMueL98kMWR/G8jA2ZZMtuwyiHJs3LSqEuM90SsT0zbo7khwWGpCDmzKpZEnjVmNGmP7wkk4fDySieIQ==";
       })
       (fetchNupkg {
         pname = "runtime.osx-arm64.Microsoft.DotNet.ILCompiler";
-        version = "10.0.6";
-        hash = "sha512-K7aqq/2Pmwc+EvczTxlYqc2cbgfQqf64iskbcZp+Se87tpDGR9sE1hYhZ0F7lPPIQVrPyWr/64SVmBVPsDA7eA==";
+        version = "10.0.7";
+        hash = "sha512-6GgEcFXNkY88K/ns7rXVfOoKg8IlesaUKpM69Rw5yFqFoSRqg16oyy51b0jXhJzPGTT608KCKD/UBaofpa9sNw==";
       })
     ];
     osx-x64 = [
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Crossgen2.osx-x64";
-        version = "10.0.6";
-        hash = "sha512-bNnBKCjlaCUvMGu2rvs3p915quVYtlnI+bMEUldTv2DWS4lx2rYmIDY2gu3GFAUVp22PJwQf0pk0yXkUaswkeA==";
+        version = "10.0.7";
+        hash = "sha512-ShMydyfpyAraILh3iCfCe7MUJoaAjxjYxEvNcMkKfnl+0YrjdZv0msq97k30q2XOpyhlvI4wx1UEmp0Ca6YVuw==";
       })
       (fetchNupkg {
         pname = "runtime.osx-x64.Microsoft.DotNet.ILCompiler";
-        version = "10.0.6";
-        hash = "sha512-lAqZuJ/5tST6KCGeCJnZru7IJymSw8QH7zYKGIvHgwMGygSit3tkPMrbX7EW6ZeEU7CoX/OupMEl6bjGNvK0zg==";
+        version = "10.0.7";
+        hash = "sha512-v4fNH3zO6mJs4o7hhggzsmkRdlgQIjOM6dctVs++2wdeBI62R9jm7+NL4Mvv+5tlBPxHBNA+rgRXVei41P9PtQ==";
       })
     ];
     win-arm64 = [
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Crossgen2.win-arm64";
-        version = "10.0.6";
-        hash = "sha512-6a01f3cOSCrS0zmCB0Ika71eHyluY88m0Hcfv/rXrjoeuFF3v5ceM4fvAURgUrdQQDd5x036dnSvW84Ea7mhjQ==";
+        version = "10.0.7";
+        hash = "sha512-1DJD0k0hLlYCe8im/x51wMVKrSgJCVEVstt/9WXqBb1ZryIC6OIwuIiQpYL8uqZjOgXfHzLRGR6Nm9qKE556GA==";
       })
       (fetchNupkg {
         pname = "runtime.win-arm64.Microsoft.DotNet.ILCompiler";
-        version = "10.0.6";
-        hash = "sha512-nhZ03840PspgZAWpzvPTOHGMo1R6SuJW00WVWe36U/O8kaLsWYBoha9PFdxqOevDekFIzBUvwl3U3o1Z3PgF6w==";
+        version = "10.0.7";
+        hash = "sha512-zVk5uCU0St7JeHitXNOEzmS1F+pe8QmREE8i1VK2ejNQGS+GEwAVADYQy0Kh9eZZjF6LBMwr+OkM2KNh1MPSEA==";
       })
     ];
     win-x64 = [
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Crossgen2.win-x64";
-        version = "10.0.6";
-        hash = "sha512-PmU5/Eyx6f5iY+MZ9bzeaj0UkorTaUXegyXQSQqEwElmDDC7YvRAlb9mbXrV1shZMajM4ai5THJQPOUkCwgUQw==";
+        version = "10.0.7";
+        hash = "sha512-Ckzj+ydnPySIMZXzGcZzg88Pa0/Z1zTb8P36Ebt+q+/7t4++EXgD/GLeNpcXBqyhVnfZTo+U2X4k7NdtUAI3PQ==";
       })
       (fetchNupkg {
         pname = "runtime.win-x64.Microsoft.DotNet.ILCompiler";
-        version = "10.0.6";
-        hash = "sha512-Yt38xUcp3ZcxUmhEYNN9ETORRJM4kVMK4uBzNJAda7PbJoxquzSaKIkb98xQb4Y12p3QTsY/c61G9PCmxnS7Qw==";
+        version = "10.0.7";
+        hash = "sha512-XlMuELNoGKe4o0WZ4kCVDCDK+PWCuVkCWn5bvHu6+Dzu3Vgrkz6fpbEiueHo/JygAv6mJ7xuh3DmIFhcADLJZA==";
       })
     ];
     win-x86 = [
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Crossgen2.win-x86";
-        version = "10.0.6";
-        hash = "sha512-/9NPTCMxwyE0X5XwLgoNRTICXXdmUMlt0ZC6yq2fDzqpaTtytlGZJV/slCuQGvUC8SaJZQIUN4cGB7XPHNtmuQ==";
+        version = "10.0.7";
+        hash = "sha512-egYUtga/dY/TdaCnAnvz2prLMKyhR1urLwy8oRjpz9H2zPoHGEwEUcYfvWsKQx329wqwKLbEb2tUf1kMXY9xKg==";
       })
     ];
   };
@@ -165,416 +165,416 @@ let
     linux-arm = [
       (fetchNupkg {
         pname = "Microsoft.AspNetCore.App.Runtime.linux-arm";
-        version = "10.0.6";
-        hash = "sha512-iDJ/vB/y87Lp8HD50CjQKT/ywcjGh1QON1+Qs99YWW425noDMaGcsa41pPe+nVeVCh+wDOiaBcXoHx8iomkyiw==";
+        version = "10.0.7";
+        hash = "sha512-W3jeXr/8XA+5GRuO54E2Z0+lzvnQjlUFKUG85OmuTuXBZq1lAYpx11wv3UWnThF5tpfCo/JQdKdlQmCUnT66Cg==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Host.linux-arm";
-        version = "10.0.6";
-        hash = "sha512-qpuImg8ZzYmMudU8AHlCsHKK9cOFO6asf/+rIGHHWCvdIdp+iUq96MLP7dcc3oythKNMll63tal1UYG/+Pio5w==";
+        version = "10.0.7";
+        hash = "sha512-FWFqLaPZrzvDsMXg0gzehxd8pjn1qTwd/ztiJNbaQdfzb7J674FkNewdxYRNcHOKJ11efmC274ZwHYFfjytajQ==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Runtime.linux-arm";
-        version = "10.0.6";
-        hash = "sha512-/sL7qy4PLDDcNhGhSGbz/m2nQHNRKUnAOJMTcjCEzSTZ1yLTbF+OOpCSxGn8vIuAXXAxAzaEpEMW9l67IYvfAg==";
+        version = "10.0.7";
+        hash = "sha512-8AaRL1qvkqWPVjOHQwC0l/OaEW+kB55ZEPpVy+va9DsdKbacluwM6ntw1wyYMqDmT+RY3am3xowGC8BPTLXJfw==";
       })
       (fetchNupkg {
         pname = "runtime.linux-arm.Microsoft.NETCore.DotNetAppHost";
-        version = "10.0.6";
-        hash = "sha512-+UihxId38Pacatt5hJ4XB15vcBFPiJMy/ihuWCSEn24P37lv3/LjAIsOiQH8c+WRnt15dcPFIpFZlUMMdf6Fjw==";
+        version = "10.0.7";
+        hash = "sha512-H1Jb8J18xiMqKw/6wivEMjfarw8+vEwK8ka1JmhnEYzhtTXa+pI4ygsZZqpYo70QcAUqL6JA40aeLJeLs4FS5Q==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Runtime.NativeAOT.linux-arm";
-        version = "10.0.6";
-        hash = "sha512-aa3qMrx88zamTl4nOjt6NrOkHAgqCnFAvVy17MBKTFcESs4O5MIUPiqqN9BRrh+cVY46hovq40BiRWJYfHn/wA==";
+        version = "10.0.7";
+        hash = "sha512-3WJjA3DvD1bOiC90bBCaD7uYRNxwlI/q9WqhJGPfQL0ev9J4IEbhnjDBnfHpvNcQq+94olv7uNULqDuF+0dFoA==";
       })
     ];
     linux-arm64 = [
       (fetchNupkg {
         pname = "Microsoft.AspNetCore.App.Runtime.linux-arm64";
-        version = "10.0.6";
-        hash = "sha512-G4/r1CuSzuoDI9LsxlNS4oWsyb/ONvTfIlbluwpZ7y5J1iiSFWvT1j/zYPs48Uxv0AwbNfeyWd+By9yOBnspdQ==";
+        version = "10.0.7";
+        hash = "sha512-yvySI2llwH3C5SJu7nMPXdiMt9I8mE6yYe2o7uGRmLioYdavL8IWJTe0z+eHqUHBJNGTOecu4iXyewFyBnXRUQ==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Host.linux-arm64";
-        version = "10.0.6";
-        hash = "sha512-ecImFJUtXuQRH0fg3B8Q63JwBjRHLP2DR46VWEeR3Sfm7tGinudqtY/gaZfj9Wslbb6fGbYBFGpkClGgH/Fk+w==";
+        version = "10.0.7";
+        hash = "sha512-CZtMaOZZBFNnUMzTt+32vISPd3EnlLy2SseAG7r+yjKMCToC8RAtd/Nb5brf5JGxqGk6O0XZgis/GLEdYS8s3A==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Runtime.linux-arm64";
-        version = "10.0.6";
-        hash = "sha512-MSFOpfXL6b31I7/+S3BclL179sywe3UA96Aj95AspBm2C0rhhgu21k5wuDGoD33M8KsPAHI99WU3lzBwu1Jw4A==";
+        version = "10.0.7";
+        hash = "sha512-l/M0JFy+BqVl0Vmh/7XW/uStC5kcJxs20RQXrB9gty1/1+jeMPtNjPMxQhX4l8IpnvxJKxHrQwS4fmGxeVLckw==";
       })
       (fetchNupkg {
         pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetAppHost";
-        version = "10.0.6";
-        hash = "sha512-twaK5Q916666uZcne3sWdYCwl7y7rDi6lyVfcwwp/hQs7RyY3INI1E51KCRzNZ0l3c5uFC6YlT3q3Fsky6FUwA==";
+        version = "10.0.7";
+        hash = "sha512-3kbzH8vl6k7kJmyFPpqg+TcC3S2pExh62dH0crOFhwHdrXzh10IKcWOEZA72YMkq1h+Q5Qx7tzhw7f/x9AXzjA==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Runtime.NativeAOT.linux-arm64";
-        version = "10.0.6";
-        hash = "sha512-+Gbf7MOMfX9ZiRg0oco5WUGS0jVF4ZTSMtFgz3dbyIeRKmJuUGBnRlnz/F4WvUpW4VsHs76XyV5aIy1RLh//Sg==";
+        version = "10.0.7";
+        hash = "sha512-OnV4dqKsgne7wa8fAnDcFd64j/rXnCinhIa7lZK8TkxE/VolLBj+ozTlZQnJRTvFRH3qWhCRCxuZ4quTm0031g==";
       })
     ];
     linux-x64 = [
       (fetchNupkg {
         pname = "Microsoft.AspNetCore.App.Runtime.linux-x64";
-        version = "10.0.6";
-        hash = "sha512-EOU7zsnqY0o+MkSSPful0E6cevUqCwGAmTlsYoHPMR6AwzB3OLmVvZ1M9yRJtYdhA/B2GqkUH+PJmqVjl6tW8A==";
+        version = "10.0.7";
+        hash = "sha512-AYjtoZuLypZi04ufOeo3Enf4auCuTh/O+tf3lYAcf9d5aK85eIHXteObsgf3+bzRgVV9Q8ZrNZqGzmo4ET6RrA==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Host.linux-x64";
-        version = "10.0.6";
-        hash = "sha512-AGsjR/MTP9W9JcjafSIIpo/YYatm0mRSoUYcYuNJTWXrS5lW7JRBRwYM2FHrssWPCewGhGhNmEMtBPII/mZdoQ==";
+        version = "10.0.7";
+        hash = "sha512-cewXMAwMkxy7tJsWYDIs+/U8+e2k4iWB0rrWtengsP6gLrRLoMxPEKfgqcPUb8xqEKma12fXjlHSsNQ5w8o3/A==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Runtime.linux-x64";
-        version = "10.0.6";
-        hash = "sha512-Zcr5c0ZpwCsNL6vwDku2u2UlgkEAnEV0sozN990ygPL9zwGbqhrRKyWFGFg7cJdQ2BlsM2Q5LoW02p2ZpbUE1g==";
+        version = "10.0.7";
+        hash = "sha512-6M5WLHEgbkwRgIrVTNCiyKRZEXG6NdSpMHE6a3Eyta9dfnwORtTug/qFc/i0lHzKo7kcD/qSa0n8bIwvVi8alA==";
       })
       (fetchNupkg {
         pname = "runtime.linux-x64.Microsoft.NETCore.DotNetAppHost";
-        version = "10.0.6";
-        hash = "sha512-Td1l7j82rcXfcFNVBmnCvuvwBufLsHw9a252dHt5XB8rE8LZJSyH/QRddaXjT2AxpBWJC0QwzoZav9vlzpJTHA==";
+        version = "10.0.7";
+        hash = "sha512-XyNooMhkEvZOeD9LjL4l4q/2rZHnTBbJX0nXqAGkl9NusVZ32Sieh22NKbfq6VeVPpl39zkBAzW945ZInB5oIA==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Runtime.NativeAOT.linux-x64";
-        version = "10.0.6";
-        hash = "sha512-pDwoxcq38VFWF4+Fi4SMzRsqNYmD4WzhZuGhGz5Mg2RyynioenE/PsK/MReTa5uhLkzkNsaJ51rXujAkgLJNBA==";
+        version = "10.0.7";
+        hash = "sha512-NouZIzCnL2D5ksEURgbwDbvfJEp3UG3GDrb1CYlMrIT9HloDuQrup0p0RTxDLvY8KjN9z8pkKA+UndECrB8fUw==";
       })
     ];
     linux-musl-arm = [
       (fetchNupkg {
         pname = "Microsoft.AspNetCore.App.Runtime.linux-musl-arm";
-        version = "10.0.6";
-        hash = "sha512-fPtfAjLbxa1es0q/g0OntHuIa8Xl0X7yZoBzd1Xaf7BcMd2c++FX2XJzSjjOfim5AUvcSfSWrnuxoxXddiJQjw==";
+        version = "10.0.7";
+        hash = "sha512-AaYA1bOWex13FUTKkmkBqGqrdTh3roqbjUN14aRjjKsvyEWfN1sUEgXkzSppS/3fs7nTAHK3NMgKtwDqjWBOFw==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Host.linux-musl-arm";
-        version = "10.0.6";
-        hash = "sha512-McDEjK+6qJX2kbxt1rreDMPSSkwQy3qxh1EhdEsdWqvFdCZlRiaS5t6v44xC/yJrOGiDgSL2XTbQ0aWRrmRAkw==";
+        version = "10.0.7";
+        hash = "sha512-o5i44nXKDcrMn+O+bLAVz6lxTmCGFQuV6NySNruE5P1Cxl4cLN4AxyCO7O+wAdA8T+LKsMDTJ7fS5e5rD+BunQ==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Runtime.linux-musl-arm";
-        version = "10.0.6";
-        hash = "sha512-giy/2l5hNsdfYQ3hu7vtq4syY4zQYxPcR8BNeExKglwyf4DLX3DnJ8Sk9tQgsZHqqGDme1tB2t5z/AQM1hSqCg==";
+        version = "10.0.7";
+        hash = "sha512-7tqrmvF4S47ChWB4xZWZIaRo0jrdRqkEw5jyrgoh+CpIJZL1up4zH3TrDpuQqU9NwAqKkARS9v0n1bpsI2SKgg==";
       })
       (fetchNupkg {
         pname = "runtime.linux-musl-arm.Microsoft.NETCore.DotNetAppHost";
-        version = "10.0.6";
-        hash = "sha512-So9GK9T9BkPBmtFIZKE2NU8EvYsjvsRanOs4ueB4C5n3cUReIDveVJMjhyT/33P57/ghSTnFHPUNm9AgP8dkIQ==";
+        version = "10.0.7";
+        hash = "sha512-kl8Jo9paaMQ4ik1Qljlg8hEcnTPPR7eRfojoR8bRRG7Qdb5w+KfVt610iPTggbDPbqyxNGTU7JkYI7LC4iqLtQ==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Runtime.NativeAOT.linux-musl-arm";
-        version = "10.0.6";
-        hash = "sha512-VjDpiEesPtpCTvMGzYgPcZVhifNckKeiOr3+/kHeagMdyCl5qhs+wTVJPYb5xZzqSHAf8bhy9lzZBX7qgv5yvQ==";
+        version = "10.0.7";
+        hash = "sha512-rN/13GCBOpEyYDWZ9a8IdNj3XoWVo8keLvAxzCEHIdo61ofoehOkrqKd4nAzICJcahPi3GnpZ6cwgs6QeSEa2Q==";
       })
     ];
     linux-musl-arm64 = [
       (fetchNupkg {
         pname = "Microsoft.AspNetCore.App.Runtime.linux-musl-arm64";
-        version = "10.0.6";
-        hash = "sha512-7PTkVV/BWsI7e3gGEbFOoWfNik6fxvgF/KQBfRw/PMDFDV07b1hCSeuwxgSzjSkI3W+lTCP7a6S6EqS5dkyqsA==";
+        version = "10.0.7";
+        hash = "sha512-Il39r2goFQsKhv1dMkcHZHO5qyHKeidhiWjPnUTem0vAxc5aQ+SuA0LluoqmOMNyMkjf9dcT2LFWA8WAL1m94w==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Host.linux-musl-arm64";
-        version = "10.0.6";
-        hash = "sha512-HJDMoUi8E4Y/dGqldBQ1APvHwNw1vGj95xepeSi0/h8gCYK4uTpIWXU/ZEcSNeKOcDQBV9zfbzxqMbm4iN6nvw==";
+        version = "10.0.7";
+        hash = "sha512-rsZBFUi9cydryfJbMExykLK4PJ9r6tiMtW9qW8RTXNaxw4mIOU91OawP13SNDLXRxKJxf4zWh67zs3Wd+pJt4w==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Runtime.linux-musl-arm64";
-        version = "10.0.6";
-        hash = "sha512-6Cvd/jDu1iitejEqS+xOc5jSjfW4OHDRuVuIZmVjmV2BKx2Qri9iLo6484QZ1+R2DrdfcsVlFpsW47clh3Br1A==";
+        version = "10.0.7";
+        hash = "sha512-0/38WPpfkGB8jNRv/P/h9zOzmW9tA+wbTcIdywd7nz3MOr3ezlrvlUTZqy8//EO0YhF55dJxVYHK/v+qoWGJvA==";
       })
       (fetchNupkg {
         pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetAppHost";
-        version = "10.0.6";
-        hash = "sha512-w6a0yXaPHGp4PE8MgE0fEdqnm2qH7iqe6dqaKHs+e3QPcRgZJa0tj5H7p80sqfCyJEREesyQR/zd4tIlZkaUQg==";
+        version = "10.0.7";
+        hash = "sha512-2P1hgTVIOPQ+EPRXAvyG/dL/XOi3byg61DDtoRcVRjiDKIxQ+Kp9NUV+xU7z+0PleaWMu6kpr0PggCHHx3DBGA==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Runtime.NativeAOT.linux-musl-arm64";
-        version = "10.0.6";
-        hash = "sha512-i/xLNwkkQSL8iP4PTuzCn7Y03JDX8XCrniTmCWcMPD8UPI5TLWoKzpZtXi1cSK+ycyQcZmL5pJtTkYmWrKD3mg==";
+        version = "10.0.7";
+        hash = "sha512-Y73m/2fWqxv6Gj9iuKMyKgUFkQ4JEjBj9KKs5oQ6fSI9sW4G9FBVqKteszr+6F9J5zxHw09BHu06LSLK9O0HTg==";
       })
     ];
     linux-musl-x64 = [
       (fetchNupkg {
         pname = "Microsoft.AspNetCore.App.Runtime.linux-musl-x64";
-        version = "10.0.6";
-        hash = "sha512-u+sBPLJ91iU0l+DeQ5s6iBjlnlygCmT6KBblAGMn8J524k5k6rvXeY2Jo/YzSpZOz+Y4Ym8xMLdmPThuCKUTsQ==";
+        version = "10.0.7";
+        hash = "sha512-4PFWe3vISUFhfMWc2+RCXIEkFuYCb7aCrRuWF/MuOIHEAZrfa9o8jCESjCseRFJrgkFpVZ9S3JUe7xTnxYNxNA==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Host.linux-musl-x64";
-        version = "10.0.6";
-        hash = "sha512-NkLwgpFuWaaodP9DM/aHvoEPNPoEjbBWp5hsXajByz/Z2QXIcR0moUNwJnv+ZSVk4tddO2BgyEhKGrxqw7S05Q==";
+        version = "10.0.7";
+        hash = "sha512-OFrMKJnf3HI4rbcg1yxm7QCdz20X8ZtzwshHx/Fx1UuXzecJwF6Y/LDefw5Iff/UIQq0bC8H3QD/NFqV2VAfwg==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Runtime.linux-musl-x64";
-        version = "10.0.6";
-        hash = "sha512-lT51NcUPT5ucBJfRfmTW9gewi41ZldiNz7nyUhemuGtl9LIcUcgkDcQiyQvkI61RYFCmRxf4q1Q+dB3ponv9AA==";
+        version = "10.0.7";
+        hash = "sha512-VVgCm8sbMKhDoIdtaB5/dlhukHjbk1L2dJTojNWe+2c2D0G6uBtPEJ7x0D0DXYn8uxJQzk2sEetU0FPvF99K6g==";
       })
       (fetchNupkg {
         pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetAppHost";
-        version = "10.0.6";
-        hash = "sha512-sqPvGL7zJGI6eUdHzxWKJNYGhIShTX8aiDV8ttrPm0NQMadAvy0JCEWQpq18SnB50g84/Io5Sc1g5MRjgQxVGA==";
+        version = "10.0.7";
+        hash = "sha512-1m7ER7WC3H/tlboiWD1UOIgjAQbR9Umj44jqE9GRYok3MxnPJekzI2zD7iI6Ay5UFgpXP6xmvA9Dox65eTyIUw==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Runtime.NativeAOT.linux-musl-x64";
-        version = "10.0.6";
-        hash = "sha512-j72wa85OWcE2S2XdLHQjjDlET4B/FMCrfejNI8wKjhXEg0hx+REi2uz7GZkjls0skheE2zxfF7As1o1TO+zDXA==";
+        version = "10.0.7";
+        hash = "sha512-9v2ckKCtY6Dgu3Tm/ojFsoEDdPDcbxW+XPp2hG8joEq3XMbRCDuNUPo+XWkXekthxSk1pDpfYmUF3ecJ/PfwUA==";
       })
     ];
     osx-arm64 = [
       (fetchNupkg {
         pname = "Microsoft.AspNetCore.App.Runtime.osx-arm64";
-        version = "10.0.6";
-        hash = "sha512-3oG/WjxXnVBlZfa6qCS1IfZfNrz1y1at4Lu2opKPItroTMIsqO+OdEKOxmnPTdaoa77wYrNbNNkeclGoeDqZhw==";
+        version = "10.0.7";
+        hash = "sha512-qIDf88Gn7X3DyHFa8aoBvKjCyzS1DjIUbcYkTUTkNiOm0Wjbx4y1LWIhkQBbLIRyZYXtRllnVef2lp6lXC1DcQ==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Host.osx-arm64";
-        version = "10.0.6";
-        hash = "sha512-S2RslgZXc6MuZ+D3Lm/fJGFuol9ke/b0ooFhdBbdo229nKTkgvWiE9kwbHj1cHl8Hze/i7Wb0yAd9IjozUXEVw==";
+        version = "10.0.7";
+        hash = "sha512-4wokP6wGw1Q9CeXIQmj64y9VJs4zETB8GAEX0lfv3HOJgaRA+1PU80qDEjkiG/n8I92PFcP2AYI+XIhUhFn0AA==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Runtime.osx-arm64";
-        version = "10.0.6";
-        hash = "sha512-B1W1PBR6WQN4UkhRwTNvEtlsmrkGOu49Nq/qJiXCVMlZVwwvDZEKm6C+E3PoPbYPCNtPQqtE51Sy+c7DtjX7Ow==";
+        version = "10.0.7";
+        hash = "sha512-fG6yfTwqumXfgFem0ohTTMhaR4wu8GF/ZAQFxoPJckD254ybGLTrBM8F+/SXjjvZD+fezVIippCtU7vbIucztw==";
       })
       (fetchNupkg {
         pname = "runtime.osx-arm64.Microsoft.NETCore.DotNetAppHost";
-        version = "10.0.6";
-        hash = "sha512-4I9jfv+drwsjR8fb7omZN+7I9br/7dpjelh++EIo45CpOmbTHqyDZhQidT0LdrJW/c59J7UEOIWF6A56NRO1rQ==";
+        version = "10.0.7";
+        hash = "sha512-YGuhrT3LwE1xKkxCZO13d6Nd2I50/i1t7Z2IfuRC2HWEdbbCPT+r2ZaSWoq6W/7q4Qm6Q1Y5EB6sIzAg6b/5pQ==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Runtime.NativeAOT.osx-arm64";
-        version = "10.0.6";
-        hash = "sha512-2ZaNKsIbhULYFXl8L5enl6uhPo3Wbrcpm8//FCVih6nuLbzX5uSFZhD9hDYfVSy1YO71PHTCQrA+NYLoh+0R2w==";
+        version = "10.0.7";
+        hash = "sha512-pqXWdyhY8KTm0SO3vHkhXb6n5fWIKGb51k/0GLZqCPxc4CJ8bmjK3y7ps/sw7TUi6Iut8+OnOL3VsEHAT2aP6Q==";
       })
     ];
     osx-x64 = [
       (fetchNupkg {
         pname = "Microsoft.AspNetCore.App.Runtime.osx-x64";
-        version = "10.0.6";
-        hash = "sha512-GkRJpqTrG4m0vnJ3cB8x9Zfu5+lqOnDu+kOtyrSlxY0e+fxwymQSUNDceXYEw+CcT5bnzHSvgz2kxsSg1jy0hw==";
+        version = "10.0.7";
+        hash = "sha512-X+dsme3aKiRQA4ZlmtziV0N/bjUZ/XNThRbHmfNy1eMQ+fhZX9nyh2qzgJlAFL8PajK/HdLDgT8kJgyGBla/Ow==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Host.osx-x64";
-        version = "10.0.6";
-        hash = "sha512-PQRtRloq1sdF7bssl6D2tdKTF+qiiWtz9aGBMGJkr5g6HHSCdQeGPKOaK+HslSU9HqKNwLGTWRanhBUL2jr4FA==";
+        version = "10.0.7";
+        hash = "sha512-kBtKMk5UcAxvErG6FQkiNwHq0cDomo2v0GfUfrhd1h/AZfWyhNQDiKhrpjTXG7Ub3MFWVjpsTQXtzU3JJCRiMg==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Runtime.osx-x64";
-        version = "10.0.6";
-        hash = "sha512-t1nQr12txLQwU+Dpe21qyG2CIlhWBW0iCfK1qiyjjlB/XD4ySAPHNy6SdNrS6I8W/FF9P+kEDtvnuUnocW+z0g==";
+        version = "10.0.7";
+        hash = "sha512-TLSsnX75VsuNe/RSqRU4bk6vUVUXaVAxv7gV/qld13TUkHpsIe/6sOtke1mQDe6wW4IlQil9se5XbSxL6D3k9A==";
       })
       (fetchNupkg {
         pname = "runtime.osx-x64.Microsoft.NETCore.DotNetAppHost";
-        version = "10.0.6";
-        hash = "sha512-HwghUeLMn6uClRHq4Mw+ATaqmAeREuP7n2TksHPs1K7hHp4/W802wHl9oNOwzKJNMkfuy5TjUxPtSUbUHX5wGA==";
+        version = "10.0.7";
+        hash = "sha512-CWNXzdoE9Hv+p75M81rx6UmM4m3jDHvqJOYb6MSPkSyDOxffeSHv5xR05vYBTX9oWUyquJxPZvQ4fl5myzzR+A==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Runtime.NativeAOT.osx-x64";
-        version = "10.0.6";
-        hash = "sha512-5b2W5bJMpJS5j0h4dC0YZoyFDOysCmpV7l0W59C6jfIoVIB08lAlEhwL7wt/YHi8d5A7AX0L1PitkhCgUreqCg==";
+        version = "10.0.7";
+        hash = "sha512-R/SGs73Z5LpzfwBXz0qGecTFWMVBppU7D+hP6oAi5AWU/N9afccqDPp4x5hSn6L1K9LFI5z8dCOW3Diw0mJhng==";
       })
     ];
     win-arm64 = [
       (fetchNupkg {
         pname = "Microsoft.AspNetCore.App.Runtime.win-arm64";
-        version = "10.0.6";
-        hash = "sha512-5BuC87z4VTVqAYSclM0OYEFmKKQK9qX4k/XeIoxarwJIPQRK3G9o/oU0VHaDEoPTVpwCwnzWFPdS1Bn0B/ZOpw==";
+        version = "10.0.7";
+        hash = "sha512-nJMZXK37LvDspllFJu0fSNoReXeMOPt0/LGlX5FWkNnYix9VdmdgsjqKrOeAX2RVeNNwIC0+sP7PCGM4JXDbmQ==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Host.win-arm64";
-        version = "10.0.6";
-        hash = "sha512-sHwySUT1UMFBzBIUnA/j9/u9gP8Umlul9gc6qrM7u6toxB3tylMc7yhX9ul5sGRWUPv2IIVfuZkvuSWTN//1ug==";
+        version = "10.0.7";
+        hash = "sha512-W+Lqs/iBco9XsVJHQyPOEOP/+fLdRTAvyU7rGDBnYpvBYSa8kjX3z4vsoz3d6A1hPLcgLIPkNQBDwKX+2PjqtQ==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Runtime.win-arm64";
-        version = "10.0.6";
-        hash = "sha512-olNum2yYdf+2LblLZ0RktAzcrsgEnNu/X9IvU5ddPqgRshF+uOu6rPxSv7gegdnlN7w3sGwqiJPlQP0mBc6Xew==";
+        version = "10.0.7";
+        hash = "sha512-yRumRTvwYVpED8yQEml9H3h4uhb7hCZ16rAumQuRDOZbF6/kH+qCAiWU8Fu+kTaKeU6BEFfm+t9h4lrMFFZagw==";
       })
       (fetchNupkg {
         pname = "runtime.win-arm64.Microsoft.NETCore.DotNetAppHost";
-        version = "10.0.6";
-        hash = "sha512-f9oAat7sFvWFt9kOOuLzYjvYiyi3LVNyPzmSWtBAV8dewrqM9llXG3GKGzaMC80OIO9Y25XrbI6hEyFg/15Hyw==";
+        version = "10.0.7";
+        hash = "sha512-LkYzLczrxRP1D0BN0A3xkULppNn0NQdlZknZDiiKpJsPZZH9dGni+9tzUfsXIMqNG9o0XDa1U3nXQYve6yh8hQ==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Runtime.NativeAOT.win-arm64";
-        version = "10.0.6";
-        hash = "sha512-PM66kNEWUm4GwPikbHPL/hjp7RaDrVd6fMBnhV04t4Y36xfiKA+cKE/emPJHfWRd0WKFL8k/c9k8Tw3mqCvg1g==";
+        version = "10.0.7";
+        hash = "sha512-6ND+mgGFzzTugMT97ffy2puJTiKLhtmyMdgLw/UnmL6lXU655dnX8CJuvqI8KOuQPnLLNZ7h0GkEzCuC0lbk3A==";
       })
     ];
     win-x64 = [
       (fetchNupkg {
         pname = "Microsoft.AspNetCore.App.Runtime.win-x64";
-        version = "10.0.6";
-        hash = "sha512-bo1NORQPVlxf8O29OGK1JiiEvFLLAcTrFo/w3XS4bni40+JeVbfKk1WD+gHlSy/Gea5YH4tVgG0mZ++0kfVoAg==";
+        version = "10.0.7";
+        hash = "sha512-Pjr+XpDcUQPxqKgnF9rbU0ADgEXhHgyNuvZcJzzKKc4X1NaV688+sIVSBeHGZNvwk8PEmzxnjBsoBKMZXW+Q3w==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Host.win-x64";
-        version = "10.0.6";
-        hash = "sha512-MQIZEn8x2fi7UL/ngd9XqSN7rMlTKPlH5umaG7rninMmcoPy/hL866/gRL8BQv9yRC60QtX050hM12JH+gzIzA==";
+        version = "10.0.7";
+        hash = "sha512-uW9XlYNPtSF/4+sVgbR5rgqRUwudAzU6tfHKGkdW4vBhEQU7VGOKQK6KDHivcYSKKAef+LP0lT44eRgV0aHSuw==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Runtime.win-x64";
-        version = "10.0.6";
-        hash = "sha512-5Oxt114RgC3oNWAs2qnpkqe28xFQq+4YI40fcO+03oaoZW3sHaGystdG5RcE2EqAeVaQ2/g5gaON+bMgc2phtQ==";
+        version = "10.0.7";
+        hash = "sha512-PL1kRf9LOeD1eFBXXiqZ+2vlIV6LsI5D7tEvGvZxDOvp8hvA2iULFEb0mU6skGA/yDBT4Dr/XJ1JhV7HQWP2bQ==";
       })
       (fetchNupkg {
         pname = "runtime.win-x64.Microsoft.NETCore.DotNetAppHost";
-        version = "10.0.6";
-        hash = "sha512-qxeQpjdYIOpqWn9w5Avv3I0v9QJDLgxSKvEkQzNZpnK+KPjeBjyOLNXKiwHkBL8/KoCGLyMmIG1rijxBtYFZsA==";
+        version = "10.0.7";
+        hash = "sha512-OczZHGOHTApFWcx8MFrepzZeN7qDy6hnByoJUXkRbEMVtXlYzP29UNcwxB38YMQDVeiLvd9GqyOg32iqw5oM/w==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Runtime.NativeAOT.win-x64";
-        version = "10.0.6";
-        hash = "sha512-LI37KjRfGiAvG03utxM+Z6b8FEzqd0Oo9MXCGJCPbI8qXmkELw+kYvqhvXFjlf3+oe+SNhll6AuZXL0kpLkHTQ==";
+        version = "10.0.7";
+        hash = "sha512-kkhmYV8OMVus/0jL4OYfuIVz1fLdHq297yYAiId2jHtV6rUHmMm1ThG5s8ZIk0JxBBP6JMlgU8cczjaPNeu5ig==";
       })
     ];
     win-x86 = [
       (fetchNupkg {
         pname = "Microsoft.AspNetCore.App.Runtime.win-x86";
-        version = "10.0.6";
-        hash = "sha512-62zV5HvUEb9wmxwbVzrlo8HJxXJ/gddW/Q8iSuLSRYRzRF0Bmd40q+VZowvB+LbUDKFW0PhQWUOrCWxcqxT6xA==";
+        version = "10.0.7";
+        hash = "sha512-Uje+J51MwnW9Djhhq7tA917T0H14NyDkZZKXpMIc0ik82dEqimk+pt74zyFQpqNbhFmAbNgXqFSytbENdWKN+A==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Host.win-x86";
-        version = "10.0.6";
-        hash = "sha512-xRmMqD5dCksz9UYX5xzMNTrOQhEDGSi4avLakJsBzn8vCsbPwah/ixosVHhmKAOyS+eql84U2M5cw4UK3q25QA==";
+        version = "10.0.7";
+        hash = "sha512-bjeWG2AMv0gJxRcghFT+S9HheguHo8UzXegN//z2bjr3S0g2IhyLtZvnW1kT2OzfTjNEoMMqdAZxsFZXglOqRg==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Runtime.win-x86";
-        version = "10.0.6";
-        hash = "sha512-yL9Anp59gXZjC1R3IxbtZINvV+m7QuDxbhUqogQZCZFUhIkyJQYHVGwSKXeNhRZek2moMwak7jUzV9R2lROCNQ==";
+        version = "10.0.7";
+        hash = "sha512-vJyCtsD2RG6A7ZrRPV4tsrucoICEHuWn1DnQR7T1dQGIuQ1rpot6PUrkfeD/NVTUnC5mb5lJnLdBfWdH3IMQxw==";
       })
       (fetchNupkg {
         pname = "runtime.win-x86.Microsoft.NETCore.DotNetAppHost";
-        version = "10.0.6";
-        hash = "sha512-ZgWfYcGFdGN6+4hdE1Z7+k+gox2AvjzfHlDbwSk8x68vrew4XMuOSiN/dqI+L7gq9NiSr40QfL0Is3fDx2ksQw==";
+        version = "10.0.7";
+        hash = "sha512-nk01IpaPATaIVT/CJcKfswYkyvyp2dS55gR8xn5EoHnTntwc/nCMk21Q0uLtQlveHPE2y1x6UKcQp3G/YJyJ5Q==";
       })
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Runtime.NativeAOT.win-x86";
-        version = "10.0.6";
-        hash = "sha512-ti60jzEk1+MGOXgj19APSePTYQbRdg4+98TMoSy3QWwC/MpiQzk7KgOkff6RH8kPT27DRTmEDepuYaT5q2wh1Q==";
+        version = "10.0.7";
+        hash = "sha512-lxQQPY3LyvWJdqc0/+ozjDFPeW+WB1imP8O6FQwX3/2BpY5ewIuUIbNbEE9CYlAILWJc57/T5+YI5iZL671Ypg==";
       })
     ];
   };
 
 in
 rec {
-  release_10_0 = "10.0.6";
+  release_10_0 = "10.0.7";
 
   aspnetcore_10_0 = buildAspNetCore {
-    version = "10.0.6";
+    version = "10.0.7";
     srcs = {
       linux-arm = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.6/aspnetcore-runtime-10.0.6-linux-arm.tar.gz";
-        hash = "sha512-RvYJLlFWCpY7JgOXEHexcZccLUgdv4p2ACMOjVken/moC1b9fHDhXWwobdYRMVyuZhfnTaGkNTRV06lwyicyVQ==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.7/aspnetcore-runtime-10.0.7-linux-arm.tar.gz";
+        hash = "sha512-OM9v5LI+ANwyNtOhDxOlM/C6DCjdhZeWkeLpiTadl2D4Fq4viKhx+ccTicikr8kpNtrkLBpDHALOUVxahn1wzg==";
       };
       linux-arm64 = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.6/aspnetcore-runtime-10.0.6-linux-arm64.tar.gz";
-        hash = "sha512-je5OZaSnboM4Z2Ft9QijnC+KcQJpojYeR6y3PQkIDlBAXB2EIGMn/13xJ6nyBkUbDO3xRR1DFE5EDZxONQ6Ulw==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.7/aspnetcore-runtime-10.0.7-linux-arm64.tar.gz";
+        hash = "sha512-56F1ZBvs7i5t76l925YmHVMTfu1IXGL142eWC90LAS9xhVHSd+q+YG78/CJ1YB+6S0mekLpxu6sjxQ7/aI+fbw==";
       };
       linux-x64 = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.6/aspnetcore-runtime-10.0.6-linux-x64.tar.gz";
-        hash = "sha512-ie6xbRlx3AqFR1SjvEzrtjepWciJ9WIWryklgLdvv/AcMp3QkziWt072otS8VrnEu2BRltXAUgykMCdCHRVTZQ==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.7/aspnetcore-runtime-10.0.7-linux-x64.tar.gz";
+        hash = "sha512-N4ok+0MnJ14KRgOb03GbAtLWsce/Sw68q8TdbGWoGMiXeQuKC3+hcSsCHE3QqX+ZX+YDf6krLpCeQyZlAdbPGg==";
       };
       linux-musl-arm = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.6/aspnetcore-runtime-10.0.6-linux-musl-arm.tar.gz";
-        hash = "sha512-VTcABH1CdHOuT9mBJFWpkZBvvQgXTskntNZDtdui8JWOPAy2zsajsNGdNxT4UiWfHpTotcPZb/RbNH7nlAz7ow==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.7/aspnetcore-runtime-10.0.7-linux-musl-arm.tar.gz";
+        hash = "sha512-ZwmmexmdAwGTJ/uKs4eyzpF97ITtyTY8lJODktGK06tUdx6lP7xrN2K+fzB1jDWd5qQcQ7tkYg3aeNlmE4/lqw==";
       };
       linux-musl-arm64 = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.6/aspnetcore-runtime-10.0.6-linux-musl-arm64.tar.gz";
-        hash = "sha512-NzBG9TKQUsV+G7VNVMrXgP76crGw1DWnf3BLSGYhs6cUyRIYaAv4YCIILRiSUv1pdtbizwXuUnmw/q1nogPEgQ==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.7/aspnetcore-runtime-10.0.7-linux-musl-arm64.tar.gz";
+        hash = "sha512-7whP1bO5X0fHQoE2f3fZ7RktoC6uXt5BNeyIH4/5c9ul8q9QhgwnOUTZ8gle3VMHBVcOd4f7VTXNqJflgYuv1w==";
       };
       linux-musl-x64 = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.6/aspnetcore-runtime-10.0.6-linux-musl-x64.tar.gz";
-        hash = "sha512-hgKej+R6sBCbVTdgJ8GOiWC6Nteg8wCQso2Ganp8QiEPKhcZaGDBCMHwQ7MZwJVtaYggMM4F//aHKFxn7bnjbA==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.7/aspnetcore-runtime-10.0.7-linux-musl-x64.tar.gz";
+        hash = "sha512-MyxlQ91Fq7SqEmWi78GE8oVQCTVsANvloZYPRe6sftd26/0Uplkrnd1MJrK2DyOrmhtjFyP0klg1JxakiRstvQ==";
       };
       osx-arm64 = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.6/aspnetcore-runtime-10.0.6-osx-arm64.tar.gz";
-        hash = "sha512-QM3fKFKBxlCCqpAnVFmLBbBpOwSgZ1rlvnmrE2ACtaaeMfWIDOfkmSU5Bt6+HdTRoYZCLI9nWU5Q1FLr4/YFOw==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.7/aspnetcore-runtime-10.0.7-osx-arm64.tar.gz";
+        hash = "sha512-LUUxf6ATVowrhTTJE/qh+vLBcQBfMLGi73YjOVsL1B1jo6Y4V4cq9YnZLKq0dFl8vAelqTIOSi/9VD0zvMX67g==";
       };
       osx-x64 = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.6/aspnetcore-runtime-10.0.6-osx-x64.tar.gz";
-        hash = "sha512-FIJM4zrPq1ZcJI9byQBK9beATUB67YxF8CXFCZLyD3oojPWB0LXLufQ141sYRBdn8Pg3Erwmeub+ZQu0auHzBA==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.7/aspnetcore-runtime-10.0.7-osx-x64.tar.gz";
+        hash = "sha512-QnAqJb5KWNoL3WRAa4GH82IqYmPpR46n0nGlK+GzUdyq0yG7s+2l5h/h6plA5bwq0CtKEM4ByR41O8H60g/cLg==";
       };
     };
   };
 
   runtime_10_0 = buildNetRuntime {
-    version = "10.0.6";
+    version = "10.0.7";
     srcs = {
       linux-arm = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.6/dotnet-runtime-10.0.6-linux-arm.tar.gz";
-        hash = "sha512-3W+nV4AoJuX9Z0NaFgIM+rCXXSrRtRbbaQL0IQpN5Rmk6W6cXvLOKAFteF6yGrTUot1hN8sK+JiszRU4BO76PA==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.7/dotnet-runtime-10.0.7-linux-arm.tar.gz";
+        hash = "sha512-bcG4DqodChDbTTUQWoxqNYt4dwPTNTKJ99n+DGry5kILuCqh9TVMln/C3byDqiI8m32dWGSgwr0M6GVoELd0zg==";
       };
       linux-arm64 = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.6/dotnet-runtime-10.0.6-linux-arm64.tar.gz";
-        hash = "sha512-02ysowTbBpGQuBAm47TrFyIso4us0++Y10uvd+WHTunacL0u180q0XnZZafhgvlSfL0w+vmPbWYRdlUyi8GHtA==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.7/dotnet-runtime-10.0.7-linux-arm64.tar.gz";
+        hash = "sha512-f0ttF0ZTnhlBXKmoCOROHyaXx3ox88XmaH7T/E2ddMTJNnsfJoE9Xbg0dEP3wrA92yUQGtzfzNItgOJ5bxMb6Q==";
       };
       linux-x64 = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.6/dotnet-runtime-10.0.6-linux-x64.tar.gz";
-        hash = "sha512-bhHh9BQgPCQxb4VqPmewO4sd/VG1RDcdAoSshvo9rRTZA/dXBNHx8SsLQBdf3ZWz77ZBvDVPEIC2QIGA6qT2jA==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.7/dotnet-runtime-10.0.7-linux-x64.tar.gz";
+        hash = "sha512-cCOum1gDIlZsG+HcdxHMoNwY58iSGp3+RG3yeOX70S+F+c93rZd/rAoHKT2r0IeIFpNP0C2DFUWvn/XgeGpagw==";
       };
       linux-musl-arm = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.6/dotnet-runtime-10.0.6-linux-musl-arm.tar.gz";
-        hash = "sha512-wT1Y8WZNv/1fGOMAIjdXazjZ2a40bDokHCPWJ06l3r9qtgnbvcQT4mG/wFvxWgid6cPC13FFDRMXfxHyMLIvsA==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.7/dotnet-runtime-10.0.7-linux-musl-arm.tar.gz";
+        hash = "sha512-CO6cNOQhRzhlMf2Psxw2nYYpZLeWwZvNKsnW6AiZEQQ5C6Rh84B0EF7FQ0KaO1NziJVcaGOpx2578mmJKHsAUA==";
       };
       linux-musl-arm64 = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.6/dotnet-runtime-10.0.6-linux-musl-arm64.tar.gz";
-        hash = "sha512-GUTvJ5yMzV6gPUJg9IVjg9+wNlvOF4ndfE4lgX2AoJp1OWlF6/MgYS42cYe+LWW5pWEEIkLVB/GQvL11MPss9w==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.7/dotnet-runtime-10.0.7-linux-musl-arm64.tar.gz";
+        hash = "sha512-lKUGtfZKa9I8WYavkL7IjsyH9JpiSFR55LDiI/obCvejbw8dmpcGaqU7NArIouxlA+fc8eG0SQhAHoLHvi0xdA==";
       };
       linux-musl-x64 = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.6/dotnet-runtime-10.0.6-linux-musl-x64.tar.gz";
-        hash = "sha512-DLtheFzDRjyAmZ6xvqgW0ZAx6aU6WUDvkqpkYxduTyJ54kJwmnvrMGQNIdTM4HF1kg6DGHdWECjX1DWBKbC2Cw==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.7/dotnet-runtime-10.0.7-linux-musl-x64.tar.gz";
+        hash = "sha512-5v7XQ6RNToYyqF6TZ9oz/mNb9ELZXdl5xA/dMIsXIQe3uulMMK8hEIJ6StevxI26vzbTOOtLViEFglDIAJknSQ==";
       };
       osx-arm64 = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.6/dotnet-runtime-10.0.6-osx-arm64.tar.gz";
-        hash = "sha512-gOfOQJXdpetPQug21jQOG0o0IEDDi5lOGNGRS55AXltMy41jTRXGkSuV3fovocGlKrMGRm0QYjcoiHCYKijkDw==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.7/dotnet-runtime-10.0.7-osx-arm64.tar.gz";
+        hash = "sha512-zyoEOAsTjQuLBXSbWTWM9Si/i+3XseoxRFfatdjlPfzxTraRXk8z/r0pSj+A7+t+jKh5Q/S8LDMSfChZuyn9fw==";
       };
       osx-x64 = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.6/dotnet-runtime-10.0.6-osx-x64.tar.gz";
-        hash = "sha512-6QQUDtTb42ezVBuojhKfFtzGFGQoEV3KtASMc4kx/ELNVjqp1jVvMCer0zJj39TF3Bt3TQg3T8XsFu3oDW6N/g==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.7/dotnet-runtime-10.0.7-osx-x64.tar.gz";
+        hash = "sha512-+hjhBy3r1VnMqd+347dTim5QZ0XLKPOwmotwrA9Mo0PorEc5wPnOShg5bfxEo1T6FcsDnvwcjtqS+l1jZoARQA==";
       };
     };
   };
 
   sdk_10_0_2xx = buildNetSdk {
-    version = "10.0.202";
+    version = "10.0.203";
     srcs = {
       linux-arm = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.202/dotnet-sdk-10.0.202-linux-arm.tar.gz";
-        hash = "sha512-WGLFX/EhJLVyokqhD+Rbi2vL2rQVnhpNTTuoAFwAjWQF5vb+YPW4ZpYY+29GgvECXhChe3tWcRRzH5lrYSugZQ==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.203/dotnet-sdk-10.0.203-linux-arm.tar.gz";
+        hash = "sha512-k8eS7a90ABi6VgW5riFn8B/mOYJRC15DgHL2P6IUrulaP8YzzwKKfMIKsLYBGdrK/u7CjmFpIXZrVviOIYprBg==";
       };
       linux-arm64 = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.202/dotnet-sdk-10.0.202-linux-arm64.tar.gz";
-        hash = "sha512-Jib6mitQJMCmti9gBbvl1ApOT2ZjDspwXDWLqQAV4tYW+M4UpDQER5kE8i+bEMegP2QrYDLrjt175taI7kVemw==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.203/dotnet-sdk-10.0.203-linux-arm64.tar.gz";
+        hash = "sha512-f7yOiyC21stAJpVE6ktekZ3X/HsGa0KfMuf6kIciTxdEW5DHgHxGdFzELymd1+9lq9AjvsA/w0HOB6W7UqWSGA==";
       };
       linux-x64 = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.202/dotnet-sdk-10.0.202-linux-x64.tar.gz";
-        hash = "sha512-ZpDG6vGLW4+i0AS0BH5wUqNa/Wx1B0OZoACXKlyg58U22qJPN4sMHaGSbqo4KAE1AvRnsAWobDAVx1z2sS1+1g==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.203/dotnet-sdk-10.0.203-linux-x64.tar.gz";
+        hash = "sha512-/cNqJyhbbzm2JYFEVPTdPnbyJZwSedAxfX+il1FLumB94yMpDULK9n9iuQgasmtu2weeAPK4xwnFgm0zSaRR2Q==";
       };
       linux-musl-arm = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.202/dotnet-sdk-10.0.202-linux-musl-arm.tar.gz";
-        hash = "sha512-AhfP5r7qHkwPdruGSOUzuQ26OuvU5/qIi2GE81YPTL4DYuGkTe3fgNFMFhhVYFyVmtxUTT+prZNsga38jQrQKQ==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.203/dotnet-sdk-10.0.203-linux-musl-arm.tar.gz";
+        hash = "sha512-jBDeHHtqPirDgc7xIc7besnwcbYBSWvfH+6ElWJ4QluLIH7VjCy3gjbMQP+tfiA0RKDyewIlWbWmt28VUejgpQ==";
       };
       linux-musl-arm64 = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.202/dotnet-sdk-10.0.202-linux-musl-arm64.tar.gz";
-        hash = "sha512-qqB55DbMtFBXlu5MMcUsSKvzDAfvTEmsG61U36PjTpO4E2rH716nv/kRz7KcijT+LLC7xU5OdGt+P5l8iAq1CQ==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.203/dotnet-sdk-10.0.203-linux-musl-arm64.tar.gz";
+        hash = "sha512-ZipU1imsyLzhHm+aRJfiBM5YbJhK+vqpHtYCB66mw6/GBomiRIogwUy8Dh7COo7A4isvijqJOZEpb7SjOcEoAg==";
       };
       linux-musl-x64 = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.202/dotnet-sdk-10.0.202-linux-musl-x64.tar.gz";
-        hash = "sha512-1yRYmGKYf55XDr1pWJpq5EKk9FIyfAS9PJ0ujdPGNu6MHI3I2b0btEQ1BbdwphTbCtMjHrzBkzKncGOgtIRJsw==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.203/dotnet-sdk-10.0.203-linux-musl-x64.tar.gz";
+        hash = "sha512-Bun9fhgR8LeUDrp94u/Pt6aS1psx6WOYvXXWPllUnD/mbeU66muc6s3pQKSVSpkxjCvbaHPfB+L8EHHWPV7wIw==";
       };
       osx-arm64 = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.202/dotnet-sdk-10.0.202-osx-arm64.tar.gz";
-        hash = "sha512-I63cbAIOK4ASs7e8kgUNbSnjr87zO11yARQW+WQYsiMHXomP5Djv5ZZ+mF7PzSRXKb3Ti/8cVr44nX44xxGIFQ==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.203/dotnet-sdk-10.0.203-osx-arm64.tar.gz";
+        hash = "sha512-c94VjPlXjJfWquxkVFf3U5YVIoqZdPiFSBaDP7wzhh8x70jUd4Y4fuosHkXXzpbJirdg7J9bdgCdkdg+O4fANQ==";
       };
       osx-x64 = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.202/dotnet-sdk-10.0.202-osx-x64.tar.gz";
-        hash = "sha512-mdVCP8wewZhK3p7zp+Zq89bPt0hKNrb622IMTQXCtHxphZ+aXoYXOUM3MRzb4t9Ryq09q2dqwCeR8psOkT9CKg==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.203/dotnet-sdk-10.0.203-osx-x64.tar.gz";
+        hash = "sha512-8ySt8E6sIi3z67m+G4JDBszBEr2crtBlfsZaHS5H3PUvhjxeEkpY167/X0/bmhhlYqr+zJoaxe5Mxh9GJijqDg==";
       };
     };
     inherit commonPackages hostPackages targetPackages;
@@ -583,39 +583,39 @@ rec {
   };
 
   sdk_10_0_1xx = buildNetSdk {
-    version = "10.0.106";
+    version = "10.0.107";
     srcs = {
       linux-arm = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.106/dotnet-sdk-10.0.106-linux-arm.tar.gz";
-        hash = "sha512-oHd0Q5wJH6QswciBO/00LvEqP32f1wYnfwp7JTJDXP3LrDICy7ejIXnRPVPErUx2lFB7wj7xtjPBVu+hP7XMOw==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.107/dotnet-sdk-10.0.107-linux-arm.tar.gz";
+        hash = "sha512-vSE0MpXkFPmOcJItESz/a8ovNvZ1SCXHhSxvVB5cnDfIpEfbzu9Ub67RGcKtrWLtwD/8YudfIyT4Q2usbXSHaw==";
       };
       linux-arm64 = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.106/dotnet-sdk-10.0.106-linux-arm64.tar.gz";
-        hash = "sha512-u8+cdZiQLIvmS4j+n+68dh+5VZ4LQNDywB/sBO81RwIksiv09iLgfoeaf+fJgsL1qJrMsKOmJHckJaybX0sFhw==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.107/dotnet-sdk-10.0.107-linux-arm64.tar.gz";
+        hash = "sha512-z17K1AeKJdO7cAa25J0ehhxx0l9hG2CaLR0yba6frnPfqgApC8BWJ2ltA7OVJjsSBSB99AAIIZ1I1WejUJK03g==";
       };
       linux-x64 = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.106/dotnet-sdk-10.0.106-linux-x64.tar.gz";
-        hash = "sha512-gdqBFFN8pi1FZVlzPd7WHIUYUmIpIbQ9PAbjR6vrm9fMgwGxAO8fCdEO4XMeisZzVrTXTGObFasg3oUCLDgNoA==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.107/dotnet-sdk-10.0.107-linux-x64.tar.gz";
+        hash = "sha512-qS7ZucgZAsVLXgX6EO/80yWXa6srCzq0EoiXIwVunIuDcUtOlWsA+NLuMWQxKHt0rzmIF6ZyXEBsYSFG0KwRag==";
       };
       linux-musl-arm = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.106/dotnet-sdk-10.0.106-linux-musl-arm.tar.gz";
-        hash = "sha512-6UTj7S66iv7MdscfO4z2C7EZkxW3z3WpIsAUpSr+td2vzNI+4xziP8RE+6byulT0nbwiUvLylcSXnqCX9X44/w==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.107/dotnet-sdk-10.0.107-linux-musl-arm.tar.gz";
+        hash = "sha512-ohcZciL8R1Vg0X+FsWsePyaCqEhx8H0euTuPDITpNVXQygJ0uJIODlua0BbPSAeowNQi3U7tk66RFAD7MK1ahQ==";
       };
       linux-musl-arm64 = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.106/dotnet-sdk-10.0.106-linux-musl-arm64.tar.gz";
-        hash = "sha512-rXuMOWOx9dwf5RTGqYDghM/hRi6TF5thh1B7XYEOwjs64qV4aNNsdrDVk/hXTSuzNzmeman4tlCz0v4N8PQhvw==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.107/dotnet-sdk-10.0.107-linux-musl-arm64.tar.gz";
+        hash = "sha512-IQg9r+OOcFkc9p+Pz33RiCr/EZZvLyoWK6nfjcMikEqLCh6sGYBRsrUGCGrgZtL6++BkopdeX6S9nsPHAe26Fw==";
       };
       linux-musl-x64 = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.106/dotnet-sdk-10.0.106-linux-musl-x64.tar.gz";
-        hash = "sha512-T3R0HZPNwK4GyuTUHIXrD2d+2GUwd+8bOxWGfW2F7nSChJwKvTMX1+yWAC9tS9W+zGID9OF44rioUD7ymPDd4A==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.107/dotnet-sdk-10.0.107-linux-musl-x64.tar.gz";
+        hash = "sha512-wKAz8hoSYTBOXxXP4eB7a165IiR+VV+xZ5fqIn55qinMKqnwfMm7KutAjLxtuXCHeuym7CdWuBgq/EuVyGtMwA==";
       };
       osx-arm64 = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.106/dotnet-sdk-10.0.106-osx-arm64.tar.gz";
-        hash = "sha512-F0R5XidzaUbMHUZaBdFjqpu3a4/km0HMpXD4SNmYRAchQ+zu+e+sIQ3gXEn4bt0O92HgETQQg+5GeLlndXyllQ==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.107/dotnet-sdk-10.0.107-osx-arm64.tar.gz";
+        hash = "sha512-2votp+d9cf0n+v+/dGJwK4fa+N/Zsxe6KKpljm8r6en9dpJRsUYisSEAV18ZUz/ld5BH4U21JYR2NlVmGyx/Ag==";
       };
       osx-x64 = {
-        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.106/dotnet-sdk-10.0.106-osx-x64.tar.gz";
-        hash = "sha512-F7FeD/sWJbhPk0t3ZMQi5XMfjjC58fxoiG/+l3GgwoSIorAaPxrxx45p8LldFTuYRCnq278iQ/C6FhAYQu8eZA==";
+        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.107/dotnet-sdk-10.0.107-osx-x64.tar.gz";
+        hash = "sha512-d4ZRhVsewSjPbTB88l95nxPenws1cYJPBojkqrIbgZLM4vLd2AsgPZQHEuNeVs306HNHjr9O/2qn2OE5V7dddw==";
       };
     };
     inherit commonPackages hostPackages targetPackages;

--- a/pkgs/development/compilers/dotnet/11.0/releases.nix
+++ b/pkgs/development/compilers/dotnet/11.0/releases.nix
@@ -500,6 +500,18 @@ rec {
         url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/11.0.0-preview.3.26207.106/aspnetcore-runtime-11.0.0-preview.3.26207.106-osx-x64.tar.gz";
         hash = "sha512-q1Sr28wzzVdPMh56SKh6EiHz4v6ShpTtAFPhZHXqCqywiRyDkpKt8DrK+bTzJyl/+fupvF5ufIX1lXjF5rch+A==";
       };
+      win-arm64 = {
+        url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/11.0.0-preview.3.26207.106/aspnetcore-runtime-11.0.0-preview.3.26207.106-win-arm64.tar.gz";
+        hash = "sha512-y+YtmHRN03IY3iCXNOeAGh8SR1vph+41JNUm04xB0raj0Y5dsQcIrm7f23YfGMHLyAEYxNjdbCrAMdjTdm/TtQ==";
+      };
+      win-x64 = {
+        url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/11.0.0-preview.3.26207.106/aspnetcore-runtime-11.0.0-preview.3.26207.106-win-x64.tar.gz";
+        hash = "sha512-YPsD/KKykHjDTJayQmbhVGoVpnVVcI4rLTDO8UCcf2z8lxzhv51GO/YDFTT+aubSZaF/ajXXy+x7oYcBtWNtwA==";
+      };
+      win-x86 = {
+        url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/11.0.0-preview.3.26207.106/aspnetcore-runtime-11.0.0-preview.3.26207.106-win-x86.tar.gz";
+        hash = "sha512-Ks48TEOf5K+mN+JAOZx8x+LSIB4mldOK5vza+gMuCojO4bGLADexLwoFfWM6dHF31nzg9j71Sj/lEbWS+DTDSA==";
+      };
     };
   };
 
@@ -538,6 +550,18 @@ rec {
         url = "https://builds.dotnet.microsoft.com/dotnet/Runtime/11.0.0-preview.3.26207.106/dotnet-runtime-11.0.0-preview.3.26207.106-osx-x64.tar.gz";
         hash = "sha512-vrGy7EPCRHRPD42q0Z1iLtqGrKVbE1LyUVOjf11olNBVDeqsUIFS0PP0qbKXypZX9eIJ5hZ5xZ5A+gZAMqkL7g==";
       };
+      win-arm64 = {
+        url = "https://builds.dotnet.microsoft.com/dotnet/Runtime/11.0.0-preview.3.26207.106/dotnet-runtime-11.0.0-preview.3.26207.106-win-arm64.tar.gz";
+        hash = "sha512-GucJVrbMmC+dQhZOLNxGMgGbEUSvRd0crqyTa/Pg/ljIHfBMyuM3CYPdGWS91FP+bOFS+P9NomcCfGT1JW+s4g==";
+      };
+      win-x64 = {
+        url = "https://builds.dotnet.microsoft.com/dotnet/Runtime/11.0.0-preview.3.26207.106/dotnet-runtime-11.0.0-preview.3.26207.106-win-x64.tar.gz";
+        hash = "sha512-uQQwLYqookMuCIm93BK/1m08OjujLhcc0c8g7pjiT3YL8L4eupwS0slL5+Ne5P7PlukyUH9GOhiJqH5U7H0MKw==";
+      };
+      win-x86 = {
+        url = "https://builds.dotnet.microsoft.com/dotnet/Runtime/11.0.0-preview.3.26207.106/dotnet-runtime-11.0.0-preview.3.26207.106-win-x86.tar.gz";
+        hash = "sha512-MTjK9HwozoQDhyDLctxoJ8eONpyLLQYhyxBbpwfauEJZz1JinCsnSn0Jj1YfeKSBKxnnlQd9k7YaWZGSuqLj8A==";
+      };
     };
   };
 
@@ -575,6 +599,18 @@ rec {
       osx-x64 = {
         url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-osx-x64.tar.gz";
         hash = "sha512-A21Dhd/gYrwrI4URqEKslaFGJvZEAh6nkTEjs8dwgaOIzBWMtU3pYC1VAkSeQVm/TBGoYQalwSlEZWSW3jV6jg==";
+      };
+      win-arm64 = {
+        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-win-arm64.tar.gz";
+        hash = "sha512-3W31h+b/qQgYmzTdl5rAbjqFNYDuF0xQtXH0nRR3Yts0mDWPyXZdwGDZMVoBSV6UercBfnJ8T2rAbtOvXIQ7PA==";
+      };
+      win-x64 = {
+        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-win-x64.tar.gz";
+        hash = "sha512-5+9TwHdzl3+fBX+AhydtzF6nucp9y2FbZrlxndHF1LEl4X1atFLn/Yl8ijzFiTgz5ihe3AcNgGNs/YeD8EYWmA==";
+      };
+      win-x86 = {
+        url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.3.26207.106/dotnet-sdk-11.0.100-preview.3.26207.106-win-x86.tar.gz";
+        hash = "sha512-k75u4Rp7BH01XpuiJ37DqnQfAwqoFApFdLE34OtC1TZhJGwwtsyAJoASKMavfxpzwRJXxnkKk+dD0QtNKFjWVw==";
       };
     };
     inherit commonPackages hostPackages targetPackages;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
