### PR TITLE
homebridge: 2.0.0 -> 2.0.1

### DIFF
--- a/pkgs/by-name/ho/homebridge/package.nix
+++ b/pkgs/by-name/ho/homebridge/package.nix
@@ -2,29 +2,20 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
-  jq,
 }:
 
 buildNpmPackage (finalAttrs: {
   pname = "homebridge";
-  version = "2.0.0";
+  version = "2.0.1";
 
   src = fetchFromGitHub {
     owner = "homebridge";
     repo = "homebridge";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-KRDeS9qYefdafGpX8RF68ce6uSlS22aIRqJimmhI8Ko=";
+    hash = "sha256-JHeyyPh2ePIrUhqfo1Cb4pNf+lB3ldE6NR0OunbLuKk=";
   };
 
-  npmDepsHash = "sha256-CkizIWaHzmotAr/64yY2wKAtqFoBdr5ylN5WcgdpMis=";
-
-  # Homebridge's clean phase attempts to install rimraf directly, which fails in nix builds
-  # rimraf is already in the declared dependencies, so we just don't need to do it.
-  # This will replace "npm install rimraf && rimraf lib/" with "rimraf lib/".
-  preBuild = ''
-    cat package.json | ${jq}/bin/jq '.scripts.clean = "rimraf lib/"' > package.json.tmp
-    mv package.json.tmp package.json
-  '';
+  npmDepsHash = "sha256-zJ9WPnhtC0rnyT5dqPfC/eg+TRlKlDDQW3XYx67pl5s=";
 
   meta = {
     description = "Lightweight emulator of iOS HomeKit API";


### PR DESCRIPTION
Updating homebridge-config-ui-x from 2.0.0 to 2.0.1.

Changelog can be found here: [homebridge/homebridge/releases](https://github.com/homebridge/homebridge/releases)

Also, removed the preBuild phase, as the package.json was fixed upstream.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
