### PR TITLE
rustfs: init at 1.0.0-alpha.94

### DIFF
--- a/pkgs/by-name/ru/rustfs/package.nix
+++ b/pkgs/by-name/ru/rustfs/package.nix
@@ -1,0 +1,103 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  pkg-config,
+  protobuf,
+  flatbuffers,
+  nodejs_22,
+  pnpm_10_29_2,
+  pnpmConfigHook,
+  openssl,
+  systemd,
+  nixosTests,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rustfs";
+  version = "1.0.0-alpha.94";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "rustfs";
+    repo = "rustfs";
+    tag = finalAttrs.version;
+    hash = "sha256-aznYreB10pTfIEvA0X6llqysL0f8A5hr8UrUSGLtxtM=";
+  };
+
+  frontend = stdenv.mkDerivation (finalAttrs': {
+    pname = "${finalAttrs.pname}-console";
+    version = "0.1.7";
+
+    src = fetchFromGitHub {
+      owner = "rustfs";
+      repo = "console";
+      tag = "v${finalAttrs'.version}";
+      hash = "sha256-CBlfNNA4e2zXDCipMvLGWCH+DIH0JUjc+/mp3yjb16I=";
+    };
+
+    pnpmDeps = fetchPnpmDeps {
+      inherit (finalAttrs') pname version src;
+      pnpm = pnpm_10_29_2;
+      fetcherVersion = 3;
+      hash = "sha256-CYu8lRRfY9deBgFu4pV59jDWcmqDWndvSHtYX/Y8fkc=";
+    };
+
+    nativeBuildInputs = [
+      nodejs_22
+      pnpmConfigHook
+      pnpm_10_29_2
+    ];
+
+    buildPhase = ''
+      runHook preBuild
+      pnpm run build
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      cp -r out/. $out/
+      runHook postInstall
+    '';
+  });
+
+  cargoHash = "sha256-nVvqFvXY+3c+EIk8H+mF4A7DBsSojZ6Y4ZCUz/KCYAE=";
+  buildAndTestSubdir = "rustfs";
+
+  nativeBuildInputs = [
+    flatbuffers
+    pkg-config
+    protobuf
+  ];
+
+  buildInputs = [
+    openssl
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    systemd
+  ];
+
+  # Upstream enables Tokio's io-uring feature in the workspace and carries the
+  # same flag in .cargo/config.toml; Tokio requires this cfg at compile time.
+  env.RUSTFLAGS = "--cfg tokio_unstable";
+
+  postPatch = ''
+    mkdir -p rustfs/static
+    cp -r ${finalAttrs.frontend}/. rustfs/static/
+  '';
+
+  passthru.tests.rustfs = nixosTests.rustfs;
+
+  meta = {
+    description = "S3-compatible object storage server written in Rust";
+    homepage = "https://github.com/rustfs/rustfs";
+    changelog = "https://github.com/rustfs/rustfs/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ philocalyst ];
+    mainProgram = "rustfs";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/ru/rustfs/package.nix
+++ b/pkgs/by-name/ru/rustfs/package.nix
@@ -1,0 +1,106 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  pkg-config,
+  protobuf,
+  flatbuffers,
+  nodejs_22,
+  pnpm_10_29_2,
+  pnpmConfigHook,
+  openssl,
+  systemd,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rustfs";
+  version = "1.0.0-beta.4";
+  __structuredAttrs = true;
+  __darwinAllowLocalNetworking = true;
+
+  src = fetchFromGitHub {
+    owner = "rustfs";
+    repo = "rustfs";
+    tag = finalAttrs.version;
+    hash = "sha256-1GBOq6PUk/FmvgL8otFHBMS+gT5obiGDXnEVYhVbQuw=";
+  };
+
+  frontend = stdenv.mkDerivation (finalAttrs': {
+    pname = "${finalAttrs.pname}-console";
+    version = "0.1.7";
+
+    src = fetchFromGitHub {
+      owner = "rustfs";
+      repo = "console";
+      tag = "v${finalAttrs'.version}";
+      hash = "sha256-CBlfNNA4e2zXDCipMvLGWCH+DIH0JUjc+/mp3yjb16I=";
+    };
+
+    pnpmDeps = fetchPnpmDeps {
+      inherit (finalAttrs') pname version src;
+      pnpm = pnpm_10_29_2;
+      fetcherVersion = 3;
+      hash = "sha256-CYu8lRRfY9deBgFu4pV59jDWcmqDWndvSHtYX/Y8fkc=";
+    };
+
+    nativeBuildInputs = [
+      nodejs_22
+      pnpmConfigHook
+      pnpm_10_29_2
+    ];
+
+    buildPhase = ''
+      runHook preBuild
+      pnpm run build
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      cp -r out/. $out/
+      runHook postInstall
+    '';
+  });
+
+  cargoHash = "sha256-RuQb3k/0wm8ginhw/09ZDz22JdoYtDSwsOo07p4n03M=";
+  buildAndTestSubdir = "rustfs";
+
+  nativeBuildInputs = [
+    flatbuffers
+    pkg-config
+    protobuf
+  ];
+
+  buildInputs = [
+    openssl
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    systemd
+  ];
+
+  # Upstream enables Tokio's io-uring feature in the workspace and carries the
+  # same flag in .cargo/config.toml; Tokio requires this cfg at compile time.
+  env.RUSTFLAGS = "--cfg tokio_unstable";
+
+  # Faulty test-case, remove in next version.
+  checkFlags = [
+    "--skip=storage::concurrent_get_object_test::tests::test_concurrent_request_tracking"
+  ];
+
+  postPatch = ''
+    mkdir -p rustfs/static
+    cp -r ${finalAttrs.frontend}/. rustfs/static/
+  '';
+
+  meta = {
+    description = "S3-compatible object storage server written in Rust";
+    homepage = "https://github.com/rustfs/rustfs";
+    changelog = "https://github.com/rustfs/rustfs/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ philocalyst ];
+    mainProgram = "rustfs";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- There's not many s3 alternatives in nixpkgs
- Covers different ground than Garage
- I plan to cover/add a module in a future PR
- Also bundles the web interface

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
