### PR TITLE
reptyr: shrink build closure

### DIFF
--- a/pkgs/by-name/re/reptyr/package.nix
+++ b/pkgs/by-name/re/reptyr/package.nix
@@ -2,12 +2,8 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  python3,
 }:
 
-let
-  python = python3.withPackages (p: [ p.pexpect ]);
-in
 stdenv.mkDerivation (finalAttrs: {
   version = "0.10.0";
   pname = "reptyr";
@@ -24,15 +20,9 @@ stdenv.mkDerivation (finalAttrs: {
     "DESTDIR=$(out)"
   ];
 
-  nativeCheckInputs = [ python ];
-
   # reptyr needs to do ptrace of a non-child process
   # It can be neither used nor tested if the kernel is not told to allow this
   doCheck = false;
-
-  checkFlags = [
-    "PYTHON_CMD=${python.interpreter}"
-  ];
 
   meta = {
     platforms = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Since https://github.com/NixOS/nixpkgs/commit/9daae56550c8883757d122c0fb1188f24ccfe7fd the tests are always disabled unconditionally. Then we might as well get rid of the Python test dependency which unnecessarily bloats the build closure. An additional benefit of this change is that cross compiling also works now, e.g. `pkgsStatic.reptyr` can be built and doesn't fail in some dependency.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
