### PR TITLE
buildFHSEnv: fix substring match incorrectly skipping host directories

### DIFF
--- a/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
@@ -222,9 +222,14 @@ let
         ro_mounts+=(--ro-bind /etc /.host-etc)
       fi
 
+      declare -A etc_ignored_set
+      for ign in "''${etc_ignored[@]}"; do
+        etc_ignored_set[$ign]=1
+      done
+
       # link selected etc entries from the actual root
       for i in ${escapeShellArgs etcBindEntries}; do
-        if [[ "''${etc_ignored[@]}" =~ "$i" ]]; then
+        if [[ -n "''${etc_ignored_set[$i]:-}" ]]; then
           continue
         fi
         if [[ -e $i ]]; then
@@ -232,11 +237,21 @@ let
         fi
       done
 
+      declare -A ignored_set
+      for ign in "''${ignored[@]}"; do
+        ignored_set[$ign]=1
+      done
+
       declare -a auto_mounts
       # loop through all directories in the root
       for dir in /*; do
-        # if it is a directory and it is not ignored
-        if [[ -d "$dir" ]] && [[ ! "''${ignored[@]}" =~ "$dir" ]]; then
+        # if it is a directory and not already provided by the FHS env or
+        # explicitly ignored, bind-mount it into the chroot. Use exact match
+        # via associative array because regex substring matching incorrectly
+        # skips prefixes (e.g. /sb would match /sbin and never get mounted,
+        # breaking --chdir when CWD is on a custom mount like /sb/project).
+        # https://github.com/NixOS/nixpkgs/issues/241151
+        if [[ -d "$dir" ]] && [[ -z "''${ignored_set[$dir]:-}" ]]; then
           # add it to the mount list
           auto_mounts+=(--bind "$dir" "$dir")
         fi


### PR DESCRIPTION
The auto-mount loop in `buildFHSEnv` (bubblewrap variant) uses `[[ ! "${ignored[@]}" =~ "$dir" ]]` to decide which top-level host directories to bind into the chroot. Bash's `=~` does substring matching, so `/sb` matches `/sbin` in the ignored array and gets silently skipped. The result: `bwrap --chdir /sb/project` fails with `bwrap: can't chdir to $PWD: no such file or directory` because `/sb` was never mounted.

This affects any top-level directory whose name is a prefix of an FHS path: `/sb`, `/u`, `/li`, `/ho`, `/v`, `/r`, `/s`, etc. The bug has been latent since the auto-mount loop was added.

Fixed by switching to an associative array for exact-match lookups. Same fix applied to the `etc_ignored` loop, which had the same bug pattern.

Fixes #241151

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
