### PR TITLE
ownserver: fix build

### DIFF
--- a/pkgs/by-name/ow/ownserver/bump-metrics.patch
+++ b/pkgs/by-name/ow/ownserver/bump-metrics.patch
@@ -1,0 +1,104 @@
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -18,18 +18,6 @@
+ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+ 
+ [[package]]
+-name = "ahash"
+-version = "0.8.11"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+-dependencies = [
+- "cfg-if",
+- "once_cell",
+- "version_check",
+- "zerocopy 0.7.35",
+-]
+-
+-[[package]]
+ name = "aho-corasick"
+ version = "1.1.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -1584,12 +1572,12 @@
+ 
+ [[package]]
+ name = "metrics"
+-version = "0.24.1"
++version = "0.24.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7a7deb012b3b2767169ff203fadb4c6b0b82b947512e5eb9e0b78c2e186ad9e3"
++checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
+ dependencies = [
+- "ahash",
+  "portable-atomic",
++ "rapidhash",
+ ]
+ 
+ [[package]]
+@@ -2126,7 +2114,7 @@
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+ dependencies = [
+- "zerocopy 0.8.24",
++ "zerocopy",
+ ]
+ 
+ [[package]]
+@@ -2327,7 +2315,7 @@
+ dependencies = [
+  "rand_chacha 0.9.0",
+  "rand_core 0.9.3",
+- "zerocopy 0.8.24",
++ "zerocopy",
+ ]
+ 
+ [[package]]
+@@ -2378,6 +2366,15 @@
+ ]
+ 
+ [[package]]
++name = "rapidhash"
++version = "4.4.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
++dependencies = [
++ "rustversion",
++]
++
++[[package]]
+ name = "raw-cpuid"
+ version = "11.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -4242,31 +4239,11 @@
+ 
+ [[package]]
+ name = "zerocopy"
+-version = "0.7.35"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+-dependencies = [
+- "zerocopy-derive 0.7.35",
+-]
+-
+-[[package]]
+-name = "zerocopy"
+ version = "0.8.24"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+ dependencies = [
+- "zerocopy-derive 0.8.24",
+-]
+-
+-[[package]]
+-name = "zerocopy-derive"
+-version = "0.7.35"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+-dependencies = [
+- "proc-macro2",
+- "quote",
+- "syn 2.0.100",
++ "zerocopy-derive",
+ ]
+ 
+ [[package]]

--- a/pkgs/by-name/ow/ownserver/package.nix
+++ b/pkgs/by-name/ow/ownserver/package.nix
@@ -18,7 +18,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-bseDssSMerBlzlCvL3rD3X6ku5qDRYvI1wxq2W7As5k=";
   };
 
-  cargoHash = "sha256-SJm66CDrg6ZpIeKx27AnZAVs/Z25E/KmHYuZ9G4UwHQ=";
+  # Bump vendored `metrics` past 0.24.2 which fixes a borrow-checker error
+  # under newer rustc (https://github.com/rust-lang/rust/issues/141402).
+  cargoPatches = [ ./bump-metrics.patch ];
+
+  cargoHash = "sha256-EzuG3ev/6EqTGi0J0wppZz+cZJiH12WbBQLKOrTxTzs=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/ow/ownserver/package.nix
+++ b/pkgs/by-name/ow/ownserver/package.nix
@@ -33,6 +33,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     openssl
   ];
 
+  # `proxy_client::fetch_token_test` spins up a warp server during `cargo test`.
+  __darwinAllowLocalNetworking = true;
+
   passthru.updateScript = nix-update-script { };
 
   meta = {


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327063776)](https://hydra.nixos.org/build/327063776)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test