### PR TITLE
deno: only expose unit tests in passthru

### DIFF
--- a/pkgs/by-name/de/deno/package.nix
+++ b/pkgs/by-name/de/deno/package.nix
@@ -14,7 +14,6 @@
   sqlite,
   lld,
   writableTmpDirAsHomeHook,
-  fetchpatch,
 
   # Test deps
   curl,
@@ -22,6 +21,9 @@
   git,
   python3,
   esbuild,
+
+  # self for passthru
+  deno,
 }:
 
 let
@@ -90,13 +92,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # To avoid this we pre-download the file and export it via RUSTY_V8_ARCHIVE
   env.RUSTY_V8_ARCHIVE = librusty_v8;
 
-  # Many tests depend on prebuilt binaries being present at `./third_party/prebuilt`.
-  # We provide nixpkgs binaries for these for all platforms, but the test runner itself only handles
-  # these four arch+platform combinations.
-  doCheck =
-    stdenv.hostPlatform.isDarwin
-    || (stdenv.hostPlatform.isLinux && (stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isx86_64));
-
+  # Don't run checks on hydra as they've been observed to be flakey for us and
+  # other distros CI: https://gitlab.alpinelinux.org/alpine/aports/-/blob/bec8b026686323b496365b825ad14fdf4473adf2/community/deno/APKBUILD#L79
+  # We haven't reproduced it on local machines, could be related to doing other
+  # builds simultaneously.
+  # A build with tests (+ librusty_v8 tests) is included in `deno.passhtru.tests`
+  doCheck = false;
+  # check related config is left in the main package so if someone uses
+  # `overrideAttrs` to always build with tests, it'll all work.
   preCheck =
     # Provide esbuild binary at `./third_party/prebuilt/` just like upstream:
     # https://github.com/denoland/deno_third_party/tree/master/prebuilt
@@ -243,7 +246,20 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   passthru = {
     updateScript = ./update.sh;
-    tests = callPackage ./tests { };
+    tests = (callPackage ./tests { }) // {
+      build-with-unit-tests = deno.overrideAttrs (fa: {
+        # The tools test suite requires building the test server
+        dontBuild = false;
+        # Many tests depend on prebuilt binaries being present at `./third_party/prebuilt`.
+        # We provide nixpkgs binaries for these for all platforms, but the test runner itself only handles
+        # these four arch+platform combinations.
+        doCheck =
+          stdenv.hostPlatform.isDarwin
+          || (stdenv.hostPlatform.isLinux && (stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isx86_64));
+      });
+      # Also include librusty_v8 tests
+      librusty_v8-tests = librusty_v8.passthru.tests;
+    };
     inherit librusty_v8;
   };
 

--- a/pkgs/by-name/de/deno/package.nix
+++ b/pkgs/by-name/de/deno/package.nix
@@ -14,7 +14,6 @@
   sqlite,
   lld,
   writableTmpDirAsHomeHook,
-  fetchpatch,
 
   # Test deps
   curl,
@@ -22,6 +21,9 @@
   git,
   python3,
   esbuild,
+
+  # self for passthru
+  deno,
 }:
 
 let
@@ -90,13 +92,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # To avoid this we pre-download the file and export it via RUSTY_V8_ARCHIVE
   env.RUSTY_V8_ARCHIVE = librusty_v8;
 
-  # Many tests depend on prebuilt binaries being present at `./third_party/prebuilt`.
-  # We provide nixpkgs binaries for these for all platforms, but the test runner itself only handles
-  # these four arch+platform combinations.
-  doCheck =
-    stdenv.hostPlatform.isDarwin
-    || (stdenv.hostPlatform.isLinux && (stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isx86_64));
-
+  # don't run checks on hydra as they've been observed to be flakey for us and
+  # other distros CI: https://gitlab.alpinelinux.org/alpine/aports/-/blob/bec8b026686323b496365b825ad14fdf4473adf2/community/deno/APKBUILD#L79
+  # haven't reproduced on local machines, could be related to doing other builds
+  # simultaneously.
+  # a build with tests (+ librusty_v8 tests) is included in `deno.passhtru.tests`
+  doCheck = false;
+  # check related config is left in the main package so if someone uses
+  # `overrideAttrs` to always build with tests, it'll all work.
   preCheck =
     # Provide esbuild binary at `./third_party/prebuilt/` just like upstream:
     # https://github.com/denoland/deno_third_party/tree/master/prebuilt
