### PR TITLE
nixos/tests/grafana-to-ntfy: use new k8s receiver-test endpoint

### DIFF
--- a/nixos/tests/grafana-to-ntfy.nix
+++ b/nixos/tests/grafana-to-ntfy.nix
@@ -148,10 +148,10 @@ in
 
     with subtest("Grafana alert arrives at ntfy"):
       machine.succeed(
-        "curl -sf http://127.0.0.1:${toString ports.grafana}/api/alertmanager/grafana/config/api/v1/receivers/test"
+        "curl -sf http://127.0.0.1:${toString ports.grafana}/apis/notifications.alerting.grafana.app/v1beta1/namespaces/default/receivers/-/test"
         " -u admin:admin"
         " -X POST -H 'Content-Type: application/json'"
-        """ -d '{"receivers": [{"name": "grafana-to-ntfy", "grafana_managed_receiver_configs": [{"uid": "cp_webhook", "name": "webhook", "type": "webhook", "disableResolveMessage": false, "settings": {"url": "http://127.0.0.1:${toString ports.grafana-to-ntfy}", "httpMethod": "POST"}}]}]}'"""
+        """ -d '{"alert": {"labels": {"alertname": "test-alert"}, "annotations": {}}, "integration": {"type": "webhook", "settings": {"url": "http://127.0.0.1:${toString ports.grafana-to-ntfy}", "httpMethod": "POST"}}}'"""
       )
       # grep ensures we wait for the Grafana message specifically (see above)
       resp = machine.wait_until_succeeds(


### PR DESCRIPTION
Grafana 13 removed `POST /api/alertmanager/.../receivers/test` (grafana/grafana#121692, returns 410), so `passthru.tests.grafana-to-ntfy` fails on master regardless of package version.

Verified locally on x86_64-linux against current master (Grafana 13.0.1) — all three subtests pass.

Justifies #517257.