### PR TITLE
nixos/immich: add machine-learning acceleration options

### DIFF
--- a/nixos/modules/services/web-apps/immich.nix
+++ b/nixos/modules/services/web-apps/immich.nix
@@ -53,6 +53,22 @@ let
 
   postgresqlPackage =
     if cfg.database.enable then config.services.postgresql.package else pkgs.postgresql;
+
+  machineLearningPackage =
+    if cfg.machine-learning.acceleration == "rocm" then
+      cfg.package.machine-learning.override {
+        python3 = pkgs.python3.override {
+          packageOverrides = _: pyPrev: {
+            onnxruntime = pyPrev.onnxruntime.override {
+              onnxruntime = pkgs.onnxruntime.override {
+                rocmSupport = true;
+              };
+            };
+          };
+        };
+      }
+    else
+      cfg.package.machine-learning;
 in
 {
   imports = [
@@ -198,6 +214,26 @@ in
         // {
           default = true;
         };
+      acceleration = mkOption {
+        type = types.nullOr (types.enum [ "rocm" ]);
+        default = null;
+        example = "rocm";
+        description = ''
+          Hardware acceleration backend for Immich machine learning.
+
+          When set to `rocm`, this sets `DEVICE=rocm` and runs Immich machine learning with a ROCm-enabled `onnxruntime`.
+        '';
+      };
+      hsaGfxVersion = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "11.0.0";
+        description = ''
+          Override what ROCm detects the GPU model as for Immich machine learning.
+
+          This sets `HSA_OVERRIDE_GFX_VERSION` when non-null. Leave this as `null` to preserve native ROCm gfx detection. For example, RX 7900 XTX users may need `"11.0.0"`.
+        '';
+      };
       environment = mkOption {
         type = types.submodule { freeformType = types.attrsOf types.str; };
         default = { };
@@ -383,6 +419,12 @@ in
       XDG_CACHE_HOME = "/var/cache/immich";
       IMMICH_HOST = "localhost";
       IMMICH_PORT = "3003";
+    }
+    // lib.optionalAttrs (cfg.machine-learning.acceleration == "rocm") {
+      DEVICE = "rocm";
+    }
+    // lib.optionalAttrs (cfg.machine-learning.hsaGfxVersion != null) {
+      HSA_OVERRIDE_GFX_VERSION = cfg.machine-learning.hsaGfxVersion;
     };
 
     systemd.slices.system-immich = {
@@ -428,7 +470,7 @@ in
       wantedBy = [ "multi-user.target" ];
       inherit (cfg.machine-learning) environment;
       serviceConfig = commonServiceConfig // {
-        ExecStart = lib.getExe cfg.package.machine-learning;
+        ExecStart = lib.getExe machineLearningPackage;
         Slice = "system-immich.slice";
         CacheDirectory = "immich";
         User = cfg.user;

--- a/nixos/modules/services/web-apps/immich.nix
+++ b/nixos/modules/services/web-apps/immich.nix
@@ -55,13 +55,14 @@ let
     if cfg.database.enable then config.services.postgresql.package else pkgs.postgresql;
 
   machineLearningPackage =
-    if cfg.machine-learning.acceleration == "rocm" then
+    if cfg.machine-learning.acceleration != null then
       cfg.package.machine-learning.override {
         python3 = pkgs.python3.override {
           packageOverrides = _: pyPrev: {
             onnxruntime = pyPrev.onnxruntime.override {
               onnxruntime = pkgs.onnxruntime.override {
-                rocmSupport = true;
+                cudaSupport = cfg.machine-learning.acceleration == "cuda";
+                rocmSupport = cfg.machine-learning.acceleration == "rocm";
               };
             };
           };
@@ -215,13 +216,18 @@ in
           default = true;
         };
       acceleration = mkOption {
-        type = types.nullOr (types.enum [ "rocm" ]);
+        type = types.nullOr (
+          types.enum [
+            "cuda"
+            "rocm"
+          ]
+        );
         default = null;
-        example = "rocm";
+        example = "cuda";
         description = ''
           Hardware acceleration backend for Immich machine learning.
 
-          When set to `rocm`, this sets `DEVICE=rocm` and runs Immich machine learning with a ROCm-enabled `onnxruntime`.
+          When set, this sets `DEVICE` to the selected backend and runs Immich machine learning with an `onnxruntime` package built with the matching accelerator support.
         '';
       };
       hsaGfxVersion = mkOption {
@@ -311,6 +317,11 @@ in
       {
         assertion = !isPostgresUnixSocket -> cfg.secretsFile != null;
         message = "A secrets file containing at least the database password must be provided when unix sockets are not used.";
+      }
+      {
+        assertion =
+          cfg.machine-learning.hsaGfxVersion == null || cfg.machine-learning.acceleration == "rocm";
+        message = "`services.immich.machine-learning.hsaGfxVersion` can only be set when `services.immich.machine-learning.acceleration` is `\"rocm\"`.";
       }
     ];
 
@@ -420,8 +431,8 @@ in
       IMMICH_HOST = "localhost";
       IMMICH_PORT = "3003";
     }
-    // lib.optionalAttrs (cfg.machine-learning.acceleration == "rocm") {
-      DEVICE = "rocm";
+    // lib.optionalAttrs (cfg.machine-learning.acceleration != null) {
+      DEVICE = cfg.machine-learning.acceleration;
     }
     // lib.optionalAttrs (cfg.machine-learning.hsaGfxVersion != null) {
       HSA_OVERRIDE_GFX_VERSION = cfg.machine-learning.hsaGfxVersion;

