### PR TITLE
python3Packages.earth2studio: init at 0.18.0

### DIFF
--- a/pkgs/development/python-modules/cartopy/default.nix
+++ b/pkgs/development/python-modules/cartopy/default.nix
@@ -1,39 +1,56 @@
 {
   lib,
   buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
   cython,
-  fetchPypi,
-  fontconfig,
-  gdal,
+  setuptools-scm,
+
+  # nativeBuildInputs
   geos,
+  proj,
+
+  # dependencies
   matplotlib,
   numpy,
-  owslib,
-  pillow,
-  proj,
   pyproj,
   pyshp,
+  shapely,
+
+  # optional-dependencies
+  # ows
+  owslib,
+  pillow,
+  # plotting
+  gdal,
+  scipy,
+
+  # tests
+  fontconfig,
   pytest-mpl,
   pytestCheckHook,
-  scipy,
-  setuptools-scm,
-  shapely,
+  writableTmpDirAsHomeHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "cartopy";
   version = "0.25.0";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-VfGjkOXz8HWyIcfZH7ECWK2XjbeGx5MOugbrRdKHU/4=";
+  src = fetchFromGitHub {
+    owner = "SciTools";
+    repo = "cartopy";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qnsr8IgqgqQDyGslYBvpAr/+ccsUPOiA2yGOXge3nUw=";
   };
 
-  build-system = [ setuptools-scm ];
+  build-system = [
+    cython
+    setuptools-scm
+  ];
 
   nativeBuildInputs = [
-    cython
     geos # for geos-config
     proj
   ];
@@ -66,12 +83,12 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytest-mpl
     pytestCheckHook
+    writableTmpDirAsHomeHook
   ]
-  ++ lib.concatAttrValues optional-dependencies;
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
 
   preCheck = ''
     export FONTCONFIG_FILE=${fontconfig.out}/etc/fonts/fonts.conf
-    export HOME=$TMPDIR
   '';
 
   pytestFlags = [
@@ -85,16 +102,41 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
+    # Numerical errors. Example:
+    #   AssertionError: Arrays are not almost equal to 4 decimals
+    "test_LatitudeFormatter_mercator"
+    "test_cursor_values"
+    "test_default"
+    "test_extents"
+    "test_geoaxes_no_subslice"
+    "test_geoaxes_set_boundary_clipping"
+    "test_get_extent"
+    "test_gridliner_labels_zoom"
+    "test_infinite_loop_bounds"
+    "test_invalid_xy_domain_corner"
+    "test_invalid_y_domain"
+    "test_osgb_vals"
+    "test_pcolormesh_datalim"
+    "test_plot_after_contour_doesnt_shrink"
+    "test_sweep"
+    "test_tiny_point_between_boundary_points"
+    "test_transform_point"
+    "test_with_transform"
+
+    # Failed: Error: Image files did not match.
+    "test_background_img"
     "test_gridliner_constrained_adjust_datalim"
-    "test_gridliner_labels_bbox_style"
+    "test_imshow"
+    "test_pil_Image"
+    "test_stock_img"
   ];
 
   meta = {
     description = "Process geospatial data to create maps and perform analyses";
     homepage = "https://scitools.org.uk/cartopy/docs/latest/";
-    changelog = "https://github.com/SciTools/cartopy/releases/tag/v${version}";
+    changelog = "https://github.com/SciTools/cartopy/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.lgpl3Plus;
     maintainers = [ ];
     mainProgram = "feature_download";
   };
-}
+})

