### PR TITLE
veusz: skip vectorfield rendering test

### DIFF
--- a/pkgs/by-name/ve/veusz/package.nix
+++ b/pkgs/by-name/ve/veusz/package.nix
@@ -33,6 +33,9 @@ python3Packages.buildPythonApplication (finalAttrs: {
     wrapQtApp "$out/bin/veusz"
   '';
 
+  # vectorfield.vsz renders a PPM bitmap whose pixel values differ across Qt versions/platforms
+  patches = [ ./skip-vectorfield-test.patch ];
+
   # pyqt_setuptools.py uses the platlib path from sysconfig, but NixOS doesn't
   # really have a corresponding path, so patching the location of PyQt5 inplace
   postPatch = ''

--- a/pkgs/by-name/ve/veusz/skip-vectorfield-test.patch
+++ b/pkgs/by-name/ve/veusz/skip-vectorfield-test.patch
@@ -1,0 +1,10 @@
+--- a/tests/runselftest.py
++++ b/tests/runselftest.py
+@@ -113,6 +113,7 @@
+         '3d_points.vsz',
+         '3d_surface.vsz',
+         '3d_volume.vsz',
++        'vectorfield.vsz',
+     ])
+
+ class StupidFontMetrics:


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327220936)](https://hydra.nixos.org/build/327220936)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
