### PR TITLE
sndpeek: 1.4 -> 1.41; fix build with gcc15

### DIFF
--- a/pkgs/by-name/sn/sndpeek/ambiguous-complex.patch
+++ b/pkgs/by-name/sn/sndpeek/ambiguous-complex.patch
@@ -1,0 +1,40 @@
+diff --git a/src/marsyas/MagFFT.cpp b/src/marsyas/MagFFT.cpp
+index 056f998..525ffa8 100644
+--- a/src/marsyas/MagFFT.cpp
++++ b/src/marsyas/MagFFT.cpp
+@@ -37,10 +37,10 @@ typedef struct { float re ; float im ; } complex ;
+ 
+ #define CABS(x) hypot( (x).re, (x).im )
+ 
+-complex cadd(), csub(), cmult(), smult(), cdiv(), conjg(), csqrt() ;
++::complex cadd(), csub(), cmult(), smult(), cdiv(), conjg(), csqrt() ;
+ 
+-extern complex zero ;
+-extern complex one ;
++extern ::complex zero ;
++extern ::complex one ;
+ extern float synt ;
+ 
+ 
+diff --git a/src/sndpeek/sndpeek.cpp b/src/sndpeek/sndpeek.cpp
+index 77fca13..a95275f 100644
+--- a/src/sndpeek/sndpeek.cpp
++++ b/src/sndpeek/sndpeek.cpp
+@@ -1583,7 +1583,7 @@ void displayFunc( )
+         // take forward FFT; result in buffer as FFT_SIZE/2 complex values
+         rfft( (float *)buffer, g_fft_size/2, FFT_FORWARD );
+         // cast to complex
+-        complex * cbuf = (complex *)buffer;
++        ::complex * cbuf = (::complex *)buffer;
+ 
+         // reset drawing offsets
+         x = -1.8f;
+@@ -1910,7 +1910,7 @@ void extract_buffer( )
+     // take the forward fft, leaving fftsize/2 complex values
+     rfft( (float *)buffer, g_buffer_size/2, FFT_FORWARD );
+     // cast to complex
+-    complex * cbuf = (complex *)buffer;
++    ::complex * cbuf = (::complex *)buffer;
+ 
+     // get magnitude spectrum
+     for( i = 0; i < g_buffer_size/2; i++ )

--- a/pkgs/by-name/sn/sndpeek/package.nix
+++ b/pkgs/by-name/sn/sndpeek/package.nix
@@ -15,17 +15,24 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sndpeek";
-  version = "1.4";
+  version = "1.41";
 
   src = fetchurl {
     url = "https://soundlab.cs.princeton.edu/software/sndpeek/files/sndpeek-${finalAttrs.version}.tgz";
-    sha256 = "2d86cf74854fa00dcdc05a35dd92bc4cf6115e87102b17023be5cba9ead8eedf";
+    hash = "sha256-ZVMLZRDQfCCI5f+i5LEb34uHKqiTkT2pa2sBjnSyTk0=";
   };
-  sourceRoot = "sndpeek-${finalAttrs.version}/src/sndpeek";
 
-  # this patch adds -lpthread to the list of libraries, without it a
-  # symbol-not-found-error is thrown
-  patches = [ ./pthread.patch ];
+  patches = [
+    # this patch adds -lpthread to the list of libraries, without it a
+    # symbol-not-found-error is thrown
+    ./pthread.patch
+    # fix error: reference to 'complex' is ambiguous
+    ./ambiguous-complex.patch
+  ];
+
+  postPatch = ''
+    cd "src/sndpeek"
+  '';
 
   buildInputs = [
     libglut

--- a/pkgs/by-name/sn/sndpeek/pthread.patch
+++ b/pkgs/by-name/sn/sndpeek/pthread.patch
@@ -1,11 +1,11 @@
-diff --git a/makefile.alsa b/makefile.alsa
+diff --git a/src/sndpeek/makefile.alsa b/src/sndpeek/makefile.alsa
 index 34fb848..cdaeaec 100644
---- a/makefile.alsa
-+++ b/makefile.alsa
+--- a/src/sndpeek/makefile.alsa
++++ b/src/sndpeek/makefile.alsa
 @@ -4,7 +4,7 @@ CPP=g++
  INCLUDES=-I../marsyas/
  MARSYAS_DIR=../marsyas/
- CFLAGS=-D__LINUX_ALSA__ -D__LITTLE_ENDIAN__ $(INCLUDES) -O3 -c
+ CFLAGS=-D__LINUX_ALSA__ -D__LITTLE_ENDIAN__ -D__USE_GLUT__ $(INCLUDES) -O3 -c
 -LIBS=-L/usr/X11R6/lib -lglut -lGL -lGLU -lasound -lXmu -lX11 -lXext -lXi -lm -lsndfile
 +LIBS=-L/usr/X11R6/lib -lglut -lGL -lGLU -lasound -lXmu -lX11 -lXext -lXi -lm -lsndfile -lpthread
  


### PR DESCRIPTION
- #475479 
- #516381 
- https://hydra.nixos.org/build/326906499

```
sndpeek.cpp: In function 'void displayFunc()':
sndpeek.cpp:1501:9: error: reference to 'complex' is ambiguous
 1501 |         complex * cbuf = (complex *)buffer;
      |         ^~~~~~~
```

Only verified compilation.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
