### PR TITLE
python3Packages.mastodon-py: 2.1.4 -> 2.2.1

### DIFF
--- a/pkgs/development/python-modules/mastodon-py/default.nix
+++ b/pkgs/development/python-modules/mastodon-py/default.nix
@@ -5,7 +5,6 @@
   blurhash,
   cryptography,
   decorator,
-  fetchpatch,
   graphemeu,
   http-ece,
   python-dateutil,
@@ -21,23 +20,15 @@
 
 buildPythonPackage rec {
   pname = "mastodon-py";
-  version = "2.1.4";
+  version = "2.2.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "halcy";
     repo = "Mastodon.py";
     tag = "v${version}";
-    hash = "sha256-i3HMT8cabSl664UK3eopJQ9bDBpGCgbHTvBJkgeoxd8=";
+    hash = "sha256-RsSM7TkNwsirT1ksaXP/IKOmrpPrNGh/16S77Up+3MM=";
   };
-
-  patches = [
-    # Switch dependency from unmaintained `grapheme` to `graphemeu`
-    (fetchpatch {
-      url = "https://github.com/halcy/Mastodon.py/commit/939c7508414e950922c518260a9ba5a5853aeef2.patch";
-      hash = "sha256-XBiAFxYUBNyynld++UwPGIIg9j+3/EF2jGqiysVqYRM=";
-    })
-  ];
 
   build-system = [ setuptools ];
 
@@ -66,13 +57,6 @@ buildPythonPackage rec {
     requests-mock
   ]
   ++ lib.concatAttrValues optional-dependencies;
-
-  # disabledTests = [
-  #   "test_notifications_dismiss_pre_2_9_2"
-  #   "test_status_card_pre_2_9_2"
-  #   "test_stream_user_direct"
-  #   "test_stream_user_local"
-  # ];
 
   pythonImportsCheck = [ "mastodon" ];
 


### PR DESCRIPTION
Diff: https://github.com/halcy/Mastodon.py/compare/v2.1.4...v2.2.1

Changelog: https://github.com/halcy/Mastodon.py/blob/v2.2.1/CHANGELOG.rst


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
