### PR TITLE
xacro: init at 2.1.1, xacrodoc: init at 2.0.1

### DIFF
--- a/pkgs/by-name/xa/xacro/package.nix
+++ b/pkgs/by-name/xa/xacro/package.nix
@@ -1,0 +1,102 @@
+{
+  lib,
+  fetchFromGitHub,
+
+  python3Packages,
+
+  ament-cmake,
+  ament-cmake-export-definitions,
+  ament-cmake-export-include-directories,
+  ament-cmake-export-libraries,
+  ament-cmake-export-link-flags,
+  ament-cmake-export-targets,
+  ament-cmake-gen-version-h,
+  ament-cmake-include-directories,
+  ament-cmake-libraries,
+  ament-cmake-pytest,
+  ament-cmake-python,
+  ament-cmake-target-dependencies,
+  ament-cmake-test,
+  ament-cmake-version,
+  ament-lint-auto,
+  cmake,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "xacro";
+  version = "2.1.1";
+  pyproject = false; # build with CMake to get tests
+
+  src = fetchFromGitHub {
+    owner = "ros";
+    repo = "xacro";
+    tag = finalAttrs.version;
+    hash = "sha256-xYFwVM5qpy2/cYKtcf/v5sSlL2e/taIC4IQ48ZiRxiw=";
+  };
+
+  postPatch = ''
+    patchShebangs test/test-cmake.sh
+  '';
+
+  build-system = [
+    cmake
+    python3Packages.setuptools
+  ];
+
+  buildInputs = [
+    ament-cmake
+    ament-cmake-export-definitions
+    ament-cmake-export-include-directories
+    ament-cmake-export-libraries
+    ament-cmake-export-link-flags
+    ament-cmake-export-targets
+    ament-cmake-gen-version-h
+    ament-cmake-include-directories
+    ament-cmake-libraries
+    ament-cmake-python
+    ament-cmake-target-dependencies
+    ament-cmake-test
+    ament-cmake-version
+  ];
+
+  nativeCheckInputs = [
+    python3Packages.pytest
+  ];
+
+  checkInputs = [
+    python3Packages.ament-index-python
+    ament-lint-auto
+    ament-cmake-pytest
+  ];
+
+  dependencies = [
+    python3Packages.ament-package
+    python3Packages.catkin-pkg
+    python3Packages.pyyaml
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_TESTING" finalAttrs.doInstallCheck)
+  ];
+
+  preInstallCheck = ''
+    export PATH=$out/bin:$PATH
+    export PYTHONPATH=$out/${python3Packages.python.sitePackages}:$PYTHONPATH
+  '';
+
+  installCheckTarget = "test";
+
+  pythonImportsCheck = [ "xacro" ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Xacro is an XML macro language. With xacro, you can construct shorter and more readable XML files by using macros that expand to larger XML expressions";
+    homepage = "https://github.com/ros/xacro";
+    changelog = "https://github.com/ros/xacro/blob/${finalAttrs.src.rev}/CHANGELOG.rst";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ nim65s ];
+    mainProgram = "xacro";
+  };
+})

--- a/pkgs/by-name/xa/xacro/package.nix
+++ b/pkgs/by-name/xa/xacro/package.nix
@@ -3,29 +3,12 @@
   fetchFromGitHub,
 
   python3Packages,
-
-  ament-cmake,
-  ament-cmake-export-definitions,
-  ament-cmake-export-include-directories,
-  ament-cmake-export-libraries,
-  ament-cmake-export-link-flags,
-  ament-cmake-export-targets,
-  ament-cmake-gen-version-h,
-  ament-cmake-include-directories,
-  ament-cmake-libraries,
-  ament-cmake-pytest,
-  ament-cmake-python,
-  ament-cmake-target-dependencies,
-  ament-cmake-test,
-  ament-cmake-version,
-  ament-lint-auto,
-  cmake,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "xacro";
   version = "2.1.1";
-  pyproject = false; # build with CMake to get tests
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ros";
@@ -34,57 +17,14 @@ python3Packages.buildPythonApplication (finalAttrs: {
     hash = "sha256-xYFwVM5qpy2/cYKtcf/v5sSlL2e/taIC4IQ48ZiRxiw=";
   };
 
-  postPatch = ''
-    patchShebangs test/test-cmake.sh
-  '';
-
   build-system = [
-    cmake
     python3Packages.setuptools
-  ];
-
-  buildInputs = [
-    ament-cmake
-    ament-cmake-export-definitions
-    ament-cmake-export-include-directories
-    ament-cmake-export-libraries
-    ament-cmake-export-link-flags
-    ament-cmake-export-targets
-    ament-cmake-gen-version-h
-    ament-cmake-include-directories
-    ament-cmake-libraries
-    ament-cmake-python
-    ament-cmake-target-dependencies
-    ament-cmake-test
-    ament-cmake-version
-  ];
-
-  nativeCheckInputs = [
-    python3Packages.pytest
-  ];
-
-  checkInputs = [
-    python3Packages.ament-index-python
-    ament-lint-auto
-    ament-cmake-pytest
+    python3Packages.setuptools-scm
   ];
 
   dependencies = [
-    python3Packages.ament-package
-    python3Packages.catkin-pkg
     python3Packages.pyyaml
   ];
-
-  cmakeFlags = [
-    (lib.cmakeBool "BUILD_TESTING" finalAttrs.doInstallCheck)
-  ];
-
-  preInstallCheck = ''
-    export PATH=$out/bin:$PATH
-    export PYTHONPATH=$out/${python3Packages.python.sitePackages}:$PYTHONPATH
-  '';
-
-  installCheckTarget = "test";
 
   pythonImportsCheck = [ "xacro" ];
 

--- a/pkgs/by-name/xa/xacrodoc/package.nix
+++ b/pkgs/by-name/xa/xacrodoc/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  fetchFromGitHub,
+
+  python3Packages,
+  xacro,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "xacrodoc";
+  version = "2.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "adamheins";
+    repo = "xacrodoc";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-zuyd+lVcrz06yEgapoTjOZP+mxfOsk52rQE33aKV0qI=";
+  };
+
+  build-system = [
+    python3Packages.hatchling
+  ];
+
+  dependencies = [
+    python3Packages.rospkg
+    xacro
+  ];
+
+  optional-dependencies = {
+    mujoco = [
+      python3Packages.mujoco
+    ];
+  };
+
+  nativeCheckInputs = [
+    python3Packages.pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "xacrodoc"
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Compile xacro files to plain URDF or MJCF from Python or the command line (no ROS required)";
+    homepage = "https://github.com/adamheins/xacrodoc";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nim65s ];
+    mainProgram = "xacrodoc";
+  };
+})


### PR DESCRIPTION
Hi,

This add xacrodoc for https://github.com/NixOS/nixpkgs/pull/500244, but honestly I'm surprised xacro is not already in nixpkgs.

It is widely used in nix-ros-overlay at least.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
