### PR TITLE
python3Packages.pyrealsense2: fix build

### DIFF
--- a/pkgs/development/libraries/librealsense/0001-fix-pybind11.patch
+++ b/pkgs/development/libraries/librealsense/0001-fix-pybind11.patch
@@ -1,0 +1,31 @@
+From 1d4f6917c1e71c6f4716be844bc4ef99e07a64f1 Mon Sep 17 00:00:00 2001
+From: Peder Bergebakken Sundt <pbsds@hotmail.com>
+Date: Tue, 5 May 2026 20:58:35 +0200
+Subject: [PATCH] Fix building with pybind11 v3.0.2
+
+pyrealsense2 fails to build with pybind11 v3.0.2
+
+Build error log: https://cache.nixos.org/log/kcry0khph8g0crka6zzkznn8izfvsrq1-librealsense-2.56.3.drv
+
+Cause: https://github.com/pybind/pybind11/pull/5533
+
+I based this fix on https://github.com/NGSolve/netgen/commit/ceacae3844ed2f0c48c8b6a3a82904b16c594f41
+
+I'm not very familiar with pybind11, please double check whether this fix is correct.
+---
+ wrappers/python/pyrs_frame.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/wrappers/python/pyrs_frame.cpp b/wrappers/python/pyrs_frame.cpp
+index c5e07bd17f..a2a974eb1b 100644
+--- a/wrappers/python/pyrs_frame.cpp
++++ b/wrappers/python/pyrs_frame.cpp
+@@ -144,7 +144,7 @@ void init_frame(py::module &m) {
+         .def_property_readonly("frame_number", &rs2::frame::get_frame_number, "The frame number. Identical to calling get_frame_number.")
+         .def("get_data_size", &rs2::frame::get_data_size, "Retrieve data size from frame handle.")
+         .def("get_data", get_frame_data, "Retrieve data from the frame handle.", py::keep_alive<0, 1>())
+-        .def_property_readonly("data", get_frame_data, "Data from the frame handle. Identical to calling get_data.", py::keep_alive<0, 1>())
++        .def_property_readonly("data", py::cpp_function(get_frame_data, "Data from the frame handle. Identical to calling get_data.", py::keep_alive<0, 1>()))
+         .def("get_profile", &rs2::frame::get_profile, "Retrieve stream profile from frame handle.")
+         .def_property_readonly("profile", &rs2::frame::get_profile, "Stream profile from frame handle. Identical to calling get_profile.")
+         .def("keep", &rs2::frame::keep, "Keep the frame, otherwise if no refernce to the frame, the frame will be released.")

--- a/pkgs/development/libraries/librealsense/default.nix
+++ b/pkgs/development/libraries/librealsense/default.nix
@@ -78,6 +78,8 @@ stdenv'.mkDerivation rec {
   patches = [
     ./py_pybind11_no_external_download.patch
     ./install-presets.patch
+    # upstream pr: https://github.com/realsenseai/librealsense/pull/15022
+    ./0001-fix-pybind11.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
fixes https://hydra.nixos.org/build/326870962 zhf https://github.com/NixOS/nixpkgs/issues/516381

upstream pr: https://github.com/realsenseai/librealsense/pull/15022

w.r.t. correctness: the only question is whether a `__doc__` string is propagated correctly, this does not affect use.

The fix i pushed to https://github.com/NixOS/nixpkgs/pull/427314 was needed to build all non-gui variants after updating, but the python wrapper had a second issue.
I did not uncover that in time before the merge because my builders OOMed multiple times trying to build more than one variant in parallel.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
