### PR TITLE
asha-pipewire-sink: 0-unstable-2024-10-22 -> 0-unstable-2025-05-20

### DIFF
--- a/pkgs/by-name/as/asha-pipewire-sink/package.nix
+++ b/pkgs/by-name/as/asha-pipewire-sink/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation {
   pname = "asha-pipewire-sink";
-  version = "0-unstable-2024-10-22";
+  version = "0-unstable-2025-05-20";
 
   src = fetchFromGitHub {
     owner = "thewierdnut";
     repo = "asha_pipewire_sink";
-    rev = "bbf665b9a3b90fcdbaeb092799ea3c5ba4347e31";
-    hash = "sha256-PuJ6lBV7s5OqGe1X4wD7T+8LVMCFpgvM1pnMjXYr8gs=";
+    rev = "16a9c1cfba2d9aaa2cedbd86b4aa4f8e556736ae";
+    hash = "sha256-9nfcFB37rBvgu0usySxovbxwQLrGCKDg6dk5kBU50C4=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/326953359)](https://hydra.nixos.org/build/326953359)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test