### PR TITLE
bitlbee-steam: fix build with GCC 15; refactor

### DIFF
--- a/pkgs/by-name/bi/bitlbee-steam/package.nix
+++ b/pkgs/by-name/bi/bitlbee-steam/package.nix
@@ -15,10 +15,10 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "bitlbee-steam";
 
   src = fetchFromGitHub {
-    rev = "v${finalAttrs.version}";
     owner = "bitlbee";
     repo = "bitlbee-steam";
-    sha256 = "121r92mgwv445wwxzh35n19fs5k81ihr0j19k256ia5502b1xxaq";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-WPUelgClqGiKmClIkGEMaBbtUrBlwN85L4Rs/qpIOYg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/bi/bitlbee-steam/package.nix
+++ b/pkgs/by-name/bi/bitlbee-steam/package.nix
@@ -37,6 +37,9 @@ stdenv.mkDerivation (finalAttrs: {
     ./autogen.sh
   '';
 
+  # Source uses `bool` as a variable name, reserved in C23.
+  env.NIX_CFLAGS_COMPILE = "-std=gnu17";
+
   meta = {
     description = "Steam protocol plugin for BitlBee";
 


### PR DESCRIPTION
GCC 15 Regression Tracking: #475479
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/326957256)](https://hydra.nixos.org/build/326957256)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test