### PR TITLE
proton-cli: init at 1.9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23596,6 +23596,12 @@
     githubId = 7335;
     name = "Roman Gonzalez";
   };
+  roman-16 = {
+    email = "roman@lerchster.dev";
+    github = "roman-16";
+    githubId = 15262665;
+    name = "Roman";
+  };
   romildo = {
     email = "malaquias@gmail.com";
     github = "romildo";

--- a/pkgs/by-name/pr/proton-cli/package.nix
+++ b/pkgs/by-name/pr/proton-cli/package.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  pkg-config,
+  stdenv,
+  webkitgtk_4_1,
+  gtk3,
+  nix-update-script,
+  testers,
+  proton-cli,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "proton-cli";
+  version = "1.4.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "roman-16";
+    repo = "proton-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JZ6Lr7mcL8sHeiptdB1CPv5zPaLsMKfUXd/KCf1tTDM=";
+  };
+
+  vendorHash = "sha256-1p63FiV9lFquADaV0/mhxdWhefBRY1IT91t7OdEH9BM=";
+
+  subPackages = [ "." ];
+
+  tags = [ "embed_hv" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=github.com/roman-16/proton-cli/cmd.version=${finalAttrs.version}"
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
+    pkg-config
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    webkitgtk_4_1
+    gtk3
+  ];
+
+  preBuild = ''
+    bash scripts/build-hv-helpers.sh
+  '';
+
+  overrideModAttrs = _: {
+    preBuild = null;
+  };
+
+  postInstall = ''
+    installShellCompletion --cmd proton-cli \
+      --bash <($out/bin/proton-cli completion bash) \
+      --fish <($out/bin/proton-cli completion fish) \
+      --zsh  <($out/bin/proton-cli completion zsh)
+  '';
+
+  passthru = {
+    tests.version = testers.testVersion {
+      package = proton-cli;
+      command = "proton-cli --version";
+      version = finalAttrs.version;
+    };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Unofficial command-line client for the Proton suite (Mail, Drive, Calendar, Contacts, Pass)";
+    homepage = "https://github.com/roman-16/proton-cli";
+    changelog = "https://github.com/roman-16/proton-cli/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "proton-cli";
+    maintainers = with lib.maintainers; [ roman-16 ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})

--- a/pkgs/by-name/pr/proton-cli/package.nix
+++ b/pkgs/by-name/pr/proton-cli/package.nix
@@ -8,8 +8,7 @@
   webkitgtk_4_1,
   gtk3,
   nix-update-script,
