### PR TITLE
z13ctl: init at 1.1.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2921,6 +2921,12 @@
     githubId = 2806307;
     keys = [ { fingerprint = "00F4 21C4 C537 7BA3 9820 E13F 6B95 E13D E469 CC5D"; } ];
   };
+  badheuristic = {
+    email = "steveoncaffeine@gmail.com";
+    github = "badheuristic";
+    githubId = 233336560;
+    name = "Stephen Adebambo";
+  };
   badmutex = {
     email = "github@badi.sh";
     github = "badmutex";

--- a/pkgs/by-name/z1/z13ctl/package.nix
+++ b/pkgs/by-name/z1/z13ctl/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "z13ctl";
+  version = "1.1.6";
+
+  src = fetchFromGitHub {
+    owner = "dahui";
+    repo = "z13ctl";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-21mdAzbw8JISDLG7iSEI4VCephDTtbioN0/RRxvCLR8=";
+  };
+
+  vendorHash = "sha256-ftkcianIR36PNAoMOVuk4lUr7goWUcHhjyNseUraJU0=";
+
+  subPackages = [ "." ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/dahui/z13ctl/cmd.Version=${finalAttrs.version}"
+  ];
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Utility for ASUS ROG Flow Z13 (2025)";
+    homepage = "https://github.com/dahui/z13ctl";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    mainProgram = "z13ctl";
+    maintainers = with lib.maintainers; [ badheuristic ];
+  };
+})


### PR DESCRIPTION
### Summary
This PR adds `z13ctl`, a specialized utility for the 2025 ASUS ROG Flow Z13 (GZ302). It provides high-level control over hardware features that are otherwise difficult to manage on Linux for this specific model.

Features included:
- TDP power limits and custom Fan curves via `asus-wmi`.
- Keyboard and Lightbar RGB control via hidraw.
- Battery charge limits and BIOS attributes (boot sound, panel overdrive).
- CPU Curve Optimizer (undervolting) support via `ryzen_smu`.

Homepage: https://github.com/dahui/z13ctl

### Things done
- [x] Built on platform: x86_64-linux
- [x] Tested basic functionality of all binary files in `./result/bin/`
- [x] Verified hardware communication (fans/TDP/RGB) on a 2025 GZ302 device.
- [x] Follows `pkgs/by-name` structure.
- [x] Added myself (`badheuristic`) to `maintainers/maintainer-list.nix`.
