### PR TITLE
function-runner: 9.0.0 -> 9.1.2

### DIFF
--- a/pkgs/by-name/fu/function-runner/package.nix
+++ b/pkgs/by-name/fu/function-runner/package.nix
@@ -2,20 +2,37 @@
   lib,
   fetchFromGitHub,
   rustPlatform,
+  openssl,
+  pkg-config,
+  writableTmpDirAsHomeHook,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "function-runner";
-  version = "9.0.0";
+  version = "9.1.2";
 
   src = fetchFromGitHub {
     owner = "Shopify";
     repo = "function-runner";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-xzajHtFs7cp7D1ZdG3jBFbjheTSgWR/Vz4fkew3iAkc=";
+    sha256 = "sha256-KvReKvmF3i4zlfM8uj3KHamjfudcrhqrKGfK8O5tMpE=";
   };
 
-  cargoHash = "sha256-fRLBKHsb+y2uyqWejRBmJm+t5CAkL9ScQl6iVCksahU=";
+  cargoHash = "sha256-gnEps/o+C8UpukO1oRF4qlhNsoAmyUmxMKGAgSykNY0=";
+
+  buildInputs = [ openssl ];
+  nativeBuildInputs = [ pkg-config ];
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+  ];
+
+  # Skip tests that require network.
+  checkFlags = [
+    "--skip=engine::tests::test_wasm_api_v1_function"
+    "--skip=tests::run_wasm_api_v2_function"
+    "--skip=tests::run_wasm_api_v1_function"
+  ];
 
   meta = {
     description = "CLI tool which allows you to run Wasm Functions intended for the Shopify Functions infrastructure";


### PR DESCRIPTION
Update to 9.1.2

add openssl dependency and skip tests that require network.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
