### PR TITLE
hidden-bar: 1.9 -> 1.10

### DIFF
--- a/pkgs/by-name/hi/hidden-bar/package.nix
+++ b/pkgs/by-name/hi/hidden-bar/package.nix
@@ -2,16 +2,16 @@
   lib,
   stdenvNoCC,
   fetchurl,
-  undmg,
+  unzip,
 }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "hidden-bar";
-  version = "1.9";
+  version = "1.10";
 
   src = fetchurl {
-    url = "https://github.com/dwarvesf/hidden/releases/download/v${version}/Hidden.Bar.${version}.dmg";
-    hash = "sha256-P1SwJPXBxAvBiuvjkBRxAom0fhR+cVYfriKmYcqybQI=";
+    url = "https://github.com/dwarvesf/hidden/releases/download/v${version}/Hidden-Bar-v${version}-macos.zip";
+    hash = "sha256-qKX1KZ/fq1K9/7L1cop21MumkHVOmzsS8nvTjy52wLw=";
   };
 
   sourceRoot = ".";
@@ -25,7 +25,7 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
-  nativeBuildInputs = [ undmg ];
+  nativeBuildInputs = [ unzip ];
 
   meta = {
     description = "Ultra-light MacOS utility that helps hide menu bar icons";


### PR DESCRIPTION
Updates hidden-bar from 1.9 to 1.10.

Upstream changed the macOS release artifact from dmg to zip, so this switches the unpacker from `undmg` to `unzip`.

Release: https://github.com/dwarvesf/hidden/releases/tag/v1.10

Tested on macOS: built successfully with sandboxing and launched the app.

## Things done

- [x] Tested using sandboxing
- [x] Built on platform(s)
  - [x] aarch64-darwin
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Meets Nixpkgs contribution standards