### PR TITLE
reaction: 2.3.0 -> 2.3.1; reaction-plugin-nftables: init

### DIFF
--- a/nixos/modules/services/security/reaction.nix
+++ b/nixos/modules/services/security/reaction.nix
@@ -240,6 +240,10 @@ in
             ''
           );
 
+      systemd.slices.system-reaction = {
+        description = "Reaction system slice";
+      };
+
       systemd.services.reaction = {
         description = "A daemon that scans program outputs for repeated patterns, and takes action.";
         documentation = [ "https://reaction.ppom.me" ];
@@ -250,6 +254,7 @@ in
         serviceConfig = {
           Type = "simple";
           KillMode = "mixed"; # for plugins
+          Slice = "system-reaction.slice";
           User = if (!cfg.runAsRoot) then "reaction" else "root";
           ExecStart = ''
             ${getExe cfg.package} start -c ${settingsDir}${

--- a/pkgs/by-name/re/reaction/package.nix
+++ b/pkgs/by-name/re/reaction/package.nix
@@ -13,22 +13,17 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "reaction";
-  version = "2.3.0";
+  version = "2.3.1-11";
 
   src = fetchFromGitLab {
     domain = "framagit.org";
     owner = "ppom";
     repo = "reaction";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-OvNJsR9W5MlicqUpr1aOLJ7pI7H7guq1vAlC/hh1Q2o=";
+    rev = "c0868d6fe1d155de183a89729b5f3f0ede7be4a2";
+    hash = "sha256-QlSXZ2Wk1OXzAY2x6YjtW+xNchY+Ghb/6AsJgjfgoFE=";
   };
 
-  patches = [
-    # remove patch in next tagged version
-    ./add-support-for-macos.patch
-  ];
-
-  cargoHash = "sha256-BOFZlVBKf6fjW1L1J8u7Vf+fzNJHlEtQI6YafDjlZ4U=";
+  cargoHash = "sha256-FYd7I93MAAzD6y0VMd9kMU7DAgS6v5CKt2KjrskaKeo=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/re/reaction/plugins/reaction-plugin-nftables.nix
+++ b/pkgs/by-name/re/reaction/plugins/reaction-plugin-nftables.nix
@@ -1,0 +1,14 @@
+{
+  nftables,
+  pkg-config,
+  rustPlatform,
+  reaction,
+  ...
+}:
+reaction.mkReactionPlugin "reaction-plugin-nftables" {
+  buildInputs = [ nftables ];
+  nativeBuildInputs = [
+    rustPlatform.bindgenHook
+    pkg-config
+  ];
+}


### PR DESCRIPTION
https://framagit.org/ppom/reaction/-/releases/v2.3.1

Adding the `system-reaction.slice` based on https://framagit.org/ppom/reaction/-/commit/5a6c203c016daf752b30d3754bd2afc1073d9ef6.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
