### PR TITLE
memtier-benchmark: 2.2.2 -> 2.4.1, adopt

### DIFF
--- a/pkgs/by-name/me/memtier-benchmark/package.nix
+++ b/pkgs/by-name/me/memtier-benchmark/package.nix
@@ -37,7 +37,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/redis/memtier_benchmark";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ thoughtpolice ];
+    maintainers = with lib.maintainers; [
+      thoughtpolice
+      hythera
+    ];
     mainProgram = "memtier_benchmark";
   };
 })

--- a/pkgs/by-name/me/memtier-benchmark/package.nix
+++ b/pkgs/by-name/me/memtier-benchmark/package.nix
@@ -5,41 +5,36 @@
   autoreconfHook,
   pkg-config,
   libevent,
-  pcre,
   zlib,
   openssl,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "memtier-benchmark";
-  version = "2.2.2";
+  version = "2.4.1";
 
   src = fetchFromGitHub {
-    owner = "redislabs";
+    owner = "redis";
     repo = "memtier_benchmark";
     tag = finalAttrs.version;
-    hash = "sha256-/t7OY3N9VBa9o2amOFb2/MUr5Y4ep4HGUil8OtwKkng=";
+    hash = "sha256-pvi5p/0HZIiZYi5+eqcAu4MMrF0Hh42ByPEHuA9jcug=";
   };
-
-  patchPhase = ''
-    substituteInPlace ./configure.ac \
-      --replace '1.2.8' '${finalAttrs.version}'
-  '';
 
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
   ];
+
   buildInputs = [
     libevent
-    pcre
     zlib
     openssl
   ];
 
   meta = {
+    changelog = "https://github.com/redis/memtier_benchmark/releases/tag/${finalAttrs.version}";
     description = "Redis and Memcached traffic generation and benchmarking tool";
-    homepage = "https://github.com/redislabs/memtier_benchmark";
+    homepage = "https://github.com/redis/memtier_benchmark";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ thoughtpolice ];

--- a/pkgs/by-name/me/memtier-benchmark/package.nix
+++ b/pkgs/by-name/me/memtier-benchmark/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Redis and Memcached traffic generation and benchmarking tool";
     homepage = "https://github.com/redis/memtier_benchmark";
     license = lib.licenses.gpl2Only;
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [
       thoughtpolice
       hythera


### PR DESCRIPTION
changelog: https://github.com/redis/memtier_benchmark/releases/tag/2.4.1
diff: https://github.com/redis/memtier_benchmark/compare/2.2.2...2.4.1

Seing no activity in #500813, I would like to help maintain it.

Supersedes #500813
Supersedes #499060
Supersedes #485124

Part of #356387

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
