### PR TITLE
sjmcl: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18845,6 +18845,12 @@
     githubId = 93703653;
     name = "Marko Müller";
   };
+  mx6436 = {
+    email = "mx6436@foxmail.com";
+    github = "mx6436";
+    githubId = 96968598;
+    name = "Ming Xin";
+  };
   mxkrsv = {
     email = "mxkrsv@disroot.org";
     github = "mxkrsv";

--- a/pkgs/by-name/sj/sjmcl-unwrapped/package.nix
+++ b/pkgs/by-name/sj/sjmcl-unwrapped/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  cargo-tauri,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  nix-update-script,
+  nodejs,
+  npmHooks,
+  pkg-config,
+  rustPlatform,
+  webkitgtk_4_1,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "sjmcl-unwrapped";
+  version = "1.0.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "UNIkeEN";
+    repo = "SJMCL";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-+Ok+AuPvn1OSL6lBGd3x4AIOvjc2YAExUM8RmCydfck=";
+  };
+
+  cargoHash = "sha256-cn2xpMshREAmHfV0Lv4cSXwctzSNLk9AR4a50xu0j7E=";
+
+  npmDeps = fetchNpmDeps {
+    name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
+    inherit (finalAttrs) src;
+    hash = "sha256-tP8qJc/e2pVK7XbUWoAGIbhrKN8MnWEwKCodfBBC2bU=";
+  };
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    nodejs
+    npmHooks.npmConfigHook
+    pkg-config
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    webkitgtk_4_1
+  ];
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+
+  cargoTestFlags = [
+    # skip doctests (doc examples are not compilable code)
+    "--lib"
+    "--bins"
+    "--tests"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A Minecraft launcher from SJTU Minecraft Club";
+    homepage = "https://mc.sjtu.cn/sjmcl";
+    changelog = "https://github.com/UNIkeEN/SJMCL/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ mx6436 ];
+    mainProgram = "SJMCL";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})

--- a/pkgs/by-name/sj/sjmcl/package.nix
+++ b/pkgs/by-name/sj/sjmcl/package.nix
@@ -1,0 +1,126 @@
+{
+  addDriverRunpath,
+  alsa-lib,
+  desktop-file-utils,
+  flite,
+  gamemode,
+  glfw3-minecraft,
+  glib-networking,
+  jdk17,
+  jdk21,
+  jdk25,
+  jdk8,
+  lib,
+  libGL,
+  libjack2,
+  libpulseaudio,
+  libusb1,
+  libx11,
+  libxcursor,
+  libxext,
+  libxrandr,
+  libxxf86vm,
+  openal,
+  pciutils,
+  pipewire,
+  sjmcl-unwrapped,
+  stdenv,
+  symlinkJoin,
+  udev,
+  vulkan-loader,
+  wrapGAppsHook3,
+  xrandr,
+
+  additionalLibs ? [ ],
+  additionalPrograms ? [ ],
+  jdks ? [
+    jdk25
+    jdk21
+    jdk17
+    jdk8
+  ],
+}:
+
+let
+
+  runtimeLibs = [
+    # openal
+    alsa-lib
+    libjack2
+    libpulseaudio
+    openal
+    pipewire
+
+    # glfw
+    glfw3-minecraft
+    libGL
+    libx11
+    libxcursor
+    libxext
+    libxrandr
+    libxxf86vm
+
+    flite # narrator support
+    gamemode.lib # gamemode support
+    glib-networking # Tauri
+    libusb1 # controller support
+    udev # oshi
+    vulkan-loader # VulkanMod's lwjgl
+  ]
+  ++ additionalLibs;
+
+  runtimePrograms = [
+    desktop-file-utils # Tauri
+    pciutils # need lspci
+    xrandr # needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
+  ]
+  ++ additionalPrograms;
+
+in
+
+symlinkJoin {
+  pname = "sjmcl";
+  inherit (sjmcl-unwrapped) version;
+
+  paths = [ sjmcl-unwrapped ];
+
+  strictDeps = true;
+  # breaks symlinkJoin
+  # https://github.com/NixOS/nixpkgs/pull/510526
+  # __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    wrapGAppsHook3
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    glib-networking
+  ];
+
+  postBuild = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : ${lib.makeBinPath jdks}
+      ${lib.optionalString stdenv.hostPlatform.isLinux ''
+        --set-default APPIMAGE SJMCL
+        --set LD_LIBRARY_PATH ${addDriverRunpath.driverLink}/lib:${lib.makeLibraryPath runtimeLibs}
+        --prefix PATH : ${lib.makeBinPath runtimePrograms}
+      ''}
+    )
+
+    glibPostInstallHook
+    gappsWrapperArgsHook
+    wrapGAppsHook
+  '';
+
+  meta = {
+    inherit (sjmcl-unwrapped.meta)
+      description
+      homepage
+      changelog
+      license
+      maintainers
+      mainProgram
+      platforms
+      ;
+  };
+}


### PR DESCRIPTION
Adds [SJMCL](https://github.com/UNIkeEN/SJMCL), a Minecraft launcher from SJTU Minecraft Club

draft: #510526 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
