### PR TITLE
clojure-lsp: {2025.11.28-12.47.43 -> 2026.02.20-16.08.58, modernize}

### DIFF
--- a/pkgs/by-name/cl/clojure-lsp/package.nix
+++ b/pkgs/by-name/cl/clojure-lsp/package.nix
@@ -3,11 +3,9 @@
   stdenvNoCC,
   buildGraalvmNativeImage,
   fetchurl,
-  fetchFromGitHub,
   writeScript,
   writableTmpDirAsHomeHook,
   versionCheckHook,
-  testers,
 }:
 
 buildGraalvmNativeImage (finalAttrs: {
@@ -18,6 +16,9 @@ buildGraalvmNativeImage (finalAttrs: {
     url = "https://github.com/clojure-lsp/clojure-lsp/releases/download/${finalAttrs.version}/clojure-lsp-standalone.jar";
     hash = "sha256-sSE/BIRT5CNc2ZS3LwSMLvQDVKLMlM1BIhKq6joX3c8=";
   };
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   extraNativeImageBuildArgs = [
     # These build args mirror the build.clj upstream

--- a/pkgs/by-name/cl/clojure-lsp/package.nix
+++ b/pkgs/by-name/cl/clojure-lsp/package.nix
@@ -12,11 +12,11 @@
 
 buildGraalvmNativeImage (finalAttrs: {
   pname = "clojure-lsp";
-  version = "2025.11.28-12.47.43";
+  version = "2026.02.20-16.08.58";
 
   src = fetchurl {
     url = "https://github.com/clojure-lsp/clojure-lsp/releases/download/${finalAttrs.version}/clojure-lsp-standalone.jar";
-    hash = "sha256-An7sTudpP2Ct32sYShNhgRsHgJJIN9H+sR5MlQ8i+7o=";
+    hash = "sha256-sSE/BIRT5CNc2ZS3LwSMLvQDVKLMlM1BIhKq6joX3c8=";
   };
 
   extraNativeImageBuildArgs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/clojure-lsp/clojure-lsp/releases
closes: #516558

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
