### PR TITLE
fakecloud: init at 0.13.3, buildGithubBinary: init

### DIFF
--- a/pkgs/build-support/github-binary/default.nix
+++ b/pkgs/build-support/github-binary/default.nix
@@ -1,0 +1,130 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  callPackage,
+}:
+
+{
+  pname,
+  owner,
+  repo,
+  sourcesJson,
+  tagPrefix ? "v",
+  ...
+}@args:
+
+let
+  sources = lib.importJSON sourcesJson;
+  inherit (sources) version assets;
+
+  asset =
+    assets.${stdenv.hostPlatform.system}
+      or (throw "buildGithubBinary: unsupported platform ${stdenv.hostPlatform.system} for ${pname}");
+
+  src = fetchurl {
+    url = "https://github.com/${owner}/${repo}/releases/download/${tagPrefix}${version}/${asset.asset}";
+    inherit (asset) sha256;
+  };
+
+  isTarball = lib.any (ext: lib.hasSuffix ext asset.asset) [
+    ".tar.gz"
+    ".tgz"
+    ".tar.xz"
+    ".tar.bz2"
+    ".tar.zst"
+  ];
+  isGzippedBinary = lib.hasSuffix ".gz" asset.asset && !lib.hasSuffix ".tar.gz" asset.asset;
+
+  mainProgram = args.meta.mainProgram or pname;
+
+  unpackPhase =
+    if isTarball then
+      ''
+        runHook preUnpack
+        tar -xf $src --strip-components=1
+        runHook postUnpack
+      ''
+    else if isGzippedBinary then
+      ''
+        runHook preUnpack
+        gzip -d < $src > ${mainProgram}
+        chmod +x ${mainProgram}
+        runHook postUnpack
+      ''
+    else
+      ''
+        runHook preUnpack
+        cp $src ${mainProgram}
+        chmod +x ${mainProgram}
+        runHook postUnpack
+      '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 ${mainProgram} $out/bin/${mainProgram}
+    runHook postInstall
+  '';
+
+  nixpkgsRoot = toString ../../..;
+  sourcesJsonAbsolute = toString sourcesJson;
+  sourcesJsonRelative =
+    if lib.hasPrefix (nixpkgsRoot + "/") sourcesJsonAbsolute then
+      lib.removePrefix (nixpkgsRoot + "/") sourcesJsonAbsolute
+    else
+      throw "buildGithubBinary: sourcesJson (${sourcesJsonAbsolute}) must live inside the nixpkgs tree (${nixpkgsRoot})";
+
+  updateScript = callPackage ./update.nix { } {
+    inherit
+      pname
+      owner
+      repo
+      tagPrefix
+      ;
+    sourcesJson = sourcesJsonRelative;
+    platforms = builtins.attrNames assets;
+  };
+
+  forwardedArgs = removeAttrs args [
+    "owner"
+    "repo"
+    "tagPrefix"
+    "sourcesJson"
+  ];
+
+  passthru = (args.passthru or { }) // {
+    inherit updateScript;
+  };
+
+  meta = {
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = builtins.attrNames assets;
+  }
+  // (args.meta or { });
+in
+stdenv.mkDerivation (
+  forwardedArgs
+  // {
+    inherit
+      pname
+      version
+      src
+      unpackPhase
+      installPhase
+      passthru
+      meta
+      ;
+
+    strictDeps = args.strictDeps or true;
+    __structuredAttrs = args.__structuredAttrs or true;
+
+    nativeBuildInputs =
+      (args.nativeBuildInputs or [ ]) ++ lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook;
+
+    buildInputs =
+      (args.buildInputs or [ ]) ++ lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.cc ];
+
+    dontStrip = args.dontStrip or true;
+  }
+)

