### PR TITLE
kdePackages: add signon-plugin-oauth2, signon-ui, signond wrapper, nixos/signond module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -595,6 +595,7 @@
   ./services/desktops/playerctld.nix
   ./services/desktops/profile-sync-daemon.nix
   ./services/desktops/seatd.nix
+  ./services/desktops/signond.nix
   ./services/desktops/system76-scheduler.nix
   ./services/desktops/system-config-printer.nix
   ./services/desktops/telepathy.nix

--- a/nixos/modules/services/desktops/signond.nix
+++ b/nixos/modules/services/desktops/signond.nix
@@ -1,0 +1,47 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  package = config.services.signond.package.override { plugins = config.services.signond.plugins; };
+in
+{
+  options = {
+    services.signond = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether to enable signond, a DBus service
+          which performs user authentication on behalf of its clients.
+        '';
+      };
+
+      package = lib.mkPackageOption pkgs.kdePackages "signond" { };
+
+      plugins = lib.mkOption {
+        type = lib.types.listOf lib.types.package;
+        default = with pkgs.kdePackages; [
+          signon-plugin-oauth2
+          signon-kwallet-extension
+        ];
+        defaultText = lib.literalExpression ''
+          with pkgs.kdePackages; [ signon-plugin-oauth2 signon-kwallet-extension ]
+        '';
+        description = ''
+          What plugins to use with the signon daemon.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf config.services.signond.enable {
+    services.dbus.packages = [ package ];
+    environment.systemPackages = [
+      (lib.hiPrio package)
+      pkgs.kdePackages.signon-ui
+    ];
+  };
+}

--- a/pkgs/development/libraries/signond/default.nix
+++ b/pkgs/development/libraries/signond/default.nix
@@ -6,37 +6,49 @@
   qtbase,
   wrapQtAppsHook,
   doxygen,
+  makeWrapper,
+  symlinkJoin,
+  plugins ? [ ],
 }:
 
-stdenv.mkDerivation {
-  pname = "signond";
-  version = "8.61-unstable-2023-11-24";
+let
+  unwrapped = stdenv.mkDerivation {
+    pname = "signond";
+    version = "8.61-unstable-2023-11-24";
 
-  # pinned to fork with Qt6 support
-  src = fetchFromGitLab {
-    owner = "nicolasfella";
-    repo = "signond";
-    rev = "c8ad98249af541514ff7a81634d3295e712f1a39";
-    hash = "sha256-0FcSVF6cPuFEU9h7JIbanoosW/B4rQhFPOq7iBaOdKw=";
+    # pinned to fork with Qt6 support
+    src = fetchFromGitLab {
+      owner = "nicolasfella";
+      repo = "signond";
+      rev = "c8ad98249af541514ff7a81634d3295e712f1a39";
+      hash = "sha256-0FcSVF6cPuFEU9h7JIbanoosW/B4rQhFPOq7iBaOdKw=";
+    };
+
+    nativeBuildInputs = [
+      qmake
+      doxygen
+      wrapQtAppsHook
+    ];
+
+    buildInputs = [ qtbase ];
+
+    preConfigure = ''
+      substituteInPlace src/signond/signond.pro \
+        --replace "/etc" "@out@/etc"
+    '';
+
+    meta = with lib; {
+      homepage = "https://gitlab.com/accounts-sso/signond";
+      description = "Signon Daemon for Qt";
+      maintainers = [ ];
+      platforms = platforms.linux;
+    };
   };
-
-  nativeBuildInputs = [
-    qmake
-    doxygen
-    wrapQtAppsHook
-  ];
-
-  buildInputs = [ qtbase ];
-
-  preConfigure = ''
-    substituteInPlace src/signond/signond.pro \
-      --replace "/etc" "@out@/etc"
-  '';
-
-  meta = {
-    homepage = "https://gitlab.com/accounts-sso/signond";
-    description = "Signon Daemon for Qt";
-    maintainers = [ ];
-    platforms = lib.platforms.linux;
-  };
-}
+in
+if plugins == [ ] then
+  unwrapped
+else
+  import ./wrapper.nix {
+    inherit makeWrapper symlinkJoin plugins;
+    signond = unwrapped;
+  }

--- a/pkgs/development/libraries/signond/wrapper.nix
+++ b/pkgs/development/libraries/signond/wrapper.nix
@@ -1,0 +1,27 @@
+{
+  makeWrapper,
+  symlinkJoin,
+  signond,
+  plugins,
+}:
+
+symlinkJoin {
+  name = "signond-with-plugins-${signond.version}";
+
+  paths = [ signond ] ++ plugins;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postBuild = ''
+    wrapProgram $out/bin/signond \
+      --set SSO_PLUGINS_DIR "$out/lib/signond/" \
+      --set SSO_EXTENSIONS_DIR "$out/lib/signond/extensions/"
+
+    rm $out/share/dbus-1/services/com.google.code.AccountsSSO.SingleSignOn.service
+
+    substitute ${signond}/share/dbus-1/services/com.google.code.AccountsSSO.SingleSignOn.service $out/share/dbus-1/services/com.google.code.AccountsSSO.SingleSignOn.service \
+      --replace-fail ${signond} $out
+  '';
+
+  inherit (signond) meta;
+}

--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -96,6 +96,7 @@ let
         krohnkite = self.callPackage ./third-party/krohnkite { };
         kzones = self.callPackage ./third-party/kzones { };
         signon-plugin-oauth2 = self.callPackage ./third-party/signon-plugin-oauth2 { };
+        signon-ui = self.callPackage ./third-party/signon-ui { };
         wallpaper-engine-plugin = self.callPackage ./third-party/wallpaper-engine-plugin { };
       }
     );

