### PR TITLE
gen6dns: fix build with gcc15

### DIFF
--- a/pkgs/by-name/ge/gen6dns/fix-gcc15.patch
+++ b/pkgs/by-name/ge/gen6dns/fix-gcc15.patch
@@ -1,0 +1,24 @@
+diff --git a/parse.c b/parse.c
+index d4bb28b..90a307d 100644
+--- a/parse.c
++++ b/parse.c
+@@ -43,7 +43,7 @@ static	int	parsehostline (const char *line, host_t *h, ip6_t *hid, ip6_t *sid, c
+ static	int	parseextralines (FILE *fp, int *lnrp, char *extra_rr, size_t len);
+ static	void	dumphostline (FILE *fp, const host_t *host, const ip6_t *hid, const ip6_t *sid, const char *scope);
+ 
+-int	parsefile (const char *fname, FILE *outfp, int (*genfunc)())
++int	parsefile (const char *fname, FILE *outfp, int (*genfunc)(int type, const ip6_t *prfx, const scope_t *scope, const host_t *host, const ip6_t *hid, ip6_t *sid, const char *extra_rr))
+ {
+ 	char	extra_rr[MAXEXTRARR+1];
+ 	char	line[MAXLINE+1];
+diff --git a/parse.h b/parse.h
+index 10e7997..fbb452d 100644
+--- a/parse.h
++++ b/parse.h
+@@ -7,5 +7,5 @@
+ # define	MAXLINE		511
+ # define	MAXEXTRARR	(3*MAXLINE)
+ 
+-extern	int	parsefile (const char *fname, FILE *outfp, int (*genfunc)());
++extern	int	parsefile (const char *fname, FILE *outfp, int (*genfunc)(int type, const ip6_t *prfx, const scope_t *scope, const host_t *host, const ip6_t *hid, ip6_t *sid, const char *extra_rr));
+ #endif

--- a/pkgs/by-name/ge/gen6dns/package.nix
+++ b/pkgs/by-name/ge/gen6dns/package.nix
@@ -14,6 +14,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-MhYfgzbGPmrhPx89EpObrEkxaII7uz4TbWXeEGF7Xws=";
   };
 
+  patches = [
+    ./fix-gcc15.patch
+  ];
+
   nativeBuildInputs = [ installShellFiles ];
 
   preInstall = ''


### PR DESCRIPTION
- #475479 
- #516381
- https://hydra.nixos.org/build/324220031

```
gen6dns.c: In function 'main':
gen6dns.c:336:44: error: passing argument 3 of 'parsefile' from incompatible pointer type [-Wincompatible-pointer-types]
  336 |                 parsefile ("stdin", outfp, gen_dns);
      |                                            ^~~~~~~
      |                                            |
      |                                            int (*)(int,  const ip6_t *, const scope_t *, const host_t *, const ip6_t *, ip6_t *, const char *)
In file included from gen6dns.c:28:
parse.h:10:66: note: expected 'int (*)(void)' but argument is of type 'int (*)(int,  const ip6_t *, const scope_t *, const host_t *, const ip6_t *, ip6_t *, const char *)'
   10 | extern  int     parsefile (const char *fname, FILE *outfp, int (*genfunc)());
      |                                                            ~~~~~~^~~~~~~~~~
gen6dns.c:109:17: note: 'gen_dns' declared here
  109 | static  int     gen_dns (int type, const ip6_t *prfx, const scope_t *scope, const host_t *host, const ip6_t *hid, ip6_t *sid, const char *extra_rr);
      |                 ^~~~~~~
gen6dns.c:340:52: error: passing argument 3 of 'parsefile' from incompatible pointer type [-Wincompatible-pointer-types]
  340 |                         parsefile (*argv++, outfp, gen_dns);
      |                                                    ^~~~~~~
      |                                                    |
      |                                                    int (*)(int,  const ip6_t *, const scope_t *, const host_t *, const ip6_t *, ip6_t *, const char *)
parse.h:10:66: note: expected 'int (*)(void)' but argument is of type 'int (*)(int,  const ip6_t *, const scope_t *, const host_t *, const ip6_t *, ip6_t *, const char *)'
   10 | extern  int     parsefile (const char *fname, FILE *outfp, int (*genfunc)());
      |                                                            ~~~~~~^~~~~~~~~~
gen6dns.c:109:17: note: 'gen_dns' declared here
  109 | static  int     gen_dns (int type, const ip6_t *prfx, const scope_t *scope, const host_t *host, const ip6_t *hid, ip6_t *sid, const char *extra_rr);
      |                 ^~~~~~~
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
