### PR TITLE
lha: 1.14i-unstable-2024-11-27 -> 1.14i-unstable-2026-01-01

### DIFF
--- a/pkgs/by-name/lh/lha/package.nix
+++ b/pkgs/by-name/lh/lha/package.nix
@@ -3,20 +3,28 @@
   lib,
   fetchFromGitHub,
   autoreconfHook,
+  testers,
+  lha,
 }:
 
 stdenv.mkDerivation {
   pname = "lha";
-  version = "1.14i-unstable-2024-11-27";
+  version = "1.14i-unstable-2026-01-01";
 
   src = fetchFromGitHub {
     owner = "jca02266";
     repo = "lha";
-    rev = "26b71be85a762098bdeb95f4533045c7dad86f31";
-    hash = "sha256-jiYTBqDXvxTdrvHYaK+1eo4xIpl+B9ZljhBBYD0BGzQ=";
+    rev = "86094cb56aba34de45668f39f74fcfb61e9d7fb6";
+    hash = "sha256-ckzcCvt5v6rBcp9n8XXzgS2XkURbO8bsqTURGLRzpAU=";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
+
+  passthru.tests.version = testers.testVersion {
+    package = lha;
+    command = "lha --help";
+    version = "1.14i";
+  };
 
   meta = {
     description = "Archiver and compressor using the LZSS and Huffman encoding compression algorithms";

--- a/pkgs/by-name/lh/lha/package.nix
+++ b/pkgs/by-name/lh/lha/package.nix
@@ -3,20 +3,27 @@
   lib,
   fetchFromGitHub,
   autoreconfHook,
+  testers,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "lha";
-  version = "1.14i-unstable-2024-11-27";
+  version = "1.14i-unstable-2026-01-01";
 
   src = fetchFromGitHub {
     owner = "jca02266";
     repo = "lha";
-    rev = "26b71be85a762098bdeb95f4533045c7dad86f31";
-    hash = "sha256-jiYTBqDXvxTdrvHYaK+1eo4xIpl+B9ZljhBBYD0BGzQ=";
+    rev = "86094cb56aba34de45668f39f74fcfb61e9d7fb6";
+    hash = "sha256-ckzcCvt5v6rBcp9n8XXzgS2XkURbO8bsqTURGLRzpAU=";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "lha --help";
+    version = "1.14i";
+  };
 
   meta = {
     description = "Archiver and compressor using the LZSS and Huffman encoding compression algorithms";
@@ -33,4 +40,4 @@ stdenv.mkDerivation {
     license = lib.licenses.unfree;
     mainProgram = "lha";
   };
-}
+})


### PR DESCRIPTION
Update to latest upstream commit to fix build with modern GCC.
The pinned revision (Nov 2024) uses K&R-style function declarations
that newer GCC rejects. Upstream fixed this in Sep 2025 with C23 support.

Also adds `passthru.tests.version`.

\#ZHF for 26.05

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test