### PR TITLE
kati: 2019-09-23 -> 0-unstable-2026-02-12

### DIFF
--- a/pkgs/by-name/ka/kati/package.nix
+++ b/pkgs/by-name/ka/kati/package.nix
@@ -2,20 +2,25 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  replaceVars,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "kati-unstable";
-  version = "2019-09-23";
+  version = "0-unstable-2026-02-12";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "kati";
-    rev = "9da3296746a0cd55b38ebebf91e7f57105a4c36f";
-    sha256 = "0s5dfhgpcbx12b1fqmm8p0jpvrhgrnl9qywv1ksbwhw3pfp7j866";
+    rev = "985493689b70e28970952bde44ac2a8433257b5e";
+    sha256 = "sha256-fn+eA/TBmiyQYeUQvviL/zc9qxUYfW1BaeqNCILsk+w=";
   };
 
-  patches = [ ./version.patch ];
+  patches = [
+    (replaceVars ./version.patch {
+      version = finalAttrs.src.rev;
+    })
+  ];
 
   installPhase = ''
     install -D ckati $out/bin/ckati
@@ -29,4 +34,4 @@ stdenv.mkDerivation {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ danielfullmer ];
   };
-}
+})

--- a/pkgs/by-name/ka/kati/version.patch
+++ b/pkgs/by-name/ka/kati/version.patch
@@ -1,19 +1,22 @@
 diff --git a/Makefile.ckati b/Makefile.ckati
-index e4067bb..15518f3 100644
+index d585106..7e15d08 100644
 --- a/Makefile.ckati
 +++ b/Makefile.ckati
-@@ -102,14 +102,8 @@ $(KATI_CXX_TEST_EXES): $(KATI_BIN_PATH)/%: $(KATI_INTERMEDIATES_PATH)/%.o
+@@ -101,16 +101,8 @@ $(KATI_CXX_TEST_EXES): $(KATI_BIN_PATH)/%: $(KATI_INTERMEDIATES_PATH)/%.o
  	$(KATI_LD) $^ -o $@ $(KATI_LIBS)
  
  # Rule to generate version.cc
--KATI_GIT_DIR := $(shell git -C $(KATI_SRC_PATH) rev-parse --show-toplevel)
+-KATI_GIT_DIR := $(shell cd $(KATI_SRC_PATH); realpath `git rev-parse --git-dir`)
+ KATI_VERSION_DEPS :=
 -ifneq ($(KATI_GIT_DIR),)
--KATI_VERSION_DEPS := $(KATI_GIT_DIR)/.git/HEAD $(KATI_GIT_DIR)/.git/index
+-KATI_VERSION_DEPS := $(wildcard $(KATI_GIT_DIR)/HEAD $(KATI_GIT_DIR)/index)
+-endif
+-ifneq ($(KATI_VERSION_DEPS),)
 -KATI_VERSION := $(shell git -C $(KATI_GIT_DIR) rev-parse HEAD)
 -else
- KATI_VERSION_DEPS :=
- KATI_VERSION := unknown
+-KATI_VERSION := unknown
 -endif
++KATI_VERSION := @version@
  $(KATI_INTERMEDIATES_PATH)/version.cc: $(KATI_VERSION_DEPS)
  	@mkdir -p $(dir $@)
  	echo '// +build ignore' > $@


### PR DESCRIPTION
- #475479 
- #516381 
- https://hydra.nixos.org/build/324244536
- Diff: https://github.com/google/kati/compare/9da3296746a0cd55b38ebebf91e7f57105a4c36f...985493689b70e28970952bde44ac2a8433257b5e

```
exec.cc:129:3: error: 'uint64_t' does not name a type
  129 |   uint64_t Count() { return num_commands_; }
      |   ^~~~~~~~
exec.cc:39:1: note: 'uint64_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
   38 | #include "var.h"
  +++ |+#include <cstdint>
   39 | 
exec.cc:136:3: error: 'uint64_t' does not name a type
  136 |   uint64_t num_commands_;
      |   ^~~~~~~~
exec.cc:136:3: note: 'uint64_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
exec.cc: In constructor '{anonymous}::Executor::Executor(Evaluator*)':
exec.cc:47:47: error: class '{anonymous}::Executor' does not have any field named 'num_commands_'
   47 |   explicit Executor(Evaluator* ev) : ce_(ev), num_commands_(0) {
      |                                               ^~~~~~~~~~~~~
exec.cc: In member function 'double {anonymous}::Executor::ExecNode(DepNode*, DepNode*)':
exec.cc:101:7: error: 'num_commands_' was not declared in this scope; did you mean 'commands'?
  101 |       num_commands_ += 1;
      |       ^~~~~~~~~~~~~
      |       commands
exec.cc: In function 'void Exec(const std::vector<std::pair<Symbol, DepNode*> >&, Evaluator*)':
exec.cc:146:17: error: 'class {anonymous}::Executor' has no member named 'Count'
  146 |   if (executor->Count() == 0) {
      |                 ^~~~~
```

Updated to latest git commit. Seems to fix the compilation problems. Also changed the version patch to properly inject git revision instead of filling "unknown".

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
