### PR TITLE
linux/kernel: support empty-string values via `lib.kernel.freeform ""`

### DIFF
--- a/nixos/modules/system/boot/kernel_config.nix
+++ b/nixos/modules/system/boot/kernel_config.nix
@@ -70,9 +70,7 @@ let
         ];
 
     in
-    if (val == "") then
-      "\"\""
-    else if val == "y" || val == "m" || val == "n" then
+    if val == "y" || val == "m" || val == "n" then
       val
     else if all isNumber (stringToCharacters val) then
       val
@@ -87,6 +85,9 @@ let
   #       VIRTIO_BLK y
   #       VIRTIO_CONSOLE n
   #       NET_9P_VIRTIO? y
+  #       LOCALVERSION
+  #
+  # A line without a value means an empty string.
   #
   # Borrowed from copumpkin https://github.com/NixOS/nixpkgs/pull/12158
   # returns a string, expr should be an attribute set
@@ -100,9 +101,8 @@ let
         let
           val = if item.freeform != null then item.freeform else item.tristate;
         in
-        optionalString (val != null) (
-          if (item.optional) then "${key}? ${mkValue val}\n" else "${key} ${mkValue val}\n"
-        );
+        optionalString (val != null)
+          "${key}${optionalString item.optional "?"}${optionalString (val != "") " ${mkValue val}"}\n";
 
       mkConf = cfg: concatStrings (mapAttrsToList mkConfigLine cfg);
     in
@@ -119,6 +119,7 @@ in
       example = ''
         USB? y
         DEBUG n
+        LOCALVERSION
       '';
       description = ''
         The result of converting the structured kernel configuration in settings

--- a/pkgs/os-specific/linux/kernel/generate-config.pl
+++ b/pkgs/os-specific/linux/kernel/generate-config.pl
@@ -4,10 +4,10 @@
 # and otherwise uses the default answer (as determined by the default
 # config for the architecture).  Overrides are read from the file
 # $KERNEL_CONFIG, which on each line contains an option name and an
-# answer, e.g. "EXT2_FS_POSIX_ACL y".  The script warns about ignored
-# options in $KERNEL_CONFIG, and barfs if `make config' selects
-# another answer for an option than the one provided in
-# $KERNEL_CONFIG.
+# answer, e.g. "EXT2_FS_POSIX_ACL y".  A name without an answer means
+# an empty string.  The script warns about ignored options in
+# $KERNEL_CONFIG, and barfs if `make config' selects another answer
+# for an option than the one provided in $KERNEL_CONFIG.
 
 use strict;
 use IPC::Open2;
@@ -29,8 +29,12 @@ open ANSWERS, "<$ENV{KERNEL_CONFIG}" or die "Could not open answer file";
 while (<ANSWERS>) {
     chomp;
     s/#.*//;
-    if (/^\s*([A-Za-z0-9_]+)(\?)?\s+(.*\S)\s*$/) {
-        $answers{$1} = $3;
+    if (/^\s*([A-Za-z0-9_]+)(\?)?(?:\s+(.*\S))?\s*$/) {
+        if (defined $3) {
+            $answers{$1} = $3;
+        } else {
+            $answers{$1} = "";
+        }
         $requiredAnswers{$1} = !(defined $2);
     } elsif (!/^\s*$/) {
         die "invalid config line: $_";
@@ -140,20 +144,32 @@ runConfig;
 # Read the final .config file and check that our answers are in
 # there.  `make config' often overrides answers if later questions
 # cause options to be selected.
+#
+# The same pass rewrites the options we answered with an empty string.
+# `make config' reads an empty answer as "keep the default", so a
+# non-empty defconfig value such as CONFIG_LOCALVERSION="-v8" survives
+# and we overwrite it here.  Options missing from .config stay missing,
+# so the check below reports them as unused.
 my %config;
-open CONFIG, "<$buildRoot/.config" or die "Could not read .config";
-while (<CONFIG>) {
-    chomp;
-    if (/^CONFIG_([A-Za-z0-9_]+)="(.*)"$/) {
-        # String options have double quotes, e.g. 'CONFIG_NLS_DEFAULT="utf8"' and allow escaping.
-        ($config{$1} = $2) =~ s/\\([\\"])/$1/g;
-    } elsif (/^CONFIG_([A-Za-z0-9_]+)=(.*)$/) {
-        $config{$1} = $2;
-    } elsif (/^# CONFIG_([A-Za-z0-9_]+) is not set$/) {
-        $config{$1} = "n";
+{
+    local @ARGV = ("$buildRoot/.config");
+    local $^I = ""; # edit in place
+    while (<>) {
+        if (/^CONFIG_([^=]+)=/ && exists $answers{$1} && $answers{$1} eq "") {
+            $_ = "CONFIG_$1=\"\"\n";
+        }
+        chomp(my $line = $_);
+        if ($line =~ /^CONFIG_([A-Za-z0-9_]+)="(.*)"$/) {
+            # String options have double quotes, e.g. 'CONFIG_NLS_DEFAULT="utf8"' and allow escaping.
+            ($config{$1} = $2) =~ s/\\([\\"])/$1/g;
+        } elsif ($line =~ /^CONFIG_([A-Za-z0-9_]+)=(.*)$/) {
+            $config{$1} = $2;
+        } elsif ($line =~ /^# CONFIG_([A-Za-z0-9_]+) is not set$/) {
+            $config{$1} = "n";
+        }
+        print;
     }
 }
-close CONFIG;
 
 my $ret = 0;
 foreach my $name (sort (keys %answers)) {


### PR DESCRIPTION
`lib.kernel.freeform ""` currently produces `CONFIG_FOO="\"\""`. The intermediate config writes `""` as the answer, and `generate-config.pl` passes those quote characters to Kconfig instead of setting an empty value.

This PR represents an empty value as an option with no value:

```
 REQUIRED_EMPTY
 OPTIONAL_EMPTY?
```

`generate-config.pl` records these as empty strings. After both `make config` runs, it rewrites matching assignments in `.config` to `CONFIG_<name>=""`.

Resolves #516936.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
