### PR TITLE
supermodel: 0-unstable-2025-04-17 -> 0-unstable-2026-03-01; fix build with GCC 15

### DIFF
--- a/pkgs/by-name/su/supermodel/package.nix
+++ b/pkgs/by-name/su/supermodel/package.nix
@@ -20,6 +20,11 @@ stdenv.mkDerivation {
     hash = "sha256-3FdLBGxmi4Xj7ao2nvjLleJSTXvKQrhUWvnQr8DK/RY=";
   };
 
+  # Game.h is missing #include <cstdint>, which GCC 15 no longer provides transitively.
+  postPatch = ''
+    sed -i '/^#include <memory>/a #include <cstdint>' Src/Game.h
+  '';
+
   buildInputs = [
     libGLU
     SDL2

--- a/pkgs/by-name/su/supermodel/package.nix
+++ b/pkgs/by-name/su/supermodel/package.nix
@@ -11,12 +11,12 @@
 
 stdenv.mkDerivation {
   pname = "supermodel";
-  version = "0-unstable-2025-04-17";
+  version = "0-unstable-2026-03-01";
 
   src = fetchFromGitHub {
     owner = "trzy";
     repo = "supermodel";
-    rev = "2272893a0511c0b3b50f6dda64addb7014717dd3";
+    rev = "d6dec3dcf0922459801907950d966e5767c674de";
     hash = "sha256-3FdLBGxmi4Xj7ao2nvjLleJSTXvKQrhUWvnQr8DK/RY=";
   };
 


### PR DESCRIPTION
Diff: https://github.com/trzy/supermodel/compare/2272893a0511c0b3b50f6dda64addb7014717dd3...d6dec3dcf0922459801907950d966e5767c674de

Related GCC 15 Tracking: #475479
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327186452)](https://hydra.nixos.org/build/327186452)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
