### PR TITLE
 python3Packages.bittensor: init at 10.5.0

### DIFF
--- a/pkgs/development/python-modules/async-substrate-interface/default.nix
+++ b/pkgs/development/python-modules/async-substrate-interface/default.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  aiosqlite,
+  cyscale,
+  websockets,
+  xxhash,
+  pytestCheckHook,
+  pytest-asyncio,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "async-substrate-interface";
+  version = "2.2.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "latent-to";
+    repo = "async-substrate-interface";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-39QL0h47ubKI26rIYxniNlchNAFEkPtKw6MyKuu2AXY=";
+  };
+
+  # On darwin the sandbox isolation is not as strict as on linux,
+  # and we can get permission erros when trying to create/delete arbitrary dirs in /tmp
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    substituteInPlace tests/unit_tests/test_types.py \
+      --replace-fail '/tmp/async-substrate-interface-test-cache' "$(mktemp -d)/cache"
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    aiosqlite
+    cyscale
+    websockets
+    xxhash
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+  ];
+
+  # these tests open a live websocket/subtensor endpoint, unavailable in the build sandbox
+  disabledTestPaths = [
+    "tests/integration_tests"
+    "tests/e2e_tests"
+    "tests/unit_tests/sync/test_block.py"
+  ];
+
+  pythonImportsCheck = [ "async_substrate_interface" ];
+
+  meta = {
+    description = "Modernised py-substrate-interface and associated utils";
+    longDescription = "This project provides an asynchronous interface for interacting with Substrate-based blockchains. It is based on the py-substrate-interface project.";
+    homepage = "https://github.com/latent-to/async-substrate-interface";
+    changelog = "https://github.com/latent-to/async-substrate-interface/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kilyanni ];
+  };
+})

--- a/pkgs/development/python-modules/bittensor-cli/default.nix
+++ b/pkgs/development/python-modules/bittensor-cli/default.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  flit-core,
+  aiohttp,
+  async-substrate-interface,
+  backoff,
+  bittensor-drand,
+  bittensor-wallet,
+  cyscale,
+  gitpython,
+  jinja2,
+  netaddr,
+  numpy,
+  packaging,
+  plotille,
+  plotly,
+  pycryptodome,
+  pyyaml,
+  rich,
+  typer,
+  pytestCheckHook,
+  pytest-asyncio,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "bittensor-cli";
+  version = "9.23.1";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "latent-to";
+    repo = "btcli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rwPYuDfRi3L1BvNN+MoqJlJjyp/vyK7/p6iyB7RJ9Wk=";
+  };
+
+  build-system = [ flit-core ];
+
+  dependencies = [
+    aiohttp
+    async-substrate-interface
+    backoff
+    bittensor-drand
+    bittensor-wallet
+    cyscale
+    gitpython
+    jinja2
+    netaddr
+    numpy
+    packaging
+    plotille
+    plotly
+    pycryptodome
+    pyyaml
+    rich
+    typer
+  ];
+
+  pythonRelaxDeps = [
+    "rich"
+    "typer"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+  ];
+
+  # e2e tests require a running subtensor node
+  disabledTestPaths = [ "tests/e2e_tests" ];
+
+  pythonImportsCheck = [ "bittensor_cli" ];
+
+  meta = {
+    description = "Bittensor command line tool";
+    homepage = "https://github.com/latent-to/btcli";
+    changelog = "https://github.com/latent-to/btcli/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kilyanni ];
+    mainProgram = "btcli";
+  };
+})

