### PR TITLE
display-managers: add niri to list of systemd-aware display managers

### DIFF
--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -48,7 +48,7 @@ let
       IFS=:
       for i in $XDG_CURRENT_DESKTOP; do
         case $i in
-          KDE|GNOME|Pantheon|Hyprland|X-NIXOS-SYSTEMD-AWARE) echo "1"; exit; ;;
+          KDE|GNOME|Pantheon|Hyprland|niri|X-NIXOS-SYSTEMD-AWARE) echo "1"; exit; ;;
           *) ;;
         esac
       done


### PR DESCRIPTION
Similar to https://github.com/NixOS/nixpkgs/pull/493701, this adds Niri to the list of display managers which properly start `graphical-session.target` themselves. Without this `nixos-fake-graphical-session.target` would occasionally cause other services to start prematurely, before Niri could export `WAYLAND_DISPLAY`.

An example here which caused `ibus-ui-gtk3` to crash:

```
2026-04-17T18:46:37.308980+01:00 pej systemd[2337]: Reached target Current graphical user session.
2026-04-17T18:46:37.309173+01:00 pej systemd[2337]: Reached target Fake graphical-session target for non-systemd-aware sessions.
2026-04-17T18:46:37.396238+01:00 pej systemd[2337]: Starting IBus...
2026-04-17T18:46:37.397197+01:00 pej systemd[2337]: Starting A scrollable-tiling Wayland compositor...
2026-04-17T18:46:37.430559+01:00 pej systemd[2337]: Started IBus.
2026-04-17T18:46:37.715281+01:00 pej dbus-daemon[2410]: [session uid=1000 pid=2410] Activating service name='org.freedesktop.portal.IBus' requested by ':1.4' (uid=1000 pid=2456 comm="/nix/store/s4inca3hhk8q660mcwc4f3377ca2cqh4-ibus-w")
2026-04-17T18:46:37.724015+01:00 pej dbus-daemon[2410]: [session uid=1000 pid=2410] Successfully activated service 'org.freedesktop.portal.IBus'
2026-04-17T18:46:37.736358+01:00 pej kernel: traps: .ibus-ui-gtk3-w[2500] trap int3 ip:7fb6df82616f sp:7ffe3168a370 error:0 in libglib-2.0.so.0.8600.3[6f16f,7fb6df7da000+aa000]
2026-04-17T18:46:37.742722+01:00 pej systemd-coredump[2527]: Process 2500 (.ibus-ui-gtk3-w) of user 1000 terminated abnormally with signal 5/TRAP, processing...
2026-04-17T18:46:38.004781+01:00 pej niri[2416]: 2026-04-17T17:46:38.004765Z  INFO niri: listening on Wayland socket: wayland-1
2026-04-17T18:46:38.018204+01:00 pej niri[2416]: 2026-04-17T17:46:38.018175Z  INFO niri: listening on X11 socket: :1
2026-04-17T18:46:38.077335+01:00 pej systemd[2337]: Started A scrollable-tiling Wayland compositor.
2026-04-17T18:46:38.077906+01:00 pej systemd[2337]: Reached target Startup of XDG autostart applications.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
