### PR TITLE
paperless-ngx-beta: init at 3.0.0-beta.rc1

### DIFF
--- a/pkgs/by-name/pa/paperless-ngx/beta.nix
+++ b/pkgs/by-name/pa/paperless-ngx/beta.nix
@@ -1,0 +1,112 @@
+{
+  paperless-ngx,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  tesseract5,
+  nix-update-script,
+  pythonPackageOverrides ? null,
+}:
+(paperless-ngx.override {
+  pythonPackageOverrides =
+    if pythonPackageOverrides != null then
+      pythonPackageOverrides
+    else
+      final: prev: {
+        django = prev.django_5;
+
+        # Drop the fido2 patch, paperless v3 uses latest v2
+
+        # tesseract5 may be overwritten in the paperless module and we need to propagate that to make the closure reduction effective
+        ocrmypdf = prev.ocrmypdf.override { tesseract = tesseract5; };
+      };
+}).overrideAttrs
+  (prev: {
+    version = "3.0.0-beta.rc1";
+
+    src = fetchFromGitHub {
+      inherit (prev.src) owner repo tag;
+      hash = "sha256-dnPv+QUOm55bS8Ysk0cw4o9nP2pGRw16gF0G0kboxPU=";
+    };
+
+    nativeInstallCheckInputs = prev.nativeInstallCheckInputs ++ [
+      prev.passthru.python.pkgs.time-machine
+    ];
+
+    disabledTests = prev.disabledTests ++ [
+      # Requires network access to download tiktoken data
+      "test_build_document_node"
+      "test_update_llm_index"
+      "test_update_llm_index_removes_meta"
+      "test_update_llm_index_partial_update"
+      "test_load_or_build_index_builds_when_nodes_given"
+      "test_add_or_update_document_updates_existing_entry"
+      "test_remove_document_deletes_node_from_docstore"
+      "test_query_similar_documents"
+      "test_get_ai_document_classification_success"
+      "test_prompt_with_without_rag"
+      "test_stream_chat_with_one_document_full_content"
+      "test_stream_chat_with_multiple_documents_retrieval"
+    ];
+
+    pythonRelaxDeps = prev.pythonRelaxDeps ++ [
+      "django-guardian"
+      "filelock"
+      "llama-index-core"
+      "openai"
+      "regex"
+      "zxing-cpp"
+    ];
+
+    propagatedBuildInputs =
+      prev.propagatedBuildInputs
+      ++ (with prev.passthru.python.pkgs; [
+        azure-ai-documentintelligence
+        django-rich
+        faiss-cpu
+        ijson
+        llama-index-core
+        llama-index-embeddings-huggingface
+        llama-index-embeddings-openai-like
+        llama-index-llms-ollama
+        llama-index-llms-openai-like
+        llama-index-vector-stores-faiss
+        openai
+        sentence-transformers
+        tantivy
+        torch
+        watchfiles
+      ]);
+
+    frontend = prev.frontend.overrideAttrs (prevFrontend: {
+      pnpmDeps = fetchPnpmDeps {
+        inherit (prevFrontend.pnpmDeps)
+          pnpm
+          fetcherVersion
+          src
+          version
+          ;
+        inherit (prev) pname;
+        hash = "sha256-SOgMpS4Xq9VmXYzQjOzfN3lj1nf+dUc8pKUpbo6uvTk=";
+      };
+    });
+
+    # v3 enforces a non-default PAPERLESS_SECRET_KEY at import time
+    # since postBuild calls manage.py, this ends up getting triggered
+    postBuild = ''
+      export PAPERLESS_SECRET_KEY=super-safe-secret-key
+      ${prev.postBuild}
+    '';
+
+    passthru = prev.passthru // {
+      updateScript = nix-update-script {
+        extraArgs = [
+          "--version"
+          "unstable"
+          "--subpackage"
+          "frontend"
+          "--override-filename"
+          "pkgs/by-name/pa/paperless-ngx/beta.nix"
+        ];
+      };
+    };
+  })

--- a/pkgs/by-name/pa/paperless-ngx/frontend.nix
+++ b/pkgs/by-name/pa/paperless-ngx/frontend.nix
@@ -13,6 +13,7 @@
   xcbuild,
   src,
   version,
+  meta,
 }:
 let
   pnpm = pnpm_10;
@@ -82,4 +83,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  inherit meta;
 })

