### PR TITLE
command-not-found: don't require lib.mkForce to set dbPath

### DIFF
--- a/nixos/modules/programs/command-not-found/command-not-found.nix
+++ b/nixos/modules/programs/command-not-found/command-not-found.nix
@@ -62,7 +62,7 @@ in
     {
       programs.command-not-found = {
         enable = lib.mkDefault (builtins.pathExists cfg.dbPath);
-        dbPath = pkgs.path + "/programs.sqlite";
+        dbPath = lib.mkDefault (pkgs.path + "/programs.sqlite");
       };
     }
 

--- a/nixos/modules/programs/command-not-found/command-not-found.nix
+++ b/nixos/modules/programs/command-not-found/command-not-found.nix
@@ -45,6 +45,11 @@ in
     };
 
     dbPath = lib.mkOption {
+      type = lib.types.path;
+      default = pkgs.path + "/programs.sqlite";
+      defaultText = lib.literalExpression ''
+        pkgs.path + "/programs.sqlite"
+      '';
       description = ''
         Absolute path to `programs.sqlite`, which contains mappings from binary names to package names.
 
@@ -54,7 +59,6 @@ in
         `/nix/var/nix/profiles/per-user/root/channels/nixos/programs.sqlite`.
         If you do so, you can update it with `sudo nix-channels --update`.
       '';
-      type = lib.types.path;
     };
   };
 
@@ -62,7 +66,6 @@ in
     {
       programs.command-not-found = {
         enable = lib.mkDefault (builtins.pathExists cfg.dbPath);
-        dbPath = lib.mkDefault (pkgs.path + "/programs.sqlite");
       };
     }
 

--- a/nixos/modules/programs/command-not-found/command-not-found.nix
+++ b/nixos/modules/programs/command-not-found/command-not-found.nix
@@ -33,7 +33,10 @@ in
 
     enable = lib.mkOption {
       type = lib.types.bool;
-      default = false;
+      default = builtins.pathExists config.programs.command-not-found.dbPath;
+      defaultText = lib.literalExpression ''
+        builtins.pathExists config.programs.command-not-found.dbPath
+      '';
       description = ''
         Whether interactive shells should show which Nix package (if
         any) provides a missing command.
@@ -62,34 +65,26 @@ in
     };
   };
 
-  config = lib.mkMerge [
-    {
-      programs.command-not-found = {
-        enable = lib.mkDefault (builtins.pathExists cfg.dbPath);
-      };
-    }
+  config = lib.mkIf cfg.enable {
+    programs.bash.interactiveShellInit = ''
+      command_not_found_handle() {
+        '${commandNotFound}/bin/command-not-found' "$@"
+      }
+    '';
 
-    (lib.mkIf cfg.enable {
-      programs.bash.interactiveShellInit = ''
-        command_not_found_handle() {
-          '${commandNotFound}/bin/command-not-found' "$@"
-        }
-      '';
+    programs.zsh.interactiveShellInit = ''
+      command_not_found_handler() {
+        '${commandNotFound}/bin/command-not-found' "$@"
+      }
+    '';
 
-      programs.zsh.interactiveShellInit = ''
-        command_not_found_handler() {
-          '${commandNotFound}/bin/command-not-found' "$@"
-        }
-      '';
+    # NOTE: Fish by itself checks for nixos command-not-found, let's instead makes it explicit.
+    programs.fish.interactiveShellInit = ''
+      function fish_command_not_found
+         "${commandNotFound}/bin/command-not-found" $argv
+      end
+    '';
 
-      # NOTE: Fish by itself checks for nixos command-not-found, let's instead makes it explicit.
-      programs.fish.interactiveShellInit = ''
-        function fish_command_not_found
-           "${commandNotFound}/bin/command-not-found" $argv
-        end
-      '';
-
-      environment.systemPackages = [ commandNotFound ];
-    })
-  ];
+    environment.systemPackages = [ commandNotFound ];
+  };
 }


### PR DESCRIPTION
Recent changes to `command-not-found` dropped the use of mechanisms for setting a default for dbPath and instead set it directly. As a result, any user who wants to set this option is forced to use lib.mkForce when previously they did not. The documentation in the upstream changes say that "If a nixpkgs tarball from https://channels.nixos.org is used as the source of nixpkgs, this file will be provided and this option be set by default."; the code does not match this behavior.

This change uses lib.mkDefault to restore the old behavior.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
