### PR TITLE
passless: init at 0.11.2

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -98,6 +98,8 @@
 
 - [nohang](https://github.com/hakavlad/nohang), a daemon for Linux that prevents out of memory (OOM) situations from affecting system responsiveness. Available as [services.nohang](#opt-services.nohang.enable)
 
+- [passless](https://github.com/pando85/passless), a daemon for using Webauthn Passkeys backed by password-store.
+
 - [bentopdf](https://github.com/alam00000/bentopdf), a privacy-first PDF toolkit running completely in-browser. Available as [services.bentopdf](#opt-services.bentopdf.enable).
 
 - [hyprwhspr-rs](https://github.com/better-slop/hyprwhspr-rs), a keybind activated speech-to-text voice dictation utility built for use with Hyprland. Available as `services.hyprwhspr-rs`

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -110,6 +110,8 @@
 
 - [clevis-luks-askpass](https://github.com/latchset/clevis), automatic LUKS unlocking in initrd using clevis token bindings stored in LUKS headers. Available as [boot.initrd.clevisLuksAskpass](#opt-boot.initrd.clevisLuksAskpass.enable).
 
+- [passless](https://github.com/pando85/passless), a daemon for using Webauthn Passkeys backed by password-store.
+
 - [bentopdf](https://github.com/alam00000/bentopdf), a privacy-first PDF toolkit running completely in-browser. Available as [services.bentopdf](#opt-services.bentopdf.enable).
 
 - [hyprwhspr-rs](https://github.com/better-slop/hyprwhspr-rs), a keybind activated speech-to-text voice dictation utility built for use with Hyprland. Available as [services.hyprwhspr-rs](#opt-services.hyprwhspr-rs.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -292,6 +292,7 @@
   ./programs/opengamepadui.nix
   ./programs/openvpn3.nix
   ./programs/partition-manager.nix
+  ./programs/passless.nix
   ./programs/pay-respects.nix
   ./programs/plotinus.nix
   ./programs/pmount.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -295,6 +295,7 @@
   ./programs/opengamepadui.nix
   ./programs/openvpn3.nix
   ./programs/partition-manager.nix
+  ./programs/passless.nix
   ./programs/pay-respects.nix
   ./programs/plotinus.nix
   ./programs/pmount.nix

--- a/nixos/modules/programs/passless.nix
+++ b/nixos/modules/programs/passless.nix
@@ -1,0 +1,134 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.passless;
+  settingsFormat = pkgs.formats.toml { };
+  settingsFile = settingsFormat.generate "passless.toml" cfg.settings;
+in
+{
+
+  options.programs.passless = {
+    enable = lib.mkEnableOption "passless";
+
+    package = lib.mkPackageOption pkgs "passless" { };
+
+    users = lib.options.mkOption {
+      type = with lib.types; listOf str;
+      description = ''
+        Users that intend to use passless and should be added to the fido group.
+      '';
+      default = [ ];
+      example = [ "alice" ];
+    };
+
+    settings = lib.mkOption {
+      inherit (settingsFormat) type;
+      default = { };
+      example = {
+        pass.store-path = "/home/alice/.local/share/password-store";
+      };
+      description = ''
+        Configuration included in `config.toml`.
+
+        See <https://github.com/pando85/passless#configuration-1> for documentation or run `passless config print` to see default configuration.
+      '';
+    };
+  };
+
+  config = lib.mkIf config.programs.passless.enable {
+    users.groups.fido.members = cfg.users;
+
+    boot.kernelModules = [ "uhid" ];
+
+    services.udev.extraRules = ''
+      KERNEL=="uhid", GROUP="fido", MODE="0660"
+    '';
+
+    # From https://github.com/pando85/passless/blob/master/contrib/systemd/passless.service
+    systemd.user.services.passless = {
+      description = "Passless FIDO2 Software Authenticator";
+      documentation = [ "https://github.com/pando85/passless" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "default.target" ];
+      path = with pkgs; [ config.programs.gnupg.package ];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${lib.getExe cfg.package} --config-path ${settingsFile}";
+        Restart = "on-failure";
+        RestartSec = "5s";
+        # Security hardening
+        # The application already handles its own memory locking and core dump prevention
+        # but we can add additional systemd protections
+        NoNewPrivileges = true;
+        LimitMEMLOCK = "2M";
+        SyslogIdentifier = "passless";
+
+        # Found with shh
+        ProtectSystem = "strict";
+        PrivateTmp = "disconnected";
+        PrivateMounts = "true";
+        ProtectKernelTunables = "true";
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        LockPersonality = true;
+        RestrictRealtime = true;
+        ProtectClock = true;
+        MemoryDenyWriteExecute = true;
+        RestrictAddressFamilies = "AF_UNIX";
+        SocketBindDeny = [
+          "ipv4:tcp"
+          "ipv4:udp"
+          "ipv6:tcp"
+          "ipv6:udp"
+        ];
+        CapabilityBoundingSet = [
+          "~CAP_BLOCK_SUSPEND"
+          "CAP_BPF"
+          "CAP_CHOWN"
+          "CAP_MKNOD"
+          "CAP_NET_RAW"
+          "CAP_PERFMON"
+          "CAP_SYS_BOOT"
+          "CAP_SYS_CHROOT"
+          "CAP_SYS_MODULE"
+          "CAP_SYS_NICE"
+          "CAP_SYS_PACCT"
+          "CAP_SYS_PTRACE"
+          "CAP_SYS_TIME"
+          "CAP_SYSLOG"
+          "CAP_WAKE_ALARM"
+        ];
+        SystemCallFilter = [
+          "~@aio:EPERM"
+          "@chown:EPERM"
+          "@clock:EPERM"
+          "@cpu-emulation:EPERM"
+          "@debug:EPERM"
+          "@ipc:EPERM"
+          "@keyring:EPERM"
+          "@module:EPERM"
+          "@mount:EPERM"
+          "@obsolete:EPERM"
+          "@pkey:EPERM"
+          "@privileged:EPERM"
+          "@raw-io:EPERM"
+          "@reboot:EPERM"
+          "@resources:EPERM"
+          "@sandbox:EPERM"
+          "@setuid:EPERM"
+          "@swap:EPERM"
+          "@sync:EPERM"
+        ];
+
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ erictapen ];
+
+}

--- a/nixos/modules/programs/passless.nix
+++ b/nixos/modules/programs/passless.nix
@@ -1,0 +1,134 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.passless;
+  settingsFormat = pkgs.formats.toml { };
+  settingsFile = settingsFormat.generate "passless.toml" cfg.settings;
+in
+{
+
+  options.programs.passless = {
+    enable = lib.mkEnableOption "passless";
+
+    package = lib.mkPackageOption pkgs "passless" { };
+
+    users = lib.options.mkOption {
+      type = with lib.types; listOf str;
+      description = ''
+        Users that intend to use passless and should be added to the fido group.
+      '';
+      default = [ ];
+      example = [ "alice" ];
+    };
+
+    settings = lib.mkOption {
+      inherit (settingsFormat) type;
+      default = { };
+      example = {
+        pass.store-path = "/home/alice/.local/share/password-store";
+      };
+      description = ''
+        Configuration included in `config.toml`.
+
+        See <https://github.com/pando85/passless#configuration-1> for documentation or run `passless config print` to see default configuration.
+      '';
+    };
+  };
+
+  config = lib.mkIf config.programs.passless.enable {
+    users.groups.fido.members = cfg.users;
+
+    boot.kernelModules = [ "uhid" ];
+
+    services.udev.extraRules = ''
+      KERNEL=="uhid", GROUP="fido", MODE="0660"
+    '';
+
+    # From https://github.com/pando85/passless/blob/master/contrib/systemd/passless.service
+    systemd.user.services.passless = {
+      description = "Passless FIDO2 Software Authenticator";
+      documentation = [ "https://github.com/pando85/passless" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "default.target" ];
+      path = [ config.programs.gnupg.package ];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${lib.getExe cfg.package} --config-path ${settingsFile}";
+        Restart = "on-failure";
+        RestartSec = "5s";
+        # Security hardening
+        # The application already handles its own memory locking and core dump prevention
+        # but we can add additional systemd protections
+        NoNewPrivileges = true;
+        LimitMEMLOCK = "2M";
+        SyslogIdentifier = "passless";
+
+        # Found with shh
+        ProtectSystem = "strict";
+        PrivateTmp = "disconnected";
+        PrivateMounts = "true";
+        ProtectKernelTunables = "true";
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        LockPersonality = true;
+        RestrictRealtime = true;
+        ProtectClock = true;
+        MemoryDenyWriteExecute = true;
+        RestrictAddressFamilies = "AF_UNIX";
+        SocketBindDeny = [
+          "ipv4:tcp"
+          "ipv4:udp"
+          "ipv6:tcp"
+          "ipv6:udp"
+        ];
+        CapabilityBoundingSet = [
+          "~CAP_BLOCK_SUSPEND"
+          "CAP_BPF"
+          "CAP_CHOWN"
+          "CAP_MKNOD"
+          "CAP_NET_RAW"
+          "CAP_PERFMON"
+          "CAP_SYS_BOOT"
+          "CAP_SYS_CHROOT"
+          "CAP_SYS_MODULE"
+          "CAP_SYS_NICE"
+          "CAP_SYS_PACCT"
+          "CAP_SYS_PTRACE"
+          "CAP_SYS_TIME"
+          "CAP_SYSLOG"
+          "CAP_WAKE_ALARM"
+        ];
+        SystemCallFilter = [
+          "~@aio:EPERM"
+          "@chown:EPERM"
+          "@clock:EPERM"
+          "@cpu-emulation:EPERM"
+          "@debug:EPERM"
+          "@ipc:EPERM"
+          "@keyring:EPERM"
+          "@module:EPERM"
+          "@mount:EPERM"
+          "@obsolete:EPERM"
+          "@pkey:EPERM"
+          "@privileged:EPERM"
+          "@raw-io:EPERM"
+          "@reboot:EPERM"
+          "@resources:EPERM"
+          "@sandbox:EPERM"
+          "@setuid:EPERM"
+          "@swap:EPERM"
+          "@sync:EPERM"
+        ];
+
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ erictapen ];
+
+}

--- a/pkgs/by-name/pa/passless/package.nix
+++ b/pkgs/by-name/pa/passless/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  installShellFiles,
+  udev,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "passless";
+  version = "0.10.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "pando85";
+    repo = "passless";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qUTaDWsnHFW3QyfzN58Gp3Z3y2jL1jyCfRTOPG+louE=";
+  };
+
+  cargoHash = "sha256-M+LmCTBHd7XDswJqF34nd1DZBxgUHiyWSySZw66bMpc=";
+
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+  ];
+
+  buildInputs = [
+    udev
+  ];
+
+  postInstall = ''
+    install -Dm644 contrib/udev/* $out/etc/udev/rules.d
+
+    export COMPLETIONS="target/${stdenv.targetPlatform.config}/$cargoBuildType/build/passless-rs-*/out/completions"
+
+    installShellCompletion --cmd passless \
+      --bash $COMPLETIONS/passless.bash \
+      --fish $COMPLETIONS/passless.fish \
+      --zsh $COMPLETIONS/_passless
+  '';
+
+  meta = {
+    homepage = "https://github.com/pando85/passless";
+    description = "Virtual FIDO2 device and client FIDO 2 utility";
+    changelog = "https://github.com/pando85/passless/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "passless";
+    maintainers = [ lib.maintainers.erictapen ];
+    platforms = lib.platforms.linux;
+  };
+
+})

--- a/pkgs/by-name/pa/passless/package.nix
+++ b/pkgs/by-name/pa/passless/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  installShellFiles,
+  udev,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "passless";
+  version = "0.12.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "pando85";
+    repo = "passless";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-tPlCiXokONUswwEDB2e23gR/NU6G+VYHgqfE+RyRsxw=";
+  };
+
+  cargoHash = "sha256-cNVmzK/W1jER6eK33JgFVnAN/6vGY4gw3GHB/H5DbIQ=";
+
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+  ];
+
+  buildInputs = [
+    udev
+  ];
+
+  postInstall = ''
+    install -Dm644 contrib/udev/* $out/etc/udev/rules.d
+
+    export COMPLETIONS="target/${stdenv.targetPlatform.config}/$cargoBuildType/build/passless-rs-*/out/completions"
+
+    installShellCompletion --cmd passless \
+      --bash $COMPLETIONS/passless.bash \
+      --fish $COMPLETIONS/passless.fish \
+      --zsh $COMPLETIONS/_passless
+  '';
+
+  meta = {
+    homepage = "https://github.com/pando85/passless";
+    description = "Virtual FIDO2 device and client FIDO 2 utility";
+    changelog = "https://github.com/pando85/passless/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "passless";
+    maintainers = [ lib.maintainers.erictapen ];
+    platforms = lib.platforms.linux;
+  };
+
+})


### PR DESCRIPTION
A neat utility for using Webauthn Passkeys with password-store

https://github.com/pando85/passless

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
