### PR TITLE
python3Packages.celery: remove pytest-xdist do to flaky test results

### DIFF
--- a/pkgs/development/python-modules/celery/default.nix
+++ b/pkgs/development/python-modules/celery/default.nix
@@ -34,7 +34,6 @@
   pytest-celery,
   pytest-click,
   pytest-timeout,
-  pytest-xdist,
   pytestCheckHook,
   python-dateutil,
   python-memcached,
@@ -155,11 +154,6 @@ buildPythonPackage (finalAttrs: {
     pytest-click
     pytest-timeout
     pytestCheckHook
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
-    # Using `pytest-xdist` leads to incomplete tests which hang `pytestRemoveBytecode`
-    # under `sandbox=false` (the default on Darwin).
-    pytest-xdist
   ]
   ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
 


### PR DESCRIPTION
The celery test suite fails on high core system, this is likly do to multiple tests creating or removing the test sqlite database file in there respectiv cleanup step.

Fixes: #516582


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
