### PR TITLE
chromium,chromedriver: 147.0.7727.137 -> 148.0.7778.96

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -600,7 +600,7 @@ let
         hash = "sha256-tJ//HE7o9R8nSQDGhi+MKXdNUwnkCZI++CzpAmFn2YY=";
       })
     ]
-    ++ lib.optionals (chromiumVersionAtLeast "146" && lib.versionOlder llvmVersion "23") [
+    ++ lib.optionals (versionRange "146" "148" && lib.versionOlder llvmVersion "23") [
       # clang++: error: unknown argument: '-fsanitize-ignore-for-ubsan-feature=array-bounds'
       (fetchpatch {
         name = "chromium-146-revert-Update-fsanitizer=array-bounds-config.patch";
@@ -626,6 +626,47 @@ let
     ++ lib.optionals (chromiumVersionAtLeast "147" && lib.versionOlder llvmVersion "23") [
       # clang++: error: unknown argument: '-fno-lifetime-dse'
       ./patches/chromium-147-llvm-22.patch
+    ]
+    ++ lib.optionals (chromiumVersionAtLeast "148" && lib.versionOlder llvmVersion "23") [
+      # clang++: error: unknown argument: '-fsanitize-ignore-for-ubsan-feature=return'
+      (fetchpatch {
+        name = "chromium-148-revert-build-Add--fsanitizer=return-config.patch";
+        # https://chromium-review.googlesource.com/c/chromium/src/+/7629257
+        url = "https://chromium.googlesource.com/chromium/src/+/99ba1f5302f9433efdb4df302cb7b7de56c72e4c^!?format=TEXT";
+        decode = "base64 -d";
+        revert = true;
+        hash = "sha256-/qzzxwTdPMwIdsqD/G02S7kKHCj3QxECL+g1WYEaWmU=";
+      })
+      # ERROR Unresolved dependencies.
+      # //apps:apps(//build/toolchain/linux/unbundle:default)
+      #   needs //build/config/compiler:sanitize_return(//build/toolchain/linux/unbundle:default)
+      (fetchpatch {
+        name = "chromium-148-revert-build-Enable--fsanitizer=return-config.patch";
+        # https://chromium-review.googlesource.com/c/chromium/src/+/7629258
+        url = "https://chromium.googlesource.com/chromium/src/+/9357bfbea03753fe52264c9ec36abe74f48cfef5^!?format=TEXT";
+        decode = "base64 -d";
+        revert = true;
+        hash = "sha256-14fTHNh3vGsf4KgeH8uLX+aK3lrjK0VKd1dfK1g7r0I=";
+      })
+      # [33377/55552] LINK ./mksnapshot
+      # ld.lld: error: undefined symbol: __sanitizer_set_death_callback
+      # https://gitlab.archlinux.org/archlinux/packaging/packages/chromium/-/blob/148.0.7778.96-1/PKGBUILD#L168-174
+      (fetchpatch {
+        name = "archlinux-chromium-146-drop-unknown-clang-flag.patch";
+        url = "https://gitlab.archlinux.org/archlinux/packaging/packages/chromium/-/raw/148.0.7778.96-1/chromium-146-drop-unknown-clang-flag.patch";
+        hash = "sha256-jR0G9z2R8VGl2tkB3u0368RyWM1J6qYXqNWwKkYd5zU=";
+      })
+    ]
+    ++ lib.optionals (chromiumVersionAtLeast "148") [
+      # ninja: error: '../../third_party/rust-toolchain/bin/rustc', needed by 'phony/default_for_rust_host_build_tools_rust_bin_inputs', missing and no known rule to make it
+      (fetchpatch {
+        name = "chromium-148-revert-Reland-build-use-tool-inputs-instead-of-siso-config-for-rust-actions.patch";
+        # https://chromium-review.googlesource.com/c/chromium/src/+/7719879
+        url = "https://chromium.googlesource.com/chromium/src/+/9193ab90af24c23ee983e0a8da9bed45712f0d26^!?format=TEXT";
+        decode = "base64 -d";
+        revert = true;
+        hash = "sha256-7xg8IZ2gO+Wtnv7lWLVE3lLpcmMgvtDtcWwUuMBzkrE=";
+      })
     ];
 
     postPatch =
@@ -750,6 +791,12 @@ let
         # Allow building against system libraries in official builds
         sed -i 's/OFFICIAL_BUILD/GOOGLE_CHROME_BUILD/' tools/generate_shim_headers/generate_shim_headers.py
 
+      ''
+      # https://chromium-review.googlesource.com/c/chromium/src/+/7677517
+      # ninja: error: '../../third_party/gperf/cipd/bin/gperf', needed by 'gen/third_party/blink/renderer/core/css/parser/at_rule_descriptors.cc', missing and no known rule to make it
+      + lib.optionalString (chromiumVersionAtLeast "148") ''
+        mkdir -p third_party/gperf/cipd/bin
+        ln -s "${pkgsBuildHost.gperf}/bin/gperf" third_party/gperf/cipd/bin/gperf
       ''
       +
         lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform && stdenv.hostPlatform.isAarch64)
@@ -903,6 +950,11 @@ let
       # but lit_reactive_element.patch only patches the former.
       + lib.optionalString (chromiumVersionAtLeast "146") ''
         rm -r third_party/node/node_modules/@lit/reactive-element/development
+      ''
+      # Similarly, having @types/estree causes:
+      # error TS2352: Conversion of type 'Node[]' to type 'TSPropertySignature[]' [...]
+      + lib.optionalString (chromiumVersionAtLeast "148") ''
+        rm -r third_party/node/node_modules/@types/estree
       '';
 
     configurePhase = ''

--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,6 +1,6 @@
 {
   "chromium": {
-    "version": "147.0.7727.137",
+    "version": "148.0.7778.96",
     "chromedriver": {
       "version": "147.0.7727.138",
       "hash_darwin": "sha256-d2dEPcR2mlfkL6XGhzMsgH/OwAI+yLXdS0dF4luPRfM=",
@@ -8,21 +8,21 @@
     },
     "deps": {
       "depot_tools": {
-        "rev": "d0e1a84d5b0c3c556b0fbdbeb77908d9817e6bbb",
-        "hash": "sha256-mc/W0D9MEtNQPeJ66X9T28IB+pvYqDRXj9UYb9hLlvA="
+        "rev": "41c40cfaec7ee3bf0423c59925d8b23982a601f1",
+        "hash": "sha256-s9uvmYHCJKWnNhztmOPb+OHj/HbGo30PupwT4mHWjnM="
       },
       "gn": {
-        "version": "0-unstable-2026-03-05",
-        "rev": "d8c2f07d653520568da7cace755a87dad241b72d",
-        "hash": "sha256-3AfExm7NL5GJXyC5JCPbGC70D59doRfIZIgpt6MLy9Y="
+        "version": "0-unstable-2026-04-01",
+        "rev": "6e8dcdebbadf4f8aa75e6a4b6e0bdf89dce1513a",
+        "hash": "sha256-BTPD8WM1pVAMkFDlHekMdWFGyf63KdhKkKwsqikqoBQ="
       },
-      "npmHash": "sha256-ByB1Ea5tduIJZXyydeBWsoS8OPABOgwHe+dNXRssdvc="
+      "npmHash": "sha256-JuVcY8iFRDWcPcP4Pg+qm5rnTXkiVfNsqSkXbDWqsE8="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "68ba233a543d25e75c30f1228dd3bafa2da96937",
-        "hash": "sha256-ktIkQRYWcyKnZKEhvxFGssMZ///ctd/Ue3VIYPvQzuM=",
+        "rev": "8625e066febc721e015ea99842da12901eb7ed73",
+        "hash": "sha256-coeBYfNPtiRRPuqoBRaxkTQI/a2pYNLI1slUdU1dZAc=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -32,8 +32,8 @@
       },
       "src/third_party/compiler-rt/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/compiler-rt.git",
-        "rev": "338a5c004c774a8927899b1f1c0c25a82d14510f",
-        "hash": "sha256-2lj4oF8IbJoPOBWwQ4ZfDQjPklxQyNyG5AcHazxEYcs="
+        "rev": "76287b5da8e155135536c8e3a67432d97d74fe3a",
+        "hash": "sha256-q6syHriTR8TCQSqTWbbAkVVK0a/i4wojdEGN7sWGxUY="
       },
       "src/third_party/libc++/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxx.git",
@@ -47,13 +47,13 @@
       },
       "src/third_party/libunwind/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libunwind.git",
-        "rev": "78884e23fe39cf5cc6987ea188a9b802d65a21c9",
-        "hash": "sha256-G8CtxDHzo8WtJ6qrtghXBoYCWwnDvXcAueEGzLc6C14="
+        "rev": "6ca46ff28e3578c57cbead6f233969eb3dabc176",
+        "hash": "sha256-JW4kqpVTCFDN4WZE2S5gEkX1O7eDycl+adm3KGlUoTU="
       },
       "src/third_party/llvm-libc/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libc.git",
-        "rev": "c42ab4598a74eea2cf3efff9d44b22de155d41af",
-        "hash": "sha256-NJCdrmVyF80aQLtrdVgcWQadhj5w7nKrLShaZDen1GA="
+        "rev": "2a826f2fda3cf8d75b47cbc3bb1d9b244f13a6ab",
+        "hash": "sha256-OWe2lAT5XbADWuxHgg53lZiU0My/ys86FEXvn4zlVx0="
       },
       "src/chrome/test/data/perf/canvas_bench": {
         "url": "https://chromium.googlesource.com/chromium/canvas_bench.git",
@@ -72,18 +72,18 @@
       },
       "src/docs/website": {
         "url": "https://chromium.googlesource.com/website.git",
-        "rev": "d3b3b620e65ebaf511c6c8399b98a081cd644a66",
-        "hash": "sha256-xTGvhQUKOgt007WdvzN4eDpue8nheEMSV+Cl3Tnwviw="
+        "rev": "44319eca109f9678595924a90547c1f6650d8664",
+        "hash": "sha256-Trkan7bzRaLFlTkRfNGh7ssoZ3QpMh+mxQacsSM+d2I="
       },
       "src/media/cdm/api": {
         "url": "https://chromium.googlesource.com/chromium/cdm.git",
-        "rev": "9920660ea0162f88c44a648de177e6f8cb976d07",
-        "hash": "sha256-rC/aV3vsFzXQ8BiOIK+OTXxTsgTLEEqC19KDAot1PTs="
+        "rev": "33c977516b3dfe5b065bc298aa74175e1999ab51",
+        "hash": "sha256-GsaRxLnsz1jrFZ3m5tv65d1dioG23uJnmfa+WD7XcFc="
       },
       "src/net/third_party/quiche/src": {
         "url": "https://quiche.googlesource.com/quiche.git",
-        "rev": "435c98c0d9ab7a2b60592c5297635b4791745191",
-        "hash": "sha256-dhsq9kLRcXPxv0Ih6CQhDvLAGjh3EgSCl28Cxjk2aos="
+        "rev": "21ffbe4c7b717d00d2d768c259b5b330fd754ac3",
+        "hash": "sha256-yKMmfdSBvbB3T042TJbZ1Mw+y0kyfHP0knQVFWAFPTg="
       },
       "src/testing/libfuzzer/fuzzers/wasm_corpus": {
         "url": "https://chromium.googlesource.com/v8/fuzzer_wasm_corpus.git",
@@ -92,8 +92,8 @@
       },
       "src/third_party/angle": {
         "url": "https://chromium.googlesource.com/angle/angle.git",
-        "rev": "534e0d1c1d0fcb4b57fd6a3fb9284cd14eaa28cd",
-        "hash": "sha256-o3UV8X27G7wpaDiKDzgMZN64+d9JQrvcQXpSybxi/h4="
+        "rev": "cc0e3572e8789f4a184dd9714a04b3d98ae81015",
+        "hash": "sha256-3KVTEBcnQTn99ccdKzylzUvua2jlS4g8/nfIDdLk6ug="
       },
       "src/third_party/angle/third_party/glmark2/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glmark2/glmark2",
@@ -107,8 +107,8 @@
       },
       "src/third_party/angle/third_party/VK-GL-CTS/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/VK-GL-CTS",
