### PR TITLE
crosvm: enable gfxstream cargo feature

### DIFF
--- a/pkgs/by-name/cr/crosvm/package.nix
+++ b/pkgs/by-name/cr/crosvm/package.nix
@@ -6,6 +6,8 @@
   protobuf,
   python3,
   wayland-scanner,
+  aemu,
+  gfxstream,
   libcap,
   libdrm,
   libepoxy,
@@ -43,6 +45,8 @@ rustPlatform.buildRustPackage {
   ];
 
   buildInputs = [
+    aemu
+    gfxstream
     libcap
     libdrm
     libepoxy
@@ -59,7 +63,10 @@ rustPlatform.buildRustPackage {
   CROSVM_USE_SYSTEM_MINIGBM = true;
   CROSVM_USE_SYSTEM_VIRGLRENDERER = true;
 
-  buildFeatures = [ "virgl_renderer" ];
+  buildFeatures = [
+    "virgl_renderer"
+    "gfxstream"
+  ];
 
   passthru = {
     updateScript = writeShellScript "update-crosvm.sh" ''


### PR DESCRIPTION
## Summary

Enables the `gfxstream` cargo feature on `crosvm` alongside the existing `virgl_renderer`. This wires the rutabaga gfxstream backend into the binary, so VMs can use the `gfxstream` context type — needed for guest Vulkan via `RUTABAGA_CAPSET_GFXSTREAM_VULKAN`. The `virgl_renderer` backend (OpenGL/GLES) remains enabled.

The pkg-config dependencies rutabaga's `build.rs` probes — `gfxstream_backend` and `aemu_base`/`aemu_host_common`/`aemu_logging`/`aemu_snapshot` — are already packaged in nixpkgs (`pkgs/by-name/gf/gfxstream/` and `pkgs/by-name/ae/aemu/`, both at `0.1.2`, both maintained by @qyliss). This change just adds them to `buildInputs` and appends `"gfxstream"` to `buildFeatures`.

Verified locally:

- `nix build .#crosvm` succeeds; cargo tests pass
- `ldd $out/bin/crosvm` shows `libgfxstream_backend.so.0` linked alongside `libvirglrenderer.so.1`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. (nixpkgs-review-gha dispatched; will update once it concludes.)
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.