### PR TITLE
inklingreader: unstable-2017-09-07 -> 0.8-unstable-2026-05-06

### DIFF
--- a/pkgs/by-name/in/inklingreader/package.nix
+++ b/pkgs/by-name/in/inklingreader/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   autoreconfHook,
   pkg-config,
+  wrapGAppsHook3,
   gtk3,
   librsvg,
   libusb1,
@@ -11,18 +12,19 @@
 
 stdenv.mkDerivation {
   pname = "inklingreader";
-  version = "unstable-2017-09-07";
+  version = "0.8-unstable-2026-05-06";
 
   src = fetchFromGitHub {
     owner = "roelj";
     repo = "inklingreader";
-    rev = "90f9d0d7f5353657f4d25fd75635e29c10c08d2e";
-    sha256 = "sha256-852m8g61r+NQhCYz9ghSbCG0sjao2E8B9GS06NG4GyY=";
+    rev = "44026d82e494b8068ebd8be377516053487cc2c6";
+    hash = "sha256-NfjLzgFxo3h3gpPeQ+un5f8n1kIxUBQLLRV2CptuxzA=";
   };
 
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
+    wrapGAppsHook3
   ];
   buildInputs = [
     gtk3


### PR DESCRIPTION
- #475479 
- #516381 
- https://hydra.nixos.org/build/324243007
- Diff: https://github.com/roelj/inklingreader/compare/90f9d0d7f5353657f4d25fd75635e29c10c08d2e...44026d82e494b8068ebd8be377516053487cc2c6

```
src/gui/mainwindow.c: In function 'gui_mainwindow_play':
src/gui/mainwindow.c:524:40: error: passing argument 2 of 'g_timeout_add' from incompatible pointer type [-Wincompatible-pointer-types]
  524 |       timeout_id = g_timeout_add (100, gui_mainwindow_update_clock, NULL);
      |                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                        |
      |                                        gboolean (*)(void) {aka int (*)(void)}
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
