### PR TITLE
vcs2l: add shell completion + mainProgram

### DIFF
--- a/pkgs/by-name/vc/vcs2l/package.nix
+++ b/pkgs/by-name/vc/vcs2l/package.nix
@@ -5,6 +5,7 @@
   git,
   breezy,
   subversion,
+  installShellFiles,
 }:
 
 with python3Packages;
@@ -26,6 +27,8 @@ buildPythonApplication (finalAttrs: {
     setuptools # pkg_resources is imported during runtime
   ];
 
+  nativeBuildInputs = [ installShellFiles ];
+
   makeWrapperArgs = [
     "--prefix"
     "PATH"
@@ -41,6 +44,11 @@ buildPythonApplication (finalAttrs: {
 
   pythonImportsCheck = [ "vcs2l" ];
 
+  postInstall = ''
+    installShellCompletion $out/share/vcs2l-completion/vcs.{bash,fish,zsh}
+    rm -rf $out/share/vcs2l-completion
+  '';
+
   meta = {
     description = "Provides a command line tool to invoke vcs commands on multiple repositories";
     homepage = "https://github.com/ros-infrastructure/vcs2l";
@@ -49,5 +57,6 @@ buildPythonApplication (finalAttrs: {
       esteve
       sivteck
     ];
+    mainProgram = "vcs";
   };
 })


### PR DESCRIPTION
fix shell completion install path, and allow `nix run nixpkgs#vcs2l`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
