### PR TITLE
nixos/cloudflare-ddns: Security harden the service & Support API token files containing only the token

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -429,6 +429,7 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 - `services.slurm` now supports slurmrestd usage through the `services.slurm.rest` NixOS options.
 
 - `services.cloudflare-ddns` has been security hardened with additional sandboxing restrictions.
+  Also, a new option `apiTokenFile` can be set instead of `credentialsFile` to support files containing only the token.
 
 - The `networking.firewall.logRefusedConnections` option now defaults to
   `false`.  Logging of refused or dropped incoming connections can generate a

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -316,6 +316,10 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 - `services.homepage-dashboard.environmentFile` has been renamed to `services.homepage-dashboard.environmentFiles`, and now expects a list of strings.
 
+- The `services.cloudflare-ddns` has been security hardened which has brought the following breaking changes:
+  - The module does not create the user and group specified in the options anymore.
+  - The systemd service runs with a dynamic user and group by default.
+
 - `services.pingvin-share` has been removed as the `pingvin-share.backend` package was broken and the project was archived upstream.
 
 - `geph` package's built-in GUI `geph5-client-gui` has been [removed](https://github.com/geph-official/geph5/commit/f2221fb8386312daf2cef05483ebb353ff48bdb4) by the upstream. All users who wish to continue using the GUI should install the `gephgui-wry`, which is consistent with the official release version.
@@ -423,6 +427,8 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
   If you set custom Caddy options for a InvoicePlane site, migrate these options by removing `http://` from `services.caddy.virtualHosts."http://example.com"`.
 
 - `services.slurm` now supports slurmrestd usage through the `services.slurm.rest` NixOS options.
+
+- `services.cloudflare-ddns` has been security hardened with additional sandboxing restrictions.
 
 - The `networking.firewall.logRefusedConnections` option now defaults to
   `false`.  Logging of refused or dropped incoming connections can generate a

--- a/nixos/modules/services/networking/cloudflare-ddns.nix
+++ b/nixos/modules/services/networking/cloudflare-ddns.nix
@@ -21,9 +21,8 @@ in
       description = ''
         Path to a file containing the Cloudflare API authentication token.
         The file content should be in the format `CLOUDFLARE_API_TOKEN=YOUR_SECRET_TOKEN`.
-        The service user needs read access to this file.
-        Ensure permissions are secure (e.g., `0400` or `0440`) and ownership is appropriate
-        Using `CLOUDFLARE_API_TOKEN` is preferred over the deprecated `CF_API_TOKEN`.
+        The file does not need to be readable by the service user.
+        Ensure permissions are secure (e.g., `0400` or `0440`) and ownership is appropriate (e.g., owned by root).
       '';
       example = "/run/secrets/cloudflare-ddns-token";
     };
@@ -197,15 +196,21 @@ in
     };
 
     user = lib.mkOption {
-      type = lib.types.str;
-      default = "cloudflare-ddns";
-      description = "User account under which the service runs.";
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        User account under which the service runs.
+        If null (the default), the service will use a dynamic user.
+      '';
     };
 
     group = lib.mkOption {
-      type = lib.types.str;
-      default = "cloudflare-ddns";
-      description = "Group under which the service runs.";
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        Group under which the service runs.
+        If null (the default), the service will use a dynamic group.
+      '';
     };
   };
 
@@ -230,97 +235,91 @@ in
       }
     ];
 
