### PR TITLE
opentabletdriver-bin: init at 0.6.7

### DIFF
--- a/pkgs/by-name/op/opentabletdriver-bin/package.nix
+++ b/pkgs/by-name/op/opentabletdriver-bin/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  makeBinaryWrapper,
+  nix-update-script,
+  versionCheckHook,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "opentabletdriver-bin";
+  version = "0.6.7";
+
+  src = fetchurl {
+    url = "https://github.com/OpenTabletDriver/OpenTabletDriver/releases/download/v${finalAttrs.version}/OpenTabletDriver-${finalAttrs.version}_osx-x64.tar.gz";
+    hash = "sha256-xLDZ6yrujue+EtDfgPlh6gpyNfVLX1miti76m57EkQ4=";
+  };
+
+  sourceRoot = ".";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+  ];
+
+  postInstall = ''
+    mkdir -p $out/Applications
+    cp -r OpenTabletDriver.app $out/Applications/
+    makeWrapper $out/Applications/OpenTabletDriver.app/Contents/MacOS/OpenTabletDriver.Console $out/bin/${finalAttrs.meta.mainProgram}
+    makeWrapper $out/Applications/OpenTabletDriver.app/Contents/MacOS/OpenTabletDriver.Daemon $out/bin/otd-daemon
+    makeWrapper $out/Applications/OpenTabletDriver.app/Contents/MacOS/OpenTabletDriver.UX.MacOS $out/bin/otd-gui
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/OpenTabletDriver/OpenTabletDriver/releases/tag/v${finalAttrs.version}";
+    description = "Open source, cross-platform, user-mode tablet driver";
+    homepage = "https://opentabletdriver.net/";
+    license = lib.licenses.lgpl3Plus;
+    mainProgram = "otd";
+    maintainers = with lib.maintainers; [ MysteryBlokHed ];
+    platforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
Adds a package for [OpenTabletDriver] for macOS.

Currently, the project does not have proper AArch64 support for macOS, so a build from source doesn't work properly (I tried). It might work for x86_64-darwin, but since that is going to be deprecated for Nixpkgs quite soon, I figured there wasn't any point in testing it.

This package just fetches the latest macOS binary from the GitHub release instead. If and when the project supports aarch64-darwin, then the main `opentabletdriver` package can be extended to build on macOS from source, and this package can be removed and aliased.

[OpenTabletDriver]: https://github.com/OpenTabletDriver/OpenTabletDriver

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
