### PR TITLE
mikmod: 3.2.8 -> 3.2.9

### DIFF
--- a/pkgs/by-name/mi/mikmod/package.nix
+++ b/pkgs/by-name/mi/mikmod/package.nix
@@ -9,23 +9,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mikmod";
-  version = "3.2.8";
+  version = "3.2.9";
 
   src = fetchurl {
     url = "mirror://sourceforge/mikmod/mikmod-${finalAttrs.version}.tar.gz";
-    sha256 = "1k54p8pn3jinha0f2i23ad15pf1pamibzcxjrbzjbklpcz1ipc6v";
+    sha256 = "sha256-IUwQqjAZgHoesmsscJWS9j28wAtymFqoak+3rDzYuQE=";
   };
-
-  patches = [
-    # Fix player startup crash due to stack overflow check:
-    #   https://sourceforge.net/p/mikmod/patches/17/
-    (fetchpatch {
-      name = "fortify-source-3.patch";
-      url = "https://sourceforge.net/p/mikmod/patches/17/attachment/0001-mikmod-fix-startup-crash-on-_FROTIFY_SOURCE-3-system.patch";
-      stripLen = 1;
-      hash = "sha256-YtbnLTsW3oYPo4r3fh3DUd3DD5ogWrCNlrDcneY03U0=";
-    })
-  ];
 
   buildInputs = [
     libmikmod


### PR DESCRIPTION
- #475479 
- #516381 
- https://hydra.nixos.org/build/326832673
- Changelog: https://sourceforge.net/p/mikmod/news/2024/12/new-mikmod-player-version-329-is-released/

```
mlistedit.c: In function 'freq_set_marks':
mlistedit.c:172:56: error: passing argument 5 of 'bsearch' from incompatible pointer type [-Wincompatible-pointer-types]
  172 |                                          sizeof(char*),(int(*)())searchlist_search_cmp))
      |                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                        |
      |                                                        int (*)(void)
In file included from /nix/store/fbbw928argckfii0j322346ihmllg7a7-glibc-2.42-61-dev/include/stdlib.h:965,
                 from mlistedit.c:37:
/nix/store/fbbw928argckfii0j322346ihmllg7a7-glibc-2.42-61-dev/include/bits/stdlib-bsearch.h:21:24: note: expected 'int (*)(const void *, const void *)' but argument is of type 'int (*)(void)'
   21 |          __compar_fn_t __compar)
      |          ~~~~~~~~~~~~~~^~~~~~~~
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
