### PR TITLE
maintainers: remove mmai

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18246,12 +18246,6 @@
     githubId = 104795;
     name = "Marek Mahut";
   };
-  mmai = {
-    email = "henri.bourcereau@gmail.com";
-    github = "mmai";
-    githubId = 117842;
-    name = "Henri Bourcereau";
-  };
   mmesch = {
     github = "MMesch";
     githubId = 2597803;

--- a/pkgs/development/python-modules/aioredis/default.nix
+++ b/pkgs/development/python-modules/aioredis/default.nix
@@ -42,6 +42,6 @@ buildPythonPackage rec {
     description = "Asyncio (PEP 3156) Redis client library";
     homepage = "https://github.com/aio-libs-abandoned/aioredis-py";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ mmai ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/channels-redis/default.nix
+++ b/pkgs/development/python-modules/channels-redis/default.nix
@@ -46,6 +46,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/django/channels_redis/";
     changelog = "https://github.com/django/channels_redis/blob/${src.tag}/CHANGELOG.txt";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ mmai ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/django-auth-ldap/default.nix
+++ b/pkgs/development/python-modules/django-auth-ldap/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
     description = "Django authentication backend that authenticates against an LDAP service";
     homepage = "https://github.com/django-auth-ldap/django-auth-ldap";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ mmai ];
+    maintainers = [ ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 }

--- a/pkgs/development/python-modules/django-cleanup/default.nix
+++ b/pkgs/development/python-modules/django-cleanup/default.nix
@@ -28,6 +28,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/un1t/django-cleanup";
     changelog = "https://github.com/un1t/django-cleanup/blob/${version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ mmai ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/django-dynamic-preferences/default.nix
+++ b/pkgs/development/python-modules/django-dynamic-preferences/default.nix
@@ -47,6 +47,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/agateblue/django-dynamic-preferences/blob/${version}/HISTORY.rst";
     homepage = "https://github.com/agateblue/django-dynamic-preferences";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ mmai ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/django-filter/default.nix
+++ b/pkgs/development/python-modules/django-filter/default.nix
@@ -42,6 +42,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/carltongibson/django-filter";
     changelog = "https://github.com/carltongibson/django-filter/blob/${version}/CHANGES.rst";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ mmai ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/django-oauth-toolkit/default.nix
+++ b/pkgs/development/python-modules/django-oauth-toolkit/default.nix
@@ -64,6 +64,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/jazzband/django-oauth-toolkit";
     changelog = "https://github.com/jazzband/django-oauth-toolkit/django-filer/blob/${version}/CHANGELOG.md";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ mmai ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/django-storages/default.nix
+++ b/pkgs/development/python-modules/django-storages/default.nix
@@ -74,6 +74,6 @@ buildPythonPackage rec {
     downloadPage = "https://github.com/jschneier/django-storages/";
     homepage = "https://django-storages.readthedocs.io";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ mmai ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/django-versatileimagefield/default.nix
+++ b/pkgs/development/python-modules/django-versatileimagefield/default.nix
@@ -32,6 +32,6 @@ buildPythonPackage rec {
     description = "Replaces django's ImageField with a more flexible interface";
     homepage = "https://github.com/respondcreate/django-versatileimagefield/";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ mmai ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/hiredis/default.nix
+++ b/pkgs/development/python-modules/hiredis/default.nix
@@ -38,6 +38,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/redis/hiredis-py";
     changelog = "https://github.com/redis/hiredis-py/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ mmai ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/persisting-theory/default.nix
+++ b/pkgs/development/python-modules/persisting-theory/default.nix
@@ -23,6 +23,6 @@ buildPythonPackage rec {
     homepage = "https://code.agate.blue/agate/persisting-theory";
     description = "Automate data discovering and access inside a list of packages";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ mmai ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pymemoize/default.nix
+++ b/pkgs/development/python-modules/pymemoize/default.nix
@@ -25,6 +25,6 @@ buildPythonPackage rec {
     description = "Simple Python cache and memoizing module";
     homepage = "https://github.com/mikeboers/PyMemoize";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ mmai ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/requests-http-signature/default.nix
+++ b/pkgs/development/python-modules/requests-http-signature/default.nix
@@ -44,6 +44,6 @@ buildPythonPackage rec {
     description = "Requests authentication module for HTTP Signature";
     homepage = "https://github.com/kislyuk/requests-http-signature";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ mmai ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
## Reasons

- Last commented in [August 2022](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Ammai)
- Hasn't created any PRs / Issues since [February 2020](https://github.com/NixOS/nixpkgs/issues?q=author%3Ammai)
- About 112 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Ammai%20-commenter%3Ammai%20-author%3Ammai%20-reviewed-by%3Ammai) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] pythonPackages.aioredis
- [ ] pythonPackages.channels-redis
- [ ] pythonPackages.django-auth-ldap
- [ ] pythonPackages.django-cleanup
- [ ] pythonPackages.django-dynamic-preferences
- [ ] pythonPackages.django-filter
- [ ] pythonPackages.django-oauth-toolkit
- [ ] pythonPackages.django-storages
- [ ] pythonPackages.django-versatileimagefield
- [ ] pythonPackages.hiredis
- [ ] pythonPackages.persisting-theory
- [ ] pythonPackages.pymemoize
- [ ] pythonPackages.requests-http-signature