### PR TITLE
octodns-providers.porkbun: init at 0.1.0

### DIFF
--- a/pkgs/by-name/oc/octodns/providers/porkbun/package.nix
+++ b/pkgs/by-name/oc/octodns/providers/porkbun/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  uv-build,
+  octodns,
+  oinker,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "octodns-porkbun";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "major";
+    repo = finalAttrs.pname;
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-RDYP0hF8nnG8lzeaWxfLXiG+mNDt+wf7yDfNMl6kDE0=";
+  };
+
+  build-system = [ uv-build ];
+
+  dependencies = [
+    octodns
+    oinker
+  ];
+
+  pythonImportsCheck = [ (lib.replaceStrings [ "-" ] [ "_" ] finalAttrs.pname) ];
+
+  meta = {
+    description = "Porkbun DNS provider for octoDNS";
+    homepage = "https://github.com/major/${finalAttrs.pname}";
+    changelog = "https://github.com/major/${finalAttrs.pname}/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ philocalyst ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/oc/octodns/providers/porkbun/package.nix
+++ b/pkgs/by-name/oc/octodns/providers/porkbun/package.nix
@@ -2,9 +2,12 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  uv-build,
   octodns,
   oinker,
+  pytest-cov-stub,
+  pytest-randomly,
+  pytestCheckHook,
+  uv-build,
 }:
 buildPythonPackage (finalAttrs: {
   pname = "octodns-porkbun";
@@ -23,6 +26,12 @@ buildPythonPackage (finalAttrs: {
   dependencies = [
     octodns
     oinker
+  ];
+
+  nativeCheckInputs = [
+    pytest-cov-stub
+    pytest-randomly
+    pytestCheckHook
   ];
 
   pythonImportsCheck = [ "octodns_porkbun" ];

--- a/pkgs/by-name/oc/octodns/providers/porkbun/package.nix
+++ b/pkgs/by-name/oc/octodns/providers/porkbun/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  uv-build,
+  octodns,
+  oinker,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "octodns-porkbun";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "major";
+    repo = "octodns-porkbun";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-RDYP0hF8nnG8lzeaWxfLXiG+mNDt+wf7yDfNMl6kDE0=";
+  };
+
+  build-system = [ uv-build ];
+
+  dependencies = [
+    octodns
+    oinker
+  ];
+
+  pythonImportsCheck = [ "octodns_porkbun" ];
+
+  meta = {
+    description = "Porkbun DNS provider for octoDNS";
+    homepage = "https://github.com/major/octodns-porkbun";
+    changelog = "https://github.com/major/octodns-porkbun/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ philocalyst ];
+    platforms = lib.platforms.all;
+    teams = [ lib.teams.octodns ];
+  };
+})

--- a/pkgs/development/python-modules/oinker/default.nix
+++ b/pkgs/development/python-modules/oinker/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  httpx,
+  uv-build,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "oinker";
+  version = "0.1.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "major";
+    repo = finalAttrs.pname;
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jDQKTllteOL30mY089URl/36hY3f5KzSFPNubqnd0d8=";
+  };
+
+  build-system = [ uv-build ];
+
+  dependencies = [ httpx ];
+
+  pythonImportsCheck = [ finalAttrs.pname ];
+
+  meta = {
+    description = "Pythonic client library for Porkbun DNS";
+    mainProgram = finalAttrs.pname;
+    homepage = "https://major.github.io/oinker";
+    changelog = "https://github.com/major/${finalAttrs.pname}/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ philocalyst ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/development/python-modules/oinker/default.nix
+++ b/pkgs/development/python-modules/oinker/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  httpx,
+  uv-build,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "oinker";
+  version = "0.1.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "major";
+    repo = "oinker";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jDQKTllteOL30mY089URl/36hY3f5KzSFPNubqnd0d8=";
+  };
+
+  build-system = [ uv-build ];
+
+  dependencies = [ httpx ];
+
+  pythonImportsCheck = [ "oinker" ];
+
+  meta = {
+    description = "Pythonic client library for Porkbun DNS";
+    mainProgram = "oinker";
+    homepage = "https://major.github.io/oinker";
+    changelog = "https://github.com/major/oinker/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ philocalyst ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/development/python-modules/oinker/default.nix
+++ b/pkgs/development/python-modules/oinker/default.nix
@@ -3,6 +3,9 @@
   buildPythonPackage,
   fetchFromGitHub,
   httpx,
+  pytest-asyncio,
+  pytest-cov-stub,
+  pytestCheckHook,
   uv-build,
 }:
 buildPythonPackage (finalAttrs: {
@@ -20,6 +23,12 @@ buildPythonPackage (finalAttrs: {
   build-system = [ uv-build ];
 
   dependencies = [ httpx ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-cov-stub
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [ "oinker" ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11427,6 +11427,8 @@ self: super: with self; {
 
   oic = callPackage ../development/python-modules/oic { };
 
+  oinker = callPackage ../development/python-modules/oinker { };
+
   okonomiyaki = callPackage ../development/python-modules/okonomiyaki { };
 
   okta = callPackage ../development/python-modules/okta { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- Brought octodns to porkbun (or vice-versa?)
- I use porkbun so this is nice to have
- Have been using for my own config quite nicely yo

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
