### PR TITLE
ink: fix build with gcc15

### DIFF
--- a/pkgs/by-name/in/ink/package.nix
+++ b/pkgs/by-name/in/ink/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchDebianPatch,
   libinklevel,
 }:
 
@@ -13,6 +14,16 @@ stdenv.mkDerivation (finalAttrs: {
     url = "mirror://sourceforge/ink/ink-${finalAttrs.version}.tar.gz";
     sha256 = "1fk0b8vic04a3i3vmq73hbk7mzbi57s8ks6ighn3mvr6m2v8yc9d";
   };
+
+  patches = [
+    (fetchDebianPatch {
+      pname = "ink";
+      version = "0.5.3";
+      debianRevision = "7";
+      patch = "gcc15.patch";
+      hash = "sha256-2Qn8jDAY/ub8MEiG68J7nEnz9GQ/8ScF9nweTkuCibQ=";
+    })
+  ];
 
   buildInputs = [
     libinklevel


### PR DESCRIPTION
- #475479 
- #516381 
- https://hydra.nixos.org/build/324243001

```
malloc.c:6:7: warning: conflicting types for built-in function 'malloc'; expected 'void *(long unsigned int)' [-Wbuiltin-declaration-mismatch]
    6 | void *malloc ();
      |       ^~~~~~
malloc.c:5:1: note: 'malloc' is declared in header '<stdlib.h>'
    4 | #include <sys/types.h>
  +++ |+#include <stdlib.h>
    5 | 
malloc.c: In function 'rpl_malloc':
malloc.c:16:10: error: too many arguments to function 'malloc'; expected 0, have 1
   16 |   return malloc (n);
      |          ^~~~~~  ~
malloc.c:6:7: note: declared here
    6 | void *malloc ();
      |       ^~~~~~
```

Fetched a debian patch. Only verified compilation.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