-    users.users.${cfg.user} = {
-      description = "Cloudflare DDNS service user";
-      isSystemUser = true;
-      group = cfg.group;
-      home = "/var/lib/${cfg.user}";
-    };
-
-    users.groups.${cfg.group} = { };
-
-    systemd.tmpfiles.settings."cloudflare-ddns" = {
-      "/var/lib/${cfg.user}".d = {
-        mode = "0750";
-        user = cfg.user;
-        group = cfg.group;
-      };
-    };
-
     systemd.services.cloudflare-ddns = {
       description = "Cloudflare Dynamic DNS Client Service (favonia)";
       wantedBy = [ "multi-user.target" ];
       after = [ "network-online.target" ];
       wants = [ "network-online.target" ];
 
+      environment = lib.filterAttrs (_: value: value != "") {
+        DOMAINS = formatList cfg.domains;
+        IP4_DOMAINS = lib.optionalString (cfg.ip4Domains != null) (formatList cfg.ip4Domains);
+        IP6_DOMAINS = lib.optionalString (cfg.ip6Domains != null) (formatList cfg.ip6Domains);
+
+        IP4_PROVIDER = cfg.provider.ipv4;
+        IP6_PROVIDER = cfg.provider.ipv6;
+
+        WAF_LISTS = formatList cfg.wafLists;
+        WAF_LIST_DESCRIPTION = cfg.wafListDescription;
+
+        UPDATE_CRON = cfg.updateCron;
+        UPDATE_ON_START = boolToString cfg.updateOnStart;
+        DELETE_ON_STOP = boolToString cfg.deleteOnStop;
+        CACHE_EXPIRATION = cfg.cacheExpiration;
+
+        TTL = toString cfg.ttl;
+        PROXIED = cfg.proxied;
+        RECORD_COMMENT = cfg.recordComment;
+
+        DETECTION_TIMEOUT = cfg.detectionTimeout;
+        UPDATE_TIMEOUT = cfg.updateTimeout;
+
+        HEALTHCHECKS = cfg.healthchecks;
+        UPTIMEKUMA = cfg.healthchecks;
+        SHOUTRRR = lib.optionalString (cfg.shoutrrr != null) (lib.concatStringsSep "\n" cfg.shoutrrr);
+      };
+
       serviceConfig = {
+        DynamicUser = true;
         User = cfg.user;
         Group = cfg.group;
 
-        WorkingDirectory = "/var/lib/${cfg.user}";
-
         EnvironmentFile = cfg.credentialsFile;
 
-        Environment =
-          let
-            toEnv = name: value: "${name}=\"${toString value}\"";
-            toEnvList = name: value: "${name}=\"${formatList value}\"";
-            toEnvBool = name: value: "${name}=\"${boolToString value}\"";
-            toEnvMaybe =
-              pred: name: value:
-              lib.optionalString pred (toEnv name value);
-            toEnvMaybeList =
-              pred: name: value:
-              lib.optionalString pred (toEnvList name value);
-          in
-          lib.filter (envVar: envVar != "") [
-            (toEnvList "DOMAINS" cfg.domains)
-            (toEnvMaybeList (cfg.ip4Domains != null) "IP4_DOMAINS" cfg.ip4Domains)
-            (toEnvMaybeList (cfg.ip6Domains != null) "IP6_DOMAINS" cfg.ip6Domains)
-
-            (toEnv "IP4_PROVIDER" cfg.provider.ipv4)
-            (toEnv "IP6_PROVIDER" cfg.provider.ipv6)
-
-            (toEnvMaybeList (cfg.wafLists != [ ]) "WAF_LISTS" cfg.wafLists)
-            (toEnvMaybe (cfg.wafListDescription != "") "WAF_LIST_DESCRIPTION" cfg.wafListDescription)
-
-            (toEnv "UPDATE_CRON" cfg.updateCron)
-            (toEnvBool "UPDATE_ON_START" cfg.updateOnStart)
-            (toEnvBool "DELETE_ON_STOP" cfg.deleteOnStop)
-            (toEnv "CACHE_EXPIRATION" cfg.cacheExpiration)
-
-            (toEnv "TTL" cfg.ttl)
-            (toEnv "PROXIED" cfg.proxied)
-            (toEnvMaybe (cfg.recordComment != "") "RECORD_COMMENT" cfg.recordComment)
-
-            (toEnv "DETECTION_TIMEOUT" cfg.detectionTimeout)
-            (toEnv "UPDATE_TIMEOUT" cfg.updateTimeout)
-
-            (toEnvMaybe (cfg.healthchecks != null) "HEALTHCHECKS" cfg.healthchecks)
-            (toEnvMaybe (cfg.uptimeKuma != null) "UPTIMEKUMA" cfg.uptimeKuma)
-            (toEnvMaybeList (cfg.shoutrrr != null) "SHOUTRRR" (lib.concatStringsSep "\n" cfg.shoutrrr))
-          ];
 
         ExecStart = lib.getExe cfg.package;
 
         Restart = "on-failure";
         RestartSec = "30s";
 
-        ProtectSystem = "strict";
-        ProtectHome = true;
-        PrivateTmp = true;
-        PrivateDevices = true;
-        ProtectKernelTunables = true;
-        ProtectKernelModules = true;
-        ProtectControlGroups = true;
+        ReadOnlyPaths = [ "/" ];
+
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
         NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        SystemCallArchitectures = "native";
+
         RestrictAddressFamilies = [
           "AF_INET"
           "AF_INET6"
         ];
+        CapabilityBoundingSet = [ "" ];
+        AmbientCapabilities = [ "" ];
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+          "~@resources"
+        ];
+        UMask = "077";
       };
     };
   };