--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -95,6 +95,7 @@ let
         koi = self.callPackage ./third-party/koi { };
         krohnkite = self.callPackage ./third-party/krohnkite { };
         kzones = self.callPackage ./third-party/kzones { };
+        signon-plugin-oauth2 = self.callPackage ./third-party/signon-plugin-oauth2 { };
         wallpaper-engine-plugin = self.callPackage ./third-party/wallpaper-engine-plugin { };
       }
     );

--- a/pkgs/kde/gear/kaccounts-providers/default.nix
+++ b/pkgs/kde/gear/kaccounts-providers/default.nix
@@ -1,9 +1,20 @@
 {
+  lib,
   mkKdeDerivation,
   intltool,
   qtdeclarative,
   qtwebengine,
+  googleClientId ? null,
+  googleClientSecret ? null,
+  withGoogleDriveScope ? false,
+  withYoutubeScope ? true,
 }:
+let
+  scopes =
+    lib.optional withYoutubeScope "'https://www.googleapis.com/auth/youtube.upload'"
+    ++ lib.optional withGoogleDriveScope "'https://www.googleapis.com/auth/drive'";
+  scopeLine = lib.concatStringsSep ",\n              " scopes;
+in
 mkKdeDerivation {
   pname = "kaccounts-providers";
 
@@ -12,4 +23,19 @@ mkKdeDerivation {
     qtdeclarative
     qtwebengine
   ];
+
+  postPatch =
+    lib.optionalString (googleClientId != null) ''
+      sed -i 's|<setting name="ClientId">[^<]*</setting>|<setting name="ClientId">${googleClientId}</setting>|' \
+        providers/google.provider.in
+    ''
+    + lib.optionalString (googleClientSecret != null) ''
+      sed -i 's|<setting name="ClientSecret">[^<]*</setting>|<setting name="ClientSecret">${googleClientSecret}</setting>|' \
+        providers/google.provider.in
+    ''
+    + ''
+      substituteInPlace providers/google.provider.in \
+        --replace-fail "'https://www.googleapis.com/auth/youtube.upload'" \
+                       ${lib.escapeShellArg scopeLine}
+    '';
 }

