### PR TITLE
python3Packages.pyquaternion: fix build

### DIFF
--- a/pkgs/development/python-modules/pyquaternion/default.nix
+++ b/pkgs/development/python-modules/pyquaternion/default.nix
@@ -21,6 +21,9 @@ buildPythonPackage rec {
 
   patches = [
     ./numpy2-repr.patch
+    # patch tests for numpy v2.4 behaviour
+    # https://numpy.org/devdocs/release/2.4.0-notes.html#raise-typeerror-on-attempt-to-convert-array-with-ndim-0-to-scalar
+    ./numpy2-float.patch
   ];
 
   # The VERSION.txt file is required for setup.py

--- a/pkgs/development/python-modules/pyquaternion/default.nix
+++ b/pkgs/development/python-modules/pyquaternion/default.nix
@@ -21,6 +21,7 @@ buildPythonPackage rec {
 
   patches = [
     ./numpy2-repr.patch
+    ./numpy2-float.patch
   ];
 
   # The VERSION.txt file is required for setup.py

--- a/pkgs/development/python-modules/pyquaternion/numpy2-float.patch
+++ b/pkgs/development/python-modules/pyquaternion/numpy2-float.patch
@@ -1,0 +1,13 @@
+diff --git a/pyquaternion/test/test_quaternion.py b/pyquaternion/test/test_quaternion.py
+index f56afff..1a121c4 100644
+--- a/pyquaternion/test/test_quaternion.py
++++ b/pyquaternion/test/test_quaternion.py
+@@ -936,7 +936,7 @@ class TestQuaternionFeatures(unittest.TestCase):
+         for i in range(20):
+             v = np.random.uniform(-1, 1, 3)
+             v /= np.linalg.norm(v)
+-            theta = float(np.random.uniform(-2,2, 1)) * pi
++            theta = np.random.uniform(-2,2, 1).item() * pi
+             self.validate_axis_angle(v, theta)
+ 
+     def test_exp(self):


### PR DESCRIPTION
fixes https://hydra.nixos.org/build/326891336 zhf https://github.com/NixOS/nixpkgs/issues/516381


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
