### PR TITLE
blogtato: init at 0.1.24

### DIFF
--- a/pkgs/by-name/bl/blogtato/package.nix
+++ b/pkgs/by-name/bl/blogtato/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  makeWrapper,
+
+  gitMinimal,
+  libgit2,
+  openssl,
+  pkg-config,
+  zlib,
+
+  # according to README blogtato can be used almost entirely without jq
+  jq ? null,
+
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "blogtato";
+  version = "0.1.24";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "kantord";
+    repo = "blogtato";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-lzefjInuGariix6BOSjgXCD1dR5IJcZhE1VegTuURG8=";
+  };
+
+  cargoHash = "sha256-AZXqyF6LxBLWRo8mMPgdXZ9AK/2b8nv292O6xHQRUUc=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ]
+  ++ lib.optionals (jq != null) [ makeWrapper ];
+
+  buildInputs = [
+    libgit2
+    openssl
+    zlib
+  ];
+
+  env.OPENSSL_NO_VENDOR = 1;
+
+  nativeCheckInputs = [ gitMinimal ] ++ lib.optionals (jq != null) [ jq ];
+
+  checkFlags = lib.optionals (jq == null) [
+    # these tests rely on jq in PATH
+    "--skip=utils::jq::tests::"
+    "--skip=test_ingest_filter_readme_examples"
+  ];
+
+  # yes, this uses both libgit2 and the git cli
+  postInstall = ''
+    wrapProgram $out/bin/blog \
+      --prefix PATH : "${lib.makeBinPath ([ gitMinimal ] ++ lib.optionals (jq != null) [ jq ])}"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI RSS/Atom feed reader inspired by Taskwarrior";
+    homepage = "https://github.com/kantord/blogtato";
+    changelog = "https://github.com/kantord/blogtato/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = with lib.licenses; [
+      asl20
+      # or
+      mit
+    ];
+    maintainers = with lib.maintainers; [ dtomvan ];
+    mainProgram = "blog";
+  };
+})


### PR DESCRIPTION
https://github.com/kantord/blogtato

Yet another CLI RSS reader, RIIR, inspired by taskwarrior.

- Added the possibility to build jqless with an override, do we want `blogtatoMinimal`?
- Do we want `gitMinimal` or `git` for wrapping the `blog` commmand? I think `gitMinimal` is fine, but the point of that package is quickly defeated when users have `git` installed anyways...

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
