### PR TITLE
wasmer: 5.0.4 -> 7.1.0, add v8 support

### DIFF
--- a/pkgs/by-name/wa/wasmer/package.nix
+++ b/pkgs/by-name/wa/wasmer/package.nix
@@ -2,30 +2,79 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchurl,
   rustPlatform,
   cargo,
   rustc,
-  llvmPackages_18,
+  nix-update,
+  curl,
+  writeShellApplication,
+  llvmPackages_21,
   libffi,
   libxml2,
   withLLVM ?
     stdenv.hostPlatform.isLinux || (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64),
+  withV8 ? (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64),
 }:
 
-stdenv.mkDerivation  (finalAttrs: {
+let
+  v8Version = "11.9.2";
+
+  # Prebuilt V8 from wasmerio's custom builds, only evaluated when withV8 = true.
+
+  # Per-platform hashes, auto-updated via the general updateScript
+  v8Hashes = {
+    "v8-linux-amd64.tar.xz" = "sha256-nTCVdBKtyVMb7lE+Db4RDsShKkLbG/0r980ejd+EAvo=";
+    "v8-linux-musl-amd64.tar.xz" = "sha256-XgRs3I46B2PG7Jrv5E+KSeuNfXLhgB7R66cAkA/Bvv8=";
+    "v8-darwin-arm64.tar.xz" = "sha256-xAG1PcAGw8a0A9k8d78/whTUXnqdfRZBz8yrg/+iz0M=";
+  };
+
+  v8Prebuilt =
+    let
+      assetName =
+        if stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64 && stdenv.hostPlatform.isMusl then
+          "v8-linux-musl-amd64.tar.xz"
+        else if stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64 then
+          "v8-linux-amd64.tar.xz"
+        else if stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64 then
+          "v8-darwin-arm64.tar.xz"
+        else
+          throw "withV8 = true is not supported on ${stdenv.hostPlatform.system}";
+    in
+    stdenv.mkDerivation {
+      name = "wasmer-v8-prebuilt-${v8Version}";
+      src = fetchurl {
+        url = "https://github.com/wasmerio/v8-custom-builds/releases/download/${v8Version}/${assetName}";
+        hash = v8Hashes.${assetName};
+      };
+      sourceRoot = ".";
+      dontBuild = true;
+      installPhase = ''
+        cp -r . $out
+      '';
+
+      meta.sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    };
+in
+
+stdenv.mkDerivation (finalAttrs: {
   pname = "wasmer";
-  version = "6.0.1";
+  version = "7.1.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "wasmerio";
     repo = "wasmer";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-nw/4hcEDkAabcpatVBRozxvVLzYOKbj3ylrGeQtNzMQ=";
+    hash = "sha256-A1SkZY+iSR9xlu6R1p9uZYsGFPAOifuYTHtEXaEgves=";
+    fetchSubmodules = true;
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-Nui8KxDk4+sqcmzeoZ6hGRb9Ux71+Nckz8seqq07cdE=";
+    hash = "sha256-wBEwGKjj9DdZESFlXS8T7B0Xdp7yMe08DYTGr4wnTVI=";
   };
 
   nativeBuildInputs = [
@@ -36,28 +85,71 @@ stdenv.mkDerivation  (finalAttrs: {
   ];
 
   buildInputs = lib.optionals withLLVM [
-    llvmPackages_18.llvm
+    llvmPackages_21.llvm
     libffi
     libxml2
   ];
 
+  # In 7.1.0 there is no nice flag to toggle napi/v8 on or off,
+  # so we manually delete the Makefile entry when we don't want v8
+  # TODO: v7.2.0 pre-release has a flag, when updating to 7.2.0
+  #  add "ENABLE_NAPI_V8=${if withV8 then "1" else "0"}" to makeFlags
+  postPatch =
+    lib.optionalString (!withV8) ''
+      substituteInPlace Makefile \
+        --replace-fail '	build_wasmer_extra_features += napi-v8' ""
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      substituteInPlace Makefile \
+        --replace-fail 'install: install-wasmer install-capi-headers install-capi-lib install-pkgconfig install-misc' \
+                       'install: install-wasmer install-capi-headers install-misc'
+    '';
+
   makeFlags = [
     "WASMER_INSTALL_PREFIX=${placeholder "out"}"
     "DESTDIR=${placeholder "out"}"
-  ];
-
-  buildFlags = [
     "ENABLE_LLVM=${if withLLVM then "1" else "0"}"
   ];
 
-  env = lib.optionalAttrs withLLVM {
-    LLVM_SYS_180_PREFIX = llvmPackages_18.llvm.dev;
-  };
+  # Default all target includes headless C API which doesn't get installed
+  # by their Makefile and is quite niche to include, so we opt out
+  buildFlags = [
+    "build-wasmer"
+    "build-capi"
+  ];
+
+  env =
+    lib.optionalAttrs withLLVM {
+      LLVM_SYS_211_PREFIX = llvmPackages_21.llvm.dev;
+    }
+    // lib.optionalAttrs withV8 {
+      # build.rs skips the download when these are set; see resolve_explicit_v8 in lib/napi/build.rs
+      NAPI_V8_INCLUDE_DIR = "${v8Prebuilt}/include";
+      V8_LIB_DIR = "${v8Prebuilt}/lib";
+    };
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    install -Dm755 target/release/libwasmer.dylib $out/lib/libwasmer.dylib
+    if pc="$(WASMER_DIR="" target/release/wasmer config --pkg-config 2>/dev/null)"; then
+      mkdir -p "$out/lib/pkgconfig"
+      printf '%s\n' "$pc" > "$out/lib/pkgconfig/wasmer.pc"
+    fi
+  '';
+
+  passthru.updateScript = lib.getExe (writeShellApplication {
+    name = "update-wasmer";
+    runtimeInputs = [
+      nix-update
+      curl
+    ];
+    text = builtins.readFile ./update.sh;
+  });
 
   # Tests are failing due to `Cannot allocate memory` and other reasons
   doCheck = false;
 
   meta = {
+    sourceProvenance = with lib.sourceTypes; [ fromSource ] ++ lib.optional withV8 binaryNativeCode;
     description = "Universal WebAssembly Runtime";
     mainProgram = "wasmer";
     longDescription = ''

--- a/pkgs/by-name/wa/wasmer/package.nix
+++ b/pkgs/by-name/wa/wasmer/package.nix
@@ -1,28 +1,37 @@
 {
   lib,
-  rustPlatform,
+  stdenv,
   fetchFromGitHub,
+  rustPlatform,
+  cargo,
+  rustc,
   llvmPackages_18,
   libffi,
   libxml2,
-  withLLVM ? true,
-  withSinglepass ? true,
+  withLLVM ?
+    stdenv.hostPlatform.isLinux || (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64),
 }:
 
-rustPlatform.buildRustPackage (finalAttrs: {
+stdenv.mkDerivation  (finalAttrs: {
   pname = "wasmer";
-  version = "5.0.4";
+  version = "6.0.1";
 
   src = fetchFromGitHub {
     owner = "wasmerio";
     repo = "wasmer";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-rP0qvSb9PxsTMAq0hpB+zdSTHvridyCVdukLUYxdao8=";
+    hash = "sha256-nw/4hcEDkAabcpatVBRozxvVLzYOKbj3ylrGeQtNzMQ=";
   };
 
-  cargoHash = "sha256-Fympp2A04viibo4U79FiBSJIeGDUWS34OOwebCks6S0=";
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-Nui8KxDk4+sqcmzeoZ6hGRb9Ux71+Nckz8seqq07cdE=";
+  };
 
   nativeBuildInputs = [
+    cargo
+    rustc
+    rustPlatform.cargoSetupHook
     rustPlatform.bindgenHook
   ];
 
@@ -32,25 +41,18 @@ rustPlatform.buildRustPackage (finalAttrs: {
     libxml2
   ];
 
-  # check references to `compiler_features` in Makefile on update
-  buildFeatures = [
-    "cranelift"
-    "wasmer-artifact-create"
-    "static-artifact-create"
-    "wasmer-artifact-load"
-    "static-artifact-load"
-  ]
-  ++ lib.optional withLLVM "llvm"
-  ++ lib.optional withSinglepass "singlepass";
-
-  cargoBuildFlags = [
-    "--manifest-path"
-    "lib/cli/Cargo.toml"
-    "--bin"
-    "wasmer"
+  makeFlags = [
+    "WASMER_INSTALL_PREFIX=${placeholder "out"}"
+    "DESTDIR=${placeholder "out"}"
   ];
 
-  env.LLVM_SYS_180_PREFIX = lib.optionalString withLLVM llvmPackages_18.llvm.dev;
+  buildFlags = [
+    "ENABLE_LLVM=${if withLLVM then "1" else "0"}"
+  ];
+
+  env = lib.optionalAttrs withLLVM {
+    LLVM_SYS_180_PREFIX = llvmPackages_18.llvm.dev;
+  };
 
   # Tests are failing due to `Cannot allocate memory` and other reasons
   doCheck = false;

--- a/pkgs/by-name/wa/wasmer/package.nix
+++ b/pkgs/by-name/wa/wasmer/package.nix
@@ -2,30 +2,80 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchurl,
   rustPlatform,
   cargo,
   rustc,
-  llvmPackages_18,
+  nix-update,
+  curl,
+  writeShellApplication,
+  llvmPackages_21,
   libffi,
   libxml2,
+  fixDarwinDylibNames,
   withLLVM ?
     stdenv.hostPlatform.isLinux || (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64),
+  withV8 ? (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64),
 }:
 
-stdenv.mkDerivation  (finalAttrs: {
+let
+  v8Version = "11.9.2";
+
+  # Prebuilt V8 from wasmerio's custom builds, only evaluated when withV8 = true.
+
+  # Per-platform hashes, auto-updated via the general updateScript
+  v8Hashes = {
+    "v8-linux-amd64.tar.xz" = "sha256-nTCVdBKtyVMb7lE+Db4RDsShKkLbG/0r980ejd+EAvo=";
+    "v8-linux-musl-amd64.tar.xz" = "sha256-XgRs3I46B2PG7Jrv5E+KSeuNfXLhgB7R66cAkA/Bvv8=";
+    "v8-darwin-arm64.tar.xz" = "sha256-xAG1PcAGw8a0A9k8d78/whTUXnqdfRZBz8yrg/+iz0M=";
+  };
+
+  v8Prebuilt =
+    let
+      assetName =
+        if stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64 && stdenv.hostPlatform.isMusl then
+          "v8-linux-musl-amd64.tar.xz"
+        else if stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64 then
+          "v8-linux-amd64.tar.xz"
+        else if stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64 then
+          "v8-darwin-arm64.tar.xz"
+        else
+          throw "withV8 = true is not supported on ${stdenv.hostPlatform.system}";
+    in
+    stdenv.mkDerivation {
+      name = "wasmer-v8-prebuilt-${v8Version}";
+      src = fetchurl {
+        url = "https://github.com/wasmerio/v8-custom-builds/releases/download/${v8Version}/${assetName}";
+        hash = v8Hashes.${assetName};
+      };
+      sourceRoot = ".";
+      dontBuild = true;
+      installPhase = ''
+        cp -r . $out
+      '';
+
+      meta.sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    };
+in
+
+stdenv.mkDerivation (finalAttrs: {
   pname = "wasmer";
-  version = "6.0.1";
+  version = "7.1.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "wasmerio";
     repo = "wasmer";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-nw/4hcEDkAabcpatVBRozxvVLzYOKbj3ylrGeQtNzMQ=";
+    hash = "sha256-A1SkZY+iSR9xlu6R1p9uZYsGFPAOifuYTHtEXaEgves=";
+    fetchSubmodules = true;
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-Nui8KxDk4+sqcmzeoZ6hGRb9Ux71+Nckz8seqq07cdE=";
+    hash = "sha256-wBEwGKjj9DdZESFlXS8T7B0Xdp7yMe08DYTGr4wnTVI=";
   };
 
   nativeBuildInputs = [
@@ -33,31 +83,83 @@ stdenv.mkDerivation  (finalAttrs: {
     rustc
     rustPlatform.cargoSetupHook
     rustPlatform.bindgenHook
-  ];
+  ]
+  ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
 
   buildInputs = lib.optionals withLLVM [
-    llvmPackages_18.llvm
+    llvmPackages_21.llvm
     libffi
     libxml2
   ];
 
+  postPatch =
+    # In 7.1.0 there is no nice flag to toggle napi/v8 on or off,
+    # so we manually delete the Makefile entry when we don't want v8
+    # TODO: v7.2.0 pre-release has a flag, when updating to 7.2.0
+    #  add "ENABLE_NAPI_V8=${if withV8 then "1" else "0"}" to makeFlags
+    lib.optionalString (!withV8) ''
+      substituteInPlace Makefile \
+        --replace-fail '	build_wasmer_extra_features += napi-v8' ""
+    ''
+    +
+      lib.optionalString stdenv.hostPlatform.isDarwin
+        # `install -Dm644 /dev/stdin DEST` fails on darwin with
+        # "skipping file '/dev/stdin', as it was replaced while being copied".
+        (
+          ''
+            substituteInPlace Makefile \
+              --replace-fail 'echo "$$pc" | install -Dm644 /dev/stdin "$(DESTDIR)"/lib/pkgconfig/wasmer.pc;' \
+                             'mkdir -p "$(DESTDIR)/lib/pkgconfig" && printf "%s\n" "$$pc" > "$(DESTDIR)/lib/pkgconfig/wasmer.pc";'
+          ''
+          # install-capi-lib hardcodes libwasmer.so and a Linux SONAME symlink chain
+          # (also marked Linux only in the Makefile)
+          + ''
+            substituteInPlace Makefile \
+              --replace-fail 'install-capi-lib ' ""
+          ''
+        );
+
   makeFlags = [
     "WASMER_INSTALL_PREFIX=${placeholder "out"}"
     "DESTDIR=${placeholder "out"}"
-  ];
-
-  buildFlags = [
     "ENABLE_LLVM=${if withLLVM then "1" else "0"}"
   ];
 
-  env = lib.optionalAttrs withLLVM {
-    LLVM_SYS_180_PREFIX = llvmPackages_18.llvm.dev;
-  };
+  # Default all target includes headless C API which doesn't get installed
+  # by their Makefile and is quite niche to include, so we opt out
+  buildFlags = [
+    "build-wasmer"
+    "build-capi"
+  ];
+
+  env =
+    lib.optionalAttrs withLLVM {
+      LLVM_SYS_211_PREFIX = llvmPackages_21.llvm.dev;
+    }
+    // lib.optionalAttrs withV8 {
+      # build.rs skips the download when these are set; see resolve_explicit_v8 in lib/napi/build.rs
+      NAPI_V8_INCLUDE_DIR = "${v8Prebuilt}/include";
+      V8_LIB_DIR = "${v8Prebuilt}/lib";
+    };
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    install -Dm755 target/release/libwasmer.dylib $out/lib/libwasmer.dylib
+  '';
+
+  passthru.updateScript = lib.getExe (writeShellApplication {
+    name = "update-wasmer";
+    runtimeInputs = [
+      nix-update
+      curl
+    ];
+    text = builtins.readFile ./update.sh;
+  });
 
   # Tests are failing due to `Cannot allocate memory` and other reasons
   doCheck = false;
 
   meta = {
+    sourceProvenance = with lib.sourceTypes; [ fromSource ] ++ lib.optional withV8 binaryNativeCode;
     description = "Universal WebAssembly Runtime";
     mainProgram = "wasmer";
     longDescription = ''

--- a/pkgs/by-name/wa/wasmer/update.sh
+++ b/pkgs/by-name/wa/wasmer/update.sh
@@ -1,0 +1,49 @@
+old_version=$(grep -oP '^  version = "\K[^"]+(?=";)' pkgs/by-name/wa/wasmer/package.nix)
+echo "Current wasmer version: $old_version"
+
+nix-update wasmer "$@"
+
+new_version=$(grep -oP '^  version = "\K[^"]+(?=";)' pkgs/by-name/wa/wasmer/package.nix)
+if [ "$old_version" = "$new_version" ]; then
+  echo "Already at $old_version, nothing to do"
+  exit 0
+fi
+echo "Updated wasmer $old_version -> $new_version"
+
+# v8Version is pinned in package.nix to match PREBUILT_V8_VERSION in lib/napi/build.rs.
+# lib/napi is a submodule, so resolve its pinned SHA first, then fetch build.rs from that repo.
+echo "Fetching PREBUILT_V8_VERSION from lib/napi/build.rs..."
+napi_sha=$(curl -fsSL "https://api.github.com/repos/wasmerio/wasmer/contents/lib/napi?ref=v${new_version}" \
+           | grep -oP '"sha":\s*"\K[^"]+' | head -1)
+new_v8=$(curl -fsSL "https://raw.githubusercontent.com/wasmerio/napi/${napi_sha}/build.rs" \
+         | grep -oP 'PREBUILT_V8_VERSION\s*:\s*&str\s*=\s*"\K[^"]+')
+cur_v8=$(grep -oP '^  v8Version = "\K[^"]+(?=";)' pkgs/by-name/wa/wasmer/package.nix)
+echo "V8: current=$cur_v8, required=$new_v8"
+
+if [ "$new_v8" = "$cur_v8" ]; then
+  echo "V8 version unchanged, done"
+  exit 0
+fi
+
+echo "V8 bumped $cur_v8 -> $new_v8, fetching hashes for all platforms..."
+sed -i "s|^  v8Version = \"[^\"]*\";$|  v8Version = \"$new_v8\";|" \
+  pkgs/by-name/wa/wasmer/package.nix
+
+base="https://github.com/wasmerio/v8-custom-builds/releases/download/$new_v8"
+declare -A assets=(
+  ["v8-linux-amd64.tar.xz"]="$base/v8-linux-amd64.tar.xz"
+  ["v8-linux-musl-amd64.tar.xz"]="$base/v8-linux-musl-amd64.tar.xz"
+  ["v8-darwin-arm64.tar.xz"]="$base/v8-darwin-arm64.tar.xz"
+)
+
+for asset in "${!assets[@]}"; do
+  url="${assets[$asset]}"
+  echo "  Fetching hash for $asset..."
+  hash=$(nix-prefetch-url --type sha256 "$url" 2>/dev/null \
+         | xargs nix hash convert --hash-algo sha256 --to sri)
+  echo "  $asset -> $hash"
+  sed -i "s|\"$asset\" = \"[^\"]*\"|\"$asset\" = \"$hash\"|" \
+    pkgs/by-name/wa/wasmer/package.nix
+done
+
+echo "Done"


### PR DESCRIPTION
Updates wasmer to the latest version and adds support for the v8 compiler backend

Diff: https://github.com/wasmerio/wasmer/compare/refs/tags/v5.0.4...refs/tags/v7.1.0

Supersedes #433805 (stale)
Closes #405782 and #403981

cc @NickCao 

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
