### PR TITLE
c-blosc2: 2.23.1 -> 3.0.2

### DIFF
--- a/pkgs/by-name/c-/c-blosc2/package.nix
+++ b/pkgs/by-name/c-/c-blosc2/package.nix
@@ -12,16 +12,59 @@
   zstd,
 }:
 
+let
+  zfpVersion = "1.0.1";
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "c-blosc2";
-  version = "2.23.1";
+  version = "3.0.2";
 
-  src = fetchFromGitHub {
-    owner = "Blosc";
-    repo = "c-blosc2";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-iyEB1Hnvo42tMHyB4pDfXru5doFwNiFuxq21Tr3zLIg=";
-  };
+  srcs = [
+    (fetchFromGitHub {
+      owner = "Blosc";
+      repo = "c-blosc2";
+      rev = "v${finalAttrs.version}";
+      sha256 = "sha256-YR8iArp81QK12RazxYMVq3YEFaR24TFKCHDkvjwJIhE=";
+    })
+    (fetchFromGitHub {
+      name = "zfp";
+      owner = "LLNL";
+      repo = "zfp";
+      rev = zfpVersion;
+      hash = "sha256-iZxA4lIviZQgaeHj6tEQzEFSKocfgpUyf4WvUykb9qk=";
+    })
+  ];
+  sourceRoot = "source";
+
+  # perform parameter expansion for cmakeFlags
+  preUnpack =
+    let
+      cmakeFlags = toString [
+        (lib.cmakeBool "BUILD_STATIC" static)
+        (lib.cmakeBool "BUILD_SHARED" (!static))
+
+        (lib.cmakeBool "PREFER_EXTERNAL_LZ4" true)
+        (lib.cmakeBool "PREFER_EXTERNAL_ZLIB" true)
+        (lib.cmakeBool "PREFER_EXTERNAL_ZSTD" true)
+
+        (lib.cmakeBool "BUILD_EXAMPLES" false)
+        (lib.cmakeBool "BUILD_BENCHMARKS" false)
+        (lib.cmakeBool "BUILD_TESTS" finalAttrs.finalPackage.doCheck)
+
+        (lib.cmakeFeature "BLOSC_ZFP_SOURCE_DIR" "$PWD/zfp")
+      ];
+    in
+    ''
+      export cmakeFlags="${cmakeFlags}"
+    '';
+  postUnpack = ''
+    # ensure our separately pinned versions correspond to those in source
+    if ! grep -F 'BLOSC_ZFP_VERSION "${zfpVersion}"' source/CMakeLists.txt ; then
+      echo 'Expected to find BLOSC_ZFP_VERSION "${zfpVersion}" in source/CMakeLists.txt:' \
+        'has zfp source been updated to match pinned version?'
+      exit 1
+    fi
+  '';
 
   # https://github.com/NixOS/nixpkgs/issues/144170
   postPatch = ''
@@ -37,19 +80,6 @@ stdenv.mkDerivation (finalAttrs: {
     lz4
     zlib-ng
     zstd
-  ];
-
-  cmakeFlags = [
-    "-DBUILD_STATIC=${if static then "ON" else "OFF"}"
-    "-DBUILD_SHARED=${if static then "OFF" else "ON"}"
-
-    "-DPREFER_EXTERNAL_LZ4=ON"
-    "-DPREFER_EXTERNAL_ZLIB=ON"
-    "-DPREFER_EXTERNAL_ZSTD=ON"
-
-    "-DBUILD_EXAMPLES=OFF"
-    "-DBUILD_BENCHMARKS=OFF"
-    "-DBUILD_TESTS=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}"
   ];
 
   doCheck = !static;

--- a/pkgs/by-name/c-/c-blosc2/package.nix
+++ b/pkgs/by-name/c-/c-blosc2/package.nix
@@ -12,16 +12,63 @@
   zstd,
 }:
 
+let
+  zfpVersion = "1.0.1";
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "c-blosc2";
-  version = "2.23.1";
+  version = "3.0.2";
 
