### PR TITLE
flake-du: init at 0.1.0

### DIFF
--- a/pkgs/by-name/fl/flake-du/package.nix
+++ b/pkgs/by-name/fl/flake-du/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  rustPlatform,
+  fetchgit,
+}:
+let
+  version = "0.1.0";
+in
+rustPlatform.buildRustPackage {
+  pname = "flake-du";
+  inherit version;
+
+  src = fetchgit {
+    url = "https://github.com/kmein/flake-du";
+    rev = "v${version}";
+    sha256 = "sha256-+YfQRi6QE4xNUcIcEc9HWIbnin6GCVp4SYrjvBwksys=";
+  };
+
+  cargoHash = "sha256-DYVT9jM9WcgoVSOnoUIWWR9EmNywR1f4xZOAzkbNkCk=";
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Tool for managing flake inputs with disk usage insights";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/kmein/flake-du";
+    maintainers = [ lib.maintainers.kmein ];
+  };
+}


### PR DESCRIPTION
This is a project of mine written at [Ocean sprint](https://oceansprint.org/) which is a companion to @a-kenji's excellent [flake-edit](https://github.com/a-kenji/flake-edit) (`pkgs.flake-edit`).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
