### PR TITLE
lnx: unstable-2022-06-25 -> 0.9.0-master

### DIFF
--- a/pkgs/by-name/ln/lnx/package.nix
+++ b/pkgs/by-name/ln/lnx/package.nix
@@ -6,17 +6,15 @@
 
 # unstable was chosen because of an added Cargo.lock
 # revert to stable for the version after 0.9.0
-let
-  version = "unstable-2022-06-25";
-in
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "lnx";
-  inherit version;
+  version = "unstable-2022-06-25";
+  
   src = fetchFromGitHub {
     owner = "lnx-search";
     repo = "lnx";
     rev = "2cb80f344c558bfe37f21ccfb83265bf351419d9";
-    sha256 = "sha256-iwoZ6xRzEDArmhWYxIrbIXRTQjOizyTsXCvMdnUrs2g=";
+    hash = "sha256-iwoZ6xRzEDArmhWYxIrbIXRTQjOizyTsXCvMdnUrs2g=";
   };
 
   cargoHash = "sha256-9fro1Dx7P+P9NTsg0gtMfr0s4TEpkZA31EFAnObiNFo=";
@@ -28,4 +26,4 @@ rustPlatform.buildRustPackage {
     maintainers = with lib.maintainers; [ happysalada ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/ln/lnx/package.nix
+++ b/pkgs/by-name/ln/lnx/package.nix
@@ -1,23 +1,26 @@
 {
   lib,
+  stdenv,
   rustPlatform,
   fetchFromGitHub,
 }:
 
-# unstable was chosen because of an added Cargo.lock
-# revert to stable for the version after 0.9.0
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "lnx";
-  version = "unstable-2022-06-25";
-  
+  version = "0.9.0-master";
+
   src = fetchFromGitHub {
     owner = "lnx-search";
     repo = "lnx";
-    rev = "2cb80f344c558bfe37f21ccfb83265bf351419d9";
-    hash = "sha256-iwoZ6xRzEDArmhWYxIrbIXRTQjOizyTsXCvMdnUrs2g=";
+    tag = finalAttrs.version;
+    hash = "sha256-J2WP+/f6g1UsjpAdCvkdSpiAyDn9dyAXEbqNfWbNbHk=";
   };
 
   cargoHash = "sha256-9fro1Dx7P+P9NTsg0gtMfr0s4TEpkZA31EFAnObiNFo=";
+
+  # mimalloc uses ATOMIC_VAR_INIT which was removed in C23 (GCC 15 default)
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isGNU "-std=c17";
+
   meta = {
     description = "Ultra-fast, adaptable deployment of the tantivy search engine via REST";
     mainProgram = "lnx";


### PR DESCRIPTION
Release: https://github.com/lnx-search/lnx/releases/tag/0.9.0-master
Diff: https://github.com/lnx-search/lnx/compare/2cb80f344c558bfe37f21ccfb83265bf351419d9...0.9.0-master
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327035834)](https://hydra.nixos.org/build/327035834)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
