### PR TITLE
[Backport staging-25.11] nspr: 4.38.2 -> 4.39

### DIFF
--- a/pkgs/by-name/ns/nspr/0001-Makefile-use-SOURCE_DATE_EPOCH-for-reproducibility.patch
+++ b/pkgs/by-name/ns/nspr/0001-Makefile-use-SOURCE_DATE_EPOCH-for-reproducibility.patch
@@ -1,20 +1,8 @@
-From e5cc8f7c387e3238ebb8239e2555c933a41502c0 Mon Sep 17 00:00:00 2001
-From: Graham Christensen <graham@grahamc.com>
-Date: Thu, 7 Mar 2019 08:11:32 -0500
-Subject: [PATCH] Makefile: use SOURCE_DATE_EPOCH for reproducibility
-
----
- nspr/lib/ds/Makefile.in        | 4 ++--
- nspr/lib/libc/src/Makefile.in  | 4 ++--
- nspr/lib/prstreams/Makefile.in | 4 ++--
- nspr/pr/src/Makefile.in        | 6 +++---
- 4 files changed, 9 insertions(+), 9 deletions(-)
-
 diff --git a/nspr/lib/ds/Makefile.in b/nspr/lib/ds/Makefile.in
-index e737791..d56b0a7 100644
+index fa8c783..eff1ac3 100644
 --- a/nspr/lib/ds/Makefile.in
 +++ b/nspr/lib/ds/Makefile.in
-@@ -101,8 +101,8 @@ ECHO = echo
+@@ -91,8 +91,8 @@ ECHO = echo
  TINC = $(OBJDIR)/_pl_bld.h
  PROD = $(notdir $(SHARED_LIBRARY))
  NOW = $(MOD_DEPTH)/config/$(OBJDIR)/now
@@ -26,10 +14,10 @@ index e737791..d56b0a7 100644
  ifeq ($(NS_USE_GCC)_$(OS_ARCH),_WINNT)
  	SUF = i64
 diff --git a/nspr/lib/libc/src/Makefile.in b/nspr/lib/libc/src/Makefile.in
-index e8a6d9f..0485737 100644
+index 9ef2007..2d5db8f 100644
 --- a/nspr/lib/libc/src/Makefile.in
 +++ b/nspr/lib/libc/src/Makefile.in
-@@ -103,8 +103,8 @@ ECHO = echo
+@@ -93,8 +93,8 @@ ECHO = echo
  TINC = $(OBJDIR)/_pl_bld.h
  PROD = $(notdir $(SHARED_LIBRARY))
  NOW = $(MOD_DEPTH)/config/$(OBJDIR)/now
@@ -39,37 +27,13 @@ index e8a6d9f..0485737 100644
 +SH_NOW = $(SOURCE_DATE_EPOCH)000000
  
  ifeq ($(NS_USE_GCC)_$(OS_ARCH),_WINNT)
- 	SUF = i64
-diff --git a/nspr/lib/prstreams/Makefile.in b/nspr/lib/prstreams/Makefile.in
-index aeb2944..83ae423 100644
---- a/nspr/lib/prstreams/Makefile.in
-+++ b/nspr/lib/prstreams/Makefile.in
-@@ -105,8 +105,8 @@ ECHO = echo
- TINC = $(OBJDIR)/_pl_bld.h
- PROD = $(notdir $(SHARED_LIBRARY))
- NOW = $(MOD_DEPTH)/config/$(OBJDIR)/now
--SH_DATE = $(shell date "+%Y-%m-%d %T")
--SH_NOW = $(shell $(NOW))
-+SH_DATE = $(shell date "+%Y-%m-%d %T" --date $(SOURCE_DATE_EPOCH))
-+SH_NOW = $(SOURCE_DATE_EPOCH)000000
- 
- ifeq ($(OS_ARCH), WINNT)
  	SUF = i64
 diff --git a/nspr/pr/src/Makefile.in b/nspr/pr/src/Makefile.in
-index 19c5a69..989cc8c 100644
+index a9e86f5..854c0a9 100644
 --- a/nspr/pr/src/Makefile.in
 +++ b/nspr/pr/src/Makefile.in
-@@ -46,7 +46,7 @@ MKSHLIB += -M $(MAPFILE)
- endif
- #
- # In Solaris 2.6 or earlier, -lrt is called -lposix4.
--# 
-+#
- LIBRT_TEST=$(firstword $(sort 5.7 $(OS_RELEASE)))
- ifeq (5.7, $(LIBRT_TEST))
- LIBRT=-lrt
-@@ -311,8 +311,8 @@ PROD = $(notdir $(SHARED_LIBRARY))
- endif
+@@ -276,8 +276,8 @@ TINC = $(OBJDIR)/_pr_bld.h
+ PROD = $(notdir $(SHARED_LIBRARY))
  
  NOW = $(MOD_DEPTH)/config/$(OBJDIR)/now
 -SH_DATE = $(shell date "+%Y-%m-%d %T")
@@ -79,6 +43,3 @@ index 19c5a69..989cc8c 100644
  
  ifeq ($(NS_USE_GCC)_$(OS_ARCH),_WINNT)
  	SUF = i64
--- 
-2.19.2
-

--- a/pkgs/by-name/ns/nspr/package.nix
+++ b/pkgs/by-name/ns/nspr/package.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation rec {
   pname = "nspr";
-  version = "4.38.2";
+  version = "4.39";
 
   src = fetchurl {
     url = "mirror://mozilla/nspr/releases/v${version}/src/nspr-${version}.tar.gz";
-    hash = "sha256-5Akvrqt3vcmzLbERPkIVlI7naOJsRmbbO1pgs18skQU=";
+    hash = "sha256-u9Au6HpVZ2Bjpj5byBngIn3iZmtHMHsqATRBTN9CNo4=";
   };
 
   patches = [


### PR DESCRIPTION
NSPR 4.39 contains the following changes:

- Improved error handling in PR_CreateThread on Windows
- Cleanup and Type-cast fixes for prtime
- Remove unused prstreams C++ wrapper from NSPR
- Memory poisoning and Arena redzone fixes
- Removed emacs/vim modelines and .cvsignore files
- Added .editorconfig

via dev-tech-crypto

(cherry picked from commit 5b3df9d80eb15152f58e130d2a3567626376c33d) #516882


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
