### PR TITLE
vimPlugins.nordic-nvim: 0-unstable-2024-06-16 -> 0.2.0

### DIFF
--- a/pkgs/applications/editors/vim/plugins/generated.nix
+++ b/pkgs/applications/editors/vim/plugins/generated.nix
@@ -11948,14 +11948,14 @@ final: prev: {
 
   nordic-nvim = buildVimPlugin {
     pname = "nordic.nvim";
-    version = "0-unstable-2024-06-16";
+    version = "0.2.0";
     src = fetchFromGitHub {
-      owner = "andersevenrud";
+      owner = "alexvzyl";
       repo = "nordic.nvim";
-      rev = "c88388b2a5f6e621df2718c316b856d4971bb89d";
-      hash = "sha256-ipmt0xD2zTfoh8fyYG4+09uVL2ef98FE9VwWpWJtQks=";
+      tag = "0.2.0";
+      hash = "sha256-kjr4SsRbKfVgNjAFWybkRQ8/QDOPLm7lbysi6Gblpfg=";
     };
-    meta.homepage = "https://github.com/andersevenrud/nordic.nvim/";
+    meta.homepage = "https://github.com/alexvzyl/nordic.nvim/";
     meta.license = getLicenseFromSpdxId "MIT";
     meta.hydraPlatforms = [ ];
   };
@@ -25838,7 +25838,7 @@ final: prev: {
       hash = "sha256-I+nPSItC/0M8QTs1mVX7F+KjtezYpq9GFpUdsFl6bTE=";
     };
     meta.homepage = "https://codeberg.org/ziglang/zig.vim/";
-    meta.license = lib.licenses.unfree;
+    meta.license = unfree;
     meta.hydraPlatforms = [ ];
   };
 

--- a/pkgs/applications/editors/vim/plugins/vim-plugin-names
+++ b/pkgs/applications/editors/vim/plugins/vim-plugin-names
@@ -851,7 +851,7 @@ https://github.com/folke/noice.nvim/,,
 https://github.com/nvimtools/none-ls.nvim/,,
 https://github.com/nordtheme/vim/,,nord-vim
 https://github.com/shaunsingh/nord.nvim/,,
-https://github.com/andersevenrud/nordic.nvim/,,
+https://github.com/alexvzyl/nordic.nvim/,,
 https://github.com/vigoux/notifier.nvim/,,
 https://github.com/jlesquembre/nterm.nvim/,,
 https://github.com/jose-elias-alvarez/null-ls.nvim/,,


### PR DESCRIPTION
https://github.com/alexvzyl/nordic.nvim

Replace the old long unmaintained andersevenrud/nordic.nvim with the actively developed and more popular alexvzyl/nordic.nvim
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
