### PR TITLE
python314Packages.dbt-semantic-interfaces: drop

### DIFF
--- a/pkgs/development/python-modules/dbt-semantic-interfaces/default.nix
+++ b/pkgs/development/python-modules/dbt-semantic-interfaces/default.nix
@@ -12,6 +12,7 @@
   more-itertools,
   pydantic,
   pytestCheckHook,
+  pythonAtLeast,
   pyyaml,
   typing-extensions,
 }:
@@ -20,6 +21,10 @@ buildPythonPackage (finalAttrs: {
   pname = "dbt-semantic-interfaces";
   version = "0.10.5";
   pyproject = true;
+
+  # This project uses pydantic.v1 which doesn't support Python 3.14 or later:
+  # https://pydantic.dev/articles/pydantic-v2-12-release#support-for-python-314
+  disabled = pythonAtLeast "3.14";
 
   src = fetchFromGitHub {
     owner = "dbt-labs";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR disables `python314Packages.dbt-semantic-interfaces`, since [it forces usage of Pydantic v1](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/v0.10.5/dsi_pydantic_shim.py#L26-L27) which is [incompatible with Python 3.14 and newer](https://pydantic.dev/articles/pydantic-v2-12-release#support-for-python-314):

> Pydantic V1 core functionality will _not_ work properly with Python 3.14 or greater. As such, Python 3.13 is the latest supported Python version for V1.

It's also worth noting that this project has been deprecated: dbt-labs/dbt-semantic-interfaces#470

Disclosure: this patch was assisted by GPT-5.5 via Codex.

ZHF: #516381

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
