### PR TITLE
luaPackages.luaossl: mark broken for lua 5.5

### DIFF
--- a/pkgs/development/lua-modules/luaossl-lua55.patch
+++ b/pkgs/development/lua-modules/luaossl-lua55.patch
@@ -1,0 +1,180 @@
+From dc891ba243e6dc7c327e8c63ad404a40314c61e3 Mon Sep 17 00:00:00 2001
+From: Achill Gilgenast <achill@achill.org>
+Date: Tue, 23 Dec 2025 15:49:27 +0100
+Subject: [PATCH] Support Lua 5.5
+
+---
+ GNUmakefile                        |  7 +++++--
+ src/GNUmakefile                    | 21 +++++++++++++++++----
+ vendor/compat53/c-api/compat-5.3.h |  6 +++---
+ 3 files changed, 25 insertions(+), 9 deletions(-)
+
+diff --git a/GNUmakefile b/GNUmakefile
+index 0105102..69d14a1 100644
+--- a/GNUmakefile
++++ b/GNUmakefile
+@@ -12,7 +12,7 @@ all: # default target
+ #
+ # G N U  M A K E  F U N C T I O N S
+ #
+-KNOWN_APIS = 5.1 5.2 5.3 5.4
++KNOWN_APIS = 5.1 5.2 5.3 5.4 5.5
+ 
+ # template for invoking luapath script
+ LUAPATH := $(d)/mk/luapath
+@@ -42,6 +42,8 @@ lua53cpath ?= $(libdir)/lua/5.3
+ lua53path ?= $(datadir)/lua/5.3
+ lua54cpath ?= $(libdir)/lua/5.4
+ lua54path ?= $(datadir)/lua/5.4
++lua55cpath ?= $(libdir)/lua/5.5
++lua55path ?= $(datadir)/lua/5.5
+ 
+ 
+ AR ?= ar
+@@ -99,7 +101,7 @@ endif
+ 
+ # set LUA_APIS if empty or "?"
+ ifeq ($(or $(strip $(LUA_APIS)),?),?)
+-override LUA_APIS := $(call HAVE_API_FN,5.1) $(call HAVE_API_FN,5.2) $(call HAVE_API_FN,5.3) $(call HAVE_API_FN,5.4)
++override LUA_APIS := $(call HAVE_API_FN,5.1) $(call HAVE_API_FN,5.2) $(call HAVE_API_FN,5.3) $(call HAVE_API_FN,5.4 )$(call HAVE_API_FN,5.5)
+ endif
+ 
+ define LUAXY_template
+@@ -135,6 +137,7 @@ $(eval $(call LUAXY_template,5.1))
+ $(eval $(call LUAXY_template,5.2))
+ $(eval $(call LUAXY_template,5.3))
+ $(eval $(call LUAXY_template,5.4))
++$(eval $(call LUAXY_template,5.5))
+ 
+ #
+ # A U T O D E T E C T  C O M P I L A T I O N  F L A G S
+diff --git a/src/GNUmakefile b/src/GNUmakefile
+index f7462af..76ecb16 100644
+--- a/src/GNUmakefile
++++ b/src/GNUmakefile
+@@ -41,6 +41,7 @@ $$(d)/$(1)/%.o: $$(d)/%.c $$(d)/config.h
+ 
+ ifneq ($(1), 5.3)
+ ifneq ($(1), 5.4)
++ifneq ($(1), 5.5)
+ $$(d)/$(1)/compat53.o: $$(d)/../vendor/compat53/c-api/compat-5.3.c $$(d)/../vendor/compat53/c-api/compat-5.3.h $$(d)/config.h
+ 	$$(MKDIR) -p $$(@D)
+ 	$$(CC) $$(CFLAGS_$(d)) $$(ALL_LUA$(subst .,,$(1))_CPPFLAGS) $$(CPPFLAGS_$(d)) -c -o $$@ $$<
+@@ -50,6 +51,7 @@ $$(d)/$(1)/%.o: $$(d)/../vendor/compat53/c-api/compat-5.3.h
+ $$(d)/$(1)/openssl.so: $$(d)/$(1)/compat53.o
+ endif
+ endif
++endif
+ 
+ .SECONDARY: liblua$(1)-openssl openssl$(1) openssl
+ 
+@@ -61,14 +63,16 @@ $(eval $(call BUILD_$(d),5.1))
+ $(eval $(call BUILD_$(d),5.2))
+ $(eval $(call BUILD_$(d),5.3))
+ $(eval $(call BUILD_$(d),5.4))
++$(eval $(call BUILD_$(d),5.5))
+ 
+ ifneq "$(filter $(abspath $(d)/..)/%, $(abspath $(firstword $(MAKEFILE_LIST))))" ""
+-.SECONDARY: all all5.1 all5.2 all5.3 all5.4
++.SECONDARY: all all5.1 all5.2 all5.3 all5.4 all5.5
+ 
+ all5.1: liblua5.1-openssl
+ all5.2: liblua5.2-openssl
+ all5.3: liblua5.3-openssl
+ all5.4: liblua5.4-openssl
++all5.5: liblua5.5-openssl
+ all: $(foreach API,$(strip $(LUA_APIS)),all$(API))
+ 
+ endif
+@@ -157,23 +161,26 @@ $(eval $(call INSTALL_$(d),5.1,$$(lua51cpath),$$(lua51path)))
+ $(eval $(call INSTALL_$(d),5.2,$$(lua52cpath),$$(lua52path)))
+ $(eval $(call INSTALL_$(d),5.3,$$(lua53cpath),$$(lua53path)))
+ $(eval $(call INSTALL_$(d),5.4,$$(lua54cpath),$$(lua54path)))
++$(eval $(call INSTALL_$(d),5.5,$$(lua55cpath),$$(lua55path)))
+ 
+ ifneq "$(filter $(abspath $(d)/..)/%, $(abspath $(firstword $(MAKEFILE_LIST))))" ""
+ 
+-.SECONDARY: install5.1 install5.2 install5.3 install5.4 install
++.SECONDARY: install5.1 install5.2 install5.3 install5.4 install5.5 install
+ 
+ install5.1: liblua5.1-openssl-install
+ install5.2: liblua5.2-openssl-install
+ install5.3: liblua5.3-openssl-install
+ install5.4: liblua5.4-openssl-install
++install5.5: liblua5.5-openssl-install
+ install: $(foreach API,$(strip $(LUA_APIS)),install$(API))
+ 
+-.PHONY: uninstall5.1 uninstall5.2 uninstall5.3 uninstall5.4 uninstall
++.PHONY: uninstall5.1 uninstall5.2 uninstall5.3 uninstall5.4 uninstall5.5 uninstall
+ 
+ uninstall5.1: liblua5.1-openssl-uninstall
+ uninstall5.2: liblua5.2-openssl-uninstall
+ uninstall5.3: liblua5.3-openssl-uninstall
+ uninstall5.4: liblua5.4-openssl-uninstall
++uninstall5.5: liblua5.5-openssl-uninstall
+ uninstall: $(foreach API,$(strip $(LUA_APIS)),uninstall$(API))
+ 
+ endif
+@@ -185,7 +192,7 @@ endif
+ .PHONY: $(d)/clean $(d)/clean~ clean clean~
+ 
+ $(d)/clean:
+-	$(RM) -fr $(@D)/config.h $(@D)/*.dSYM $(@D)/5.1 $(@D)/5.2 $(@D)/5.3 $(@D)/5.4
++	$(RM) -fr $(@D)/config.h $(@D)/*.dSYM $(@D)/5.1 $(@D)/5.2 $(@D)/5.3 $(@D)/5.4 $(@D)/5.5
+ 
+ $(d)/clean~: $(d)/clean
+ 	$(RM) -f $(@D)/*~
+@@ -209,16 +216,19 @@ $(d)/help:
+ 	@echo "      all5.2 - build 5.2/openssl.so"
+ 	@echo "      all5.3 - build 5.3/openssl.so"
+ 	@echo "      all5.4 - build 5.4/openssl.so"
++	@echo "      all5.5 - build 5.5/openssl.so"
+ 	@echo "     install - install all API targets"
+ 	@echo "  install5.1 - install openssl Lua 5.1 modules"
+ 	@echo "  install5.2 - install openssl Lua 5.2 modules"
+ 	@echo "  install5.3 - install openssl Lua 5.3 modules"
+ 	@echo "  install5.4 - install openssl Lua 5.4 modules"
++	@echo "  install5.5 - install openssl Lua 5.5 modules"
+ 	@echo "   uninstall - uninstall all API targets"
+ 	@echo "uninstall5.1 - uninstall openssl Lua 5.1 modules"
+ 	@echo "uninstall5.2 - uninstall openssl Lua 5.2 modules"
+ 	@echo "uninstall5.3 - uninstall openssl Lua 5.3 modules"
+ 	@echo "uninstall5.4 - uninstall openssl Lua 5.4 modules"
++	@echo "uninstall5.5 - uninstall openssl Lua 5.5 modules"
+ 	@echo "       clean - rm binary targets, object files, debugging symbols, etc"
+ 	@echo "      clean~ - clean + rm *~"
+ 	@echo "        help - echo this help message"
+@@ -235,11 +245,14 @@ $(d)/help:
+ 	@echo 'lua53cpath - install path for Lua 5.3 C modules ($(value lua53cpath))'
+ 	@echo ' lua54path - install path for Lua 5.4 modules ($(value lua54path))'
+ 	@echo 'lua54cpath - install path for Lua 5.4 C modules ($(value lua54cpath))'
++	@echo ' lua55path - install path for Lua 5.5 modules ($(value lua54path))'
++	@echo 'lua55cpath - install path for Lua 5.5 C modules ($(value lua54cpath))'
+ 	@echo ""
+ 	@echo 'LUA51_CPPFLAGS - cpp flags for Lua 5.1 headers ($(LUA51_CPPFLAGS))'
+ 	@echo 'LUA52_CPPFLAGS - cpp flags for Lua 5.2 headers ($(LUA52_CPPFLAGS))'
+ 	@echo 'LUA53_CPPFLAGS - cpp flags for Lua 5.3 headers ($(LUA53_CPPFLAGS))'
+ 	@echo 'LUA54_CPPFLAGS - cpp flags for Lua 5.4 headers ($(LUA54_CPPFLAGS))'
++	@echo 'LUA55_CPPFLAGS - cpp flags for Lua 5.5 headers ($(LUA54_CPPFLAGS))'
+ 	@echo ""
+ 	@echo "(NOTE: all the common GNU-style paths are supported, including"
+ 	@echo "prefix, bindir, libdir, datadir, includedir, and DESTDIR.)"
+diff --git a/vendor/compat53/c-api/compat-5.3.h b/vendor/compat53/c-api/compat-5.3.h
+index b730a4b..845f803 100644
+--- a/vendor/compat53/c-api/compat-5.3.h
++++ b/vendor/compat53/c-api/compat-5.3.h
+@@ -399,11 +399,11 @@ COMPAT53_API void luaL_requiref (lua_State *L, const char *modname,
+ 
+ 
+ /* other Lua versions */
+-#if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 501 || LUA_VERSION_NUM > 504
++#if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 501 || LUA_VERSION_NUM > 505
+ 
+-#  error "unsupported Lua version (i.e. not Lua 5.1, 5.2, 5.3, or 5.4)"
++#  error "unsupported Lua version (i.e. not Lua 5.1, 5.2, 5.3, 5.4, or 5.5)"
+ 
+-#endif /* other Lua versions except 5.1, 5.2, 5.3, and 5.4 */
++#endif /* other Lua versions except 5.1, 5.2, 5.3, 5.4, and 5.5 */
+ 
+ 
+ 

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -693,6 +693,11 @@ in
     env = old.env // {
       NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types"; # for gcc15
     };
+
+    meta = (old.meta or { }) // {
+      # https://github.com/wahern/luaossl/pull/221
+      broken = luaAtLeast "5.5";
+    };
   });
 
   luaposix = prev.luaposix.overrideAttrs (old: {

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -690,6 +690,11 @@ in
       }
     ];
 
+    patches = [
+      # https://github.com/wahern/luaossl/pull/221
+      ./luaossl-lua55.patch
+    ];
+
     env = old.env // {
       NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types"; # for gcc15
     };


### PR DESCRIPTION
- #516381
- https://hydra.nixos.org/build/326830139

```
In file included from vendor/compat53/c-api/compat-5.3.c:7:
vendor/compat53/c-api/compat-5.3.h:404:4: error: #error "unsupported Lua version (i.e. not Lua 5.1, 5.2, 5.3, or 5.4)"
  404 | #  error "unsupported Lua version (i.e. not Lua 5.1, 5.2, 5.3, or 5.4)"
      |    ^~~~~
```

Vendorred an upstream pull request.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
