### PR TITLE
bacnet-stack: 1.3.5 -> 1.5.0

### DIFF
--- a/pkgs/by-name/ba/bacnet-stack/package.nix
+++ b/pkgs/by-name/ba/bacnet-stack/package.nix
@@ -2,34 +2,42 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  cmake,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "bacnet-stack";
-  version = "1.3.5";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "bacnet-stack";
     repo = "bacnet-stack";
     rev = "bacnet-stack-${finalAttrs.version}";
-    sha256 = "sha256-Iwo0bNulKdFNwNU2xj6Uin+5hQt1I3N6+zso5BHrIOU=";
+    hash = "sha256-CJmEEIGT6u2nsnl3btWL/JJPxQM53JF6l+mLBSF+Q8Q=";
   };
 
-  hardeningDisable = [ "all" ];
+  nativeBuildInputs = [ cmake ];
 
-  buildPhase = ''
-    make BUILD=debug BACNET_PORT=linux BACDL_DEFINE=-DBACDL_BIP=1 BACNET_DEFINES=" -DPRINT_ENABLED=1 -DBACFILE -DBACAPP_ALL -DBACNET_PROPERTY_LISTS"
-  '';
+  cmakeFlags = [
+    (lib.cmakeBool "BACDL_BIP" true)
+    (lib.cmakeBool "BACNET_STACK_BUILD_APPS" true)
+  ];
 
-  installPhase = ''
-    mkdir $out
-    cp -r bin $out/bin
+  # bacnet-stack's CMakeLists builds the apps via add_executable() but never
+  # adds install(TARGETS ...) rules for them, so `make install` skips them.
+  # Copy them out of the CMake build tree manually.
+  postInstall = ''
+    mkdir -p $out/bin
+    find . -maxdepth 2 -type f -executable -not -name '*.so*' -not -name '*.a' \
+      -exec cp -t $out/bin {} +
   '';
 
   meta = {
     description = "BACnet open source protocol stack for embedded systems, Linux, and Windows";
-    platforms = lib.platforms.linux;
+    homepage = "https://bacnet.sourceforge.net/";
+    changelog = "https://github.com/bacnet-stack/bacnet-stack/releases/tag/bacnet-stack-${finalAttrs.version}";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ WhittlesJr ];
+    platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ba/bacnet-stack/package.nix
+++ b/pkgs/by-name/ba/bacnet-stack/package.nix
@@ -2,35 +2,42 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  cmake,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "bacnet-stack";
-  version = "1.3.5";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "bacnet-stack";
     repo = "bacnet-stack";
-    rev = "bacnet-stack-${finalAttrs.version}";
-    sha256 = "sha256-Iwo0bNulKdFNwNU2xj6Uin+5hQt1I3N6+zso5BHrIOU=";
+    tag = "bacnet-stack-${finalAttrs.version}";
+    hash = "sha256-CJmEEIGT6u2nsnl3btWL/JJPxQM53JF6l+mLBSF+Q8Q=";
   };
 
-  hardeningDisable = [ "all" ];
+  nativeBuildInputs = [ cmake ];
 
-  buildPhase = ''
-    make BUILD=debug BACNET_PORT=linux BACDL_DEFINE=-DBACDL_BIP=1 BACNET_DEFINES=" -DPRINT_ENABLED=1 -DBACFILE -DBACAPP_ALL -DBACNET_PROPERTY_LISTS"
-  '';
-
-  installPhase = ''
-    mkdir $out
-    cp -r bin $out/bin
+  # bacnet-stack's CMakeLists builds the apps via add_executable() but never
+  # adds install(TARGETS ...) rules for them, so `make install` skips them.
+  # Copy them out of the CMake build tree manually.
+  postInstall = ''
+    mkdir -p $out/bin
+    find . -maxdepth 2 -type f -executable -not -name '*.so*' -not -name '*.a' \
+      -exec cp -t $out/bin {} +
   '';
 
   meta = {
     description = "BACnet open source protocol stack for embedded systems, Linux, and Windows";
     homepage = "https://github.com/bacnet-stack/bacnet-stack";
-    platforms = lib.platforms.linux;
-    license = lib.licenses.gpl2Plus;
+    changelog = "https://github.com/bacnet-stack/bacnet-stack/blob/bacnet-stack-${finalAttrs.version}/CHANGELOG.md";
+    license = with lib.licenses; [
+      gpl2Plus # Core stack (WITH GCC-exception-2.0)
+      mit # Examples and applications
+      asl20 # Auxiliary files (SPDX identified)
+      bsd3 # Auxiliary files (SPDX identified)
+    ];
     maintainers = with lib.maintainers; [ WhittlesJr ];
+    platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
- Switch from manual `make` invocation to CMake, which is the upstream-supported build system in 1.5.0 and handles datalink/app selection correctly.
- Drop `hardeningDisable = [ "all" ]`; the package now builds with the default nixpkgs hardening flags.
- Drop `BUILD=debug`; ship a release build.
- Add `postInstall` to copy the app binaries to `$out/bin`. Upstream's CMakeLists builds the apps via `add_executable()` but does not declare `install(TARGETS ...)` rules for them, so they are not picked up by `make install`.
- Add `meta.homepage` and `meta.changelog`.

Changelog: https://github.com/bacnet-stack/bacnet-stack/releases/tag/bacnet-stack-1.5.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test