--- a/pkgs/by-name/pa/paperless-ngx/frontend.nix
+++ b/pkgs/by-name/pa/paperless-ngx/frontend.nix
@@ -1,0 +1,85 @@
+{
+  stdenv,
+  lib,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  pnpm_10,
+  nodejs,
+  node-gyp,
+  pkg-config,
+  python3,
+  pango,
+  giflib,
+  xcbuild,
+  src,
+  version,
+}:
+let
+  pnpm = pnpm_10;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "paperless-ngx-frontend";
+  inherit version;
+
+  src = src + "/src-ui";
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit pnpm;
+    inherit (finalAttrs) pname version src;
+    fetcherVersion = 3;
+    hash = "sha256-HO+IDNB3NXWgvV0cvZ5zx46JuXv6Tgroz+YfVump5MA=";
+  };
+
+  nativeBuildInputs = [
+    node-gyp
+    nodejs
+    pkg-config
+    pnpmConfigHook
+    pnpm
+    python3
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    xcbuild
+  ];
+
+  buildInputs = [
+    pango
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    giflib
+  ];
+
+  CYPRESS_INSTALL_BINARY = "0";
+  NG_CLI_ANALYTICS = "false";
+
+  buildPhase = ''
+    runHook preBuild
+
+    pushd node_modules/canvas
+    node-gyp rebuild
+    popd
+
+    # cat forcefully disables angular cli's spinner which doesn't work with nix' tty which is 0x0
+    pnpm run build --configuration production | cat
+
+    runHook postBuild
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+
+    pnpm run test | cat
+
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/paperless-ui
+    mv ../src/documents/static/frontend $out/lib/paperless-ui/
+
+    runHook postInstall
+  '';
+})

