### PR TITLE
python3Packages.python-magic: fix parquet tests for file 5.47

### DIFF
--- a/pkgs/development/python-modules/python-magic/default.nix
+++ b/pkgs/development/python-modules/python-magic/default.nix
@@ -38,6 +38,9 @@ buildPythonPackage rec {
       url = "https://github.com/ahupp/python-magic/commit/3d2405ca80cd39b2a91decd26af81dcf181390a4.patch";
       hash = "sha256-HRsnO9MGfMD9BkJdC4SrEFQ1OZEaXpwakXFLoaCPK94=";
     })
+
+    # Fix test failures due to modified output in file 5.47
+    ./fix-parquet-test.patch
   ];
 
   preCheck = ''

--- a/pkgs/development/python-modules/python-magic/fix-parquet-test.patch
+++ b/pkgs/development/python-modules/python-magic/fix-parquet-test.patch
@@ -1,0 +1,20 @@
+--- a/test/python_magic_test.py
++++ b/test/python_magic_test.py
+@@ -93,7 +93,7 @@ class MagicTest(unittest.TestCase):
+                 'magic._pyc_': ('application/octet-stream', 'text/x-bytecode.python', 'application/x-bytecode.python'),
+                 'test.pdf': 'application/pdf',
+                 'test.gz': ('application/gzip', 'application/x-gzip'),
+-                'test.snappy.parquet': 'application/octet-stream',
++                'test.snappy.parquet': ('application/octet-stream', 'application/vnd.apache.parquet'),
+                 'text.txt': 'text/plain',
+                 b'\xce\xbb'.decode('utf-8'): 'text/plain',
+                 b'\xce\xbb': 'text/plain',
+@@ -123,7 +123,7 @@ class MagicTest(unittest.TestCase):
+                      ': Sun Jun 29 01:32:52 2008, from Unix, truncated'
+                      ),
+                 'text.txt': 'ASCII text',
+-                'test.snappy.parquet': ('Apache Parquet', 'Par archive data'),
++                'test.snappy.parquet': ('Apache Parquet', 'Apache Parquet file', 'Par archive data'),
+             }, buf_equals_file=False)
+         finally:
+             del os.environ['TZ']


### PR DESCRIPTION
Edits the test to accept outputs from file 5.47 in addition to older versions.

This will be relevant if nixpkgs updates file to 5.47. For discussion, see #514964

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
