### PR TITLE
worktrunk: 0.37.0 -> 0.50.0

### DIFF
--- a/pkgs/by-name/wo/worktrunk/package.nix
+++ b/pkgs/by-name/wo/worktrunk/package.nix
@@ -11,16 +11,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "worktrunk";
-  version = "0.37.0";
+  version = "0.49.0";
 
   src = fetchFromGitHub {
     owner = "max-sixty";
     repo = "worktrunk";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-z+Wb0xgu15cSSYB3hPhp6qVwUUXmLJcP788LiQLowqs=";
+    hash = "sha256-booga2TXGXcSgFE4AoA9offhfaiT3dSLH3pSaKNCuJA=";
   };
 
-  cargoHash = "sha256-nBbLlM4Y5IOSeGrgiu7Bm9PcTSarXiqFbC2RnTrhWeE=";
+  cargoHash = "sha256-lccWTEdYr4RHbOZomZIN01h0g+ug5kL69FOurrJ/o8E=";
 
   cargoBuildFlags = [ "--package=worktrunk" ];
 
@@ -45,10 +45,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeCheckInputs = [ gitMinimal ];
 
   checkFlags = [
-    # Expects to run inside a git repository
-    "--skip=git::recover::tests::test_current_or_recover_returns_repo_when_cwd_exists"
-    # Insta snapshot mismatch across git versions
-    "--skip=git::recover::tests::test_hint_for_repo_suggests_switch"
     # Expects `which` on PATH
     "--skip=output::commit_generation::tests::test_command_exists_known_command"
     # Integration tests use insta snapshots with environment-specific paths

--- a/pkgs/by-name/wo/worktrunk/package.nix
+++ b/pkgs/by-name/wo/worktrunk/package.nix
@@ -11,16 +11,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "worktrunk";
-  version = "0.49.0";
+  version = "0.50.0";
 
   src = fetchFromGitHub {
     owner = "max-sixty";
     repo = "worktrunk";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-booga2TXGXcSgFE4AoA9offhfaiT3dSLH3pSaKNCuJA=";
+    hash = "sha256-ZCcrTXVVbB61r2tMTFwN3x5+C1i6T/wn28dviGr5rtM=";
   };
 
-  cargoHash = "sha256-lccWTEdYr4RHbOZomZIN01h0g+ug5kL69FOurrJ/o8E=";
+  cargoHash = "sha256-GTWoOaDjXS1Lu2JuWw1A/RYbPreivLYuhHhoWj4bFHM=";
 
   cargoBuildFlags = [ "--package=worktrunk" ];
 


### PR DESCRIPTION
Version bump from 0.37.0 to 0.50.0. Changelog: https://github.com/max-sixty/worktrunk/blob/v0.50.0/CHANGELOG.md

Key changes since 0.37.0:
- First-class `wt <alias>` top-level dispatch (0.39.0)
- Sandbox/non-git-CWD test fixes (0.49.0, upstream issues #2615 and #2624 which were filed while packaging this)
- Experimental Azure DevOps and Gitea support (0.50.0)
- Per-worktree hook config resolution (0.50.0)

Two sandbox-related skips have been removed - they were fixed upstream in response to our reports.


## Things done

- Built on platform(s):
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- Nixpkgs Release Notes
  - N/A (no breaking changes to the package)
- NixOS Release Notes
  - N/A
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md