### PR TITLE
nixos/tests/invidious: replace sig-helper with companion

### DIFF
--- a/nixos/tests/invidious.nix
+++ b/nixos/tests/invidious.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ ... }:
 {
   name = "invidious";
 
@@ -24,7 +24,7 @@
         networking.firewall.allowedTCPPorts = [ config.services.postgresql.settings.port ];
       };
     machine =
-      { lib, pkgs, ... }:
+      { pkgs, ... }:
       {
         services.invidious = {
           enable = true;
@@ -142,7 +142,7 @@
       # invidious does connect to the sig helper though and crashes when the sig helper is not available
       machine.wait_for_open_port(80)
       curl_assert_status_code("http://invidious.example.com/search", 200)
-      machine.succeed("journalctl -eu invidious.service | grep -o \"SigHelper: Using helper at 'tcp://127.0.0.1:2999'\"")
+      machine.succeed("journalctl -eu invidious.service | grep -o \"WARNING: Invidious companion is required to view and playback videos\"")
 
       postgres_tcp.wait_for_unit("postgresql.target")
       activate_specialisation("postgres-tcp")


### PR DESCRIPTION
According to the [docs](https://docs.invidious.io/installation/#migration-needed-new-invidious-companion), sig-helper has been replaced with Invidious Companion. This fix changes the captured logs to match.

This pull request _does not_ change the NixOS module to deprecate sig-helper. It only addresses the Hydra failure.

ZHF: #516381

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
