### PR TITLE
python3Packages.django-rich: init at 2.2.0

### DIFF
--- a/pkgs/development/python-modules/django-rich/default.nix
+++ b/pkgs/development/python-modules/django-rich/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+
+  # dependencies
+  django,
+  rich,
+
+  # tests
+  coverage,
+  pytest-django,
+  pytest-randomly,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "django-rich";
+  version = "2.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "adamchainz";
+    repo = "django-rich";
+    tag = finalAttrs.version;
+    hash = "sha256-Nd787s55ozqiSGdU8/2S3xbPF0rJuLTyvGqs8Fhu3n8=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    django
+    rich
+  ];
+
+  nativeCheckInputs = [
+    coverage
+    pytest-django
+    pytest-randomly
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "django_rich" ];
+
+  meta = {
+    description = "Extensions for using Rich with Django";
+    homepage = "https://github.com/adamchainz/django-rich";
+    changelog = "https://github.com/adamchainz/django-rich/blob/${finalAttrs.version}/CHANGELOG.rst";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kilyanni ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4358,6 +4358,8 @@ self: super: with self; {
 
   django-reversion = callPackage ../development/python-modules/django-reversion { };
 
+  django-rich = callPackage ../development/python-modules/django-rich { };
+
   django-rosetta = callPackage ../development/python-modules/django-rosetta { };
 
   django-rq = callPackage ../development/python-modules/django-rq { };


### PR DESCRIPTION
https://github.com/adamchainz/django-rich

Extensions for using [Rich](https://rich.readthedocs.io/) with Django.

Dependency of Paperless-NGX v3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
