### PR TITLE
libfyaml: Fix C11 atomics detection and buggy macros for C++ compatibility

### DIFF
--- a/pkgs/by-name/li/libfyaml/package.nix
+++ b/pkgs/by-name/li/libfyaml/package.nix
@@ -29,6 +29,11 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/pantoniou/libfyaml/commit/9192deaac095f9881cc1e5756dede683f36b09d6.diff";
       hash = "sha256-cNL9wQtxIRg/ShZLJP4qHYNFRrYo9kRG+/U+3FiUeaI=";
     })
+    # backport "Fix C11 atomics detection and buggy macros for C++ compatibility"
+    (fetchpatch {
+      url = "https://github.com/pantoniou/libfyaml/commit/1026d76850909dc9b1c5f95b8cd94e865a313fd5.diff";
+      hash = "sha256-0YfOqdqHdELFMqr52TDAC3BNFLkcuxvuJY5b9yZ7NFk=";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
This fixes the following build failure that I experience in nix-ros-overlay:

    In file included from /nix/store/siismk0v9aifm29q8qy5v02zy9s2006a-libfyaml-0.9.6-dev/include/libfyaml.h:83,
                     from /build/mrpt_ros-release-release-lyrical-mrpt_libbase-2.15.14-3/build/mrpt-build/src/mrpt/libs/containers/src/yaml.cpp:24:
    /nix/store/siismk0v9aifm29q8qy5v02zy9s2006a-libfyaml-0.9.6-dev/include/libfyaml/libfyaml-atomics.h:431:33: error: expected primary-expression before ')' token
      431 | fy_atomic_get_and_clear_counter(FY_ATOMIC(uint64_t) *ptr)
          |                                 ^~~~~~~~~

See https://github.com/pantoniou/libfyaml/pull/267.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
