### PR TITLE
 python3Packages.faiss-cpu: init 1.14.1

### DIFF
--- a/pkgs/development/python-modules/autofaiss/default.nix
+++ b/pkgs/development/python-modules/autofaiss/default.nix
@@ -8,7 +8,7 @@
 
   # dependencies
   embedding-reader,
-  faiss,
+  faiss-cpu,
   fire,
   fsspec,
   numpy,
@@ -37,8 +37,6 @@ buildPythonPackage rec {
     # The `dataclasses` packages is a python2-only backport, unnecessary in
     # python3.
     "dataclasses"
-    # We call it faiss, not faiss-cpu.
-    "faiss-cpu"
   ];
 
   pythonRelaxDeps = [
@@ -55,7 +53,7 @@ buildPythonPackage rec {
 
   dependencies = [
     embedding-reader
-    faiss
+    faiss-cpu
     fire
     fsspec
     numpy

--- a/pkgs/development/python-modules/faiss-cpu/default.nix
+++ b/pkgs/development/python-modules/faiss-cpu/default.nix
@@ -1,0 +1,13 @@
+{
+  mkPythonMetaPackage,
+  faiss,
+}:
+
+mkPythonMetaPackage {
+  pname = "faiss-cpu";
+  inherit (faiss) version;
+  dependencies = [ faiss ];
+  meta = {
+    inherit (faiss.meta) description homepage;
+  };
+}

--- a/pkgs/development/python-modules/haystack-ai/default.nix
+++ b/pkgs/development/python-modules/haystack-ai/default.nix
@@ -68,7 +68,7 @@
   seqeval,
   pdf2image,
   pytesseract,
-  faiss,
+  faiss-cpu,
   # , faiss-gpu
   pinecone-client,
   onnxruntime,
@@ -103,11 +103,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     hatchling
-  ];
-
-  pythonRemoveDeps = [
-    # We call it faiss, not faiss-cpu.
-    "faiss-cpu"
   ];
 
   propagatedBuildInputs = [
@@ -210,7 +205,7 @@ buildPythonPackage rec {
       pdf2image
       pytesseract
     ];
-    only-faiss = [ faiss ];
+    only-faiss = [ faiss-cpu ];
     # only-faiss-gpu = [
     #   faiss-gpu
     # ];

--- a/pkgs/development/python-modules/txtai/default.nix
+++ b/pkgs/development/python-modules/txtai/default.nix
@@ -7,7 +7,7 @@
   setuptools,
 
   # dependencies
-  faiss,
+  faiss-cpu,
   torch,
   transformers,
   huggingface-hub,
@@ -251,13 +251,8 @@ buildPythonPackage {
 
   build-system = [ setuptools ];
 
-  pythonRemoveDeps = [
-    # We call it faiss, not faiss-cpu.
-    "faiss-cpu"
-  ];
-
   dependencies = [
-    faiss
+    faiss-cpu
     huggingface-hub
     msgpack
     numpy

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5337,6 +5337,16 @@ self: super: with self; {
     };
   };
 
+  faiss-cpu = callPackage ../development/python-modules/faiss-cpu {
+    faiss = self.faiss.override {
+      faiss-build = pkgs.faiss.override {
+        pythonSupport = true;
+        python3Packages = self;
+        cudaSupport = false;
+      };
+    };
+  };
+
   fake-useragent = callPackage ../development/python-modules/fake-useragent { };
 
   faker = callPackage ../development/python-modules/faker { };


### PR DESCRIPTION
Adds a meta-package for `faiss-cpu`, and drops workarounds for packages that depend on it upstream but used regular `faiss`

Dependency of Paperless-NGX v3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
