### PR TITLE
nixos/console: build xkb-console-keymap on build platform

### DIFF
--- a/nixos/modules/config/console.nix
+++ b/nixos/modules/config/console.nix
@@ -143,7 +143,13 @@ in
           inherit (config.services.xserver) xkb;
         in
         lib.mkIf cfg.useXkbConfig (
-          pkgs.runCommand "xkb-console-keymap" { preferLocalBuild = true; } ''
+          # `buildPackages.runCommand` so the assembly derivation is built on
+          # the build platform; the `ckbcomp` binary already comes from
+          # `buildPackages` and the output is an arch-independent text keymap.
+          # Identical to `pkgs.runCommand` for native builds (`buildPackages
+          # == pkgs`); fixes cross builds where the host-platform runner
+          # cannot execute on the build host.
+          pkgs.buildPackages.runCommand "xkb-console-keymap" { preferLocalBuild = true; } ''
             '${pkgs.buildPackages.ckbcomp}/bin/ckbcomp' \
               ${
                 lib.optionalString (


### PR DESCRIPTION
`pkgs.runCommand` produces a derivation with `system = stdenv.hostPlatform.system`. In a cross build (`nixpkgs.crossSystem` set, or any build host that differs from the target host) the assembly drv is host-platform — the build host cannot realise it without binfmt or a remote builder.

The body already invokes `${pkgs.buildPackages.ckbcomp}/bin/ckbcomp` (build-platform binary), and the output is an arch-independent text keymap consumed by systemd-vconsole-setup at first boot. Switching the runner to `pkgs.buildPackages.runCommand` keeps the assembly on the build platform alongside the binary it executes.

In a native build `pkgs.buildPackages == pkgs`, so the derivation is referentially identical (same hash, same content). Verified locally:
- Native eval and build (x86_64-linux) produce a valid console keymap.
- Cross eval (`localSystem = x86_64-linux; crossSystem = aarch64-linux`) now emits `system = x86_64-linux` instead of `system = aarch64-linux`.

`nixpkgs-review-gha` run: https://github.com/caniko/nixpkgs-review-gha/actions/runs/25429530875 — passed on x86_64-linux, aarch64-linux, x86_64-darwin, aarch64-darwin.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable: N/A — single-line cross-build idiom correction; output is identical text on native (verified by drv hash equality on x86_64-linux).
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].

[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage