### PR TITLE
ecl: 26.3.27 -> 26.5.5

### DIFF
--- a/pkgs/development/compilers/ecl/default.nix
+++ b/pkgs/development/compilers/ecl/default.nix
@@ -24,29 +24,12 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "ecl";
-  version = "26.3.27";
+  version = "26.5.5";
 
   src = fetchurl {
     url = "https://common-lisp.net/project/ecl/static/files/release/ecl-${version}.tgz";
-    hash = "sha256-QW1XB78R0rPY0z1nkUGaeG5MxZrAzD7FBe5ZtRqfXJo=";
+    hash = "sha256-oBpbzajFtz5Z3aNJT9E+X+xdtqodrXgsPMO7V/FjNDU=";
   };
-
-  patches = [
-    # https://gitlab.com/embeddable-common-lisp/ecl/-/merge_requests/370
-    (fetchpatch {
-      name = "allocate-first_env-dynamically.patch";
-      url = "https://gitlab.com/embeddable-common-lisp/ecl/-/commit/61a14dfc6681f674ae5673856c0749fdf4af6564.patch";
-      hash = "sha256-DOn0mtlW1Bl59LxqEQiE90ZJlXDSbTbxL0s8NNL882o=";
-      includes = [ "src/c/main.d" ];
-    })
-
-    # https://gitlab.com/embeddable-common-lisp/ecl/-/work_items/838
-    (fetchpatch {
-      name = "clang-miscompilation.patch";
-      url = "https://gitlab.com/embeddable-common-lisp/ecl/-/commit/d39cc449f770c52cc4c8b297cf600d7bd53d172a.patch";
-      hash = "sha256-C+zVjAY/+hQ4Te62DQxIQsHu0AqewygmSEQpcmrA5EU=";
-    })
-  ];
 
   nativeBuildInputs = [
     libtool


### PR DESCRIPTION
https://ecl.common-lisp.dev/posts/ECL-2655-release.html


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
