### PR TITLE
codex-acp: co-build codex in passthru tests

### DIFF
--- a/pkgs/by-name/co/codex-acp/package.nix
+++ b/pkgs/by-name/co/codex-acp/package.nix
@@ -11,9 +11,9 @@
   librusty_v8 ? callPackage ./librusty_v8.nix { },
 }:
 let
-  # codex-acp 0.12.0 pins openai/codex rust-v0.124.0 in Cargo.lock.
-  codexRev = "e9fb49366c93a1478ec71cc41ecee415a197d036";
-  codexHash = "sha256-YFnzzwCm9/b30qLDMbkf/rEizuTjeqdCgoBZeS0wNBo=";
+  # codex-acp 0.13.0 pins openai/codex rust-v0.128.0 in Cargo.lock.
+  codexRev = "e4310be51f617f5e60382038fa9cbf53a2429ca4";
+  codexHash = "sha256-v2W0eslPOPHxHX76+bnkE/f4y+MnQuopeOoAC5X16TA=";
   codexSrc = fetchFromGitHub {
     owner = "openai";
     repo = "codex";
@@ -23,21 +23,23 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "codex-acp";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "zed-industries";
     repo = "codex-acp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-qPqg95FpXHBtyHBJtrfJUwu9GokfmOJgKgqLKQ48u+8=";
+    hash = "sha256-8Mz3xPhGSjaucZ9c0etGOe4JJC8vJhGFOnAhkwXmhyY=";
   };
 
-  cargoHash = "sha256-/BZ82qiTy/mPwhf5v5CFrNSB6AxCRFdmHB72L0+KjJw=";
+  cargoHash = "sha256-kneMay6MGXhHA0q/usKsLFs/YKmdSHmrgSthzhaPgbk=";
 
-  # fetchCargoVendor only keeps the individual git crate subtrees, so restore
-  # the workspace-root file that codex-core includes via ../../../../node-version.txt.
+  # fetchCargoVendor only keeps the individual git crate subtrees. Older Codex
+  # crates included this workspace-root file from codex-core.
   postPatch = ''
-    cp ${codexSrc}/codex-rs/node-version.txt "$cargoDepsCopy/source-git-0/node-version.txt"
+    if [ -e ${codexSrc}/codex-rs/node-version.txt ]; then
+      cp ${codexSrc}/codex-rs/node-version.txt "$cargoDepsCopy/source-git-0/node-version.txt"
+    fi
   '';
 
   env = {

--- a/pkgs/by-name/co/codex-acp/package.nix
+++ b/pkgs/by-name/co/codex-acp/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   callPackage,
+  codex,
   fetchFromGitHub,
   rustPlatform,
   pkg-config,
@@ -62,7 +63,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doCheck = false;
 
-  passthru.updateScript = ./update.sh;
+  passthru = {
+    tests.codex = codex;
+    updateScript = ./update.sh;
+  };
 
   meta = {
     description = "An ACP-compatible coding agent powered by Codex";

--- a/pkgs/by-name/co/codex-acp/package.nix
+++ b/pkgs/by-name/co/codex-acp/package.nix
@@ -73,7 +73,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/zed-industries/codex-acp";
     changelog = "https://github.com/zed-industries/codex-acp/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ tlvince ];
+    maintainers = with lib.maintainers; [ caniko tlvince ];
     platforms = lib.platforms.unix;
     sourceProvenance = with lib.sourceTypes; [ fromSource ];
     mainProgram = "codex-acp";

--- a/pkgs/by-name/co/codex-acp/package.nix
+++ b/pkgs/by-name/co/codex-acp/package.nix
@@ -73,6 +73,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/zed-industries/codex-acp";
     changelog = "https://github.com/zed-industries/codex-acp/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ caniko ];
     platforms = [
       "x86_64-linux"
       "aarch64-linux"

--- a/pkgs/by-name/co/codex-acp/update.sh
+++ b/pkgs/by-name/co/codex-acp/update.sh
@@ -88,7 +88,15 @@ update_codex_pins() {
   local tmp
   tmp="$(mktemp)"
 
-  awk -v codex_rev="$CODEX_REV" -v codex_hash="$CODEX_HASH" '
+  awk \
+    -v latest_version="$latest_version" \
+    -v codex_tag="$CODEX_TAG" \
+    -v codex_rev="$CODEX_REV" \
+    -v codex_hash="$CODEX_HASH" '
+    /# codex-acp [^ ]+ pins openai\/codex rust-v[0-9.]+ in Cargo.lock\./ {
+      comment_count++
+      sub(/# codex-acp [^ ]+ pins openai\/codex rust-v[0-9.]+ in Cargo.lock\./, "# codex-acp " latest_version " pins openai/codex " codex_tag " in Cargo.lock.")
+    }
     /codexRev = "[0-9a-f]+";/ {
       rev_count++
       sub(/codexRev = "[0-9a-f]+";/, "codexRev = \"" codex_rev "\";")
@@ -99,6 +107,10 @@ update_codex_pins() {
     }
     { print }
     END {
+      if (comment_count != 1) {
+        print "Failed to update codex pin comment in package.nix" > "/dev/stderr"
+        exit 1
+      }
       if (rev_count != 1) {
         print "Failed to update codexRev in package.nix" > "/dev/stderr"
         exit 1


### PR DESCRIPTION
This is a follow-up to #516781 that starts co-validating `codex-acp` with the packaged OpenAI `codex` CLI.

`codex-acp` vendors the Codex Rust crates pinned by its upstream `Cargo.lock`, while nixpkgs also packages OpenAI Codex directly as `codex`. The previous 0.13.0 update showed why these should be validated together: an upstream Codex layout change broke `codex-acp`'s packaging before compilation.

This PR adds `codex` as `codex-acp.tests.codex`, which gives maintainers and review automation a stable target to build both packages together without forcing them to share the same upstream version.

Stacked on #516781 while that update is still pending.

Checks run:
- `nix fmt pkgs/by-name/co/codex-acp/package.nix`
- `nix eval --impure --expr 'let pkgs = import ./. { config.allowUnfree = true; }; in builtins.attrNames pkgs.codex-acp.tests'`
- `git diff --check`
- `nix-build -A codex-acp`
- `nix-build -A codex-acp.tests.codex`

nixpkgs-review-gha is running for the current head: https://github.com/caniko/nixpkgs-review-gha/actions/runs/25736381002

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
