### PR TITLE
gputils: fix build with gcc15

### DIFF
--- a/pkgs/by-name/gp/gputils/package.nix
+++ b/pkgs/by-name/gp/gputils/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchDebianPatch,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -12,6 +13,16 @@ stdenv.mkDerivation (finalAttrs: {
     url = "mirror://sourceforge/gputils/gputils-${finalAttrs.version}.tar.bz2";
     sha256 = "sha256-j7iCCzHXwffHdhQcyzxPBvQK+RXaY3QSjXUtHu463fI=";
   };
+
+  patches = [
+    (fetchDebianPatch {
+      pname = "gputils";
+      version = "1.5.2";
+      debianRevision = "2";
+      patch = "01-use-stdbool.diff";
+      hash = "sha256-YuQqWWKC5cntaok1J7hZUv6NX/Xv1mI6+K3if3Owkzc=";
+    })
+  ];
 
   meta = {
     homepage = "https://gputils.sourceforge.io";


### PR DESCRIPTION
- #475479 
- #516381 
- https://hydra.nixos.org/build/324224683

```
In file included from libgputils.h:28,
                 from gparchive.c:23:
gptypes.h:30:3: error: cannot use keyword 'false' as enumeration constant
   30 |   false = (0 == 1),
      |   ^~~~~
gptypes.h:30:3: note: 'false' is a keyword with '-std=c23' onwards
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
