### PR TITLE
nixos/clash-verge: relax `checkReversePath` in TUN mode

### DIFF
--- a/nixos/modules/programs/clash-verge.nix
+++ b/nixos/modules/programs/clash-verge.nix
@@ -21,7 +21,16 @@
       defaultText = lib.literalExpression "pkgs.clash-verge-rev";
     };
     serviceMode = lib.mkEnableOption "Service Mode";
-    tunMode = lib.mkEnableOption "Setcap for TUN Mode. DNS settings won't work on this way";
+    tunMode = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      example = true;
+      description = ''
+        Whether to set capabilities for TUN Mode. DNS settings won't work this way.
+
+        When enabled, reverse path filtering will be set to loose instead of strict.
+      '';
+    };
     autoStart = lib.mkEnableOption "Clash Verge auto launch";
     group = lib.mkOption {
       type = lib.types.str;
@@ -58,6 +67,8 @@
         capabilities = "cap_net_bind_service,cap_net_raw,cap_net_admin=+ep";
         source = "${lib.getExe cfg.package}";
       };
+
+      networking.firewall.checkReversePath = lib.mkIf cfg.tunMode "loose";
 
       systemd.services.clash-verge = lib.mkIf cfg.serviceMode {
         enable = true;

--- a/nixos/modules/programs/clash-verge.nix
+++ b/nixos/modules/programs/clash-verge.nix
@@ -21,7 +21,15 @@
       defaultText = lib.literalExpression "pkgs.clash-verge-rev";
     };
     serviceMode = lib.mkEnableOption "Service Mode";
-    tunMode = lib.mkEnableOption "Setcap for TUN Mode. DNS settings won't work on this way";
+    tunMode = lib.mkEnableOption "" // {
+      description = ''
+        Whether to set the capabilities required for TUN mode.
+
+        Without these capabilities, Clash Verge's DNS settings will not work in TUN mode.
+
+        When enabled, reverse path filtering will be set to loose instead of strict.
+      '';
+    };
     autoStart = lib.mkEnableOption "Clash Verge auto launch";
     group = lib.mkOption {
       type = lib.types.str;
@@ -58,6 +66,22 @@
         capabilities = "cap_net_bind_service,cap_net_raw,cap_net_admin=+ep";
         source = "${lib.getExe cfg.package}";
       };
+
+      assertions = [
+        {
+          assertion =
+            cfg.tunMode
+            ->
+              config.networking.firewall.checkReversePath != true
+              && config.networking.firewall.checkReversePath != "strict";
+          message = ''
+            {option}`programs.clash-verge.tunMode` requires {option}`networking.firewall.checkReversePath`
+            to be set to `false` or `"loose"`.
+          '';
+        }
+      ];
+
+      networking.firewall.checkReversePath = lib.mkIf cfg.tunMode (lib.mkDefault "loose");
 
       systemd.services.clash-verge = lib.mkIf cfg.serviceMode {
         enable = true;


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR close #477636 .

I ran into the same issue and figured out why it happens.

DNS resolution may fail, causing Clash Verge / Mihomo to stop working, when all of the following conditions are true:

* TUN mode is enabled;
* the firewall is enabled;
* the DNS server in `/etc/resolv.conf` is an on-link LAN address, such as `192.168.1.1`. If the network provides a public DNS resolver, such as `8.8.8.8` or `223.5.5.5`, everything works fine. This is why the issue only appears in some network environments;
* `checkReversePath` is not relaxed. Some NixOS modules already set `checkReversePath` to `loose` automatically for similar reasons, such as Tailscale: https://github.com/NixOS/nixpkgs/blob/e3f3598f6dcc165901cf6e07d0f7c22a09df6b1c/nixos/modules/services/networking/tailscale.nix#L259

Therefore, I think the Clash Verge NixOS module could use a similar approach: when TUN mode is enabled, set `networking.firewall.checkReversePath` to `loose`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
