### PR TITLE
python3Packages.pyfaidx: 0.9.0.3 -> 0.9.0.4; python3Packages.cnvkit: 0.9.12 -> 0.9.13

### DIFF
--- a/pkgs/development/python-modules/cnvkit/default.nix
+++ b/pkgs/development/python-modules/cnvkit/default.nix
@@ -12,6 +12,7 @@
   pandas,
   pomegranate,
   pyfaidx,
+  pyparsing,
   pysam,
   reportlab,
   rPackages,
@@ -24,27 +25,29 @@
 }:
 buildPythonPackage rec {
   pname = "cnvkit";
-  version = "0.9.12";
+  version = "0.9.13";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "etal";
     repo = "cnvkit";
     tag = "v${version}";
-    hash = "sha256-ZdE3EUNZpEXRHTRKwVhuj3BWQWczpdFbg4pVr0+AHiQ=";
+    hash = "sha256-6W0rJUeHO7m3zacgkL3WzyFVmdet1zJAGyafsQv1AXE=";
   };
 
   patches = [
+    # test: update a call to --smooth-bootstrap[=int, now]
     (fetchpatch {
-      name = "fix-numpy2-compat";
-      url = "https://github.com/etal/cnvkit/commit/5cb6aeaf40ea5572063cf9914c456c307b7ddf7a.patch";
-      hash = "sha256-VwGAMGKuX2Kx9xL9GX/PB94/7LkT0dSLbWIfVO8F9NI=";
+      url = "https://github.com/etal/cnvkit/commit/c5c7c06b7fb873ed7ae44593c11a91d45f433e54.patch";
+      hash = "sha256-H9Nr4JL7bc9CQ/BmXkOAwjbr/ykvbnjyyWrVSrVH9kg=";
     })
   ];
 
   pythonRelaxDeps = [
     # https://github.com/etal/cnvkit/issues/815
     "pomegranate"
+    # https://github.com/etal/cnvkit/pull/1048
+    "pyparsing"
   ];
 
   nativeBuildInputs = [
@@ -59,13 +62,8 @@ buildPythonPackage rec {
     let
       rscript = lib.getExe' R "Rscript";
     in
-    # Numpy 2 compatibility
-    ''
-      substituteInPlace skgenome/intersect.py \
-        --replace-fail "np.string_" "np.bytes_"
-    ''
     # Patch shebang lines in R scripts
-    + ''
+    ''
       substituteInPlace cnvlib/segmentation/flasso.py \
         --replace-fail "#!/usr/bin/env Rscript" "#!${rscript}"
 
@@ -73,7 +71,7 @@ buildPythonPackage rec {
         --replace-fail "#!/usr/bin/env Rscript" "#!${rscript}"
 
       substituteInPlace cnvlib/segmentation/__init__.py \
-        --replace-fail 'rscript_path="Rscript"' 'rscript_path="${rscript}"'
+        --replace-fail 'rscript_path: str = "Rscript"' 'rscript_path="${rscript}"'
 
       substituteInPlace cnvlib/commands.py \
         --replace-fail 'default="Rscript"' 'default="${rscript}"'
@@ -87,6 +85,7 @@ buildPythonPackage rec {
     pandas
     pomegranate
     pyfaidx
+    pyparsing
     pysam
     reportlab
     rPackages.DNAcopy

--- a/pkgs/development/python-modules/cnvkit/default.nix
+++ b/pkgs/development/python-modules/cnvkit/default.nix
@@ -23,7 +23,7 @@
   pytestCheckHook,
 
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "cnvkit";
   version = "0.9.13";
   pyproject = true;
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "etal";
     repo = "cnvkit";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-6W0rJUeHO7m3zacgkL3WzyFVmdet1zJAGyafsQv1AXE=";
   };
 
@@ -133,8 +133,8 @@ buildPythonPackage rec {
   meta = {
     homepage = "https://cnvkit.readthedocs.io";
     description = "Python library and command-line software toolkit to infer and visualize copy number from high-throughput DNA sequencing data";
-    changelog = "https://github.com/etal/cnvkit/releases/tag/v${version}";
+    changelog = "https://github.com/etal/cnvkit/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.jbedo ];
   };
-}
+})

--- a/pkgs/development/python-modules/pyfaidx/default.nix
+++ b/pkgs/development/python-modules/pyfaidx/default.nix
@@ -13,7 +13,7 @@
   setuptools-scm,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pyfaidx";
   version = "0.9.0.4";
   pyproject = true;
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "mdshw5";
     repo = "pyfaidx";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-hefRqpI9xzlfdUbr8mpQ6I1+EGAmS50f28avbtRMlSk=";
   };
 
@@ -51,9 +51,9 @@ buildPythonPackage rec {
   meta = {
     description = "Python classes for indexing, retrieval, and in-place modification of FASTA files using a samtools compatible index";
     homepage = "https://github.com/mdshw5/pyfaidx";
-    changelog = "https://github.com/mdshw5/pyfaidx/releases/tag/${src.tag}";
+    changelog = "https://github.com/mdshw5/pyfaidx/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ jbedo ];
     mainProgram = "faidx";
   };
-}
+})

--- a/pkgs/development/python-modules/pyfaidx/default.nix
+++ b/pkgs/development/python-modules/pyfaidx/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "pyfaidx";
-  version = "0.9.0.3";
+  version = "0.9.0.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mdshw5";
     repo = "pyfaidx";
     tag = "v${version}";
-    hash = "sha256-R8k1h2FAlA/6eTJqH/Z2jHAyis2w5VDd1LcyE1hgbFc=";
+    hash = "sha256-hefRqpI9xzlfdUbr8mpQ6I1+EGAmS50f28avbtRMlSk=";
   };
 
   build-system = [
@@ -45,9 +45,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pyfaidx" ];
 
-  preCheck = ''
-    bgzip --keep tests/data/genes.fasta
-  '';
+  # Require a network access to download test files
+  doCheck = false;
 
   meta = {
     description = "Python classes for indexing, retrieval, and in-place modification of FASTA files using a samtools compatible index";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
ZHF: #516381

**python3Packages.pyfaidx**
https://github.com/mdshw5/pyfaidx/releases/tag/v0.9.0.4

The files that were tested (`Anomala_cuprea_entomopoxvirus.faa.gz`, `genes.fasta`, `genes.fasta.lower` and `issue_141.fasta`) are not in the repo anymore and must be downloaded via a script (require network access).

We can either:
- Disable the tests
- Add them to Nixpkgs, but I'm not a fan of adding 183Ki just for tests.
- Add the main one (`genes.fasta`, 47Ki) and skip the tests for the others (4 tests)

I went for the first one, but I'm open to other opinions.

**python3Packages.cnvkit**
Removed the old (now merged) patch
A new fetchpatch was required for another more recent patch fixing a testing issue
Opened https://github.com/etal/cnvkit/pull/1048 upstream regarding `pyparsing` dependency relaxation (our version is `>3.3.0`)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
