### PR TITLE
rtl_fm_streamer: fix build with gcc 15

### DIFF
--- a/pkgs/by-name/rt/rtl_fm_streamer/package.nix
+++ b/pkgs/by-name/rt/rtl_fm_streamer/package.nix
@@ -30,6 +30,10 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "cmake_minimum_required(VERSION 2.6)" "cmake_minimum_required(VERSION 3.10)"
   '';
 
+  patches = [
+    ./use-stdbool.patch
+  ];
+
   nativeBuildInputs = [
     cmake
     pkg-config

--- a/pkgs/by-name/rt/rtl_fm_streamer/use-stdbool.patch
+++ b/pkgs/by-name/rt/rtl_fm_streamer/use-stdbool.patch
@@ -1,0 +1,18 @@
+Drop the hand-rolled bool enum: `bool`, `true`, and `false` are reserved
+keywords in C23 (the default since GCC 15), so the typedef no longer compiles.
+
+--- a/src/rtl_fm_streamer.c
++++ b/src/rtl_fm_streamer.c
+@@ -100,11 +100,7 @@
+
+ #define DEFAULT_PORT_NUMBER "2346"
+
+-typedef enum
+-{
+-    false = 0,
+-    true
+-}bool;
++#include <stdbool.h>
+
+ struct dongle_state
+ {


### PR DESCRIPTION
GCC 15 Regression Tracking: #475479
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327172274)](https://hydra.nixos.org/build/327172274)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test