### PR TITLE
[Backport release-25.11] zoxide: 0.9.8 -> 0.9.9

### DIFF
--- a/pkgs/by-name/zo/zoxide/package.nix
+++ b/pkgs/by-name/zo/zoxide/package.nix
@@ -11,13 +11,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "zoxide";
-  version = "0.9.8";
+  version = "0.9.9";
 
   src = fetchFromGitHub {
     owner = "ajeetdsouza";
     repo = "zoxide";
     tag = "v${version}";
-    hash = "sha256-8hXoC3vyR08hN8MMojnAO7yIskg4FsEm28GtFfh5liI=";
+    hash = "sha256-2scJ5/+A3ZSpIdce5GLYqxjc0so9sVsYiXNULmjMzLY=";
   };
 
   nativeBuildInputs = [ installShellFiles ];
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage rec {
       --replace '"fzf"' '"${fzf}/bin/fzf"'
   '';
 
-  cargoHash = "sha256-Nonid/5Jh0WIQV0G3fpmkW0bql6bvlcNJBMZ+6MTTPQ=";
+  cargoHash = "sha256-4BXZ5NnwY2izzJFkPkECKvpuyFWfZ2CguybDDk0GDU0=";
 
   postInstall = ''
     installManPage man/man*/*


### PR DESCRIPTION
Backport of the following master PR that landed after 25.11 cut:

- zoxide: 0.9.8 -> 0.9.9 (#485581)

No breaking changes; patch-level release with bug fixes and minor improvements. See [upstream changelog](https://github.com/ajeetdsouza/zoxide/blob/v0.9.9/CHANGELOG.md) for details.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is sandboxing enabled in `nix.conf`?
- [x] Tested, as applicable:
  - [x] The package builds successfully (`nix-build -A zoxide`)
  - [x] Verified the binary works: `./result/bin/zoxide --version` returns `0.9.9`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Ran `nixpkgs-review wip --branch release-25.11` — 8 packages built, 0 failed
- [ ] 25.11 Release Notes (or backporting [25.05 release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).