### PR TITLE
function-runner: 9.0.0 -> 9.1.2

### DIFF
--- a/pkgs/by-name/fu/function-runner/package.nix
+++ b/pkgs/by-name/fu/function-runner/package.nix
@@ -1,27 +1,51 @@
 {
   lib,
   fetchFromGitHub,
+  writableTmpDirAsHomeHook,
   rustPlatform,
+  pkg-config,
+  openssl,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "function-runner";
-  version = "9.0.0";
+  version = "9.1.2";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "Shopify";
     repo = "function-runner";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-xzajHtFs7cp7D1ZdG3jBFbjheTSgWR/Vz4fkew3iAkc=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KvReKvmF3i4zlfM8uj3KHamjfudcrhqrKGfK8O5tMpE=";
   };
 
-  cargoHash = "sha256-fRLBKHsb+y2uyqWejRBmJm+t5CAkL9ScQl6iVCksahU=";
+  cargoHash = "sha256-gnEps/o+C8UpukO1oRF4qlhNsoAmyUmxMKGAgSykNY0=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [ openssl ];
+
+  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
+
+  # Failed to download trampoline: error sending request for url
+  checkFlags = map (t: "--skip=${t}") [
+    "engine::tests::test_wasm_api_v1_function"
+    "tests::run_wasm_api_v1_function"
+    "tests::run_wasm_api_v2_function"
+  ];
 
   meta = {
     description = "CLI tool which allows you to run Wasm Functions intended for the Shopify Functions infrastructure";
-    mainProgram = "function-runner";
     homepage = "https://github.com/Shopify/function-runner";
+    changelog = "https://github.com/Shopify/function-runner/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ nintron ];
+    maintainers = with lib.maintainers; [
+      nintron
+      kybe236
+    ];
+    mainProgram = "function-runner";
   };
 })


### PR DESCRIPTION
Diff: https://github.com/Shopify/function-runner/compare/v9.0.0...v9.1.2

Changelogs:

- https://github.com/Shopify/function-runner/releases/tag/v9.1.0
- https://github.com/Shopify/function-runner/releases/tag/v9.1.1
- https://github.com/Shopify/function-runner/releases/tag/v9.1.2

fixes https://nixpkgs-update-logs.nix-community.org/function-runner/2026-05-06.log

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
