### PR TITLE
pantheon.xdg-desktop-portal-pantheon: 8.1.0 -> 8.2.0

### DIFF
--- a/pkgs/desktops/pantheon/services/xdg-desktop-portal-pantheon/default.nix
+++ b/pkgs/desktops/pantheon/services/xdg-desktop-portal-pantheon/default.nix
@@ -8,24 +8,26 @@
   pkg-config,
   vala,
   wrapGAppsHook4,
+  accountsservice,
   glib,
   granite7,
   gsettings-desktop-schemas,
   gtk4,
   pantheon-wayland,
   systemd,
+  libadwaita,
   libx11,
 }:
 
 stdenv.mkDerivation rec {
   pname = "xdg-desktop-portal-pantheon";
-  version = "8.1.0";
+  version = "8.2.0";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = "portals";
     tag = version;
-    hash = "sha256-e02cVUEzRGVIJQQh2bONLUhrjRfeSpYQYWup5Sn9HhM=";
+    hash = "sha256-LmPLjOZVVHKMfYTEyOH2IkB/fw47pK0VqdWrckdBQ6w=";
   };
 
   nativeBuildInputs = [
@@ -37,12 +39,14 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    accountsservice
     glib
     granite7
     gsettings-desktop-schemas
     gtk4
     pantheon-wayland
     systemd
+    libadwaita
     libx11
   ];
 


### PR DESCRIPTION
https://github.com/elementary/portals/compare/8.1.0...8.2.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