--- a/nixos/tests/web-apps/immich.nix
+++ b/nixos/tests/web-apps/immich.nix
@@ -17,6 +17,7 @@
       services.immich = {
         enable = true;
         environment.IMMICH_LOG_LEVEL = "verbose";
+        machine-learning.hsaGfxVersion = "11.0.0";
         settings = {
           backup.database = {
             enabled = true;
@@ -45,6 +46,7 @@
     machine.wait_for_open_port(2283) # Server
     machine.wait_for_open_port(3003) # Machine learning
     machine.succeed("curl --fail http://localhost:2283/")
+    machine.succeed("systemctl show immich-machine-learning.service -p Environment | grep HSA_OVERRIDE_GFX_VERSION=11.0.0")
 
     machine.succeed("""
       curl -f --json '{ "email": "test@example.com", "name": "Admin", "password": "admin" }' http://localhost:2283/api/auth/admin-sign-up

--- a/nixos/tests/web-apps/immich.nix
+++ b/nixos/tests/web-apps/immich.nix
@@ -17,7 +17,6 @@
       services.immich = {
         enable = true;
         environment.IMMICH_LOG_LEVEL = "verbose";
-        machine-learning.hsaGfxVersion = "11.0.0";
         settings = {
           backup.database = {
             enabled = true;
@@ -46,7 +45,7 @@
     machine.wait_for_open_port(2283) # Server
     machine.wait_for_open_port(3003) # Machine learning
     machine.succeed("curl --fail http://localhost:2283/")
-    machine.succeed("systemctl show immich-machine-learning.service -p Environment | grep HSA_OVERRIDE_GFX_VERSION=11.0.0")
+    machine.succeed("curl --fail http://localhost:3003/ping")
 
     machine.succeed("""
       curl -f --json '{ "email": "test@example.com", "name": "Admin", "password": "admin" }' http://localhost:2283/api/auth/admin-sign-up


### PR DESCRIPTION
Adds Immich machine-learning acceleration configuration to the NixOS module:

- `services.immich.machine-learning.acceleration = "cuda"` sets `DEVICE=cuda` and runs the machine-learning service with a CUDA-enabled `onnxruntime`.
- `services.immich.machine-learning.acceleration = "rocm"` sets `DEVICE=rocm` and runs the machine-learning service with a ROCm-enabled `onnxruntime`.
- `services.immich.machine-learning.hsaGfxVersion` sets `HSA_OVERRIDE_GFX_VERSION` when non-null and is asserted to be ROCm-only, while `null` preserves native ROCm gfx detection.
- Extends the existing Immich NixOS test to check the machine-learning service `/ping` endpoint instead of only asserting environment propagation.

This was split out after downstream Keystone work needed the same wiring for RX 7900 XTX / RDNA 3 (`11.0.0`) and native ROCm detection. CUDA support was added after review feedback that a ROCm-only acceleration enum would make the CUDA path unclear.

Local validation on current head `9f538081f1073b1f93d46332452b7d062d0592ce`:

- `nix-instantiate --parse nixos/modules/services/web-apps/immich.nix`
- `nix-instantiate --parse nixos/tests/web-apps/immich.nix`
- `nix eval --impure --raw .#nixosTests.immich.driver.drvPath`
- targeted module evals for CUDA/ROCm `immich-machine-learning` `ExecStart`
- targeted negative assertion eval for `hsaGfxVersion` with CUDA
- `nix build --no-link .#nixosTests.immich.driver`
- `nix build --no-link .#nixosTests.immich`
- `git diff --check`

Earlier remote `nixpkgs-review-gha` runs on the original ROCm-only head passed: https://github.com/caniko/nixpkgs-review-gha/actions/runs/25396808014 and https://github.com/caniko/nixpkgs-review-gha/actions/runs/25397148487. A fresh current-head review is queued/running at https://github.com/caniko/nixpkgs-review-gha/actions/runs/26719054957.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test



