### PR TITLE
aniworld-cli: init at 0.1.0

### DIFF
--- a/pkgs/by-name/an/aniworld-cli/package.nix
+++ b/pkgs/by-name/an/aniworld-cli/package.nix
@@ -1,0 +1,77 @@
+{
+  fetchFromGitHub,
+  makeWrapper,
+  stdenvNoCC,
+  lib,
+  gnugrep,
+  gnused,
+  curl,
+  catt,
+  syncplay,
+  ffmpeg,
+  fzf,
+  aria2,
+  mpv,
+  vlc,
+  iina,
+  withMpv ? true,
+  withVlc ? false,
+  withIina ? false,
+  chromecastSupport ? false,
+  syncSupport ? false,
+}:
+
+let
+  players = lib.optional withMpv mpv ++ lib.optional withVlc vlc ++ lib.optional withIina iina;
+in
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "aniworld-cli";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "dxmoc";
+    repo = "aniworld-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6kO5FYXkQ9WAU4sAT3Fsrge6qFiIvFmGTPYPAbIFi18=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  runtimeInputs = [
+    gnugrep
+    gnused
+    curl
+    fzf
+    ffmpeg
+    aria2
+  ]
+  ++ lib.optional chromecastSupport catt
+  ++ lib.optional syncSupport syncplay;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 aniworld-cli $out/bin/aniworld-cli
+    cp -r lib $out/bin/lib
+
+    wrapProgram $out/bin/aniworld-cli \
+      --prefix PATH : ${lib.makeBinPath finalAttrs.runtimeInputs} \
+      ${lib.optionalString (builtins.length players > 0) "--suffix PATH : ${lib.makeBinPath players}"}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/dxmoc/aniworld-cli";
+    description = "CLI tool for streaming German anime - Fork of ani-cli";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      v3rm1n0
+    ];
+    platforms = lib.platforms.unix;
+    mainProgram = "aniworld-cli";
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+    ];
+  };
+})

--- a/pkgs/by-name/an/aniworld-cli/package.nix
+++ b/pkgs/by-name/an/aniworld-cli/package.nix
@@ -1,0 +1,53 @@
+{
+  fetchFromGitHub,
+  makeWrapper,
+  lib,
+  python3,
+  mpv,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "aniworld-cli";
+  version = "0.1.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "dxmoc";
+    repo = "aniworld-cli";
+    tag = "v${version}";
+    hash = "sha256-rIMZeomEe/kRvC07tbCX3cKAoIobFZaWgeG4HietlYA=";
+  };
+
+  build-system = with python3.pkgs; [ setuptools ];
+
+  dependencies = with python3.pkgs; [
+    requests
+    beautifulsoup4
+    questionary
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/aniworld-cli \
+      --suffix PATH : ${lib.makeBinPath [ mpv ]}
+  '';
+
+  pythonImportsCheck = [ "aniworld_cli" ];
+
+  meta = {
+    homepage = "https://github.com/dxmoc/aniworld-cli";
+    description = "Pure-Python streaming-only CLI for aniworld.to, playback via mpv";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      v3rm1n0
+    ];
+    platforms = lib.platforms.unix;
+    mainProgram = "aniworld-cli";
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+    ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Package aniworld-cli. Will keep it as a draft at the moment, as there are potential upstream changes incoming soon

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
