### PR TITLE
jitterentropy: 3.6.3 -> 3.7.0; jitterentropy-rngd: 1.2.8 -> 1.3.1

### DIFF
--- a/nixos/modules/services/security/jitterentropy-rngd.nix
+++ b/nixos/modules/services/security/jitterentropy-rngd.nix
@@ -11,12 +11,53 @@ in
   options.services.jitterentropy-rngd = {
     enable = lib.mkEnableOption "jitterentropy-rngd service configuration";
     package = lib.mkPackageOption pkgs "jitterentropy-rngd" { };
+    osr = lib.mkOption {
+      type = lib.types.ints.between 3 20;
+      default = 3;
+      description = "Oversampling rate for jitterentropy (3 to 20)";
+    };
+    flags = lib.mkOption {
+      type = lib.types.int;
+      default = 0;
+      description = "Additional flags to pass to jitterentropy";
+    };
+    forceSP800-90B = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Force SP800-90B mode for entropy reading";
+    };
+    verbose = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable verbose log messages";
+    };
   };
 
-  config = lib.mkIf cfg.enable {
-    systemd.packages = [ cfg.package ];
-    systemd.services."jitterentropy".wantedBy = [ "basic.target" ];
-  };
+  config =
+    let
+      # use identical arguments for status and service execution,
+      # in order to get meaningful output
+      args =
+        "--osr ${builtins.toString cfg.osr} --flags ${builtins.toString cfg.flags}"
+        + lib.optionalString cfg.forceSP800-90B " --sp800-90b"
+        + lib.optionalString cfg.verbose " -vvv";
+    in
+    lib.mkIf cfg.enable {
+      systemd.packages = [ cfg.package ];
+      systemd.services."jitterentropy".wantedBy = [ "basic.target" ];
+      systemd.services."jitterentropy".serviceConfig = {
+        # logs used configuration for comparison
+        ExecStartPre = [
+          "-${cfg.package}/bin/jitterentropy-rngd --status ${args}"
+        ];
+        ExecStart = [
+          # clear old setting from built-in service file
+          ""
+          # use service from package with our configured args
+          "${cfg.package}/bin/jitterentropy-rngd ${args}"
+        ];
+      };
+    };
 
   meta.maintainers = with lib.maintainers; [ thillux ];
 }

--- a/pkgs/by-name/ji/jitterentropy-rngd/package.nix
+++ b/pkgs/by-name/ji/jitterentropy-rngd/package.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "jitterentropy-rngd";
-  version = "1.2.8";
+  version = "1.3.1";
 
   src = fetchFromGitHub {
     owner = "smuellerDD";
     repo = "jitterentropy-rngd";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-LDym636ss3B1G/vrqatu9g5vbVEeDX0JQcxZ/IxGeY0=";
+    hash = "sha256-iXpeN0PAPk8mcaNXwj6TlyK57NSFNOVs/XmEmUG1gIg=";
   };
 
   enableParallelBuilding = true;
@@ -25,6 +25,13 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  # this package internally compiles without optimization by choice,
+  # as it introduces more execution time jitter, therefore disable fortify.
+  hardeningDisable = [
+    "fortify"
+    "fortify3"
+  ];
 
   meta = {
     description = "Random number generator, which injects entropy to the kernel";

--- a/pkgs/by-name/ji/jitterentropy/package.nix
+++ b/pkgs/by-name/ji/jitterentropy/package.nix
@@ -8,22 +8,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "jitterentropy";
-  version = "3.6.3";
+  version = "3.7.0";
 
   src = fetchFromGitHub {
     owner = "smuellerDD";
     repo = "jitterentropy-library";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-A7a0kg9JRiNNKJbLJu5Fbu6ZgCwv3+3oDhZr3jwNXmM=";
+    hash = "sha256-sJWgPx3GbvnBBVlCML/eRtUoMXux38tpWi1ZKhz41xY=";
   };
-
-  patches = [
-    # cmake 4 compatibility
-    (fetchpatch {
-      url = "https://github.com/smuellerDD/jitterentropy-library/commit/047beb1bf9ef7a14e63f3e4f2d4e79f673baa7ec.patch";
-      hash = "sha256-m/cfI7s7sdjkZjkKL/w/rNZzP/t3eimbVryMW5+crw4=";
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
 
@@ -32,7 +24,18 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ];
 
-  hardeningDisable = [ "fortify" ]; # avoid warnings
+  # disable internal timer thread and only use processor high-resolution timer
+  # this also fixes the rng-tools build
+  cmakeFlags = [
+    "-DINTERNAL_TIMER=OFF"
+  ];
+
+  # this package internally compiles without optimization by choice,
+  # as it introduces more execution time jitter, therefore disable fortify.
+  hardeningDisable = [
+    "fortify"
+    "fortify3"
+  ];
 
   meta = {
     description = "Provides a noise source using the CPU execution timing jitter";

--- a/pkgs/by-name/ji/jitterentropy/package.nix
+++ b/pkgs/by-name/ji/jitterentropy/package.nix
@@ -48,6 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     maintainers = with lib.maintainers; [
       johnazoidberg
+      thillux
     ];
   };
 })


### PR DESCRIPTION
This updates jitterentropy to 3.7.0 and the related jitterentropy-rngd to 1.3.1. These are the first NTG.1 compliant versions, when used in a validated configuration.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
