### PR TITLE
postgresqlPackages.age: 1.6.0 -> 1.7.0

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/age.nix
+++ b/pkgs/servers/sql/postgresql/ext/age.nix
@@ -11,9 +11,8 @@
 
 let
   hashes = {
-    # Issue tracking PostgreSQL 18 support: https://github.com/apache/age/issues/2164
-    # "18" = "";
-    "17" = "sha256-gqoAhVqQaDhe5CIcTc//1HonQLP1zoBIGuCQuXsJy+A=";
+    "18" = "sha256-Hqjg62YLTLEa6wRA5S4MAIED7Hobtiih4E55cSzVTqE";
+    "17" = "sha256-hAjhNj/benwZbbuxDl9RSjwWRai9CUozbEN6ecPKoFE=";
     "16" = "sha256-iukdi2c3CukGvjuTojybFFAZBlAw8GEfzFPr2qJuwTA=";
     "15" = "sha256-webZWgWZGnSoXwTpk816tjbtHV1UIlXkogpBDAEL4gM=";
     "14" = "sha256-jZXhcYBubpjIJ8M5JHXKV5f6VK/2BkypH3P7nLxZz3E=";
@@ -22,7 +21,13 @@ let
 in
 postgresqlBuildExtension (finalAttrs: {
   pname = "age";
-  version = if lib.versionAtLeast postgresql.version "16" then "1.6.0-rc0" else "1.5.0-rc0";
+  version =
+    if lib.versionAtLeast postgresql.version "17" then
+      "1.7.0-rc0"
+    else if lib.versionAtLeast postgresql.version "16" then
+      "1.6.0-rc0"
+    else
+      "1.5.0-rc0";
 
   src = fetchFromGitHub {
     owner = "apache";


### PR DESCRIPTION
[Release v1.7.0 for PG17](https://github.com/apache/age/releases/tag/PG17%2Fv1.7.0-rc0)
[Release v1.7.0 for PG18](https://github.com/apache/age/releases/tag/PG18%2Fv1.7.0-rc0)

I have not updated PG14/PG15, as there seem to be a breaking change between 1.5.0 -> 1.6.0 (see [Release v1.6.0 for PG14](https://github.com/apache/age/releases/tag/PG14%2Fv1.6.0-rc0)). Version 1.6.0 is still latest for PG16.

Please double-check this MR before merging. Thank you.

## Things done

I built the package against PostgreSQL 18 and ran `CREATE EXTENSION age`. I have not built the package against PostgreSQL 17, only prefetched the hash. There should be no changes for PG16 and below.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
