### PR TITLE
nixos/incus-image: disable cloneConfig module

### DIFF
--- a/nixos/maintainers/scripts/incus/incus-container-image.nix
+++ b/nixos/maintainers/scripts/incus/incus-container-image.nix
@@ -32,6 +32,9 @@
       };
     };
 
+  # Disable the cloneConfig module. We have our own Service to generate a configuration.nix.
+  installer.cloneConfig = false;
+
   networking = {
     dhcpcd.enable = false;
     useDHCP = false;

--- a/nixos/maintainers/scripts/incus/incus-virtual-machine-image.nix
+++ b/nixos/maintainers/scripts/incus/incus-virtual-machine-image.nix
@@ -32,6 +32,9 @@
       };
     };
 
+  # Disable the cloneConfig module. We have our own Service to generate a configuration.nix.
+  installer.cloneConfig = false;
+
   # Network
   networking = {
     dhcpcd.enable = false;

--- a/nixos/tests/incus/incus-tests-module.nix
+++ b/nixos/tests/incus/incus-tests-module.nix
@@ -164,6 +164,7 @@ in
 
                   with subtest("[${image_id}] default configuration.nix is created on first boot"):
                       server.succeed(f"incus exec {instance_name} -- test -f /etc/nixos/configuration.nix")
+                      server.succeed(f"incus exec {instance_name} -- grep -q 'default incus configuration' /etc/nixos/configuration.nix")
 
                   with subtest("[${image_id}] configuration.nix create service does not overwrite existing config"):
                       server.succeed(f"incus exec {instance_name} -- systemctl restart incus-create-nixos-config.service")


### PR DESCRIPTION
The cloneConfig module can prevent the incus-create-nixos-config.service from running because it will already have generated a configuration.nix.

Fixes #499313

Currently our (unstable) images get the following configuration.nix:

```
[root@nixos:~]# ls -lah /etc/nixos/configuration.nix 
-r--r--r-- 1 root root 123 May  5 21:29 /etc/nixos/configuration.nix

[root@nixos:~]# cat /etc/nixos/configuration.nix 
{ config, pkgs, ... }:

{
  imports = [ <nixpkgs/nixos/maintainers/scripts/incus/incus-virtual-machine-image.nix> ];

  
}
```

With this Patch applied it's the following again:

```

[root@nixos:~]# ls -lah /etc/nixos/configuration.nix 
-rw-r--r-- 1 root root 862 May  5 23:19 /etc/nixos/configuration.nix

[root@nixos:~]# cat /etc/nixos/configuration.nix 
# Edit this configuration file to define what should be installed on
# your system.  Help is available in the configuration.nix(5) man page
# and in the NixOS manual (accessible by running ‘nixos-help’).

{ modulesPath, ... }:

{
  imports = [
    # Include the default incus configuration.
    "${modulesPath}/virtualisation/incus-virtual-machine.nix"
    # Include the container-specific autogenerated configuration.
    ./incus.nix
  ];

  networking = {
    dhcpcd.enable = false;
    useDHCP = false;
    useHostResolvConf = false;
  };

  systemd.network = {
    enable = true;
    networks."50-enp5s0" = {
      matchConfig.Name = "enp5s0";
      networkConfig = {
        DHCP = "ipv4";
        IPv6AcceptRA = true;
      };
      linkConfig.RequiredForOnline = "routable";
    };
  };

  system.stateVersion = "26.05"; # Did you read the comment?
}
```

I tested this like so:

```
nix-build nixos/release.nix -A incusVirtualMachineImage -A incusVirtualMachineImageMeta --arg supportedSystems '[ "x86_64-linux" ]'
incus image import result-2/tarball/*.tar.xz result/nixos.qcow2 --alias testnixcf1
```

(This will seem like it works if you run this as a non-root towards an remote incus server. The image is transmitted and seemingly some amount of information is stored (maybe in the db idk) because it will tell you `Error: Image with same fingerprint already exists` if you run it again but it isn't beeing listed in `incus image list`. So if your incus server is remote copy it to your incus server and then import it locally. In the help it sounds like this is also the only supported scenario.)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
