### PR TITLE
mlvwm: fix build with gcc15

### DIFF
--- a/pkgs/by-name/ml/mlvwm/package.nix
+++ b/pkgs/by-name/ml/mlvwm/package.nix
@@ -21,6 +21,12 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-ElKmi+ANuB3LPwZTMcr5HEMESjDwENbYnNIGdRP24d0=";
   };
 
+  postPatch = ''
+    # gcc15
+    substituteInPlace mlvwm/functions.h \
+      --replace-fail "void (*action)();" "void (*action)(char *);"
+  '';
+
   nativeBuildInputs = [ installShellFiles ];
 
   buildInputs = [


### PR DESCRIPTION
- #475479 
- #516381 
- https://hydra.nixos.org/build/326833113

```
functions.c: At top level:
functions.c:843:27: error: initialization of 'void (*)(void)' from incompatible pointer type 'void (*)(char *)' [-Wincompatible-pointer-types]
  843 |         { "DebugWinList", DebugWinList },
      |                           ^~~~~~~~~~~~
functions.c:843:27: note: (near initialization for 'funcs[0].action')
functions.c:829:6: note: 'DebugWinList' declared here
  829 | void DebugWinList( char *action )
      |      ^~~~~~~~~~~~
```

Only verified compilation.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
