### PR TITLE
simple-dftd3, python3Packages.[pyscf, simple-dft3]: update and fix builds

### DIFF
--- a/pkgs/development/libraries/science/chemistry/simple-dftd3/default.nix
+++ b/pkgs/development/libraries/science/chemistry/simple-dftd3/default.nix
@@ -24,13 +24,13 @@ assert (
 
 stdenv.mkDerivation rec {
   pname = "simple-dftd3";
-  version = "1.2.1";
+  version = "1.3.2";
 
   src = fetchFromGitHub {
     owner = "dftd3";
     repo = "simple-dftd3";
     tag = "v${version}";
-    hash = "sha256-c4xctcMcPQ70ippqbwtinygmnZ5en6ZGF5/v0ZWtzys=";
+    hash = "sha256-h9KFqZOfH7c7hntfL/C5WG9HVof64O4U1BNCCOuQhpA=";
   };
 
   patches = [

--- a/pkgs/development/libraries/science/chemistry/simple-dftd3/python.nix
+++ b/pkgs/development/libraries/science/chemistry/simple-dftd3/python.nix
@@ -9,10 +9,13 @@
   pyscf,
   ase,
   pytestCheckHook,
+  meson-python,
+  meson,
+  setuptools,
+  pkg-config,
 }:
 
 buildPythonPackage {
-  format = "setuptools";
   inherit (simple-dftd3)
     pname
     version
@@ -20,12 +23,21 @@ buildPythonPackage {
     meta
     ;
 
-  # pytest is also required for installation, not only testing
-  nativeBuildInputs = [ pytestCheckHook ];
+  pyproject = true;
+
+  build-system = [
+    meson-python
+    setuptools
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    meson
+  ];
 
   buildInputs = [ simple-dftd3 ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     cffi
     numpy
     toml
@@ -35,6 +47,7 @@ buildPythonPackage {
     ase
     qcengine
     pyscf
+    pytestCheckHook
   ];
 
   preConfigure = ''

--- a/pkgs/development/python-modules/pyscf/default.nix
+++ b/pkgs/development/python-modules/pyscf/default.nix
@@ -24,7 +24,7 @@
 
 buildPythonPackage {
   pname = "pyscf";
-  version = "2.12.1-unstable-2026-03-21";
+  version = "2.13.0";
   format = "setuptools";
 
   src = fetchFromGitHub {


### PR DESCRIPTION
Supersedes #503800

* Simple-DFTD3 release notes https://github.com/dftd3/simple-dftd3/releases
* PySCF release notes https://github.com/pyscf/pyscf/releases/tag/v2.13.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
