### PR TITLE
qmk_hid, qmk-udev-rules: update versions, add telometto as maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26989,6 +26989,13 @@
     githubId = 5663576;
     keys = [ { fingerprint = "6F0F D43B 80E5 583E 60FC  51DC 4936 D067 EB12 AB32"; } ];
   };
+  telometto = {
+     name = "telometto";
+     email = "nixpkgs.vck46@simplelogin.com";
+     github = "telometto";
+     githubId = 65364211;
+     keys = [ { fingerprint = "1BD2 0559 D5B7 910E C8D2  DC56 04A4 F2BD 258B D627"; } ];
+  };
   telotortium = {
     email = "rirelan@gmail.com";
     github = "telotortium";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26990,11 +26990,11 @@
     keys = [ { fingerprint = "6F0F D43B 80E5 583E 60FC  51DC 4936 D067 EB12 AB32"; } ];
   };
   telometto = {
-     name = "telometto";
-     email = "nixpkgs.vck46@simplelogin.com";
-     github = "telometto";
-     githubId = 65364211;
-     keys = [ { fingerprint = "1BD2 0559 D5B7 910E C8D2  DC56 04A4 F2BD 258B D627"; } ];
+    name = "telometto";
+    email = "nixpkgs.vck46@simplelogin.com";
+    github = "telometto";
+    githubId = 65364211;
+    keys = [ { fingerprint = "1BD2 0559 D5B7 910E C8D2  DC56 04A4 F2BD 258B D627"; } ];
   };
   telotortium = {
     email = "rirelan@gmail.com";

--- a/pkgs/by-name/qm/qmk-udev-rules/package.nix
+++ b/pkgs/by-name/qm/qmk-udev-rules/package.nix
@@ -10,35 +10,30 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "qmk-udev-rules";
-  version = "0.27.13";
+  version = "0.1.20";
 
   src = fetchFromGitHub {
     owner = "qmk";
-    repo = "qmk_firmware";
-    tag = finalAttrs.version;
-    hash = "sha256-Zs508OQ0RYCg0f9wqR+VXUmVvhP/jCA3piwRq2ZpR84=";
+    repo = "qmk_udev";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-sxwvyMniEXTnmHEs8ldsBjwReKUT5FlqYxcUULV0cpI=";
   };
-
-  dontBuild = true;
 
   nativeBuildInputs = [
     udevCheckHook
   ];
 
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
   doInstallCheck = true;
 
-  installPhase = ''
-    runHook preInstall
-
-    install -D util/udev/50-qmk.rules $out/lib/udev/rules.d/50-qmk.rules
-
-    runHook postInstall
-  '';
-
   meta = {
-    homepage = "https://github.com/qmk/qmk_firmware";
-    description = "Official QMK udev rules list";
+    homepage = "https://github.com/qmk/qmk_udev";
+    description = "Official QMK udev rules and udev helper program";
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [
+      telometto
+    ];
   };
 })

--- a/pkgs/by-name/qm/qmk/package.nix
+++ b/pkgs/by-name/qm/qmk/package.nix
@@ -77,7 +77,9 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
       - ... and many more!
     '';
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      telometto
+    ];
     mainProgram = "qmk";
   };
 })

--- a/pkgs/by-name/qm/qmk_hid/package.nix
+++ b/pkgs/by-name/qm/qmk_hid/package.nix
@@ -33,7 +33,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   meta = {
-    description = "Commandline tool for interactng with QMK devices over HID";
+    description = "Commandline tool for interacting with QMK devices over HID";
     homepage = "https://github.com/FrameworkComputer/qmk_hid";
     license = with lib.licenses; [ bsd3 ];
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/qm/qmk_hid/package.nix
+++ b/pkgs/by-name/qm/qmk_hid/package.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "qmk_hid";
-  version = "0.1.12";
+  version = "0.1.13";
 
   src = fetchFromGitHub {
     owner = "FrameworkComputer";
     repo = "qmk_hid";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-wJi7FQrvMbdTwvbbjBnzmxupMbEuM8TeZ0JIK5ulQKI=";
+    hash = "sha256-GuI/hDqMEpJ5Flcs4hRXZr3pbVFreelJIlS/idViHmY=";
   };
 
-  cargoHash = "sha256-ytg4pgPzl9dKyCWgRRVRg1noNRvBhBnWNf9bmNcHnjY=";
+  cargoHash = "sha256-s6SF6L+5YQ9/yNuyrPPM8xztvn6PUyaUD29M+C7kSnE=";
 
   nativeBuildInputs = [
     pkg-config
@@ -36,7 +36,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "Commandline tool for interactng with QMK devices over HID";
     homepage = "https://github.com/FrameworkComputer/qmk_hid";
     license = with lib.licenses; [ bsd3 ];
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      telometto
+    ];
     mainProgram = "qmk_hid";
   };
 })


