### PR TITLE
hexcurse: fix build with gcc15

### DIFF
--- a/pkgs/by-name/he/hexcurse/package.nix
+++ b/pkgs/by-name/he/hexcurse/package.nix
@@ -3,6 +3,7 @@
   lib,
   fetchFromGitHub,
   fetchpatch,
+  fetchDebianPatch,
   ncurses,
 }:
 
@@ -47,6 +48,15 @@ stdenv.mkDerivation (finalAttrs: {
       name = "ncurses-6.3.patch";
       url = "https://github.com/LonnyGomes/hexcurse/commit/cb70d4a93a46102f488f471fad31a7cfc9fec025.patch";
       sha256 = "19674zhhp7gc097kl4bxvi0gblq6jzjy8cw8961svbq5y3hv1v5y";
+    })
+
+    # Fix build with GCC 15 (old-style function definitions)
+    (fetchDebianPatch {
+      pname = "hexcurse";
+      version = "1.60.0";
+      debianRevision = "1";
+      patch = "gcc-15.patch";
+      hash = "sha256-nWwYjI18fsJ9LSby6OJoJ0QXENgyVbUY3LpEYWoCBkI=";
     })
   ];
 


### PR DESCRIPTION
- #475479 
- #516381
- https://hydra.nixos.org/build/324240722

```
getopt.c: In function 'exchange':
getopt.c:73:1: error: old-style function definition [-Werror=old-style-definition]
   73 | exchange (argv)
      | ^~~~~~~~
getopt.c: In function 'getopt_set_posix_option_order':
getopt.c:98:1: error: old-style function definition [-Werror=old-style-definition]
   98 | getopt_set_posix_option_order (on_or_off)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
getopt.c: In function '_getopt_internal':
getopt.c:108:1: error: old-style function definition [-Werror=old-style-definition]
  108 | _getopt_internal (argc, argv, optstring, longopts, longind, long_only)
      | ^~~~~~~~~~~~~~~~
getopt.c: In function 'hgetopt':
getopt.c:450:1: error: old-style function definition [-Werror=old-style-definition]
  450 | hgetopt (argc, argv, optstring)
      | ^~~~~~~
cc1: all warnings being treated as errors
```

Fetching a [debian patch](https://sources.debian.org/patches/hexcurse/1.60.0-1/gcc-15.patch/) to fix the problem.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
