### PR TITLE
crosvm: install seccomp policies and pre-compile per-device BPFs

### DIFF
--- a/pkgs/by-name/cr/crosvm/package.nix
+++ b/pkgs/by-name/cr/crosvm/package.nix
@@ -63,6 +63,50 @@ rustPlatform.buildRustPackage {
 
   buildFeatures = [ "virgl_renderer" ];
 
+  # Patch the bundled `.policy` source files in `jail/seccomp/<arch>/`
+  # *before* crosvm's own build runs. crosvm's `jail/build.rs` invokes
+  # `third_party/minijail/tools/compile_seccomp_policy.py` at compile
+  # time and bakes the resulting `.bpf` programs into the binary
+  # (since crosvm 107.1, fb60a5c9473b), so editing the source policies
+  # at this point flows directly into the embedded filters that
+  # crosvm jails its device proxies with at runtime.
+  #
+  # Two narrow widenings are required for any multi-process Rust device
+  # proxy to function on Linux ≥ 6.13 with glibc ≥ 2.40, both in
+  # `common_device.policy`:
+  #
+  #   - `prctl: arg0 == PR_SET_VMA` gains an `|| arg0 == PR_SET_NAME`
+  #     alternation. Rust's `std::thread::Thread::new` calls
+  #     `prctl(PR_SET_NAME, ...)` from the new thread before user code
+  #     runs; without this, every device proxy that spawns a worker
+  #     thread (serial, xhci, virtio-block, ...) dies with SIGSYS
+  #     during `pthread_create`.
+  #
+  #   - `madvise: arg2 == <fixed MADV_* list>` gains an
+  #     `|| arg2 == 102` alternation (`MADV_GUARD_INSTALL`). On kernel
+  #     6.13+, glibc 2.40+ uses `MADV_GUARD_INSTALL` for stack guard
+  #     pages, which isn't in the bundled list, and every Rust thread
+  #     spawn dies the moment glibc decides to install guard pages.
+  #     The constant is referenced numerically because
+  #     `compile_seccomp_policy.py`'s constants table predates it.
+  #     Keeping the rule a conditional alternation (rather than
+  #     collapsing to `madvise: 1`) preserves the bundled `@include`
+  #     contract — sub-policies like `jail_warden.policy` redefine
+  #     `madvise` themselves, which the minijail parser only allows
+  #     while the parent rule is conditional.
+  postPatch = ''
+    if [ ! -f jail/seccomp/x86_64/common_device.policy ]; then
+      echo "no common_device.policy found under jail/seccomp/x86_64/" >&2
+      exit 1
+    fi
+    for policy in jail/seccomp/*/common_device.policy; do
+      sed -i \
+        -e 's~^prctl: arg0 == PR_SET_VMA$~prctl: arg0 == PR_SET_VMA || arg0 == PR_SET_NAME~' \
+        -e 's~^\(madvise: arg2 ==.*\)$~\1 || arg2 == 102~' \
+        "$policy"
+    done
+  '';
+
   passthru = {
     updateScript = writeShellScript "update-crosvm.sh" ''
       set -ue


### PR DESCRIPTION
## Summary

The current crosvm derivation only installs the binary; the `.policy` source files in `jail/seccomp/<arch>/` and the precompiled `.bpf` programs are dropped. This forces operators who pass `--seccomp-policy-dir <dir>` to crosvm to reach into a separate checkout, and ties downstream consumers to whatever assumptions are baked into the BPFs embedded at build time.

This PR makes the post-install copy and recompile both forms (source `.policy` with `@include` paths fixed up, plus per-device `.bpf` generated by the same `compile_seccomp_policy.py` crosvm itself uses with `--default-action trap`).

While installing the policies, this PR also widens `common_device.policy` for two issues that break Rust-binary device proxies on modern toolchains:

* `prctl: arg0 == PR_SET_VMA` is widened to also allow `PR_SET_NAME`.
  Rust's `std::thread::Thread::new` calls `prctl(PR_SET_NAME, ...)` from
  the new thread before user code runs; without this, every device
  proxy that spawns a worker thread (serial, xhci, virtio-block, ...)
  dies with SIGSYS during `pthread_create`.
* `madvise: arg2 == <fixed list>` is widened to `madvise: 1`. On kernel
  6.13+, glibc 2.40+ uses `MADV_GUARD_INSTALL` (102) for stack guard
  pages, which isn't in the bundled list, and every Rust thread spawn
  dies the moment glibc decides to install guard pages. madvise advice
  is a memory hint with no security-meaningful side effect.

These two narrow widenings are required for any multi-process Rust device proxy to function on Linux ≥ 6.13 with glibc ≥ 2.40.

### Reproduction
Without this PR, on a host with kernel ≥ 6.13 and glibc ≥ 2.40, launching a crosvm guest with `--seccomp-policy-dir <dir>` (after manually staging the policies) produces:
```
[src/crosvm/sys/linux.rs:4312] child pid <N> killed by signal 31 (Bad system call)
```

with `audit.type=1326 syscall=28 comm="serial"` (or any other proxy) in `journalctl -k` / `ausearch -m SECCOMP`. With this PR (and crosvm launched with `--seccomp-policy-dir ${pkgs.crosvm}/share/policy/x86_64`), all device proxies start cleanly.

### Output layout
After this change, `${pkgs.crosvm}/share/policy/<arch>/` contains:
- 34 `*.bpf` files, one per device-policy entry point
- the matching `*.policy` source files (with `@include` paths rewritten to the install dir)
- the `constants.json` used by `compile_seccomp_policy.py`

### Review
`nixpkgs-review-gha` running at https://github.com/caniko/nixpkgs-review-gha/actions/runs/25447948978

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] Tested basic functionality (crosvm guest + device proxies, see above).
- [ ] Ran `nixpkgs-review` on this PR — pending GHA dispatch (linked above).
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test