### PR TITLE
paperless-ngx: refactor for easier overriding

### DIFF
--- a/nixos/modules/services/misc/paperless.nix
+++ b/nixos/modules/services/misc/paperless.nix
@@ -621,7 +621,7 @@ in
             PrivateNetwork = false;
           };
           environment = env // {
-            PYTHONPATH = "${cfg.package.python.pkgs.makePythonPath cfg.package.propagatedBuildInputs}:${cfg.package}/lib/paperless-ngx/src";
+            PYTHONPATH = "${cfg.package.python.pkgs.makePythonPath cfg.package.passthru.dependencies}:${cfg.package}/lib/paperless-ngx/src";
           };
           # Allow the web interface to access the private /tmp directory of the server.
           # This is required to support uploading files via the web interface.

--- a/pkgs/by-name/pa/paperless-ngx/frontend.nix
+++ b/pkgs/by-name/pa/paperless-ngx/frontend.nix
@@ -1,0 +1,88 @@
+{
+  stdenv,
+  lib,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  pnpm_10,
+  nodejs,
+  node-gyp,
+  pkg-config,
+  python3,
+  pango,
+  giflib,
+  xcbuild,
+  src,
+  version,
+  meta,
+}:
+let
+  pnpm = pnpm_10;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "paperless-ngx-frontend";
+  inherit version;
+
+  src = src + "/src-ui";
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit pnpm;
+    inherit (finalAttrs) pname version src;
+    fetcherVersion = 3;
+    hash = "sha256-HO+IDNB3NXWgvV0cvZ5zx46JuXv6Tgroz+YfVump5MA=";
+  };
+
+  nativeBuildInputs = [
+    node-gyp
+    nodejs
+    pkg-config
+    pnpmConfigHook
+    pnpm
+    python3
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    xcbuild
+  ];
+
+  buildInputs = [
+    pango
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    giflib
+  ];
+
+  CYPRESS_INSTALL_BINARY = "0";
+  NG_CLI_ANALYTICS = "false";
+
+  buildPhase = ''
+    runHook preBuild
+
+    pushd node_modules/canvas
+    node-gyp rebuild
+    popd
+
+    # cat forcefully disables angular cli's spinner which doesn't work with nix' tty which is 0x0
+    pnpm run build --configuration production | cat
+
+    runHook postBuild
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+
+    pnpm run test | cat
+
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/paperless-ui
+    mv ../src/documents/static/frontend $out/lib/paperless-ui/
+
+    runHook postInstall
+  '';
+
+  inherit meta;
+})

--- a/pkgs/by-name/pa/paperless-ngx/package.nix
+++ b/pkgs/by-name/pa/paperless-ngx/package.nix
@@ -27,30 +27,36 @@
   symlinkJoin,
   nltk-data,
   lndir,
+  extraPythonPackageOverrides ? (_final: _prev: { }),
 }:
 let
   pnpm = pnpm_10;
 
