### PR TITLE
litemdview: fix build with gcc15

### DIFF
--- a/pkgs/by-name/li/litemdview/fix-gcc15.patch
+++ b/pkgs/by-name/li/litemdview/fix-gcc15.patch
@@ -1,0 +1,15 @@
+diff --git a/xxd/xxd.c b/xxd/xxd.c
+index 20f06ab..55e64fe 100644
+--- a/xxd/xxd.c
++++ b/xxd/xxd.c
+@@ -132,8 +132,8 @@ extern void perror __P((char *));
+ # endif
+ #endif
+ 
+-extern long int strtol();
+-extern long int ftell();
++extern long int strtol(const char *restrict, char **restrict, int);
++extern long int ftell(FILE *);
+ 
+ char version[] = "xxd V1.10 27oct98 by Juergen Weigert";
+ #ifdef WIN32

--- a/pkgs/by-name/li/litemdview/package.nix
+++ b/pkgs/by-name/li/litemdview/package.nix
@@ -19,6 +19,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-XGjP+7i3mYCEzPYwVY+75DARdXJFY4vUWHFpPeoNqAE=";
   };
 
+  patches = [
+    ./fix-gcc15.patch
+  ];
+
   buildInputs = [
     gtkmm3
   ];


### PR DESCRIPTION
- #475479 
- #516381 
- https://hydra.nixos.org/build/326827273

```
xxd.c: In function 'main':
xxd.c:516:25: error: too many arguments to function 'strtol'; expected 0, have 3
  516 |             cols = (int)strtol(pp + 2, NULL, 0);
      |                         ^~~~~~ ~~~~~~
xxd.c:135:17: note: declared here
  135 | extern long int strtol();
      |                 ^~~~~~
xxd.c:716:19: error: too many arguments to function 'ftell'; expected 0, have 1
  716 |         seekoff = ftell(fp);
      |                   ^~~~~ ~~
xxd.c:136:17: note: declared here
  136 | extern long int ftell();
      |                 ^~~~~
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
