### PR TITLE
ldmtool: 0.2.4 -> 0.2.5-unstable-2025-02-06

### DIFF
--- a/pkgs/by-name/ld/ldmtool/package.nix
+++ b/pkgs/by-name/ld/ldmtool/package.nix
@@ -14,35 +14,23 @@
   lvm2,
   libxslt,
   docbook_xsl,
-  fetchpatch,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ldmtool";
-  version = "0.2.4";
+  version = "0.2.5-unstable-2025-02-06";
 
   src = fetchFromGitHub {
     owner = "mdbooth";
     repo = "libldm";
-    rev = "libldm-${finalAttrs.version}";
-    sha256 = "1fy5wbmk8kwl86lzswq0d1z2j5y023qzfm2ppm8knzv9c47kniqk";
+    rev = "1eafb653ac6347a9d4281848c8295f9daffb1613";
+    hash = "sha256-Vd+3FnM+U5y2FxuslEsEzgZEx+5AQWuTjUVRnoFhm3I=";
   };
-
-  patches = [
-    # Remove usage of deprecrated G_PARAM_PRIVATE
-    (fetchpatch {
-      url = "https://github.com/mdbooth/libldm/commit/ee1b37a034038f09d61b121cc8b3651024acc46f.patch";
-      sha256 = "02y34kbcpcpffvy1n9yqngvdldmxmvdkha1v2xjqvrnclanpigcp";
-    })
-  ];
 
   preConfigure = ''
     sed -i docs/reference/ldmtool/Makefile.am \
       -e 's|-nonet http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl|--nonet ${docbook_xsl}/xml/xsl/docbook/manpages/docbook.xsl|g'
   '';
-
-  # glib-2.62 deprecations
-  env.NIX_CFLAGS_COMPILE = "-DGLIB_DISABLE_DEPRECATION_WARNINGS";
 
   configureScript = "sh autogen.sh";
 

--- a/pkgs/by-name/ld/ldmtool/package.nix
+++ b/pkgs/by-name/ld/ldmtool/package.nix
@@ -19,30 +19,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ldmtool";
-  version = "0.2.4";
+  version = "0.2.5-unstable-2025-02-06";
 
   src = fetchFromGitHub {
     owner = "mdbooth";
     repo = "libldm";
-    rev = "libldm-${finalAttrs.version}";
-    sha256 = "1fy5wbmk8kwl86lzswq0d1z2j5y023qzfm2ppm8knzv9c47kniqk";
+    rev = "1eafb653ac6347a9d4281848c8295f9daffb1613";
+    hash = "sha256-Vd+3FnM+U5y2FxuslEsEzgZEx+5AQWuTjUVRnoFhm3I=";
   };
-
-  patches = [
-    # Remove usage of deprecrated G_PARAM_PRIVATE
-    (fetchpatch {
-      url = "https://github.com/mdbooth/libldm/commit/ee1b37a034038f09d61b121cc8b3651024acc46f.patch";
-      sha256 = "02y34kbcpcpffvy1n9yqngvdldmxmvdkha1v2xjqvrnclanpigcp";
-    })
-  ];
 
   preConfigure = ''
     sed -i docs/reference/ldmtool/Makefile.am \
       -e 's|-nonet http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl|--nonet ${docbook_xsl}/xml/xsl/docbook/manpages/docbook.xsl|g'
   '';
-
-  # glib-2.62 deprecations
-  env.NIX_CFLAGS_COMPILE = "-DGLIB_DISABLE_DEPRECATION_WARNINGS";
 
   configureScript = "sh autogen.sh";
 


### PR DESCRIPTION
- #475479 
- #516381 
- https://hydra.nixos.org/build/326820688

```
ldmtool.c: In function 'main':
ldmtool.c:786:23: error: too many arguments to function 'ldm_new'; expected 0, have 1
  786 |     LDM * const ldm = ldm_new(&err);
      |                       ^~~~~~~ ~~~~
In file included from ldmtool.c:37:
ldm.h:257:6: note: declared here
  257 | LDM *ldm_new();
      |      ^~~~~~~
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
