### PR TITLE
textlint-plugin-html: init at 1.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -245,6 +245,11 @@
     githubId = 882455;
     name = "Elliot Cameron";
   };
+  _3w36zj6 = {
+    github = "3w36zj6";
+    githubId = 52315048;
+    name = "3w36zj6";
+  };
   _404wolf = {
     email = "wolfmermelstein@gmail.com";
     github = "404Wolf";

--- a/pkgs/by-name/te/textlint-plugin-html/package.nix
+++ b/pkgs/by-name/te/textlint-plugin-html/package.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchYarnDeps,
+  fixup-yarn-lock,
+  nodejs,
+  yarn,
+  textlint,
+  textlint-plugin-html,
+  textlint-rule-max-comma,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "textlint-plugin-html";
+  version = "1.0.1";
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "textlint";
+    repo = "textlint-plugin-html";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/G1broo4QJHYoBXUHZzK8DLDxKFHpHVWDmkEExkFEPk=";
+  };
+
+  offlineCache = fetchYarnDeps {
+    yarnLock = "${finalAttrs.src}/yarn.lock";
+    hash = "sha256-poZsWLtMH6Gy3tcWLhuv5c65AU0KVoMJD62m5r+ZLu4=";
+  };
+
+  nativeBuildInputs = [
+    fixup-yarn-lock
+    nodejs
+    yarn
+  ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    export HOME=$(mktemp -d)
+    yarn config --offline set yarn-offline-mirror "$offlineCache"
+    fixup-yarn-lock yarn.lock
+    yarn --offline --frozen-lockfile --ignore-platform --ignore-scripts --no-progress --non-interactive install
+    patchShebangs node_modules
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    yarn --offline build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    yarn --offline --production install
+    rm -rf test
+    mkdir -p $out/lib/node_modules/textlint-plugin-html
+    cp -r . $out/lib/node_modules/textlint-plugin-html/
+
+    runHook postInstall
+  '';
+
+  passthru.tests = textlint.testPackages {
+    inherit (textlint-plugin-html) pname;
+    rule = textlint-rule-max-comma;
+    plugin = textlint-plugin-html;
+    testFile = ./test.html;
+  };
+
+  meta = {
+    description = "Add HTML support for textlint";
+    homepage = "https://github.com/textlint/textlint-plugin-html";
+    changelog = "https://github.com/textlint/textlint-plugin-html/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ _3w36zj6 ];
+    platforms = textlint.meta.platforms;
+  };
+})

--- a/pkgs/by-name/te/textlint-plugin-html/test.html
+++ b/pkgs/by-name/te/textlint-plugin-html/test.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html lang="en">
+  <body>
+    <p>Nix, is a tool, that takes a unique approach to package management and system configuration, Learn how to make reproducible, declarative, and reliable systems.</p>
+  </body>
+</html>


### PR DESCRIPTION
[textlint-plugin-html](https://www.npmjs.com/package/textlint-plugin-html) is a [textlint](https://github.com/NixOS/nixpkgs/blob/34af45f89cdc0a3d6185caa5bdd916f928d4d66b/pkgs/by-name/te/textlint/package.nix) plugin for linting HTML.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