-        "rev": "1cf4ed5bc0620ea514404609b1a2958c4518b86d",
-        "hash": "sha256-IZ5tVrld2+wDOWaYX93j2eLZJJs/EMW1+FtxhOeWi6w="
+        "rev": "f52e89f885064b9109501bca16c813bb29389993",
+        "hash": "sha256-3jx4QVR9nB3WggfrORGJGifmJQhAYVSPusa7RlR16qg="
       },
       "src/third_party/anonymous_tokens/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/anonymous-tokens.git",
@@ -127,48 +127,53 @@
       },
       "src/third_party/dav1d/libdav1d": {
         "url": "https://chromium.googlesource.com/external/github.com/videolan/dav1d.git",
-        "rev": "b546257f770768b2c88258c533da38b91a06f737",
-        "hash": "sha256-E3da/LJ8HNy1osExmupovqnL8JHgVNzPUCG5F8TJKXQ="
+        "rev": "d69235dd804b24c04ed05639cffcc912cd6cfd75",
+        "hash": "sha256-iKq6TYscIBK4ydv+0msNV3tcs82Ljk5ZNr954Qv2lII="
       },
       "src/third_party/dawn": {
         "url": "https://dawn.googlesource.com/dawn.git",
-        "rev": "049880d58d6636a819168c00f44f8a4ed1e33e51",
-        "hash": "sha256-AHUos4ejvcsHTDdretkDHAeyLugtI6Jg14Hb9MbbPPs="
+        "rev": "19696dd088b8ed5804e2f02a8f83f5afdb3e99e3",
+        "hash": "sha256-ihnVPCk9412UzCmoABWVUhiGaIdIYxiYMkk43KDqpg8="
       },
