### PR TITLE
terminal-rain: init at 0-unstable-2026-04-30

### DIFF
--- a/pkgs/by-name/te/terminal-rain-lightning/package.nix
+++ b/pkgs/by-name/te/terminal-rain-lightning/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  ffmpeg,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "terminal-rain-lightning";
+  version = "0-unstable-2026-04-30";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "rmaake1";
+    repo = "terminal-rain-lightning";
+    rev = "cc3aa19e1e9aec628a608b0ca6b7c475cce98c05";
+    hash = "sha256-GJvGnvo78l4RK2Y9ACbqOXHLQkNtIwIktbm/FK1vOcc=";
+  };
+
+  build-system = [
+    python3Packages.setuptools
+  ];
+
+  preFixup = ''
+    makeWrapperArgs+=("--prefix" "PATH" ":" "${lib.makeBinPath [ ffmpeg ]}")
+  '';
+
+  __structuredAttrs = true;
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Terminal-based ASCII rain and lightning animation";
+    homepage = "https://github.com/rmaake1/terminal-rain-lightning";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nicolas-goudry ];
+    mainProgram = "terminal-rain";
+  };
+})


### PR DESCRIPTION
This is useless but very cool, hence we need it in nixpkgs.

It shows a rain animation with optional thunder in ASCII art inside the terminal, with sound support (opt-in at runtime, but ffmpeg is always pulled in bin path to ensure support).

[View project on GitHub](https://github.com/rmaake1/terminal-rain-lightning)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
