### PR TITLE
[25.11] redis: 8.2.3 -> 8.6.3, adopt

### DIFF
--- a/pkgs/by-name/re/redis/package.nix
+++ b/pkgs/by-name/re/redis/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   fetchpatch2,
+  apple-sdk,
   lua,
   jemalloc,
   pkg-config,
@@ -26,19 +27,33 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "redis";
-  version = "8.2.3";
+  version = "8.6.3";
 
   src = fetchFromGitHub {
     owner = "redis";
     repo = "redis";
     tag = finalAttrs.version;
-    hash = "sha256-PsTAo92Vz+LNxOsbI9VVnx+rHFm67a3bBMeDcLdhXFA=";
+    hash = "sha256-Zg2bghU4uExwI1SWplYIGCeGRhgRxdh3Oy9k1DZPado=";
   };
 
   patches = lib.optional useSystemJemalloc (fetchpatch2 {
     url = "https://gitlab.archlinux.org/archlinux/packaging/packages/redis/-/raw/102cc861713c796756abd541bf341a4512eb06e6/redis-5.0-use-system-jemalloc.patch";
     hash = "sha256-A9qp+PWQRuNy/xmv9KLM7/XAyL7Tzkyn0scpVCGngcc=";
   });
+
+  postPatch = ''
+    # Using `yes` seems to be an invalid value and causes the test to fail. See
+    # https://github.com/redis/redis/blob/bd3b38d41070b478c58bc8b72d2af89cbccd1a40/redis.conf#L674-L688
+    substituteInPlace tests/integration/replication.tcl \
+      --replace-fail 'repl-diskless-load yes' ' repl-diskless-load on-empty-db'
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # The path `/Library/...` isn't available in the build sandbox. The package `apple-sdk`
+    # can provide that functionality for us.
+    substituteInPlace src/modules/Makefile modules/vector-sets/Makefile tests/modules/Makefile \
+      --replace-fail '/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib' \
+        '${apple-sdk.sdkroot}/usr/lib'
+  '';
 
   nativeBuildInputs = [
     pkg-config
@@ -82,7 +97,7 @@ stdenv.mkDerivation (finalAttrs: {
     # disable test "Connect multiple replicas at the same time": even
     # upstream find this test too timing-sensitive
     substituteInPlace tests/integration/replication.tcl \
-      --replace-fail 'foreach sdl {disabled swapdb} {' 'foreach sdl {} {'
+      --replace-fail 'foreach sdl {disabled swapdb flushdb} {' 'foreach sdl {} {'
 
     substituteInPlace tests/support/server.tcl \
       --replace-fail 'exec /usr/bin/env' 'exec env'
@@ -105,6 +120,7 @@ stdenv.mkDerivation (finalAttrs: {
       --skipunit integration/aof-multi-part \
       --skipunit integration/failover \
       --skipunit integration/replication-rdbchannel \
+      --skipunit unit/cluster/atomic-slot-migration \
       --skiptest "Check MEMORY USAGE for embedded key strings with jemalloc"
       # ^ breaks due to unexpected and varying address space sizes that jemalloc gets built with
 

--- a/pkgs/by-name/re/redis/package.nix
+++ b/pkgs/by-name/re/redis/package.nix
@@ -144,9 +144,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.agpl3Only;
     platforms = lib.platforms.all;
     changelog = "https://github.com/redis/redis/releases/tag/${finalAttrs.version}";
-    maintainers = with lib.maintainers; [
-      globin
-    ];
+    maintainers = with lib.maintainers; [ hythera ];
     mainProgram = "redis-cli";
   };
 })


### PR DESCRIPTION
Backports #508449
Backports #468656 (partially)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
