### PR TITLE
mcrypt: fix build with gcc15

### DIFF
--- a/pkgs/by-name/mc/mcrypt/gcc15.patch
+++ b/pkgs/by-name/mc/mcrypt/gcc15.patch
@@ -1,0 +1,48 @@
+diff --git a/src/defines.h b/src/defines.h
+index 9533476..1999826 100644
+--- a/src/defines.h
++++ b/src/defines.h
+@@ -164,7 +164,7 @@
+ #endif
+ 
+ /*extern char *getpass();*/
+-extern char *crypt(); /* libufc */
++extern char *crypt(const char *key, const char *salt); /* libufc */
+ 
+ #if HAVE_TERMIOS_H
+ # include <termios.h>
+diff --git a/src/extra.h b/src/extra.h
+index b655291..bae372e 100644
+--- a/src/extra.h
++++ b/src/extra.h
+@@ -14,7 +14,7 @@ char *get_cfile(int uid, char*);
+ void Bzero(void *s, size_t n);
+ void mcrypt_tolow(char *str, int size);
+ 
+-char *my_getpass();
++char *my_getpass(char *prt);
+ int check_file_head(FILE *fstream, char *algorithm, char* mode, char* keymode, int *keysize, void* salt, int* salt_size);
+ void* read_iv(FILE *fstream, int ivsize);
+ int write_file_head(FILE * filedes, char* algorithm, char* mode, char* keymode, int* keysize, void *salt, int salt_size);
+diff --git a/src/ufc_crypt.c b/src/ufc_crypt.c
+index 8c452d7..7f3a68f 100644
+--- a/src/ufc_crypt.c
++++ b/src/ufc_crypt.c
+@@ -28,7 +28,7 @@
+ 
+ /* UFC optimized for 32 bit machines */
+ 
+-extern word32 *_ufc_dofinalperm();
++extern word32 *_ufc_dofinalperm(word32 l1, word32 l2, word32 r1, word32 r2);
+ 
+ 
+ /*
+@@ -668,7 +668,7 @@ char *salt;
+ 	return outbuf;
+ }
+ 
+-word32 *_ufc_doit();
++word32 *_ufc_doit(word32 l1, word32 l2, word32 r1, word32 r2, word32 itr);
+ 
+ /* 
+  * UNIX crypt function

--- a/pkgs/by-name/mc/mcrypt/package.nix
+++ b/pkgs/by-name/mc/mcrypt/package.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
     ./segv.patch
     ./sprintf_CVE-2012-4527.patch
     ./malloc_to_stdlib.patch
+    ./gcc15.patch
   ];
 
   buildInputs = [


### PR DESCRIPTION
- #475479 
- #516381
- https://hydra.nixos.org/build/326832173

```
In file included from extra.c:24:
./defines.h:167:14: error: conflicting types for 'crypt'; have 'char *(void)'
  167 | extern char *crypt(); /* libufc */
      |              ^~~~~
In file included from /nix/store/vh0jy0l1hl4gpf3fwi293sql0zmx5hif-mhash-0.9.9.9/include/mutils/mincludes.h:78,
                 from /nix/store/vh0jy0l1hl4gpf3fwi293sql0zmx5hif-mhash-0.9.9.9/include/mhash.h:6,
                 from ./defines.h:8:
/nix/store/fbbw928argckfii0j322346ihmllg7a7-glibc-2.42-61-dev/include/unistd.h:1162:14: note: previous declaration of 'crypt' with type 'char *(const char *, const char *)'
 1162 | extern char *crypt (const char *__key, const char *__salt)
      |              ^~~~~
extra.c:71:7: error: conflicting types for 'my_getpass'; have 'char *(char *)'
   71 | char *my_getpass(char *prt)
      |       ^~~~~~~~~~
In file included from extra.c:27:
extra.h:17:7: note: previous declaration of 'my_getpass' with type 'char *(void)'
   17 | char *my_getpass();
      |       ^~~~~~~~~~
extra.c: In function 'my_getpass':
extra.c:78:17: warning: the comparison will always evaluate as 'false' for the address of 'ztmp' will never be NULL [-Waddress]
   78 |         if (ztmp==NULL) return NULL;
      |                 ^~
extra.c:74:21: note: 'ztmp' declared here
   74 |         static char ztmp[MAX_KEY_LEN];
      |                     ^~~~
...
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
