### PR TITLE
python3Packages.llama-index-embeddings-openai-like: init at 0.3.1

### DIFF
--- a/pkgs/development/python-modules/llama-index-embeddings-openai-like/default.nix
+++ b/pkgs/development/python-modules/llama-index-embeddings-openai-like/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  hatchling,
+  llama-index-embeddings-openai,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "llama-index-embeddings-openai-like";
+  version = "0.3.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "llama_index_embeddings_openai_like";
+    inherit (finalAttrs) version;
+    hash = "sha256-zvevS84oTo5nMFMtvQqjJedzmKXVUk7bLS46yxIvtbY=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [ llama-index-embeddings-openai ];
+
+  # Tests are only available in the mono repo
+  doCheck = false;
+
+  pythonImportsCheck = [ "llama_index.embeddings.openai_like" ];
+
+  meta = {
+    description = "LlamaIndex Embeddings Integration for OpenAI like";
+    homepage = "https://github.com/run-llama/llama_index/tree/main/llama-index-integrations/embeddings/llama-index-embeddings-openai-like";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      fab
+      kilyanni
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9105,6 +9105,10 @@ self: super: with self; {
     callPackage ../development/python-modules/llama-index-embeddings-openai
       { };
 
+  llama-index-embeddings-openai-like =
+    callPackage ../development/python-modules/llama-index-embeddings-openai-like
+      { };
+
   llama-index-graph-stores-nebula =
     callPackage ../development/python-modules/llama-index-graph-stores-nebula
       { };


### PR DESCRIPTION
Adds `llama-index-vector-stores-faiss`, following the pattern  of the other `llama-index-*` packages.

Dependency of Paperless-NGX v3

cc @fabaff

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
