### PR TITLE
git-instafix: fix build by using system oniguruma; cleanup; use finalAttrs

### DIFF
--- a/pkgs/by-name/gi/git-instafix/package.nix
+++ b/pkgs/by-name/gi/git-instafix/package.nix
@@ -1,48 +1,40 @@
 {
-  git,
+  gitMinimal,
   lib,
   libgit2,
   rustPlatform,
   stdenv,
   fetchFromGitHub,
 }:
-let
-  inherit (lib)
-    licenses
-    maintainers
-    ;
-
-  version = "0.2.7";
-in
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "git-instafix";
-  inherit version;
+  version = "0.2.7";
 
   src = fetchFromGitHub {
     owner = "quodlibetor";
     repo = "git-instafix";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Uz+KQ8cQT3v97EtmbAv2II30dUrFD0hMo/GhnqcdBOs=";
   };
 
   cargoHash = "sha256-B0XTk0KxA60AuaS6eO3zF/eA/cTcLwA31ipG4VjvO8Q=";
 
   buildInputs = [ libgit2 ];
-  nativeCheckInputs = [ git ];
+  nativeCheckInputs = [ gitMinimal ];
 
   meta = {
     description = "Quickly fix up an old commit using your currently-staged changes";
     mainProgram = "git-instafix";
     homepage = "https://github.com/quodlibetor/git-instafix";
-    license = with licenses; [
+    changelog = "https://github.com/quodlibetor/git-instafix/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [
       mit
       asl20
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       mightyiam
       quodlibetor
     ];
-    changelog = "https://github.com/quodlibetor/git-instafix/releases/tag/v${version}";
     broken = stdenv.hostPlatform.isDarwin;
   };
-}
+})

--- a/pkgs/by-name/gi/git-instafix/package.nix
+++ b/pkgs/by-name/gi/git-instafix/package.nix
@@ -2,6 +2,8 @@
   gitMinimal,
   lib,
   libgit2,
+  oniguruma,
+  pkg-config,
   rustPlatform,
   stdenv,
   fetchFromGitHub,
@@ -19,8 +21,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-B0XTk0KxA60AuaS6eO3zF/eA/cTcLwA31ipG4VjvO8Q=";
 
-  buildInputs = [ libgit2 ];
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libgit2
+    oniguruma
+  ];
+
   nativeCheckInputs = [ gitMinimal ];
+
+  env.RUSTONIG_SYSTEM_LIBONIG = true;
 
   meta = {
     description = "Quickly fix up an old commit using your currently-staged changes";


### PR DESCRIPTION
I feel that the package is a little messy, so I took this chance to migrate it to use `finalAttrs` and switch `git` to `gitMinimal` in `nativeCheckInputs`.

ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/326978189)](https://hydra.nixos.org/build/326978189)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
