### PR TITLE
buildkite-agent-metrics: 5.10.0 -> 5.12.2

### DIFF
--- a/pkgs/by-name/bu/buildkite-agent-metrics/package.nix
+++ b/pkgs/by-name/bu/buildkite-agent-metrics/package.nix
@@ -5,7 +5,7 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "buildkite-agent-metrics";
-  version = "5.10.0";
+  version = "5.12.2";
 
   __darwinAllowLocalNetworking = true;
 
@@ -18,10 +18,13 @@ buildGoModule (finalAttrs: {
     owner = "buildkite";
     repo = "buildkite-agent-metrics";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-QE4IY1yU8X1zG+jf7eBWiSjN3HvDqr2Avhs3Bub+xB0=";
+    hash = "sha256-O/6YGxX7sJEaqmMMzOPxkiIWJs1VRa+tgZ2w8UjfoKk=";
   };
 
-  vendorHash = "sha256-r088XQKYx0D0OVfz/nqhWL0LLCf4X13WqYikJKlLr3c=";
+  vendorHash = "sha256-2os2V1iyw1k6XwX2wLz0abMnu+X5p+Aqau7ajC3JIRc=";
+
+  # This is a Google Cloud Function and is not needed for compiling the binary
+  excludedPackages = [ "./cloud_function" ];
 
   postInstall = ''
     mkdir -p $lambda/bin


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Release: https://github.com/buildkite/buildkite-agent-metrics/releases/tag/v5.12.2
Diff: https://github.com/buildkite/buildkite-agent-metrics/compare/v5.10.0...v5.12.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## `nixpkgs-review` result for [#516714](https://github.com/NixOS/nixpkgs/pull/516714)

Generated using [`nixpkgs-review-gha`](https://github.com/Defelo/nixpkgs-review-gha)

Command: `nixpkgs-review pr 516714`
Commit: [`ebfb435d2e2d337e7576157be547fd6a85e22b83`](https://github.com/NixOS/nixpkgs/commit/ebfb435d2e2d337e7576157be547fd6a85e22b83) ([subsequent changes](https://github.com/NixOS/nixpkgs/compare/ebfb435d2e2d337e7576157be547fd6a85e22b83..pull/516714/head))
Merge: [`023a968a6bcf6d3125527e29bb308866dc8ee1ae`](https://github.com/NixOS/nixpkgs/commit/023a968a6bcf6d3125527e29bb308866dc8ee1ae)

Logs: https://github.com/cbrxyz/nixpkgs-review-gha/actions/runs/25355784659


---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>buildkite-agent-metrics</li>
    <li>buildkite-agent-metrics.lambda</li>
  </ul>
</details>

---
### `aarch64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>buildkite-agent-metrics</li>
    <li>buildkite-agent-metrics.lambda</li>
  </ul>
</details>

---
### `x86_64-darwin` (sandbox = relaxed)
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>buildkite-agent-metrics</li>
    <li>buildkite-agent-metrics.lambda</li>
  </ul>
</details>

---
### `aarch64-darwin` (sandbox = relaxed)
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>buildkite-agent-metrics</li>
    <li>buildkite-agent-metrics.lambda</li>
  </ul>
</details>
