### PR TITLE
gpac: 2.4.0 -> 26.02.0

### DIFF
--- a/pkgs/by-name/gp/gpac/package.nix
+++ b/pkgs/by-name/gp/gpac/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   gitUpdater,
   unstableGitUpdater,
   cctools,
@@ -39,27 +40,16 @@
 
 let
   stable = rec {
-    version = "2.4.0"; # See below TODO.
+    version = "26.02.0";
     src = fetchFromGitHub {
       owner = "gpac";
       repo = "gpac";
       rev = "v${version}";
-      hash = "sha256-RADDqc5RxNV2EfRTzJP/yz66p0riyn81zvwU3r9xncM=";
+      hash = "sha256-UtL+KG3dsp6dD7cfTK7e17ngt/RHKJL0s5IopTM3VOk=";
     };
     updateScript = gitUpdater {
-      odd-unstable = true;
       rev-prefix = "v";
       ignoredVersions = "^(abi|test)";
-    };
-  }
-  // {
-    # ffmpeg 7.0.2 works, but 7.1.1 (which is packaged in nixpkgs) doesn't
-    # because v2.4.0 of this package relies on internal private ffmpeg fields.
-    # TODO: remove this, and switch to simply using ffmpeg-headless,
-    #       when updating stable to 2.6
-    ffmpeg-headless = ffmpeg-headless.override {
-      version = "7.0.2";
-      hash = "sha256-6bcTxMt0rH/Nso3X7zhrFNkkmWYtxsbUqVQKh25R1Fs=";
     };
   };
   unstable = {
@@ -74,7 +64,6 @@ let
       tagFormat = "v*";
       tagPrefix = "v";
     };
-    inherit ffmpeg-headless;
   };
   channelToUse = if releaseChannel == "unstable" then unstable else stable;
 in
@@ -89,7 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
     cctools
   ]
   ++ lib.optionals withFfmpeg [
-    channelToUse.ffmpeg-headless
+    ffmpeg-headless
   ];
 
   # ref: https://wiki.gpac.io/Build/build/GPAC-Build-Guide-for-Linux/#gpac-easy-build-recommended-for-most-users
@@ -120,6 +109,14 @@ stdenv.mkDerivation (finalAttrs: {
     pulseaudio
     SDL2
     curl
+  ];
+
+  patches = lib.optionals (releaseChannel == "stable") [
+    (fetchpatch2 {
+      # CVE-2026-7135 fix
+      url = "https://github.com/gpac/gpac/commit/cf6ac48c972eaaee2af270adc3f36615325deb3e.patch?full_index=1";
+      hash = "sha256-JaJiQAQvzdB74ag2/aZTiQa2NqlgqgMYS1tsk/R+wiI=";
+    })
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
This update fixes [CVE-2026-7135](https://nvd.nist.gov/vuln/detail/CVE-2026-7135)

Fixes https://github.com/NixOS/nixpkgs/issues/514412

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
