### PR TITLE
whatstyle: migrate to by-name, modernize derivation

### DIFF
--- a/pkgs/by-name/wh/whatstyle/package.nix
+++ b/pkgs/by-name/wh/whatstyle/package.nix
@@ -2,8 +2,12 @@
   lib,
   python3,
   fetchFromGitHub,
-  clang-unwrapped,
+  llvmPackages,
 }:
+
+let
+  inherit (llvmPackages) clang-unwrapped;
+in
 
 python3.pkgs.buildPythonApplication rec {
   pname = "whatstyle";

--- a/pkgs/by-name/wh/whatstyle/package.nix
+++ b/pkgs/by-name/wh/whatstyle/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchFromGitHub,
   llvmPackages,
 }:
@@ -9,21 +9,21 @@ let
   inherit (llvmPackages) clang-unwrapped;
 in
 
-python3.pkgs.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "whatstyle";
   version = "0.2.0";
   format = "setuptools";
   src = fetchFromGitHub {
     owner = "mikr";
     repo = "whatstyle";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-4LCZAEUQFPl4CBPeuqsodiAlwd8uBg+SudF5d+Vz4Gc=";
   };
 
   # Fix references to previous version, to avoid confusion:
   postPatch = ''
-    substituteInPlace setup.py --replace-fail 0.1.9 ${version}
-    substituteInPlace whatstyle.py --replace-fail 0.1.9 ${version}
+    substituteInPlace setup.py --replace-fail 0.1.9 ${finalAttrs.version}
+    substituteInPlace whatstyle.py --replace-fail 0.1.9 ${finalAttrs.version}
   '';
 
   nativeCheckInputs = [
@@ -40,4 +40,4 @@ python3.pkgs.buildPythonApplication rec {
     maintainers = [ ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5891,10 +5891,6 @@ with pkgs;
       '';
     };
 
-  whatstyle = callPackage ../development/tools/misc/whatstyle {
-    inherit (llvmPackages) clang-unwrapped;
-  };
-
   whisper-cpp-vulkan = whisper-cpp.override {
     vulkanSupport = true;
   };


### PR DESCRIPTION
This pull request refactors the packaging of the `whatstyle` Python tool to follow Nixpkgs best practices by moving its package definition to the `by-name` directory and updating its dependencies. The changes simplify dependency management and improve maintainability.

**Refactoring and packaging improvements:**

* Moved the `whatstyle` package definition from `pkgs/development/tools/misc/whatstyle/default.nix` to `pkgs/by-name/wh/whatstyle/package.nix` to follow the by-name directory structure.
* Updated the package to use `python3Packages` and `llvmPackages` for dependency management, replacing direct usage of `python3` and `clang-unwrapped`.
* Refactored the build function to use the `finalAttrs` pattern for better attribute referencing (e.g., `finalAttrs.version`).
* Removed the old reference to `whatstyle` from `pkgs/top-level/all-packages.nix` as it is now handled by the by-name system.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
