### PR TITLE
watchyourlan: 2.1.3 -> 2.1.4

### DIFF
--- a/pkgs/by-name/wa/watchyourlan/package.nix
+++ b/pkgs/by-name/wa/watchyourlan/package.nix
@@ -8,21 +8,23 @@
 
 buildGoModule (finalAttrs: {
   pname = "watchyourlan";
-  version = "2.1.3";
+  version = "2.1.4";
 
   src = fetchFromGitHub {
     owner = "aceberg";
     repo = "WatchYourLAN";
     tag = finalAttrs.version;
-    hash = "sha256-TFqBuJHoHKJ/ftorgNG9JpiOrjSmqw+tHhaOYzoTeUM=";
+    hash = "sha256-bSjigrnZH4dztx0Ho4w7Mmi20eVysWwYKGT1hsxSAZg=";
   };
 
-  vendorHash = "sha256-3HxpKahFa8keM9wbNJ3anEBMCoEphaj5rOhydajtnY0=";
+  vendorHash = "sha256-ywNi0BIGU40kqWa2q3QqR/LCohdlmUThCrdVQhD1wGU=";
 
   ldflags = [
     "-s"
     "-w"
   ];
+
+  sourceRoot = "${finalAttrs.src.name}/backend";
 
   nativeBuildInputs = [ makeBinaryWrapper ];
 


### PR DESCRIPTION
Update to 2.1.4

Upstream repo layout changed and moved go source to backend/

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
