### PR TITLE
python3Packages.hyper-connections: 0.4.7 -> 0.4.9; python3Packages.torch-einops-utils: init at 0.0.29

### DIFF
--- a/pkgs/development/python-modules/hyper-connections/default.nix
+++ b/pkgs/development/python-modules/hyper-connections/default.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   hatchling,
   pytestCheckHook,
+  stdenv,
   torch,
   torch-einops-utils,
 }:
@@ -30,6 +31,12 @@ buildPythonPackage (finalAttrs: {
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTests = lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+    # torch's cpuinfo init fails to parse /sys/devices/system/cpu/{possible,present}
+    # in the build sandbox on aarch64-linux, breaking `.half()` calls
+    "test_mhc_dtype_restoration"
+  ];
 
   pythonImportsCheck = [ "hyper_connections" ];
 

--- a/pkgs/development/python-modules/hyper-connections/default.nix
+++ b/pkgs/development/python-modules/hyper-connections/default.nix
@@ -6,18 +6,19 @@
   hatchling,
   pytestCheckHook,
   torch,
+  torch-einops-utils,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "hyper-connections";
-  version = "0.4.7";
+  version = "0.4.9";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "lucidrains";
     repo = "hyper-connections";
     tag = finalAttrs.version;
-    hash = "sha256-x1Yx9Fnow9154kFGLmjeCBLYJsbv6oJiC6Rk1XudqJQ=";
+    hash = "sha256-RDwnRtHUWilyqsDmdiV+kRg7BqTS1yghiu9RAM+MNjE=";
   };
 
   build-system = [ hatchling ];
@@ -25,6 +26,7 @@ buildPythonPackage (finalAttrs: {
   dependencies = [
     einops
     torch
+    torch-einops-utils
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/torch-einops-utils/default.nix
+++ b/pkgs/development/python-modules/torch-einops-utils/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  einops,
+  fetchFromGitHub,
+  hatchling,
+  pytestCheckHook,
+  torch,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "torch-einops-utils";
+  version = "0.0.29";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "lucidrains";
+    repo = "torch-einops-utils";
+    tag = finalAttrs.version;
+    hash = "sha256-ja3HeBvAQRyGL2anqIQa2iiHhOZUhF73do7pvrTyRo0=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    einops
+    torch
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "torch_einops_utils" ];
+
+  meta = {
+    description = "Utility functions for torch and einops";
+    homepage = "https://github.com/lucidrains/torch-einops-utils";
+    changelog = "https://github.com/lucidrains/torch-einops-utils/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ miniharinn ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19598,6 +19598,8 @@ self: super: with self; {
 
   torch-c-dlpack-ext = callPackage ../development/python-modules/torch-c-dlpack-ext { };
 
+  torch-einops-utils = callPackage ../development/python-modules/torch-einops-utils { };
+
   torch-geometric = callPackage ../development/python-modules/torch-geometric { };
 
   # Required to test triton


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327826591)](https://hydra.nixos.org/build/327826591)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
