### PR TITLE
nixos-install: make channel environment a bit more sanely-shaped

### DIFF
--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -264,6 +264,11 @@ let
           target.succeed("nix-env -iA nixos.procps >&2")
           assert ".nix-profile" in target.succeed("type -tP ps | tee /dev/stderr")
 
+          # This test is a bit hacky, and relies on `zzz` being lower in the alphabet
+          # than `nixos`, the only other channel we have.
+          target.succeed("nix-channel --add http://example.com zzz")
+          assert "Invalid argument" not in target.execute("nix-channel --update zzz")[1]
+
       with subtest(
           "Check that the daemon works, and that non-root users can run builds "
           "(this will build a new profile generation through the daemon)"

--- a/pkgs/by-name/ni/nixos-install/nixos-install.sh
+++ b/pkgs/by-name/ni/nixos-install/nixos-install.sh
@@ -255,7 +255,7 @@ if [[ -z $noChannelCopy ]]; then
         echo "copying channel..."
         mkdir -p "$mountPoint"/nix/var/nix/profiles/per-user/root
         nix-env --store "$mountPoint" "${extraBuildFlags[@]}" --extra-substituters "$sub" \
-                -p "$mountPoint"/nix/var/nix/profiles/per-user/root/channels --set "$channelPath" --quiet \
+                -p "$mountPoint"/nix/var/nix/profiles/per-user/root/channels --remove-all --install "$channelPath" --quiet \
                 "${verbosity[@]}"
         install -m 0700 -d "$mountPoint"/root/.nix-defexpr
         ln -sfn /nix/var/nix/profiles/per-user/root/channels "$mountPoint"/root/.nix-defexpr/channels


### PR DESCRIPTION
When using `--set`, `nix-env` puts a literal `nixos` folder in `/nix/var/nix/profiles/per-user/root/channels`, which isn't what `nix-channel` expects.

For stupid reasons [0], if one does `nix-channel --add ... foo && nix-channel --update foo` as soon as installing NixOS, but *before* running an update including the `nixos` channel, the update will fail. Using `nix-env --install` instead of `nix-env --set` gives us what we want (and we use `--remove-all` just to keep parity with `--set`).

[0]: `nix-channel` tries to rebuild the environment every time, as well as expects channel names within said environment to always be symlinks: https://git.lix.systems/lix-project/lix/src/commit/010d0629261248ad846f9f12b356053514e464eb/lix/legacy/nix-channel.cc#L120


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
