### PR TITLE
subversionClient: fix Perl bindings with SWIG 4.4

### DIFF
--- a/pkgs/applications/version-management/subversion/default.nix
+++ b/pkgs/applications/version-management/subversion/default.nix
@@ -40,7 +40,7 @@ let
   common =
     {
       version,
-      sha256,
+      hash,
       extraPatches ? [ ],
     }:
     stdenv.mkDerivation (finalAttrs: {
@@ -49,7 +49,7 @@ let
 
       src = fetchurl {
         url = "mirror://apache/subversion/subversion-${finalAttrs.version}.tar.bz2";
-        inherit sha256;
+        inherit hash;
       };
 
       # Can't do separate $lib and $bin, as libs reference bins
@@ -98,10 +98,15 @@ let
       ]
       ++ extraPatches;
 
-      # remove vendored swig-3 files as these will shadow the swig provided
-      # ones and result in compile errors
+      # Remove vendored swig-3 files as these will shadow the swig provided
+      # ones and result in compile errors.
+      # Also remove the generated Perl wrappers from the release tarball
+      # so they are rebuilt with the same SWIG runtime as libsvn_swig_perl.
       postPatch = ''
         rm subversion/bindings/swig/proxy/{perlrun.swg,pyrun.swg,python.swg,rubydef.swg,rubyhead.swg,rubytracking.swg,runtime.swg,swigrun.swg}
+      ''
+      + lib.optionalString perlBindings ''
+        rm subversion/bindings/swig/perl/native/{core.c,svn_*.c}
       '';
 
       env = {
@@ -141,32 +146,26 @@ let
         makeFlagsArray=(APACHE_LIBEXECDIR=$out/modules)
       '';
 
-      postInstall = ''
-        if test -n "$pythonBindings"; then
-            make swig-py swig_pydir=$(toPythonPath $out)/libsvn swig_pydir_extra=$(toPythonPath $out)/svn
-            make install-swig-py swig_pydir=$(toPythonPath $out)/libsvn swig_pydir_extra=$(toPythonPath $out)/svn
-        fi
+      postInstall =
+        lib.optionalString pythonBindings ''
+          make swig-py swig_pydir=$(toPythonPath $out)/libsvn swig_pydir_extra=$(toPythonPath $out)/svn
+          make install-swig-py swig_pydir=$(toPythonPath $out)/libsvn swig_pydir_extra=$(toPythonPath $out)/svn
+        ''
+        + lib.optionalString perlBindings ''
+          make install-swig-pl
+        ''
+        + ''
+          mkdir -p $out/share/bash-completion/completions
+          cp tools/client-side/bash_completion $out/share/bash-completion/completions/subversion
 
-        if test -n "$perlBindings"; then
-            make swig-pl-lib
-            make install-swig-pl-lib
-            cd subversion/bindings/swig/perl/native
-            perl Makefile.PL PREFIX=$out
-            make install
-            cd -
-        fi
-
-        mkdir -p $out/share/bash-completion/completions
-        cp tools/client-side/bash_completion $out/share/bash-completion/completions/subversion
-
-        for f in $out/lib/*.la $out/lib/python*/site-packages/*/*.la; do
-          substituteInPlace $f \
-            --replace "${expat.dev}/lib" "${expat.out}/lib" \
-            --replace "${zlib.dev}/lib" "${zlib.out}/lib" \
-            --replace "${sqlite.dev}/lib" "${sqlite.out}/lib" \
-            --replace "${openssl.dev}/lib" "${lib.getLib openssl}/lib"
-        done
-      '';
+          for f in $out/lib/*.la $out/lib/python*/site-packages/*/*.la; do
+            substituteInPlace $f \
+              --replace "${expat.dev}/lib" "${expat.out}/lib" \
+              --replace "${zlib.dev}/lib" "${zlib.out}/lib" \
+              --replace "${sqlite.dev}/lib" "${sqlite.out}/lib" \
+              --replace "${openssl.dev}/lib" "${lib.getLib openssl}/lib"
+          done
+        '';
 
       inherit perlBindings pythonBindings;
 
@@ -195,6 +194,6 @@ in
 {
   subversion = common {
     version = "1.14.5";
-    sha256 = "sha256-54op53Zri3s1RJfQj3GlVkGrxTZ1zhh1WEeBquNWRKE=";
+    hash = "sha256-54op53Zri3s1RJfQj3GlVkGrxTZ1zhh1WEeBquNWRKE=";
   };
 }

--- a/pkgs/by-name/gi/git/package.nix
+++ b/pkgs/by-name/gi/git/package.nix
@@ -51,6 +51,7 @@
   deterministic-host-uname, # trick Makefile into targeting the host platform when cross-compiling
   doInstallCheck ? !stdenv.hostPlatform.isDarwin, # extremely slow on darwin
   tests,
+  testers,
   rustSupport ? lib.meta.availableOn stdenv.hostPlatform rustc,
   cargo,
   rustc,
@@ -591,6 +592,13 @@ stdenv.mkDerivation (finalAttrs: {
         doInstallCheck = true;
       });
       buildbot-integration = nixosTests.buildbot;
+    }
+    // lib.optionalAttrs svnSupport {
+      git-svn-version = testers.testVersion {
+        package = finalAttrs.finalPackage;
+        command = "git svn --version";
+        version = "git-svn version ${version}";
+      };
     }
     // tests.fetchgit;
     updateScript = ./update.sh;


### PR DESCRIPTION
ZHF: #516381

**Fix Subversion Perl bindings**.

This also fixes:
- `perlPackages.SVNSimple`
  https://hydra.nixos.org/build/327873107
- `git svn`, which previously crashed with signal 11

Also add a version test for `git svn`.

Before:
```sh
git svn --version
error: git-svn died of signal 11
```

After:
```sh
git svn --version
git-svn version 2.53.0 (svn 1.14.5)
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
