### PR TITLE
simbaplusplus: 0-unstable-2024-11-05 -> 0-unstable-2025-11-05; fix build

### DIFF
--- a/pkgs/by-name/si/simbaplusplus/package.nix
+++ b/pkgs/by-name/si/simbaplusplus/package.nix
@@ -25,6 +25,9 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail 'set(Z3_INCLUDE_DIRS “/usr/include”)' ""
   '';
 
+  # llvm-config --cxxflags exports -fno-exceptions, but z3's C++ headers require exception support.
+  env.NIX_CFLAGS_COMPILE = "-fexceptions";
+
   nativeBuildInputs = [
     cmake
   ];

--- a/pkgs/by-name/si/simbaplusplus/package.nix
+++ b/pkgs/by-name/si/simbaplusplus/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   llvmPackages,
   z3,
@@ -11,22 +10,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "simbaplusplus";
-  version = "0-unstable-2024-11-05";
+  version = "0-unstable-2025-11-05";
 
   src = fetchFromGitHub {
     owner = "pgarba";
     repo = "SiMBA-";
-    rev = "a030a187df0b650718b2aab18ccebc1f810e18b4";
-    hash = "sha256-h2in203bwfb7ArhoBN0PoWM6DZtxI4jSGQuSTTaBJ7A=";
+    rev = "cbef1fc868d5de1b659ed317db9e0a1cecf6462b";
+    hash = "sha256-GISI66DuNA7KYJ/trdSdx3CkjdqXn9mQs+EwVxSlgoE=";
   };
-
-  patches = [
-    # CMakeLists: minimum cmake version 3.5
-    (fetchpatch {
-      url = "https://github.com/pgarba/SiMBA-/commit/0d5dcaf0a0e85e342141a9c525cc8a10934c2f9d.patch?full_index=1";
-      hash = "sha256-rL/jzq4eoJI6j1aEK8vg6b2uqGjxN6P+8vsC8oYTxng=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327183020)](https://hydra.nixos.org/build/327183020)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test