### PR TITLE
minimal-bootstrap: fix early-musl-userland flake on parallel builds

### DIFF
--- a/pkgs/os-specific/linux/minimal-bootstrap/gnumake/musl.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnumake/musl.nix
@@ -4,6 +4,7 @@
   hostPlatform,
   fetchurl,
   bash,
+  coreutils,
   tinycc,
   gnumakeBoot,
   gnupatch,
@@ -37,6 +38,7 @@ bash.runCommand "${pname}-${version}"
     inherit pname version meta;
 
     nativeBuildInputs = [
+      coreutils
       tinycc.compiler
       gnumakeBoot
       gnupatch
@@ -58,6 +60,13 @@ bash.runCommand "${pname}-${version}"
     # Unpack
     tar xzf ${src}
     cd make-${version}
+
+    # Defeat parallel-build automake regen race, see gnused/default.nix.
+    touch Makefile.in Makefile aclocal.m4 config.h.in configure 2>/dev/null || true
+    for f in */Makefile.in; do touch "$f" 2>/dev/null || true; done
+    chmod +x configure config.guess config.sub install-sh missing compile \
+      depcomp mkinstalldirs help2man 2>/dev/null || true
+    [ -d build-aux ] && chmod +x build-aux/* 2>/dev/null || true
 
     # Patch
     ${lib.concatMapStringsSep "\n" (f: "patch -Np1 -i ${f}") patches}

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnused/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnused/default.nix
@@ -4,6 +4,7 @@
   hostPlatform,
   fetchurl,
   bash,
+  coreutils,
   gnumake,
   tinycc,
   gnused,
@@ -33,6 +34,7 @@ bash.runCommand "${pname}-${version}"
     inherit pname version meta;
 
     nativeBuildInputs = [
+      coreutils
       gnumake
       tinycc.compiler
       gnused
@@ -52,6 +54,14 @@ bash.runCommand "${pname}-${version}"
     # Unpack
     tar xzf ${src}
     cd sed-${version}
+
+    # Defeat parallel-build automake regen race: refresh generated-file
+    # mtimes and restore +x on autotools helpers.
+    touch Makefile.in Makefile aclocal.m4 config.h.in configure 2>/dev/null || true
+    for f in */Makefile.in; do touch "$f" 2>/dev/null || true; done
+    chmod +x configure config.guess config.sub install-sh missing compile \
+      depcomp mkinstalldirs help2man 2>/dev/null || true
+    [ -d build-aux ] && chmod +x build-aux/* 2>/dev/null || true
 
     # Configure
     export CC="tcc -B ${tinycc.libs}/lib"

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnutar/mes.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnutar/mes.nix
@@ -4,6 +4,7 @@
   hostPlatform,
   fetchurl,
   bash,
+  coreutils,
   tinycc,
   gnumake,
   gnused,
@@ -25,6 +26,7 @@ bash.runCommand "${pname}-${version}"
     inherit pname version meta;
 
     nativeBuildInputs = [
+      coreutils
       tinycc.compiler
       gnumake
       gnused
@@ -44,6 +46,14 @@ bash.runCommand "${pname}-${version}"
     untar --file tar.tar
     rm tar.tar
     cd tar-${version}
+
+    # untar drops mtimes and +x on autotools helpers, restore them so
+    # parallel builds don't trip into automake regeneration.
+    touch Makefile.in Makefile aclocal.m4 config.h.in configure 2>/dev/null || true
+    for f in */Makefile.in; do touch "$f" 2>/dev/null || true; done
+    chmod +x configure config.guess config.sub install-sh missing compile \
+      depcomp mkinstalldirs help2man 2>/dev/null || true
+    [ -d build-aux ] && chmod +x build-aux/* 2>/dev/null || true
 
     # Configure
     export CC="tcc -B ${tinycc.libs}/lib"

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnutar/musl.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnutar/musl.nix
@@ -4,6 +4,7 @@
   hostPlatform,
   fetchurl,
   bash,
+  coreutils,
   tinycc,
   gnumake,
   gnugrep,
@@ -26,6 +27,7 @@ bash.runCommand "${pname}-${version}"
     inherit pname version meta;
 
     nativeBuildInputs = [
+      coreutils
       tinycc.compiler
       gnumake
       gnused
@@ -45,6 +47,14 @@ bash.runCommand "${pname}-${version}"
     untar --file tar.tar
     rm tar.tar
     cd tar-${version}
+
+    # untar drops mtimes and +x on autotools helpers, restore them so
+    # parallel builds don't trip into automake regeneration.
+    touch Makefile.in Makefile aclocal.m4 config.h.in configure 2>/dev/null || true
+    for f in */Makefile.in; do touch "$f" 2>/dev/null || true; done
+    chmod +x configure config.guess config.sub install-sh missing compile \
+      depcomp mkinstalldirs help2man 2>/dev/null || true
+    [ -d build-aux ] && chmod +x build-aux/* 2>/dev/null || true
 
     # Configure
     export CC="tcc -B ${tinycc.libs}/lib"


### PR DESCRIPTION
At `--max-jobs >= 2`, four `early-musl-userland` derivations flake intermittently (~10% rate on x86_64-linux): `gnused` (4.2), `gnumake-musl`, `gnutar-musl`, and the heirloom `gnutar` (1.12).

Two failure modes, same post-unpack root cause:

- `gnutar` / `gnutar-musl`: extracted with mescc-tools `untar`, which drops exec bit on `build-aux/missing`
- `gnused-4.2` / `gnumake-musl`: extracted with `tar xzf`, which preserves perms but occasionally leaves `Makefile.am` newer than `Makefile.in`

Fix: after unpack, `touch` the generated autotools files so regen never triggers, and `chmod +x` the helpers. `touch`/`chmod` come from heirloom `coreutils`, already built earlier via `tinycc-mes`, so adding it as a nativeBuildInput introduces no cycle.

Built all four with `nix-build -A minimal-bootstrap.<pkg>` on x86_64-linux (sandbox, `--max-jobs 2`); all build first try.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test].
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
