### PR TITLE
yazi-unwrapped: 26.1.22 -> 26.5.6

### DIFF
--- a/pkgs/by-name/ya/yazi-unwrapped/package.nix
+++ b/pkgs/by-name/ya/yazi-unwrapped/package.nix
@@ -8,17 +8,17 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "yazi";
-  version = "26.1.22";
+  version = "26.5.6";
 
   srcs = builtins.attrValues finalAttrs.passthru.srcs;
 
   sourceRoot = finalAttrs.passthru.srcs.code_src.name;
 
-  cargoHash = "sha256-VcoIjPZqLimo44atXh7pnCtF+QaZA7uHtKEE6FgTL2k=";
+  cargoHash = "sha256-gc0uEMNJ+eCIymXK10+Swi11xuyP5cj6MbLLB/ZDgXw=";
 
   env.YAZI_GEN_COMPLETIONS = true;
   env.VERGEN_GIT_SHA = "Nixpkgs";
-  env.VERGEN_BUILD_DATE = "2026-01-22";
+  env.VERGEN_BUILD_DATE = "2026-05-05";
 
   nativeBuildInputs = [ installShellFiles ];
   buildInputs = [ rust-jemalloc-sys ];
@@ -36,18 +36,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
     install -Dm444 assets/logo.png $out/share/pixmaps/yazi.png
   '';
 
-  postPatch = ''
-    substituteInPlace yazi-shared/Cargo.toml \
-      --replace-fail 'rust-version = "1.92.0"' 'rust-version = "1.91"'
-  '';
-
   passthru.updateScript.command = [ ./update.sh ];
   passthru.srcs = {
     code_src = fetchFromGitHub {
       owner = "sxyazi";
       repo = "yazi";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-BZktPXn+8vyFyHapvW+9nepFsWRW/XBtdBcnLKrCNCw=";
+      hash = "sha256-sdaqZwLb+fBTg5Pd6WWfOWKCavsXWSSZrBEXuYuc8iM=";
     };
 
     man_src = fetchFromGitHub {

--- a/pkgs/by-name/ya/yazi-unwrapped/update.sh
+++ b/pkgs/by-name/ya/yazi-unwrapped/update.sh
@@ -41,12 +41,12 @@ echo "Updating cargoHash"
 sed -i -E 's/cargoHash = ".*?"/cargoHash = ""/' package.nix
 
 # Build and get new hash
-cargoHash=$( (nix-build "$NIXPKGS_DIR" -A yazi-unwrapped 2>&1 || true) | awk '/got/{print $2}')
+cargoHash=$( (nix-build "$NIXPKGS_DIR" -A yazi-unwrapped 2>&1 || true) | awk '/got:/{print $2}')
 
 if [ "$cargoHash" == "" ]; then
     echo "Failed to get cargoHash, please update it manually"
     exit 0
 fi
 
-sed -i -E 's/cargoHash = ".*?"/cargoHash = "'"$cargoHash"'"/' package.nix
+sed -i -E 's#cargoHash = ".*?"#cargoHash = "'"$cargoHash"'"#' package.nix
 popd


### PR DESCRIPTION
https://github.com/sxyazi/yazi/releases/tag/v26.5.6
https://github.com/sxyazi/yazi/blob/main/CHANGELOG.md#v2656

Depends on https://github.com/NixOS/nixpkgs/pull/510674

Targeting staging-next for rust 1.95.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
