### PR TITLE
maintainers: remove kennyballou

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14011,13 +14011,6 @@
     github = "keller00";
     githubId = 8452750;
   };
-  kennyballou = {
-    email = "kb@devnulllabs.io";
-    github = "kennyballou";
-    githubId = 2186188;
-    name = "Kenny Ballou";
-    keys = [ { fingerprint = "932F 3E8E 1C0F 4A98 95D7  B8B8 B0CA A28A 0295 8308"; } ];
-  };
   kenran = {
     email = "johannes.maier@mailbox.org";
     github = "kenranunderscore";


### PR DESCRIPTION
## Reasons

- Last commented in [May 2021](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Akennyballou)
- Hasn't created any PRs / Issues since [May 2021](https://github.com/NixOS/nixpkgs/issues?q=author%3Akennyballou)
- About 1 [unanswered ](https://github.com/NixOS/nixpkgs/issues?q=involves%3Akennyballou%20-commenter%3Akennyballou%20-author%3Akennyballou%20-reviewed-by%3Akennyballou) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.