### PR TITLE
ocamlPackages.lwd: 0.4 → 0.5

### DIFF
--- a/pkgs/applications/networking/instant-messengers/jackline/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jackline/default.nix
@@ -19,6 +19,10 @@ buildDunePackage {
     hash = "sha256-6QZZ77C1G3x/GOJsUEQMrCatVsyyxNjq36ez/TgeHSY=";
   };
 
+  postPatch = ''
+    substituteInPlace cli/dune --replace-warn 'notty notty.lwt' 'notty-community.lwt'
+  '';
+
   nativeBuildInputs = [
     ppx_sexp_conv
     ppx_deriving
@@ -35,7 +39,7 @@ buildDunePackage {
     otr
     astring
     ptime
-    notty
+    notty-community
     sexplib
     hex
     uchar

--- a/pkgs/by-name/do/docfd/nottui-unix.patch
+++ b/pkgs/by-name/do/docfd/nottui-unix.patch
@@ -1,20 +1,8 @@
-diff --git a/bin/dune b/bin/dune
-index e0ddc1f..a4e8523 100644
---- a/bin/dune
-+++ b/bin/dune
-@@ -47,6 +47,7 @@
-             notty
-             notty.unix
-             nottui
-+            nottui-unix
-             lwd
-             oseq
-             eio
-diff --git a/bin/ui_base.ml b/bin/ui_base.ml
-index f56ee8d..8d8ed70 100644
+diff --git a/bin/UI_base.ml b/bin/UI_base.ml
+index efb1d14..ce6a2a4 100644
 --- a/bin/UI_base.ml
 +++ b/bin/UI_base.ml
-@@ -587,7 +587,7 @@ let ui_loop ~quit ~term root =
+@@ -787,7 +787,7 @@ let ui_loop ~quit ~term root =
        if term_width <> prev_term_width || term_height <> prev_term_height then (
          Lwd.set Vars.term_width_height (term_width, term_height)
        );
@@ -23,3 +11,20 @@ index f56ee8d..8d8ed70 100644
          ~process_event:true
          ~timeout:0.05
          ~renderer
+diff --git a/bin/dune b/bin/dune
+index c4905a4..7c7b55d 100644
+--- a/bin/dune
++++ b/bin/dune
+@@ -44,9 +44,10 @@
+             containers.unix
+             cmdliner
+             fmt
+-            notty
+-            notty.unix
++            notty-community
++            notty-community.unix
+             nottui
++            nottui-unix
+             lwd
+             oseq
+             eio

--- a/pkgs/by-name/do/docfd/package.nix
+++ b/pkgs/by-name/do/docfd/package.nix
@@ -53,7 +53,7 @@ ocamlPackages.buildDunePackage rec {
     lwd
     nottui
     nottui-unix
-    notty
+    notty-community
     ocaml_sqlite3
     ocolor
     oseq

--- a/pkgs/by-name/do/docfd/package.nix
+++ b/pkgs/by-name/do/docfd/package.nix
@@ -3,6 +3,7 @@
   ocamlPackages,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   python3,
   dune,
   makeWrapper,
@@ -25,8 +26,16 @@ ocamlPackages.buildDunePackage rec {
     hash = "sha256-d7c72jXadwBtUqarfdGnEDo9yFwCAeEX0GGVqCe70Ak=";
   };
 
-  # Compatibility with nottui ≥ 0.4
-  patches = [ ./nottui-unix.patch ];
+  patches = [
+    # Compatibility with nottui ≥ 0.4
+    ./nottui-unix.patch
+    # Compatibility with lwd ≥ 0.5
+    (fetchpatch {
+      url = "https://github.com/darrenldl/docfd/commit/439ff57e80778f684cf8526b3b33c745a02da2a7.patch";
+      includes = [ "*.ml" ];
+      hash = "sha256-bB+zta2VcrDd42FUD9ExBui787LmtN3PMyb/MJQO7u0=";
+    })
+  ];
 
   nativeBuildInputs = [
     python3

--- a/pkgs/development/ocaml-modules/lwd/default.nix
+++ b/pkgs/development/ocaml-modules/lwd/default.nix
@@ -5,15 +5,13 @@
   seq,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "lwd";
-  version = "0.4";
-
-  minimalOCamlVersion = "4.08";
+  version = "0.5";
 
   src = fetchurl {
-    url = "https://github.com/let-def/lwd/releases/download/v${version}/lwd-${version}.tbz";
-    hash = "sha256-nnFltlBWfPOerF4HuVNGzXcZxRSdsM+abeD5ZdQ+x8U=";
+    url = "https://github.com/let-def/lwd/releases/download/v${finalAttrs.version}/lwd-${finalAttrs.version}.tbz";
+    hash = "sha256-YAZjeLuhAxUCB3RrBul4u70g5TEqT2C7Z09YbYyPZOY=";
   };
 
   propagatedBuildInputs = [ seq ];
@@ -24,4 +22,4 @@ buildDunePackage rec {
     maintainers = [ lib.maintainers.alizter ];
     homepage = "https://github.com/let-def/lwd";
   };
-}
+})

--- a/pkgs/development/ocaml-modules/lwd/nottui-unix.nix
+++ b/pkgs/development/ocaml-modules/lwd/nottui-unix.nix
@@ -3,7 +3,6 @@
   buildDunePackage,
   lwd,
   nottui,
-  notty,
 }:
 
 buildDunePackage {
@@ -14,7 +13,6 @@ buildDunePackage {
   propagatedBuildInputs = [
     lwd
     nottui
-    notty
   ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/lwd/nottui.nix
+++ b/pkgs/development/ocaml-modules/lwd/nottui.nix
@@ -2,7 +2,7 @@
   lib,
   buildDunePackage,
   lwd,
-  notty,
+  notty-community,
 }:
 
 buildDunePackage {
@@ -12,7 +12,7 @@ buildDunePackage {
 
   propagatedBuildInputs = [
     lwd
-    notty
+    notty-community
   ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/notty-community/default.nix
+++ b/pkgs/development/ocaml-modules/notty-community/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  fetchurl,
+  buildDunePackage,
+  cppo,
+  uutf,
+  lwt,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "notty-community";
+  version = "0.2.4";
+
+  src = fetchurl {
+    url = "https://github.com/ocaml-community/notty-community/releases/download/v${finalAttrs.version}/notty-community-${finalAttrs.version}.tar.gz";
+    hash = "sha256-FrA3wGX4lQZtrwXked1K/8LLvXel8xYIZ57gEmxX/d8=";
+  };
+
+  nativeBuildInputs = [ cppo ];
+
+  propagatedBuildInputs = [
+    lwt
+    uutf
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "A declarative terminal library for OCaml";
+    homepage = "https://github.com/ocaml-community/notty-community";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+})

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1444,6 +1444,8 @@ let
 
         notty = callPackage ../development/ocaml-modules/notty { };
 
+        notty-community = callPackage ../development/ocaml-modules/notty-community { };
+
         npy = callPackage ../development/ocaml-modules/npy {
           inherit (pkgs.python3Packages) numpy;
         };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1442,8 +1442,6 @@ let
 
         nottui-unix = callPackage ../development/ocaml-modules/lwd/nottui-unix.nix { };
 
-        notty = callPackage ../development/ocaml-modules/notty { };
-
         notty-community = callPackage ../development/ocaml-modules/notty-community { };
 
         npy = callPackage ../development/ocaml-modules/npy {
@@ -2363,6 +2361,7 @@ let
         dune_2 = pkgs.dune_2; # Added 2025-12-08
         dune_3 = pkgs.dune_3; # Added 2025-12-08
         gd4o = throw "ocamlPackages.gd4o is not maintained, use ocamlPackages.gd instead";
+        notty = throw "2026-05-05: notty is no longer maintained, use notty-community instead";
         ocaml-freestanding = throw "ocamlPackages.ocaml-freestanding has been removed due to being broken for more than a year; see RFC 180"; # Added 2026-02-05
         ocaml-vdom = throw "2023-10-09: ocamlPackages.ocaml-vdom was renamed to ocamlPackages.vdom";
         ocaml_lwt = throw "ocamlPackages.ocaml_lwt has been renamed to ocamlPackages.lwt"; # Added 2025-12-05


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
