### PR TITLE
[Backport release-25.11] nix: bump 2.28.5 -> 2.28.7, 2.29.1 -> 2.29.4, 2.30.2 -> 2.30.5

### DIFF
--- a/nixos/modules/installer/tools/nix-fallback-paths.nix
+++ b/nixos/modules/installer/tools/nix-fallback-paths.nix
@@ -1,8 +1,8 @@
 {
-  x86_64-linux = "/nix/store/0bvxg6fr61zrlhi93azhp8yfhb5rcrs9-nix-2.28.5";
-  i686-linux = "/nix/store/m5na49mxl4xpcs3xh086s5v08jqjhbmb-nix-2.28.5";
-  aarch64-linux = "/nix/store/95rhdhjfwbi7ilwy5j0knj1852p7x6c6-nix-2.28.5";
-  riscv64-linux = "/nix/store/cqiiv36c773023p6lp9h4ff57fjlzisk-nix-riscv64-unknown-linux-gnu-2.28.5";
-  x86_64-darwin = "/nix/store/xiw5636h616yi3balx96pmdk6b052rhk-nix-2.28.5";
-  aarch64-darwin = "/nix/store/sax8chv80d9fy4s0y3ahsr9y4kc2f0ib-nix-2.28.5";
+  x86_64-linux = "/nix/store/2vwlnd413zr0n61rsmr410f2mkhd9jbg-nix-2.28.7";
+  i686-linux = "/nix/store/vcrn1id1n7d03h5wsg8nqdq60caf594l-nix-2.28.7";
+  aarch64-linux = "/nix/store/mxi789k2gp8mdm8zq3i3yi0x6wig8vsr-nix-2.28.7";
+  riscv64-linux = "/nix/store/958diz27w36abhks26g0yckpygqvq8j2-nix-riscv64-unknown-linux-gnu-2.28.7";
+  x86_64-darwin = "/nix/store/a3ixb2m56vgrbgl0mkv5091lwsz5s86v-nix-2.28.7";
+  aarch64-darwin = "/nix/store/yhkay14nr2a9zl9i0c7bgm7pmza9gri8-nix-2.28.7";
 }

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -190,34 +190,34 @@ lib.makeExtensible (
       };
 
       nix_2_28 = commonMeson {
-        version = "2.28.5";
-        hash = "sha256-oIfAHxO+BCtHXJXLHBnsKkGl1Pw+Uuq1PwNxl+lZ+Oc=";
+        version = "2.28.7";
+        hash = "sha256-Fq4+7uYz6bdE1HvPqn+qZcYX1rNilVKT7YAAPLA8170=";
         self_attribute_name = "nix_2_28";
       };
 
       nixComponents_2_29 = nixDependencies.callPackage ./modular/packages.nix {
-        version = "2.29.1";
+        version = "2.29.4";
         inherit (self.nix_2_24.meta) maintainers teams;
         otherSplices = generateSplicesForNixComponents "nixComponents_2_29";
         src = fetchFromGitHub {
           owner = "NixOS";
           repo = "nix";
-          rev = "2.29.1";
-          hash = "sha256-rCL3l4t20jtMeNjCq6fMaTzWvBKgj+qw1zglLrniRfY=";
+          rev = "2.29.4";
+          hash = "sha256-eVELGOeQg37AZLu7xnsaW9VA4fBr3x1d97I0iAoIt8A=";
         };
       };
 
       nix_2_29 = addTests "nix_2_29" self.nixComponents_2_29.nix-everything;
 
       nixComponents_2_30 = nixDependencies.callPackage ./modular/packages.nix rec {
-        version = "2.30.2";
+        version = "2.30.5";
         inherit (self.nix_2_24.meta) maintainers teams;
         otherSplices = generateSplicesForNixComponents "nixComponents_2_30";
         src = fetchFromGitHub {
           owner = "NixOS";
           repo = "nix";
           tag = version;
-          hash = "sha256-U46fAs+j2PfWWqP1zNi1odhnV4030SQ0RoEC8Eah1OQ=";
+          hash = "sha256-tGiV71RxtCNcUNX86ZwmOIghG4pLwm5nlRKd89er7Gk=";
         };
       };
 


### PR DESCRIPTION
Bump nix versions to latest patch releases for release-25.05.

- 2.28.5 -> 2.28.7
- 2.29.1 -> 2.29.4
- 2.30.2 -> 2.30.5
- Update nix-fallback-paths to 2.28.7

Related PRs for staging-nixos:
- https://github.com/NixOS/nixpkgs/pull/516608 (nix 2.34.6 -> 2.34.7)
- https://github.com/NixOS/nixpkgs/pull/516612 (nix 2.28.7, 2.30.5, 2.31.5)