### PR TITLE
todoist-cli: init at 1.61.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12921,6 +12921,13 @@
     name = "João Moreira";
     keys = [ { fingerprint = "F457 0A3A 5F89 22F8 F572  E075 EF8B F2C8 C5F4 097D"; } ];
   };
+  joaosreis = {
+    email = "joaosreis@outlook.pt";
+    github = "joaosreis";
+    githubId = 3420596;
+    name = "João Santos Reis";
+    keys = [ { fingerprint = "9BEB F137 4CAC 96D6 A4ED  EC49 BA2E 05BD B7F8 C0EE"; } ];
+  };
   joaquintrinanes = {
     email = "hi@joaquint.io";
     github = "JoaquinTrinanes";

--- a/pkgs/by-name/to/todoist-cli/package.nix
+++ b/pkgs/by-name/to/todoist-cli/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  testers,
+  todoist-cli,
+}:
+buildNpmPackage rec {
+  pname = "todoist-cli";
+  version = "1.61.2";
+
+  src = fetchFromGitHub {
+    owner = "Doist";
+    repo = "todoist-cli";
+    rev = "v${version}";
+    sha256 = "sha256-A7SrwLD1296YCtiHRvrtN2AQ1PKDsvFCTWPwyimFWMI=";
+  };
+
+  npmDepsHash = "sha256-vPts0GjwpDRiiWG7cP2N4Jlci3JGtaqpA8MYdrGCBkI=";
+
+  doCheck = true;
+
+  __structuredAttrs = true;
+
+  passthru.tests.version = testers.testVersion {
+    package = todoist-cli;
+  };
+
+  meta = {
+    description = "A command-line interface for Todoist";
+    homepage = "https://github.com/Doist/todoist-cli";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ joaosreis ];
+    mainProgram = "td";
+  };
+}


### PR DESCRIPTION
Adds [todoist-cli](https://github.com/Doist/todoist-cli), a CLI for Todoist developed by their own team. 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
