### PR TITLE
boost191: init at 1.91.0

### DIFF
--- a/pkgs/by-name/bo/boost-build/package.nix
+++ b/pkgs/by-name/bo/boost-build/package.nix
@@ -35,7 +35,9 @@ stdenv.mkDerivation {
   patches =
     useBoost.boostBuildPatches or [ ]
     ++ lib.optional (
-      useBoost ? version && lib.versionAtLeast useBoost.version "1.81"
+      useBoost ? version
+      && lib.versionAtLeast useBoost.version "1.81"
+      && lib.versionOlder useBoost.version "1.91"
     ) ./fix-clang-target.patch;
 
   postPatch =

--- a/pkgs/development/libraries/boost/1.91.nix
+++ b/pkgs/development/libraries/boost/1.91.nix
@@ -1,21 +1,26 @@
-{ callPackage, fetchurl, ... }@args:
+{
+  lib,
+  callPackage,
+  fetchurl,
+  ...
+}@args:
 
 callPackage ./generic.nix (
   args
   // rec {
     version = "1.91.0";
 
-    src =
-      let
-        underVersion = builtins.replaceStrings [ "." ] [ "_" ] version;
-      in
-      fetchurl {
-        urls = [
-          "https://archives.boost.io/release/${version}/source/boost_${underVersion}.tar.bz2"
-          # "mirror://sourceforge/boost/boost_${underVersion}.tar.bz2" 1.91.0.beta1 is available, but not 1.91.0
-        ];
-        # SHA256 from https://www.boost.org/releases/1.91.0/
-        sha256 = "de5e6b0e4913395c6bdfa90537febd9028ea4c0735d2cdb0cd9b45d5f51264f5";
-      };
+    src = fetchurl {
+      urls = [
+        "https://archives.boost.io/release/${version}/source/boost_${
+          lib.replaceString "." "_" version
+        }.tar.bz2"
+        # "mirror://sourceforge/boost/boost_${underVersion}.tar.bz2" 1.91.0.beta1 is available, but not 1.91.0
+      ];
+      # SHA256 from https://www.boost.org/releases/1.91.0/
+      sha256 = "de5e6b0e4913395c6bdfa90537febd9028ea4c0735d2cdb0cd9b45d5f51264f5";
+    };
+
+    strictDeps = true;
   }
 )

--- a/pkgs/development/libraries/boost/1.91.nix
+++ b/pkgs/development/libraries/boost/1.91.nix
@@ -1,0 +1,21 @@
+{ callPackage, fetchurl, ... }@args:
+
+callPackage ./generic.nix (
+  args
+  // rec {
+    version = "1.91.0";
+
+    src =
+      let
+        underVersion = builtins.replaceStrings [ "." ] [ "_" ] version;
+      in
+      fetchurl {
+        urls = [
+          "https://archives.boost.io/release/${version}/source/boost_${underVersion}.tar.bz2"
+          # "mirror://sourceforge/boost/boost_${underVersion}.tar.bz2" 1.91.0.beta1 is available, but not 1.91.0
+        ];
+        # SHA256 from https://www.boost.org/releases/1.91.0/
+        sha256 = "de5e6b0e4913395c6bdfa90537febd9028ea4c0735d2cdb0cd9b45d5f51264f5";
+      };
+  }
+)

--- a/pkgs/development/libraries/boost/default.nix
+++ b/pkgs/development/libraries/boost/default.nix
@@ -31,4 +31,5 @@ in
   boost188 = makeBoost ./1.88.nix;
   boost189 = makeBoost ./1.89.nix;
   boost190 = makeBoost ./1.90.nix;
+  boost191 = makeBoost ./1.91.nix;
 }

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -45,6 +45,7 @@
   # Attributes inherit from specific versions
   version,
   src,
+  strictDeps ? false,
   ...
 }:
 
@@ -161,7 +162,7 @@ in
 stdenv.mkDerivation {
   pname = "boost";
 
-  inherit src version;
+  inherit src version strictDeps;
 
   patchFlags = [ ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6037,6 +6037,7 @@ with pkgs;
     boost188
     boost189
     boost190
+    boost191
     ;
 
   boost = boost189;


### PR DESCRIPTION
Hi,

This add boost 1.91.

Urls changed again: jfrog seems out of the game, and sourceforge not (yet ?) up to date.

I also had to update boost-build. Technically, I think `./fix-clang-target.patch` should follow https://github.com/NixOS/nixpkgs/blob/85deaf4d5c997e40d23472fffd65a9f447fb5ce0/pkgs/development/libraries/boost/generic.nix#L228 but I guess avoiding rebuilds is better.

I already build a bunch of things with that, everything seems fine so far.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
