### PR TITLE
intercal: 0.31 -> 0.34

### DIFF
--- a/pkgs/by-name/in/intercal/package.nix
+++ b/pkgs/by-name/in/intercal/package.nix
@@ -3,37 +3,37 @@
   stdenv,
   fetchurl,
   fetchpatch,
-  pkg-config,
+  autoreconfHook,
   bison,
   flex,
   makeWrapper,
+  pkg-config,
 }:
 
 stdenv.mkDerivation rec {
 
   pname = "intercal";
-  version = "0.31";
+  version = "0.34";
 
   src = fetchurl {
     url = "http://catb.org/esr/intercal/intercal-${version}.tar.gz";
-    sha256 = "1z2gpa5rbqb7jscqlf258k0b0jc7d2zkyipb5csjpj6d3sw45n4k";
+    hash = "sha256-fvYUjDUd9mhGbi3L15UXci+RwzyqORWVcTfzgzcfjVU=";
   };
 
   patches = [
-    # Pull patch pending upstream inclusion for -fno-common toolchains:
-    #   https://gitlab.com/esr/intercal/-/issues/4
+    # fix user program compilation with gcc15, remove after next release
     (fetchpatch {
-      name = "fno-common.patch";
-      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-lang/c-intercal/files/c-intercal-31.0-no-common.patch?id=a110a98b4de6f280d770ba3cc92a4612326205a3";
-      sha256 = "03523fc40042r2ryq5val27prlim8pld4950qqpawpism4w3y1p2";
+      url = "https://gitlab.com/esr/intercal/-/commit/ad504ff6f800a40902d5472b2ca7fc310eae0270.patch";
+      hash = "sha256-hEMsudpqzZXB1pdV7y+Tc1YFIaJwen8288jGBFku82M=";
     })
   ];
 
   nativeBuildInputs = [
-    pkg-config
+    autoreconfHook
     bison
     flex
     makeWrapper
+    pkg-config
   ];
 
   # Intercal invokes gcc, so we need an explicit PATH


### PR DESCRIPTION
- #475479 
- #516381
- Changelog: https://gitlab.com/esr/intercal/-/blob/0.34/HISTORY?ref_type=tags
- Diff: https://gitlab.com/esr/intercal/-/compare/0.31...0.34
- https://hydra.nixos.org/build/324243121

```
In file included from src/ick.h:3,
                 from src/feh2.c:36:
src/ick_bool.h:21:15: error: 'bool' cannot be defined via 'typedef'
   21 | typedef _Bool bool;
      |               ^~~~
src/ick_bool.h:21:15: note: 'bool' is a keyword with '-std=c23' onwards
src/ick_bool.h:21:1: warning: useless type name in empty declaration
   21 | typedef _Bool bool;
      | ^~~~~~~
```

Upstream fixed the compilation error with the `ick` compiler. However a small hack is still needed to fix compiling user programs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
