### PR TITLE
stdenv/check-meta: avoid running platformMatch if we can help it

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -125,7 +125,11 @@ let
   # Logical inversion of meta.availableOn for hostPlatform
   hasUnsupportedPlatform =
     let
-      anyHostPlatform = any (platformMatch hostPlatform);
+      inherit (hostPlatform) system;
+      # in almost all cases, meta.platforms is a simple list of strings, and we
+      # can just check if it contains the current system. we only run the more
+      # intensive platformMatch if necessary
+      anyHostPlatform = list: elem system list || any (platformMatch hostPlatform) list;
     in
     pkg:
     pkg ? meta.platforms && !(anyHostPlatform pkg.meta.platforms)


### PR DESCRIPTION
Ran a `NIX_COUNT_CALLS` and found that `matchAttrs` was one of the most used functions. Taking a look at its usages, we can avoid entering `platformMatch` in almost all cases. Gives me a nice stats diff for `pkgs.hello`:
```json
{
  "attrset": {
    "lookups": "-4.14%",
    "merges": null,
    "mergeCopies": null
  },
  "list": {
    "concats": null
  },
  "parser": {
    "expressions": null
  },
  "memory": {
    "envs": "-2.69%",
    "list": null,
    "sets": null,
    "symbols": null,
    "values": false,
    "total": "-0.18%"
  },
  "speed": {
    "primops": "-5.06%",
    "functionCalls": "-3.81%",
    "thunksMade": "+0%",
    "thunksAvoided": "-2.48%"
  }
}
```
Improvement also seems to scale well - I got 7% less primops for firefox.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
