### PR TITLE
nixos/blueman: define services in nix

### DIFF
--- a/nixos/modules/services/desktops/blueman.nix
+++ b/nixos/modules/services/desktops/blueman.nix
@@ -9,15 +9,33 @@ let
   cfg = config.services.blueman;
 in
 {
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "services" "blueman" "withApplet" ]
+      [ "services" "blueman" "applet" "enable" ]
+    )
+  ];
   ###### interface
   options = {
     services.blueman = {
       enable = lib.mkEnableOption "blueman, a bluetooth manager";
 
-      withApplet = lib.mkOption {
-        type = lib.types.bool;
-        default = true;
-        description = "Whether to spawn the Blueman tray applet.";
+      package = lib.mkPackageOption pkgs "blueman" { };
+      applet = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Whether to spawn the Blueman tray applet.";
+        };
+
+        systemdTargets = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ "graphical-session.target" ];
+          example = [ "sway-session.target" ];
+          description = ''
+            The systemd targets that will automatically start the blueman applet service.
+          '';
+        };
       };
     };
   };
@@ -25,19 +43,49 @@ in
   ###### implementation
   config = lib.mkIf cfg.enable {
 
-    environment.systemPackages = [ pkgs.blueman ];
+    environment.systemPackages = [ cfg.package ];
 
-    services.dbus.packages = [ pkgs.blueman ];
+    services.dbus.packages = [ cfg.package ];
 
-    systemd.packages = [ pkgs.blueman ];
+    systemd.user.services = {
 
-    systemd.user.services.blueman-applet = lib.mkIf cfg.withApplet {
-      description = "Blueman tray applet";
-      wantedBy = [ "graphical-session.target" ];
-      partOf = [ "graphical-session.target" ];
+      # this is a bit awkward: we always want the service definition.
+      # If the applet is disabled, the service from the package will be loaded,
+      # but the service will not be started on startup, which is fine.
+      blueman-applet = lib.mkIf cfg.applet.enable {
+        description = "Blueman tray applet";
+
+        wantedBy = cfg.applet.systemdTargets;
+        partOf = cfg.applet.systemdTargets;
+
+        serviceConfig = {
+          Type = "dbus";
+          BusName = "org.blueman.Applet";
+          ExecStart = "${cfg.package}/bin/blueman-applet";
+          Restart = "on-failure";
+        };
+      };
+
+      blueman-manager = {
+        description = "Bluetooth Manager";
+
+        serviceConfig = {
+          Type = "dbus";
+          BusName = "org.blueman.Manager";
+          ExecStart = "${cfg.package}/bin/blueman-manager";
+        };
+      };
+    };
+
+    systemd.services.blueman-mechanism = {
+      description = "Bluetooth management mechanism";
+      wantedBy = [ "multi-user.target" ];
+
       serviceConfig = {
-        ExecStart = "${pkgs.blueman}/bin/blueman-applet";
-        Restart = "on-failure";
+        Type = "dbus";
+        KillMode = "process";
+        BusName = "org.blueman.Mechanism";
+        ExecStart = "${cfg.package}/libexec/blueman-mechanism";
       };
     };
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

fix the bug inroduced in https://github.com/NixOS/nixpkgs/pull/475107, see issue here: https://github.com/NixOS/nixpkgs/issues/514705


This mostly reimplements the service definitions from the blueman package in nix (removing the `systemd.packages` option previously used in the module), with only notable difference being that now the blueman-applet service will run on startup.

Also added an option to set systemd targets for the applet service, this is yoinked from home manager.

Manually confirmed that the changes do not conflict with hm options

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
