### PR TITLE
maintainers: remove hamburger1984

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10407,12 +10407,6 @@
     githubId = 2192042;
     name = "Colin King";
   };
-  hamburger1984 = {
-    email = "hamburger1984@gmail.com";
-    github = "hamburger1984";
-    githubId = 438976;
-    name = "Andreas Krohn";
-  };
   hamhut1066 = {
     email = "github@hamhut1066.com";
     github = "moredhel";

--- a/pkgs/by-name/hw/hwatch/package.nix
+++ b/pkgs/by-name/hw/hwatch/package.nix
@@ -41,7 +41,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       execution results and can check this differences at after.
     '';
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ hamburger1984 ];
+    maintainers = [ ];
     mainProgram = "hwatch";
   };
 })


### PR DESCRIPTION
## Reasons

- Last commented in [July 2022](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Ahamburger1984)
- Hasn't created any PRs / Issues since [January 2025](https://github.com/NixOS/nixpkgs/issues?q=author%3Ahamburger1984)
- About 10 [unanswered ](https://github.com/NixOS/nixpkgs/issues?q=involves%3Ahamburger1984%20-commenter%3Ahamburger1984%20-author%3Ahamburger1984%20-reviewed-by%3Ahamburger1984) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] hwatch