-  src = fetchFromGitHub {
-    owner = "Blosc";
-    repo = "c-blosc2";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-iyEB1Hnvo42tMHyB4pDfXru5doFwNiFuxq21Tr3zLIg=";
-  };
+  srcs = [
+    (fetchFromGitHub {
+      owner = "Blosc";
+      repo = "c-blosc2";
+      rev = "v${finalAttrs.version}";
+      sha256 = "sha256-YR8iArp81QK12RazxYMVq3YEFaR24TFKCHDkvjwJIhE=";
+    })
+    (fetchFromGitHub {
+      name = "zfp";
+      owner = "LLNL";
+      repo = "zfp";
+      rev = zfpVersion;
+      hash = "sha256-iZxA4lIviZQgaeHj6tEQzEFSKocfgpUyf4WvUykb9qk=";
+    })
+  ];
+  sourceRoot = "source";
+
+  # perform parameter expansion for cmakeFlags
+  preUnpack =
+    let
+      cmakeFlags = toString [
+        (lib.cmakeBool "BUILD_STATIC" static)
+        (lib.cmakeBool "BUILD_SHARED" (!static))
+
+        (lib.cmakeBool "PREFER_EXTERNAL_LZ4" true)
+        (lib.cmakeBool "PREFER_EXTERNAL_ZLIB" true)
+        (lib.cmakeBool "PREFER_EXTERNAL_ZSTD" true)
+
+        (lib.cmakeBool "BUILD_EXAMPLES" false)
+        (lib.cmakeBool "BUILD_BENCHMARKS" false)
+        (lib.cmakeBool "BUILD_TESTS" finalAttrs.finalPackage.doCheck)
+
+        (lib.cmakeFeature "BLOSC_ZFP_SOURCE_DIR" "$PWD/zfp")
+      ];
+    in
+    ''
+      export cmakeFlags="${cmakeFlags}"
+    '';
+  postUnpack = ''
+    # ensure our separately pinned versions correspond to those in source
+    if ! grep -F 'BLOSC_ZFP_VERSION "${zfpVersion}"' source/CMakeLists.txt ; then
+      echo 'Expected to find BLOSC_ZFP_VERSION "${zfpVersion}" in source/CMakeLists.txt:' \
+        'has zfp source been updated to match pinned version?'
+      exit 1
+    fi
+  '';
+
+  patches = [
+    ./restore-blosc2-max-dim.patch
+  ];
 
   # https://github.com/NixOS/nixpkgs/issues/144170
   postPatch = ''
@@ -37,19 +84,6 @@ stdenv.mkDerivation (finalAttrs: {
     lz4
     zlib-ng
     zstd
-  ];
-
-  cmakeFlags = [
-    "-DBUILD_STATIC=${if static then "ON" else "OFF"}"
-    "-DBUILD_SHARED=${if static then "OFF" else "ON"}"
-
-    "-DPREFER_EXTERNAL_LZ4=ON"
-    "-DPREFER_EXTERNAL_ZLIB=ON"
-    "-DPREFER_EXTERNAL_ZSTD=ON"
-
-    "-DBUILD_EXAMPLES=OFF"
-    "-DBUILD_BENCHMARKS=OFF"
-    "-DBUILD_TESTS=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}"
   ];
 
   doCheck = !static;

--- a/pkgs/by-name/c-/c-blosc2/restore-blosc2-max-dim.patch
+++ b/pkgs/by-name/c-/c-blosc2/restore-blosc2-max-dim.patch
@@ -1,0 +1,22 @@
+See https://github.com/Blosc/c-blosc2/issues/769
+
+3.0.0 removed BLOSC2_MAX_DIM. Restoring it temporarily allows
+us to upgrade past 3.0.0 without waiting for every depending
+package to upgrade their bundled hdf5-blosc2 past
+https://github.com/Blosc/HDF5-Blosc2/pull/3. Remove once
+hdf5plugin, pytables et al compile without it.
+
+--- b/include/blosc2.h
++++ a/include/blosc2.h
+@@ -39,8 +39,11 @@
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
++
++/* The maximum number of dimensions for Blosc2 NDim arrays */
++#define BLOSC2_MAX_DIM 8
+ 
+ // For compatibility with the Blosc 1.x series
+ #ifdef BLOSC1_COMPAT
+   // Blosc2 symbols that should be accessible from Blosc 1.x API
+   #define BLOSC_VERSION_MAJOR BLOSC2_VERSION_MAJOR


### PR DESCRIPTION
Now requiring a separate fetch of the `zfp` source, and the added awkwardness that brings.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