### PR DESCRIPTION
This PR introduces myself, `telometto`, as maintainer, updates the `qmk_hid` and `qmk-udev-rules` packages, and adds me as maintainer to them. It also adds some improvements to package definitions.

**Maintainer additions and updates:**

* Added `telometto` to the `maintainers/maintainer-list.nix` file with relevant contact and key information.
* Added `telometto` as a maintainer to the `qmk`, `qmk_udev_rules`, and `qmk_hid` packages. [[1]](diffhunk://#diff-5d27b45589c8c7b3116f38d3f2739d1a5261cf736502051c37a70d051bf5dab0L80-R82) [[2]](diffhunk://#diff-28b943fd183d682e9874437542093b5572c97e290209517ac39ce33ab4717f3dL13-R37) [[3]](diffhunk://#diff-495cfafebd4c86f30a0a3ba485a2b24d57418632688ff5295e882b6591ae552dL39-R41)

**QMK package improvements:**

* Updated `qmk-udev-rules` to version 0.1.20, switched the source repository to `qmk_udev`, updated the install method to use `makeFlags`, and improved package metadata.
* Updated `qmk_hid` to version 0.1.13 and refreshed the source and cargo hashes.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


<details>
<summary>nixpkgs-review log</summary>

```
# logs/qmk-udev-rules-x86_64-linux.log
[nix-shell:~/.cache/nixpkgs-review/rev-0708e7bd81a37c6d6cfc65d8dce3b516237f4e2d]$ bat logs/qmk-udev-rules-x86_64-linux

[nix-shell:~/.cache/nixpkgs-review/rev-0708e7bd81a37c6d6cfc65d8dce3b516237f4e2d]$ cat !$
cat logs/qmk-udev-rules-x86_64-linux.log
Using udevCheckHook
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/rhv5wijlc1f29xqb4j0qpjhdn2ibimzy-source
source root is source
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
no configure script, doing nothing
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
build flags: SHELL=/nix/store/i27rhb3nr65rkrwz36bchkwmav6ggsmn-bash-5.3p9/bin/bash PREFIX=/nix/store/m06j3d564w1bzc1xg
gcc -Wall -Wextra -static -nostdlib -Inolibc -fno-asynchronous-unwind-tables -fno-ident -fno-stack-protector -Os    qm
./qmk_id_test
TAP version 13
1..12
ok 1 - empty input
ok 2 - console: basic descriptor
ok 3 - console: different usage page
ok 4 - console: different usage
ok 5 - console: empty long items
ok 6 - console: long items
ok 7 - raw hid: basic descriptor
ok 8 - raw hid: different usage page
ok 9 - raw hid: different usage
ok 10 - xap: basic descriptor
ok 11 - xap: different usage page
ok 12 - xap: different usage
gcc -Wall -Wextra -static -nostdlib -Inolibc -fno-asynchronous-unwind-tables -fno-ident -fno-stack-protector -Os    qm
Running phase: installPhase
@nix { "action": "setPhase", "phase": "installPhase" }
install flags: SHELL=/nix/store/i27rhb3nr65rkrwz36bchkwmav6ggsmn-bash-5.3p9/bin/bash PREFIX=/nix/store/m06j3d564w1bzc1
./qmk_id_test
TAP version 13
1..12
ok 1 - empty input
ok 2 - console: basic descriptor
ok 3 - console: different usage page
ok 4 - console: different usage
ok 5 - console: empty long items
ok 6 - console: long items
ok 7 - raw hid: basic descriptor
ok 8 - raw hid: different usage page
ok 9 - raw hid: different usage
ok 10 - xap: basic descriptor
ok 11 - xap: different usage page
ok 12 - xap: different usage
install -m644 -D 50-qmk.rules /nix/store/m06j3d564w1bzc1xgmajy8pp7drg2lf6-qmk-udev-rules-0.1.20/lib/udev/rules.d/50-qmk.rules
install -m755 -D qmk_id /nix/store/m06j3d564w1bzc1xgmajy8pp7drg2lf6-qmk-udev-rules-0.1.20/lib/udev/qmk_id
Running phase: fixupPhase
@nix { "action": "setPhase", "phase": "fixupPhase" }
shrinking RPATHs of ELF executables and libraries in /nix/store/m06j3d564w1bzc1xgmajy8pp7drg2lf6-qmk-udev-rules-0.1.20
shrinking /nix/store/m06j3d564w1bzc1xgmajy8pp7drg2lf6-qmk-udev-rules-0.1.20/lib/udev/qmk_id
patchelf: cannot find section '.dynamic'. The input file is most likely statically linked
checking for references to /build/ in /nix/store/m06j3d564w1bzc1xgmajy8pp7drg2lf6-qmk-udev-rules-0.1.20...
patchelf: cannot find section '.dynamic'. The input file is most likely statically linked
patching script interpreter paths in /nix/store/m06j3d564w1bzc1xgmajy8pp7drg2lf6-qmk-udev-rules-0.1.20
stripping (with command strip and flags -S -p) in  /nix/store/m06j3d564w1bzc1xgmajy8pp7drg2lf6-qmk-udev-rules-0.1.20/lib
Running phase: installCheckPhase
@nix { "action": "setPhase", "phase": "installCheckPhase" }
Executing udevCheckPhase

1 udev rules files have been checked.
  Success: 1
  Fail:    0
Finished udevCheckPhase
no installcheck target in Makefile, doing nothing
```

```
# logs/qmk_hid-x86_64-linux.log
[nix-shell:~/.cache/nixpkgs-review/rev-0708e7bd81a37c6d6cfc65d8dce3b516237f4e2d]$ cat logs/qmk_hid-x86_64-linux.log
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/dgjkgz1f1kcvvwr1ylh7bckwdwqphm3m-source
source root is source
Executing cargoSetupPostUnpackHook
Finished cargoSetupPostUnpackHook
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
Executing cargoSetupPostPatchHook
Validating consistency between /build/source/Cargo.lock and /build/qmk_hid-0.1.13-vendor/Cargo.lock
Finished cargoSetupPostPatchHook
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
Executing cargoBuildHook
cargoBuildHook flags: -j 24 --target x86_64-unknown-linux-gnu --offline --profile release
   Compiling proc-macro2 v1.0.104
   Compiling shlex v1.3.0
   Compiling quote v1.0.42
   Compiling unicode-ident v1.0.22
   Compiling find-msvc-tools v0.1.6
   Compiling utf8parse v0.2.2
   Compiling pkg-config v0.3.32
   Compiling colorchoice v1.0.4
   Compiling anstyle v1.0.13
   Compiling is_terminal_polyfill v1.70.2
   Compiling anstyle-query v1.1.5
   Compiling libc v0.2.178
   Compiling static_vcruntime v3.0.0
   Compiling clap_lex v0.7.6
   Compiling heck v0.5.0
   Compiling strsim v0.11.1
   Compiling cfg-if v1.0.4
   Compiling anstyle-parse v0.2.7
   Compiling qmk_hid v0.1.13 (/build/source)
   Compiling cc v1.2.51
   Compiling anstream v0.6.21
   Compiling clap_builder v4.5.53
   Compiling hidapi v2.6.4
   Compiling syn v2.0.111
   Compiling clap_derive v4.5.49
   Compiling clap v4.5.53
    Finished `release` profile [optimized] target(s) in 7.42s
Executing cargoInstallPostBuildHook
Finished cargoInstallPostBuildHook
Finished cargoBuildHook
Running phase: checkPhase
@nix { "action": "setPhase", "phase": "checkPhase" }
Executing cargoCheckHook
cargoCheckHook flags: -j 24 --profile release --target x86_64-unknown-linux-gnu --offline -- --skip=src/lib.rs
   Compiling qmk_hid v0.1.13 (/build/source)
    Finished `release` profile [optimized] target(s) in 0.39s
     Running unittests src/lib.rs (target/x86_64-unknown-linux-gnu/release/deps/qmk_hid-c2262219bbd853b3)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/main.rs (target/x86_64-unknown-linux-gnu/release/deps/qmk_hid-a4c1845a263cb760)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests qmk_hid

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s

all doctests ran in 0.06s; merged doctests compilation took 0.06s
Finished cargoCheckHook
Running phase: installPhase
@nix { "action": "setPhase", "phase": "installPhase" }
Executing cargoInstallHook
Finished cargoInstallHook
Running phase: fixupPhase
@nix { "action": "setPhase", "phase": "fixupPhase" }
shrinking RPATHs of ELF executables and libraries in /nix/store/jzhiwaq6jjw287019fp0lg341vid6jcg-qmk_hid-0.1.13
shrinking /nix/store/jzhiwaq6jjw287019fp0lg341vid6jcg-qmk_hid-0.1.13/bin/qmk_hid
checking for references to /build/ in /nix/store/jzhiwaq6jjw287019fp0lg341vid6jcg-qmk_hid-0.1.13...
patching script interpreter paths in /nix/store/jzhiwaq6jjw287019fp0lg341vid6jcg-qmk_hid-0.1.13
stripping (with command strip and flags -S -p) in  /nix/store/jzhiwaq6jjw287019fp0lg341vid6jcg-qmk_hid-0.1.13/bin
```

</details>