### PR TITLE
piglit: unstable-2025-04-15 -> unstable-2026-05-04

### DIFF
--- a/pkgs/by-name/pi/piglit/package.nix
+++ b/pkgs/by-name/pi/piglit/package.nix
@@ -29,14 +29,14 @@
 
 stdenv.mkDerivation {
   pname = "piglit";
-  version = "unstable-2025-04-15";
+  version = "unstable-2026-05-04";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "mesa";
     repo = "piglit";
-    rev = "d06f7bac988e67db53cbc05dc0b096b00856ab93";
-    hash = "sha256-bH9NjLEldlZwylq7S0q2vC5IQhUej0xZ6wD+mrWBK5A=";
+    rev = "1bb2910c3fced64396feddd205e356d80e5ff7d9";
+    hash = "sha256-/3OQeZiK7fHfPpSlFtbW7DLEFV3YFBL1cLMndXyxwYs=";
   };
 
   buildInputs = [


### PR DESCRIPTION
Diff: https://gitlab.freedesktop.org/mesa/piglit/-/compare/d06f7bac988e67db53cbc05dc0b096b00856ab93...1bb2910c3fced64396feddd205e356d80e5ff7d9
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327083473)](https://hydra.nixos.org/build/327083473)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test