### PR TITLE
nixos/immich: Make machine learning and server independent

### DIFF
--- a/nixos/modules/services/web-apps/immich.nix
+++ b/nixos/modules/services/web-apps/immich.nix
@@ -49,6 +49,7 @@ let
     mkIf
     mkOption
     mkEnableOption
+    mkMerge
     ;
 
   postgresqlPackage =
@@ -78,7 +79,7 @@ in
       ]
       ''
         `database.enableVectorChord` has been deprecated as the pgvecto.rs alternative
-        is no longer available. From now on, vectorchord is always enabled.
+         is no longer available. From now on, vectorchord is always enabled.
       ''
     )
     (lib.mkRemovedOptionModule
@@ -196,7 +197,8 @@ in
       enable =
         mkEnableOption "immich's machine-learning functionality to detect faces and search for objects"
         // {
-          default = true;
+          default = config.services.immich.enable;
+          defaultText = lib.literalExpression "config.services.immich.enable";
         };
       environment = mkOption {
         type = types.submodule { freeformType = types.attrsOf types.str; };
@@ -270,196 +272,204 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
-    assertions = [
-      {
-        assertion = !isPostgresUnixSocket -> cfg.secretsFile != null;
-        message = "A secrets file containing at least the database password must be provided when unix sockets are not used.";
-      }
-    ];
+  config = mkMerge [
+    (mkIf (cfg.enable || cfg.machine-learning.enable) {
+      systemd.slices.system-immich = {
+        description = "Immich (self-hosted photo and video backup solution) slice";
+        documentation = [ "https://immich.app/docs" ];
+      };
+      users.users = mkIf (cfg.user == "immich") {
+        immich = {
+          name = "immich";
+          group = cfg.group;
+          isSystemUser = true;
+        };
+      };
+      users.groups = mkIf (cfg.group == "immich") { immich = { }; };
+    })
 
-    services.postgresql = mkIf cfg.database.enable {
-      enable = true;
-      ensureDatabases = mkIf cfg.database.createDB [ cfg.database.name ];
-      ensureUsers = mkIf cfg.database.createDB [
+    (mkIf cfg.enable {
+      assertions = [
         {
-          name = cfg.database.user;
-          ensureDBOwnership = true;
-          ensureClauses.login = true;
+          assertion = !isPostgresUnixSocket -> cfg.secretsFile != null;
+          message = "A secrets file containing at least the database password must be provided when unix sockets are not used.";
         }
       ];
-      extensions = ps: [
-        ps.pgvector
-        ps.vectorchord
-      ];
-      settings = {
-        shared_preload_libraries = [ "vchord.so" ];
-        search_path = "\"$user\", public, vectors";
-      };
-    };
-    systemd.services.postgresql-setup.serviceConfig.ExecStartPost =
-      let
-        extensions = [
-          "unaccent"
-          "uuid-ossp"
-          "cube"
-          "earthdistance"
-          "pg_trgm"
-          "vector"
-          "vchord"
-        ];
-        sqlFile = pkgs.writeText "immich-pgvectors-setup.sql" ''
-          -- save previous version of vectorchord to trigger reindex on update
-          SELECT COALESCE(installed_version, ''') AS vchord_version_before FROM pg_available_extensions WHERE name = 'vchord' \gset
 
-          ${lib.concatMapStringsSep "\n" (ext: "CREATE EXTENSION IF NOT EXISTS \"${ext}\";") extensions}
-          ${lib.concatMapStringsSep "\n" (ext: "ALTER EXTENSION \"${ext}\" UPDATE;") extensions}
-          ALTER SCHEMA public OWNER TO ${cfg.database.user};
-
-          -- trigger reindex if vectorchord updates
-          -- https://docs.immich.app/administration/postgres-standalone/#updating-vectorchord
-          SELECT COALESCE(installed_version, ''') AS vchord_version_after FROM pg_available_extensions WHERE name = 'vchord' \gset
-
-          SELECT (:'vchord_version_before' != ''' AND :'vchord_version_before' != :'vchord_version_after') AS has_vchord_updated \gset
-          \if :has_vchord_updated
-            REINDEX INDEX face_index;
-            REINDEX INDEX clip_index;
-          \endif
-        '';
-      in
-      [
-        ''
-          ${lib.getExe' postgresqlPackage "psql"} -d "${cfg.database.name}" -f "${sqlFile}"
-        ''
-      ];
-
-    services.redis.servers = mkIf cfg.redis.enable {
-      immich = {
+      services.postgresql = mkIf cfg.database.enable {
         enable = true;
-        port = cfg.redis.port;
-        bind = mkIf (!isRedisUnixSocket) cfg.redis.host;
-      };
-    };
-
-    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.port ];
-
-    services.immich.environment =
-      let
-        postgresEnv =
-          if isPostgresUnixSocket then
-            { DB_URL = "postgresql:///${cfg.database.name}?host=${cfg.database.host}"; }
-          else
-            {
-              DB_HOSTNAME = cfg.database.host;
-              DB_PORT = toString cfg.database.port;
-              DB_DATABASE_NAME = cfg.database.name;
-              DB_USERNAME = cfg.database.user;
-            };
-        redisEnv =
-          if isRedisUnixSocket then
-            { REDIS_SOCKET = cfg.redis.host; }
-          else
-            {
-              REDIS_PORT = toString cfg.redis.port;
-              REDIS_HOSTNAME = cfg.redis.host;
-            };
-      in
-      postgresEnv
-      // redisEnv
-      // {
-        IMMICH_HOST = cfg.host;
-        IMMICH_PORT = toString cfg.port;
-        IMMICH_MEDIA_LOCATION = cfg.mediaLocation;
-        IMMICH_MACHINE_LEARNING_URL = "http://localhost:3003";
-      }
-      // lib.optionalAttrs (cfg.settings != null) {
-        IMMICH_CONFIG_FILE = "/run/immich/config.json";
-      };
-
-    services.immich.machine-learning.environment = {
-      MACHINE_LEARNING_WORKERS = "1";
-      MACHINE_LEARNING_WORKER_TIMEOUT = "120";
-      MACHINE_LEARNING_CACHE_FOLDER = "/var/cache/immich";
-      XDG_CACHE_HOME = "/var/cache/immich";
-      IMMICH_HOST = "localhost";
-      IMMICH_PORT = "3003";
-    };
-
-    systemd.slices.system-immich = {
-      description = "Immich (self-hosted photo and video backup solution) slice";
-      documentation = [ "https://immich.app/docs" ];
-    };
-
-    systemd.services.immich-server = {
-      description = "Immich backend server (Self-hosted photo and video backup solution)";
-      requires = lib.mkIf cfg.database.enable [ "postgresql.target" ];
-      after = [ "network.target" ] ++ lib.optionals cfg.database.enable [ "postgresql.target" ];
-      wantedBy = [ "multi-user.target" ];
-      inherit (cfg) environment;
-      path = [
-        # gzip and pg_dumpall are used by the backup service
-        pkgs.gzip
-        postgresqlPackage
-      ];
-
-      preStart = mkIf (cfg.settings != null) secretsReplacement.script;
-
-      serviceConfig = commonServiceConfig // {
-        LoadCredential = secretsReplacement.credentials;
-        ExecStart = lib.getExe cfg.package;
-        EnvironmentFile = mkIf (cfg.secretsFile != null) cfg.secretsFile;
-        Slice = "system-immich.slice";
-        StateDirectory = "immich";
-        SyslogIdentifier = "immich";
-        RuntimeDirectory = "immich";
-        User = cfg.user;
-        Group = cfg.group;
-        # ensure that immich-server has permission to connect to the redis socket.
-        SupplementaryGroups = mkIf (cfg.redis.enable && isRedisUnixSocket) [
-          config.services.redis.servers.immich.group
+        ensureDatabases = mkIf cfg.database.createDB [ cfg.database.name ];
+        ensureUsers = mkIf cfg.database.createDB [
+          {
+            name = cfg.database.user;
+            ensureDBOwnership = true;
+            ensureClauses.login = true;
+          }
         ];
+        extensions = ps: [
+          ps.pgvector
+          ps.vectorchord
+        ];
+        settings = {
+          shared_preload_libraries = [ "vchord.so" ];
+          search_path = "\"$user\", public, vectors";
+        };
       };
-    };
+      systemd.services.postgresql-setup.serviceConfig.ExecStartPost =
+        let
+          extensions = [
+            "unaccent"
+            "uuid-ossp"
+            "cube"
+            "earthdistance"
+            "pg_trgm"
+            "vector"
+            "vchord"
+          ];
+          sqlFile = pkgs.writeText "immich-pgvectors-setup.sql" ''
+            -- save previous version of vectorchord to trigger reindex on update
+            SELECT COALESCE(installed_version, ''') AS vchord_version_before FROM pg_available_extensions WHERE name = 'vchord' \gset
 
-    systemd.services.immich-machine-learning = mkIf cfg.machine-learning.enable {
-      description = "immich machine learning";
-      requires = lib.mkIf cfg.database.enable [ "postgresql.target" ];
-      after = [ "network.target" ] ++ lib.optionals cfg.database.enable [ "postgresql.target" ];
-      wantedBy = [ "multi-user.target" ];
-      inherit (cfg.machine-learning) environment;
-      serviceConfig = commonServiceConfig // {
-        ExecStart = lib.getExe cfg.package.machine-learning;
-        Slice = "system-immich.slice";
-        CacheDirectory = "immich";
-        User = cfg.user;
-        Group = cfg.group;
+            ${lib.concatMapStringsSep "\n" (ext: "CREATE EXTENSION IF NOT EXISTS \"${ext}\";") extensions}
+            ${lib.concatMapStringsSep "\n" (ext: "ALTER EXTENSION \"${ext}\" UPDATE;") extensions}
+            ALTER SCHEMA public OWNER TO ${cfg.database.user};
+
+            -- trigger reindex if vectorchord updates
+            -- https://docs.immich.app/administration/postgres-standalone/#updating-vectorchord
+            SELECT COALESCE(installed_version, ''') AS vchord_version_after FROM pg_available_extensions WHERE name = 'vchord' \gset
+
+            SELECT (:'vchord_version_before' != ''' AND :'vchord_version_before' != :'vchord_version_after') AS has_vchord_updated \gset
+            \if :has_vchord_updated
+              REINDEX INDEX face_index;
+              REINDEX INDEX clip_index;
+            \endif
+          '';
+        in
+        [
+          ''
+            ${lib.getExe' postgresqlPackage "psql"} -d "${cfg.database.name}" -f "${sqlFile}"
+          ''
+        ];
+
+      services.redis.servers = mkIf cfg.redis.enable {
+        immich = {
+          enable = true;
+          port = cfg.redis.port;
+          bind = mkIf (!isRedisUnixSocket) cfg.redis.host;
+        };
       };
-    };
 
-    systemd.tmpfiles.settings = {
-      immich = {
-        # Redundant to the `UMask` service config setting on new installs, but installs made in
-        # early 24.11 created world-readable media storage by default, which is a privacy risk. This
-        # fixes those installs.
-        "${cfg.mediaLocation}" = {
-          e = {
-            user = cfg.user;
-            group = cfg.group;
-            mode = "0700";
+      networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.port ];
+
+      services.immich.environment =
+        let
+          postgresEnv =
+            if isPostgresUnixSocket then
+              { DB_URL = "postgresql:///${cfg.database.name}?host=${cfg.database.host}"; }
+            else
+              {
+                DB_HOSTNAME = cfg.database.host;
+                DB_PORT = toString cfg.database.port;
+                DB_DATABASE_NAME = cfg.database.name;
+                DB_USERNAME = cfg.database.user;
+              };
+          redisEnv =
+            if isRedisUnixSocket then
+              { REDIS_SOCKET = cfg.redis.host; }
+            else
+              {
+                REDIS_PORT = toString cfg.redis.port;
+                REDIS_HOSTNAME = cfg.redis.host;
+              };
+        in
+        postgresEnv
+        // redisEnv
+        // {
+          IMMICH_HOST = cfg.host;
+          IMMICH_PORT = toString cfg.port;
+          IMMICH_MEDIA_LOCATION = cfg.mediaLocation;
+          IMMICH_MACHINE_LEARNING_URL = "http://localhost:3003";
+        }
+        // lib.optionalAttrs (cfg.settings != null) {
+          IMMICH_CONFIG_FILE = "/run/immich/config.json";
+        };
+
+      systemd.services.immich-server = {
+        description = "Immich backend server (Self-hosted photo and video backup solution)";
+        requires = lib.mkIf cfg.database.enable [ "postgresql.target" ];
+        after = [ "network.target" ] ++ lib.optionals cfg.database.enable [ "postgresql.target" ];
+        wantedBy = [ "multi-user.target" ];
+        inherit (cfg) environment;
+        path = [
+          # gzip and pg_dumpall are used by the backup service
+          pkgs.gzip
+          postgresqlPackage
+        ];
+
+        preStart = mkIf (cfg.settings != null) secretsReplacement.script;
+
+        serviceConfig = commonServiceConfig // {
+          LoadCredential = secretsReplacement.credentials;
+          ExecStart = lib.getExe cfg.package;
+          EnvironmentFile = mkIf (cfg.secretsFile != null) cfg.secretsFile;
+          Slice = "system-immich.slice";
+          StateDirectory = "immich";
+          SyslogIdentifier = "immich";
+          RuntimeDirectory = "immich";
+          User = cfg.user;
+          Group = cfg.group;
+          # ensure that immich-server has permission to connect to the redis socket.
+          SupplementaryGroups = mkIf (cfg.redis.enable && isRedisUnixSocket) [
+            config.services.redis.servers.immich.group
+          ];
+        };
+      };
+
+      systemd.tmpfiles.settings = {
+        immich = {
+          # Redundant to the `UMask` service config setting on new installs, but installs made in
+          # early 24.11 created world-readable media storage by default, which is a privacy risk. This
+          # fixes those installs.
+          "${cfg.mediaLocation}" = {
+            e = {
+              user = cfg.user;
+              group = cfg.group;
+              mode = "0700";
+            };
           };
         };
       };
-    };
+    })
 
-    users.users = mkIf (cfg.user == "immich") {
-      immich = {
-        name = "immich";
-        group = cfg.group;
-        isSystemUser = true;
+    (mkIf cfg.machine-learning.enable {
+      services.immich.machine-learning.environment = {
+        MACHINE_LEARNING_WORKERS = "1";
+        MACHINE_LEARNING_WORKER_TIMEOUT = "120";
+        MACHINE_LEARNING_CACHE_FOLDER = "/var/cache/immich";
+        XDG_CACHE_HOME = "/var/cache/immich";
+        IMMICH_HOST = "localhost";
+        IMMICH_PORT = "3003";
       };
-    };
-    users.groups = mkIf (cfg.group == "immich") { immich = { }; };
-  };
+      systemd.services.immich-machine-learning = {
+        description = "immich machine learning";
+        requires = lib.mkIf (cfg.enable && cfg.database.enable) [ "postgresql.target" ];
+        after = [
+          "network.target"
+        ]
+        ++ lib.optionals (cfg.enable && cfg.database.enable) [ "postgresql.target" ];
+        wantedBy = [ "multi-user.target" ];
+        inherit (cfg.machine-learning) environment;
+        serviceConfig = commonServiceConfig // {
+          ExecStart = lib.getExe cfg.package.machine-learning;
+          Slice = "system-immich.slice";
+          CacheDirectory = "immich";
+          User = cfg.user;
+          Group = cfg.group;
+        };
+      };
+    })
+  ];
+
   meta = {
     maintainers = with lib.maintainers; [ jvanbruegge ];
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Make `immich.enable` independent on `immich.machine-learning.enable` which will allow users to run machine learning without server.

closes https://github.com/NixOS/nixpkgs/issues/436487
replaces outdated https://github.com/NixOS/nixpkgs/pull/480510

## Things done
The module has been separated into blocks which make it possible to run ML without server as Immich supports multiple ml instances.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
