### PR TITLE
id3: fix build with gcc15

### DIFF
--- a/pkgs/by-name/id/id3/fix-gcc15.patch
+++ b/pkgs/by-name/id/id3/fix-gcc15.patch
@@ -1,0 +1,12 @@
+diff --git a/fileops.c b/fileops.c
+index 1e70af1..9017bd0 100644
+--- a/fileops.c
++++ b/fileops.c
+@@ -68,7 +68,6 @@ FILE *ftemp(char *templ, const char *mode)
+ #else
+     int fd = mkstemp(templ);
+     if(fd >= 0) {
+-        FILE* fdopen();                         /* in case -ansi is used */
+         if(f = fdopen(fd, mode)) return f;
+         close(fd);
+ #endif

--- a/pkgs/by-name/id/id3/package.nix
+++ b/pkgs/by-name/id/id3/package.nix
@@ -16,6 +16,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-+h1wwgTB7CpbjyUAK+9BNRhmy83D+1I+cZ70E1m3ENk=";
   };
 
+  patches = [
+    # https://github.com/squell/id3/pull/35
+    ./fix-gcc15.patch
+  ];
+
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
 
   makeFlags = [ "prefix=$(out)" ];


### PR DESCRIPTION
- #475479 
- #516381 
- https://hydra.nixos.org/build/324242400

```
fileops.c: In function 'ftemp':
fileops.c:71:15: error: conflicting types for 'fdopen'; have 'FILE *(void)'
   71 |         FILE* fdopen();                         /* in case -ansi is used */
      |               ^~~~~~
In file included from fileops.c:2:
/nix/store/h0ip0h6qp7kc2wm7mwjaglkxxbzmjri4-glibc-2.42-51-dev/include/stdio.h:302:14: note: previous declaration of 'fdopen' with type 'FILE *(int,  const char *)'
  302 | extern FILE *fdopen (int __fd, const char *__modes) __THROW
      |              ^~~~~~
fileops.c:72:16: error: too many arguments to function 'fdopen'; expected 0, have 2
   72 |         if(f = fdopen(fd, mode)) return f;
      |                ^~~~~~ ~~
fileops.c:71:15: note: declared here
   71 |         FILE* fdopen();                         /* in case -ansi is used */
      |               ^~~~~~
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
