### PR TITLE
python3Packages.llama-index-vector-stores-faiss: init at 0.6.0

### DIFF
--- a/pkgs/development/python-modules/llama-index-vector-stores-faiss/default.nix
+++ b/pkgs/development/python-modules/llama-index-vector-stores-faiss/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildPythonPackage,
+  faiss,
+  fetchPypi,
+  hatchling,
+  llama-index-core,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "llama-index-vector-stores-faiss";
+  version = "0.6.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "llama_index_vector_stores_faiss";
+    inherit (finalAttrs) version;
+    hash = "sha256-AL/rbLdXHg6FZWbLTxDIm0FbYQjxUdmtSO6cMdpWP14=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    faiss
+    llama-index-core
+  ];
+
+  pythonImportsCheck = [ "llama_index.vector_stores.faiss" ];
+
+  meta = {
+    description = "LlamaIndex Vector Store Integration for Faiss";
+    homepage = "https://github.com/run-llama/llama_index/tree/main/llama-index-integrations/vector_stores/llama-index-vector-stores-faiss";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      fab
+      kilyanni
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9163,6 +9163,10 @@ self: super: with self; {
     callPackage ../development/python-modules/llama-index-vector-stores-chroma
       { };
 
+  llama-index-vector-stores-faiss =
+    callPackage ../development/python-modules/llama-index-vector-stores-faiss
+      { };
+
   llama-index-vector-stores-google =
     callPackage ../development/python-modules/llama-index-vector-stores-google
       { };


### PR DESCRIPTION
Adds `llama-index-vector-stores-faiss`, following the pattern  of the other `llama-index-*` packages.

Dependency of Paperless-NGX v3

cc @fabaff

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
