### PR TITLE
paisa: nodejs_20 EOL -> nodejs_22

### DIFF
--- a/pkgs/by-name/pa/paisa/package.nix
+++ b/pkgs/by-name/pa/paisa/package.nix
@@ -4,7 +4,7 @@
   buildGoModule,
   buildNpmPackage,
   fetchFromGitHub,
-  nodejs_20,
+  nodejs_22,
   versionCheckHook,
   node-gyp,
   python3,
@@ -20,10 +20,7 @@
 }:
 
 let
-  # paisa docker builds with nodejs 22, but we need node 20 so we can build
-  # node-canvas from source (which currently fails with nodejs 22 due to some
-  # deprecations in the v8 javascript engine and nan c++
-  buildNpmPackage' = buildNpmPackage.override { nodejs = nodejs_20; };
+  buildNpmPackage' = buildNpmPackage.override { nodejs = nodejs_22; };
 in
 buildGoModule (finalAttrs: {
   pname = "paisa";
@@ -44,6 +41,12 @@ buildGoModule (finalAttrs: {
     inherit (finalAttrs) version src;
 
     npmDepsHash = "sha256-86LvGTSs2PaxrYMGaU7yOUGiAMZY1MfFIexpYVNwvZ8=";
+
+    # canvas fails to build with Node 22 (upstream nan/V8 incompatibility).
+    # It is only used client-side via pdf-js, so the native binding is never
+    # loaded. Other install scripts in this tree are no-ops or re-run during
+    # `vite build`. See Automattic/node-canvas#2448.
+    npmFlags = [ "--ignore-scripts" ];
 
     buildInputs = [
       # needed for building node-canvas from source which is a dependency of
@@ -92,11 +95,6 @@ buildGoModule (finalAttrs: {
   };
 
   meta = {
-    # package is marked as broken on darwin, because due to upgrades to the
-    # darwin clang compiler the native node-addon-api cannot be built anymore.
-    # this can only be fixed by upstream upgrading dependencies (especially
-    # node-gyp and node-addon-api).
-    broken = stdenv.isDarwin;
     homepage = "https://paisa.fyi/";
     changelog = "https://github.com/ananthakumaran/paisa/releases/tag/v${finalAttrs.version}";
     description = "Personal finance manager, building on top of the ledger double entry accounting tool";


### PR DESCRIPTION
See NixOS#515284 for reference.

Update Paisa dependencies to use NodeJS 22 since NodeJS 20 is EOL in nixpkgs.
This coincidentally also unbreaks this package on Darwin.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
