### PR TITLE
packetdrill: unstable-2020-08-22 -> 2.0-unstable-2026-04-29

### DIFF
--- a/pkgs/by-name/pa/packetdrill/package.nix
+++ b/pkgs/by-name/pa/packetdrill/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   bison,
   flex,
   cmake,
@@ -10,33 +9,19 @@
 }:
 stdenv.mkDerivation {
   pname = "packetdrill";
-  version = "unstable-2020-08-22";
+  version = "2.0-unstable-2026-04-29";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "packetdrill";
-    rev = "68a34fa73cf221e5f52d6fa4f203bcd93062be1b";
-    sha256 = "0djkwb6l2959f44d98vwb092rghf0qmii8391vrpxqb99j6pv4h6";
+    rev = "faa0dfb54065118625e169d3111ce09c65b20229";
+    hash = "sha256-+9qfNT2veOsShj9JvLiBm7i842zFhUiPmrt8QA/ZuKs=";
   };
-  patches = [
-    # Upstream fix for -fno-common toolchains
-    (fetchpatch {
-      name = "fno-common.patch";
-      url = "https://github.com/google/packetdrill/commit/c08292838de81a71ee477d5bf9d95b1130a1292b.patch";
-      sha256 = "1irbar1zkydmgqb12r3xd80dwj2jfxnxayxpb4nmbma8xm7knb10";
-      stripLen = 3;
-    })
-  ];
 
   setSourceRoot = ''
     export sourceRoot=$(realpath */gtests/net/packetdrill)
   '';
 
-  env.NIX_CFLAGS_COMPILE = toString [
-    "-Wno-error=unused-result"
-    "-Wno-error=stringop-truncation"
-    "-Wno-error=address-of-packed-member"
-  ];
   nativeBuildInputs = [
     bison
     flex


### PR DESCRIPTION
- #475479 
- #516381
- https://hydra.nixos.org/build/326843424
- Diff: https://github.com/google/packetdrill/compare/68a34fa73cf221e5f52d6fa4f203bcd93062be1b...faa0dfb54065118625e169d3111ce09c65b20229

Fixes compilation error:

```
In file included from /build/source/gtests/net/packetdrill/code.h:29,
                 from /build/source/gtests/net/packetdrill/code.c:26:
/build/source/gtests/net/packetdrill/types.h:64:12: error: two or more data types in declaration specifiers
   64 | typedef u8 bool;
      |            ^~~~
/build/source/gtests/net/packetdrill/types.h:64:1: warning: useless type name in empty declaration
   64 | typedef u8 bool;
      | ^~~~~~~
/build/source/gtests/net/packetdrill/types.h:66:9: error: cannot use keyword 'false' as enumeration constant
   66 |         false = 0,
      |         ^~~~~
/build/source/gtests/net/packetdrill/types.h:66:9: note: 'false' is a keyword with '-std=c23' onwards
In file included from /build/source/gtests/net/packetdrill/checksum.h:28,
                 from /build/source/gtests/net/packetdrill/checksum.c:25:
/build/source/gtests/net/packetdrill/types.h:64:12: error: two or more data types in declaration specifiers
   64 | typedef u8 bool;
      |            ^~~~
/build/source/gtests/net/packetdrill/types.h:64:1: warning: useless type name in empty declaration
   64 | typedef u8 bool;
      | ^~~~~~~
/build/source/gtests/net/packetdrill/types.h:66:9: error: cannot use keyword 'false' as enumeration constant
   66 |         false = 0,
      |         ^~~~~
/build/source/gtests/net/packetdrill/types.h:66:9: note: 'false' is a keyword with '-std=c23' onwards
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
