### PR TITLE
python3Packages.redis-om: 0.3.5 -> 1.1.0

### DIFF
--- a/pkgs/development/python-modules/redis-om/default.nix
+++ b/pkgs/development/python-modules/redis-om/default.nix
@@ -2,16 +2,17 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
+  hatchling,
   unasync,
-  poetry-core,
   python,
   click,
   hiredis,
   more-itertools,
   pydantic,
+  pydantic-extra-types,
   python-ulid,
   redis,
+  redisvl,
   redisTestHook,
   types-redis,
   typing-extensions,
@@ -21,45 +22,43 @@
 
 buildPythonPackage rec {
   pname = "redis-om";
-  version = "0.3.5";
+  version = "1.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "redis";
     repo = "redis-om-python";
     tag = "v${version}";
-    hash = "sha256-TfwMYDZYDKCdI5i8izBVZaXN5GC/Skhkl905c/DHuXY=";
+    hash = "sha256-qjGrhEINW9p2Rd3O5WI4QKYcj8tn/FI3pjnhI1k3mmc=";
   };
 
-  patches = [
-    # Include redis_om package, https://github.com/redis/redis-om-python/pull/718
-    (fetchpatch {
-      name = "include-redis_om.patch";
-      url = "https://github.com/redis/redis-om-python/commit/cc03485f148dcc2f455dd8cafd3b116758504c50.patch";
-      hash = "sha256-UzQfRbLCTnKW5jxQhldI9KCuN//bx3/PvNnfd872D+o=";
-    })
-  ];
-
   build-system = [
+    hatchling
     unasync
-    poetry-core
   ];
-
-  # it has not been maintained at all for a half year and some dependencies are outdated
-  # https://github.com/redis/redis-om-python/pull/554
-  # https://github.com/redis/redis-om-python/pull/577
-  pythonRelaxDeps = true;
 
   dependencies = [
     click
     hiredis
     more-itertools
     pydantic
+    pydantic-extra-types
     python-ulid
     redis
+    redisvl
     types-redis
     typing-extensions
   ];
+
+  postPatch = ''
+    # We don't want to use a formatter in our build.
+    substituteInPlace make_sync.py \
+      --replace-fail 'ruff' 'true'
+
+    # Fix `click` not finding the correct package to use for the version command.
+    substituteInPlace aredis_om/cli/main.py \
+      --replace-fail '@click.version_option()' '@click.version_option(package_name = "redis_om")'
+  '';
 
   preBuild = ''
     ${python.pythonOnBuildForHost.interpreter} make_sync.py
@@ -82,7 +81,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Object mapping, and more, for Redis and Python";
-    mainProgram = "migrate";
+    mainProgram = "om";
     homepage = "https://github.com/redis/redis-om-python";
     changelog = "https://github.com/redis/redis-om-python/releases/tag/${src.tag}";
     license = lib.licenses.mit;


### PR DESCRIPTION
changelog: https://github.com/redis/redis-om-python/releases/tag/v1.1.0
diff: https://github.com/redis/redis-om-python/compare/v0.3.5...v1.1.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