--- a/pkgs/kde/third-party/signon-plugin-oauth2/default.nix
+++ b/pkgs/kde/third-party/signon-plugin-oauth2/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  qtbase,
+  signond,
+  wrapQtAppsHook,
+  pkg-config,
+  qmake,
+}:
+
+stdenv.mkDerivation {
+  pname = "signon-plugin-oauth2";
+  version = "0.25-unstable-2023-10-15";
+
+  src = fetchFromGitLab {
+    owner = "accounts-sso";
+    repo = "signon-plugin-oauth2";
+    # See MR: https://gitlab.com/accounts-sso/signon-plugin-oauth2/-/merge_requests/28
+    rev = "fab698862466994a8fdc9aa335c87b4f05430ce6";
+    hash = "sha256-KCBLaqQdBkb6KfVKMmFSLOiXx3rUiEmK41Bc3mi86Ls=";
+  };
+
+  postPatch = ''
+    echo 'INSTALLS =' >>tests/tests.pro
+    echo 'INSTALLS =' >>example/example.pro
+  '';
+
+  buildInputs = [
+    qtbase
+    signond
+  ];
+
+  nativeBuildInputs = [
+    wrapQtAppsHook
+    pkg-config
+    qmake
+  ];
+
+  qmakeFlags = [
+    "SIGNON_PLUGINS_DIR=${placeholder "out"}/lib/signond"
+  ];
+
+  meta = {
+    homepage = "https://gitlab.com/accounts-sso/signon-plugin-oauth2";
+    description = "Signond plugin which handles OAuth authentication";
+    license = lib.licenses.lgpl21Only;
+    maintainers = with lib.maintainers; [ marie ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/kde/third-party/signon-ui/default.nix
+++ b/pkgs/kde/third-party/signon-ui/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  qmake,
+  qtbase,
+  qtdeclarative,
+  qtwebengine,
+  wrapQtAppsHook,
+  signond,
+  pkg-config,
+  libnotify,
+  accounts-qt,
+}:
+
+stdenv.mkDerivation {
+  pname = "signon-ui";
+  version = "0.17-unstable-2023-10-16";
+
+  src = fetchFromGitLab {
+    owner = "accounts-sso";
+    repo = "signon-ui";
+    rev = "eef943f0edf3beee8ecb85d4a9dae3656002fc24";
+    hash = "sha256-L37nypdrfg3ZGZE4uGtFoJlzNbFgTVgA36zCgzvzk6E=";
+  };
+
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    qtbase
+    qtdeclarative
+    qtwebengine
+    signond
+    libnotify
+    accounts-qt
+  ];
+
+  qmakeFlags = [ "SUBDIRS=src" ];
+
+  meta = {
+    homepage = "https://gitlab.com/accounts-sso/signon-ui";
+    description = "UI component responsible for handling the user interactions which can happen during the login process of an online account";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ marie ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
This PR adds the missing pieces of the KDE Online Accounts / accounts-sso stack for Qt6. Once `services.signond.enable = true` is set, Google Drive becomes accessible via Dolphin and kio-gdrive on NixOS.

### What is added

- `kdePackages.signon-plugin-oauth2` - OAuth 1.0/2.0 plugin for signond, pinned to the Qt6-support MR (!28) tip
- `kdePackages.signon-ui` - D-Bus daemon that opens the OAuth browser window during account login
- `kdePackages.signond` - wraps the bare signond with a composable plugin list via `symlinkJoin`, sets `SSO_PLUGINS_DIR`/`SSO_EXTENSIONS_DIR`, and patches the D-Bus `.service` file to point at the wrapper so D-Bus activation picks up the plugins
- `nixos/services/desktops/signond` - new NixOS module (`services.signond`) with `enable`, `package`, and `plugins` options; defaults to `signon-plugin-oauth2` + `signon-kwallet-extension`; also registers `signon-ui` in `environment.systemPackages` so D-Bus can activate it when signond requests an auth UI
- `kdePackages.kaccounts-providers` - gains `googleClientId`, `googleClientSecret`, `withGoogleDriveScope`, and `withYoutubeScope` override arguments for build-time credential and scope substitution

### Usage

Enable the daemon and add the relevant packages to your system:

```nix
services.signond.enable = true;

environment.systemPackages = with pkgs.kdePackages; [
  kaccounts-integration
  kaccounts-providers
  kio-gdrive
];
```

Then open *System Settings → Online Accounts*, add a Google account, and Google Drive will appear in Dolphin.

The packages are not added automatically because not every user wants kio-gdrive - the module's responsibility is only to run the daemon correctly.

#### Google Drive scope and custom OAuth credentials

The default KDE OAuth client is not approved by Google for Drive access. `kaccounts-providers` exposes override arguments to substitute credentials and control which scopes are requested:

- `googleClientId` / `googleClientSecret` - replace the KDE OAuth app credentials with your own
- `withGoogleDriveScope` - add the `drive` scope (default `false`)
- `withYoutubeScope` - keep the `youtube.upload` scope (default `true`)

These are build-time substitutions into `google.provider`, so they are package override arguments, not NixOS module options. Apply them via an overlay:

```nix
nixpkgs.overlays = [
  (final: prev: {
    kdePackages = prev.kdePackages.overrideScope (kfinal: kprev: {
      kaccounts-providers = kprev.kaccounts-providers.override {
        googleClientId = "YOUR_CLIENT_ID";
        googleClientSecret = "YOUR_CLIENT_SECRET";
        withGoogleDriveScope = true;
        withYoutubeScope = false;
      };
    });
  })
];
```

The KDE credentials are left untouched by default. Users who want Drive access must supply credentials that are approved for the `drive` scope - either their own registered OAuth app or another client that has Google's approval for that scope.

### What is deliberately not done

Auto-enabling signond in `plasma6.nix` is omitted. The accounts-sso upstream is effectively unmaintained (Qt6 support lives in a fork and an open MR), and KDE is actively building a replacement (KOnlineAccounts). Making it opt-in keeps the default Plasma6 configuration clean until the situation upstream stabilises.

### Relation to previous PR

This is a rebase and refinement of #343023 ("nixos/plasma6: wrap signond", Sep 2024, closed Oct 2024) by @NyCodeGHG. The core packaging approach (symlinkJoin wrapper, SSO_PLUGINS_DIR) is taken directly from that PR. Differences from #343023:

- Auto-enabling in `plasma6.nix` removed (see above)
- `services.signond` module has sensible defaults (`package` defaults to `kdePackages.signond`, `plugins` defaults to `[signon-plugin-oauth2, signon-kwallet-extension]`) so a minimal `services.signond.enable = true;` is sufficient
- Version dates corrected to match actual upstream commit timestamps
- License fields added to both new packages

---

## Background and prior art

### Previous packaging attempts in nixpkgs

- <https://github.com/NixOS/nixpkgs/pull/343023> (Sep 2024, closed Oct 2024): comprehensive PR by @NyCodeGHG adding signon-plugin-oauth2, signon-ui, a NixOS signond module, and enabling kaccounts/kio-gdrive by default. Closed after @K900 noted "accounts-sso upstream is effectively already dead, and KDE stuff is moving away from it." NyCodeGHG closed it pending a KDE replacement. Note: as of 2026 no production replacement has materialised and kio-gdrive remains the only working Google Drive solution for KDE.
- <https://github.com/NixOS/nixpkgs/pull/164233> (merged Apr 2022): last upstream version bump of signond in nixpkgs, showing it was maintained at the Qt5 level but never ported to Qt6.

### User reports: signon-plugin-oauth2 / signon-ui missing from NixOS

- <https://github.com/NixOS/nixpkgs/issues/263299> - package request that confirmed both were missing
- <https://discourse.nixos.org/t/unable-to-configure-google-account-in-kde-plasma-6/49297>
- <https://discourse.nixos.org/t/add-google-account-in-kde/24631>
- <https://discourse.nixos.org/t/how-can-i-enable-online-accounts-like-google-in-kde/31721>
- <https://discourse.nixos.org/t/how-to-use-kaccounts/14533>

### Root cause: `userActionFinished error: 2` = missing signon-ui

The OAuth browser window is opened by signon-ui. Without it, the D-Bus call from signond returns `CommunicationError` (error code 2).

- <https://discuss.kde.org/t/cannot-add-gdrive-online-account-fails-with-useractionfinished-error-2-after-user-name/34739>
- <https://gitlab.com/accounts-sso/signon-ui/-/issues/1>
- <https://bugs.kde.org/show_bug.cgi?id=506700>

### Why kio-gdrive stopped working: KDE's OAuth client lost Drive access

In June 2024 Google formally demanded that KDE either remove restricted Drive scopes from its OAuth registration or submit for re-verification within 90 days (or face a 100-user cap and an "unverified app" warning). KDE chose to remove the scope, breaking kio-gdrive for all users.

- <https://bugs.kde.org/show_bug.cgi?id=480779> - primary tracking bug; covers the June 2024 Google block and the January 2025 decision to remove the Drive scope
- <https://invent.kde.org/network/kio-gdrive/-/issues/1> - opened by Nate Graham (Feb 15, 2024), tracking the Google API Data Safety Team email and the choice between removing restricted Drive scopes or applying for re-verification
- <https://invent.kde.org/-/project/2380/uploads/5df1df971aba566ba3d743661fe4438b/_Action_Required__Changes_to_Google_Drive_API_Access.eml> - the formal demand from the Google API Data Safety Team to <kde-ev-board@kde.org>
- <https://invent.kde.org/network/kaccounts-providers/-/commits/master/providers/google.provider.in> - commit 1652091b by Nate Graham, "Google: stop requesting gdrive permission"
- <https://discuss.kde.org/t/google-blocks-access-from-dolphin-kio-gdrive/26007>
- <https://discuss.kde.org/t/kio-gdrive-not-working/36637>
- <https://discourse.nixos.org/t/kde-dolphin-without-online-accounts-setting-kde-package-kio-gdrive-googledrive/22085>
- <https://discourse.nixos.org/t/virtually-mounting-google-drive/46338>

### Future: KOnlineAccounts - the planned replacement

The accounts-sso stack (signond, signon-plugin-oauth2, signon-ui) is effectively unmaintained and KDE is actively working on a replacement. This PR is a stopgap until KOnlineAccounts matures and kio-gdrive or its successor adopts it.

- <https://nicolasfella.de/posts/a-new-online-accounts-system/> - blog post by Nicolas Fella proposing a new daemon-based system with D-Bus, per-application access control, and minimal dependencies; working prototype supports Nextcloud, Mastodon, and Google
- <https://invent.kde.org/system/konlineaccounts> - the implementation; early-stage (v0.1.0, ~42 commits) but actively developed; latest commits focus on security hardening (access control, secret passing via fd exchange). Not yet viable for kio-gdrive: no token refresh logic.
- <https://bugs.kde.org/show_bug.cgi?id=378814#c8> - KDE bug thread where the replacement effort was announced

---

cc @NyCodeGHG @K900 @OPNA2608 @Scrumplex @NickCao

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
