### PR TITLE
bcompare: add SMB drive mounting support via python3 + pygobject3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3101,6 +3101,12 @@
     githubId = 75235;
     name = "Michael Walker";
   };
+  barsikus007 = {
+    name = "barsikus007";
+    email = "barsikus07@gmail.com";
+    github = "barsikus007";
+    githubId = 37113583;
+  };
   bartoostveen = {
     name = "Bart Oostveen";
     github = "bartoostveen";

--- a/pkgs/by-name/bc/bcompare/package.nix
+++ b/pkgs/by-name/bc/bcompare/package.nix
@@ -4,10 +4,13 @@
   bzip2,
   fetchurl,
   glibc,
+  gobject-introspection,
   kdePackages,
+  python3,
   stdenv,
   runtimeShell,
   unzip,
+  wrapGAppsHook3,
 }:
 
 let
@@ -32,53 +35,68 @@ let
 
   src = srcs.${stdenv.hostPlatform.system} or throwSystem;
 
-  linux = stdenv.mkDerivation {
-    inherit
-      pname
-      version
-      src
-      meta
-      ;
-    unpackPhase = ''
-      ar x $src
-      tar xfz data.tar.gz
-    '';
+  linux =
+    let
+      python = python3.withPackages (
+        pp: with pp; [
+          pygobject3
+        ]
+      );
+    in
+    stdenv.mkDerivation {
+      inherit
+        pname
+        version
+        src
+        meta
+        ;
+      unpackPhase = ''
+        ar x $src
+        tar xfz data.tar.gz
+      '';
 
-    installPhase = ''
-      mkdir -p $out/{bin,lib,share}
+      installPhase = ''
+        mkdir -p $out/{bin,lib,share}
 
-      cp -R usr/{bin,lib,share} $out/
+        cp -R usr/{bin,lib,share} $out/
 
-      # Remove library that refuses to be autoPatchelf'ed
-      #  - bcompare_ext_kde.amd64.so is linked with Qt4
-      #  - bcompare_ext_kde5.amd64.so is linked with Qt5
-      rm $out/lib/beyondcompare/ext/bcompare_ext_kde.amd64.so
-      rm $out/lib/beyondcompare/ext/bcompare_ext_kde5.amd64.so
+        # Remove library that refuses to be autoPatchelf'ed
+        #  - bcompare_ext_kde.amd64.so is linked with Qt4
+        #  - bcompare_ext_kde5.amd64.so is linked with Qt5
+        rm $out/lib/beyondcompare/ext/bcompare_ext_kde.amd64.so
+        rm $out/lib/beyondcompare/ext/bcompare_ext_kde5.amd64.so
 
-      substituteInPlace $out/bin/bcompare \
-        --replace "/usr/lib/beyondcompare" "$out/lib/beyondcompare" \
-        --replace "ldd" "${glibc.bin}/bin/ldd" \
-        --replace "/bin/bash" "${runtimeShell}"
-    '';
+        substituteInPlace $out/bin/bcompare \
+          --replace-fail "/usr/lib/beyondcompare" "$out/lib/beyondcompare" \
+          --replace-fail "ldd" "${glibc.bin}/bin/ldd" \
+          --replace-fail "/bin/bash" "${runtimeShell}"
 
-    nativeBuildInputs = [ autoPatchelfHook ];
+        substituteInPlace $out/lib/beyondcompare/bcmount.sh \
+          --replace-fail "python3" "${python.interpreter}"
+      '';
 
-    buildInputs = [
-      (lib.getLib stdenv.cc.cc)
-      kdePackages.kio
-      kdePackages.kservice
-      kdePackages.ki18n
-      kdePackages.kcoreaddons
-      bzip2
-    ];
+      nativeBuildInputs = [
+        autoPatchelfHook
+        gobject-introspection
+        wrapGAppsHook3
+      ];
 
-    dontBuild = true;
-    dontConfigure = true;
-    dontWrapQtApps = true;
+      buildInputs = [
+        (lib.getLib stdenv.cc.cc)
+        kdePackages.kio
+        kdePackages.kservice
+        kdePackages.ki18n
+        kdePackages.kcoreaddons
+        bzip2
+      ];
 
-    __structuredAttrs = true;
-    strictDeps = true;
-  };
+      dontBuild = true;
+      dontConfigure = true;
+      dontWrapQtApps = true;
+
+      __structuredAttrs = true;
+      strictDeps = true;
+    };
 
   darwin = stdenv.mkDerivation {
     inherit

--- a/pkgs/by-name/bc/bcompare/package.nix
+++ b/pkgs/by-name/bc/bcompare/package.nix
@@ -4,10 +4,13 @@
   bzip2,
   fetchurl,
   glibc,
+  gobject-introspection,
   kdePackages,
+  python3,
   stdenv,
   runtimeShell,
   unzip,
+  wrapGAppsHook3,
 }:
 
 let