-  python = python3.override {
-    self = python;
-    packageOverrides = final: prev: {
-      django = prev.django_5;
+  defaultPythonPackageOverrides = final: prev: {
+    django = prev.django_5;
 
-      fido2 = prev.fido2.overridePythonAttrs {
+    fido2 = prev.fido2.overridePythonAttrs {
+      version = "1.2.0";
+
+      src = fetchPypi {
+        pname = "fido2";
         version = "1.2.0";
-
-        src = fetchPypi {
-          pname = "fido2";
-          version = "1.2.0";
-          hash = "sha256-45+VkgEi1kKD/aXlWB2VogbnBPpChGv6RmL4aqDTMzs=";
-        };
-
-        pytestFlags = [ ];
+        hash = "sha256-45+VkgEi1kKD/aXlWB2VogbnBPpChGv6RmL4aqDTMzs=";
       };
 
-      # tesseract5 may be overwritten in the paperless module and we need to propagate that to make the closure reduction effective
-      ocrmypdf = prev.ocrmypdf_16.override { tesseract = tesseract5; };
+      pytestFlags = [ ];
     };
+
+    # tesseract5 may be overwritten in the paperless module and we need to propagate that to make the closure reduction effective
+    ocrmypdf = prev.ocrmypdf_16.override { tesseract = tesseract5; };
+  };
+
+  python = python3.override {
+    self = python;
+    packageOverrides = lib.composeManyExtensions [
+      defaultPythonPackageOverrides
+      extraPythonPackageOverrides
+    ];
   };
 
   path = lib.makeBinPath [

--- a/pkgs/by-name/pa/paperless-ngx/package.nix
+++ b/pkgs/by-name/pa/paperless-ngx/package.nix
@@ -31,15 +31,6 @@
 let
   pnpm = pnpm_10;
 
-  version = "2.20.15";
-
-  src = fetchFromGitHub {
-    owner = "paperless-ngx";
-    repo = "paperless-ngx";
-    tag = "v${version}";
-    hash = "sha256-Czh4Knel0IIHsTc3kEnp1153Kv+3721GRCbTYTkeCDg=";
-  };
-
   python = python3.override {
     self = python;
     packageOverrides = final: prev: {
@@ -73,15 +64,25 @@ let
     poppler-utils
   ];
 
-  frontend = stdenv.mkDerivation (finalAttrs: {
+  nltkDataDir = symlinkJoin {
+    name = "paperless_ngx_nltk_data";
+    paths = with nltk-data; [
+      punkt-tab
+      snowball-data
+      stopwords
+    ];
+  };
+in
+python.pkgs.buildPythonApplication (finalAttrs: let
+  frontend = stdenv.mkDerivation (feAttrs: {
     pname = "paperless-ngx-frontend";
-    inherit version;
+    version = finalAttrs.version;
 
-    src = src + "/src-ui";
+    src = finalAttrs.src + "/src-ui";
 
     pnpmDeps = fetchPnpmDeps {
       inherit pnpm;
-      inherit (finalAttrs) pname version src;
+      inherit (feAttrs) pname version src;
       fetcherVersion = 3;
       hash = "sha256-HO+IDNB3NXWgvV0cvZ5zx46JuXv6Tgroz+YfVump5MA=";
     };
@@ -139,21 +140,18 @@ let
       runHook postInstall
     '';
   });
-
-  nltkDataDir = symlinkJoin {
-    name = "paperless_ngx_nltk_data";
-    paths = with nltk-data; [
-      punkt-tab
-      snowball-data
-      stopwords
-    ];
-  };
-in
-python.pkgs.buildPythonApplication rec {
+in {
   pname = "paperless-ngx";
   pyproject = true;
 
-  inherit version src;
+  version = "2.20.15";
+
+  src = fetchFromGitHub {
+    owner = "paperless-ngx";
+    repo = "paperless-ngx";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Czh4Knel0IIHsTc3kEnp1153Kv+3721GRCbTYTkeCDg=";
+  };
 
   postPatch = ''
     # pytest-xdist with to many threads makes the tests flaky
@@ -266,7 +264,7 @@ python.pkgs.buildPythonApplication rec {
 
   installPhase =
     let
-      pythonPath = python.pkgs.makePythonPath dependencies;
+      pythonPath = python.pkgs.makePythonPath finalAttrs.passthru.dependencies;
     in
     ''
       runHook preInstall
@@ -319,7 +317,7 @@ python.pkgs.buildPythonApplication rec {
     export PATH="${path}:$PATH"
     export HOME=$(mktemp -d)
     export XDG_DATA_DIRS="${liberation_ttf}/share:$XDG_DATA_DIRS"
-    export PAPERLESS_NLTK_DIR=${passthru.nltkDataDir}
+    export PAPERLESS_NLTK_DIR=${finalAttrs.passthru.nltkDataDir}
     # Limit threads per worker based on NIX_BUILD_CORES, capped at 256
     # ocrmypdf has an internal limit of 256 jobs and will fail with more:
     # https://github.com/ocrmypdf/OCRmyPDF/blob/66308c281306302fac3470f587814c3b212d0c40/src/ocrmypdf/cli.py#L234
@@ -364,7 +362,7 @@ python.pkgs.buildPythonApplication rec {
   meta = {
     description = "Tool to scan, index, and archive all of your physical documents";
     homepage = "https://docs.paperless-ngx.com/";
-    changelog = "https://github.com/paperless-ngx/paperless-ngx/releases/tag/${src.tag}";
+    changelog = "https://github.com/paperless-ngx/paperless-ngx/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.unix;
     mainProgram = "paperless-ngx";
@@ -374,4 +372,4 @@ python.pkgs.buildPythonApplication rec {
       erikarvstedt
     ];
   };
-}
+})

--- a/pkgs/by-name/pa/paperless-ngx/package.nix
+++ b/pkgs/by-name/pa/paperless-ngx/package.nix
@@ -27,6 +27,7 @@
   symlinkJoin,
   nltk-data,
   lndir,
+  nix-update-script,
   extraPythonPackageOverrides ? (_final: _prev: { }),
 }:
 let
@@ -363,6 +364,12 @@ in {
       tesseract5
       ;
     tests = { inherit (nixosTests) paperless; };
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--subpackage"
+        "frontend"
+      ];
+    };
   };
 
   meta = {

--- a/pkgs/by-name/pa/paperless-ngx/package.nix
+++ b/pkgs/by-name/pa/paperless-ngx/package.nix
@@ -3,12 +3,10 @@
   stdenv,
   fetchFromGitHub,
   fetchPypi,
-  node-gyp,
-  nodejs,
+  callPackage,
   nixosTests,
   gettext,
   python3,
-  giflib,
   ghostscript_headless,
   imagemagickBig,
   jbig2enc,
@@ -16,14 +14,8 @@
   pngquant,
   qpdf,
   tesseract5,
-  fetchPnpmDeps,
-  pnpmConfigHook,
-  pnpm_10,
   poppler-utils,
   liberation_ttf,
-  xcbuild,
-  pango,
-  pkg-config,
   symlinkJoin,
   nltk-data,
   lndir,
@@ -31,8 +23,6 @@
   extraPythonPackageOverrides ? (_final: _prev: { }),
 }:
 let
-  pnpm = pnpm_10;
-
   defaultPythonPackageOverrides = final: prev: {
     django = prev.django_5;
 
@@ -80,74 +70,7 @@ let
     ];
   };
 in
-python.pkgs.buildPythonApplication (finalAttrs: let
-  frontend = stdenv.mkDerivation (feAttrs: {
-    pname = "paperless-ngx-frontend";
-    version = finalAttrs.version;
-
-    src = finalAttrs.src + "/src-ui";
-
-    pnpmDeps = fetchPnpmDeps {
-      inherit pnpm;
-      inherit (feAttrs) pname version src;
-      fetcherVersion = 3;
-      hash = "sha256-HO+IDNB3NXWgvV0cvZ5zx46JuXv6Tgroz+YfVump5MA=";
-    };
-
-    nativeBuildInputs = [
-      node-gyp
-      nodejs
-      pkg-config
-      pnpmConfigHook
-      pnpm
-      python3
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      xcbuild
-    ];
-
-    buildInputs = [
-      pango
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      giflib
-    ];
-
-    CYPRESS_INSTALL_BINARY = "0";
-    NG_CLI_ANALYTICS = "false";
-
-    buildPhase = ''
-      runHook preBuild
-
-      pushd node_modules/canvas
-      node-gyp rebuild
-      popd
-
-      # cat forcefully disables angular cli's spinner which doesn't work with nix' tty which is 0x0
-      pnpm run build --configuration production | cat
-
-      runHook postBuild
-    '';
-
-    doCheck = true;
-    checkPhase = ''
-      runHook preCheck
-
-      pnpm run test | cat
-
-      runHook postCheck
-    '';
-
-    installPhase = ''
-      runHook preInstall
-
-      mkdir -p $out/lib/paperless-ui
-      mv ../src/documents/static/frontend $out/lib/paperless-ui/
-
-      runHook postInstall
-    '';
-  });
-in {
+python.pkgs.buildPythonApplication (finalAttrs: {
   pname = "paperless-ngx";
   pyproject = true;
 
@@ -278,7 +201,7 @@ in {
 
       mkdir -p $out/lib/paperless-ngx/static/frontend
       cp -r {src,static,LICENSE} $out/lib/paperless-ngx
-      lndir -silent ${frontend}/lib/paperless-ui/frontend $out/lib/paperless-ngx/static/frontend
+      lndir -silent ${finalAttrs.passthru.frontend}/lib/paperless-ui/frontend $out/lib/paperless-ngx/static/frontend
       chmod +x $out/lib/paperless-ngx/src/manage.py
       makeWrapper $out/lib/paperless-ngx/src/manage.py $out/bin/paperless-ngx \
         --prefix PYTHONPATH : "${pythonPath}" \
@@ -356,8 +279,11 @@ in {
   doCheck = !stdenv.hostPlatform.isDarwin;
 
   passthru = {
+    frontend = callPackage ./frontend.nix {
+      inherit (finalAttrs) src version;
+      meta = removeAttrs finalAttrs.meta [ "mainProgram" ];
+    };
     inherit
-      frontend
       nltkDataDir
       path
       python


### PR DESCRIPTION
Refactors paperless to allow for better overriding the version, as well as adding `nix-update-script` parameters to auto-update the frontend deps.

The diff looks big, but mostly just because git gets confused by indentation changes. Split it into a handful of commits for easier reviewing.

The last commit is the only one that changes the derivation, all others cause no rebuild. (the final build is also unaffected, the change is purely nix-stuff)

This allows for example to build paperless v3;

```nix
(paperless-ngx.override {
  pythonPackageOverrides =
    if pythonPackageOverrides != null then
      pythonPackageOverrides
    else
      final: prev: {
        django = prev.django_5;

        # Drop the fido2 patch, paperless v3 uses latest v2

        # tesseract5 may be overwritten in the paperless module and we need to propagate that to make the closure reduction effective
        ocrmypdf = prev.ocrmypdf.override { tesseract = tesseract5; };
      };
}).overrideAttrs
  (prev: {
    version = "3.0.0-beta.rc1";

    src = fetchFromGitHub {
      inherit (prev.src) owner repo tag;
      hash = "sha256-dnPv+QUOm55bS8Ysk0cw4o9nP2pGRw16gF0G0kboxPU=";
    };

    frontend = prev.frontend.overrideAttrs (prevFrontend: {
      pnpmDeps = fetchPnpmDeps {
        inherit (prevFrontend.pnpmDeps)
          pnpm
          fetcherVersion
          src
          version
          ;
        inherit (prev) pname;
        hash = "sha256-MC1ODaAXh1ukWGzZ/7cPV3m6cBMqlVRz/83AmSM5EKI=";
      };
    });

    # Other compat overrides omitted
  })
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
