### PR TITLE
nixos-test-driver: make testScript mergeable

### DIFF
--- a/nixos/lib/testing/testScript.nix
+++ b/nixos/lib/testing/testScript.nix
@@ -8,19 +8,32 @@ testModuleArgs@{
 }:
 let
   inherit (lib) mkOption types;
-  inherit (types) either str functionTo;
+  inherit (types)
+    lines
+    str
+    functionTo
+    coercedTo
+    ;
+  testScriptArgs = {
+    nodes = lib.mapAttrs (
+      k: v:
+      if v.virtualisation.useNixStoreImage then
+        # prevent infinite recursion when testScript would
+        # reference v's toplevel
+        config.withoutTestScriptReferences.nodesCompat.${k}
+      else
+        # reuse memoized config
+        v
+    ) config.nodesCompat;
+    containers = config.containers;
+  };
 in
 {
   options = {
     testScript = mkOption {
-      type = either str (functionTo str);
-      apply =
-        v:
-        if lib.isFunction v then
-          # Only pass args the testScript function expects.
-          args: v (builtins.intersectAttrs (lib.functionArgs v) args)
-        else
-          v;
+      type = coercedTo (functionTo lines) (
+        v: v (builtins.intersectAttrs (lib.functionArgs v) testScriptArgs)
+      ) lines;
       description = ''
         A series of python declarations and statements that you write to perform
         the test.
@@ -50,23 +63,7 @@ in
     withoutTestScriptReferences.includeTestScriptReferences = false;
     withoutTestScriptReferences.testScript = lib.mkForce "testscript omitted";
 
-    testScriptString =
-      if lib.isFunction config.testScript then
-        config.testScript {
-          nodes = lib.mapAttrs (
-            k: v:
-            if v.virtualisation.useNixStoreImage then
-              # prevent infinite recursion when testScript would
-              # reference v's toplevel
-              config.withoutTestScriptReferences.nodesCompat.${k}
-            else
-              # reuse memoized config
-              v
-          ) config.nodesCompat;
-          containers = config.containers;
-        }
-      else
-        config.testScript;
+    testScriptString = config.testScript;
 
     nodeDefaults =
       { config, name, ... }:


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Uses `coercedType` to make the `testScript` option mergeable. This enables:
  - Easier test "parameterization" through the module system, i.e. can compose multiple scripts together, or add script "prologue" that is only applied under `interactive` runs
  - Easier extension of the test driver downstream

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]: `nixosTests.nixos-test-driver.busybox`
  - [x] [Package tests] at `passthru.tests`: `rsync.passthru.tests.rsyncd`
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