--- a/pkgs/by-name/pa/paperless-ngx/package.nix
+++ b/pkgs/by-name/pa/paperless-ngx/package.nix
@@ -283,6 +283,7 @@ python.pkgs.buildPythonApplication (
     passthru = {
       frontend = callPackage ./frontend.nix {
         inherit (finalAttrs) src version;
+        meta = removeAttrs finalAttrs.meta [ "mainProgram" ];
       };
       inherit
         nltkDataDir

--- a/pkgs/by-name/pa/paperless-ngx/package.nix
+++ b/pkgs/by-name/pa/paperless-ngx/package.nix
@@ -78,6 +78,8 @@ python.pkgs.buildPythonApplication (
 
     version = "2.20.15";
 
+    __structuredAttrs = true;
+
     src = fetchFromGitHub {
       owner = "paperless-ngx";
       repo = "paperless-ngx";

--- a/pkgs/by-name/pa/paperless-ngx/package.nix
+++ b/pkgs/by-name/pa/paperless-ngx/package.nix
@@ -63,10 +63,6 @@ python.pkgs.buildPythonApplication (
       poppler-utils
     ];
 
-    frontend = callPackage ./frontend.nix {
-      inherit (finalAttrs) src version;
-    };
-
     nltkDataDir = symlinkJoin {
       name = "paperless_ngx_nltk_data";
       paths = with nltk-data; [
@@ -207,7 +203,7 @@ python.pkgs.buildPythonApplication (
 
         mkdir -p $out/lib/paperless-ngx/static/frontend
         cp -r {src,static,LICENSE} $out/lib/paperless-ngx
-        lndir -silent ${frontend}/lib/paperless-ui/frontend $out/lib/paperless-ngx/static/frontend
+        lndir -silent ${finalAttrs.passthru.frontend}/lib/paperless-ui/frontend $out/lib/paperless-ngx/static/frontend
         chmod +x $out/lib/paperless-ngx/src/manage.py
         makeWrapper $out/lib/paperless-ngx/src/manage.py $out/bin/paperless-ngx \
           --prefix PYTHONPATH : "${pythonPath}" \
@@ -285,8 +281,10 @@ python.pkgs.buildPythonApplication (
     doCheck = !stdenv.hostPlatform.isDarwin;
 
     passthru = {
+      frontend = callPackage ./frontend.nix {
+        inherit (finalAttrs) src version;
+      };
       inherit
-        frontend
         nltkDataDir
         path
         python

--- a/pkgs/by-name/pa/paperless-ngx/package.nix
+++ b/pkgs/by-name/pa/paperless-ngx/package.nix
@@ -3,12 +3,10 @@
   stdenv,
   fetchFromGitHub,
   fetchPypi,
-  node-gyp,
-  nodejs,
+  callPackage,
   nixosTests,
   gettext,
   python3,
-  giflib,
   ghostscript_headless,
   imagemagickBig,
   jbig2enc,
@@ -16,14 +14,8 @@
   pngquant,
   qpdf,
   tesseract5,
-  fetchPnpmDeps,
-  pnpmConfigHook,
-  pnpm_10,
   poppler-utils,
   liberation_ttf,
-  xcbuild,
-  pango,
-  pkg-config,
   symlinkJoin,
   nltk-data,
   lndir,
@@ -31,8 +23,6 @@
   pythonPackageOverrides ? null,
 }:
 let
-  pnpm = pnpm_10;
-
   python = python3.override {
     self = python;
     packageOverrides =
@@ -73,72 +63,9 @@ python.pkgs.buildPythonApplication (
       poppler-utils
     ];
 
-    frontend = stdenv.mkDerivation (feAttrs: {
-      pname = "paperless-ngx-frontend";
-      version = finalAttrs.version;
-
-      src = finalAttrs.src + "/src-ui";
-
-      pnpmDeps = fetchPnpmDeps {
-        inherit pnpm;
-        inherit (feAttrs) pname version src;
-        fetcherVersion = 3;
-        hash = "sha256-HO+IDNB3NXWgvV0cvZ5zx46JuXv6Tgroz+YfVump5MA=";
-      };
-
-      nativeBuildInputs = [
-        node-gyp
-        nodejs
-        pkg-config
-        pnpmConfigHook
-        pnpm
-        python3
-      ]
-      ++ lib.optionals stdenv.hostPlatform.isDarwin [
-        xcbuild
-      ];
-
-      buildInputs = [
-        pango
-      ]
-      ++ lib.optionals stdenv.hostPlatform.isDarwin [
-        giflib
-      ];
-
-      CYPRESS_INSTALL_BINARY = "0";
-      NG_CLI_ANALYTICS = "false";
-
-      buildPhase = ''
-        runHook preBuild
-
-        pushd node_modules/canvas
-        node-gyp rebuild
-        popd
-
-        # cat forcefully disables angular cli's spinner which doesn't work with nix' tty which is 0x0
-        pnpm run build --configuration production | cat
-
-        runHook postBuild
-      '';
-
-      doCheck = true;
-      checkPhase = ''
-        runHook preCheck
-
-        pnpm run test | cat
-
-        runHook postCheck
-      '';
-
-      installPhase = ''
-        runHook preInstall
-
-        mkdir -p $out/lib/paperless-ui
-        mv ../src/documents/static/frontend $out/lib/paperless-ui/
-
-        runHook postInstall
-      '';
-    });
+    frontend = callPackage ./frontend.nix {
+      inherit (finalAttrs) src version;
+    };
 
     nltkDataDir = symlinkJoin {
       name = "paperless_ngx_nltk_data";

--- a/pkgs/by-name/pa/paperless-ngx/package.nix
+++ b/pkgs/by-name/pa/paperless-ngx/package.nix
@@ -27,6 +27,7 @@
   symlinkJoin,
   nltk-data,
   lndir,
+  nix-update-script,
   pythonPackageOverrides ? null,
 }:
 let
@@ -365,6 +366,12 @@ python.pkgs.buildPythonApplication (
         tesseract5
         ;
       tests = { inherit (nixosTests) paperless; };
+      updateScript = nix-update-script {
+        extraArgs = [
+          "--subpackage"
+          "frontend"
+        ];
+      };
     };
 
     meta = {

--- a/pkgs/by-name/pa/paperless-ngx/package.nix
+++ b/pkgs/by-name/pa/paperless-ngx/package.nix
@@ -27,30 +27,35 @@
   symlinkJoin,
   nltk-data,
   lndir,
+  pythonPackageOverrides ? null,
 }:
 let
   pnpm = pnpm_10;
 
   python = python3.override {
     self = python;
-    packageOverrides = final: prev: {
-      django = prev.django_5;
+    packageOverrides =
+      if pythonPackageOverrides != null then
+        pythonPackageOverrides
+      else
+        final: prev: {
+          django = prev.django_5;
 
-      fido2 = prev.fido2.overridePythonAttrs {
-        version = "1.2.0";
+          fido2 = prev.fido2.overridePythonAttrs {
+            version = "1.2.0";
 
-        src = fetchPypi {
-          pname = "fido2";
-          version = "1.2.0";
-          hash = "sha256-45+VkgEi1kKD/aXlWB2VogbnBPpChGv6RmL4aqDTMzs=";
+            src = fetchPypi {
+              pname = "fido2";
+              version = "1.2.0";
+              hash = "sha256-45+VkgEi1kKD/aXlWB2VogbnBPpChGv6RmL4aqDTMzs=";
+            };
+
+            pytestFlags = [ ];
+          };
+
+          # tesseract5 may be overwritten in the paperless module and we need to propagate that to make the closure reduction effective
+          ocrmypdf = prev.ocrmypdf_16.override { tesseract = tesseract5; };
         };
-
-        pytestFlags = [ ];
-      };
-
-      # tesseract5 may be overwritten in the paperless module and we need to propagate that to make the closure reduction effective
-      ocrmypdf = prev.ocrmypdf_16.override { tesseract = tesseract5; };
-    };
   };
 in
 python.pkgs.buildPythonApplication (

--- a/pkgs/by-name/pa/paperless-ngx/package.nix
+++ b/pkgs/by-name/pa/paperless-ngx/package.nix
@@ -31,15 +31,6 @@
 let
   pnpm = pnpm_10;
 
-  version = "2.20.15";
-
-  src = fetchFromGitHub {
-    owner = "paperless-ngx";
-    repo = "paperless-ngx";
-    tag = "v${version}";
-    hash = "sha256-Czh4Knel0IIHsTc3kEnp1153Kv+3721GRCbTYTkeCDg=";
-  };
-
   python = python3.override {
     self = python;
     packageOverrides = final: prev: {
@@ -61,317 +52,328 @@ let
       ocrmypdf = prev.ocrmypdf_16.override { tesseract = tesseract5; };
     };
   };
+in
+python.pkgs.buildPythonApplication (
+  finalAttrs:
+  let
+    path = lib.makeBinPath [
+      ghostscript_headless
+      (imagemagickBig.override { ghostscript = ghostscript_headless; })
+      jbig2enc
+      optipng
+      pngquant
+      qpdf
+      tesseract5
+      poppler-utils
+    ];
 
-  path = lib.makeBinPath [
-    ghostscript_headless
-    (imagemagickBig.override { ghostscript = ghostscript_headless; })
-    jbig2enc
-    optipng
-    pngquant
-    qpdf
-    tesseract5
-    poppler-utils
-  ];
+    frontend = stdenv.mkDerivation (feAttrs: {
+      pname = "paperless-ngx-frontend";
+      version = finalAttrs.version;
 
-  frontend = stdenv.mkDerivation (finalAttrs: {
-    pname = "paperless-ngx-frontend";
-    inherit version;
+      src = finalAttrs.src + "/src-ui";
 
-    src = src + "/src-ui";
+      pnpmDeps = fetchPnpmDeps {
+        inherit pnpm;
+        inherit (feAttrs) pname version src;
+        fetcherVersion = 3;
+        hash = "sha256-HO+IDNB3NXWgvV0cvZ5zx46JuXv6Tgroz+YfVump5MA=";
+      };
 
-    pnpmDeps = fetchPnpmDeps {
-      inherit pnpm;
-      inherit (finalAttrs) pname version src;
-      fetcherVersion = 3;
-      hash = "sha256-HO+IDNB3NXWgvV0cvZ5zx46JuXv6Tgroz+YfVump5MA=";
+      nativeBuildInputs = [
+        node-gyp
+        nodejs
+        pkg-config
+        pnpmConfigHook
+        pnpm
+        python3
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [
+        xcbuild
+      ];
+
+      buildInputs = [
+        pango
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [
+        giflib
+      ];
+
+      CYPRESS_INSTALL_BINARY = "0";
+      NG_CLI_ANALYTICS = "false";
+
+      buildPhase = ''
+        runHook preBuild
+
+        pushd node_modules/canvas
+        node-gyp rebuild
+        popd
+
+        # cat forcefully disables angular cli's spinner which doesn't work with nix' tty which is 0x0
+        pnpm run build --configuration production | cat
+
+        runHook postBuild
+      '';
+
+      doCheck = true;
+      checkPhase = ''
+        runHook preCheck
+
+        pnpm run test | cat
+
+        runHook postCheck
+      '';
+
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p $out/lib/paperless-ui
+        mv ../src/documents/static/frontend $out/lib/paperless-ui/
+
+        runHook postInstall
+      '';
+    });
+
+    nltkDataDir = symlinkJoin {
+      name = "paperless_ngx_nltk_data";
+      paths = with nltk-data; [
+        punkt-tab
+        snowball-data
+        stopwords
+      ];
+    };
+  in
+  {
+    pname = "paperless-ngx";
+    pyproject = true;
+
+    version = "2.20.15";
+
+    src = fetchFromGitHub {
+      owner = "paperless-ngx";
+      repo = "paperless-ngx";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-Czh4Knel0IIHsTc3kEnp1153Kv+3721GRCbTYTkeCDg=";
     };
 
+    postPatch = ''
+      # pytest-xdist with to many threads makes the tests flaky
+      if (( $NIX_BUILD_CORES > 3)); then
+        NIX_BUILD_CORES=3
+      fi
+      substituteInPlace pyproject.toml \
+        --replace-fail '"--numprocesses=auto",' "" \
+        --replace-fail '--maxprocesses=16' "--numprocesses=$NIX_BUILD_CORES"
+    '';
+
+    build-system = [ python.pkgs.setuptools ];
+
     nativeBuildInputs = [
-      node-gyp
-      nodejs
-      pkg-config
-      pnpmConfigHook
-      pnpm
-      python3
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      xcbuild
+      gettext
+      lndir
     ];
 
-    buildInputs = [
-      pango
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      giflib
+    pythonRelaxDeps = [
+      "celery"
+      "django-allauth"
+      "django-auditlog"
+      "django-cachalot"
+      "drf-spectacular-sidecar"
+      "python-dotenv"
+      "gotenberg-client"
+      "redis"
+      "scikit-learn"
+      "tika-client"
+      # requested by maintainer
+      "imap-tools"
+      "ocrmypdf"
     ];
 
-    CYPRESS_INSTALL_BINARY = "0";
-    NG_CLI_ANALYTICS = "false";
+    dependencies =
+      with python.pkgs;
+      [
+        babel
+        bleach
+        channels
+        channels-redis
+        concurrent-log-handler
+        dateparser
+        django
+        django-allauth
+        django-auditlog
+        django-cachalot
+        django-celery-results
+        django-compression-middleware
+        django-cors-headers
+        django-extensions
+        django-filter
+        django-guardian
+        django-multiselectfield
+        django-soft-delete
+        django-treenode
+        djangorestframework
+        djangorestframework-guardian
+        drf-spectacular
+        drf-spectacular-sidecar
+        drf-writable-nested
+        filelock
+        flower
+        gotenberg-client
+        granian
+        httpx-oauth
+        imap-tools
+        inotifyrecursive
+        jinja2
+        langdetect
+        mysqlclient
+        nltk
+        ocrmypdf
+        pathvalidate
+        pdf2image
+        psycopg
+        psycopg-pool
+        python-dateutil
+        python-dotenv
+        python-gnupg
+        python-ipware
+        python-magic
+        pyzbar
+        rapidfuzz
+        redis
+        scikit-learn
+        setproctitle
+        tika-client
+        tqdm
+        watchdog
+        whitenoise
+        whoosh-reloaded
+        zxing-cpp
+      ]
+      ++ django-allauth.optional-dependencies.mfa
+      ++ django-allauth.optional-dependencies.socialaccount
+      ++ redis.optional-dependencies.hiredis;
 
-    buildPhase = ''
-      runHook preBuild
+    postBuild = ''
+      # Compile manually because `pythonRecompileBytecodeHook` only works
+      # for files in `python.sitePackages`
+      ${python.pythonOnBuildForHost.interpreter} -OO -m compileall src
 
-      pushd node_modules/canvas
-      node-gyp rebuild
-      popd
+      # Collect static files
+      ${python.pythonOnBuildForHost.interpreter} src/manage.py collectstatic --clear --no-input
 
-      # cat forcefully disables angular cli's spinner which doesn't work with nix' tty which is 0x0
-      pnpm run build --configuration production | cat
-
-      runHook postBuild
+      # Compile string translations using gettext
+      ${python.pythonOnBuildForHost.interpreter} src/manage.py compilemessages
     '';
 
-    doCheck = true;
-    checkPhase = ''
-      runHook preCheck
+    installPhase =
+      let
+        pythonPath = python.pkgs.makePythonPath finalAttrs.propagatedBuildInputs;
+      in
+      ''
+        runHook preInstall
 
-      pnpm run test | cat
+        mkdir -p $out/lib/paperless-ngx/static/frontend
+        cp -r {src,static,LICENSE} $out/lib/paperless-ngx
+        lndir -silent ${frontend}/lib/paperless-ui/frontend $out/lib/paperless-ngx/static/frontend
+        chmod +x $out/lib/paperless-ngx/src/manage.py
+        makeWrapper $out/lib/paperless-ngx/src/manage.py $out/bin/paperless-ngx \
+          --prefix PYTHONPATH : "${pythonPath}" \
+          --prefix PATH : "${path}"
+        makeWrapper ${lib.getExe python.pkgs.celery} $out/bin/celery \
+          --prefix PYTHONPATH : "${pythonPath}:$out/lib/paperless-ngx/src" \
+          --prefix PATH : "${path}"
 
-      runHook postCheck
+        runHook postInstall
+      '';
+
+    postFixup = ''
+      # Remove tests with samples (~14M)
+      find $out/lib/paperless-ngx -type d -name tests -exec rm -rv {} +
     '';
 
-    installPhase = ''
-      runHook preInstall
-
-      mkdir -p $out/lib/paperless-ui
-      mv ../src/documents/static/frontend $out/lib/paperless-ui/
-
-      runHook postInstall
-    '';
-  });
-
-  nltkDataDir = symlinkJoin {
-    name = "paperless_ngx_nltk_data";
-    paths = with nltk-data; [
-      punkt-tab
-      snowball-data
-      stopwords
+    nativeCheckInputs = with python.pkgs; [
+      daphne
+      factory-boy
+      imagehash
+      pytest-cov-stub
+      pytest-django
+      pytest-env
+      pytest-httpx
+      pytest-mock
+      pytest-rerunfailures
+      pytest-xdist
+      pytestCheckHook
     ];
-  };
-in
-python.pkgs.buildPythonApplication rec {
-  pname = "paperless-ngx";
-  pyproject = true;
 
-  inherit version src;
+    # manually managed in postPatch
+    dontUsePytestXdist = false;
 
-  postPatch = ''
-    # pytest-xdist with to many threads makes the tests flaky
-    if (( $NIX_BUILD_CORES > 3)); then
-      NIX_BUILD_CORES=3
-    fi
-    substituteInPlace pyproject.toml \
-      --replace-fail '"--numprocesses=auto",' "" \
-      --replace-fail '--maxprocesses=16' "--numprocesses=$NIX_BUILD_CORES"
-  '';
+    enabledTestPaths = [
+      "src"
+    ];
 
-  build-system = [ python.pkgs.setuptools ];
+    preCheck = ''
+      # The tests require:
+      # - PATH with runtime binaries
+      # - A temporary HOME directory for gnupg
+      # - XDG_DATA_DIRS with test-specific fonts
+      export PATH="${path}:$PATH"
+      export HOME=$(mktemp -d)
+      export XDG_DATA_DIRS="${liberation_ttf}/share:$XDG_DATA_DIRS"
+      export PAPERLESS_NLTK_DIR=${finalAttrs.passthru.nltkDataDir}
+      # Limit threads per worker based on NIX_BUILD_CORES, capped at 256
+      # ocrmypdf has an internal limit of 256 jobs and will fail with more:
+      # https://github.com/ocrmypdf/OCRmyPDF/blob/66308c281306302fac3470f587814c3b212d0c40/src/ocrmypdf/cli.py#L234
+      export PAPERLESS_THREADS_PER_WORKER=$(( NIX_BUILD_CORES > 256 ? 256 : NIX_BUILD_CORES ))
 
-  nativeBuildInputs = [
-    gettext
-    lndir
-  ];
-
-  pythonRelaxDeps = [
-    "celery"
-    "django-allauth"
-    "django-auditlog"
-    "django-cachalot"
-    "drf-spectacular-sidecar"
-    "python-dotenv"
-    "gotenberg-client"
-    "redis"
-    "scikit-learn"
-    "tika-client"
-    # requested by maintainer
-    "imap-tools"
-    "ocrmypdf"
-  ];
-
-  dependencies =
-    with python.pkgs;
-    [
-      babel
-      bleach
-      channels
-      channels-redis
-      concurrent-log-handler
-      dateparser
-      django
-      django-allauth
-      django-auditlog
-      django-cachalot
-      django-celery-results
-      django-compression-middleware
-      django-cors-headers
-      django-extensions
-      django-filter
-      django-guardian
-      django-multiselectfield
-      django-soft-delete
-      django-treenode
-      djangorestframework
-      djangorestframework-guardian
-      drf-spectacular
-      drf-spectacular-sidecar
-      drf-writable-nested
-      filelock
-      flower
-      gotenberg-client
-      granian
-      httpx-oauth
-      imap-tools
-      inotifyrecursive
-      jinja2
-      langdetect
-      mysqlclient
-      nltk
-      ocrmypdf
-      pathvalidate
-      pdf2image
-      psycopg
-      psycopg-pool
-      python-dateutil
-      python-dotenv
-      python-gnupg
-      python-ipware
-      python-magic
-      pyzbar
-      rapidfuzz
-      redis
-      scikit-learn
-      setproctitle
-      tika-client
-      tqdm
-      watchdog
-      whitenoise
-      whoosh-reloaded
-      zxing-cpp
-    ]
-    ++ django-allauth.optional-dependencies.mfa
-    ++ django-allauth.optional-dependencies.socialaccount
-    ++ redis.optional-dependencies.hiredis;
-
-  postBuild = ''
-    # Compile manually because `pythonRecompileBytecodeHook` only works
-    # for files in `python.sitePackages`
-    ${python.pythonOnBuildForHost.interpreter} -OO -m compileall src
-
-    # Collect static files
-    ${python.pythonOnBuildForHost.interpreter} src/manage.py collectstatic --clear --no-input
-
-    # Compile string translations using gettext
-    ${python.pythonOnBuildForHost.interpreter} src/manage.py compilemessages
-  '';
-
-  installPhase =
-    let
-      pythonPath = python.pkgs.makePythonPath dependencies;
-    in
-    ''
-      runHook preInstall
-
-      mkdir -p $out/lib/paperless-ngx/static/frontend
-      cp -r {src,static,LICENSE} $out/lib/paperless-ngx
-      lndir -silent ${frontend}/lib/paperless-ui/frontend $out/lib/paperless-ngx/static/frontend
-      chmod +x $out/lib/paperless-ngx/src/manage.py
-      makeWrapper $out/lib/paperless-ngx/src/manage.py $out/bin/paperless-ngx \
-        --prefix PYTHONPATH : "${pythonPath}" \
-        --prefix PATH : "${path}"
-      makeWrapper ${lib.getExe python.pkgs.celery} $out/bin/celery \
-        --prefix PYTHONPATH : "${pythonPath}:$out/lib/paperless-ngx/src" \
-        --prefix PATH : "${path}"
-
-      runHook postInstall
+      # the generated pyc files conflict when running the tests
+      rm -r build/lib
     '';
 
-  postFixup = ''
-    # Remove tests with samples (~14M)
-    find $out/lib/paperless-ngx -type d -name tests -exec rm -rv {} +
-  '';
-
-  nativeCheckInputs = with python.pkgs; [
-    daphne
-    factory-boy
-    imagehash
-    pytest-cov-stub
-    pytest-django
-    pytest-env
-    pytest-httpx
-    pytest-mock
-    pytest-rerunfailures
-    pytest-xdist
-    pytestCheckHook
-  ];
-
-  # manually managed in postPatch
-  dontUsePytestXdist = false;
-
-  enabledTestPaths = [
-    "src"
-  ];
-
-  preCheck = ''
-    # The tests require:
-    # - PATH with runtime binaries
-    # - A temporary HOME directory for gnupg
-    # - XDG_DATA_DIRS with test-specific fonts
-    export PATH="${path}:$PATH"
-    export HOME=$(mktemp -d)
-    export XDG_DATA_DIRS="${liberation_ttf}/share:$XDG_DATA_DIRS"
-    export PAPERLESS_NLTK_DIR=${passthru.nltkDataDir}
-    # Limit threads per worker based on NIX_BUILD_CORES, capped at 256
-    # ocrmypdf has an internal limit of 256 jobs and will fail with more:
-    # https://github.com/ocrmypdf/OCRmyPDF/blob/66308c281306302fac3470f587814c3b212d0c40/src/ocrmypdf/cli.py#L234
-    export PAPERLESS_THREADS_PER_WORKER=$(( NIX_BUILD_CORES > 256 ? 256 : NIX_BUILD_CORES ))
-
-    # the generated pyc files conflict when running the tests
-    rm -r build/lib
-  '';
-
-  disabledTests = [
-    # FileNotFoundError(2, 'No such file or directory'): /build/tmp...
-    "test_script_with_output"
-    "test_script_exit_non_zero"
-    # Something broken with new Tesseract and inline RTL/LTR overrides?
-    "test_rtl_language_detection"
-    # Favicon tests fail due to static file handling in the test environment
-    # https://github.com/NixOS/nixpkgs/issues/421393
-    "test_favicon_view"
-    "test_favicon_view_missing_file"
-    # Requires DNS
-    "test_send_webhook_data_or_json"
-    # execnet.gateway_base.DumpError: can't serialize <class 'pathlib._local.PosixPath'>
-    # https://github.com/pytest-dev/pytest-xdist/issues/384
-    "test_subdirectory_upload"
-    # AssertionError: 4 != 3
-    "testNormalOperation"
-  ];
-
-  doCheck = !stdenv.hostPlatform.isDarwin;
-
-  passthru = {
-    inherit
-      frontend
-      nltkDataDir
-      path
-      python
-      tesseract5
-      ;
-    tests = { inherit (nixosTests) paperless; };
-  };
-
-  meta = {
-    description = "Tool to scan, index, and archive all of your physical documents";
-    homepage = "https://docs.paperless-ngx.com/";
-    changelog = "https://github.com/paperless-ngx/paperless-ngx/releases/tag/${src.tag}";
-    license = lib.licenses.gpl3Only;
-    platforms = lib.platforms.unix;
-    mainProgram = "paperless-ngx";
-    maintainers = with lib.maintainers; [
-      leona
-      SuperSandro2000
-      erikarvstedt
+    disabledTests = [
+      # FileNotFoundError(2, 'No such file or directory'): /build/tmp...
+      "test_script_with_output"
+      "test_script_exit_non_zero"
+      # Something broken with new Tesseract and inline RTL/LTR overrides?
+      "test_rtl_language_detection"
+      # Favicon tests fail due to static file handling in the test environment
+      # https://github.com/NixOS/nixpkgs/issues/421393
+      "test_favicon_view"
+      "test_favicon_view_missing_file"
+      # Requires DNS
+      "test_send_webhook_data_or_json"
+      # execnet.gateway_base.DumpError: can't serialize <class 'pathlib._local.PosixPath'>
+      # https://github.com/pytest-dev/pytest-xdist/issues/384
+      "test_subdirectory_upload"
+      # AssertionError: 4 != 3
+      "testNormalOperation"
     ];
-  };
-}
+
+    doCheck = !stdenv.hostPlatform.isDarwin;
+
+    passthru = {
+      inherit
+        frontend
+        nltkDataDir
+        path
+        python
+        tesseract5
+        ;
+      tests = { inherit (nixosTests) paperless; };
+    };
+
+    meta = {
+      description = "Tool to scan, index, and archive all of your physical documents";
+      homepage = "https://docs.paperless-ngx.com/";
+      changelog = "https://github.com/paperless-ngx/paperless-ngx/releases/tag/${finalAttrs.src.tag}";
+      license = lib.licenses.gpl3Only;
+      platforms = lib.platforms.unix;
+      mainProgram = "paperless-ngx";
+      maintainers = with lib.maintainers; [
+        leona
+        SuperSandro2000
+        erikarvstedt
+      ];
+    };
+  }
+)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3053,6 +3053,8 @@ with pkgs;
 
   pakcs = callPackage ../development/compilers/pakcs { };
 
+  paperless-ngx-beta = callPackage ../by-name/pa/paperless-ngx/beta.nix { };
+
   paperwork = callPackage ../applications/office/paperwork/paperwork-gtk.nix { };
 
   patchutils = callPackage ../tools/text/patchutils { };


### PR DESCRIPTION
Adds the Paperless NGX 3.0.0 beta release as a new top-level derivation, alongside the existing 2.20 one

https://github.com/paperless-ngx/paperless-ngx/tree/v3.0.0-beta.rc1

Blocked on:
~~https://github.com/NixOS/nixpkgs/pull/517459~~ ~~https://github.com/NixOS/nixpkgs/pull/517460~~ ~~https://github.com/NixOS/nixpkgs/pull/517463~~ ~~https://github.com/NixOS/nixpkgs/pull/517461~~
https://github.com/NixOS/nixpkgs/pull/517473

Due to the lack of stacked diffs on github, I rebased this PR on top of all the dependencies.
The only files from the diff that this PR touches are `paperless-ngx/beta.nix` and `all-packages.nix`. See the very last two commits (all others are the PRs above)
(and paperless/package.nix to add `__structuredAttrs`)

Using it with the nixos module works as expected on my machine

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
