### PR TITLE
fallow: init at 2.101.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3055,6 +3055,12 @@
     matrix = "@bart:bartoostveen.nl";
     keys = [ { fingerprint = "81FF AB19 BAA5 6FFD 6571  890B 992D 94B5 7AC4 3430"; } ];
   };
+  bartwaardenburg = {
+    name = "Bart Waardenburg";
+    email = "bart@waardenburg.dev";
+    github = "BartWaardenburg";
+    githubId = 1352352;
+  };
   bartuka = {
     email = "wand@hey.com";
     github = "wandersoncferreira";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3062,6 +3062,12 @@
     name = "Wanderson Ferreira";
     keys = [ { fingerprint = "A3E1 C409 B705 50B3 BF41  492B 5684 0A61 4DBE 37AE"; } ];
   };
+  bartwaardenburg = {
+    name = "Bart Waardenburg";
+    email = "bart@waardenburg.dev";
+    github = "BartWaardenburg";
+    githubId = 1352352;
+  };
   bashsu = {
     name = "Joeal Subash";
     email = "joeal.subash@cern.ch";

--- a/pkgs/by-name/fa/fallow/package.nix
+++ b/pkgs/by-name/fa/fallow/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  fetchFromGitHub,
+  gitMinimal,
+  rustPlatform,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "fallow";
+  version = "2.65.0";
+
+  src = fetchFromGitHub {
+    owner = "fallow-rs";
+    repo = "fallow";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MhQMbS6/zxcVzcUOM1sMs2ECAfwVvXt/U8irfUF2ZlU=";
+  };
+
+  cargoHash = "sha256-EczmP2z5haocsok84LJDUTqbqjvbuCfFwFrTGy3tH/c=";
+
+  buildAndTestSubdir = "crates/cli";
+
+  nativeCheckInputs = [
+    gitMinimal
+  ];
+
+  preCheck = ''
+    # Some integration tests create temporary fixture projects and expect Git
+    # discovery to find a parent repository for hotspot analysis.
+    git init "$TMPDIR"
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/${finalAttrs.meta.mainProgram}";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Rust-native codebase intelligence for TypeScript and JavaScript";
+    homepage = "https://docs.fallow.tools";
+    changelog = "https://github.com/fallow-rs/fallow/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bartwaardenburg ];
+    mainProgram = "fallow";
+  };
+})

--- a/pkgs/by-name/fa/fallow/package.nix
+++ b/pkgs/by-name/fa/fallow/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  fetchFromGitHub,
+  gitMinimal,
+  rustPlatform,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "fallow";
+  version = "2.101.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "fallow-rs";
+    repo = "fallow";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-NrEyMOkutqBmJ6g/t3QWNvhjlxYmH7/lWOeoLRarKIk=";
+  };
+
+  cargoHash = "sha256-DDVyKPF0w3Zzg491Pxmq5aMxosJ6y4fV5IjzoskvhGI=";
+
+  # Build the three user-facing binaries: the CLI, the language server, and the
+  # MCP server. Editor and agent integrations launch `fallow-lsp` and
+  # `fallow-mcp` directly, so a system package that ships only the CLI cannot
+  # wire them up. The build is scoped to these bins because crates/cli also
+  # produces internal helper binaries (stub_sidecar, fallow-schema-emit) that
+  # are not part of the public interface.
+  cargoBuildFlags = [
+    "--bin"
+    "fallow"
+    "--bin"
+    "fallow-lsp"
+    "--bin"
+    "fallow-mcp"
+  ];
+
+  # Keep the check phase on the CLI crate, which exercises the shared analysis
+  # core. Its integration tests create temporary fixture projects and expect
+  # Git discovery to find a parent repository for hotspot analysis (see
+  # preCheck).
+  cargoTestFlags = [
+    "-p"
+    "fallow-cli"
+  ];
+
+  nativeCheckInputs = [
+    gitMinimal
+  ];
+
+  preCheck = ''
+    # Some integration tests create temporary fixture projects and expect Git
+    # discovery to find a parent repository for hotspot analysis.
+    git init "$TMPDIR"
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/${finalAttrs.meta.mainProgram}";
+
+  # versionCheckHook only covers mainProgram; confirm the language server and
+  # MCP server were installed and are runnable too.
+  postInstallCheck = ''
+    $out/bin/fallow-lsp --version
+    $out/bin/fallow-mcp --version
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Rust-native codebase intelligence for TypeScript and JavaScript";
+    homepage = "https://docs.fallow.tools";
+    changelog = "https://github.com/fallow-rs/fallow/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bartwaardenburg ];
+    mainProgram = "fallow";
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`?
  - [ ] sandboxing enabled
  - [x] sandboxing disabled
- [x] Tested, as applicable:
  - `nix-build -A fallow --no-out-link`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`
- [x] Tested basic functionality of all binary files (install check verifies `fallow --version`)
- [x] Ensured that the package builds without network access during build
- [ ] Determined the impact on package closure size
- [x] Fits CONTRIBUTING.md.

## Notes

Adds `fallow`, a Rust-native codebase analyzer for TypeScript and JavaScript projects.

The package builds from the GitHub release tag instead of the crates.io crate because the upstream test suite references repository-level files. The derivation initializes `$TMPDIR` as a parent Git repository before checks so temporary fixture projects can exercise hotspot analysis the same way they do in a normal checkout.