### PR TITLE
gst123: 0.4.1 -> 0.4.1-unstable-2025-11-28

### DIFF
--- a/pkgs/by-name/gs/gst123/package.nix
+++ b/pkgs/by-name/gs/gst123/package.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gst123";
-  version = "0.4.1";
+  version = "0.4.1-unstable-2025-11-28";
 
   src = fetchFromGitHub {
     owner = "swesterfeld";
     repo = "gst123";
-    rev = finalAttrs.version;
-    hash = "sha256-7qS7JJ7EY1uFGX3FxBxgH6LzK4XUoTPHR0QVwUWRz+g=";
+    rev = "3680535cb5ab12d9bfba8f7de8cf9a83fb01fe22";
+    hash = "sha256-+thGzcmBQanj7fGRImWk4PVRFBFLVHYQIP1HYoUzglk=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Diff: https://github.com/swesterfeld/gst123/compare/0.4.1...3680535cb5ab12d9bfba8f7de8cf9a83fb01fe22
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/326984540)](https://hydra.nixos.org/build/326984540)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
