### PR TITLE
unnaturalscrollwheels: 1.3.0 -> 1.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12511,6 +12511,12 @@
     githubId = 30251156;
     name = "Jesse Moore";
   };
+  jesssullivan = {
+    email = "jess@sulliwood.org";
+    github = "Jesssullivan";
+    githubId = 37297218;
+    name = "Jess Sullivan";
+  };
   jethair = {
     email = "jethair@duck.com";
     github = "JetHair";

--- a/pkgs/by-name/un/unnaturalscrollwheels/package.nix
+++ b/pkgs/by-name/un/unnaturalscrollwheels/package.nix
@@ -2,15 +2,16 @@
   lib,
   stdenvNoCC,
   fetchurl,
+  nix-update-script,
   _7zz,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "unnaturalscrollwheels";
-  version = "1.3.0";
+  version = "1.4.0";
 
   src = fetchurl {
     url = "https://github.com/ther0n/UnnaturalScrollWheels/releases/download/${finalAttrs.version}/UnnaturalScrollWheels-${finalAttrs.version}.dmg";
-    sha256 = "1c6vlf0kc7diz0hb1fmrqaj7kzzfvr65zcchz6xv5cxf0md4n70r";
+    hash = "sha256-KJQnV/XWM+JpW3O29nyGo64Jte6Gw3I54bXfFSAkUrc=";
   };
   sourceRoot = ".";
 
@@ -26,12 +27,18 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Invert scroll direction for physical scroll wheels";
     homepage = "https://github.com/ther0n/UnnaturalScrollWheels";
+    changelog = "https://github.com/ther0n/UnnaturalScrollWheels/releases/tag/${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    maintainers = with lib.maintainers; [ emilytrau ];
+    maintainers = with lib.maintainers; [
+      emilytrau
+      jesssullivan
+    ];
     platforms = lib.platforms.darwin;
   };
 })


### PR DESCRIPTION
Bumps `unnaturalscrollwheels` from 1.3.0 to 1.4.0 — the first notarized release ([changelog](https://github.com/ther0n/UnnaturalScrollWheels/releases/tag/1.4.0)), published 2026-04-03 with macOS Tahoe support.

Also adds `nix-update-script`, `meta.changelog`, migrates `sha256` → SRI `hash`, and adds me as co-maintainer.

### Signing identity

The 1.4.0 DMG is signed by **Dan Oak (Team ID `VH8UL6UKQL`)**, not the original ther0n team. ther0n acknowledged this in [issue #111](https://github.com/ther0n/UnnaturalScrollWheels/issues/111):

> *"1.4.0 is fully notarized... Older versions were signed by me, and the newest versions signed by @do4k."*

### Tested

- Built on `aarch64-darwin`.
- `codesign --verify --deep --strict` and `xcrun stapler validate` pass against the build output.
- Launches; menu bar item appears; accessibility prompt fires.

Let me know if I am missing anything here, I just recently noticed there is a nixpkg available for `unnaturalscrollwheels`.  

Also, glad to keep this package from up to date @emilytrau -- all the macs in my lab get `unnaturalscrollwheels` treatment and will for the foreseeable future ... alas the macos builds must go on  👀 


---

### Edits:

- **Added [PR template](https://github.com/NixOS/nixpkgs/pull/516711#pullrequestreview-4426653403)**
- **FWIW, these two small commits, prose & PR made by a human, thanks for the pointer to the updated LLM Policy**  @sportshead 👍 

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
  
— Jess
