### PR TITLE
rustus: fix build

### DIFF
--- a/pkgs/by-name/ru/rustus/bump-mobc.patch
+++ b/pkgs/by-name/ru/rustus/bump-mobc.patch
@@ -1,0 +1,57 @@
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -33,7 +33,7 @@
+ sentry-actix = "0.35.0"
+ mime = "0.3.17"
+ mime_guess = "2.0.5"
+-mobc = "0.8.5"
++mobc = "0.9.0"
+ rust-s3 = "~0.35.1"
+ futures = "^0.3.31"
+ lapin = "^2.5.0"
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -2295,12 +2295,12 @@
+ 
+ [[package]]
+ name = "metrics"
+-version = "0.23.0"
++version = "0.24.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "884adb57038347dfbaf2d5065887b6cf4312330dc8e94bc30a1a839bd79d3261"
++checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
+ dependencies = [
+- "ahash",
+  "portable-atomic",
++ "rapidhash",
+ ]
+ 
+ [[package]]
+@@ -2357,9 +2357,9 @@
+ 
+ [[package]]
+ name = "mobc"
+-version = "0.8.5"
++version = "0.9.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "316a7d198b51958a0ab57248bf5f42d8409551203cb3c821d5925819a8d5415f"
++checksum = "4ee4c321f7581ff6d3b02c1fd05dc0b1f17c05f23c8532d1af9413890ab5fab5"
+ dependencies = [
+  "async-trait",
+  "futures-channel",
+@@ -2930,6 +2930,15 @@
+ ]
+ 
+ [[package]]
++name = "rapidhash"
++version = "4.4.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
++dependencies = [
++ "rustversion",
++]
++
++[[package]]
+ name = "rc2"
+ version = "0.8.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/pkgs/by-name/ru/rustus/package.nix
+++ b/pkgs/by-name/ru/rustus/package.nix
@@ -58,6 +58,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--skip=notifiers::impls::http_notifier::tests::unknown_url"
     "--skip=notifiers::impls::kafka_notifier::test::simple_success_on_prefix"
     "--skip=notifiers::impls::kafka_notifier::test::simple_success_on_topic"
+
+    # flaky: ETXTBSY race on parallel fork/exec
+    "--skip=notifiers::impls::file_notifier::tests::success"
   ];
 
   meta = {

--- a/pkgs/by-name/ru/rustus/package.nix
+++ b/pkgs/by-name/ru/rustus/package.nix
@@ -19,7 +19,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-ALnb6ICg+TZRuHayhozwJ5+imabgjBYX4W42ydhkzv0=";
   };
 
-  cargoHash = "sha256-df92+gp/DtdHwPxJF89zKHjmVWzfrjnD8wAlrPRyyxk=";
+  # Bump mobc 0.8.5 -> 0.9.0 to pull in metrics >= 0.24.2, which fixes a borrow-checker error under newer rustc
+  # (https://github.com/rust-lang/rust/issues/141402).
+  cargoPatches = [ ./bump-mobc.patch ];
+
+  cargoHash = "sha256-FyuUdskTEGiBs7qC7cv1u8d4BCZ2IEOduhAe3m4IDV0=";
 
   env = {
     OPENSSL_NO_VENDOR = 1;


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/324670396)](https://hydra.nixos.org/build/324670396)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test