### PR TITLE
nip2: fix build with gcc 15; switch to fetchFromGithub

### DIFF
--- a/pkgs/by-name/ni/nip2/package.nix
+++ b/pkgs/by-name/ni/nip2/package.nix
@@ -1,8 +1,9 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   fetchpatch,
+  autoreconfHook,
   pkg-config,
   glib,
   libxml2,
@@ -21,9 +22,11 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "nip2";
   version = "8.9.1";
 
-  src = fetchurl {
-    url = "https://github.com/libvips/nip2/releases/download/v${finalAttrs.version}/nip2-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-t14m6z+5lPqpiOjgdDbKwqSWXCyrCL7zlo6BeoZtds0=";
+  src = fetchFromGitHub {
+    owner = "libvips";
+    repo = "nip2";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-SemlINqrqzWa7/sU6KnWiDJW8FLSYVZnCDtJNE0wjhg=";
   };
 
   patches = [
@@ -40,11 +43,17 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeBuildInputs = [
+    autoreconfHook
     bison
     flex
     pkg-config
     makeWrapper
+    glib
   ];
+
+  preAutoreconf = ''
+    glib-gettextize --force --copy
+  '';
 
   buildInputs = [
     glib

--- a/pkgs/by-name/ni/nip2/package.nix
+++ b/pkgs/by-name/ni/nip2/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   pkg-config,
   glib,
   libxml2,
@@ -24,6 +25,19 @@ stdenv.mkDerivation (finalAttrs: {
     url = "https://github.com/libvips/nip2/releases/download/v${finalAttrs.version}/nip2-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-t14m6z+5lPqpiOjgdDbKwqSWXCyrCL7zlo6BeoZtds0=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "do-not-redeclare-statfs.patch";
+      url = "https://github.com/libvips/nip2/commit/045268a78c40d7f546220504f971c728aebc00be.patch";
+      hash = "sha256-A17+/Vmjf0l1Jpl22VL11gj5m6oFB8DnvkH2EHiRTw8=";
+    })
+    (fetchpatch {
+      name = "declare-function-arguments-for-function-pointer.patch";
+      url = "https://github.com/libvips/nip2/commit/8c60c517b59f806da84d57cb1d083a213b811151.patch";
+      hash = "sha256-o5OHNSbUORGquhyCYCtGQTY74IfroByaa0UAXYsP484=";
+    })
+  ];
 
   nativeBuildInputs = [
     bison


### PR DESCRIPTION
GCC 15 Regression Tracking: #475479
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327835373)](https://hydra.nixos.org/build/327835373)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
