### PR TITLE
subtitlecomposer: replace qt5/kf5 with qt6/kf6

### DIFF
--- a/pkgs/by-name/su/subtitlecomposer/package.nix
+++ b/pkgs/by-name/su/subtitlecomposer/package.nix
@@ -5,8 +5,10 @@
   extra-cmake-modules,
   ffmpeg_6,
   openal,
+  pocketsphinx,
   stdenv,
-  libsForQt5,
+  kdePackages,
+  qt6,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -21,16 +23,65 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-zGbI960NerlOEUvhOLm+lEJdbhj8VFUfm8pkOYGRcGw=";
   };
 
+  prePatch = ''
+    # Replace KF6 monolithic find_package with individual component finds
+    sed -i '/^find_package(KF\''${KF_MAJOR_VERSION}/,/WidgetsAddons)/c\
+if(KF_MAJOR_VERSION EQUAL 6)\n\
+	find_package(KF6Config REQUIRED)\n\
+	find_package(KF6ConfigWidgets REQUIRED)\n\
+	find_package(KF6CoreAddons REQUIRED)\n\
+	find_package(KF6I18n REQUIRED)\n\
+	find_package(KF6KIO REQUIRED)\n\
+	find_package(KF6XmlGui REQUIRED)\n\
+	find_package(KF6Sonnet REQUIRED)\n\
+	find_package(KF6Codecs REQUIRED)\n\
+	find_package(KF6TextWidgets REQUIRED)\n\
+	find_package(KF6WidgetsAddons REQUIRED)\n\
+else()\n\
+	find_package(KF\''${KF_MAJOR_VERSION} \''${KF_MIN_VERSION} REQUIRED COMPONENTS\n\
+		Config ConfigWidgets CoreAddons I18n KIO XmlGui\n\
+		Sonnet Codecs TextWidgets WidgetsAddons)\n\
+endif()' CMakeLists.txt
+
+    # Remove WidgetsPrivate from the linker target since it's not available in nixpkgs
+    perl -i -pe 's/Qt\$\{QT_MAJOR_VERSION\}::WidgetsPrivate\s+//g' src/CMakeLists.txt
+
+    # Explicitly add Qt6 private include directories since Qt6Gui_PRIVATE_INCLUDE_DIRS
+    # may not be populated by find_package in nixpkgs.
+    # Qt's private headers require two include levels:
+    #   include/QtGui/<ver>         (for <QtGui/private/...>)
+    #   include/QtGui/<ver>/QtGui   (for <private/...>)
+    # and similarly for QtCore and QtWidgets private headers.
+    QT_PRIVATE_BASE="${qt6.qtbase}/include"
+    for module in QtCore QtGui QtWidgets; do
+      QT_MOD_VER=$(ls -d "$QT_PRIVATE_BASE/$module"/*/ 2>/dev/null | head -1)
+      if [ -n "$QT_MOD_VER" ]; then
+        sed -i "1s|^|include_directories(\"$QT_MOD_VER\" \"$QT_MOD_VER$module\")\n|" src/CMakeLists.txt
+      fi
+    done
+  '';
+
   nativeBuildInputs = [
     cmake
     extra-cmake-modules
-    libsForQt5.wrapQtAppsHook
+    kdePackages.wrapQtAppsHook
   ];
+
+  cmakeFlags = [
+    "-DQT_MAJOR_VERSION=6"
+    "-DCMAKE_PREFIX_PATH=${qt6.qtbase}:${qt6.qt5compat}:${kdePackages.extra-cmake-modules}/share/ECM"
+    "-DSC_WARN_ERRORS=OFF"
+    "-DCMAKE_BUILD_TYPE=Release"
+  ];
+
   buildInputs = [
     ffmpeg_6
     openal
+    pocketsphinx
+    qt6.qtbase
+    qt6.qt5compat
   ]
-  ++ (with libsForQt5; [
+  ++ (with kdePackages; [
     kcodecs
     kconfig
     kconfigwidgets


### PR DESCRIPTION
As KF5 is going to be dropped (#513691), this commit changes subtitlecomposer to build with Qt6 and KF6.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
