### PR TITLE
goaway: 0.63.7 -> 0.63.15

### DIFF
--- a/pkgs/by-name/go/goaway/package.nix
+++ b/pkgs/by-name/go/goaway/package.nix
@@ -12,13 +12,13 @@
 }:
 
 let
-  version = "0.63.7";
+  version = "0.63.15";
 
   src = fetchFromGitHub {
     owner = "pommee";
     repo = "goaway";
     tag = "v${version}";
-    hash = "sha256-XNjp9fSMu5AdLnFNsh7Lrf1J06sPZPjvlNFkDa1QDJQ=";
+    hash = "sha256-jtUAMCGdFmt89kchHdy9AnSMKu1rZeTLPcFIzqipOyw=";
   };
 
   goaway-web = stdenvNoCC.mkDerivation (finalAttrs: {
@@ -29,7 +29,7 @@ let
       inherit (finalAttrs) pname version src;
       sourceRoot = "${finalAttrs.src.name}/client";
       fetcherVersion = 3;
-      hash = "sha256-1YZf32lDwX3e9EC0Uixyo+yDczfU4/ZSlG+jFZwf+38=";
+      hash = "sha256-GM86Os1OQaagD61BEIIsqhWJNVPFA9Z5RiYWyHlQlwY=";
     };
 
     pnpmRoot = "client";
@@ -66,7 +66,7 @@ buildGo126Module (finalAttrs: {
     goaway-web
     ;
 
-  vendorHash = "sha256-QgacBw+kpGdv8fAPQyndrHTxY1JrxFRf2qCS7etjNfw=";
+  vendorHash = "sha256-tSTvySLBo9cM9+Ul45TrGDruTllE/HWLdYmzqMDIYEQ=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
Update to 0.63.15

Update all deps hashes (r-ryantm fails automaticall updating the -web hash)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