--- a/pkgs/build-support/github-binary/update.nix
+++ b/pkgs/build-support/github-binary/update.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  curl,
+  writeShellScript,
+  jq,
+  gnused,
+  git,
+  nix,
+  coreutils,
+}:
+{
+  pname,
+  owner,
+  repo,
+  tagPrefix,
+  sourcesJson,
+  platforms,
+}:
+
+writeShellScript "${pname}-update-script" ''
+  set -o errexit
+  PATH=${
+    lib.makeBinPath [
+      curl
+      jq
+      gnused
+      git
+      nix
+      coreutils
+    ]
+  }
+
+  nixpkgs=$(git rev-parse --show-toplevel)
+  sources_json="$nixpkgs/${sourcesJson}"
+  if [[ ! -f "$sources_json" ]]; then
+    echo "buildGithubBinary update: $sources_json not found (run from inside the nixpkgs checkout)" >&2
+    exit 1
+  fi
+
+  old_version=$(jq --raw-output ".version" < "$sources_json")
+  latest_version=$(curl -s "https://api.github.com/repos/${owner}/${repo}/releases?per_page=1" \
+    | jq --raw-output ".[0].tag_name" \
+    | sed 's/^${tagPrefix}//')
+
+  if [[ "$old_version" = "$latest_version" ]]; then
+      echo "${pname} is already at the latest version $latest_version."
+      exit 0
+  fi
+
+  platform_assets=()
+
+  for platform in ${lib.concatStringsSep " " platforms}; do
+    old_asset=$(jq --raw-output ".assets.\"$platform\".asset" < "$sources_json")
+    new_asset=''${old_asset//$old_version/$latest_version}
+    release_asset_url="https://github.com/${owner}/${repo}/releases/download/${tagPrefix}$latest_version/$new_asset"
+
+    asset_hash=$(nix-prefetch-url "$release_asset_url")
+
+    asset_object=$(jq --compact-output --null-input \
+      --arg asset "$new_asset" \
+      --arg sha256 "$asset_hash" \
+      --arg platform "$platform" \
+      '{asset: $asset, sha256: $sha256, platform: $platform}')
+    platform_assets+=("$asset_object")
+  done
+
+  printf '%s\n' "''${platform_assets[@]}" \
+    | jq -s "map ( { (.platform): . | del(.platform) }) | add" \
+    | jq --arg version "$latest_version" \
+        '{ version: $version, assets: . }' > "$sources_json"
+''

--- a/pkgs/by-name/fa/fakecloud/package.nix
+++ b/pkgs/by-name/fa/fakecloud/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  buildGithubBinary,
+  testers,
+  fakecloud,
+}:
+
+buildGithubBinary {
+  pname = "fakecloud";
+  owner = "faiscadev";
+  repo = "fakecloud";
+  sourcesJson = ./sources.json;
+
+  passthru.tests.version = testers.testVersion {
+    package = fakecloud;
+    command = "fakecloud --version";
+  };
+
+  meta = {
+    description = "Free, open-source AWS emulator (LocalStack alternative)";
+    homepage = "https://github.com/faiscadev/fakecloud";
+    downloadPage = "https://github.com/faiscadev/fakecloud/releases";
+    license = lib.licenses.agpl3Only;
+    mainProgram = "fakecloud";
+    maintainers = with lib.maintainers; [ kubukoz ];
+  };
+}

--- a/pkgs/by-name/fa/fakecloud/sources.json
+++ b/pkgs/by-name/fa/fakecloud/sources.json
@@ -1,0 +1,21 @@
+{
+  "version": "0.13.3",
+  "assets": {
+    "aarch64-darwin": {
+      "asset": "fakecloud-v0.13.3-darwin-arm64.tar.gz",
+      "sha256": "1gi439kzxm4jph9i7j6d20jjdn8wc1mgmcy2sj629gs86cmxzrb7"
+    },
+    "aarch64-linux": {
+      "asset": "fakecloud-v0.13.3-linux-arm64.tar.gz",
+      "sha256": "0cnvnr43c501shrd0drfqz1cj59c6j313xl9dmbzdw7j8zbam3dd"
+    },
+    "x86_64-darwin": {
+      "asset": "fakecloud-v0.13.3-darwin-amd64.tar.gz",
+      "sha256": "06l0s4dwl43m7h4avz5sv7x0w3abaxi3yr73nra4qh016f59nsnk"
+    },
+    "x86_64-linux": {
+      "asset": "fakecloud-v0.13.3-linux-amd64.tar.gz",
+      "sha256": "1y6nrgw86lr62cdzfnav8q01p36gpn826d7vkr82z7bp9lffb60c"
+    }
+  }
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4260,6 +4260,8 @@ with pkgs;
   openjdk = jdk;
   openjdk_headless = jdk_headless;
 
+  buildGithubBinary = callPackage ../build-support/github-binary { };
+
   graalvmPackages = recurseIntoAttrs (callPackage ../development/compilers/graalvm { });
   buildGraalvmNativeImage = callPackage ../build-support/build-graalvm-native-image { };
 


### PR DESCRIPTION
## Summary

- Adds `buildGithubBinary`, a generic builder for prebuilt-binary packages distributed as multi-platform GitHub release assets, under `pkgs/build-support/github-binary/`. This pattern is pretty common, and I intend to upstream a few more packages using it.
- Adds `fakecloud` 0.13.3 (free, open-source AWS emulator / LocalStack alternative) as the first consumer.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
  - [x] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests` (`testers.testVersion` against `fakecloud --version`).
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files (`fakecloud --version` reports `fakecloud 0.13.3`).
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.

## Verification

- `nix-build -A fakecloud` succeeds on aarch64-darwin.
- `nix-build -A fakecloud.tests.version` passes.
- `nix-instantiate --eval` succeeds for all four declared platforms.
- `nixfmt --check` clean on all changed files.
- `passthru.updateScript` runs end-to-end (no-ops since 0.13.3 is current).

🤖 Built with assistance of [Claude Code](https://claude.com/claude-code)