### PR TITLE
various: drop maintainership of some packges

### DIFF
--- a/pkgs/development/python-modules/django-cte/default.nix
+++ b/pkgs/development/python-modules/django-cte/default.nix
@@ -38,6 +38,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/dimagi/django-cte";
     changelog = "https://github.com/dimagi/django-cte/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ jopejoe1 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/django-pgactivity/default.nix
+++ b/pkgs/development/python-modules/django-pgactivity/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/AmbitionEng/django-pgactivity";
     changelog = "https://github.com/AmbitionEng/django-pgactivity/blob/${version}/CHANGELOG.md";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ jopejoe1 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/django-pglock/default.nix
+++ b/pkgs/development/python-modules/django-pglock/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/AmbitionEng/django-pglock";
     changelog = "https://github.com/AmbitionEng/django-pglock/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ jopejoe1 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/django-tenants/default.nix
+++ b/pkgs/development/python-modules/django-tenants/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/django-tenants/django-tenants";
     changelog = "https://github.com/django-tenants/django-tenants/releases/tag/${src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ jopejoe1 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pytest-unmagic/default.nix
+++ b/pkgs/development/python-modules/pytest-unmagic/default.nix
@@ -37,6 +37,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/dimagi/pytest-unmagic";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ jopejoe1 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/tenant-schemas-celery/default.nix
+++ b/pkgs/development/python-modules/tenant-schemas-celery/default.nix
@@ -29,6 +29,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/maciej-gol/tenant-schemas-celery";
     changelog = "https://github.com/maciej-gol/tenant-schemas-celery/releases/tag/${src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ jopejoe1 ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
I don't care about these packages anymore and no longer want to maintain them.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
