### PR TITLE
nixos/gitea-actions-runner: re-register on token change

### DIFF
--- a/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
@@ -241,13 +241,16 @@ in
                   mkdir -vp "$INSTANCE_DIR"
                   cd "$INSTANCE_DIR"
 
-                  # force reregistration on changed labels
+                  # force reregistration on changed token or labels
+                  export TOKEN_HASH_FILE="$INSTANCE_DIR/.token-hash"
+                  export TOKEN_HASH_CURRENT="$(printf '%s' "$TOKEN" | sha256sum | cut -d' ' -f1)"
+                  export TOKEN_HASH_STORED="$(cat "$TOKEN_HASH_FILE" 2>/dev/null || echo "")"
                   export LABELS_FILE="$INSTANCE_DIR/.labels"
                   export LABELS_WANTED="$(echo ${escapeShellArg (concatStringsSep "\n" instance.labels)} | sort)"
                   export LABELS_CURRENT="$(cat $LABELS_FILE 2>/dev/null || echo 0)"
 
-                  if [ ! -e "$INSTANCE_DIR/.runner" ] || [ "$LABELS_WANTED" != "$LABELS_CURRENT" ]; then
-                    # remove existing registration file, so that changing the labels forces a re-registration
+                  if [ ! -e "$INSTANCE_DIR/.runner" ] || [ "$LABELS_WANTED" != "$LABELS_CURRENT" ] || [ "$TOKEN_HASH_CURRENT" != "$TOKEN_HASH_STORED" ]; then
+                    # remove existing registration file, so that changing the token or labels forces a re-registration
                     rm -v "$INSTANCE_DIR/.runner" || true
 
                     # perform the registration
@@ -258,7 +261,8 @@ in
                       --labels ${escapeShellArg (concatStringsSep "," instance.labels)} \
                       --config ${configFile}
 
-                    # and write back the configured labels
+                    # and write back the configured labels and token hash
+                    printf '%s' "$TOKEN_HASH_CURRENT" > "$TOKEN_HASH_FILE"
                     echo "$LABELS_WANTED" > "$LABELS_FILE"
                   fi
 


### PR DESCRIPTION
nixos/gitea-actions-runner: re-register on token change

The ExecStartPre script already re-registers when labels change
(.labels fingerprint) but ignores token changes. A token change
(e.g. switching from user-level to instance-level scope) has no
effect until the .runner file is manually deleted.

CC @mweinelt 