--- a/pkgs/development/python-modules/bittensor/default.nix
+++ b/pkgs/development/python-modules/bittensor/default.nix
@@ -1,0 +1,144 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  aiohttp,
+  aioresponses,
+  async-substrate-interface,
+  asyncstdlib,
+  bittensor-drand,
+  bittensor-wallet,
+  colorama,
+  cyscale,
+  fastapi,
+  msgpack-numpy-opentensor,
+  netaddr,
+  numpy,
+  packaging,
+  pycryptodome,
+  pydantic,
+  python-statemachine,
+  pyyaml,
+  requests,
+  retry,
+  uvicorn,
+  freezegun,
+  httpx,
+  hypothesis,
+  pytest-mock,
+  pytestCheckHook,
+  pytest-asyncio,
+  writableTmpDirAsHomeHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "bittensor";
+  version = "10.5.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "latent-to";
+    repo = "bittensor";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-4oP0QIrKoxNKJWKpO1Ns4Z3O+e8XniVL9ONwr934Q7k=";
+  };
+
+  # python-statemachine >= 3.1 stores its active-state Configuration on `self._config`,
+  # which collides with LoggingMachine's logging-config attribute of the same name and
+  # breaks import ("'NoneType' object is not iterable"). Rename the latter. Drop once
+  # upstream relaxes/supports python-statemachine 3.x.
+  postPatch = ''
+    substituteInPlace bittensor/utils/btlogging/loggingmachine.py \
+      --replace-fail 'self._config = ' 'self._logging_config = ' \
+      --replace-fail 'self._config.' 'self._logging_config.' \
+      --replace-fail '(self._config)' '(self._logging_config)' \
+      --replace-fail 'return self._config' 'return self._logging_config'
+  '';
+
+  build-system = [ setuptools ];
+
+  pythonRelaxDeps = [
+    "asyncstdlib"
+    "python-statemachine"
+  ];
+
+  dependencies = [
+    aiohttp
+    async-substrate-interface
+    asyncstdlib
+    bittensor-drand
+    bittensor-wallet
+    colorama
+    cyscale
+    fastapi
+    msgpack-numpy-opentensor
+    netaddr
+    numpy
+    packaging
+    pycryptodome
+    pydantic
+    python-statemachine
+    pyyaml
+    requests
+    retry
+    uvicorn
+  ];
+
+  nativeBuildInputs = [
+    # bittensor/core/settings.py calls Path.home().mkdir() at import time.
+    # This is also hit by pythonImportsCheck when doCheck = false, so this does not go in nativeCheckInputs
+    writableTmpDirAsHomeHook
+  ];
+
+  nativeCheckInputs = [
+    aioresponses
+    freezegun
+    httpx
+    hypothesis
+    pytest-mock
+    pytestCheckHook
+    pytest-asyncio
+  ];
+
+  # integration/e2e tests require a live subtensor node; torch tests require optional dep
+  disabledTestPaths = [
+    "tests/e2e_tests"
+    "tests/integration_tests"
+    "tests/unit_tests/test_chain_data.py"
+    "tests/unit_tests/test_tensor.py"
+    "tests/unit_tests/utils/test_weight_utils.py"
+  ];
+
+  disabledTests = [
+    # requires torch, which would be a very large dependency to pull in for one test
+    "test_lazy_loaded_torch__torch_installed"
+    # requires network
+    "test__methods_comparable_with_passed_legacy_methods"
+    # issues with sandbox
+    "test_sync_warning_cases"
+    # statemachine 3.0 emits extra internal debug logs not expected by the test which expect an older version
+    "test_all_log_levels_output"
+    # Broken wiith aiohttp 3.13, can be re-enabled once https://github.com/NixOS/nixpkgs/pull/526853 hits master
+    "test_dendrite__call__success_response"
+    "test_dendrite__call__handles_http_error_response"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # This test requires local networking, yet this gets
+    # blocked by the sandbox even with `__darwinAllowLocalNetworking`
+    "test_threaded_fastapi"
+  ];
+
+  pythonImportsCheck = [ "bittensor" ];
+
+  meta = {
+    description = "Bittensor SDK";
+    homepage = "https://github.com/latent-to/bittensor";
+    changelog = "https://github.com/latent-to/bittensor/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kilyanni ];
+  };
+})

--- a/pkgs/development/python-modules/msgpack-numpy-opentensor/default.nix
+++ b/pkgs/development/python-modules/msgpack-numpy-opentensor/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  msgpack,
+  numpy,
+  python,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "msgpack-numpy-opentensor";
+  version = "0.5.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  # The GitHub repo does not tag the same releases as PyPi, so we use PyPi directly instead.
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-ITIywg4u/VKOyKmIK2Beith8/DW1ffz+/gXTOqqr5XQ=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    msgpack
+    numpy
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    ${python.interpreter} tests.py
+
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "Numpy data serialization using msgpack (opentensor fork)";
+    homepage = "https://github.com/opentensor/msgpack-numpy";
+    changelog = "https://pypi.org/project/msgpack-numpy-opentensor/${finalAttrs.version}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ kilyanni ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -967,6 +967,8 @@ with pkgs;
 
   auditwheel = with python3Packages; toPythonApplication auditwheel;
 
+  btcli = with python3Packages; toPythonApplication bittensor-cli;
+
   btrsync = with python3Packages; toPythonApplication btrsync;
 
   davinci-resolve-studio = callPackage ../by-name/da/davinci-resolve/package.nix {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2192,6 +2192,8 @@ self: super: with self; {
 
   bitstruct = callPackage ../development/python-modules/bitstruct { };
 
+  bittensor = callPackage ../development/python-modules/bittensor { };
+
   bittensor-cli = callPackage ../development/python-modules/bittensor-cli { };
 
   bittensor-drand = callPackage ../development/python-modules/bittensor-drand { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2192,6 +2192,8 @@ self: super: with self; {
 
   bitstruct = callPackage ../development/python-modules/bitstruct { };
 
+  bittensor-cli = callPackage ../development/python-modules/bittensor-cli { };
+
   bittensor-drand = callPackage ../development/python-modules/bittensor-drand { };
 
   bittensor-wallet = callPackage ../development/python-modules/bittensor-wallet { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1208,6 +1208,8 @@ self: super: with self; {
 
   async-stagger = callPackage ../development/python-modules/async-stagger { };
 
+  async-substrate-interface = callPackage ../development/python-modules/async-substrate-interface { };
+
   async-tiff = callPackage ../development/python-modules/async-tiff { };
 
   async-timeout = callPackage ../development/python-modules/async-timeout { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10617,6 +10617,8 @@ self: super: with self; {
 
   msgpack-numpy = callPackage ../development/python-modules/msgpack-numpy { };
 
+  msgpack-numpy-opentensor = callPackage ../development/python-modules/msgpack-numpy-opentensor { };
+
   msgraph-core = callPackage ../development/python-modules/msgraph-core { };
 
   msgraph-sdk = callPackage ../development/python-modules/msgraph-sdk { };


### PR DESCRIPTION
Adds the [Bittensor SDK](https://github.com/latent-to/bittensor), the core library for interacting with the Bittensor network.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