-  testers,
-  proton-cli,
+  versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
@@ -62,14 +61,10 @@ buildGoModule (finalAttrs: {
       --zsh  <($out/bin/proton-cli completion zsh)
   '';
 
-  passthru = {
-    tests.version = testers.testVersion {
-      package = proton-cli;
-      command = "proton-cli --version";
-      version = finalAttrs.version;
-    };
-    updateScript = nix-update-script { };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Unofficial command-line client for the Proton suite (Mail, Drive, Calendar, Contacts, Pass)";

--- a/pkgs/by-name/pr/proton-cli/package.nix
+++ b/pkgs/by-name/pr/proton-cli/package.nix
@@ -13,7 +13,7 @@
 
 buildGoModule (finalAttrs: {
   pname = "proton-cli";
-  version = "1.5.0";
+  version = "1.7.0";
 
   __structuredAttrs = true;
 
@@ -21,10 +21,10 @@ buildGoModule (finalAttrs: {
     owner = "roman-16";
     repo = "proton-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-RJBC5oxTv27SrEfBd5DqlR3FcD56BkIf+046Jwfctzo=";
+    hash = "sha256-cUAHeNzJu9hZRSrLdJXk3LbA8Wo/CR0kfqQSKxMBdXA=";
   };
 
-  vendorHash = "sha256-SlvrTjL8CMWSvoIU4rp4hP4dtDVGH7HAs3xyycfrKQA=";
+  vendorHash = "sha256-75zPvpyGHgmQRhWdkQWdWafkMgpWvLKwAoaRXDwmO3k=";
 
   subPackages = [ "." ];
 

--- a/pkgs/by-name/pr/proton-cli/package.nix
+++ b/pkgs/by-name/pr/proton-cli/package.nix
@@ -14,7 +14,7 @@
 
 buildGoModule (finalAttrs: {
   pname = "proton-cli";
-  version = "1.4.0";
+  version = "1.5.0";
 
   __structuredAttrs = true;
 
@@ -22,10 +22,10 @@ buildGoModule (finalAttrs: {
     owner = "roman-16";
     repo = "proton-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-JZ6Lr7mcL8sHeiptdB1CPv5zPaLsMKfUXd/KCf1tTDM=";
+    hash = "sha256-RJBC5oxTv27SrEfBd5DqlR3FcD56BkIf+046Jwfctzo=";
   };
 
-  vendorHash = "sha256-1p63FiV9lFquADaV0/mhxdWhefBRY1IT91t7OdEH9BM=";
+  vendorHash = "sha256-SlvrTjL8CMWSvoIU4rp4hP4dtDVGH7HAs3xyycfrKQA=";
 
   subPackages = [ "." ];
 
@@ -34,7 +34,7 @@ buildGoModule (finalAttrs: {
   ldflags = [
     "-s"
     "-w"
-    "-X=github.com/roman-16/proton-cli/cmd.version=${finalAttrs.version}"
+    "-X=github.com/roman-16/proton-cli/internal/cli.version=${finalAttrs.version}"
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/pr/proton-cli/package.nix
+++ b/pkgs/by-name/pr/proton-cli/package.nix
@@ -13,7 +13,7 @@
 
 buildGoModule (finalAttrs: {
   pname = "proton-cli";
-  version = "1.7.0";
+  version = "1.8.0";
 
   __structuredAttrs = true;
 
@@ -21,10 +21,10 @@ buildGoModule (finalAttrs: {
     owner = "roman-16";
     repo = "proton-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-cUAHeNzJu9hZRSrLdJXk3LbA8Wo/CR0kfqQSKxMBdXA=";
+    hash = "sha256-pEQfLb17RfRe6GwE7NnMpIamabYtM/lkknDWWpHgVsU=";
   };
 
-  vendorHash = "sha256-75zPvpyGHgmQRhWdkQWdWafkMgpWvLKwAoaRXDwmO3k=";
+  vendorHash = "sha256-H4q7b+NfiktjWRyStV9/lXF9fuAkApepq6l6CNV/5co=";
 
   subPackages = [ "." ];
 

--- a/pkgs/by-name/pr/proton-cli/package.nix
+++ b/pkgs/by-name/pr/proton-cli/package.nix
@@ -13,7 +13,7 @@
 
 buildGoModule (finalAttrs: {
   pname = "proton-cli";
-  version = "1.8.0";
+  version = "1.9.0";
 
   __structuredAttrs = true;
 
@@ -21,7 +21,7 @@ buildGoModule (finalAttrs: {
     owner = "roman-16";
     repo = "proton-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-pEQfLb17RfRe6GwE7NnMpIamabYtM/lkknDWWpHgVsU=";
+    hash = "sha256-0IVWoDUHXvJusFceerlz5DgifFme9PN/NaAdwwwkCK4=";
   };
 
   vendorHash = "sha256-H4q7b+NfiktjWRyStV9/lXF9fuAkApepq6l6CNV/5co=";


### PR DESCRIPTION
Initial packaging of [proton-cli](https://github.com/roman-16/proton-cli),
an unofficial Go CLI that provides a unified command-line interface to the
Proton suite (Mail, Drive, Calendar, Contacts, Pass).

It complements the existing official Proton packages in nixpkgs
(`protonmail-bridge`, `proton-pass-cli`, `proton-vpn-cli`,
`proton-authenticator`, `protonmail-export`), which each target a single
service. `proton-cli` is a single binary covering all five.

The CLI ships an embedded webview helper to solve Proton's CAPTCHA-based
human-verification challenges from the terminal — that's why
`webkitgtk_4_1` and `gtk3` appear as Linux build inputs.

The package is built from source with `buildGoModule`, has
`__structuredAttrs = true;` per the current convention, and installs shell
completion for bash, zsh, and fish.

Upstream is actively maintained by [@roman-16](https://github.com/roman-16),
who is also adding themselves as the package maintainer in this PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## Local CI output

`./ci/nixpkgs-vet.sh master`:

```
Validated successfully
```

`nixpkgs-review rev HEAD --branch master --no-shell` on `x86_64-linux`:

```
1 package built:
proton-cli
```

