### PR TITLE
warp-terminal: 0.2026.04.15.08.45.stable_04 -> 0.2026.04.29.08.57.stable_01

### DIFF
--- a/pkgs/by-name/wa/warp-terminal/package.nix
+++ b/pkgs/by-name/wa/warp-terminal/package.nix
@@ -122,7 +122,10 @@ let
   meta = {
     description = "Rust-based terminal";
     homepage = "https://www.warp.dev";
-    license = lib.licenses.unfree;
+    license = with lib.licenses; [
+      agpl3Only
+      mit
+    ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     maintainers = with lib.maintainers; [
       imadnyc

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-Mff9jfrWQJ2YovS+yW7/NhwGDGASIvUFEAaH04YF6rw=",
-    "version": "0.2026.04.15.08.45.stable_04"
+    "hash": "sha256-5HoZzXI2Kwc1vzp+5FuhO4/P/p57X7Z62yQT8ZM1vAc=",
+    "version": "0.2026.04.29.08.57.stable_01"
   },
   "linux_x86_64": {
-    "hash": "sha256-tGhC+pjPQTTd5XTKwQJ/ctnLcQY6lvvI6zRjXByon5g=",
-    "version": "0.2026.04.15.08.45.stable_04"
+    "hash": "sha256-93IBcHfExMduG2idnpCif6hD3vO+/tsQGF7FlgS6meE=",
+    "version": "0.2026.04.29.08.57.stable_01"
   },
   "linux_aarch64": {
-    "hash": "sha256-U7gctUpWhJP2hfF62I7wh/cdE9ixVEVnKd6B1dOoLfc=",
-    "version": "0.2026.04.15.08.45.stable_04"
+    "hash": "sha256-2XGgK20SLFiSBix/WXuW0yCkp46HzBtWJD+5I+H9js8=",
+    "version": "0.2026.04.29.08.57.stable_01"
   }
 }


### PR DESCRIPTION
Warp went open-source on 2026-04-28 (https://www.warp.dev/blog/warp-is-now-open-source). The core client is now AGPLv3, the UI framework crates (`warpui_core`/`warpui`) are MIT. Updated license accordingly.

<!-- Maintainers are automatically notified via the maintainers list. -->

#### Tested using sandboxing
- [x] Built on: `x86_64-linux`

#### Built on platform(s)
- [x] `x86_64-linux`
- [ ] `aarch64-linux` (covered by ofborg)
- [ ] `x86_64-darwin` / `aarch64-darwin` (covered by ofborg)

#### Tested execution of all binary files (usually in `./result/bin/`)
- [x] `./result/bin/warp-terminal` launches without errors

#### Meets Nixpkgs contribution standards
- [x] Yes