### PR TITLE
cargo-wizard: fix aarch64-linux test expectation, adopt package

### DIFF
--- a/pkgs/by-name/ca/cargo-wizard/package.nix
+++ b/pkgs/by-name/ca/cargo-wizard/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "kobzol";
     repo = "cargo-wizard";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-WLGE2ZuytjSridZwfUTtNQF5woeBbx5ZoHfB9eyvedI=";
   };
 
@@ -33,9 +33,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Cargo subcommand for configuring Cargo profile for best performance";
     homepage = "https://github.com/kobzol/cargo-wizard";
-    changelog = "https://github.com/kobzol/cargo-wizard/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/kobzol/cargo-wizard/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ iamanaws ];
     mainProgram = "cargo-wizard";
   };
 })

--- a/pkgs/by-name/ca/cargo-wizard/package.nix
+++ b/pkgs/by-name/ca/cargo-wizard/package.nix
@@ -18,6 +18,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-vRakgwZRyYkk3xFfZzl197tgRmx+/g2b8eaDunwrCzM=";
 
+  # cargo-wizard still suggests lld for aarch64-linux on Rust 1.90+, so the
+  # nightly integration test must expect both rustflags there.
+  postPatch = ''
+    substituteInPlace tests/integration/dialog.rs \
+      --replace-fail 'if rustversion::cfg!(before(1.90.0)) {' \
+        'if rustversion::cfg!(before(1.90.0)) || cfg!(all(target_os = "linux", target_arch = "aarch64")) {'
+  '';
+
   preCheck = ''
     export PATH=$PATH:$PWD/target/${stdenv.hostPlatform.rust.rustcTarget}/$cargoBuildType
   '';


### PR DESCRIPTION
Fix build error https://hydra.nixos.org/build/326783661

ZHF: #516381

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
