### PR TITLE
makeModulesClosure: build assembly drv on the build platform

### DIFF
--- a/pkgs/build-support/kernel/modules-closure.nix
+++ b/pkgs/build-support/kernel/modules-closure.nix
@@ -4,7 +4,7 @@
 # Also generate an appropriate modules.dep.
 
 {
-  stdenvNoCC,
+  buildPackages,
   kernel,
   firmware,
   nukeReferences,
@@ -14,7 +14,13 @@
   extraFirmwarePaths ? [ ],
 }:
 
-stdenvNoCC.mkDerivation {
+# `buildPackages.stdenvNoCC.mkDerivation` so the assembly derivation is
+# built on the build platform; the script reads ELF metadata from kernel
+# modules and emits text (modules.dep, symbol info), which is
+# arch-independent. `kmod`/`nukeReferences` are listed as nativeBuildInputs
+# and will be auto-spliced to their build-platform variants in cross builds.
+# In native builds `buildPackages == self`, so the derivation is identical.
+buildPackages.stdenvNoCC.mkDerivation {
   name = kernel.name + "-shrunk";
   builder = ./modules-closure.sh;
   nativeBuildInputs = [


### PR DESCRIPTION
`stdenvNoCC.mkDerivation` produces a derivation with `system = hostPlatform.system`. In a cross build the build host cannot realise the resulting `kernel-shrunk` drv without binfmt or a remote builder of the host platform — even though the work performed by `./modules-closure.sh` is just reading ELF metadata from kernel modules and emitting text files (`modules.dep`, `modules.builtin*`), which is architecture-independent.

Switch to `buildPackages.stdenvNoCC.mkDerivation` so the assembly runs on the build platform. `kmod` and `nukeReferences` are listed in `nativeBuildInputs` and are auto-spliced to their build-platform variants in cross builds, so the script's `modprobe`/`depmod` invocations execute natively on the build host. The kernel modules themselves remain host-arch and are referenced (not executed) by the script.

In native builds `buildPackages == self`, so the derivation is referentially identical. Verified locally:
- Native (x86_64-linux): drvPath unchanged at `b9vw5pwfn3vgp6chw6kbqv1q4qjz84iz-linux-6.18.26-shrunk.drv` before and after the patch.
- Cross (`localSystem = x86_64-linux; crossSystem = aarch64-linux`): `system` flips from `aarch64-linux` to `x86_64-linux`, so the build host can build it natively.

`nixpkgs-review-gha` run: https://github.com/caniko/nixpkgs-review-gha/actions/runs/25429532206 — passed on x86_64-linux, aarch64-linux, x86_64-darwin, aarch64-darwin.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable: N/A — verified drvPath identity for native; cross unblocks an already-broken-by-design configuration.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].

[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage