### PR TITLE
drawy: 1.0.0-alpha -> 1.0.0

### DIFF
--- a/pkgs/by-name/dr/drawy/package.nix
+++ b/pkgs/by-name/dr/drawy/package.nix
@@ -1,56 +1,58 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
+  fetchFromGitLab,
   cmake,
+  pkg-config,
   qt6,
+  shared-mime-info,
+  kdePackages,
   nix-update-script,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "drawy";
-  version = "1.0.0-alpha-unstable-2025-11-17";
+  version = "1.0.0";
 
-  src = fetchFromGitHub {
-    owner = "Prayag2";
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "graphics";
     repo = "drawy";
-    rev = "ca02b66a9615c45c78f2e29839a40c1e5bf8f71c";
-    hash = "sha256-PzIeyhF/1wKD6JyybNRzruuxzSKJZvIq+L7X0rrcQUY=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-K070SiIf2bj1r44tixUZbsLYDxT65lEW0g68ENg3ZiE=";
   };
 
   strictDeps = true;
 
   nativeBuildInputs = [
     cmake
+    pkg-config
     qt6.wrapQtAppsHook
+    shared-mime-info
   ];
 
-  buildInputs = with qt6; [
-    qtbase
-    qttools
+  buildInputs = [
+    qt6.qtbase
+    qt6.qttools
+
+    kdePackages.extra-cmake-modules
+    kdePackages.kconfig
+    kdePackages.kconfigwidgets
+    kdePackages.kcoreaddons
+    kdePackages.kcrash
+    kdePackages.kdoctools
+    kdePackages.ki18n
+    kdePackages.kiconthemes
+    kdePackages.kwidgetsaddons
+    kdePackages.kxmlgui
+    kdePackages.syntax-highlighting
   ];
-
-  postInstall = ''
-    for size in 16 32 256 512; do
-      install -D --mode=644 \
-        "$src"/assets/logo-$size.png \
-        "$out/share/icons/hicolor/''${size}x''${size}/apps/drawy.png"
-    done
-
-    install -D --mode=644 \
-      "$src"/assets/logo.svg \
-      "$out"/share/icons/hicolor/scalable/apps/drawy.svg
-
-    install -D --mode=644 \
-      "$src"/deploy/appimage/AppDir/usr/share/applications/drawy.desktop \
-      --target-directory="$out"/share/applications
-  '';
 
   passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Handy and infinite brainstorming tool";
-    homepage = "https://github.com/Prayag2/drawy";
+    homepage = "https://apps.kde.org/drawy/";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
       yiyu
@@ -59,4 +61,4 @@ stdenv.mkDerivation {
     mainProgram = "drawy";
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
Drawy has been adopted as a KDE project, so it's now significantly less of a pain to build.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
