### PR TITLE
ratpoison-sloppymove: init at 1.01

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28219,6 +28219,12 @@
     githubId = 303489;
     name = "Manuel Bärenz";
   };
+  turtley12 = {
+    email = "grant_trier@mines.edu";
+    github = "turtley12";
+    githubId = 76929530;
+    name = "Grant Trier";
+  };
   tuxinaut = {
     email = "trash4you@tuxinaut.de";
     github = "tuxinaut";

--- a/pkgs/by-name/ra/ratpoison-sloppymove/package.nix
+++ b/pkgs/by-name/ra/ratpoison-sloppymove/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  libx11,
+  makeWrapper,
+  procps,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "ratpoison-sloppymove";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "cactus-d";
+    repo = "ratpoison-sloppymove";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-l+RCOdeLAW8tg+pZDFDNpqq3pBZrf8clhnNemHjsYtc=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  buildInputs = [
+    libx11
+  ];
+
+  outputs = [
+    "out"
+  ];
+
+  strictDeps = true;
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  postInstall = ''
+    wrapProgram $out/bin/ratpoison-sloppymove \
+      --prefix PATH : "${lib.makeBinPath [ procps ]}:$out/bin"
+  '';
+
+  meta = {
+    homepage = "https://github.com/cactus-d/ratpoison-sloppymove";
+    description = "Improved version of sloppy focus for Ratpoison that allows for keyboard frame switches when the rat is not in motion";
+    longDescription = ''
+      A companion program to ratpoison (https://www.nongnu.org/ratpoison/) which causes the frame focus to follow the mouse movement
+
+      An improvement on the original "Sloppy Focus" packaged with ratpoison
+
+      Implements a compromise between "rat" and "no rat" -- changes focus based on rat movement but still allows for keyboard-based focus changes too, which the original Sloppy Focus inhibited
+
+      Based on the original Sloppy Focus by Shawn Betts sabetts@vcn.bc.ca GNU General Public License
+    '';
+    license = lib.licenses.gpl3;
+    mainProgram = "ratpoison-sloppymove";
+    maintainers = [ lib.maintainers.turtley12 ];
+  };
+})


### PR DESCRIPTION
Extremely useful "plugin" for the ratpoison window manager, already in nixpkgs.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
