### PR TITLE
luaPackages.tomlua: init at 1.1.5

### DIFF
--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -5978,6 +5978,40 @@ final: prev: {
     }
   ) { };
 
+  tomlua = callPackage (
+    {
+      buildLuarocksPackage,
+      fetchurl,
+      fetchzip,
+      luaOlder,
+    }:
+    buildLuarocksPackage {
+      pname = "tomlua";
+      version = "1.1.5-1";
+      knownRockspec =
+        (fetchurl {
+          url = "mirror://luarocks/tomlua-1.1.5-1.rockspec";
+          sha256 = "0xqxlw1pzvy63kw8d98nfh0k9269s4dg90md72m8kfcrj7isrb6m";
+        }).outPath;
+      src = fetchzip {
+        url = "https://github.com/BirdeeHub/tomlua/archive/v1.1.5.zip";
+        sha256 = "136jxj26dk3jl17dm86ifvfmpfbj0mf6yp2yy6i8g4xxfqs27n9q";
+      };
+
+      disabled = luaOlder "5.1";
+
+      meta = {
+        homepage = "https://github.com/BirdeeHub/tomlua";
+        maintainers = [ lib.maintainers.birdee ];
+        license.fullName = "MIT";
+        description = "Speedy toml parsing for lua, implemented in C";
+        longDescription = ''
+          Speedy toml parsing for lua, implemented in C
+              for use in hot-path or startup-time parsing of toml files.'';
+      };
+    }
+  ) { };
+
   toml-edit = callPackage (
     {
       buildLuarocksPackage,

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -1240,6 +1240,22 @@ in
     ];
   });
 
+  tomlua = prev.tomlua.overrideAttrs (old: {
+    postConfigure = ''
+      chmod +w "$rockspecFilename"
+      echo "deploy = { wrap_bin_scripts = false, }" >> "$rockspecFilename"
+    '';
+    checkPhase = ''
+      runHook preCheck
+      runHook postCheck
+    '';
+    installCheckPhase = ''
+      runHook preInstallCheck
+      make test
+      runHook postInstallCheck
+    '';
+  });
+
   tree-sitter-cli = prev.tree-sitter-cli.overrideAttrs (_: {
     # Keep this package hermetic: provide the already-packaged tree-sitter
     # binary instead of using the LuaRocks backend that downloads from GitHub.


### PR DESCRIPTION
[tomlua](https://github.com/BirdeeHub/tomlua)

Very simple, very fast, 0 dependency, cjson-like toml lua parser.

Has a handy feature where it can read from the toml file directly into your table of defaults in lua.

It can do this because it has no internal representation. It reads in 1 pass straight into a lua table. And you can provide the table it reads into.

Can input and output toml. Will not preserve comments, this is for simple input output and conversion tasks that need to be done quickly.

Also has a cli command which accepts lua syntax which is useful for tasks like quickly outputting a toml file.

```bash
# a handy cli command
# it gets file content (or paths) via ..., return lua tables to re-output as toml
tomlua --cmd 'return tomlua.decode(..., nil)' -- ./tests/example.toml
# default behavior will merge files together by passing each as the default for the next, and then re-emit
tomlua --output combined.toml -- ./tests/example.toml ./tests/example2.toml
```

Would this be the right place for me to put this? Where do I put something that is not a luarocks package?

It is on luarocks, but the luarocks tests do not work properly here, as they run before it is built, and doing it this way leads to a much lighter closure anyway.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
