### PR TITLE
ament-cmake: init at 2.9.0, python3Packages.ament-index-python: init at 1.14.0, ament-lint: init at 0.21.0 

### DIFF
--- a/pkgs/by-name/am/ament-cmake-auto/package.nix
+++ b/pkgs/by-name/am/ament-cmake-auto/package.nix
@@ -1,0 +1,59 @@
+{
+  stdenv,
+  ament-cmake-core,
+
+  ament-cmake,
+  ament-cmake-export-definitions,
+  ament-cmake-export-include-directories,
+  ament-cmake-export-libraries,
+  ament-cmake-export-link-flags,
+  ament-cmake-export-targets,
+  ament-cmake-gen-version-h,
+  ament-cmake-gmock,
+  ament-cmake-gtest,
+  ament-cmake-include-directories,
+  ament-cmake-libraries,
+  ament-cmake-python,
+  ament-cmake-target-dependencies,
+  ament-cmake-test,
+  ament-cmake-version,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-auto";
+  inherit (ament-cmake-core) version src nativeBuildInputs;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_auto";
+
+  propagatedBuildInputs = [
+    ament-cmake
+    ament-cmake-core
+    ament-cmake-export-definitions
+    ament-cmake-export-include-directories
+    ament-cmake-export-libraries
+    ament-cmake-export-link-flags
+    ament-cmake-export-targets
+    ament-cmake-gen-version-h
+    ament-cmake-gmock
+    ament-cmake-gtest
+    ament-cmake-include-directories
+    ament-cmake-libraries
+    ament-cmake-python
+    ament-cmake-target-dependencies
+    ament-cmake-test
+    ament-cmake-version
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-cmake-core.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Auto-magic functions for ease to use of the ament buildsystem in CMake";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-clang-format/package.nix
+++ b/pkgs/by-name/am/ament-cmake-clang-format/package.nix
@@ -1,0 +1,35 @@
+{
+  stdenv,
+
+  python3Packages,
+
+  ament-cmake-core,
+  ament-cmake-test,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-clang-format";
+  inherit (python3Packages.ament-lint) version src;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_clang_format/";
+
+  inherit (ament-cmake-core) nativeBuildInputs;
+
+  buildInputs = [
+    ament-cmake-core
+    ament-cmake-test
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (python3Packages.ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "CMake API for ament_clang_format to lint C / C++ code using clang format";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-clang-tidy/package.nix
+++ b/pkgs/by-name/am/ament-cmake-clang-tidy/package.nix
@@ -1,0 +1,35 @@
+{
+  stdenv,
+
+  python3Packages,
+
+  ament-cmake-core,
+  ament-cmake-test,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-clang-tidy";
+  inherit (python3Packages.ament-lint) version src;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_clang_tidy/";
+
+  inherit (ament-cmake-core) nativeBuildInputs;
+
+  buildInputs = [
+    ament-cmake-core
+    ament-cmake-test
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (python3Packages.ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "CMake API for ament_clang_tidy to lint C / C++ code using clang tidy";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-copyright/package.nix
+++ b/pkgs/by-name/am/ament-cmake-copyright/package.nix
@@ -1,0 +1,35 @@
+{
+  stdenv,
+
+  python3Packages,
+
+  ament-cmake-core,
+  ament-cmake-test,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-copyright";
+  inherit (python3Packages.ament-lint) version src;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_copyright/";
+
+  inherit (ament-cmake-core) nativeBuildInputs;
+
+  buildInputs = [
+    ament-cmake-core
+    ament-cmake-test
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (python3Packages.ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "CMake API for ament_copyright to check every source file contains copyright reference";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-core/package.nix
+++ b/pkgs/by-name/am/ament-cmake-core/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  python3,
+}:
+
+let
+  python = python3.withPackages (ps: [
+    ps.ament-package
+    ps.catkin-pkg
+    ps.setuptools
+  ]);
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-core";
+  version = "2.9.0";
+
+  src = fetchFromGitHub {
+    owner = "ament";
+    repo = "ament_cmake";
+    tag = finalAttrs.version;
+    hash = "sha256-voT1D5oYs+fPO1subbqS59M5j1tpcsUkEzXvTZ5Ej4U=";
+  };
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_core";
+
+  nativeBuildInputs = [
+    cmake
+    python
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Core of the ament buildsystem in CMake";
+    homepage = "https://github.com/ament/ament_cmake";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nim65s ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-cppcheck/package.nix
+++ b/pkgs/by-name/am/ament-cmake-cppcheck/package.nix
@@ -1,0 +1,35 @@
+{
+  stdenv,
+
+  python3Packages,
+
+  ament-cmake-core,
+  ament-cmake-test,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-cppcheck";
+  inherit (python3Packages.ament-lint) version src;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_cppcheck/";
+
+  inherit (ament-cmake-core) nativeBuildInputs;
+
+  buildInputs = [
+    ament-cmake-core
+    ament-cmake-test
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (python3Packages.ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "CMake API for ament_cppcheck to perform static code analysis on C/C++ code using Cppcheck";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-cpplint/package.nix
+++ b/pkgs/by-name/am/ament-cmake-cpplint/package.nix
@@ -1,0 +1,35 @@
+{
+  stdenv,
+
+  python3Packages,
+
+  ament-cmake-core,
+  ament-cmake-test,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-cpplint";
+  inherit (python3Packages.ament-lint) version src;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_cpplint/";
+
+  inherit (ament-cmake-core) nativeBuildInputs;
+
+  buildInputs = [
+    ament-cmake-core
+    ament-cmake-test
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (python3Packages.ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "CMake API for ament_cpplint to lint C / C++ code using cpplint";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-export-definitions/package.nix
+++ b/pkgs/by-name/am/ament-cmake-export-definitions/package.nix
@@ -1,0 +1,28 @@
+{
+  stdenv,
+  ament-cmake-core,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-export-definitions";
+  inherit (ament-cmake-core) version src nativeBuildInputs;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_export_definitions";
+
+  propagatedBuildInputs = [
+    ament-cmake-core
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-cmake-core.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Ability to export definitions to downstream packages in the ament buildsystem";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-export-dependencies/package.nix
+++ b/pkgs/by-name/am/ament-cmake-export-dependencies/package.nix
@@ -1,0 +1,28 @@
+{
+  stdenv,
+  ament-cmake-core,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-export-dependencies";
+  inherit (ament-cmake-core) version src nativeBuildInputs;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_export_dependencies";
+
+  propagatedBuildInputs = [
+    ament-cmake-core
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-cmake-core.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Ability to export dependencies to downstream packages in the ament buildsystem in CMake";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-export-include-directories/package.nix
+++ b/pkgs/by-name/am/ament-cmake-export-include-directories/package.nix
@@ -1,0 +1,28 @@
+{
+  stdenv,
+  ament-cmake-core,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-export-include-directories";
+  inherit (ament-cmake-core) version src nativeBuildInputs;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_export_include_directories";
+
+  propagatedBuildInputs = [
+    ament-cmake-core
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-cmake-core.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Ability to export include directories to downstream packages in the ament buildsystem in CMake";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-export-libraries/package.nix
+++ b/pkgs/by-name/am/ament-cmake-export-libraries/package.nix
@@ -1,0 +1,28 @@
+{
+  stdenv,
+  ament-cmake-core,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-export-libraries";
+  inherit (ament-cmake-core) version src nativeBuildInputs;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_export_libraries";
+
+  propagatedBuildInputs = [
+    ament-cmake-core
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-cmake-core.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Ability to export libraries to downstream packages in the ament buildsystem in CMake";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-export-link-flags/package.nix
+++ b/pkgs/by-name/am/ament-cmake-export-link-flags/package.nix
@@ -1,0 +1,28 @@
+{
+  stdenv,
+  ament-cmake-core,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-export-link-flags";
+  inherit (ament-cmake-core) version src nativeBuildInputs;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_export_link_flags";
+
+  propagatedBuildInputs = [
+    ament-cmake-core
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-cmake-core.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Ability to export link flags to downstream packages in the ament buildsystem in CMake";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-export-targets/package.nix
+++ b/pkgs/by-name/am/ament-cmake-export-targets/package.nix
@@ -1,0 +1,28 @@
+{
+  stdenv,
+  ament-cmake-core,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-export-targets";
+  inherit (ament-cmake-core) version src nativeBuildInputs;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_export_targets";
+
+  propagatedBuildInputs = [
+    ament-cmake-core
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-cmake-core.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Ability to export targets to downstream packages in the ament buildsystem in CMake";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-flake8/package.nix
+++ b/pkgs/by-name/am/ament-cmake-flake8/package.nix
@@ -1,0 +1,35 @@
+{
+  stdenv,
+
+  python3Packages,
+
+  ament-cmake-core,
+  ament-cmake-test,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-flake8";
+  inherit (python3Packages.ament-lint) version src;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_flake8/";
+
+  inherit (ament-cmake-core) nativeBuildInputs;
+
+  buildInputs = [
+    ament-cmake-core
+    ament-cmake-test
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (python3Packages.ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "CMake API for ament_flake8 to check code syntax and style conventions with flake8";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-gen-version-h/package.nix
+++ b/pkgs/by-name/am/ament-cmake-gen-version-h/package.nix
@@ -1,0 +1,38 @@
+{
+  stdenv,
+  ament-cmake-core,
+
+  ament-cmake-gtest,
+  ament-cmake-test,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-gen-version-h";
+  inherit (ament-cmake-core) version src nativeBuildInputs;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_gen_version_h";
+
+  propagatedBuildInputs = [
+    ament-cmake-core
+  ];
+
+  doCheck = true;
+
+  checkInputs = [
+    ament-cmake-gtest
+    ament-cmake-test
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-cmake-core.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Generate a C header containing the version number of the package";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-gmock/package.nix
+++ b/pkgs/by-name/am/ament-cmake-gmock/package.nix
@@ -1,0 +1,28 @@
+{
+  stdenv,
+  ament-cmake-core,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-gmock";
+  inherit (ament-cmake-core) version src nativeBuildInputs;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_gmock";
+
+  propagatedBuildInputs = [
+    ament-cmake-core
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-cmake-core.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Ability to add Google mock-based tests in the ament buildsystem in CMake";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-google-benchmark/package.nix
+++ b/pkgs/by-name/am/ament-cmake-google-benchmark/package.nix
@@ -1,0 +1,38 @@
+{
+  python3Packages,
+  ament-cmake-core,
+
+  ament-cmake-export-dependencies,
+  ament-cmake-python,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "ament-cmake-google-benchmark";
+  pyproject = false; # cmake
+
+  inherit (ament-cmake-core) version src nativeBuildInputs;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_google_benchmark";
+
+  propagatedBuildInputs = [
+    ament-cmake-core
+    ament-cmake-export-dependencies
+    ament-cmake-python
+  ];
+
+  nativeCheckInputs = [ python3Packages.pythonImportsCheckHook ];
+  pythonImportsCheck = [ "ament_cmake_google_benchmark" ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-cmake-core.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Ability to add Google Benchmark tests in the ament buildsystem in CMake";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-gtest/package.nix
+++ b/pkgs/by-name/am/ament-cmake-gtest/package.nix
@@ -1,0 +1,30 @@
+{
+  stdenv,
+  ament-cmake-core,
+  gtest,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-gtest";
+  inherit (ament-cmake-core) version src nativeBuildInputs;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_gtest";
+
+  propagatedBuildInputs = [
+    ament-cmake-core
+    gtest
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-cmake-core.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Ability to add gtest-based tests in the ament buildsystem in CMake";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-include-directories/package.nix
+++ b/pkgs/by-name/am/ament-cmake-include-directories/package.nix
@@ -1,0 +1,28 @@
+{
+  stdenv,
+  ament-cmake-core,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-include-directories";
+  inherit (ament-cmake-core) version src nativeBuildInputs;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_include_directories";
+
+  propagatedBuildInputs = [
+    ament-cmake-core
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-cmake-core.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Functionality to order include directories according to a chain of prefixes in the ament buildsystem in CMake";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-libraries/package.nix
+++ b/pkgs/by-name/am/ament-cmake-libraries/package.nix
@@ -1,0 +1,30 @@
+{
+  stdenv,
+  ament-cmake-core,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-libraries";
+  inherit (ament-cmake-core) version src nativeBuildInputs;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_libraries";
+
+  propagatedBuildInputs = [
+    ament-cmake-core
+  ];
+
+  doCheck = true;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-cmake-core.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Functionality to deduplicate libraries in the ament buildsystem in CMake";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-lint-cmake/package.nix
+++ b/pkgs/by-name/am/ament-cmake-lint-cmake/package.nix
@@ -1,0 +1,35 @@
+{
+  stdenv,
+
+  python3Packages,
+
+  ament-cmake-core,
+  ament-cmake-test,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-lint-cmake";
+  inherit (python3Packages.ament-lint) version src;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_lint_cmake/";
+
+  inherit (ament-cmake-core) nativeBuildInputs;
+
+  buildInputs = [
+    ament-cmake-core
+    ament-cmake-test
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (python3Packages.ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "CMake API for ament_lint_cmake to lint CMake code using cmakelint";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-mypy/package.nix
+++ b/pkgs/by-name/am/ament-cmake-mypy/package.nix
@@ -1,0 +1,35 @@
+{
+  stdenv,
+
+  python3Packages,
+
+  ament-cmake-core,
+  ament-cmake-test,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-mypy";
+  inherit (python3Packages.ament-lint) version src;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_mypy/";
+
+  inherit (ament-cmake-core) nativeBuildInputs;
+
+  buildInputs = [
+    ament-cmake-core
+    ament-cmake-test
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (python3Packages.ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "CMake API for ament_mypy to perform static type analysis on python code with mypy";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-pclint/package.nix
+++ b/pkgs/by-name/am/ament-cmake-pclint/package.nix
@@ -1,0 +1,35 @@
+{
+  stdenv,
+
+  python3Packages,
+
+  ament-cmake-core,
+  ament-cmake-test,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-pclint";
+  inherit (python3Packages.ament-lint) version src;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_pclint/";
+
+  inherit (ament-cmake-core) nativeBuildInputs;
+
+  buildInputs = [
+    ament-cmake-core
+    ament-cmake-test
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (python3Packages.ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "CMake API for ament_pclint to perform static code analysis on C/C++ code using PC-lint";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-pep257/package.nix
+++ b/pkgs/by-name/am/ament-cmake-pep257/package.nix
@@ -1,0 +1,35 @@
+{
+  stdenv,
+
+  python3Packages,
+
+  ament-cmake-core,
+  ament-cmake-test,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-pep257";
+  inherit (python3Packages.ament-lint) version src;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_pep257/";
+
+  inherit (ament-cmake-core) nativeBuildInputs;
+
+  buildInputs = [
+    ament-cmake-core
+    ament-cmake-test
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (python3Packages.ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "CMake API for ament_pep257 to check code against the docstring style conventions in PEP 257";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-pycodestyle/package.nix
+++ b/pkgs/by-name/am/ament-cmake-pycodestyle/package.nix
@@ -1,0 +1,35 @@
+{
+  stdenv,
+
+  python3Packages,
+
+  ament-cmake-core,
+  ament-cmake-test,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-pycodestyle";
+  inherit (python3Packages.ament-lint) version src;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_pycodestyle/";
+
+  inherit (ament-cmake-core) nativeBuildInputs;
+
+  buildInputs = [
+    ament-cmake-core
+    ament-cmake-test
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (python3Packages.ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "CMake API for ament_pycodestyle to check code against the style conventions in PEP 8";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-pyflakes/package.nix
+++ b/pkgs/by-name/am/ament-cmake-pyflakes/package.nix
@@ -1,0 +1,35 @@
+{
+  stdenv,
+
+  python3Packages,
+
+  ament-cmake-core,
+  ament-cmake-test,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-pyflakes";
+  inherit (python3Packages.ament-lint) version src;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_pyflakes/";
+
+  inherit (ament-cmake-core) nativeBuildInputs;
+
+  buildInputs = [
+    ament-cmake-core
+    ament-cmake-test
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (python3Packages.ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "CMake API for ament_pyflakes to check code using pyflakes";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-pytest/package.nix
+++ b/pkgs/by-name/am/ament-cmake-pytest/package.nix
@@ -1,0 +1,35 @@
+{
+  stdenv,
+  ament-cmake-core,
+
+  ament-cmake-test,
+  python3Packages,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-pytest";
+  inherit (ament-cmake-core) version src nativeBuildInputs;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_pytest";
+
+  propagatedBuildInputs = [
+    ament-cmake-core
+    ament-cmake-test
+    python3Packages.pytest
+  ];
+
+  doCheck = true;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-cmake-core.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Ability to run Python tests using pytest in the ament buildsystem in CMake";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-python-test/package.nix
+++ b/pkgs/by-name/am/ament-cmake-python-test/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  stdenv,
+  ament-cmake-core,
+
+  ament-cmake-pytest,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-python-test";
+  inherit (ament-cmake-core) version src nativeBuildInputs;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_python_test";
+
+  propagatedBuildInputs = [
+    ament-cmake-core
+  ];
+
+  doInstallCheck = true;
+  cmakeFlags = [ (lib.cmakeBool "BUILD_TESTING" finalAttrs.doInstallCheck) ];
+  installCheckInputs = [ ament-cmake-pytest ];
+  installCheckTarget = "test";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-cmake-core.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Test package for ament_cmake_python";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-python-test/package.nix
+++ b/pkgs/by-name/am/ament-cmake-python-test/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   doInstallCheck = true;
-  cmakeFlags = [ (lib.cmakeBool "BUILD_TESTING" finalAttrs.doInstallCheck) ];
+  cmakeFlags = [ (lib.cmakeBool "BUILD_TESTING" finalAttrs.finalPackage.doInstallCheck) ];
   installCheckInputs = [ ament-cmake-pytest ];
   installCheckTarget = "test";
 

--- a/pkgs/by-name/am/ament-cmake-python/package.nix
+++ b/pkgs/by-name/am/ament-cmake-python/package.nix
@@ -1,0 +1,28 @@
+{
+  stdenv,
+  ament-cmake-core,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-python";
+  inherit (ament-cmake-core) version src nativeBuildInputs;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_python";
+
+  propagatedBuildInputs = [
+    ament-cmake-core
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-cmake-core.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Ability to use Python in the ament buildsystem in CMake";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-target-dependencies/package.nix
+++ b/pkgs/by-name/am/ament-cmake-target-dependencies/package.nix
@@ -1,0 +1,28 @@
+{
+  stdenv,
+  ament-cmake-core,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-target-dependencies";
+  inherit (ament-cmake-core) version src nativeBuildInputs;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_target_dependencies";
+
+  propagatedBuildInputs = [
+    ament-cmake-core
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-cmake-core.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Ability to add definitions, include directories and libraries of a package to a target in the ament buildsystem in CMake";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-test/package.nix
+++ b/pkgs/by-name/am/ament-cmake-test/package.nix
@@ -1,0 +1,36 @@
+{
+  python3Packages,
+  ament-cmake-core,
+
+  ament-cmake-python,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "ament-cmake-test";
+  pyproject = false; # cmake
+
+  inherit (ament-cmake-core) version src nativeBuildInputs;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_test";
+
+  propagatedBuildInputs = [
+    ament-cmake-core
+    ament-cmake-python
+  ];
+
+  nativeCheckInputs = [ python3Packages.pythonImportsCheckHook ];
+  pythonImportsCheck = [ "ament_cmake_test" ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-cmake-core.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Ability to add tests in the ament buildsystem in CMake";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-uncrustify/package.nix
+++ b/pkgs/by-name/am/ament-cmake-uncrustify/package.nix
@@ -1,0 +1,35 @@
+{
+  stdenv,
+
+  python3Packages,
+
+  ament-cmake-core,
+  ament-cmake-test,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-uncrustify";
+  inherit (python3Packages.ament-lint) version src;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_uncrustify/";
+
+  inherit (ament-cmake-core) nativeBuildInputs;
+
+  buildInputs = [
+    ament-cmake-core
+    ament-cmake-test
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (python3Packages.ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "CMake API for ament_uncrustify to check code against styleconventions using uncrustify";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-vendor-package/package.nix
+++ b/pkgs/by-name/am/ament-cmake-vendor-package/package.nix
@@ -1,0 +1,35 @@
+{
+  stdenv,
+  ament-cmake-core,
+
+  ament-cmake-export-dependencies,
+  ament-cmake-test,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-vendor-package";
+  inherit (ament-cmake-core) version src nativeBuildInputs;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_vendor_package";
+
+  propagatedBuildInputs = [
+    ament-cmake-core
+    ament-cmake-export-dependencies
+  ];
+
+  doCheck = true;
+  checkInputs = [ ament-cmake-test ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-cmake-core.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Macros for maintaining a 'vendor' package";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-version/package.nix
+++ b/pkgs/by-name/am/ament-cmake-version/package.nix
@@ -1,0 +1,28 @@
+{
+  stdenv,
+  ament-cmake-core,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-version";
+  inherit (ament-cmake-core) version src nativeBuildInputs;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_version";
+
+  propagatedBuildInputs = [
+    ament-cmake-core
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-cmake-core.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Ability to override the exported package version in the ament buildsystem";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake-xmllint/package.nix
+++ b/pkgs/by-name/am/ament-cmake-xmllint/package.nix
@@ -1,0 +1,35 @@
+{
+  stdenv,
+
+  python3Packages,
+
+  ament-cmake-core,
+  ament-cmake-test,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake-xmllint";
+  inherit (python3Packages.ament-lint) version src;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake_xmllint/";
+
+  inherit (ament-cmake-core) nativeBuildInputs;
+
+  buildInputs = [
+    ament-cmake-core
+    ament-cmake-test
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (python3Packages.ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "CMake API for ament_xmllint to check XML file using xmmlint";
+  };
+})

--- a/pkgs/by-name/am/ament-cmake/package.nix
+++ b/pkgs/by-name/am/ament-cmake/package.nix
@@ -1,0 +1,29 @@
+{
+  stdenv,
+  ament-cmake-core,
+  ament-cmake-export-dependencies,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-cmake";
+  inherit (ament-cmake-core) version src nativeBuildInputs;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cmake";
+
+  propagatedBuildInputs = [
+    ament-cmake-core
+    ament-cmake-export-dependencies
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-cmake-core.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "The entry point package for the ament buildsystem in CMake";
+  };
+})

--- a/pkgs/by-name/am/ament-lint-auto/package.nix
+++ b/pkgs/by-name/am/ament-lint-auto/package.nix
@@ -1,0 +1,31 @@
+{
+  stdenv,
+
+  python3Packages,
+
+  ament-cmake-core,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-lint-auto";
+  inherit (python3Packages.ament-lint) version src;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_lint_auto";
+
+  inherit (ament-cmake-core) nativeBuildInputs;
+
+  buildInputs = [ ament-cmake-core ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (python3Packages.ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Auto-magic functions for ease to use of the ament linters in CMake";
+  };
+})

--- a/pkgs/by-name/am/ament-lint-common/package.nix
+++ b/pkgs/by-name/am/ament-lint-common/package.nix
@@ -1,0 +1,35 @@
+{
+  stdenv,
+
+  python3Packages,
+
+  ament-cmake-core,
+  ament-cmake-export-dependencies,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ament-lint-common";
+  inherit (python3Packages.ament-lint) version src;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_lint_common/";
+
+  inherit (ament-cmake-core) nativeBuildInputs;
+
+  buildInputs = [
+    ament-cmake-core
+    ament-cmake-export-dependencies
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (python3Packages.ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "List of commonly used linters in the ament build system in CMake";
+  };
+})

--- a/pkgs/by-name/xa/xacro/package.nix
+++ b/pkgs/by-name/xa/xacro/package.nix
@@ -3,12 +3,29 @@
   fetchFromGitHub,
 
   python3Packages,
+
+  ament-cmake,
+  ament-cmake-export-definitions,
+  ament-cmake-export-include-directories,
+  ament-cmake-export-libraries,
+  ament-cmake-export-link-flags,
+  ament-cmake-export-targets,
+  ament-cmake-gen-version-h,
+  ament-cmake-include-directories,
+  ament-cmake-libraries,
+  ament-cmake-pytest,
+  ament-cmake-python,
+  ament-cmake-target-dependencies,
+  ament-cmake-test,
+  ament-cmake-version,
+  ament-lint-auto,
+  cmake,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "xacro";
   version = "2.1.1";
-  pyproject = true;
+  pyproject = false; # build with CMake to get tests
 
   src = fetchFromGitHub {
     owner = "ros";
@@ -17,14 +34,57 @@ python3Packages.buildPythonApplication (finalAttrs: {
     hash = "sha256-xYFwVM5qpy2/cYKtcf/v5sSlL2e/taIC4IQ48ZiRxiw=";
   };
 
+  postPatch = ''
+    patchShebangs test/test-cmake.sh
+  '';
+
   build-system = [
+    cmake
     python3Packages.setuptools
-    python3Packages.setuptools-scm
+  ];
+
+  buildInputs = [
+    ament-cmake
+    ament-cmake-export-definitions
+    ament-cmake-export-include-directories
+    ament-cmake-export-libraries
+    ament-cmake-export-link-flags
+    ament-cmake-export-targets
+    ament-cmake-gen-version-h
+    ament-cmake-include-directories
+    ament-cmake-libraries
+    ament-cmake-python
+    ament-cmake-target-dependencies
+    ament-cmake-test
+    ament-cmake-version
+  ];
+
+  nativeCheckInputs = [
+    python3Packages.pytest
+  ];
+
+  checkInputs = [
+    python3Packages.ament-index-python
+    ament-lint-auto
+    ament-cmake-pytest
   ];
 
   dependencies = [
+    python3Packages.ament-package
+    python3Packages.catkin-pkg
     python3Packages.pyyaml
   ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_TESTING" finalAttrs.finalPackage.doInstallCheck)
+  ];
+
+  preInstallCheck = ''
+    export PATH=$out/bin:$PATH
+    export PYTHONPATH=$out/${python3Packages.python.sitePackages}:$PYTHONPATH
+  '';
+
+  installCheckTarget = "test";
 
   pythonImportsCheck = [ "xacro" ];
 

--- a/pkgs/development/python-modules/ament-clang-format/default.nix
+++ b/pkgs/development/python-modules/ament-clang-format/default.nix
@@ -1,0 +1,35 @@
+{
+  buildPythonPackage,
+  setuptools,
+  pyyaml,
+
+  ament-lint,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "ament-clang-format";
+  inherit (ament-lint) version src;
+  pyproject = true;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_clang_format/";
+
+  build-system = [ setuptools ];
+
+  dependencies = [ pyyaml ];
+
+  pythonImportsCheck = [ "ament_clang_format" ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Ability to check code against style conventions using clang-format and generate xUnit test result files";
+    mainProgram = "ament_clang_format";
+  };
+})

--- a/pkgs/development/python-modules/ament-clang-tidy/default.nix
+++ b/pkgs/development/python-modules/ament-clang-tidy/default.nix
@@ -1,0 +1,36 @@
+{
+  buildPythonPackage,
+  setuptools,
+
+  ament-lint,
+
+  pyyaml,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "ament-clang-tidy";
+  inherit (ament-lint) version src;
+  pyproject = true;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_clang_tidy/";
+
+  build-system = [ setuptools ];
+
+  dependencies = [ pyyaml ];
+
+  pythonImportsCheck = [ "ament_clang_tidy" ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Ability to check code against style conventions using clang-tidy and generate xUnit test result files";
+    mainProgram = "ament_clang_tidy";
+  };
+})

--- a/pkgs/development/python-modules/ament-copyright/default.nix
+++ b/pkgs/development/python-modules/ament-copyright/default.nix
@@ -1,0 +1,41 @@
+{
+  buildPythonPackage,
+  setuptools,
+
+  ament-lint,
+
+  ament-flake8,
+  ament-pep257,
+  pytestCheckHook,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "ament-copyright";
+  pyproject = true;
+
+  inherit (ament-lint) version src;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_copyright";
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  checkInputs = [
+    ament-flake8
+    ament-pep257
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Ability to check source files for copyright and license information";
+    mainProgram = "ament_copyright";
+  };
+})

--- a/pkgs/development/python-modules/ament-cppcheck/default.nix
+++ b/pkgs/development/python-modules/ament-cppcheck/default.nix
@@ -1,0 +1,32 @@
+{
+  buildPythonPackage,
+  setuptools,
+
+  ament-lint,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "ament-cppcheck";
+  inherit (ament-lint) version src;
+  pyproject = true;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cppcheck/";
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "ament_cppcheck" ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Ability to perform static code analysis on C/C++ code using Cppcheck and generate xUnit test result files";
+    mainProgram = "ament_cppcheck";
+  };
+})

--- a/pkgs/development/python-modules/ament-cpplint/default.nix
+++ b/pkgs/development/python-modules/ament-cpplint/default.nix
@@ -1,0 +1,32 @@
+{
+  buildPythonPackage,
+  setuptools,
+
+  ament-lint,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "ament-cpplint";
+  inherit (ament-lint) version src;
+  pyproject = true;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_cpplint/";
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "ament_cpplint" ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Ability to check code against the Google style conventions using cpplint and generate xUnit test result files";
+    mainProgram = "ament_cpplint";
+  };
+})

--- a/pkgs/development/python-modules/ament-flake8/default.nix
+++ b/pkgs/development/python-modules/ament-flake8/default.nix
@@ -1,0 +1,37 @@
+{
+  buildPythonPackage,
+  setuptools,
+
+  ament-lint,
+
+  flake8,
+  pytestCheckHook,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "ament-flake8";
+  pyproject = true;
+
+  inherit (ament-lint) version src;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_flake8";
+
+  build-system = [ setuptools ];
+
+  dependencies = [ flake8 ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Ability to check code for style and syntax conventions with flake8";
+    mainProgram = "ament_flake8";
+  };
+})

--- a/pkgs/development/python-modules/ament-index-python/default.nix
+++ b/pkgs/development/python-modules/ament-index-python/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  setuptools,
+  pytestCheckHook,
+  ament-copyright,
+  ament-flake8,
+  ament-mypy,
+  ament-pep257,
+  ament-xmllint,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "ament-index-python";
+  version = "1.14.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ament";
+    repo = "ament_index";
+    tag = finalAttrs.version;
+    hash = "sha256-0gImRr+ZY2Wcx0uBRZVbodFbfDojhy75ZnTM2qEJ4yg=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/ament_index_python";
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  checkInputs = [
+    ament-copyright
+    ament-flake8
+    ament-mypy
+    ament-pep257
+    ament-xmllint
+  ];
+
+  env.XML_CATALOG_FILES = ament-xmllint.rosPackageCatalog;
+
+  meta = {
+    description = "Python API to access the ament resource index";
+    homepage = "https://github.com/ament/ament_index";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nim65s ];
+    mainProgram = "ament_index";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/development/python-modules/ament-index-python/default.nix
+++ b/pkgs/development/python-modules/ament-index-python/default.nix
@@ -38,8 +38,6 @@ buildPythonPackage (finalAttrs: {
     ament-xmllint
   ];
 
-  env.XML_CATALOG_FILES = ament-xmllint.rosPackageCatalog;
-
   meta = {
     description = "Python API to access the ament resource index";
     homepage = "https://github.com/ament/ament_index";

--- a/pkgs/development/python-modules/ament-lint-cmake/default.nix
+++ b/pkgs/development/python-modules/ament-lint-cmake/default.nix
@@ -1,0 +1,32 @@
+{
+  buildPythonPackage,
+  setuptools,
+
+  ament-lint,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "ament-lint-cmake";
+  inherit (ament-lint) version src;
+  pyproject = true;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_lint_cmake/";
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "ament_lint_cmake" ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Ability to lint CMake code using cmakelint and generate xUnit test result files";
+    mainProgram = "ament_lint_cmake";
+  };
+})

--- a/pkgs/development/python-modules/ament-lint/default.nix
+++ b/pkgs/development/python-modules/ament-lint/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "ament-lint";
+  version = "0.21.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ament";
+    repo = "ament_lint";
+    tag = finalAttrs.version;
+    hash = "sha256-b6PeDTUXrlvBWAiJY46avdLjRzRusjbUqbjeGOCAXAI=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/ament_lint";
+
+  build-system = [ setuptools ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Providing common API for ament linter packages";
+    homepage = "https://github.com/ament/ament_lint";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nim65s ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/development/python-modules/ament-mypy/default.nix
+++ b/pkgs/development/python-modules/ament-mypy/default.nix
@@ -1,0 +1,55 @@
+{
+  buildPythonPackage,
+  setuptools,
+
+  mypy,
+
+  ament-lint,
+
+  ament-flake8,
+  ament-xmllint,
+  pytestCheckHook,
+  pytest-mock,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "ament-mypy";
+  pyproject = true;
+
+  inherit (ament-lint) version src;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_mypy";
+
+  # avoid Duplicate module named "ament_mypy"
+  # at build/lib/ament_mypy/__init__.py and ament_mypy/__init__.py
+  postPatch = ''
+    substituteInPlace ament_mypy/main.py --replace-fail \
+      "if d[0] not in ['.', '_']" \
+      "if d[0] not in ['.', '_'] and d != 'build'"
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [ mypy ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  checkInputs = [
+    ament-flake8
+    ament-xmllint
+    pytest-mock
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Support for mypy static type checking in ament";
+    mainProgram = "ament_mypy";
+  };
+})

--- a/pkgs/development/python-modules/ament-pclint/default.nix
+++ b/pkgs/development/python-modules/ament-pclint/default.nix
@@ -1,0 +1,32 @@
+{
+  buildPythonPackage,
+  setuptools,
+
+  ament-lint,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "ament-pclint";
+  inherit (ament-lint) version src;
+  pyproject = true;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_pclint/";
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "ament_pclint" ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Ability to perform static code analysis on C/C++ code using PC-lint and generate xUnit test result files";
+    mainProgram = "ament_pclint";
+  };
+})

--- a/pkgs/development/python-modules/ament-pep257/default.nix
+++ b/pkgs/development/python-modules/ament-pep257/default.nix
@@ -1,0 +1,37 @@
+{
+  buildPythonPackage,
+  setuptools,
+
+  ament-lint,
+
+  ament-flake8,
+  pytestCheckHook,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "ament-pep257";
+  pyproject = true;
+
+  inherit (ament-lint) version src;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_pep257";
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  checkInputs = [ ament-flake8 ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Ability to check code against the docstring style conventions in PEP 257 and generate xUnit test result files";
+    mainProgram = "ament_pep257";
+  };
+})

--- a/pkgs/development/python-modules/ament-pycodestyle/default.nix
+++ b/pkgs/development/python-modules/ament-pycodestyle/default.nix
@@ -1,0 +1,32 @@
+{
+  buildPythonPackage,
+  setuptools,
+
+  ament-lint,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "ament-pycodestyle";
+  inherit (ament-lint) version src;
+  pyproject = true;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_pycodestyle/";
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "ament_pycodestyle" ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Ability to check code against the style conventions in PEP 8 and generate xUnit test result files";
+    mainProgram = "ament_pycodestyle";
+  };
+})

--- a/pkgs/development/python-modules/ament-pyflakes/default.nix
+++ b/pkgs/development/python-modules/ament-pyflakes/default.nix
@@ -1,0 +1,32 @@
+{
+  buildPythonPackage,
+  setuptools,
+
+  ament-lint,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "ament-pyflakes";
+  inherit (ament-lint) version src;
+  pyproject = true;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_pyflakes/";
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "ament_pyflakes" ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Ability to check code using pyflakes and generate xUnit test result files";
+    mainProgram = "ament_pyflakes";
+  };
+})

--- a/pkgs/development/python-modules/ament-uncrustify/default.nix
+++ b/pkgs/development/python-modules/ament-uncrustify/default.nix
@@ -1,0 +1,32 @@
+{
+  buildPythonPackage,
+  setuptools,
+
+  ament-lint,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "ament-uncrustify";
+  inherit (ament-lint) version src;
+  pyproject = true;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_uncrustify/";
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "ament_uncrustify" ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Ability to check code against style conventions using uncrustify and generate xUnit test result files";
+    mainProgram = "ament_uncrustify";
+  };
+})

--- a/pkgs/development/python-modules/ament-xmllint/default.nix
+++ b/pkgs/development/python-modules/ament-xmllint/default.nix
@@ -1,0 +1,78 @@
+{
+  buildPythonPackage,
+  setuptools,
+  fetchurl,
+  writeText,
+
+  ament-lint,
+
+  libxml2, # xmllint inside
+
+  ament-copyright,
+  ament-flake8,
+  ament-pep257,
+  pytestCheckHook,
+}:
+let
+  packageFormat2Xsd = fetchurl {
+    url = "http://download.ros.org/schema/package_format2.xsd";
+    hash = "sha256-pzKK8IWbPxWuTwSRLYRqWO3GZk2x5pr/BhsilAwZQwQ=";
+  };
+  packageFormat3Xsd = fetchurl {
+    url = "http://download.ros.org/schema/package_format3.xsd";
+    hash = "sha256-WFIBgJy/jIHsWk19hNgn9Gdt1ipLwKgS2npIXeoq1Do=";
+  };
+
+  rosPackageCatalog = writeText "ros-packages-catalog.xml" ''
+    <?xml version="1.0"?>
+    <!DOCTYPE catalog PUBLIC "-//OASIS//DTD XML Catalogs V1.1//EN" "http://www.oasis-open.org/committees/entity/release/1.1/catalog.dtd">
+    <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+      <uri name="http://download.ros.org/schema/package_format2.xsd" uri="${packageFormat2Xsd}"/>
+      <uri name="http://download.ros.org/schema/package_format3.xsd" uri="${packageFormat3Xsd}"/>
+    </catalog>
+  '';
+in
+buildPythonPackage (finalAttrs: {
+  pname = "ament-xmllint";
+  pyproject = true;
+
+  inherit (ament-lint) version src;
+
+  sourceRoot = "${finalAttrs.src.name}/ament_xmllint";
+
+  postPatch = ''
+    substituteInPlace ament_xmllint/main.py --replace-fail \
+      "cmd, cwd=" \
+      "cmd, env={**os.environ, 'XML_CATALOG_FILES': '${rosPackageCatalog}'}, cwd="
+  '';
+
+  build-system = [ setuptools ];
+
+  propagatedNativeBuildInputs = [ libxml2.bin ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  checkInputs = [
+    ament-copyright
+    ament-flake8
+    ament-pep257
+  ];
+
+  disabledTests = [ "test_flake8" ]; # line too long because catalog path in patch
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  passthru = { inherit rosPackageCatalog; };
+
+  meta = {
+    inherit (ament-lint.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+    description = "Ability to check XML files like the package manifest using xmllint and generate xUnit test result files";
+    mainProgram = "ament_xmllint";
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1057,9 +1057,39 @@ self: super: with self; {
     }
   );
 
+  ament-clang-format = callPackage ../development/python-modules/ament-clang-format { };
+
+  ament-clang-tidy = callPackage ../development/python-modules/ament-clang-tidy { };
+
+  ament-copyright = callPackage ../development/python-modules/ament-copyright { };
+
+  ament-cppcheck = callPackage ../development/python-modules/ament-cppcheck { };
+
+  ament-cpplint = callPackage ../development/python-modules/ament-cpplint { };
+
+  ament-flake8 = callPackage ../development/python-modules/ament-flake8 { };
+
   ament-index-python = callPackage ../development/python-modules/ament-index-python { };
 
+  ament-lint = callPackage ../development/python-modules/ament-lint { };
+
+  ament-lint-cmake = callPackage ../development/python-modules/ament-lint-cmake { };
+
+  ament-mypy = callPackage ../development/python-modules/ament-mypy { };
+
   ament-package = callPackage ../development/python-modules/ament-package { };
+
+  ament-pclint = callPackage ../development/python-modules/ament-pclint { };
+
+  ament-pep257 = callPackage ../development/python-modules/ament-pep257 { };
+
+  ament-pycodestyle = callPackage ../development/python-modules/ament-pycodestyle { };
+
+  ament-pyflakes = callPackage ../development/python-modules/ament-pyflakes { };
+
+  ament-uncrustify = callPackage ../development/python-modules/ament-uncrustify { };
+
+  ament-xmllint = callPackage ../development/python-modules/ament-xmllint { };
 
   amplitude-analytics = callPackage ../development/python-modules/amplitude-analytics { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1057,6 +1057,8 @@ self: super: with self; {
     }
   );
 
+  ament-index-python = callPackage ../development/python-modules/ament-index-python { };
+
   ament-package = callPackage ../development/python-modules/ament-package { };
 
   amplitude-analytics = callPackage ../development/python-modules/amplitude-analytics { };


### PR DESCRIPTION
Hi,

This add the main packages from https://github.com/ament/

Those are from "meta-packages" repositories, so I guess we could reuse src and versions, mostly to deal with 2 packages update (ament-cmake & ament-lint) instead of ~50

~~For now, this PR has enough packages for #517018, but I don't have all ament-lint things yet, and they can be very useful downstream, as the ROS community push to use those.~~ done

AI disclosure: use of XML_CATALOG_FILES env var and associated file format was a suggestion from claude. It seems way better than my previous solution.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
