### PR TITLE
ghostscript: fix i686 build, drop upstreamed 32-bit patch

### DIFF
--- a/pkgs/by-name/gh/ghostscript/package.nix
+++ b/pkgs/by-name/gh/ghostscript/package.nix
@@ -85,13 +85,6 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://salsa.debian.org/debian/ghostscript/-/raw/01e895fea033cc35054d1b68010de9818fa4a8fc/debian/patches/2010_add_build_timestamp_setting.patch";
       hash = "sha256-XTKkFKzMR2QpcS1YqoxzJnyuGk/l/Y2jdevsmbMtCXA=";
     })
-  ]
-  ++ lib.optionals stdenv.hostPlatform.is32bit [
-    # 32 bit compat. conditional as to not cause rebuilds
-    (fetchpatch2 {
-      url = "https://github.com/ArtifexSoftware/ghostpdl/commit/3c0be6e4fcffa63e4a5a1b0aec057cebc4d2562f.patch?full_index=1";
-      hash = "sha256-NrL4lI19x+OHaSIwV93Op/I9k2MWXxSWgbkwSGU7R6A=";
-    })
   ];
 
   outputs = [


### PR DESCRIPTION
Without the change the build fails on `staging` as:

```
$ nix build --no-link -f. pkgsi686Linux.ghostscript --keep-going -L
...
ghostscript-with-X> applying patch /nix/store/q1dgaydqa5rvgccxz8hcwfwanqh3s71p-3c0be6e4fcffa63e4a5a1b0aec057cebc4d2562f.patch?full_index=1
ghostscript-with-X> patching file base/gdevdbit.c
ghostscript-with-X> Reversed (or previously applied) patch detected!  Assume -R? [n]
ghostscript-with-X> Apply anyway? [n]
ghostscript-with-X> Skipping patch.
ghostscript-with-X> 1 out of 1 hunk ignored -- saving rejects to file base/gdevdbit.c.rej
ghostscript-with-X> patching file base/gdevmpla.c
ghostscript-with-X> Reversed (or previously applied) patch detected!  Assume -R? [n]
ghostscript-with-X> Apply anyway? [n]
ghostscript-with-X> Skipping patch.
ghostscript-with-X> 2 out of 2 hunks ignored -- saving rejects to file base/gdevmpla.c.rej
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
