### PR TITLE
link-grammar: 5.10.5 -> 5.13.0

### DIFF
--- a/pkgs/by-name/li/link-grammar/package.nix
+++ b/pkgs/by-name/li/link-grammar/package.nix
@@ -38,15 +38,27 @@ let
 
     buildInputs = [
       libedit
-      pcre2
       sqlite
+    ]
+    ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+      pcre2
     ];
 
     configureFlags = [
       "--disable-java-bindings"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # multi-dict and multi-threads crash when built with pcre2
+      # https://github.com/opencog/link-grammar/issues/1514
+      "--disable-pcre2"
     ];
 
-    doCheck = true;
+    preCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
+      export DYLD_LIBRARY_PATH=$(pwd)/link-grammar/.libs
+    '';
+
+    # multi-dict test randomly fails on x86_64-darwin
+    doCheck = stdenv.hostPlatform.system != "x86_64-darwin";
 
     passthru.tests = {
       quick =

--- a/pkgs/by-name/li/link-grammar/package.nix
+++ b/pkgs/by-name/li/link-grammar/package.nix
@@ -5,17 +5,18 @@
   pkg-config,
   python3,
   flex,
-  sqlite,
   libedit,
+  pcre2,
+  sqlite,
   runCommand,
   dieHook,
 }:
 
 let
 
-  link-grammar = stdenv.mkDerivation rec {
+  link-grammar = stdenv.mkDerivation (finalAttrs: {
     pname = "link-grammar";
-    version = "5.10.5";
+    version = "5.13.0";
 
     outputs = [
       "bin"
@@ -25,8 +26,8 @@ let
     ];
 
     src = fetchurl {
-      url = "http://www.abisource.com/downloads/link-grammar/${version}/link-grammar-${version}.tar.gz";
-      sha256 = "sha256-MkcQzYEyl1/5zLU1CXMvdVhHOxwZ8XiSAAo97bhhiu0=";
+      url = "https://www.gnucash.org/link-grammar/downloads/${finalAttrs.version}/link-grammar-${finalAttrs.version}.tar.gz";
+      hash = "sha256-5qDJBd+xdfNZefA1CgzzxnyzimgZ2fK3PGhN/nKpQd8=";
     };
 
     nativeBuildInputs = [
@@ -36,8 +37,9 @@ let
     ];
 
     buildInputs = [
-      sqlite
       libedit
+      pcre2
+      sqlite
     ];
 
     configureFlags = [
@@ -64,13 +66,13 @@ let
 
     meta = {
       description = "Grammar Checking library";
-      homepage = "https://www.abisource.com/projects/link-grammar/";
-      changelog = "https://github.com/opencog/link-grammar/blob/link-grammar-${version}/ChangeLog";
+      homepage = "https://opencog.github.io/link-grammar-website/";
+      changelog = "https://github.com/opencog/link-grammar/blob/link-grammar-${finalAttrs.version}/ChangeLog";
       license = lib.licenses.lgpl21Only;
       maintainers = with lib.maintainers; [ jtojnar ];
       platforms = lib.platforms.unix;
     };
-  };
+  });
 
 in
 link-grammar


### PR DESCRIPTION
- #516381 
- https://hydra.nixos.org/build/326823838
- Changelog: https://github.com/opencog/link-grammar/blob/link-grammar-5.13.0/ChangeLog
- Diff: https://github.com/opencog/link-grammar/compare/link-grammar-5.10.5...link-grammar-5.13.0

Also updated URLs.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
