### PR TITLE
Fix php-gd function detection in cross-compilation

### DIFF
--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -19,11 +19,16 @@
   html-tidy,
   icu73,
   libffi,
+  libavif,
   libiconv,
+  libjpeg,
   libkrb5,
+  libpng,
   libpq,
   libsodium,
+  libwebp,
   libxml2,
+  libxpm,
   libxslt,
   libzip,
   net-snmp,
@@ -486,11 +491,54 @@ lib.makeScope pkgs.newScope (
                 zlib
                 gd
               ];
-              configureFlags = [
-                "--enable-gd"
-                "--with-external-gd=${gd.dev}"
-                "--enable-gd-jis-conv"
-              ];
+              configureFlags =
+                let
+                  createGdImageVariable = format: "php_cv_lib_gd_gdImageCreateFrom${format}=yes";
+                  gdImageVariableIfBuildInputs =
+                    { gdLib, variableSuffix }@args:
+                    let
+                      hasSameLibName = lib: lib.name == gdLib.name;
+                      dependsOnLib = builtins.any hasSameLibName gd.buildInputs;
+                    in
+                    # See https://github.com/php/php-src/pull/14901
+                    lib.optional dependsOnLib (createGdImageVariable variableSuffix);
+
+                  defaultGdImageVariables = builtins.map createGdImageVariable [
+                    "Bmp"
+                    "Tga"
+                  ];
+
+                  gdImageVariablesLists = builtins.map gdImageVariableIfBuildInputs [
+                    {
+                      gdLib = libpng;
+                      variableSuffix = "Png";
+                    }
+                    {
+                      gdLib = libavif;
+                      variableSuffix = "Avif";
+                    }
+                    {
+                      gdLib = libwebp;
+                      variableSuffix = "Webp";
+                    }
+                    {
+                      gdLib = libjpeg;
+                      variableSuffix = "Jpeg";
+                    }
+                    {
+                      gdLib = libxpm;
+                      variableSuffix = "Xpm";
+                    }
+                  ];
+
+                  gdImageVariables = defaultGdImageVariables ++ (builtins.concatLists gdImageVariablesLists);
+                in
+                [
+                  "--enable-gd"
+                  "--with-external-gd=${gd.dev}"
+                  "--enable-gd-jis-conv"
+                ]
+                ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) gdImageVariables;
               doCheck = false;
             }
             {

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -19,11 +19,16 @@
   html-tidy,
   icu73,
   libffi,
+  libavif,
   libiconv,
+  libjpeg,
   libkrb5,
+  libpng,
   libpq,
   libsodium,
+  libwebp,
   libxml2,
+  libxpm,
   libxslt,
   libzip,
   net-snmp,
@@ -486,11 +491,54 @@ lib.makeScope pkgs.newScope (
                 zlib
                 gd
               ];
-              configureFlags = [
-                "--enable-gd"
-                "--with-external-gd=${gd.dev}"
-                "--enable-gd-jis-conv"
-              ];
+              configureFlags =
+                let
+                  createGdImageVariable = format: "php_cv_lib_gd_gdImageCreateFrom${format}=yes";
+                  gdImageVariableIfBuildInputs =
+                    { gdLib, variableSuffix }@args:
+                    let
+                      hasSameLibName = with lib; dep: getName dep == getName gdLib;
+                      dependsOnLib = builtins.any hasSameLibName gd.buildInputs;
+                    in
+                    # See https://github.com/php/php-src/pull/14901
+                    lib.optional dependsOnLib (createGdImageVariable variableSuffix);
+
+                  defaultGdImageVariables = builtins.map createGdImageVariable [
+                    "Bmp"
+                    "Tga"
+                  ];
+
+                  gdImageVariablesLists = builtins.map gdImageVariableIfBuildInputs [
+                    {
+                      gdLib = libpng;
+                      variableSuffix = "Png";
+                    }
+                    {
+                      gdLib = libavif;
+                      variableSuffix = "Avif";
+                    }
+                    {
+                      gdLib = libwebp;
+                      variableSuffix = "Webp";
+                    }
+                    {
+                      gdLib = libjpeg;
+                      variableSuffix = "Jpeg";
+                    }
+                    {
+                      gdLib = libxpm;
+                      variableSuffix = "Xpm";
+                    }
+                  ];
+
+                  gdImageVariables = defaultGdImageVariables ++ (builtins.concatLists gdImageVariablesLists);
+                in
+                [
+                  "--enable-gd"
+                  "--with-external-gd=${gd.dev}"
+                  "--enable-gd-jis-conv"
+                ]
+                ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) gdImageVariables;
               doCheck = false;
             }
             {


### PR DESCRIPTION
In case the extension is compiled in cross-compilation, the autoconf script are not correctly handling the detection of the features for the external libgd.

The workaround, documented in [php/php-src#14901](https://redirect.github.com/php/php-src/pull/14901), relies on manually setting the variables involved in the detection of the features.

Closes #516876

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
