### PR TITLE
element-{web,desktop}: 1.12.14 -> 1.12.18

### DIFF
--- a/pkgs/by-name/el/element-desktop/package.nix
+++ b/pkgs/by-name/el/element-desktop/package.nix
@@ -16,6 +16,7 @@
   fetchPnpmDeps,
   pnpmConfigHook,
   pnpm,
+  faketty,
   asar,
   copyDesktopItems,
   darwin,
@@ -28,13 +29,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "element-desktop";
-  version = "1.12.14";
+  version = "1.12.17";
 
   src = fetchFromGitHub {
     owner = "element-hq";
     repo = "element-web";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-yy7CfMOMT1DBXHDHaDyAaOgp3s2KQIKA1A6zUhVOUhM=";
+    hash = "sha256-9YUdYVsv0k9Oc55aS3pOFttcJ/kNzyu75fyq4oV6wLo=";
   };
 
   pnpmDeps = fetchPnpmDeps {
@@ -44,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
       src
       ;
     fetcherVersion = 3;
-    hash = "sha256-0yqWObZtRntsH7gk+OB8pMuWsrvCQ4L9173Qv0o5abk=";
+    hash = "sha256-aq5Z2n/rzOpgrqWvksU48kUQ4Qi5SaVHo4U54wZIAzg=";
   };
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
@@ -58,6 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
     pnpm
     pnpmConfigHook
     tsx
+    faketty
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     darwin.autoSignDarwinBinariesHook
@@ -83,13 +85,15 @@ stdenv.mkDerivation (finalAttrs: {
     cd ../../
   '';
 
+  # faketty is required to work around a bug in nx.
+  # See: https://github.com/nrwl/nx/issues/22445
   buildPhase = ''
     runHook preBuild
 
     export VERSION=${finalAttrs.version}
 
-    pnpm -C apps/desktop run build:ts
-    pnpm -C apps/desktop run build:res
+    faketty pnpm -C apps/desktop exec nx build:ts
+    faketty pnpm -C apps/desktop exec nx build:res
     pnpm -C apps/desktop exec electron-builder --dir -c.electronDist=electron-dist -c.electronVersion=${electron.version} -c.mac.identity=null
 
     cd apps/desktop

--- a/pkgs/by-name/el/element-desktop/package.nix
+++ b/pkgs/by-name/el/element-desktop/package.nix
@@ -16,6 +16,7 @@
   fetchPnpmDeps,
   pnpmConfigHook,
   pnpm_10,
+  faketty,
   asar,
   copyDesktopItems,
   darwin,
@@ -29,13 +30,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "element-desktop";
-  version = "1.12.14";
+  version = "1.12.18";
 
   src = fetchFromGitHub {
     owner = "element-hq";
     repo = "element-web";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-yy7CfMOMT1DBXHDHaDyAaOgp3s2KQIKA1A6zUhVOUhM=";
+    hash = "sha256-G2HEOv1fHVgbT79bo8ibp9VmtQ8o5vA6/i6Q5TUKqdw=";
   };
 
   pnpmDeps = fetchPnpmDeps {
@@ -46,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
       ;
     inherit pnpm;
     fetcherVersion = 3;
-    hash = "sha256-0yqWObZtRntsH7gk+OB8pMuWsrvCQ4L9173Qv0o5abk=";
+    hash = "sha256-0iGzjwT+99tvRuxYD+1+SrYrCYAI1dcjhXT3x6E/wHg=";
   };
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
@@ -60,6 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
     pnpm
     pnpmConfigHook
     tsx
+    faketty
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     darwin.autoSignDarwinBinariesHook
@@ -85,13 +87,15 @@ stdenv.mkDerivation (finalAttrs: {
     cd ../../
   '';
 
+  # faketty is required to work around a bug in nx.
+  # See: https://github.com/nrwl/nx/issues/22445
   buildPhase = ''
     runHook preBuild
 
     export VERSION=${finalAttrs.version}
 
-    pnpm -C apps/desktop run build:ts
-    pnpm -C apps/desktop run build:res
+    faketty pnpm -C apps/desktop exec nx build:ts
+    faketty pnpm -C apps/desktop exec nx build:res
     pnpm -C apps/desktop exec electron-builder --dir -c.electronDist=electron-dist -c.electronVersion=${electron.version} -c.mac.identity=null
 
     cd apps/desktop

--- a/pkgs/by-name/el/element-web-unwrapped/package.nix
+++ b/pkgs/by-name/el/element-web-unwrapped/package.nix
@@ -24,20 +24,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "element-web";
-  version = "1.12.14";
+  version = "1.12.17";
 
   src = fetchFromGitHub {
     owner = "element-hq";
     repo = "element-web";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-yy7CfMOMT1DBXHDHaDyAaOgp3s2KQIKA1A6zUhVOUhM=";
+    hash = "sha256-9YUdYVsv0k9Oc55aS3pOFttcJ/kNzyu75fyq4oV6wLo=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     pname = "element";
     inherit (finalAttrs) version src;
     fetcherVersion = 3;
-    hash = "sha256-0yqWObZtRntsH7gk+OB8pMuWsrvCQ4L9173Qv0o5abk=";
+    hash = "sha256-aq5Z2n/rzOpgrqWvksU48kUQ4Qi5SaVHo4U54wZIAzg=";
   };
 
   nativeBuildInputs = [
@@ -47,6 +47,11 @@ stdenv.mkDerivation (finalAttrs: {
     pnpmConfigHook
     faketty
   ];
+
+  preBuild = ''
+    substituteInPlace packages/module-api/node_modules/.bin/vite \
+      --replace-fail "/usr/bin/env node" "${nodejs}/bin/node"
+  '';
 
   # faketty is required to work around a bug in nx.
   # See: https://github.com/nrwl/nx/issues/22445

--- a/pkgs/by-name/el/element-web-unwrapped/package.nix
+++ b/pkgs/by-name/el/element-web-unwrapped/package.nix
@@ -26,13 +26,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "element-web";
-  version = "1.12.14";
+  version = "1.12.18";
 
   src = fetchFromGitHub {
     owner = "element-hq";
     repo = "element-web";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-yy7CfMOMT1DBXHDHaDyAaOgp3s2KQIKA1A6zUhVOUhM=";
+    hash = "sha256-G2HEOv1fHVgbT79bo8ibp9VmtQ8o5vA6/i6Q5TUKqdw=";
   };
 
   pnpmDeps = fetchPnpmDeps {
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     inherit (finalAttrs) version src;
     inherit pnpm;
     fetcherVersion = 3;
-    hash = "sha256-0yqWObZtRntsH7gk+OB8pMuWsrvCQ4L9173Qv0o5abk=";
+    hash = "sha256-0iGzjwT+99tvRuxYD+1+SrYrCYAI1dcjhXT3x6E/wHg=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
https://github.com/element-hq/element-web/releases/tag/v1.12.15
https://github.com/element-hq/element-web/releases/tag/v1.12.16
https://github.com/element-hq/element-web/releases/tag/v1.12.17
https://github.com/element-hq/element-web/releases/tag/v1.12.18

https://github.com/element-hq/element-web/compare/v1.12.14...v1.12.18


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