-      "src/third_party/dawn/third_party/glfw": {
+      "src/third_party/dawn/third_party/glfw3/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glfw/glfw",
-        "rev": "b35641f4a3c62aa86a0b3c983d163bc0fe36026d",
-        "hash": "sha256-E1zXIDiw87badrLOZTvV+Wh9NZHu51nb70ZK9vlAlqE="
+        "rev": "043378876a67b092f5d0d3d9748660121a336dd3",
+        "hash": "sha256-4QSD1/uxWfYZPMjShB0h639eqAfuBRXAVfOm6BbZCBs="
       },
       "src/third_party/dawn/third_party/dxc": {
         "url": "https://chromium.googlesource.com/external/github.com/microsoft/DirectXShaderCompiler",
-        "rev": "2888a8764a33693f5a351e0c4ec87f430ccb0f7a",
-        "hash": "sha256-xAe7SdcOeNiqNF6pYwMPMnd9/2yTWUlVdH1aCco/PEo="
+        "rev": "eb67a9085c758516d940e1ce3fed0acfb6518209",
+        "hash": "sha256-z+yIuVweIyLdOiZDRfSppjTRoYq8S93+JNUla4Umot8="
       },
       "src/third_party/dawn/third_party/dxheaders": {
         "url": "https://chromium.googlesource.com/external/github.com/microsoft/DirectX-Headers",
         "rev": "980971e835876dc0cde415e8f9bc646e64667bf7",
         "hash": "sha256-0Miw1Cy/jmOo7bLFBOHuTRDV04cSeyvUEyPkpVsX9DA="
       },
-      "src/third_party/dawn/third_party/khronos/OpenGL-Registry": {
+      "src/third_party/dawn/third_party/directx-headers/src": {
+        "url": "https://chromium.googlesource.com/external/github.com/microsoft/DirectX-Headers",
+        "rev": "980971e835876dc0cde415e8f9bc646e64667bf7",
+        "hash": "sha256-0Miw1Cy/jmOo7bLFBOHuTRDV04cSeyvUEyPkpVsX9DA="
+      },
+      "src/third_party/dawn/third_party/OpenGL-Registry/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/OpenGL-Registry",
         "rev": "5bae8738b23d06968e7c3a41308568120943ae77",
         "hash": "sha256-K3PcRIiD3AmnbiSm5TwaLs4Gu9hxaN8Y91WMKK8pOXE="
       },
-      "src/third_party/dawn/third_party/khronos/EGL-Registry": {
+      "src/third_party/dawn/third_party/EGL-Registry/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/EGL-Registry",
         "rev": "7dea2ed79187cd13f76183c4b9100159b9e3e071",
         "hash": "sha256-Z6DwLfgQ1wsJXz0KKJyVieOatnDmx3cs0qJ6IEgSq1A="
       },
       "src/third_party/dawn/third_party/webgpu-cts": {
         "url": "https://chromium.googlesource.com/external/github.com/gpuweb/cts",
-        "rev": "d213d4b8dba58ca7a0685e30cfaf1d29f4fc5d5b",
-        "hash": "sha256-6YGLG9BMQbF2pjV40su5ddHMqDW8/CEwM3RDEc/t2kM="
+        "rev": "09fdb847d90d0b5bfe57068ce2eb9283cb77fc7f",
+        "hash": "sha256-eTAwnTiAHq8rmbw7u9nAwSuAlS5adStUJKfITlYkcgU="
       },
       "src/third_party/dawn/third_party/webgpu-headers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/webgpu-native/webgpu-headers",
-        "rev": "b2b04dde36a941434c88ccff7a730d7e464d638c",
-        "hash": "sha256-+/qXZNkm26p+becMVcyHNUPyEUCejSV+tyTGFE4ivak="
+        "rev": "7d3186c3dd2c708703524027b46b8703534ab3cc",
+        "hash": "sha256-yE3/mfhqc7YtVNg4f/nrUpuRUGRjOzdwl++vPvd+mvc="
       },
       "src/third_party/highway/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/highway.git",
@@ -182,13 +187,13 @@
       },
       "src/third_party/libpfm4/src": {
         "url": "https://chromium.googlesource.com/external/git.code.sf.net/p/perfmon2/libpfm4.git",
-        "rev": "964baf9d35d5f88d8422f96d8a82c672042e7064",
-        "hash": "sha256-awpZ22rovLZWQkX/qog93vL4u2gJ+F3w5IGFNlZ0heQ="
+        "rev": "977a25bb3dfe45f653a6cee71ffaae9a92fc3095",
+        "hash": "sha256-t4LMG38GksMEM5DktyJ0qLUX1biXErQ57MaMtd7hoeo="
       },
       "src/third_party/boringssl/src": {
         "url": "https://boringssl.googlesource.com/boringssl.git",
-        "rev": "27bc28d7f03fb9e3752980dce01de1a529236532",
-        "hash": "sha256-u+yvIPrdb9fWzJXJeIidUQ1MkKUx6sKLs7vdW68QhYc="
+        "rev": "d8be2b4a71155bf82da092ef543176351eeb59ff",
+        "hash": "sha256-fZc95YrREDbf0YcO6zahIjdX6TcRJANcH9MrkLIIIHw="
       },
       "src/third_party/breakpad/breakpad": {
         "url": "https://chromium.googlesource.com/breakpad/breakpad.git",
@@ -202,13 +207,13 @@
       },
       "src/third_party/catapult": {
         "url": "https://chromium.googlesource.com/catapult.git",
-        "rev": "e0ebf38a01214aba11f31daa1c743782def031d5",
-        "hash": "sha256-njtIcvzo2v9uDuP+AostVAZRTtH2vePsshF4cANHkxo="
+        "rev": "4f1d71f6841d210b3a06ab3ef2e2ed679af0ee56",
+        "hash": "sha256-aHlf8gw3KxbKoyyajP4w586iYybx7HSkcKtLcZIgiDE="
       },
       "src/third_party/catapult/third_party/webpagereplay": {
         "url": "https://chromium.googlesource.com/webpagereplay.git",
-        "rev": "22be07d7809409644d7e292d9495fa8a251d5f29",
-        "hash": "sha256-HR6iEDwmxFaiLi+h3MwsNfBOtBNbrKvmRNgMVog3A0Y="
+        "rev": "be48b5e3387780790ecc7723434b6ea6733bcc33",
+        "hash": "sha256-KcFUlQMltsMm4WlTVMLzZXfrvu67ffkKjmBcruwZye0="
       },
       "src/third_party/ced/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/compact_enc_det.git",
@@ -232,8 +237,8 @@
       },
       "src/third_party/cpuinfo/src": {
         "url": "https://chromium.googlesource.com/external/github.com/pytorch/cpuinfo.git",
-        "rev": "7364b490b5f78d58efe23ea76e74210fd6c3c76f",
-        "hash": "sha256-lB6e5zcw5UiwTOf+a+B35apXP5t1bxI6yOMiEeFwIwY="
+        "rev": "7607ca500436b37ad23fb8d18614bec7796b68a7",
+        "hash": "sha256-LnLtCMMRg+DwB7MijBdt/tmCKD/zN5y2oTgXlYw3hTg="
       },
       "src/third_party/crc32c/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/crc32c.git",
