### PR TITLE
gitlab-runner: revise which tests we skip

### DIFF
--- a/pkgs/by-name/gi/gitlab-runner/package.nix
+++ b/pkgs/by-name/gi/gitlab-runner/package.nix
@@ -38,26 +38,30 @@ buildGoModule (finalAttrs: {
     substituteInPlace commands/helpers/file_archiver_test.go \
       --replace-fail "func TestCacheArchiverAddingUntrackedFiles" "func OFF_TestCacheArchiverAddingUntrackedFiles" \
       --replace-fail "func TestCacheArchiverAddingUntrackedUnicodeFiles" "func OFF_TestCacheArchiverAddingUntrackedUnicodeFiles"
-    rm shells/abstract_test.go
 
-    # No writable developer environment
+    # Needs `make development_setup` (git repo at tmp/gitlab-test/)
     rm common/build_settings_test.go
     rm common/build_test.go
     rm executors/custom/custom_test.go
 
-    # No Docker during build
-    rm executors/docker/docker_test.go
-    rm executors/docker/services_test.go
-    rm executors/docker/terminal_test.go
-    rm helpers/docker/auth/auth_test.go
-
-    # No Kubernetes during build
-    rm executors/kubernetes/feature_test.go
+    # Timing-dependent test causes spurious failures on Hydra.
+    # Might be fixed upstream in this MR: https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/6623
+    # Try dropping it on next major version bump
+    rm executors/kubernetes/internal/watchers/pod_test.go
+  ''
+  + lib.optionalString (!stdenv.buildPlatform.isx86_64) ''
+    # Kubernetes tests actually work fine inside the network sandbox (they don't
+    # expect real Kubernetes), but they fail on aarch64-linux because their
+    # mocks expect x86_64
     rm executors/kubernetes/kubernetes_test.go
     rm executors/kubernetes/overwrites_test.go
   ''
   + lib.optionalString stdenv.buildPlatform.isDarwin ''
-    # Invalid bind arguments break Unix socket tests
+    # Darwin's sandbox blocks sendfile(2) during local HTTP PUT uploads
+    substituteInPlace commands/helpers/cache_archiver_test.go \
+      --replace-fail "func TestUploadExistingArchiveIfNeeded" "func OFF_TestUploadExistingArchiveIfNeeded"
+
+    # Invalid bind arguments break Unix socket tests.
     substituteInPlace commands/wrapper_test.go \
       --replace-fail "func TestRunnerWrapperCommand_createListener" "func OFF_TestRunnerWrapperCommand_createListener"
 
@@ -66,6 +70,10 @@ buildGoModule (finalAttrs: {
       --replace-fail "func TestCertificate" "func OFF_TestCertificate"
     substituteInPlace network/client_test.go \
       --replace-fail "func TestClientInvalidSSL" "func OFF_TestClientInvalidSSL"
+  '';
+
+  postPatch = ''
+    patchShebangs --build helpers/docker/auth/testdata/docker-credential-bin.sh
   '';
 
   excludedPackages = [


### PR DESCRIPTION
ZHF: #516381

I saw gitlab-runner wasn't in my binary cache and it seems like a particular test prevented the checkPhase from passing on Hydra. I found an upstream issue related it and tried disabling that test, which will hopefully fix it.

While I was working in there, I noticed some tests were disabled with sort of unclear comments, and actually that some tests could be re-enabled and the build would still work.

In the course of my testing I noticed that some tests behaved differently if the job was initiated from my Mac, realized that the `sandbox = false` setting was getting passed to the remote Linux builder, and decided to try reenabling the sandbox on my Mac. I found that with one more test disabled, building works nicely in the sandbox on Darwin, so I added that as well.

A minor release also came out a couple days ago so I gave this a version bump, too.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
