### PR TITLE
texstudio: 4.9.2 -> 4.9.3

### DIFF
--- a/pkgs/by-name/te/texstudio/package.nix
+++ b/pkgs/by-name/te/texstudio/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "texstudio";
-  version = "4.9.2";
+  version = "4.9.3";
 
   src = fetchFromGitHub {
     owner = "texstudio-org";
     repo = "texstudio";
     rev = finalAttrs.version;
-    hash = "sha256-u4+QUL3bOGo81+8adovqkpCKw3H6Mw6I2V3PfcKhb60=";
+    hash = "sha256-NTabdGaB87otc1zzKQLWXx4/nU5rXeTIw2O9nWXUMi0=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Upstream release notes: https://texstudio-org.github.io/CHANGELOG.html
GitHub release: https://github.com/texstudio-org/texstudio/releases/tag/4.9.3

Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is sandboxing enabled in `nix.conf` ?
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change
- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review`
- [x] Tested basic functionality of binary (`./result/bin/texstudio --version` attempts to start but core dumps due to missing display; full GUI not tested on headless aarch64)
- [ ] Added release notes entry (not applicable — minor version bump, no breaking changes)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)

nixpkgs-review

Result of `nixpkgs-review wip` on `aarch64-linux`:
```text
1 package built:
  texstudio

0 packages failed to build