### PR TITLE
python3Packages.tt-flash: cleanup

### DIFF
--- a/pkgs/by-name/tt/tt-smi/package.nix
+++ b/pkgs/by-name/tt/tt-smi/package.nix
@@ -51,6 +51,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     mainProgram = "tt-smi";
     description = "Tenstorrent console based hardware information program";
     homepage = "https://github.com/tenstorrent/tt-smi";
+    changelog = "https://github.com/tenstorrent/tt-smi/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     maintainers = with lib.maintainers; [ RossComputerGuy ];
     license = with lib.licenses; [ asl20 ];
   };

--- a/pkgs/development/python-modules/pyluwen/default.nix
+++ b/pkgs/development/python-modules/pyluwen/default.nix
@@ -1,9 +1,9 @@
 {
   lib,
   buildPythonPackage,
-  runCommand,
   fetchFromGitHub,
   rustPlatform,
+
   maturin,
   protobuf_30,
 }:
@@ -21,11 +21,11 @@ buildPythonPackage (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-QBGXbRiBk4WIQFopq1OccmUHgx5GzR/PKhMH4Ie+fyg=";
   };
 
-  sourceRoot = "${finalAttrs.src.name}/bind/${finalAttrs.pname}";
+  sourceRoot = "${finalAttrs.src.name}/bind/pyluwen";
 
   prePatch = ''
     chmod -R u+w ../../
@@ -49,6 +49,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Tenstorrent system interface library";
     homepage = "https://github.com/tenstorrent/luwen";
+    changelog = "https://github.com/tenstorrent/luwen/releases/tag/${finalAttrs.src.tag}";
     maintainers = with lib.maintainers; [ RossComputerGuy ];
     license = with lib.licenses; [ asl20 ];
   };

--- a/pkgs/development/python-modules/tt-flash/default.nix
+++ b/pkgs/development/python-modules/tt-flash/default.nix
@@ -2,12 +2,18 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
+
+  # build-system
   setuptools,
+
+  # dependencies
   pyyaml,
   tabulate,
   pyluwen,
   tt-tools-common,
+
+  # tests
+  pytestCheckHook,
 }:
 buildPythonPackage (finalAttrs: {
   pname = "tt-flash";
@@ -26,6 +32,10 @@ buildPythonPackage (finalAttrs: {
     setuptools
   ];
 
+  pythonRelaxDeps = [
+    "pyyaml"
+    "tabulate"
+  ];
   dependencies = [
     tabulate
     pyyaml
@@ -34,14 +44,16 @@ buildPythonPackage (finalAttrs: {
   ];
 
   pythonImportsCheck = [ "tt_flash" ];
-  pythonRelaxDeps = [
-    "pyyaml"
-    "tabulate"
+
+  nativeCheckInputs = [
+    pytestCheckHook
   ];
 
   meta = {
     description = "Tenstorrent Firmware Update Utility";
     homepage = "https://tenstorrent.com";
+    downloadPage = "https://github.com/tenstorrent/tt-flash";
+    changelog = "https://github.com/tenstorrent/tt-flash/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     maintainers = with lib.maintainers; [ RossComputerGuy ];
     license = with lib.licenses; [ asl20 ];
   };


### PR DESCRIPTION
## Things done

- **python3Packages.pyluwen: cleanup**
- **python3Packages.tt-flash: cleanup, enable tests**
- **tt-smi: add changelog**

cc @RossComputerGuy

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test