### PR TITLE
eggdrop: 1.9.5 -> 1.10.1

### DIFF
--- a/pkgs/by-name/eg/eggdrop/package.nix
+++ b/pkgs/by-name/eg/eggdrop/package.nix
@@ -2,19 +2,23 @@
   lib,
   stdenv,
   fetchurl,
+  openssl,
   tcl,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "eggdrop";
-  version = "1.9.5";
+  version = "1.10.1";
 
   src = fetchurl {
     url = "https://ftp.eggheads.org/pub/eggdrop/source/${lib.versions.majorMinor finalAttrs.version}/eggdrop-${finalAttrs.version}.tar.gz";
-    hash = "sha256-4mkY6opk2YV1ecW2DGYaM38gdz7dgwhrNWUlvrWBc2o=";
+    hash = "sha256-pc33RE14HC/09dC+FCAvXQlx4AOHGBpJtyUFf+lTEtU=";
   };
 
-  buildInputs = [ tcl ];
+  buildInputs = [
+    openssl
+    tcl
+  ];
 
   hardeningDisable = [ "format" ];
 
@@ -37,5 +41,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.unix;
     homepage = "https://www.eggheads.org";
     description = "Internet Relay Chat (IRC) bot";
+    maintainers = with lib.maintainers; [ EpicEric ];
   };
 })


### PR DESCRIPTION
Fix build and adopt package.

ZHF: #516381

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
