### PR TITLE
cc-wrapper: Fix response file escaping

### DIFF
--- a/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
@@ -279,7 +279,7 @@ PATH="$path_backup"
 if (( "${NIX_LD_USE_RESPONSE_FILE:-@use_response_file_by_default@}" >= 1 )); then
     responseFile=$(@mktemp@ "${TMPDIR:-/tmp}/ld-params.XXXXXX")
     trap '@rm@ -f -- "$responseFile"' EXIT
-    printf "%q\n" \
+    escapeResponseArgs \
        ${extraBefore+"${extraBefore[@]}"} \
        ${params+"${params[@]}"} \
        ${extraAfter+"${extraAfter[@]}"} > "$responseFile"

--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -264,7 +264,7 @@ export PATH="$path_backup"
 if (( "${NIX_CC_USE_RESPONSE_FILE:-@use_response_file_by_default@}" >= 1 )); then
     responseFile=$(@mktemp@ "${TMPDIR:-/tmp}/cc-params.XXXXXX")
     trap '@rm@ -f -- "$responseFile"' EXIT
-    printf "%q\n" \
+    escapeResponseArgs \
        ${extraBefore+"${extraBefore[@]}"} \
        ${params+"${params[@]}"} \
        ${extraAfter+"${extraAfter[@]}"} > "$responseFile"

--- a/pkgs/build-support/wrapper-common/utils.bash
+++ b/pkgs/build-support/wrapper-common/utils.bash
@@ -150,6 +150,14 @@ expandResponseParams() {
     done
 }
 
+function escapeResponseArgs() {
+    for i in "$@"; do
+        # Wrap the argument in double quotes and escape all backslashes and
+        # double quotes.
+        echo '"'"${i//[\\\"]/\\&}"'"'
+    done
+}
+
 checkLinkType() {
     local arg
     type="dynamic"

--- a/pkgs/test/cc-wrapper/default.nix
+++ b/pkgs/test/cc-wrapper/default.nix
@@ -160,6 +160,10 @@ stdenv.mkDerivation {
     echo "Check whether CC and LD with NIX_X_USE_RESPONSE_FILE hardcodes all required binaries..." >&2
     NIX_CC_USE_RESPONSE_FILE=1 NIX_LD_USE_RESPONSE_FILE=1 ${CC} -v
 
+    echo "Check that non-ascii characters and spaces are passed through correctly" >&2
+    # https://github.com/NixOS/nixpkgs/issues/226034
+    LC_ALL=C NIX_CC_USE_RESPONSE_FILE=1 ${CC} -E -dM - -D "FOO=aλ\"	b\" c" < /dev/null | grep "FOO aλ"'"'"	b"'"'" c" -B 2 -A 2
+
     touch $out
   '';
 


### PR DESCRIPTION
cc-wrapper uses response files to pass arguments to the underlying c compiler. The arguments in these files need to be escaped so that the compiler can decode them, even if they contain spaces or other special characters. Currently the cc-wrapper uses `printf %q` to format the arguments. However, the actual formatting depends on the current locale, and, in particular, does not necessarily match what the compiler expectes. Especially this fails when LC_ALL=C, which is the case e.g. with rusc. After analyzing how GCC and Clang parse these files, it seems that it is enough to enclose the string in double quotes and escape the backslashes and double quotes.

GCC argument parsing: https://github.com/gcc-mirror/gcc/blob/40f567d9cabc5170ed396025d516b93838f4f141/libiberty/argv.c#L211
Clang argument parsing: https://github.com/llvm/llvm-project/blob/aeb89698843fcf18736eadfe8ab9b327b7a241af/llvm/lib/Support/CommandLine.cpp#L866

Supersedes #226166: Compared to the previous PR, this handles spaces correctly by enclosing each argument in double quotes.

Closes #419771 and #226034

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
