### PR TITLE
efficient-compression-tool: fix segfault with gcc15

### DIFF
--- a/pkgs/by-name/ef/efficient-compression-tool/ect-gcc-15-O3-fix.patch
+++ b/pkgs/by-name/ef/efficient-compression-tool/ect-gcc-15-O3-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/src/LzFind.c b/src/LzFind.c
+index 98d0ac6..f1bee55 100755
+--- a/src/LzFind.c
++++ b/src/LzFind.c
+@@ -229,7 +229,7 @@ static unsigned short * GetMatches2(UInt32 lenLimit, UInt32 curMatch, UInt32 pos
+     const unsigned char* _min = min;
+     unsigned cnt = 0;
+     if (_min < pb - (rle_len - len)) {_min = pb - (rle_len - len);}
+-    while (rle_pos > _min && *(uint64_t*)(rle_pos - 8) == starter_full) {rle_pos-=8; cnt+=8;}
++    while (rle_pos > _min && *(__typeof__(const uint64_t __attribute__((aligned(1))))*)(rle_pos - 8) == starter_full) {rle_pos-=8; cnt+=8;}
+     if (cnt) {
+       if (cnt + len > rle_len - 1) {cnt = rle_len - 1 - len;}
+       curMatch_rle -= cnt;

--- a/pkgs/by-name/ef/efficient-compression-tool/package.nix
+++ b/pkgs/by-name/ef/efficient-compression-tool/package.nix
@@ -22,6 +22,10 @@ stdenv.mkDerivation (finalAttrs: {
     fetchSubmodules = true;
   };
 
+  patches = [
+    ./ect-gcc-15-O3-fix.patch
+  ];
+
   # devendor libpng
   postPatch = ''
     substituteInPlace src/CMakeLists.txt \

--- a/pkgs/by-name/ef/efficient-compression-tool/package.nix
+++ b/pkgs/by-name/ef/efficient-compression-tool/package.nix
@@ -22,6 +22,11 @@ stdenv.mkDerivation (finalAttrs: {
     fetchSubmodules = true;
   };
 
+  patches = [
+    # from https://github.com/fhanau/Efficient-Compression-Tool/issues/145
+    ./ect-gcc-15-O3-fix.patch
+  ];
+
   # devendor libpng
   postPatch = ''
     substituteInPlace src/CMakeLists.txt \


### PR DESCRIPTION
efficient-compression-tool currently segfaults when optimizing PNG files due to a bug which presents itself when built with GCC 15.
The provided patch was lifted from https://github.com/fhanau/Efficient-Compression-Tool/issues/145.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
