### PR TITLE
midicsv: fix build with gcc15

### DIFF
--- a/pkgs/by-name/mi/midicsv/fix-gcc15.patch
+++ b/pkgs/by-name/mi/midicsv/fix-gcc15.patch
@@ -1,0 +1,12 @@
+diff --git a/getopt.c b/getopt.c
+index 1564e53..8db0459 100644
+--- a/getopt.c
++++ b/getopt.c
+@@ -73,7 +73,6 @@ int Getopt(int nargc, char *nargv[], char *ostr)
+         static char     *place = EMSG;  /* option letter processing */
+         static char     *lastostr = (char *) 0;
+         register char   *oli;           /* option letter list index */
+-        char    *index();
+ 
+         /* LANCE PATCH: dynamic reinitialization */
+         if (ostr != lastostr) {

--- a/pkgs/by-name/mi/midicsv/package.nix
+++ b/pkgs/by-name/mi/midicsv/package.nix
@@ -13,6 +13,10 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "1vvhk2nf9ilfw0wchmxy8l13hbw9cnpz079nsx5srsy4nnd78nkw";
   };
 
+  patches = [
+    ./fix-gcc15.patch
+  ];
+
   postPatch = ''
     substituteInPlace Makefile \
       --replace /usr/local $out \


### PR DESCRIPTION
- #475479 
- #516381 
- https://hydra.nixos.org/build/326832657

```
getopt.c: In function 'Getopt':
getopt.c:76:18: error: conflicting types for 'index'; have 'char *(void)'
   76 |         char    *index();
      |                  ^~~~~
In file included from /nix/store/fbbw928argckfii0j322346ihmllg7a7-glibc-2.42-61-dev/include/string.h:462,
                 from getopt.c:55:
/nix/store/fbbw928argckfii0j322346ihmllg7a7-glibc-2.42-61-dev/include/strings.h:68:14: note: previous declaration of 'index' with type 'char *(const char *, int)'
   68 | extern char *index (const char *__s, int __c)
      |              ^~~~~
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
