### PR TITLE
various: migrate to by-name

### DIFF
--- a/pkgs/by-name/ca/cambrinary/package.nix
+++ b/pkgs/by-name/ca/cambrinary/package.nix
@@ -1,13 +1,10 @@
 {
   lib,
-  buildPythonApplication,
+  python3Packages,
   fetchFromGitHub,
-  flit,
-  aiohttp,
-  beautifulsoup4,
 }:
 
-buildPythonApplication {
+python3Packages.buildPythonApplication {
   pname = "cambrinary";
   version = "unstable-2023-07-16";
   pyproject = true;
@@ -19,11 +16,11 @@ buildPythonApplication {
     hash = "sha256-wDcvpKAY/6lBjO5h3qKH3+Y2G2gm7spcKCXFMt/bAtE=";
   };
 
-  nativeBuildInputs = [
+  build-system = with python3Packages; [
     flit
   ];
 
-  propagatedBuildInputs = [
+  dependencies = with python3Packages; [
     aiohttp
     beautifulsoup4
   ];

--- a/pkgs/by-name/ev/evtest-qt/package.nix
+++ b/pkgs/by-name/ev/evtest-qt/package.nix
@@ -45,6 +45,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/Grumbel/evtest-qt";
     maintainers = with lib.maintainers; [ alexarice ];
     platforms = lib.platforms.linux;
-    license = lib.licenses.gpl3;
+    license = lib.licenses.gpl3Plus;
   };
 }

--- a/pkgs/by-name/ol/ola/package.nix
+++ b/pkgs/by-name/ol/ola/package.nix
@@ -9,7 +9,7 @@
   libftdi1,
   libuuid,
   cppunit,
-  protobuf,
+  protobuf_21,
   zlib,
   avahi,
   libmicrohttpd,
@@ -18,14 +18,14 @@
   fetchpatch,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ola";
   version = "0.10.9";
 
   src = fetchFromGitHub {
     owner = "OpenLightingProject";
     repo = "ola";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-8w8ZT3D/+8Pxl9z2KTXeydVxE5xiPjxZevgmMFgrblU=";
   };
   patches = [
@@ -47,14 +47,14 @@ stdenv.mkDerivation rec {
     libftdi1
     libuuid
     cppunit
-    protobuf
+    protobuf_21
     zlib
     avahi
     libmicrohttpd
     python3
   ];
   propagatedBuildInputs = [
-    (python3.pkgs.protobuf4.override { protobuf = protobuf; })
+    (python3.pkgs.protobuf4.override { protobuf = protobuf_21; })
     python3.pkgs.numpy
   ];
 
@@ -73,4 +73,4 @@ stdenv.mkDerivation rec {
     ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/tw/twitch-chat-downloader/package.nix
+++ b/pkgs/by-name/tw/twitch-chat-downloader/package.nix
@@ -1,16 +1,13 @@
 {
   lib,
-  buildPythonApplication,
+  python3Packages,
   fetchFromGitHub,
-  iso8601,
-  progressbar2,
-  requests,
 }:
 
-buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "twitch-chat-downloader";
   version = "2.5.5";
-  format = "setuptools";
+  pyproject = true;
 
   # NOTE: Using maintained fork because upstream has stopped working, and it has
   # not been updated in a while.
@@ -18,9 +15,11 @@ buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "TheDrHax";
     repo = "twitch-chat-downloader";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-9wIp0uttVBOdexOMb8VvpUEEdZ97SGSlZcFQ4jM/tqM=";
   };
+
+  build-system = [ python3Packages.setuptools ];
 
   postPatch = ''
     # Update client ID for Twitch changes
@@ -29,7 +28,7 @@ buildPythonApplication rec {
       --replace-fail jzkbprff40iqj646a697cyrvl0zt2m6 kd1unb4b3q4t58fwlpcbzcbnm76a8fp
   '';
 
-  propagatedBuildInputs = [
+  dependencies = with python3Packages; [
     iso8601
     progressbar2
     requests
@@ -46,4 +45,4 @@ buildPythonApplication rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ assistant ];
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1642,8 +1642,6 @@ with pkgs;
 
   intelLlvmStdenv = intel-llvm.stdenv;
 
-  cambrinary = python3Packages.callPackage ../applications/misc/cambrinary { };
-
   cplex = callPackage ../applications/science/math/cplex (config.cplex or { });
 
   cot = with python3Packages; toPythonApplication cot;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2884,10 +2884,6 @@ with pkgs;
 
   nwdiag = with python3Packages; toPythonApplication nwdiag;
 
-  ola = callPackage ../applications/misc/ola {
-    protobuf = protobuf_21;
-  };
-
   ome_zarr = with python3Packages; toPythonApplication ome-zarr;
 
   ophcrack-cli = ophcrack.override { enableGui = false; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3276,10 +3276,6 @@ with pkgs;
 
   ttfautohint-nox = ttfautohint.override { enableGUI = false; };
 
-  twitch-chat-downloader =
-    python3Packages.callPackage ../applications/misc/twitch-chat-downloader
-      { };
-
   uftraceFull = uftrace.override {
     withLuaJIT = true;
     withPython = true;


### PR DESCRIPTION
Migrate 4 packages to by-name. Won't be 0-rebuilds I don't think because of misc tweaks I've made to the python packages. Also threw in a license fix because I noticed it.

For searchability: `twitch-chat-downloader`, `ola`, `cambrinary`.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
