### PR TITLE
esphome: 2026.4.3 -> 2026.4.4

### DIFF
--- a/pkgs/by-name/es/esphome/package.nix
+++ b/pkgs/by-name/es/esphome/package.nix
@@ -33,14 +33,14 @@ let
 in
 python.pkgs.buildPythonApplication (finalAttrs: {
   pname = "esphome";
-  version = "2026.4.3";
+  version = "2026.4.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "esphome";
     repo = "esphome";
     tag = finalAttrs.version;
-    hash = "sha256-+esSczOBIT4dJEyzqmEv6YMU4wGkN4lFGmuZKRp5/bo=";
+    hash = "sha256-7ZhVi4R/wmBX1HI60eMpWGY2zZNft9H3duJ2dwkqP24=";
   };
 
   patches = [
@@ -186,6 +186,9 @@ python.pkgs.buildPythonApplication (finalAttrs: {
     # Expects a full git clone
     "test_clang_tidy_mode_full_scan"
     "test_clang_tidy_mode_targeted_scan"
+    # Patched to run platformio without the esphome wrapper
+    "test_run_platformio_cli_strips_win_long_path_prefix"
+    "test_run_platformio_cli_does_not_set_pythonexepath_without_strip"
   ];
 
   passthru = {

--- a/pkgs/by-name/es/esphome/platformio-binary-reference.patch
+++ b/pkgs/by-name/es/esphome/platformio-binary-reference.patch
@@ -1,13 +1,13 @@
 diff --git a/esphome/platformio_api.py b/esphome/platformio_api.py
-index fc21977f..e5059f1d 100644
+index 81ff01306..2dfa523dd 100644
 --- a/esphome/platformio_api.py
 +++ b/esphome/platformio_api.py
-@@ -63,7 +63,7 @@ def run_platformio_cli(*args, **kwargs) -> str | int:
-     os.environ.setdefault("PYTHONWARNINGS", "ignore::SyntaxWarning")
-     # Increase uv retry count to handle transient network errors (default is 3)
-     os.environ.setdefault("UV_HTTP_RETRIES", "10")
--    cmd = [sys.executable, "-m", "esphome.platformio_runner"] + list(args)
+@@ -64,7 +64,7 @@ def run_platformio_cli(*args, **kwargs) -> str | int:
+         # a user-provided value (or the unmodified path on platforms that
+         # don't need the strip).
+         os.environ["PYTHONEXEPATH"] = python_exe
+-    cmd = [python_exe, "-m", "esphome.platformio_runner"] + list(args)
 +    cmd = ["platformio"] + list(args)
-
+ 
      return run_external_process(*cmd, **kwargs)
-
+ 


### PR DESCRIPTION
https://github.com/esphome/esphome/releases/tag/2026.4.4


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
