### PR TITLE
yadm: allow omitting some dependencies

### DIFF
--- a/pkgs/by-name/ya/yadm/package.nix
+++ b/pkgs/by-name/ya/yadm/package.nix
@@ -26,8 +26,20 @@
   installShellFiles,
   runCommand,
   yadm,
+
+  # Templates:
+  withAwk ? true,
+  withEsh ? true,
+  withJ2 ? true,
+
+  # Encryption:
+  withGpg ? true,
+  withOpenssl ? true,
 }:
 
+let
+  withTar = withGpg || withOpenssl;
+in
 resholve.mkDerivation rec {
   pname = "yadm";
   version = "3.5.0";
@@ -62,32 +74,32 @@ resholve.mkDerivation rec {
       scripts = [ "bin/yadm" ];
       interpreter = "${bash}/bin/sh";
       inputs = [
+        bash
+        coreutils
         git
-        gnupg
-        openssl
-        gawk
         # see head comment
         # git-crypt
         # transcrypt
-        j2cli
-        esh
-        bash
-        coreutils
-        gnutar
-      ];
+      ]
+      ++ lib.optional withGpg gnupg
+      ++ lib.optional withOpenssl openssl
+      ++ lib.optional withAwk gawk
+      ++ lib.optional withJ2 j2cli
+      ++ lib.optional withEsh esh
+      ++ lib.optional withTar gnutar;
       fake = {
-        external = if stdenv.hostPlatform.isCygwin then [ ] else [ "cygpath" ];
+        external = lib.optional (!stdenv.hostPlatform.isCygwin) "cygpath" ++ lib.optional (!withTar) "tar";
       };
       fix = {
-        "$GPG_PROGRAM" = [ "gpg" ];
-        "$OPENSSL_PROGRAM" = [ "openssl" ];
         "$GIT_PROGRAM" = [ "git" ];
-        "$AWK_PROGRAM" = [ "awk" ];
+        "$GPG_PROGRAM" = lib.optional withGpg "gpg";
+        "$OPENSSL_PROGRAM" = lib.optional withOpenssl "openssl";
+        "$AWK_PROGRAM" = lib.optional withAwk "awk";
         # see head comment
         # "$GIT_CRYPT_PROGRAM" = [ "git-crypt" ];
         # "$TRANSCRYPT_PROGRAM" = [ "transcrypt" ];
-        "$J2CLI_PROGRAM" = [ "j2" ];
-        "$ESH_PROGRAM" = [ "esh" ];
+        "$J2CLI_PROGRAM" = lib.optional withJ2 "j2";
+        "$ESH_PROGRAM" = lib.optional withEsh "esh";
         # not in nixpkgs (yet)
         # "$ENVTPL_PROGRAM" = [ "envtpl" ];
         # "$LSB_RELEASE_PROGRAM" = [ "lsb_release" ];
@@ -99,6 +111,12 @@ resholve.mkDerivation rec {
         "$SHELL" = true; # probably user env? unsure
         "$hook_command" = true; # ~git hooks?
         "exec" = [ "$YADM_BOOTSTRAP" ]; # yadm bootstrap script
+
+        "$GPG_PROGRAM" = !withGpg;
+        "$OPENSSL_PROGRAM" = !withOpenssl;
+        "$AWK_PROGRAM" = !withAwk;
+        "$J2CLI_PROGRAM" = !withJ2;
+        "$ESH_PROGRAM" = !withEsh;
 
         # not in nixpkgs
         "$ENVTPL_PROGRAM" = true;

--- a/pkgs/by-name/ya/yadm/package.nix
+++ b/pkgs/by-name/ya/yadm/package.nix
@@ -135,7 +135,10 @@ resholve.mkDerivation rec {
     '';
     changelog = "https://github.com/yadm-dev/yadm/blob/${version}/CHANGES";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ abathur ];
+    maintainers = with lib.maintainers; [
+      abathur
+      sandarukasa
+    ];
     platforms = lib.platforms.unix;
     mainProgram = "yadm";
   };

--- a/pkgs/by-name/ya/yadm/package.nix
+++ b/pkgs/by-name/ya/yadm/package.nix
@@ -135,7 +135,10 @@ resholve.mkDerivation (finalAttrs: {
     '';
     changelog = "https://github.com/yadm-dev/yadm/blob/${finalAttrs.version}/CHANGES";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ abathur ];
+    maintainers = with lib.maintainers; [
+      abathur
+      sandarukasa
+    ];
     platforms = lib.platforms.unix;
     mainProgram = "yadm";
   };

--- a/pkgs/by-name/ya/yadm/package.nix
+++ b/pkgs/by-name/ya/yadm/package.nix
@@ -43,6 +43,9 @@ resholve.mkDerivation (finalAttrs: {
   pname = "yadm";
   version = "3.5.0";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   nativeBuildInputs = [ installShellFiles ];
 
   src = fetchFromGitHub {

--- a/pkgs/by-name/ya/yadm/package.nix
+++ b/pkgs/by-name/ya/yadm/package.nix
@@ -26,8 +26,19 @@
   installShellFiles,
   runCommand,
   yadm,
-}:
 
+  # Templates:
+  withAwk ? true,
+  withEsh ? true,
+  withJ2 ? true,
+
+  # Encryption:
+  withGpg ? true,
+  withOpenssl ? true,
+}:
+let
+  withTar = withGpg || withOpenssl;
+in
 resholve.mkDerivation (finalAttrs: {
   pname = "yadm";
   version = "3.5.0";
@@ -62,32 +73,32 @@ resholve.mkDerivation (finalAttrs: {
       scripts = [ "bin/yadm" ];
       interpreter = "${bash}/bin/sh";
       inputs = [
+        bash
+        coreutils
         git
-        gnupg
-        openssl
-        gawk
         # see head comment
         # git-crypt
         # transcrypt
-        j2cli
-        esh
-        bash
-        coreutils
-        gnutar
-      ];
+      ]
+      ++ lib.optional withGpg gnupg
+      ++ lib.optional withOpenssl openssl
+      ++ lib.optional withAwk gawk
+      ++ lib.optional withJ2 j2cli
+      ++ lib.optional withEsh esh
+      ++ lib.optional withTar gnutar;
       fake = {
-        external = if stdenv.hostPlatform.isCygwin then [ ] else [ "cygpath" ];
+        external = lib.optional (!stdenv.hostPlatform.isCygwin) "cygpath" ++ lib.optional (!withTar) "tar";
       };
       fix = {
-        "$GPG_PROGRAM" = [ "gpg" ];
-        "$OPENSSL_PROGRAM" = [ "openssl" ];
         "$GIT_PROGRAM" = [ "git" ];
-        "$AWK_PROGRAM" = [ "awk" ];
+        "$GPG_PROGRAM" = lib.optional withGpg "gpg";
+        "$OPENSSL_PROGRAM" = lib.optional withOpenssl "openssl";
+        "$AWK_PROGRAM" = lib.optional withAwk "awk";
         # see head comment
         # "$GIT_CRYPT_PROGRAM" = [ "git-crypt" ];
         # "$TRANSCRYPT_PROGRAM" = [ "transcrypt" ];
-        "$J2CLI_PROGRAM" = [ "j2" ];
-        "$ESH_PROGRAM" = [ "esh" ];
+        "$J2CLI_PROGRAM" = lib.optional withJ2 "j2";
+        "$ESH_PROGRAM" = lib.optional withEsh "esh";
         # not in nixpkgs (yet)
         # "$ENVTPL_PROGRAM" = [ "envtpl" ];
         # "$LSB_RELEASE_PROGRAM" = [ "lsb_release" ];
@@ -99,6 +110,12 @@ resholve.mkDerivation (finalAttrs: {
         "$SHELL" = true; # probably user env? unsure
         "$hook_command" = true; # ~git hooks?
         "exec" = [ "$YADM_BOOTSTRAP" ]; # yadm bootstrap script
+
+        "$GPG_PROGRAM" = !withGpg;
+        "$OPENSSL_PROGRAM" = !withOpenssl;
+        "$AWK_PROGRAM" = !withAwk;
+        "$J2CLI_PROGRAM" = !withJ2;
+        "$ESH_PROGRAM" = !withEsh;
 
         # not in nixpkgs
         "$ENVTPL_PROGRAM" = true;

--- a/pkgs/by-name/ya/yadmMinimal/package.nix
+++ b/pkgs/by-name/ya/yadmMinimal/package.nix
@@ -1,0 +1,10 @@
+{
+  yadm,
+}:
+yadm.override {
+  withAwk = false;
+  withEsh = false;
+  withJ2 = false;
+  withGpg = false;
+  withOpenssl = false;
+}

--- a/pkgs/development/misc/resholve/resholve-utils.nix
+++ b/pkgs/development/misc/resholve/resholve-utils.nix
@@ -287,8 +287,7 @@ rec {
 
         postFixup = unresholved.postResholve;
 
-        # don't break the metadata...
-        meta = unresholved.meta;
+        inherit (unresholved) meta strictDeps __structuredAttrs;
       };
   };
 }


### PR DESCRIPTION
Mainly to be able to get rid of python311, required by j2cli (#326134), which in turn is only an _optional_ dependency for yadm.

I've checked, `nix-build -A yadm` output is bit-by-bit identical before and after this PR.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
