### PR TITLE
python3Packages.affinegap: Revert "1.12 -> 2"

### DIFF
--- a/pkgs/development/python-modules/affinegap/default.nix
+++ b/pkgs/development/python-modules/affinegap/default.nix
@@ -41,6 +41,8 @@ buildPythonPackage rec {
     "affinegap"
   ];
 
+  passthru.skipBulkUpdate = true;
+
   meta = {
     description = "Cython implementation of the affine gap string distance";
     homepage = "https://github.com/dedupeio/affinegap";

--- a/pkgs/development/python-modules/affinegap/default.nix
+++ b/pkgs/development/python-modules/affinegap/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "affinegap";
-  version = "2";
+  version = "1.12";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "dedupeio";
     repo = "affinegap";
-    tag = "pypideploy${version}";
-    hash = "sha256-TuydLF3YfeVIP2y2uDQH+oZ9Y2b325ZFEM0Fiu0Xhus=";
+    tag = "v${version}";
+    hash = "sha256-9eX41eoME5Vdtq+c04eQbMYnViy6QKOhKkafrkeMylI=";
   };
 
   build-system = [


### PR DESCRIPTION
This reverts commit 640e5521b9828ee0025447a3b4ee2bbe3dddd102.

The "pypideploy2" tag is much older than the "v1.12" tag and does not correspond to a major version 2.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
