### PR TITLE
sentry-cli: 2.58.2 -> 3.4.1

### DIFF
--- a/pkgs/by-name/se/sentry-cli/package.nix
+++ b/pkgs/by-name/se/sentry-cli/package.nix
@@ -12,24 +12,25 @@
   gitMinimal,
   versionCheckHook,
   nix-update-script,
+  curl,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sentry-cli";
-  version = "2.58.2";
+  version = "3.4.1";
 
   src = fetchFromGitHub {
     owner = "getsentry";
     repo = "sentry-cli";
     tag = finalAttrs.version;
-    hash = "sha256-2dxnAwxIdmeA53PETUyDUgi1T4ZH9faBvPCMdRPUDxw=";
+    hash = "sha256-tL/FiEsNsymIb0H4Y0dIGqna5Lmh1ZxaScS0OIH1mSs=";
   };
 
   patches = lib.optionals stdenv.hostPlatform.isDarwin [
     (replaceVars ./fix-swift-lib-path.patch { swiftLib = lib.getLib swift; })
   ];
 
-  cargoHash = "sha256-CwULTOZN2TTpB8heLuegID38ub6J3XoiY7l7UW1VcGo=";
+  cargoHash = "sha256-CcWNQ8uvc9CrkirW0zaqmMRHCcoLr4ujmZxKNbO2etE=";
 
   # Needed to get openssl-sys to use pkgconfig.
   env.OPENSSL_NO_VENDOR = 1;
@@ -49,7 +50,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     swiftpm
   ];
 
-  buildInputs = [ openssl ];
+  buildInputs = [
+    openssl
+    curl
+  ];
 
   nativeCheckInputs = [ gitMinimal ];
 
@@ -73,7 +77,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     homepage = "https://docs.sentry.io/cli/";
-    license = lib.licenses.bsd3;
+    license = lib.licenses.fsl11Mit;
     description = "Command line utility to work with Sentry";
     mainProgram = "sentry-cli";
     changelog = "https://github.com/getsentry/sentry-cli/raw/${finalAttrs.version}/CHANGELOG.md";


### PR DESCRIPTION
`curl` had to be added. `nix-build -A sentry-cli` gave
```
error: linking with `/nix/store/rwsbw420hcq148hifv7fga6r4g0k1dw8-clang-wrapper-21.1.8/bin/cc` failed: exit status: 1
    |
    = note:  "/nix/store/rwsbw420hcq148hifv7fga6r4g0k1dw8-clang-wrapper-21.1.8/bin/cc" "/nix/var/nix/builds/nix-24427-1340378623/source/target/aarch64-apple-darwin/release/deps/rustcF8wuf2/symbols.o" ... "-Wl,-u,_AUDITABLE_VERSION_INFO"
    = note: some arguments are omitted. use `--verbose` to show all linker arguments
    = note: ld: library not found for -lcurl
            clang: error: linker command failed with exit code 1 (use -v to see invocation)
  
  
  error: could not compile `sentry-cli` (bin "sentry-cli") due to 1 previous error
```

As @lheckemann points out, upstream has changed the license from BSD-3-Clause to FSL-1.1-MIT. The meta.license has been updated accordingly. This package is now considered unfree.

Changelog: https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md

PR that bumps to 3.4.1-snapshot.20260423.342be6c at: https://github.com/NixOS/nixpkgs/pull/471040

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
