### PR TITLE
claude-agent-acp: build wrapper with set-default

### DIFF
--- a/pkgs/by-name/cl/claude-agent-acp/package.nix
+++ b/pkgs/by-name/cl/claude-agent-acp/package.nix
@@ -23,7 +23,7 @@ buildNpmPackage (finalAttrs: {
 
   postInstall = ''
     wrapProgram $out/bin/claude-agent-acp \
-      --prefix CLAUDE_CODE_EXECUTABLE ${lib.getExe claude-code}
+      --set-default CLAUDE_CODE_EXECUTABLE ${lib.getExe claude-code}
   '';
 
   meta = {


### PR DESCRIPTION
Updates the `wrapProgram` call in the post install script for `claude-agent-acp` to use the `--set-default` option instead of `--prefix`.

The previous script was using the wrong syntax, meaning the wrapper script did not actually include the expected environment variable definition (see `/nix/store/zxdd07alm2dikbx76nj9ashs53nq99vx-claude-agent-acp-0.32.0/bin/claude-agent-acp` from the package built on current `master`).

Additionally, because this environment variable is a single path it makes more sense to use `--set-default` rather than `--prefix`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
