### PR TITLE
discord: drop `openssl_1_1` from distro builds

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -49,7 +49,6 @@
   libgbm,
   nspr,
   nss,
-  openssl_1_1,
   pango,
   systemdLibs,
   libappindicator-gtk3,
@@ -231,17 +230,21 @@ stdenv.mkDerivation (finalAttrs: {
     nss
   ]
   # The new distro layout ships prebuilt `.node` modules:
-  # discord_dispatch is linked against openssl 1.1, discord_voice against libpulseaudio
-  ++ lib.optionals isDistro [
-    openssl_1_1
-    libpulseaudio
-  ];
+  # discord_dispatch is linked against openssl 1.1, discord_voice against libpulseaudio.
+  # Ignore the missing dependency on insecure openssl_1_1: discord_dispatch is
+  # effectively unused in practice.
+  ++ lib.optionals isDistro [ libpulseaudio ];
 
   strictDeps = true;
 
   dontUnpack = isDistro;
 
   inherit libPath;
+
+  autoPatchelfIgnoreMissingDeps = lib.optionals isDistro [
+    "libssl.so.1.1"
+    "libcrypto.so.1.1"
+  ];
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
Closes: https://github.com/NixOS/nixpkgs/issues/513122

Ignore the missing OpenSSL 1.1 libraries from `discord_dispatch.node` instead, since that module is effectively unused in practice

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
