### PR TITLE
spade: 0.17.0 -> 0.18.0

### DIFF
--- a/pkgs/by-name/sp/spade/package.nix
+++ b/pkgs/by-name/sp/spade/package.nix
@@ -16,18 +16,18 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "spade";
-  version = "0.17.0";
+  version = "0.18.0";
 
   src = fetchFromGitLab {
     owner = "spade-lang";
     repo = "spade";
     rev = "v${version}";
-    hash = "sha256-jdcwIn/CiibWiYhh4yICa1LWXZCI0r2w3AFDRO0ZbFw=";
+    hash = "sha256-BSbE0hJvCIaxxqCo+QltZuoS2yst6TgUnHXAE4kZD2A=";
     # only needed for vatch, which contains test data
     fetchSubmodules = true;
   };
 
-  cargoHash = "sha256-JnyICAJ+W9ZwQpJnSVkEb5dSvkrcnx6PZ/IgQMEOsag=";
+  cargoHash = "sha256-+lQiXOof6MnjnVf8CXNYgeyzFMf0myLErbSfnjLVZWU=";
 
   # TODO: somehow respect https://nixos.org/manual/nixpkgs/stable/#var-passthru-updateScript-commit
   passthru.updateScript = _experimental-update-script-combinators.sequence [

--- a/pkgs/by-name/sw/swim/package.nix
+++ b/pkgs/by-name/sw/swim/package.nix
@@ -10,25 +10,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "swim";
-  version = "0.17.0";
+  version = "0.18.0";
 
   src = fetchFromGitLab {
     owner = "spade-lang";
     repo = "swim";
     rev = "v${version}";
-    hash = "sha256-5GxOW5Np5CS1hO8Bd/CoKuRHMiQ9Q2Xz61NGyXXNF7Q=";
+    hash = "sha256-l0iEzctt3WHW7m3wnr5WdthqBlGSh0SxHCQlM6it0Ds=";
   };
 
-  cargoHash = "sha256-TmPw/vP4/LZrBOv1/vJBv3NIn75NnRQmtS4gdmZRH2w=";
-
-  preConfigure = ''
-    # de-vendor spade git submodule
-    test "$version" = "${spade.version}" || {
-      >&2 echo ERROR: version mismatch between spade and swim!
-      false
-    }
-    ln -s ${spade.src} runt/spade
-  '';
+  cargoHash = "sha256-k3sWg/oG5+ckxa10Jt/AncbyoB8kaOcG3xKPg1fl/ME=";
 
   nativeBuildInputs = [ pkg-config ];
 
@@ -36,11 +27,15 @@ rustPlatform.buildRustPackage rec {
     openssl
   ];
 
-  nativeCheckInputs = [ git ];
+  nativeCheckInputs = [
+    git
+    spade
+  ];
 
   checkFlags = [
-    # tries to clone https://gitlab.com/spade-lang/swim-templates
+    # tries to find git after clearing environ
     "--skip=init::tests::git_init_then_swim_init_works"
+    # tries to clone https://gitlab.com/spade-lang/swim-templates
     "--skip=init::tests::init_board_correctly_sets_project_name"
     "--skip=init::tests::init_board_creates_required_files"
     "--skip=plugin::test::deny_changes_to_plugins::edits_are_denied"


### PR DESCRIPTION
- **spade: 0.17.0 -> 0.18.0**
- **swim: 0.17.0 -> 0.18.0**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
