### PR TITLE
filebench: 1.4.9.1 -> 1.5-alpha3-unstable-2020-02-20, fix for gcc 15

### DIFF
--- a/pkgs/by-name/fi/filebench/package.nix
+++ b/pkgs/by-name/fi/filebench/package.nix
@@ -2,6 +2,8 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
+
   autoreconfHook,
   bison,
   flex,
@@ -17,6 +19,14 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "22620e602cbbebad90c0bd041896ebccf70dbf5f";
     hash = "sha256-IVQSEUZOC+X3C994tnk0n3NI7yu2yPAWlPA7zdSbvlg=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "gcc-15.patch";
+      url = "https://github.com/filebench/filebench/commit/82191902e44b7a136adb9285bcce3d4a52551b9e.patch?full_index=1";
+      hash = "sha256-Uf4DrHZl94m502C7MynMtYpon1886RLbXGKW6lYq1SI=";
+    })
+  ];
 
   nativeBuildInputs = [
     autoreconfHook

--- a/pkgs/by-name/fi/filebench/package.nix
+++ b/pkgs/by-name/fi/filebench/package.nix
@@ -36,9 +36,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "File system and storage benchmark that can generate both micro and macro workloads";
-    homepage = "https://sourceforge.net/projects/filebench/";
+    homepage = "https://github.com/filebench/filebench";
     license = lib.licenses.cddl;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.ryand56 ];
     platforms = lib.platforms.linux;
     mainProgram = "filebench";
   };

--- a/pkgs/by-name/fi/filebench/package.nix
+++ b/pkgs/by-name/fi/filebench/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   autoreconfHook,
   bison,
   flex,
@@ -9,11 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "filebench";
-  version = "1.4.9.1";
+  version = "1.5-alpha3-unstable-2020-02-20";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/filebench/filebench-${finalAttrs.version}.tar.gz";
-    sha256 = "13hmx67lsz367sn8lrvz1780mfczlbiz8v80gig9kpkpf009yksc";
+  src = fetchFromGitHub {
+    owner = "filebench";
+    repo = "filebench";
+    rev = "22620e602cbbebad90c0bd041896ebccf70dbf5f";
+    hash = "sha256-IVQSEUZOC+X3C994tnk0n3NI7yu2yPAWlPA7zdSbvlg=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
ZHF: #516381
https://hydra.nixos.org/build/326974185

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
