### PR TITLE
vimPlugins.nvim-treesitter: fix to allow overlay changes to affect queries packages

### DIFF
--- a/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
@@ -37,8 +37,8 @@ let
         }
         ''
           mkdir -p "$out/queries"
-          if [ -d "${super.nvim-treesitter.src}/runtime/queries/${language}" ]; then
-            ln -s "${super.nvim-treesitter.src}/runtime/queries/${language}" "$out/queries/${language}"
+          if [ -d "${self.nvim-treesitter}/runtime/queries/${language}" ]; then
+            ln -s "${self.nvim-treesitter}/runtime/queries/${language}" "$out/queries/${language}"
           else
             echo "Error: there are no queries for ${language}."
             exit 1

--- a/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
@@ -37,8 +37,8 @@ let
         }
         ''
           mkdir -p "$out/queries"
-          if [ -d "${super.nvim-treesitter.src}/runtime/queries/${language}" ]; then
-            ln -s "${super.nvim-treesitter.src}/runtime/queries/${language}" "$out/queries/${language}"
+          if [ -d "${self.nvim-treesitter.src}/runtime/queries/${language}" ]; then
+            ln -s "${self.nvim-treesitter.src}/runtime/queries/${language}" "$out/queries/${language}"
           else
             echo "Error: there are no queries for ${language}."
             exit 1


### PR DESCRIPTION
This fixes an issue that prevents users from using an overlay to patch nvim-treesitter.

The upstream nvim-treesitter defines tree-sitter queries for many languages. Those are made available as separate packages in nixpkgs via derivations that symlink to subdirectories in `vimPlugins.nvim-treesitter`'s `src` input. One example is `vimPlugins.nvim-treesitter.queries.nix`. But derivations for those queries packages are defined in an overlay where nvim-treesitter is referenced via `super` instead of `self`. That means that if end users patch nvim-treesitter's `src` input, changes do not propagate to the queries packages.

This change switches the aforementioned references from `super` to `self`.

I have tested this change, and verified that it fixes the problem I have identified. I also verified that the change did not lead to infinite recursion errors when evaluating `vimPlugins.nvim-treesitter.withAllGrammars`. AFAIK the `withAllGrammars` attribute references all of the queries packages defined via the reference that I changed.

If you want background with excessive detail, I have a [blog post](https://sitr.us/2026/05/03/embedded-sql-highlighting-in-neovim/) that explains the problem, the fix, and why the fix is useful for me.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