@@ -32,53 +35,68 @@ let
 
   src = srcs.${stdenv.hostPlatform.system} or throwSystem;
 
-  linux = stdenv.mkDerivation {
-    inherit
-      pname
-      version
-      src
-      meta
-      ;
-    unpackPhase = ''
-      ar x $src
-      tar xfz data.tar.gz
-    '';
+  linux =
+    let
+      python = python3.withPackages (
+        pp: with pp; [
+          pygobject3
+        ]
+      );
+    in
+    stdenv.mkDerivation {
+      inherit
+        pname
+        version
+        src
+        meta
+        ;
+      unpackPhase = ''
+        ar x $src
+        tar xfz data.tar.gz
+      '';
 
-    installPhase = ''
-      mkdir -p $out/{bin,lib,share}
+      installPhase = ''
+        mkdir -p $out/{bin,lib,share}
 
-      cp -R usr/{bin,lib,share} $out/
+        cp -R usr/{bin,lib,share} $out/
 
-      # Remove library that refuses to be autoPatchelf'ed
-      #  - bcompare_ext_kde.amd64.so is linked with Qt4
-      #  - bcompare_ext_kde5.amd64.so is linked with Qt5
-      rm $out/lib/beyondcompare/ext/bcompare_ext_kde.amd64.so
-      rm $out/lib/beyondcompare/ext/bcompare_ext_kde5.amd64.so
+        # Remove library that refuses to be autoPatchelf'ed
+        #  - bcompare_ext_kde.amd64.so is linked with Qt4
+        #  - bcompare_ext_kde5.amd64.so is linked with Qt5
+        rm $out/lib/beyondcompare/ext/bcompare_ext_kde.amd64.so
+        rm $out/lib/beyondcompare/ext/bcompare_ext_kde5.amd64.so
 
-      substituteInPlace $out/bin/bcompare \
-        --replace "/usr/lib/beyondcompare" "$out/lib/beyondcompare" \
-        --replace "ldd" "${glibc.bin}/bin/ldd" \
-        --replace "/bin/bash" "${runtimeShell}"
-    '';
+        substituteInPlace $out/bin/bcompare \
+          --replace-fail "/usr/lib/beyondcompare" "$out/lib/beyondcompare" \
+          --replace-fail "ldd" "${glibc.bin}/bin/ldd" \
+          --replace-fail "/bin/bash" "${runtimeShell}"
 
-    nativeBuildInputs = [ autoPatchelfHook ];
+        substituteInPlace $out/lib/beyondcompare/bcmount.sh \
+          --replace-fail "python3" "${python.interpreter}"
+      '';
 
-    buildInputs = [
-      (lib.getLib stdenv.cc.cc)
-      kdePackages.kio
-      kdePackages.kservice
-      kdePackages.ki18n
-      kdePackages.kcoreaddons
-      bzip2
-    ];
+      nativeBuildInputs = [
+        autoPatchelfHook
+        gobject-introspection
+        wrapGAppsHook3
+      ];
 
-    dontBuild = true;
-    dontConfigure = true;
-    dontWrapQtApps = true;
+      buildInputs = [
+        (lib.getLib stdenv.cc.cc)
+        kdePackages.kio
+        kdePackages.kservice
+        kdePackages.ki18n
+        kdePackages.kcoreaddons
+        bzip2
+      ];
 
-    __structuredAttrs = true;
-    strictDeps = true;
-  };
+      dontBuild = true;
+      dontConfigure = true;
+      dontWrapQtApps = true;
+
+      __structuredAttrs = true;
+      strictDeps = true;
+    };
 
   darwin = stdenv.mkDerivation {
     inherit
@@ -111,6 +129,7 @@ let
     maintainers = with lib.maintainers; [
       ktor
       arkivm
+      barsikus007
     ];
     platforms = builtins.attrNames srcs;
     mainProgram = "bcompare";


### PR DESCRIPTION
`bcompare` ships a `bcmount.sh` script for mounting SMB drives, which requires `python3` with `pygobject3` at runtime. Without it, mounting SMB shares fails with error (as noted [in comment](https://github.com/NixOS/nixpkgs/pull/435513/#issuecomment-3368026543)):
<img width="2558" height="1375" alt="Screenshot from 2026-05-06 11-40-50" src="https://github.com/user-attachments/assets/20e17696-3e60-4b44-83da-3a757b8fcadb" />

This patch:
- Adds `python3.withPackages (pp: [ pp.pygobject3 ])` and patches `bcmount.sh` to use the Nix-store interpreter path
- Adds `wrapGAppsHook3` and `gobject-introspection` to `nativeBuildInputs` so the GTK file-chooser dialog used for SMB credentials is available
- Also replaces `--replace` with `--replace-fail`

Note: `bcompare4` likely needs the same fix, but I could not verify — I don't have a v4 license. The fix should apply identically if `bcmount.sh` is present in that version

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc