### PR TITLE
gummi: fix build with gcc15

### DIFF
--- a/pkgs/by-name/gu/gummi/package.nix
+++ b/pkgs/by-name/gu/gummi/package.nix
@@ -1,7 +1,8 @@
 {
   lib,
   stdenv,
-  pkgs,
+  fetchFromGitHub,
+  fetchDebianPatch,
   glib,
   gtk3,
   gtksourceview3,
@@ -18,12 +19,22 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.8.3";
   pname = "gummi";
 
-  src = pkgs.fetchFromGitHub {
+  src = fetchFromGitHub {
     owner = "alexandervdm";
     repo = "gummi";
     rev = finalAttrs.version;
     sha256 = "sha256-71n71KjLmICp4gznd27NlbyA3kayje3hYk/cwkOXEO0=";
   };
+
+  patches = [
+    (fetchDebianPatch {
+      pname = "gummi";
+      version = "0.8.3+really0.8.3";
+      debianRevision = "6";
+      patch = "0002-build-with-gcc-15.patch";
+      hash = "sha256-YNOVgZHJIVy7y60FOZRI8N8qxoOkUsResLo0PNZ0dkY=";
+    })
+  ];
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
- #475479 
- #516381 
- https://hydra.nixos.org/build/324225463

```
configfile.c: In function 'config_init':
configfile.c:120:9: error: too many arguments to function 'config_load_defaults'; expected 0, have 1
  120 |         config_load_defaults (key_file);
      |         ^~~~~~~~~~~~~~~~~~~~  ~~~~~~~~
In file included from configfile.c:30:
configfile.h:37:6: note: declared here
   37 | void config_load_defaults ();
      |      ^~~~~~~~~~~~~~~~~~~~
```

Fetched a [debian patch](https://sources.debian.org/patches/gummi/0.8.3+really0.8.3-6/0002-build-with-gcc-15.patch/) to fix the issue.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
