### PR TITLE
sozu: fix build on x86_64-darwin

### DIFF
--- a/pkgs/by-name/so/sozu/package.nix
+++ b/pkgs/by-name/so/sozu/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   rustPlatform,
   fetchFromGitHub,
+  fetchpatch2,
   protobuf,
   nix-update-script,
   testers,
@@ -16,11 +17,19 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "sozu-proxy";
     repo = "sozu";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-a/Pna2l1gRv4kxIyGUuUHlN+lIQemGjZXwM65Ccc24Y=";
   };
 
   cargoHash = "sha256-9ZmlUUdtVAvri9v+EJb6vRQ7Yc3FjRwU5I5Xe8je9/c=";
+
+  patches = [
+    # Fix build with Rust 1.82+ on Darwin: extern blocks must be unsafe.
+    (fetchpatch2 {
+      url = "https://github.com/sozu-proxy/sozu/commit/ec83fad967f2606d5d668679e138631a70ec7de5.patch?full_index=1";
+      hash = "sha256-chXehutcI4+gDwY1uUPgE4t0fgGOsEHPP8gMsnXNB10=";
+    })
+  ];
 
   nativeBuildInputs = [ protobuf ];
 
@@ -38,7 +47,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Open Source HTTP Reverse Proxy built in Rust for Immutable Infrastructures";
     homepage = "https://www.sozu.io";
-    changelog = "https://github.com/sozu-proxy/sozu/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/sozu-proxy/sozu/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.agpl3Only;
     maintainers = [ ];
     mainProgram = "sozu";


### PR DESCRIPTION
Fix https://hydra.nixos.org/build/327184507
Patch from https://github.com/sozu-proxy/sozu/pull/1188

ZHF: #516381

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