--- a/pkgs/development/python-modules/earth2studio/default.nix
+++ b/pkgs/development/python-modules/earth2studio/default.nix
@@ -1,0 +1,94 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  cftime,
+  fsspec,
+  gcsfs,
+  h5netcdf,
+  h5py,
+  huggingface-hub,
+  loguru,
+  nest-asyncio,
+  netcdf4,
+  pandas,
+  pyarrow,
+  pygrib,
+  python-dotenv,
+  rich,
+  s3fs,
+  torch,
+  tqdm,
+  xarray,
+  zarr,
+
+  # tests
+  aiofiles,
+  pydantic,
+  pytestCheckHook,
+  redis,
+  redisTestHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "earth2studio";
+  version = "0.14.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = "earth2studio";
+    tag = finalAttrs.version;
+    hash = "sha256-K6pGYIzCRlg4u7I8uhYjmkw09RdU0MNFC+RPAqT2Tl8=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    cftime
+    fsspec
+    gcsfs
+    h5netcdf
+    h5py
+    huggingface-hub
+    loguru
+    nest-asyncio
+    netcdf4
+    pandas
+    pyarrow
+    pygrib
+    python-dotenv
+    rich
+    s3fs
+    torch
+    tqdm
+    xarray
+    zarr
+  ];
+
+  pythonImportsCheck = [ "earth2studio" ];
+
+  nativeCheckInputs = [
+    aiofiles
+    pydantic
+    pytestCheckHook
+    redis
+    redisTestHook
+  ];
+
+  meta = {
+    description = "Open-source deep-learning framework for exploring, building and deploying AI weather/climate workflows";
+    homepage = "https://github.com/NVIDIA/earth2studio";
+    changelog = "https://github.com/NVIDIA/earth2studio/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/development/python-modules/earth2studio/default.nix
+++ b/pkgs/development/python-modules/earth2studio/default.nix
@@ -1,0 +1,162 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  cftime,
+  fsspec,
+  gcsfs,
+  h5netcdf,
+  h5py,
+  huggingface-hub,
+  loguru,
+  netcdf4,
+  obspec,
+  obstore,
+  pandas,
+  pyarrow,
+  pygrib,
+  python-dotenv,
+  rich,
+  s3fs,
+  torch,
+  tqdm,
+  xarray,
+  zarr,
+
+  # tests
+  aiofiles,
+  eccodes,
+  fastapi,
+  hydra-core,
+  pydantic,
+  pytest-asyncio,
+  pytest-xdist,
+  pytestCheckHook,
+  redis,
+  rq,
+  writableTmpDirAsHomeHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "earth2studio";
+  version = "0.18.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = "earth2studio";
+    tag = finalAttrs.version;
+    hash = "sha256-7YXuqlfKB91uwPP/1GOThpnHS/VjPYYb/kCuFqebOVk=";
+  };
+
+  postPatch =
+    # Upstream tags the release without dropping the rc suffix from the version source
+    ''
+      substituteInPlace earth2studio/__init__.py \
+        --replace-fail \
+          '__version__ = "${finalAttrs.version}rc0"' \
+          '__version__ = "${finalAttrs.version}"'
+    '';
+
+  build-system = [
+    hatchling
+  ];
+
+  pythonRelaxDeps = [
+    "netcdf4"
+  ];
+  dependencies = [
+    cftime
+    fsspec
+    gcsfs
+    h5netcdf
+    h5py
+    huggingface-hub
+    loguru
+    netcdf4
+    obspec
+    obstore
+    pandas
+    pyarrow
+    pygrib
+    python-dotenv
+    rich
+    s3fs
+    torch
+    tqdm
+    xarray
+    zarr
+  ];
+
+  pythonImportsCheck = [ "earth2studio" ];
+
+  nativeCheckInputs = [
+    aiofiles
+    eccodes
+    fastapi
+    hydra-core
+    pydantic
+    pytest-asyncio
+    pytest-xdist
+    pytestCheckHook
+    redis
+    rq
+    writableTmpDirAsHomeHook
+  ];
+
+  disabledTestMarks = [
+    # Disable all tests that require GPU access
+    "cuda"
+  ];
+
+  disabledTests = [
+    # Flaky: races two timings against each other
+    "test_async_zarr_non_blocking"
+
+    # netCDF4 compares library versions as strings, so `diskless` support is wrongly rejected with
+    # netcdf-c 4.10:
+    # https://github.com/Unidata/netcdf4-python/issues/1475
+    "test_netcdf4_exceptions"
+    "test_netcdf4_fields"
+    "test_netcdf4_fields_multidim"
+    "test_netcdf4_variable"
+
+    # The `cuda:0` device parametrization is not covered by the `cuda` mark
+    "cuda"
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+    # oneDNN's aarch64 JIT fails to assemble the convolution kernel:
+    # https://github.com/pytorch/pytorch/issues/179710
+    "test_fss"
+  ];
+
+  disabledTestPaths = [
+    # Require network access
+    "test/data"
+    "test/models/test_auto_models.py"
+
+    # Requires `dask`
+    "test/utils/test_cupy.py"
+  ];
+
+  passthru.gpuCheck = finalAttrs.finalPackage.overrideAttrs (prev: {
+    requiredSystemFeatures = [ "cuda" ];
+    disabledTestMarks = [ ];
+    disabledTests = lib.remove "cuda" prev.disabledTests;
+  });
+
+  meta = {
+    description = "Open-source deep-learning framework for exploring, building and deploying AI weather/climate workflows";
+    homepage = "https://github.com/NVIDIA/earth2studio";
+    changelog = "https://github.com/NVIDIA/earth2studio/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/development/python-modules/pygrib/default.nix
+++ b/pkgs/development/python-modules/pygrib/default.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  cython,
+  numpy,
+  setuptools,
+
+  # buildInputs
+  eccodes,
+
+  # dependencies
+  packaging,
+  pyproj,
+
+  # tests
+  cartopy,
+  matplotlib,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pygrib";
+  version = "2.1.8";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jswhit";
+    repo = "pygrib";
+    tag = "v${finalAttrs.version}rel";
+    hash = "sha256-29Z81JbQgsmkmtEhf+udcnRrv3wS87Wuk3VK1EUKgSY=";
+  };
+
+  build-system = [
+    cython
+    numpy
+    setuptools
+  ];
+
+  buildInputs = [
+    eccodes
+  ];
+
+  dependencies = [
+    numpy
+    packaging
+    pyproj
+  ];
+
+  pythonImportsCheck = [ "pygrib" ];
+
+  nativeCheckInputs = [
+    cartopy
+    matplotlib
+    pytestCheckHook
+  ];
+
+  # Tests look for test data in ../sampledata
+  preCheck = ''
+    cd test
+  '';
+
+  disabledTestPaths = [
+    # Require unpackaged pyspharm
+    "test_spectral.py"
+
+    # SyntaxError: source code string cannot contain null bytes
+    "baseline_images/test_reduced_gg.py"
+  ];
+
+  meta = {
+    description = "Python interface for reading and writing GRIB data";
+    homepage = "https://github.com/jswhit/pygrib";
+    changelog = "https://github.com/jswhit/pygrib/blob/${finalAttrs.src.tag}/Changelog";
+    license = with lib.licenses; [
+      asl20
+      bsd2
+      mit
+    ];
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/development/python-modules/pygrib/default.nix
+++ b/pkgs/development/python-modules/pygrib/default.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  cython,
+  numpy,
+  setuptools,
+
+  # buildInputs
+  eccodes,
+
+  # dependencies
+  packaging,
+  pyproj,
+
+  # tests
+  cartopy,
+  matplotlib,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pygrib";
+  version = "2.1.8";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "jswhit";
+    repo = "pygrib";
+    tag = "v${finalAttrs.version}rel";
+    hash = "sha256-29Z81JbQgsmkmtEhf+udcnRrv3wS87Wuk3VK1EUKgSY=";
+  };
+
+  build-system = [
+    cython
+    numpy
+    setuptools
+  ];
+
+  buildInputs = [
+    eccodes
+  ];
+
+  dependencies = [
+    numpy
+    packaging
+    pyproj
+  ];
+
+  pythonImportsCheck = [ "pygrib" ];
+
+  nativeCheckInputs = [
+    cartopy
+    matplotlib
+    pytestCheckHook
+  ];
+
+  # Tests look for test data in ../sampledata
+  preCheck = ''
+    cd test
+  ''
+  # Prevents 'Fatal Python error: Aborted' on darwin during checkPhase
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    export MPLBACKEND="Agg"
+  '';
+
+  disabledTestPaths = [
+    # Require unpackaged pyspharm
+    "test_spectral.py"
+
+    # SyntaxError: source code string cannot contain null bytes
+    "baseline_images/test_reduced_gg.py"
+  ];
+
+  meta = {
+    description = "Python interface for reading and writing GRIB data";
+    homepage = "https://github.com/jswhit/pygrib";
+    changelog = "https://github.com/jswhit/pygrib/blob/${finalAttrs.src.tag}/Changelog";
+    license = with lib.licenses; [
+      asl20
+      bsd2
+      mit
+    ];
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4851,6 +4851,8 @@ self: super: with self; {
 
   eagle100 = callPackage ../development/python-modules/eagle100 { };
 
+  earth2studio = callPackage ../development/python-modules/earth2studio { };
+
   easy-thumbnails = callPackage ../development/python-modules/easy-thumbnails { };
 
   easydict = callPackage ../development/python-modules/easydict { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13966,6 +13966,8 @@ self: super: with self; {
 
   pygreat = callPackage ../development/python-modules/pygreat { };
 
+  pygrib = callPackage ../development/python-modules/pygrib { };
+
   pygrok = callPackage ../development/python-modules/pygrok { };
 
   pygsl = callPackage ../development/python-modules/pygsl { inherit (pkgs) gsl swig; };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5340,6 +5340,8 @@ self: super: with self; {
 
   earn-e-p1 = callPackage ../development/python-modules/earn-e-p1 { };
 
+  earth2studio = callPackage ../development/python-modules/earth2studio { };
+
   easy-thumbnails = callPackage ../development/python-modules/easy-thumbnails { };
 
   easydict = callPackage ../development/python-modules/easydict { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15031,6 +15031,8 @@ self: super: with self; {
 
   pygreat = callPackage ../development/python-modules/pygreat { };
 
+  pygrib = callPackage ../development/python-modules/pygrib { };
+
   pygrok = callPackage ../development/python-modules/pygrok { };
 
   pygsl = callPackage ../development/python-modules/pygsl { inherit (pkgs) gsl swig; };


### PR DESCRIPTION
## Things done

Add [earth2studio](https://github.com/NVIDIA/earth2studio), an open-source deep-learning framework for exploring, building and deploying AI weather/climate workflows.

- **python3Packages.pygrib: init at 2.1.8**
- **python3Packages.earth2studio: init at 0.18.0**

cc @YorikSar

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
