### PR TITLE
python3Packages.wiim: 0.1.1 -> 0.1.4

### DIFF
--- a/pkgs/development/python-modules/wiim/default.nix
+++ b/pkgs/development/python-modules/wiim/default.nix
@@ -5,20 +5,21 @@
   setuptools,
   aiohttp,
   async-upnp-client,
+  zeroconf,
   pytestCheckHook,
   pytest-asyncio,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "wiim";
-  version = "0.1.1";
+  version = "0.1.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Linkplay2020";
     repo = "wiim";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-WJbnVJ7ZM4wZk3Y8zTRc3i24CyTA8Wz9EKYr5BNlx6o=";
+    hash = "sha256-buFGfM/qgZGjE3asv/5GBD4TfHj3lf/9Q9u/W9bOq3A=";
   };
 
   build-system = [ setuptools ];
@@ -26,11 +27,17 @@ buildPythonPackage (finalAttrs: {
   dependencies = [
     aiohttp
     async-upnp-client
+    zeroconf
   ];
 
   nativeCheckInputs = [
     pytestCheckHook
     pytest-asyncio
+  ];
+
+  disabledTests = [
+    # ValueError: Device u is not managed by the controller
+    "test_async_join_group"
   ];
 
   pythonImportsCheck = [ "wiim" ];


### PR DESCRIPTION
Diff: https://github.com/Linkplay2020/wiim/compare/v0.1.1...v0.1.4

Changelog: https://github.com/Linkplay2020/wiim/releases/tag/v0.1.4


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
