### PR TITLE
nixos/vsftpd: release note PAM regression

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -200,6 +200,8 @@
 
 - `post-resume.target` has been removed. See {manpage}`systemd.special(7)` about `sleep.target` for instructions on ordering a process after resume with `ExecStop=`.
 
+- `services.vsftpd` no longer automatically configures a PAM module.  This means configurations using `services.vsftpd.localUsers` will no longer work unless `services.vsftpd.enableVirtualUsers` and `services.vsftpd.userDbPath` are also configured.  The old behaviour can be restored by setting `security.pam.services.vsftpd.enable = true`, although this only ever worked by accident and may not be secure.
+
 - `services.kubernetes.addons.dns.coredns` has been renamed to `services.kubernetes.addons.dns.corednsImage` and now expects a
 package instead of attrs. Now, by default, nixpkgs.coredns in conjunction with dockerTools.buildImage is used, instead
 of pulling the upstream container image from Docker Hub. If you want the old behavior, you can set:


### PR DESCRIPTION
Commit 5aa9012bb3fa (nixos: replace 'text' with structured PAM rules
(#420889), 2026-04-14) resulted in the vsftpd module no longer creating
a PAM module, and therefore configurations relying on `cfg.localUsers`
stopped permitting logins unless the PAM module was being set up by
other configuration.

In the absence of a better fix, document this change of behaviour as a
regression. Per the discussion at [0], provide a mechanims to restore
the previous behaviour, but with the caveat that this may be insecure.
I'd prefer more useful advice, but if I had a better understanding of
NixOS's PAM configuration and how it interacts with vsftpd, I'd just be
providing the better fix in the first place.

[0]: https://github.com/NixOS/nixpkgs/issues/515531#issuecomment-4367747991

For now, I'm leaving #515531 open, as I'd really like an actual fix for the regression, but at this point it seems unlikely there will be one in time for 26.05, and I think having the release note is better than having nothing at all.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