@@ -243,7 +246,20 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   passthru = {
     updateScript = ./update.sh;
-    tests = callPackage ./tests { };
+    tests = (callPackage ./tests { }) // {
+      build-with-unit-tests = deno.overrideAttrs (fa: {
+        # the tools test suite requires building the test server
+        dontBuild = false;
+        # Many tests depend on prebuilt binaries being present at `./third_party/prebuilt`.
+        # We provide nixpkgs binaries for these for all platforms, but the test runner itself only handles
+        # these four arch+platform combinations.
+        doCheck =
+          stdenv.hostPlatform.isDarwin
+          || (stdenv.hostPlatform.isLinux && (stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isx86_64));
+      });
+      # also include librusty_v8 tests
+      librusty_v8-tests = librusty_v8.passthru.tests;
+    };
     inherit librusty_v8;
   };
 

--- a/pkgs/by-name/de/deno/rusty-v8/default.nix
+++ b/pkgs/by-name/de/deno/rusty-v8/default.nix
@@ -153,6 +153,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "fortify3"
   ];
 
+  # Don't run checks on hydra as they've been observed to be flakey for us and
+  # other distros CI: https://gitlab.alpinelinux.org/alpine/aports/-/blob/bec8b026686323b496365b825ad14fdf4473adf2/community/deno/APKBUILD#L79
+  # We haven't reproduced it on local machines, could be related to doing other
+  # builds simultaneously.
+  # A build with tests is included as part of `deno.passhtru.tests` via `librusty_v8.passthru.tests`
+  doCheck = false;
+  # Check related config is left in the main package so if someone uses
+  # `overrideAttrs` to always build with tests, it'll all work.
   checkFlags = [
     # These tests probably fail due to a more recent rustc version (upstream: 1.89.0, here: 1.93.0)
     "--skip=ui"
@@ -166,6 +174,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru = {
+    tests = {
+      build-with-unit-tests = deno.passthru.librusty_v8.overrideAttrs (fa: {
+        doCheck = true;
+      });
+    };
+  };
 
   requiredSystemFeatures = [ "big-parallel" ];
 

--- a/pkgs/by-name/de/deno/rusty-v8/default.nix
+++ b/pkgs/by-name/de/deno/rusty-v8/default.nix
@@ -153,6 +153,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "fortify3"
   ];
 
+  # don't run checks on hydra as they've been observed to be flakey for us and
+  # other distros CI: https://gitlab.alpinelinux.org/alpine/aports/-/blob/bec8b026686323b496365b825ad14fdf4473adf2/community/deno/APKBUILD#L79
+  # haven't reproduced on local machines, could be related to doing other builds
+  # simultaneously.
+  # a build with tests is included as part of `deno.passhtru.tests` via `librusty_v8.passthru.tests`
+  doCheck = false;
+  # check related config is left in the main package so if someone uses
+  # `overrideAttrs` to always build with tests, it'll all work.
   checkFlags = [
     # These tests probably fail due to a more recent rustc version (upstream: 1.89.0, here: 1.93.0)
     "--skip=ui"
@@ -166,6 +174,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru = {
+    tests = {
+      build-with-unit-tests = deno.passthru.librusty_v8.overrideAttrs (fa: {
+        doCheck = true;
+      });
+    };
+  };
 
   requiredSystemFeatures = [ "big-parallel" ];
 


### PR DESCRIPTION
Follow up to #516229 related to #511900

The deno tests have been found to be flakey in hydra.
By exposing the full build with unit tests in the passthru
maintainers can run them locally (which seem to be fine).

One missing factor may be that `deno.passthru.with-unit-tests` doesn't automatically
use `deno.passthru.librusty_v8.passthru.with-unit-tests`.
I could probably use `override` to feed it in so it's one call but having them separate
does let us pick and choose, plus we can do the unit test build of deno with what will
realistically build in hydra. It does mean more librusty_v8 builds locally but they're
shorter than I previously expected. (still take a fair while or fail on a tiny machine)

cc: @Mynacol

I'll create this as draft to ensure we don't merge until we have some discussion.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
