### PR TITLE
[25.11] mutt: 2.2.16 -> 2.3.3

### DIFF
--- a/pkgs/by-name/mu/mutt/package.nix
+++ b/pkgs/by-name/mu/mutt/package.nix
@@ -31,7 +31,7 @@ assert gpgmeSupport -> sslSupport;
 
 stdenv.mkDerivation rec {
   pname = "mutt";
-  version = "2.2.16";
+  version = "2.3.0";
   outputs = [
     "out"
     "doc"
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://ftp.mutt.org/pub/mutt/${pname}-${version}.tar.gz";
-    hash = "sha256-HTEJp0OtiyXu+XEJsr20Zdt4N9Co0hHNOIvhtvqsPzI=";
+    hash = "sha256-XV68QIQ/cVbV7eMOUAFnmKxzNkZ/etNH5xZRBRbMITA=";
   };
 
   patches = [

--- a/pkgs/by-name/mu/mutt/package.nix
+++ b/pkgs/by-name/mu/mutt/package.nix
@@ -31,7 +31,7 @@ assert gpgmeSupport -> sslSupport;
 
 stdenv.mkDerivation rec {
   pname = "mutt";
-  version = "2.3.1";
+  version = "2.3.2";
   outputs = [
     "out"
     "doc"
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://ftp.mutt.org/pub/mutt/${pname}-${version}.tar.gz";
-    hash = "sha256-Rw17Dj0TSgX7gGTe3XR3Gwa81jnID8zXdz3DIqr7t7Y=";
+    hash = "sha256-m096RC5BwFd3S6fDb6Qaui7dLnoSqGAx5uuxE7qyx54=";
   };
 
   patches = [

--- a/pkgs/by-name/mu/mutt/package.nix
+++ b/pkgs/by-name/mu/mutt/package.nix
@@ -31,7 +31,7 @@ assert gpgmeSupport -> sslSupport;
 
 stdenv.mkDerivation rec {
   pname = "mutt";
-  version = "2.3.0";
+  version = "2.3.1";
   outputs = [
     "out"
     "doc"
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://ftp.mutt.org/pub/mutt/${pname}-${version}.tar.gz";
-    hash = "sha256-XV68QIQ/cVbV7eMOUAFnmKxzNkZ/etNH5xZRBRbMITA=";
+    hash = "sha256-Rw17Dj0TSgX7gGTe3XR3Gwa81jnID8zXdz3DIqr7t7Y=";
   };
 
   patches = [


### PR DESCRIPTION
Fixes #517166, #517165, #517164, #517163, #517155, #517151

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
