### PR TITLE
ouch: 0.6.1 -> 0.7.1

### DIFF
--- a/pkgs/by-name/ou/ouch/package.nix
+++ b/pkgs/by-name/ou/ouch/package.nix
@@ -73,6 +73,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     maintainers = with lib.maintainers; [
       psibi
       krovuxdev
+      philocalyst
     ];
     mainProgram = "ouch";
   };

--- a/pkgs/by-name/ou/ouch/package.nix
+++ b/pkgs/by-name/ou/ouch/package.nix
@@ -3,6 +3,7 @@
   rustPlatform,
   fetchFromGitHub,
   installShellFiles,
+  cmake,
   pkg-config,
   bzip2,
   bzip3,
@@ -18,18 +19,19 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ouch";
-  version = "0.6.1";
+  version = "0.7.1";
 
   src = fetchFromGitHub {
     owner = "ouch-org";
     repo = "ouch";
     rev = finalAttrs.version;
-    hash = "sha256-vNeOJOyQsjDUzScA1a/W+SI1Z67HTLiHjwWZZpr1Paw=";
+    hash = "sha256-XT2CWYZiY5UskTmHKl9EVWBIJoOiR9rOCQUoN8U9o40=";
   };
 
-  cargoHash = "sha256-mMoYJ3dLpb1Y3Ocdyxg1brE7xYeZBbtUg0J/2HTK0hE=";
+  cargoHash = "sha256-ckqzptKk6aituDMTA5JGzMWoXiVuOoK3N29KNUJnmgw=";
 
   nativeBuildInputs = [
+    cmake
     installShellFiles
     pkg-config
     rustPlatform.bindgenHook
@@ -51,7 +53,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   buildFeatures = [
     "use_zlib"
     "use_zstd_thin"
-    # "bzip3" will be optional in the next version
+    "bzip3"
     "zstd/pkg-config"
   ]
   ++ lib.optionals enableUnfree [
@@ -60,7 +62,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   postInstall = ''
     installManPage artifacts/*.1
-    installShellCompletion artifacts/ouch.{bash,fish} --zsh artifacts/_ouch
+    installShellCompletion artifacts/ouch.{bash,fish} --zsh artifacts/_ouch --nushell artifacts/ouch.nu
   '';
 
   env.OUCH_ARTIFACTS_FOLDER = "artifacts";
@@ -75,6 +77,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       krovuxdev
       philocalyst
     ];
+    platforms = lib.platforms.all;
     mainProgram = "ouch";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Updated.

- Needed cmake for the libz-ng-sys path
- bzip3 explict as its now explicit. 
- Nushell completions installed

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
