### PR TITLE
mpd-touch-screen-gui: fix build with gcc15

### DIFF
--- a/pkgs/by-name/mp/mpd-touch-screen-gui/package.nix
+++ b/pkgs/by-name/mp/mpd-touch-screen-gui/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # https://stackoverflow.com/questions/53089494/configure-error-could-not-find-a-version-of-the-library
   configureFlags = [
-    "--with-boost-libdir=${boost.out}/lib"
+    (lib.withFeatureAs true "boost-libdir" "${lib.getLib boost}/lib")
   ];
 
   doCheck = true;

--- a/pkgs/by-name/mp/mpd-touch-screen-gui/package.nix
+++ b/pkgs/by-name/mp/mpd-touch-screen-gui/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   pkg-config,
   autoreconfHook,
   SDL2,
@@ -25,6 +26,13 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "156eaebede89da2b83a98d8f9dfa46af12282fb4";
     sha256 = "sha256-vr/St4BghrndjUQ0nZI/uJq+F/MjEj6ulc4DYwQ/pgU=";
   };
+  patches = [
+    # Fixes build with gcc15. See: https://github.com/muesli4/mpd-touch-screen-gui/pull/15
+    (fetchpatch {
+      url = "https://github.com/muesli4/mpd-touch-screen-gui/pull/15/commits/ecbe6fe2d7e30b81584e1f15e3003e0dba013f24.patch";
+      hash = "sha256-p4TywZl7SQrMsKGEZgcctTY5DgnIWddQSFadVpyCbTU=";
+    })
+  ];
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/mp/mpd-touch-screen-gui/package.nix
+++ b/pkgs/by-name/mp/mpd-touch-screen-gui/package.nix
@@ -32,7 +32,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
-    sed -i s#/usr/share/fonts/TTF#${dejavu_fonts}/share/fonts/truetype#g data/program.conf
+    substituteInPlace data/program.conf \
+      --replace-fail /usr/share/fonts/TTF ${dejavu_fonts}/share/fonts/truetype
   '';
 
   buildInputs = [


### PR DESCRIPTION
- #475479 
- #516381 
- https://hydra.nixos.org/build/326833615

```
filesystem_cover_provider.cpp: In function 'std::string absolute_cover_path(std::string_view, std::string_view)':
filesystem_cover_provider.cpp:26:21: error: 'all_of' is not a member of 'std'
   26 |             && std::all_of(std::next(super_dir.begin(), 3), super_dir.end(), ::isdigit)
      |                     ^~~~~~
make[1]: *** [Makefile:614: mpd_touch_screen_gui-filesystem_cover_provider.o] Error 1
```

Only verified compilation.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
