### PR TITLE
home-assistant-custom-components.homematicip_local: 2.6.0 -> 2.7.3

### DIFF
--- a/pkgs/development/python-modules/aiohomematic-config/default.nix
+++ b/pkgs/development/python-modules/aiohomematic-config/default.nix
@@ -3,28 +3,31 @@
   buildPythonPackage,
   fetchFromGitHub,
   lib,
+  openccu-data,
   pydantic,
   pytest-asyncio,
+  pytest-xdist,
   pytestCheckHook,
   setuptools,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "aiohomematic-config";
-  version = "2026.4.1";
+  version = "2026.5.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "sukramj";
     repo = "aiohomematic-config";
     tag = finalAttrs.version;
-    hash = "sha256-I75OPUA/gdLdMAJU0iYYQUk54f5cQQ5UWsRQHayqpyo=";
+    hash = "sha256-uBIdBpjkEIPyuNxTEgTVc068K8UIVvdBXvwZ1MYh7rs=";
   };
 
   build-system = [ setuptools ];
 
   dependencies = [
     aiohomematic
+    openccu-data
     pydantic
   ];
 
@@ -32,6 +35,7 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [
     pytest-asyncio
+    pytest-xdist
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/aiohomematic/default.nix
+++ b/pkgs/development/python-modules/aiohomematic/default.nix
@@ -4,6 +4,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   freezegun,
+  openccu-data,
   orjson,
   pydantic,
   pydevccu,
@@ -18,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "aiohomematic";
-  version = "2026.4.6";
+  version = "2026.5.11";
   pyproject = true;
 
   disabled = pythonOlder "3.14";
@@ -27,13 +28,14 @@ buildPythonPackage rec {
     owner = "SukramJ";
     repo = "aiohomematic";
     tag = version;
-    hash = "sha256-R7hQprIAK7Xs+XpmMecAGGrAYzfBk+fQo17tkByC0Kc=";
+    hash = "sha256-Ua7/sLhL0mbZvJwx+TNfXoP+z+jE2TyCO3DqsFpPe6A=";
   };
 
   build-system = [ setuptools ];
 
   dependencies = [
     aiohttp
+    openccu-data
     orjson
     pydantic
     python-slugify

--- a/pkgs/development/python-modules/openccu-data/default.nix
+++ b/pkgs/development/python-modules/openccu-data/default.nix
@@ -1,0 +1,36 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "openccu-data";
+  version = "2026.5.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "SukramJ";
+    repo = "openccu-data";
+    tag = finalAttrs.version;
+    hash = "sha256-jJNNpBeEQ1CPZP/5ssenXSmvC7FMbUUBhG1Ty/3hGvk=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "openccu_data" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = {
+    changelog = "https://github.com/SukramJ/openccu-data/blob/${finalAttrs.src.tag}/changelog.md";
+    description = "Extract and distribute Homematic CCU/OpenCCU configuration metadata";
+    homepage = "https://github.com/SukramJ/openccu-data";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.dotlambda ];
+  };
+})

--- a/pkgs/development/python-modules/pydevccu/default.nix
+++ b/pkgs/development/python-modules/pydevccu/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pydevccu";
-  version = "0.2.3";
+  version = "0.2.4";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -21,7 +21,7 @@ buildPythonPackage (finalAttrs: {
     owner = "SukramJ";
     repo = "pydevccu";
     tag = finalAttrs.version;
-    hash = "sha256-dOk0Sb7RR21Mzke+wkhEca8HMVt7pcU5eXs/hzojFBQ=";
+    hash = "sha256-/Z1+k9CNTQsqTXSIqmUQn7r5WBTgZmqsg5Z+cq9nR3Q=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/servers/home-assistant/custom-components/homematicip_local/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/homematicip_local/package.nix
@@ -7,20 +7,22 @@
   aiohomematic-config,
   aiohomematic-test-support,
   home-assistant,
+  openccu-data,
   pytest-homeassistant-custom-component,
+  pytest-xdist,
   pytestCheckHook,
 }:
 
 buildHomeAssistantComponent rec {
   owner = "SukramJ";
   domain = "homematicip_local";
-  version = "2.6.0";
+  version = "2.7.3";
 
   src = fetchFromGitHub {
     owner = "SukramJ";
     repo = "custom_homematic";
     tag = version;
-    hash = "sha256-u3REMGuaQ+wQgDgiTvplBRMbzZJDUfcbyJm9tYOuYIw=";
+    hash = "sha256-9dXvIxMMdHTOi9JbRsHbySqRUYq6dN+MzrOocq9cpdA=";
   };
 
   postPatch = ''
@@ -33,20 +35,25 @@ buildHomeAssistantComponent rec {
   dependencies = [
     aiohomematic
     aiohomematic-config
+    openccu-data
   ];
 
   nativeCheckInputs = [
     aiohomematic-test-support
     async-upnp-client
     pytest-homeassistant-custom-component
+    pytest-xdist
     pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # tries to write to the Nix store
+    "tests/test_blueprints.py"
   ];
 
   disabledTests = [
     # custom_components.homematicip_local.support.InvalidConfig: C
     "test_async_validate_config_and_get_system_information"
-    # Failed: Lingering timer after test <TimerHandle when=3043632.864116499 Store._async_schedule_callback_delayed_write() created at /nix/store/5rh57mhaihd9wff1rqnskvs8nxh9sv3z-homeassistant-2026.6.0/lib/python3.14/site-packages/homeassistant/helpers/storage.py:516>
-    "test_reauth_flow_success"
   ];
 
   meta = {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11750,6 +11750,8 @@ self: super: with self; {
 
   opencc = callPackage ../development/python-modules/opencc { };
 
+  openccu-data = callPackage ../development/python-modules/openccu-data { };
+
   opencensus = callPackage ../development/python-modules/opencensus { };
 
   opencensus-context = callPackage ../development/python-modules/opencensus-context { };


### PR DESCRIPTION
Diff: https://github.com/SukramJ/homematicip_local/compare/2.6.0...2.7.3

Changelog: https://github.com/SukramJ/custom_homematic/blob/2.7.3/changelog.md

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
