### PR TITLE
raylib: 5.5-unstable-2026-01-20 -> 6.0

### DIFF
--- a/pkgs/by-name/ra/raylib-games/package.nix
+++ b/pkgs/by-name/ra/raylib-games/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation {
   pname = "raylib-games";
-  version = "2022-10-24";
+  version = "2026-05-07";
 
   src = fetchFromGitHub {
     owner = "raysan5";
     repo = "raylib-games";
-    rev = "e00d77cf96ba63472e8316ae95a23c624045dcbe";
-    hash = "sha256-N9ip8yFUqXmNMKcvQuOyxDI4yF/w1YaoIh0prvS4Xr4=";
+    rev = "2175f1fe857aa91a749b66482359545f28cc596f";
+    hash = "sha256-gmCbBcS5tlq6jySvDPUqZz4ONyDkSeUdgAd20c5sUls=";
   };
 
   buildInputs = [ raylib ];

--- a/pkgs/by-name/ra/raylib/package.nix
+++ b/pkgs/by-name/ra/raylib/package.nix
@@ -63,17 +63,17 @@ lib.checkListOfEnum "raylib: platform"
 
       # https://github.com/raysan5/raylib/wiki/CMake-Build-Options
       cmakeFlags = [
-        "-DCUSTOMIZE_BUILD=ON"
+        (lib.cmakeBool "CUSTOMIZE_BUILD" true)
         # The above also enables `SUPPORT_CUSTOM_FRAME_CONTROL` (otherwise off)
         # That skips `SwapScreenBuffer` and `PollInputEvents` from `EndDrawing`
         # In turn, normal `raylib-games` demos start but never present a window
         # Keep the default game loop behavior unless explicitly requested
         (lib.cmakeBool "SUPPORT_CUSTOM_FRAME_CONTROL" customFrameControlSupport)
-        "-DPLATFORM=${platform}"
+        (lib.cmakeFeature "PLATFORM" platform)
       ]
-      ++ optional (platform == "Desktop") "-DUSE_EXTERNAL_GLFW=ON"
-      ++ optional includeEverything "-DINCLUDE_EVERYTHING=ON"
-      ++ optional sharedLib "-DBUILD_SHARED_LIBS=ON";
+      ++ optional (platform == "Desktop") (lib.cmakeFeature "USE_EXTERNAL_GLFW" "ON")
+      ++ optional includeEverything (lib.cmakeBool "INCLUDE_EVERYTHING" true)
+      ++ optional sharedLib (lib.cmakeBool "BUILD_SHARED_LIBS" true);
 
       appendRunpaths = optional stdenv.hostPlatform.isLinux (
         lib.makeLibraryPath (optional alsaSupport alsa-lib ++ optional pulseSupport libpulseaudio)

--- a/pkgs/by-name/ra/raylib/package.nix
+++ b/pkgs/by-name/ra/raylib/package.nix
@@ -11,11 +11,13 @@
   raylib-games,
   libGLU,
   libx11,
+  libxrandr,
   platform ? "Desktop", # Note that "Web", "Android" and "Raspberry Pi" do not currently work
   pulseSupport ? stdenv.hostPlatform.isLinux,
   alsaSupport ? false,
   sharedLib ? true,
   includeEverything ? true,
+  customFrameControlSupport ? false,
 }:
 let
   inherit (lib) optional;
@@ -36,13 +38,13 @@ lib.checkListOfEnum "raylib: platform"
       __structuredAttrs = true;
 
       pname = "raylib";
-      version = "5.5-unstable-2026-01-20";
+      version = "6.0";
 
       src = fetchFromGitHub {
         owner = "raysan5";
         repo = "raylib";
-        rev = "c610d228a244f930ad53492604640f39584c66da";
-        hash = "sha256-7Lhgqb7QJwz94M1ZxWgueTwIgSVclGCvHklZXGzoJgQ=";
+        rev = finalAttrs.version;
+        hash = "sha256-8+6MDTMc7Spix4ndAUzp51Q5iWcl7pQmyXuV2RutnOk=";
       };
 
       # autoPatchelfHook is needed for appendRunpaths
@@ -56,11 +58,17 @@ lib.checkListOfEnum "raylib: platform"
       propagatedBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
         libGLU
         libx11
+        libxrandr
       ];
 
       # https://github.com/raysan5/raylib/wiki/CMake-Build-Options
       cmakeFlags = [
         "-DCUSTOMIZE_BUILD=ON"
+        # The above also enables `SUPPORT_CUSTOM_FRAME_CONTROL` (otherwise off)
+        # That skips `SwapScreenBuffer` and `PollInputEvents` from `EndDrawing`
+        # In turn, normal `raylib-games` demos start but never present a window
+        # Keep the default game loop behavior unless explicitly requested
+        (lib.cmakeBool "SUPPORT_CUSTOM_FRAME_CONTROL" customFrameControlSupport)
         "-DPLATFORM=${platform}"
       ]
       ++ optional (platform == "Desktop") "-DUSE_EXTERNAL_GLFW=ON"


### PR DESCRIPTION
Changelog: https://github.com/raysan5/raylib/blob/6.0/CHANGELOG

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
