### PR TITLE
prometheus-borgmatic-exporter: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/by-name/pr/prometheus-borgmatic-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-borgmatic-exporter/package.nix
@@ -1,20 +1,23 @@
 {
   lib,
   borgmatic,
+  nixosTests,
   fetchFromGitHub,
   python3Packages,
 }:
 
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finallAttrs: {
   pname = "prometheus-borgmatic-exporter";
-  version = "0.4.0";
+  version = "0.5.0";
   pyproject = true;
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "maxim-mityutko";
     repo = "borgmatic-exporter";
-    tag = "v${version}";
-    hash = "sha256-fhsGpQolZxX5VAAEV3hiLF7bo4pbVt9GWyertf2oeO0=";
+    tag = "v${finallAttrs.version}";
+    hash = "sha256-pa1f31jrfDzUB3+xexJUwG0byiFszj/zEt+dIwlEv0o=";
   };
 
   pythonRelaxDeps = [ "prometheus-client" ];
@@ -33,6 +36,7 @@ python3Packages.buildPythonApplication rec {
     prometheus-client
     timy
     waitress
+    flask-caching
   ]);
 
   nativeCheckInputs = with python3Packages; [
@@ -40,13 +44,17 @@ python3Packages.buildPythonApplication rec {
     pytest-mock
   ];
 
+  __darwinAllowLocalNetworking = true;
+
+  passthru.tests.borgmatic = nixosTests.prometheus-exporters.borgmatic;
+
   meta = {
     description = "Prometheus exporter for Borgmatic";
     homepage = "https://github.com/maxim-mityutko/borgmatic-exporter";
-    changelog = "https://github.com/maxim-mityutko/borgmatic-exporter/releases/tag/${src.tag}";
+    changelog = "https://github.com/maxim-mityutko/borgmatic-exporter/releases/tag/${finallAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ flandweber ];
     mainProgram = "borgmatic-exporter";
     platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/maxim-mityutko/borgmatic-exporter/compare/v0.4.0...v0.5.0
Changelog: https://github.com/maxim-mityutko/borgmatic-exporter/releases/tag/v0.5.0

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
