### PR TITLE
coal: 3.0.2 -> 3.0.3

### DIFF
--- a/pkgs/by-name/co/coal/package.nix
+++ b/pkgs/by-name/co/coal/package.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "coal";
-  version = "3.0.2";
+  version = "3.0.3";
 
   src = fetchFromGitHub {
     owner = "coal-library";
     repo = "coal";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-7Ww1vAzKaCccBpBQU1hzI7Jk+oXw73zhnH594Xn9gbw=";
+    hash = "sha256-2fmu2VZJ+Fd87q2RpnJU61v6Lj2C9r5iweFrr1HwQQI=";
   };
 
   strictDeps = true;

--- a/pkgs/development/python-modules/coal/default.nix
+++ b/pkgs/development/python-modules/coal/default.nix
@@ -17,17 +17,6 @@ toPythonModule (
   coal.overrideAttrs (super: {
     pname = "py-${super.pname}";
 
-    # Finding `boost_system` fails because the stub compiled library of
-    # Boost.System, which has been a header-only library since 1.69, was
-    # removed in 1.89.
-    # See https://www.boost.org/releases/1.89.0/ for details.
-    postPatch = ''
-      substituteInPlace CMakeLists.txt \
-        --replace-fail \
-          "find_package(Boost REQUIRED COMPONENTS system)" \
-          "find_package(Boost REQUIRED OPTIONAL_COMPONENTS system)"
-    '';
-
     cmakeFlags = super.cmakeFlags ++ [
       (lib.cmakeBool "BUILD_PYTHON_INTERFACE" true)
       (lib.cmakeBool "BUILD_STANDALONE_PYTHON_INTERFACE" buildStandalone)


### PR DESCRIPTION
supersede #516930, because we need to revert #492633 as fixed upstream

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
