### PR TITLE
nixos/rancher: wait for all nodes to be ready in multi node test

### DIFF
--- a/nixos/tests/rancher/multi-node.nix
+++ b/nixos/tests/rancher/multi-node.nix
@@ -222,6 +222,11 @@ in
       # Also wait for our service account to show up; it takes a sec
       server.wait_until_succeeds("kubectl get serviceaccount default")
 
+      # Wait for all nodes to be ready
+      server.succeed("kubectl wait --timeout=-1s --for=condition=Ready node/server")
+      server.succeed("kubectl wait --timeout=-1s --for=condition=Ready node/server2")
+      server.succeed("kubectl wait --timeout=-1s --for=condition=Ready node/agent")
+
       # Now create a pod on each node via a daemonset and verify they can talk to each other.
       server.succeed("kubectl apply -f ${networkTestDaemonset}")
       server.wait_until_succeeds("kubectl rollout status daemonset test")


### PR DESCRIPTION
Without waiting, the rollout of the test daemonset may succeed pre-maturely because only nodes that are ready are considered for rollout. This lead to failing tests on my machine.

@NixOS/k3s @maevii @zimbatm @stefan-bordei 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