@@ -242,28 +247,28 @@
       },
       "src/third_party/cros_system_api": {
         "url": "https://chromium.googlesource.com/chromiumos/platform2/system_api.git",
-        "rev": "1fb70b2851b292e48b612482a6d4d1b4c343c862",
-        "hash": "sha256-YBN8ogJn5Yup9GYrsE9UW15KPCuXbhD6hdqXWWCPD20="
+        "rev": "c27a09148de373889e5d2bf616c4e85a68050ae2",
+        "hash": "sha256-a/mAa1+if6B1FHe9crO8PDpc3o8M+CeIuXjXT0lwZOY="
       },
       "src/third_party/crossbench": {
         "url": "https://chromium.googlesource.com/crossbench.git",
-        "rev": "19cee54825bc57215266f5b14a5874bfbbb57543",
-        "hash": "sha256-HVwX8E3/7yw7zUqZrptN1iSBWF4ls0FAzPObPagNYtM="
+        "rev": "c179f7919aade97c5cff64d14b9171736e7aaef9",
+        "hash": "sha256-Hxazf58z9imnGO1aj2NRtsQ+BYrfAuIuZscADpr1NVI="
       },
       "src/third_party/crossbench-web-tests": {
         "url": "https://chromium.googlesource.com/chromium/web-tests.git",
-        "rev": "909ad1733b50f28510c840ebad7b878a5ce07715",
-        "hash": "sha256-RYih9sn4rIBnFW/styZaUl5H0A1eEy3//DypZjY6n0M="
+        "rev": "b19e4e52c33fb8a105c3fc99598b0b9b4bc59752",
+        "hash": "sha256-7vCQw91L2c97dnVdrJ53zL8hi0KZffDJJjk7GaG3b/U="
       },
       "src/third_party/depot_tools": {
         "url": "https://chromium.googlesource.com/chromium/tools/depot_tools.git",
-        "rev": "4ce8ba39a3488397a2d1494f167020f21de502f3",
-        "hash": "sha256-WTzjmLFjh1yDDEvYE7Qfx8aBxMLdATx14+Jprwh8ZgQ="
+        "rev": "41c40cfaec7ee3bf0423c59925d8b23982a601f1",
+        "hash": "sha256-s9uvmYHCJKWnNhztmOPb+OHj/HbGo30PupwT4mHWjnM="
       },
       "src/third_party/devtools-frontend/src": {
         "url": "https://chromium.googlesource.com/devtools/devtools-frontend",
-        "rev": "854a02be78c7ffea104cb523636efa991bef5c5b",
-        "hash": "sha256-CzzUueh2QXX+ExGqh5+JpnDoWF8DiFDff7fWmC01xfg="
+        "rev": "6efd6eb1d85fd67fdcc2385c54fa56c524bec3f7",
+        "hash": "sha256-1pr3+RK519m+wtcacJB3PcDTL+qSHlOn1ctxpoLzTf8="
       },
       "src/third_party/dom_distiller_js/dist": {
         "url": "https://chromium.googlesource.com/chromium/dom-distiller/dist.git",
@@ -277,8 +282,8 @@
       },
       "src/third_party/eigen3/src": {
         "url": "https://chromium.googlesource.com/external/gitlab.com/libeigen/eigen.git",
-        "rev": "54458cb39d1081d0cfe6b77ed8e085d457a4c921",
-        "hash": "sha256-WXxSe2AY3hSMXz7lHNeFefOHGGkdXoSQLC6FuOa6Exo="
+        "rev": "a3074053a614df7a3896cb4edbcba40222a5f549",
+        "hash": "sha256-9AHpSqemqdwXoMiP3hH1YuEd3+nrudeVGTpInw+8BU4="
       },
       "src/third_party/farmhash/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/farmhash.git",
@@ -292,13 +297,13 @@
       },
       "src/third_party/federated_compute/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google-parfait/federated-compute.git",
-        "rev": "271aa00f8aec5bc801f542710efe1b2f0b5f0ef9",
-        "hash": "sha256-6ZATBYkyIdGuhG0Ps2vr0DT9nq1LhW2XCWWAkiZh9Hc="
+        "rev": "eb170f645b270c7979edb863fd2cf8edab2b2fd1",
+        "hash": "sha256-Cp0WQBbqWvPdrKCMQhH4Z6zl6YlIPLjafWZEwdkYWlc="
       },
       "src/third_party/ffmpeg": {
         "url": "https://chromium.googlesource.com/chromium/third_party/ffmpeg.git",
-        "rev": "946d97db8d906277085e361892b7efda5152e2f1",
-        "hash": "sha256-UxrmVqfX6TvFy1yxWXIQbd3ABD3jEAtDesgfnbJGg1E="
+        "rev": "b5e18fb9da84e26ceef30d4e4886696bf59337c0",
+        "hash": "sha256-JHAicFKBvtkwmZPRBKYPT6JVqYqF8hyXxU0H7kfgCBs="
       },
       "src/third_party/flac": {
         "url": "https://chromium.googlesource.com/chromium/deps/flac.git",
@@ -327,18 +332,18 @@
       },
       "src/third_party/freetype/src": {
         "url": "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git",
-        "rev": "45556a19aab9502b91d6f30931e0cb5256f683f8",
-        "hash": "sha256-eMt2orPeG81o42O/HU+4B5b/G62TYAVIEeWwOmiML14="
+        "rev": "99b479dc34728936b006679a31e12b8cf432fc55",
+        "hash": "sha256-H5RzBFYWIp/QYKyeBM2wfuX7FvXHPbhCAp7qne5Zvhw="
       },
       "src/third_party/fxdiv/src": {
         "url": "https://chromium.googlesource.com/external/github.com/Maratyszcza/FXdiv.git",
         "rev": "63058eff77e11aa15bf531df5dd34395ec3017c8",
         "hash": "sha256-LjX5kivfHbqCIA5pF9qUvswG1gjOFo3CMpX0VR+Cn38="
       },
-      "src/third_party/harfbuzz-ng/src": {
+      "src/third_party/harfbuzz/src": {
         "url": "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git",
-        "rev": "5d4e96ad8d00fc871ffa17707b2ca08fa850e7d6",
-        "hash": "sha256-9ef1P2JVJc7ZiP7TObFOxJbccCLsEgjhj+Z/ooEAGiI="
+        "rev": "4fc96139259ebc35f40118e0382ac8037d928e5c",
+        "hash": "sha256-/RT2OPWFiVwFqmNS4o+gE0JrcVO1cQDkCkgrSEe7BzE="
       },
       "src/third_party/ink/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/ink.git",
@@ -347,13 +352,13 @@
       },
       "src/third_party/ink_stroke_modeler/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/ink-stroke-modeler.git",
