### PR TITLE
python3Packages.py-opendisplay: 5.5.0 -> 6.1.0

### DIFF
--- a/pkgs/development/python-modules/epaper-dithering/default.nix
+++ b/pkgs/development/python-modules/epaper-dithering/default.nix
@@ -6,30 +6,41 @@
   numpy,
   pillow,
   pytestCheckHook,
+  rustPlatform,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "epaper-dithering";
-  version = "0.6.3";
+  version = "4.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "OpenDisplay";
     repo = "epaper-dithering";
-    tag = "python-v${finalAttrs.version}";
-    hash = "sha256-h84AgWJR8zVuwoz02A3U82yTOw4MSK9DjaxkYi0nWkM=";
+    tag = "epaper-dithering-v${finalAttrs.version}";
+    hash = "sha256-m0t+Zxd+a4Mc9QkdhOPSF72l9uxgaAFctoB60i6hcV8=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/packages/python";
 
-  build-system = [ hatchling ];
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src sourceRoot;
+    hash = "sha256-RBOULCydXgTR8Snc1cecvW4KqGDLYjZsYwlJovuvN2I=";
+  };
+
+  nativeBuildInputs = [
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+  ];
 
   dependencies = [
-    numpy
     pillow
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    numpy
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [ "epaper_dithering" ];
 

--- a/pkgs/development/python-modules/py-opendisplay/default.nix
+++ b/pkgs/development/python-modules/py-opendisplay/default.nix
@@ -5,6 +5,7 @@
   hatchling,
   bleak,
   bleak-retry-connector,
+  cryptography,
   epaper-dithering,
   numpy,
   pillow,
@@ -14,14 +15,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "py-opendisplay";
-  version = "5.5.0";
+  version = "6.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "OpenDisplay";
     repo = "py-opendisplay";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-pPV4Ir9GK++66qq5QGnwyjpBinK7EvI7C7HB14tFDXU=";
+    hash = "sha256-W58knlYitI9Rdk0lKFgRVfrDe0C9uzMo5O0/U3X3mJs=";
   };
 
   build-system = [ hatchling ];
@@ -29,6 +30,7 @@ buildPythonPackage (finalAttrs: {
   dependencies = [
     bleak
     bleak-retry-connector
+    cryptography
     epaper-dithering
     numpy
     pillow


### PR DESCRIPTION
Diff: https://github.com/OpenDisplay/py-opendisplay/compare/v5.5.0...v6.1.0

Changelog: https://github.com/OpenDisplay/py-opendisplay/releases/tag/v6.1.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
