### PR TITLE
redisinsight: 2.70.0 -> 3.4.2

### DIFF
--- a/pkgs/by-name/re/redisinsight/package.nix
+++ b/pkgs/by-name/re/redisinsight/package.nix
@@ -23,13 +23,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "redisinsight";
-  version = "2.70.0";
+  version = "3.4.2";
 
   src = fetchFromGitHub {
-    owner = "RedisInsight";
+    owner = "redis";
     repo = "RedisInsight";
     rev = finalAttrs.version;
-    hash = "sha256-b97/hBhXqSFDzcyrQKu5Ebu1Ud3wpWEjyzUehj0PP9w=";
+    hash = "sha256-QV1xxpr8aMgkxWitJPVjXB/G2UaAYrV2wMM1FbltZpE=";
   };
 
   patches = [
@@ -42,21 +42,21 @@ stdenv.mkDerivation (finalAttrs: {
   baseOfflineCache = fetchYarnDeps {
     name = "redisinsight-${finalAttrs.version}-base-offline-cache";
     inherit (finalAttrs) src patches;
-    hash = "sha256-m3relh3DZGReEi4dVOJcIXU9QVClisXw+f7K5i25x24=";
+    hash = "sha256-hU8/ycljmRxqQEx0neezQmJPaianJhL0IyVOJEfLy5o=";
   };
 
   innerOfflineCache = fetchYarnDeps {
     name = "redisinsight-${finalAttrs.version}-inner-offline-cache";
     inherit (finalAttrs) src patches;
     postPatch = "cd redisinsight";
-    hash = "sha256-rqmrETlc2XoZDM4GP1+qI4eK4oGmtpmc6TVvAam2+W8=";
+    hash = "sha256-s4JTgqXT+5P/C5e3/c30/VZHt8MRct3KViZOD1Fekqc=";
   };
 
   apiOfflineCache = fetchYarnDeps {
     name = "redisinsight-${finalAttrs.version}-api-offline-cache";
     inherit (finalAttrs) src patches;
     postPatch = "cd redisinsight/api";
-    hash = "sha256-KFtmq3iYAnsAi5ysvGCzBk9RHV7EE7SIPbzPza7vBdA=";
+    hash = "sha256-GsdKJjQltpHKDZmGRF60M1TLTbnwyHt9e5ayrXgbFOU=";
   };
 
   nativeBuildInputs = [
@@ -120,9 +120,13 @@ stdenv.mkDerivation (finalAttrs: {
     # TODO: Generate defaults. Currently broken because it requires network access.
     # yarn --offline --cwd=redisinsight/api build:defaults
 
+    # Electron dist needs to be writable during the build.
+    cp -r ${electron.dist} electron-dist
+    chmod -R u+w electron-dist
+
     yarn --offline electron-builder \
       --dir \
-      -c.electronDist=${electron.dist} \
+      -c.electronDist=electron-dist \
       -c.electronVersion=${electron.version} \
       -c.npmRebuild=false # we've already rebuilt the native libs using the electron headers
 
@@ -167,7 +171,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Developer GUI for Redis";
-    homepage = "https://github.com/RedisInsight/RedisInsight";
+    homepage = "https://github.com/redis/RedisInsight";
     license = lib.licenses.sspl;
     maintainers = with lib.maintainers; [
       tomasajt

--- a/pkgs/by-name/re/redisinsight/remove-cpu-features.patch
+++ b/pkgs/by-name/re/redisinsight/remove-cpu-features.patch
@@ -1,20 +1,20 @@
 diff --git a/redisinsight/api/package.json b/redisinsight/api/package.json
-index 4a24ac8..fab339c 100644
+index 825b18a59..034bb9491 100644
 --- a/redisinsight/api/package.json
 +++ b/redisinsight/api/package.json
-@@ -49,7 +49,6 @@
-     "@nestjs/platform-socket.io/socket.io": "^4.8.0",
-     "@nestjs/cli/**/braces": "^3.0.3",
+@@ -44,7 +44,6 @@
+     "jest/**/micromatch": "^4.0.8",
+     "mocha/minimatch": "^3.0.5",
      "**/semver": "^7.5.2",
 -    "**/cpu-features": "file:./stubs/cpu-features",
      "**/cross-spawn": "^7.0.5",
      "**/redis-parser": "3.0.0",
-     "winston-daily-rotate-file/**/file-stream-rotator": "^1.0.0"
+     "winston-daily-rotate-file/**/file-stream-rotator": "^1.0.0",
 diff --git a/redisinsight/api/yarn.lock b/redisinsight/api/yarn.lock
-index e0e8495..dfed1ae 100644
+index dfdb57365..7aef4106b 100644
 --- a/redisinsight/api/yarn.lock
 +++ b/redisinsight/api/yarn.lock
-@@ -3223,9 +3223,6 @@ cosmiconfig@^8.2.0:
+@@ -3080,9 +3080,6 @@ cosmiconfig@^8.2.0:
      parse-json "^5.2.0"
      path-type "^4.0.0"
  
@@ -24,47 +24,47 @@ index e0e8495..dfed1ae 100644
  create-jest@^29.7.0:
    version "29.7.0"
    resolved "https://registry.yarnpkg.com/create-jest/-/create-jest-29.7.0.tgz#a355c5b3cb1e1af02ba177fe7afd7feee49a5320"
-@@ -7969,7 +7966,6 @@ ssh2@^1.15.0:
+@@ -6945,7 +6942,6 @@ ssh2@^1.15.0:
      asn1 "^0.2.6"
      bcrypt-pbkdf "^1.0.2"
    optionalDependencies:
 -    cpu-features "~0.0.9"
      nan "^2.18.0"
  
- ssri@^8.0.0, ssri@^8.0.1:
+ stack-trace@0.0.x:
 diff --git a/redisinsight/package.json b/redisinsight/package.json
-index 8649be7..354ed42 100644
+index c7d8a7f89..d0c06916c 100644
 --- a/redisinsight/package.json
 +++ b/redisinsight/package.json
-@@ -16,8 +16,7 @@
+@@ -15,8 +15,7 @@
+     "postinstall": "npx patch-package"
    },
    "resolutions": {
-     "**/semver": "^7.5.2",
--    "sqlite3/**/tar": "^6.2.1",
+-    "**/semver": "^7.5.2",
 -    "**/cpu-features": "file:./api/stubs/cpu-features"
-+    "sqlite3/**/tar": "^6.2.1"
++    "**/semver": "^7.5.2"
    },
    "dependencies": {
-     "keytar": "^7.9.0",
+     "better-sqlite3": "^12.8.0",
 diff --git a/redisinsight/yarn.lock b/redisinsight/yarn.lock
-index 7a063ce..22f37a7 100644
+index 1d164a2e6..b239a21eb 100644
 --- a/redisinsight/yarn.lock
 +++ b/redisinsight/yarn.lock
-@@ -183,9 +183,6 @@ console-control-strings@^1.1.0:
-   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
-   integrity sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==
+@@ -58,9 +58,6 @@ chownr@^1.1.1:
+   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
+   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
  
 -"cpu-features@file:./api/stubs/cpu-features", cpu-features@~0.0.10:
 -  version "1.0.0"
 -
- debug@4, debug@^4.3.3:
-   version "4.3.4"
-   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
-@@ -807,7 +804,6 @@ ssh2@^1.15.0:
+ decompress-response@^6.0.0:
+   version "6.0.0"
+   resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
+@@ -281,7 +278,6 @@ ssh2@^1.15.0:
      asn1 "^0.2.6"
      bcrypt-pbkdf "^1.0.2"
    optionalDependencies:
 -    cpu-features "~0.0.10"
      nan "^2.20.0"
  
- ssri@^8.0.0, ssri@^8.0.1:
+ string_decoder@^1.1.1:


### PR DESCRIPTION
changelog: https://github.com/redis/RedisInsight/releases/tag/3.4.2
diff: https://github.com/redis/RedisInsight/compare/2.70.0...3.4.2

Closes #477226

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
