### PR TITLE
torcs: 1.3.8 -> 1.3.9

### DIFF
--- a/pkgs/by-name/to/torcs/without-data.nix
+++ b/pkgs/by-name/to/torcs/without-data.nix
@@ -25,11 +25,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "torcs-without-data";
-  version = "1.3.8";
+  version = "1.3.9";
 
   src = fetchurl {
-    url = "mirror://sourceforge/torcs/torcs-${finalAttrs.version}.tar.bz2";
-    sha256 = "sha256-S5Z3NUX7NkEZgqbziXIF64/VciedTOVp8s4HsI6Jp68=";
+    url = "mirror://sourceforge/torcs/all-in-one/${finalAttrs.version}/torcs-${finalAttrs.version}.tar.bz2";
+    sha256 = "sha256-+caehtKQKVRnRRsB14ONhQBbphNkSm/oo/hafGoDzUw=";
   };
 
   patches = [


### PR DESCRIPTION
https://sourceforge.net/p/torcs/code/ci/master/tree/torcs/torcs/doc/changelogs/1_3_9.txt

Had to change the mirror URL to include all-in-one/*VERSION* because the folder structure on SourceForge changed. I tested basic functionality of the game in a development NixOS VM. Started a race and TORCS was running really slow in VirtualBox, but at least it runs.

If I use the original mirror URL, I get a "don't know how to unpack source-salted" error after nix-build downloads TORCS from SourceForge and the file size is several MB less than it should be.


Maintainer ping: @pixel-87

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