+
   meta.maintainers = with lib.maintainers; [
     shokerplz
   ];

--- a/nixos/modules/services/networking/cloudflare-ddns.nix
+++ b/nixos/modules/services/networking/cloudflare-ddns.nix
@@ -17,13 +17,29 @@ in
     package = lib.mkPackageOption pkgs "cloudflare-ddns" { };
 
     credentialsFile = lib.mkOption {
-      type = lib.types.path;
+      type = lib.types.nullOr lib.types.path;
       description = ''
         Path to a file containing the Cloudflare API authentication token.
         The file content should be in the format `CLOUDFLARE_API_TOKEN=YOUR_SECRET_TOKEN`.
         The file does not need to be readable by the service user.
         Ensure permissions are secure (e.g., `0400` or `0440`) and ownership is appropriate (e.g., owned by root).
+
+        Either this option or [](#opt-services.cloudflare-ddns.apiTokenFile) must be set.
       '';
+      default = null;
+      example = "/run/secrets/cloudflare-ddns-token";
+    };
+    apiTokenFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      description = ''
+        Path to a file containing the Cloudflare API authentication token.
+        The file must only contain the token: `YOUR_SECRET_TOKEN`.
+        The file does not need to be readable by the service user.
+        Ensure permissions are secure (e.g., `0400` or `0440`) and ownership is appropriate (e.g., owned by root).
+
+        Either this option or [](#opt-services.cloudflare-ddns.credentialsFile) must be set.
+      '';
+      default = null;
       example = "/run/secrets/cloudflare-ddns-token";
     };
 
@@ -233,6 +249,10 @@ in
         assertion = cfg.provider.ipv4 != "none" || cfg.provider.ipv6 != "none";
         message = "services.cloudflare-ddns requires at least one provider (ipv4 or ipv6) to be enabled (not 'none')";
       }
+      {
+        assertion = cfg.credentialsFile != null || cfg.apiTokenFile != null;
+        message = "services.cloudflare-ddns requires either credentialsFile or apiTokenFile to be set";
+      }
     ];
 
     systemd.services.cloudflare-ddns = {
@@ -242,6 +262,8 @@ in
       wants = [ "network-online.target" ];
 
       environment = lib.filterAttrs (_: value: value != "") {
+        CLOUDFLARE_API_TOKEN_FILE = lib.mkIf (cfg.apiTokenFile != null) "%d/apiTokenFile";
+
         DOMAINS = formatList cfg.domains;
         IP4_DOMAINS = lib.optionalString (cfg.ip4Domains != null) (formatList cfg.ip4Domains);
         IP6_DOMAINS = lib.optionalString (cfg.ip6Domains != null) (formatList cfg.ip6Domains);
@@ -274,8 +296,8 @@ in
         User = cfg.user;
         Group = cfg.group;
 
-        EnvironmentFile = cfg.credentialsFile;
-
+        EnvironmentFile = lib.optional (cfg.credentialsFile != null) cfg.credentialsFile;
+        LoadCredential = lib.optional (cfg.apiTokenFile != null) "apiTokenFile:${cfg.apiTokenFile}";
 
         ExecStart = lib.getExe cfg.package;
 


### PR DESCRIPTION
The service does not require a lot of permissions so a lot of sandboxing can be enabled without any problem.
- The [upstream docker-compose.yaml](https://github.com/favonia/cloudflare-ddns#-step-1-updating-the-compose-file) also enables similar sandboxing capabilities.

The `credentialsFile` option was documented as required to be readable by the service user, but that is not necessary (`EnvironmentFile=` can read root-owned files).
- I also added a new `apiTokenFile` option to allow users that already have a file containing only the token to use it here, instead of requiring them to maintain multiple files with the same token.

The `Environment=` section has been simplified a lot by using the `environment` option.

The PR is marked as draft because it contains potentially breaking changes and the `master` branch is currently restricted until the 2026-05-18 as per the 26.05 release, but it can still be reviewed in the meantime.
- Once it has been unrestricted, I will move the added release notes to the new file and remove the draft marker on the PR.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