-        "rev": "3fa5129ed1ae6f8b2ec4e9b60fa5d08cc81e2d78",
-        "hash": "sha256-/TBxFsmLH1h3kfeE90LhR0RWJ3NrCTiLKklcaPbean8="
+        "rev": "da42d439389c90ec7574f0381ec53e7f5be0c2eb",
+        "hash": "sha256-W5HgVe0v9O/EuhpKMHp83PLq4p6cuBul3QUGLYdF6rY="
       },
       "src/third_party/instrumented_libs": {
         "url": "https://chromium.googlesource.com/chromium/third_party/instrumented_libraries.git",
-        "rev": "69015643b3f68dbd438c010439c59adc52cac808",
-        "hash": "sha256-8kokdsnn5jD9KgM/6g0NuITBbKkGXWEM4BMr1nCrfdU="
+        "rev": "e8cb570a9a2ee9128e2214c73417ad2a3c47780b",
+        "hash": "sha256-5cb9qhSEzb941pF5HH0Br+x9wEH7MiGwQttvErb2mZo="
       },
       "src/third_party/emoji-segmenter/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/emoji-segmenter.git",
@@ -387,8 +392,8 @@
       },
       "src/third_party/icu": {
         "url": "https://chromium.googlesource.com/chromium/deps/icu.git",
-        "rev": "ee5f27adc28bd3f15b2c293f726d14d2e336cbd5",
-        "hash": "sha256-UQWSAekvYc1bTEAEQTPdeB406Uqb0mptpnGRZSaLewo="
+        "rev": "ff7995a708a10ab44db101358083c7f74752da9f",
+        "hash": "sha256-yQ55MGzqkVkp/arTlmKqySBvQFtaPaBk9UUAFE0imhE="
       },
       "src/third_party/nlohmann_json/src": {
         "url": "https://chromium.googlesource.com/external/github.com/nlohmann/json.git",
@@ -402,8 +407,8 @@
       },
       "src/third_party/leveldatabase/src": {
         "url": "https://chromium.googlesource.com/external/leveldb.git",
-        "rev": "4ee78d7ea98330f7d7599c42576ca99e3c6ff9c5",
-        "hash": "sha256-ANtMVRZmW6iOjDVn2y15ak2fTagFTTaz1Se6flUHL8w="
+        "rev": "7ee830d02b623e8ffe0b95d59a74db1e58da04c5",
+        "hash": "sha256-a1fcVI9Vsm1qE17Fnx5UxwOy4ZFMMJ0OKwNs/gZHYQI="
       },
       "src/third_party/libFuzzer/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/compiler-rt/lib/fuzzer.git",
@@ -412,8 +417,8 @@
       },
       "src/third_party/fuzztest/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/fuzztest.git",
-        "rev": "1f7726d61f7afa9aca1198a9395ede472ed70366",
-        "hash": "sha256-RhJ676e6Kr/muR0ZCfZOAcs3kfoK7CjG2cwOpYG/JCY="
+        "rev": "800c545cf9d6e9c01328a1974f93a7e6564a74fd",
+        "hash": "sha256-Pvz+CWTBcWE0N0yfNGZhXDgUrGeIaCNfEjP1jYmF6G0="
       },
       "src/third_party/domato/src": {
         "url": "https://chromium.googlesource.com/external/github.com/googleprojectzero/domato.git",
@@ -427,13 +432,13 @@
       },
       "src/third_party/libaom/source/libaom": {
         "url": "https://aomedia.googlesource.com/aom.git",
-        "rev": "ab9876a5983227865ee26e91caac87c6b8750e27",
-        "hash": "sha256-V40GL7fKj1qratP0KcrhedEPDIsg0XVb3ha5nroM0ws="
+        "rev": "b63f30b6d30028a3d7d9c5223def8f3ad97dcc4c",
+        "hash": "sha256-LaBEcVcSB8WB9ZNRgPSiGaKdQL5f3wll2sPb9OhN5SE="
       },
       "src/third_party/crabbyavif/src": {
         "url": "https://chromium.googlesource.com/external/github.com/webmproject/CrabbyAvif.git",
-        "rev": "c05daf3e2e6d83f2a359ab97094ce042944020a9",
-        "hash": "sha256-vVKAgvPdba0Lt3BUStOQsILlhiHNJeIv1jS9691+a80="
+        "rev": "7466a44ac80893803d4a7168b98dc6cd02d1fe2d",
+        "hash": "sha256-x1MRNtGLmwlRNenoQKz2Bgm3J5eHlNiJZtzhT9lttmk="
       },
       "src/third_party/nearby/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/nearby-connections.git",
