### PR TITLE
paml: fix build with GCC 15

### DIFF
--- a/pkgs/by-name/pa/paml/fix-ProcessNodeAnnotation-declaration.patch
+++ b/pkgs/by-name/pa/paml/fix-ProcessNodeAnnotation-declaration.patch
@@ -1,0 +1,11 @@
+--- a/src/mcmctree.c
++++ b/src/mcmctree.c
+@@ -42,7 +42,7 @@ extern double PjumpOptimum;
+
+ int GetOptions(char *ctlf);
+ int ReadTreeSeqs(FILE*fout);
+-int ProcessNodeAnnotation();
++int ProcessNodeAnnotation(int* haslabel);
+ int ReadBlengthGH(char infile[]);
+ int GenerateBlengthGH(char infile[]);
+ int GetMem(void);

--- a/pkgs/by-name/pa/paml/package.nix
+++ b/pkgs/by-name/pa/paml/package.nix
@@ -15,6 +15,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-P/oHaLxoQzjFuvmHyRdShHv1ayruy6O/I9w8aTyya2s=";
   };
 
+  patches = [
+    # https://github.com/abacus-gene/paml/pull/78
+    ./fix-ProcessNodeAnnotation-declaration.patch
+  ];
+
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-D_POSIX_C_SOURCE";
 
   preBuild = ''


### PR DESCRIPTION
I borrowed this from upstream's PR (https://github.com/abacus-gene/paml/pull/78). Since it's not merged yet, I vendor it instead of using `fetchpatch`.

GCC 15 Regression Tracking: #475479
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327064067)](https://hydra.nixos.org/build/327064067)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
