### PR TITLE
vcmi: fix build with GCC 15; libsquish: fix build on aarch64-linux

### DIFF
--- a/pkgs/by-name/li/libsquish/package.nix
+++ b/pkgs/by-name/li/libsquish/package.nix
@@ -30,7 +30,8 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" true)
     (lib.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.5")
-  ];
+  ]
+  ++ lib.optional (!stdenv.hostPlatform.isx86) (lib.cmakeBool "BUILD_SQUISH_WITH_SSE2" false);
 
   meta = {
     description = "Library for compressing images with the DXT/S3TC standard";

--- a/pkgs/by-name/vc/vcmi/package.nix
+++ b/pkgs/by-name/vc/vcmi/package.nix
@@ -66,6 +66,9 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optional enableMMAI onnxruntime;
 
+  # GCC 15 ICE in -Wmismatched-tags diagnostic during template specialisation lookup
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isGNU "-Wno-mismatched-tags";
+
   cmakeFlags = [
     (lib.cmakeBool "ENABLE_CLIENT" true)
     (lib.cmakeBool "ENABLE_LUA" true)


### PR DESCRIPTION
GCC 15 Regression Tracking: #475479
ZHF: #516381 (Part of)
Resolves: #514061

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327829483)](https://hydra.nixos.org/build/327829483)
[![](https://hydra-banner.harinn.dev/build/327029616)](https://hydra.nixos.org/build/327029616)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