@@ -487,8 +492,8 @@
       },
       "src/third_party/cros-components/src": {
         "url": "https://chromium.googlesource.com/external/google3/cros_components.git",
-        "rev": "ddb611c60142c72be3719e753a42fb434b6f2458",
-        "hash": "sha256-M/b7PKEu+mFxsEeedJeppkwl8aZnX/932zqWlrCx8Y4="
+        "rev": "fb512780dcc5ba4b5be9e8a3118919002077c760",
+        "hash": "sha256-7wx73HZ6aqXQvLxwX6XnJAPefi/t47gIhvDH3FRT1j4="
       },
       "src/third_party/libdrm/src": {
         "url": "https://chromium.googlesource.com/chromiumos/third_party/libdrm.git",
@@ -497,8 +502,8 @@
       },
       "src/third_party/expat/src": {
         "url": "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git",
-        "rev": "69d6c054c1bd5258c2a13405a7f5628c72c177c2",
-        "hash": "sha256-qe8O7otL6YcDDBx2DS/+c5mWIS8Rf8RQXVtLFMIAeyk="
+        "rev": "f31adfd584b7f6c50bbf4d22eb928538ffc9145a",
+        "hash": "sha256-tLz4RejYQ/kFXhsWTduuGcinfUkqxYKPCpsou+WlvBc="
       },
       "src/third_party/libipp/libipp": {
         "url": "https://chromium.googlesource.com/chromiumos/platform2/libipp.git",
@@ -542,13 +547,13 @@
       },
       "src/third_party/libvpx/source/libvpx": {
         "url": "https://chromium.googlesource.com/webm/libvpx.git",
-        "rev": "aec2a6f1cd6e3d9e8cf5d9682fcb8a442799bd22",
-        "hash": "sha256-PNreh1VisA46I0WZqq8wZRCjbQRiVMxbL5Gl2Bfzo3M="
+        "rev": "47ac1ec7f3de7d7cb3d070844c427c8f1fa9d6fc",
+        "hash": "sha256-RyYnkLYafiS6kQKeOmzohtxFRXudDzgEmQkG+qKHozc="
       },
       "src/third_party/libwebm/source": {
         "url": "https://chromium.googlesource.com/webm/libwebm.git",
-        "rev": "f2a982d748b80586ae53b89a2e6ebbc305848b8c",
-        "hash": "sha256-SxDGt7nPVkSxwRF/lMmcch1h+C2Dyh6GZUXoZjnXWb4="
+        "rev": "b7a1e4767fbb02ad467f45ba378e858e897028da",
+        "hash": "sha256-Lzfs15Us8MDDQYvLRVf6xKg9A76aXPnTukx/A8Mf7rw="
       },
       "src/third_party/libwebp/src": {
         "url": "https://chromium.googlesource.com/webm/libwebp.git",
@@ -577,8 +582,8 @@
       },
       "src/third_party/nasm": {
         "url": "https://chromium.googlesource.com/chromium/deps/nasm.git",
-        "rev": "af5eeeb054bebadfbb79c7bcd100a95e2ad4525f",
-        "hash": "sha256-vH3OUzfLZbaPY4DMAvSW0jKYRJmOa7aE8EfIJtZ1/Xs="
+        "rev": "45252858722aad12e545819b2d0f370eb865431b",
+        "hash": "sha256-0KsHYi76IaVNwk0dBhem2AnUXd9PpeS+jUsY+zPmeJ8="
       },
       "src/third_party/neon_2_sse/src": {
         "url": "https://chromium.googlesource.com/external/github.com/intel/ARM_NEON_2_x86_SSE.git",
@@ -592,8 +597,8 @@
       },
       "src/third_party/openscreen/src": {
         "url": "https://chromium.googlesource.com/openscreen",
-        "rev": "571620ad60afc9f317d77605c65335f5412aada2",
-        "hash": "sha256-ktR3EpmkjueEmEip2oUTcSclVkUlPi/7+qmhElG+Bzs="
+        "rev": "448a19d1f24e0f8ce85ad0c1c6a50cf370ae69d7",
+        "hash": "sha256-hRDFnoqAH4HoWZ3oTWlzNge2nwlxpUC/GEq0MQVzBw8="
       },
       "src/third_party/openscreen/src/buildtools": {
         "url": "https://chromium.googlesource.com/chromium/src/buildtools",
@@ -607,13 +612,13 @@
       },
       "src/third_party/pdfium": {
         "url": "https://pdfium.googlesource.com/pdfium.git",
-        "rev": "e5bafd3be58c26673576fd5bb5cbf413b485de5b",
-        "hash": "sha256-umtG2n6kWYD0hT44GpmnwUVztkZ0RtQDV0h0+4CTC9w="
+        "rev": "a78c62d93a8f514ea2cd98a70bd1d21226be9d93",
+        "hash": "sha256-qd3Oa/JFzoI5hKDY2/OQAzdr2z9srUj0H6oKz0R516U="
       },
       "src/third_party/perfetto": {
         "url": "https://chromium.googlesource.com/external/github.com/google/perfetto.git",
-        "rev": "728eb5626a3bc701d044dd16d9cd289360ff47c3",
-        "hash": "sha256-LeGGkzSMfVXuioVJmRi/TjMYgG/0YrK7PckBJTejSHU="
+        "rev": "46432bb2a7a60e10fcee516f1692e6846d098a8d",
+        "hash": "sha256-jVih4xWota4SZQi4yEtaIP+4qgD03OsELt2aaulIXik="
       },
       "src/third_party/protobuf-javascript/src": {
         "url": "https://chromium.googlesource.com/external/github.com/protocolbuffers/protobuf-javascript",
@@ -627,8 +632,8 @@
       },
       "src/third_party/pyelftools": {
         "url": "https://chromium.googlesource.com/chromiumos/third_party/pyelftools.git",
-        "rev": "19b3e610c86fcadb837d252c794cb5e8008826ae",
-        "hash": "sha256-I/7p3IEvfP/gkes4kx18PvWwhAKilQKb67GXoW4zFB4="
+        "rev": "8047437615d66d3267ac0134834b80e70639d572",
+        "hash": "sha256-rEnt08K90/Psfa+SQgTUG3YGrhp4/udXG9VKIwPM7pk="
       },
       "src/third_party/quic_trace/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/quic-trace.git",
@@ -657,8 +662,8 @@
       },
       "src/third_party/skia": {
         "url": "https://skia.googlesource.com/skia.git",
-        "rev": "6e0fbe154ccaf018b2dd1f0e42eec285e7d79d00",
-        "hash": "sha256-oqfNOSQB+5sbAnw4tPBXn22rk6Ai5b2aZNLJUyM181k="
+        "rev": "afe8b760ada5128164f9826866b4381a3463df41",
+        "hash": "sha256-HsKHffZWTls362kjokxzdhaxb/xJD1g70VHGk9l6GVM="
       },
       "src/third_party/smhasher/src": {
         "url": "https://chromium.googlesource.com/external/smhasher.git",
@@ -672,13 +677,13 @@
       },
       "src/third_party/sqlite/src": {
         "url": "https://chromium.googlesource.com/chromium/deps/sqlite.git",
-        "rev": "727f7c8991f7b622a8b5c833cff99871a8c2cd8e",
-        "hash": "sha256-L42hkqcsuyMkNUeornIul7AYNgachkYpfNFE8H/VeVc="
+        "rev": "508ab21dc25702ed6690c4dd77da209a6bcd1239",
+        "hash": "sha256-SfvLfBKdPjFvZ7CzUeFMcyoHdCzQgNRQwZyzb6MRtJg="
       },
       "src/third_party/swiftshader": {
         "url": "https://swiftshader.googlesource.com/SwiftShader.git",
-        "rev": "313545f85af72f954820e54f4110cda591a6cf7b",
-        "hash": "sha256-EGgC5nK68Wk0b466K9yvLlGMxBd/CeI+KTgyoE+x6DY="
+        "rev": "89556131bf9d48af3c5c9fbb9a3322e706da89a3",
+        "hash": "sha256-h0utcwCnzwhFufggkBNeA674x2Kqwu4sz3jQ/9eoQv0="
       },
       "src/third_party/text-fragments-polyfill/src": {
         "url": "https://chromium.googlesource.com/external/github.com/GoogleChromeLabs/text-fragments-polyfill.git",
@@ -687,23 +692,23 @@
       },
       "src/third_party/tflite/src": {
         "url": "https://chromium.googlesource.com/external/github.com/tensorflow/tensorflow.git",
-        "rev": "b476481b77f6e939e813ac93df22a4a6e7a3dd57",
-        "hash": "sha256-oKLFjed5sbYjEX5kddkAEdhkVOwFf5ddEUlOS55zLWE="
+        "rev": "de8d7f65b6eb670e4dad0225d0d6f99bebaab559",
+        "hash": "sha256-r2b+/VBffxsh1sRM2xcFiBx9K6GD6FsaQXpfFMBFUag="
       },
       "src/third_party/litert/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google-ai-edge/LiteRT.git",
