### PR TITLE
vector: fix aarch64-linux tests

### DIFF
--- a/pkgs/by-name/ve/vector/package.nix
+++ b/pkgs/by-name/ve/vector/package.nix
@@ -133,6 +133,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ]
   ++ lib.optionals (stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux) [
     # Flakey on aarch64-linux
+    "--skip=sources::exec::tests::test_graceful_shutdown"
     "--skip=sources::exec::tests::test_run_command_linux"
     "--skip=topology::test::backpressure::buffer_drop_fan_out"
     "--skip=topology::test::backpressure::default_fan_out"


### PR DESCRIPTION
Skip `sources::exec::tests::test_graceful_shutdown` on `aarch64-linux`, where it flakes in Hydra for `vector-0.55.0` with `missing exit status`.

Hydra failure: https://hydra.nixos.org/build/327220800

This keeps Vector's package checks enabled and only extends the existing aarch64-linux flaky-test skip list. Once merged and built by Hydra, this should restore the `vector.aarch64-linux` substitute and avoid local rebuilds for aarch64 NixOS systems using Vector.

Local validation:

- `nix eval --impure --expr 'let pkgs = import ./. { system = "aarch64-linux"; }; in pkgs.vector.drvPath'`
- `nix build .#legacyPackages.aarch64-linux.vector` was started locally but interrupted after ~25 minutes because it was building under `qemu-aarch64`; this PR is being validated with `nixpkgs-review-gha` instead.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
