### PR TITLE
[Backport release-25.11] vale: 3.13.0 -> 3.14.1

### DIFF
--- a/pkgs/by-name/va/vale/package.nix
+++ b/pkgs/by-name/va/vale/package.nix
@@ -11,7 +11,7 @@
 
 buildGoModule rec {
   pname = "vale";
-  version = "3.13.0";
+  version = "3.14.1";
 
   subPackages = [ "cmd/vale" ];
 
@@ -19,10 +19,10 @@ buildGoModule rec {
     owner = "errata-ai";
     repo = "vale";
     tag = "v${version}";
-    hash = "sha256-eaJSQMDHtX997pPCTCF+1s653ojm+SBj+cZ9sZWqQWE=";
+    hash = "sha256-vzOUBqoD3zwPHDN8fWn+gEWU9+EDNO92uqI6ub2of9A=";
   };
 
-  vendorHash = "sha256-kGKrOmE3Qjh8JFWFJjAAH2Qc1e03p7x6/Bdf4+ItwOg=";
+  vendorHash = "sha256-jyDvC/UOqkZf8sgHl/jJ8dWPnWWmDIRJDSGgT0bWkb4=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
Backport of the following master PRs that landed after 25.11 cut:
- vale: 3.13.0 -> 3.13.1 (#487651)
- vale: 3.13.1 -> 3.14.0 (#499450)
- vale: 3.14.0 -> 3.14.1 (#501876)

No breaking changes between these versions; 3.14.x adds tree-sitter Java support and Dasel v3 support. The breaking Front Matter change was in 3.11.0, already in stable.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is sandboxing enabled in `nix.conf`?
- [x] Tested, as applicable:
  - [x] The package builds successfully (`nix-build -A vale`)
  - [x] Verified the binary works: `./result/bin/vale --version` returns `3.14.1`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [ ] [25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05 release notes](https://github.com/NixOS/nixpkgs/blob/release-25.05/nixos/doc/manual/release-notes/rl-2505.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).