-        "rev": "82bf3bef8a04a416bcb9d1cca5bdd51a6b3ab4ba",
-        "hash": "sha256-uMBuoGQIgRhmc8KJqLUnf13XK9tveuS0/OzzwKHKNUw="
+        "rev": "588075c77c6895cce6397d41d2890b1aa0a14372",
+        "hash": "sha256-rcEPZNSV0DiDrmoBCtJ07wFzzpmpM93jG4jYaEdNWvI="
       },
       "src/third_party/vulkan-deps": {
         "url": "https://chromium.googlesource.com/vulkan-deps",
-        "rev": "4a9f2cec3d5e7cb4810cf84716f597aff768ffa4",
-        "hash": "sha256-PyBxtzesZR/5jrWt96DxK7QwRoG8qhzWzbiE1fqdqkI="
+        "rev": "0ced1107c62836f439f684a5696c4bd69e09fce3",
+        "hash": "sha256-VOyN618wzyyO2Wh18gCnw+FCr/NbegX3A/54MClyhwc="
       },
       "src/third_party/glslang/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/glslang",
-        "rev": "b11b03839c940685b0201026bd2a4ffef1d5a4b8",
-        "hash": "sha256-FjUqETWBiI91hq5wGomPmCeW7K4k9kn5r74pUP0QFNo="
+        "rev": "715c8500e7cd67f2eba9e60e98852a1ed49d2f15",
+        "hash": "sha256-vSbMdTjlRVvYLi5ZvTVmfe76oAQ4AhqyD+ohvkvIYIs="
       },
       "src/third_party/spirv-cross/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Cross",
@@ -712,38 +717,38 @@
       },
       "src/third_party/spirv-headers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Headers",
-        "rev": "f88a2d766840fc825af1fc065977953ba1fa4a91",
-        "hash": "sha256-VhcGQ+Tr9sH0ZEIk0oJsXh8MvCo2qpA2W3i8YVCwKaE="
+        "rev": "6dd7ba990830f7c15ac1345ff3b43ef6ffdad216",
+        "hash": "sha256-UKBVs2s05hP+paPq1dZFaUEQQ9Kx9acHxYUyJVx22eY="
       },
       "src/third_party/spirv-tools/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Tools",
-        "rev": "7d8d9e58c384949f1615c069d4c9346bf51b9738",
-        "hash": "sha256-AxS7vHw3RoXZLayWEDKBU7H0M1BZ9RMVdIsD/4rYap8="
+        "rev": "2d14d2e76aa7de72404b17078eda15c20a6a0389",
+        "hash": "sha256-8Xtzq8WOdFEw+uEJqMW39LLHt2m165K9OJsIFZuifoM="
       },
       "src/third_party/vulkan-headers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Headers",
-        "rev": "74d8a6cb930c68ef617b202c3ff3c59d919e086b",
-        "hash": "sha256-bZKNFiZMVYDxa6RKb1c/GxIR+eEFQAyYNaEptzQW5TE="
+        "rev": "afe9eb980aa928a66d1c9c06f38c55dd59868720",
+        "hash": "sha256-/yolWlC7ruRiJ0gSdCoSlqL9+j2uJAh+o+H0OG37pq4="
       },
       "src/third_party/vulkan-loader/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Loader",
-        "rev": "363f465abadab0a8dcfc5c85d2c691e9b0b788d6",
-        "hash": "sha256-Zk2QyKu19g52vzGpNq5Qm+mlEgqk4jCFn/861eK8+64="
+        "rev": "df84d2be47457a8dfd7eb66f8c2b031683bd1ba5",
+        "hash": "sha256-8ParcURRRU3eS9Oej/vHTwOwvYy3HsVJsKh2wQLKUgM="
       },
       "src/third_party/vulkan-tools/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Tools",
-        "rev": "59f963ce1b1d16cc92137a241a0fe98d637d21f4",
-        "hash": "sha256-Hh0N4N4XN7p7PBKk2uCU5g9TO9vmxJbomC1Gvf5oDZc="
+        "rev": "90bf5bc4fd8bea0d300f6564af256a51a34124b8",
+        "hash": "sha256-tmTD/waVX/duaKXvj0FNUS+ncL1agM73kK7pEfHEsSA="
       },
       "src/third_party/vulkan-utility-libraries/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Utility-Libraries",
-        "rev": "20fb10eb1ec08ccd5cacec32b7df1b0e99e48a0c",
-        "hash": "sha256-4XsQN94JsQXFGwJKp3W2gdTCCxUZrpCKiRVXzxL+Qs0="
+        "rev": "48b1fd1a65e436bae806cb6180c9338846b9de97",
+        "hash": "sha256-B3GXmwJEvnGcER5DJt0FGrwqNi3t8iV6VgX8uOrExlU="
       },
       "src/third_party/vulkan-validation-layers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-ValidationLayers",
-        "rev": "20948525099c0ea030ec5b149c809e48010be4ed",
-        "hash": "sha256-H05Ms2a770ApiCz5ERiIm8g893TJG9gRRuM9Qr4bj60="
+        "rev": "ac146eef210b6f52b842111c5d3419ab32a7293f",
+        "hash": "sha256-GqjVHxtda1a47+9G+nqh4qNMJmQaUdZNMUGQ8kAIIkk="
       },
       "src/third_party/vulkan_memory_allocator": {
         "url": "https://chromium.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git",
@@ -777,23 +782,23 @@
       },
       "src/third_party/webgl/src": {
         "url": "https://chromium.googlesource.com/external/khronosgroup/webgl.git",
-        "rev": "8fc2a0dff53abfc0cf2c140d8420759b2036cc54",
-        "hash": "sha256-cU7kfmxgaem6rPHGW+VwjxfKe7c0u1tCc98MQjsp5l8="
+        "rev": "216b10fafd3f6a900c715a8c758a4c7f9883b030",
+        "hash": "sha256-Aax2hr/9Zq6Avk+TMU1OMBLGshUL6hyRTX6eoOQesqM="
       },
       "src/third_party/webgpu-cts/src": {
         "url": "https://chromium.googlesource.com/external/github.com/gpuweb/cts.git",
-        "rev": "54441b8d176b12a5e2b01b8db78191ace56d7f34",
-        "hash": "sha256-gGvvKMTUJGm4ZwM7C1xTY1DKskCmlrCpSl3HLgVZqoY="
+        "rev": "09fdb847d90d0b5bfe57068ce2eb9283cb77fc7f",
+        "hash": "sha256-eTAwnTiAHq8rmbw7u9nAwSuAlS5adStUJKfITlYkcgU="
       },
       "src/third_party/webpagereplay": {
         "url": "https://chromium.googlesource.com/webpagereplay.git",
-        "rev": "22be07d7809409644d7e292d9495fa8a251d5f29",
-        "hash": "sha256-HR6iEDwmxFaiLi+h3MwsNfBOtBNbrKvmRNgMVog3A0Y="
+        "rev": "be48b5e3387780790ecc7723434b6ea6733bcc33",
+        "hash": "sha256-KcFUlQMltsMm4WlTVMLzZXfrvu67ffkKjmBcruwZye0="
       },
       "src/third_party/webrtc": {
         "url": "https://webrtc.googlesource.com/src.git",
-        "rev": "28452dff1bf86fec881a47949d4dedd4a2fe1f09",
-        "hash": "sha256-KBz94jvdVgxWuTuSoeHKNdY7wEJDGqG3xVsSVB3ubRQ="
+        "rev": "9600e77d854090669817d22aa2fc941ee92aaacd",
+        "hash": "sha256-jTJv53qt971Va5q6MaULysYiChBVmsFYxG9fzkcE0ak="
       },
       "src/third_party/wuffs/src": {
         "url": "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git",
@@ -805,25 +810,20 @@
         "rev": "b65be9e699847c975440108a42f05412cc7fddac",
         "hash": "sha256-PySen9syu0OshtlHAZw666FeSQXdnsV8nlW9RmxgapM="
       },
