### PR TITLE
home-assistant.python.pkgs.hass-web-proxy-lib: 0.0.7 -> 0.0.8

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/frigate/llmcontext-user-prompt.patch
+++ b/pkgs/servers/home-assistant/custom-components/frigate/llmcontext-user-prompt.patch
@@ -1,0 +1,24 @@
+From 16b8a6358fb996db0bc72fa155d9775e67f3b6de Mon Sep 17 00:00:00 2001
+From: Martin Weinelt <hexa@darmstadt.ccc.de>
+Date: Thu, 7 May 2026 03:13:53 +0200
+Subject: [PATCH] Drop user_prompt from LLMContext invocaction
+
+Dropped in 2025.7.0.
+
+Ref: home-assistant/core@059c12798de2c7b0f285cb79e60c01f4be231701
+---
+ tests/test_llm_functions.py | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/tests/test_llm_functions.py b/tests/test_llm_functions.py
+index b21154d1..c1c6e006 100644
+--- a/tests/test_llm_functions.py
++++ b/tests/test_llm_functions.py
+@@ -28,7 +28,6 @@ def _create_llm_context() -> llm.LLMContext:
+         language="en",
+         assistant=None,
+         device_id=None,
+-        user_prompt=None,
+     )
+ 
+ 

--- a/pkgs/servers/home-assistant/custom-components/frigate/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/frigate/package.nix
@@ -19,18 +19,20 @@
 buildHomeAssistantComponent rec {
   owner = "blakeblackshear";
   domain = "frigate";
-  version = "5.14.2";
+  version = "5.15.3";
 
   src = fetchFromGitHub {
     owner = "blakeblackshear";
     repo = "frigate-hass-integration";
     tag = "v${version}";
-    hash = "sha256-fgsYznTqJrEh4niyGfksnflRp1PpljrlzJBvs8gKn54=";
+    hash = "sha256-ZDTwC5dm9kAgT/pIHQAK56L2pjyf/PmOjDr0F+Fr+JA=";
   };
 
   patches = [
     # https://github.com/blakeblackshear/frigate-hass-integration/pull/1070
     ./service-to-action.patch
+    # https://github.com/blakeblackshear/frigate-hass-integration/pull/1085
+    ./llmcontext-user-prompt.patch
   ];
 
   dependencies = [

--- a/pkgs/servers/home-assistant/python-modules/hass-web-proxy-lib/default.nix
+++ b/pkgs/servers/home-assistant/python-modules/hass-web-proxy-lib/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  fetchpatch2,
 
   # build-system
   poetry-core,
@@ -24,23 +23,15 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "hass-web-proxy-lib";
-  version = "0.0.7";
+  version = "0.0.8";
   pyproject = true;
 
   # no tags on git
   src = fetchPypi {
     pname = "hass_web_proxy_lib";
     inherit (finalAttrs) version;
-    hash = "sha256-bhz71tNOpZ+4tSlndS+UbC3w2WW5+dAMtpk7TnnFpuQ=";
+    hash = "sha256-H9C8jwJeR6skvCVn8jeaWqmIL0fmcab+/BQ5SzUIt00=";
   };
-
-  patches = [
-    (fetchpatch2 {
-      name = "add-missing-build-system.patch";
-      url = "https://github.com/dermotduffy/hass-web-proxy-lib/commit/0eed7a57f503fc552948a45e7f490ddaff711896.patch";
-      hash = "sha256-ccOdhA0NhlTmdA51sNdB357Xh13E4PsLlvUTU4GQ9jk=";
-    })
-  ];
 
   build-system = [ poetry-core ];
 
@@ -53,11 +44,6 @@ buildPythonPackage (finalAttrs: {
     pytest-homeassistant-custom-component
     pytest-timeout
     pytestCheckHook
-  ];
-
-  disabledTests = [
-    # https://github.com/dermotduffy/hass-web-proxy-lib/issues/65
-    "test_proxy_view_aiohttp_read_error"
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
This is required for the frigate custom component: https://github.com/blakeblackshear/frigate-hass-integration/commit/9b258226adffde828c45c0663d4e4fab5155b0c2
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