-      "src/third_party/xdg-utils": {
-        "url": "https://chromium.googlesource.com/chromium/deps/xdg-utils.git",
-        "rev": "cb54d9db2e535ee4ef13cc91b65a1e2741a94a44",
-        "hash": "sha256-WuQ9uDq+QD17Y20ACFGres4nbkeOiTE2y+tY1avAT5U="
-      },
       "src/third_party/xnnpack/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/XNNPACK.git",
-        "rev": "abd8e60edf09db5f5ba8e7fa2f1fcab0ae0807e1",
-        "hash": "sha256-VdrA2UwQ7/kHbnlIXBmga3ZjAqWaxCDQcDAssbLrh/M="
+        "rev": "1812bbe2928a32f26c5e48466712ba6460cf290c",
+        "hash": "sha256-xal21wjgeql3MjQXw6F1ezcRsnhVKod5jv0nYWroJ1o="
       },
       "src/third_party/zstd/src": {
         "url": "https://chromium.googlesource.com/external/github.com/facebook/zstd.git",
-        "rev": "1168da0e567960d50cba1b58c9b0ba047ece4733",
-        "hash": "sha256-T2CwRpL/XT/OsBrRfxC8kNIm43U4qPMBju8Ug13Qebo="
+        "rev": "3ae099b48dfcfe02b1b3ba81ab85457f8a922e9f",
+        "hash": "sha256-futF0sM6z9HAl6AMJwUULBRByN92FTBjRIzYb2vBFGg="
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "c152c31c55cd54fd239772532a86c802d95b4617",
-        "hash": "sha256-7qEPh9l94LqyaA9qW0ZfFmmFyMNTjTJaeunLgDhtFuM="
+        "rev": "ddc9a95905de5268332a8f0216dc2bc67d26e829",
+        "hash": "sha256-x2FGL3J+JaWO1m6jBrcayR7Vlz90fYEAuufm4PULYyM="
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/update.mjs
+++ b/pkgs/applications/networking/browsers/chromium/update.mjs
@@ -72,11 +72,7 @@ for (const attr_path of Object.keys(lockfile)) {
       DEPS: {},
     }
 
-    // The DEPS schema was modified in https://chromium-review.googlesource.com/c/chromium/tools/depot_tools/+/7007552
-    // and https://chromium-review.googlesource.com/c/chromium/src/+/7683270. And while the breaking change itself got
-    // backported to M147 (and M146 fwiw), the necessary depot_tools roll was not.
-    // So for now we simply resort to whatever depot_tools is currently pinned on chromium's main branch.
-    const depot_tools = await fetch_depot_tools(/* chromium_rev */ 'main', lockfile_initial[attr_path].deps.depot_tools)
+    const depot_tools = await fetch_depot_tools(chromium_rev, lockfile_initial[attr_path].deps.depot_tools)
     lockfile[attr_path].deps.depot_tools = {
       rev: depot_tools.rev,
       hash: depot_tools.hash,


### PR DESCRIPTION
https://developer.chrome.com/blog/new-in-chrome-148

https://developer.chrome.com/release-notes/148

https://chromereleases.googleblog.com/2026/05/stable-channel-update-for-desktop.html

This update includes 127 security fixes.

CVEs:
CVE-2026-7896 CVE-2026-7897 CVE-2026-7898 CVE-2026-7899 CVE-2026-7900
CVE-2026-7901 CVE-2026-7902 CVE-2026-7903 CVE-2026-7904 CVE-2026-7905
CVE-2026-7906 CVE-2026-7907 CVE-2026-7908 CVE-2026-7909 CVE-2026-7910
CVE-2026-7911 CVE-2026-7912 CVE-2026-7913 CVE-2026-7914 CVE-2026-7915
CVE-2026-7916 CVE-2026-7917 CVE-2026-7918 CVE-2026-7919 CVE-2026-7920
CVE-2026-7921 CVE-2026-7922 CVE-2026-7923 CVE-2026-7924 CVE-2026-7925
CVE-2026-7926 CVE-2026-7927 CVE-2026-7928 CVE-2026-7929 CVE-2026-7930
CVE-2026-7931 CVE-2026-7932 CVE-2026-7933 CVE-2026-7934 CVE-2026-7935
CVE-2026-7936 CVE-2026-7937 CVE-2026-7938 CVE-2026-7939 CVE-2026-7940
CVE-2026-7941 CVE-2026-7942 CVE-2026-7943 CVE-2026-7944 CVE-2026-7945
CVE-2026-7946 CVE-2026-7947 CVE-2026-7948 CVE-2026-7949 CVE-2026-7950
CVE-2026-7951 CVE-2026-7952 CVE-2026-7953 CVE-2026-7954 CVE-2026-7955
CVE-2026-7956 CVE-2026-7957 CVE-2026-7958 CVE-2026-7959 CVE-2026-7960
CVE-2026-7961 CVE-2026-7962 CVE-2026-7963 CVE-2026-7964 CVE-2026-7965
CVE-2026-7966 CVE-2026-7967 CVE-2026-7968 CVE-2026-7969 CVE-2026-7970
CVE-2026-7971 CVE-2026-7972 CVE-2026-7973 CVE-2026-7974 CVE-2026-7975
CVE-2026-7976 CVE-2026-7977 CVE-2026-7978 CVE-2026-7979 CVE-2026-7980
CVE-2026-7981 CVE-2026-7982 CVE-2026-7983 CVE-2026-7984 CVE-2026-7985
CVE-2026-7986 CVE-2026-7987 CVE-2026-7988 CVE-2026-7989 CVE-2026-7990
CVE-2026-7991 CVE-2026-7992 CVE-2026-7993 CVE-2026-7994 CVE-2026-7995
CVE-2026-7996 CVE-2026-7997 CVE-2026-7998 CVE-2026-7999 CVE-2026-8000
CVE-2026-8001 CVE-2026-8002 CVE-2026-8003 CVE-2026-8004 CVE-2026-8005
CVE-2026-8006 CVE-2026-8007 CVE-2026-8008 CVE-2026-8009 CVE-2026-8010
CVE-2026-8011 CVE-2026-8012 CVE-2026-8013 CVE-2026-8014 CVE-2026-8015
CVE-2026-8016 CVE-2026-8017 CVE-2026-8018 CVE-2026-8019 CVE-2026-8020
CVE-2026-8021 CVE-2026-8022

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
