### PR TITLE
cddl: 0.12.9 -> 0.12.13

### DIFF
--- a/pkgs/by-name/cd/cddl/Gemfile
+++ b/pkgs/by-name/cd/cddl/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org'
 gem 'cddl'
+gem 'base64'

--- a/pkgs/by-name/cd/cddl/Gemfile.lock
+++ b/pkgs/by-name/cd/cddl/Gemfile.lock
@@ -2,20 +2,21 @@ GEM
   remote: https://rubygems.org/
   specs:
     abnc (0.1.1)
-    abnftt (0.2.6)
+    abnftt (0.2.10)
     base32 (0.3.4)
     base45_lite (1.0.1)
+    base64 (0.3.0)
     cbor-canonical (0.1.2)
     cbor-deterministic (0.1.3)
-    cbor-diag (0.9.5)
+    cbor-diag (0.11.8)
       cbor-canonical
       cbor-deterministic
       cbor-packed
       json_pure
       neatjson
       treetop (~> 1)
-    cbor-packed (0.1.5)
-    cddl (0.12.9)
+    cbor-packed (0.2.2)
+    cddl (0.12.13)
       abnc (~> 0.1.1)
       abnftt
       base32 (~> 0.3)
@@ -31,14 +32,15 @@ GEM
     polyglot (0.3.5)
     regexp-examples (1.5.1)
     scanf (1.0.0)
-    treetop (1.6.12)
+    treetop (1.6.18)
       polyglot (~> 0.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  base64
   cddl
 
 BUNDLED WITH
-   2.5.22
+   2.7.2

--- a/pkgs/by-name/cd/cddl/gemset.nix
+++ b/pkgs/by-name/cd/cddl/gemset.nix
@@ -14,10 +14,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1r9ay1kxn2yh9h0j2hr7iszz7cprpc7s6yjsv2k4inxndbsw5y4v";
+      sha256 = "08k659idrl977g1anlff32g9cp3rykjvk05n4nifr8jxzdczzv0r";
       type = "gem";
     };
-    version = "0.2.6";
+    version = "0.2.10";
   };
   base32 = {
     groups = [ "default" ];
@@ -38,6 +38,16 @@
       type = "gem";
     };
     version = "1.0.1";
+  };
+  base64 = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0yx9yn47a8lkfcjmigk79fykxvr80r4m1i35q82sxzynpbm7lcr7";
+      type = "gem";
+    };
+    version = "0.3.0";
   };
   cbor-canonical = {
     groups = [ "default" ];
@@ -72,20 +82,20 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1gxfs63jgvhdkfpm97mxpz14gxsvqds5pza8i175bmsqwvx3zn87";
+      sha256 = "1kjfyhavahayi5j358bn07885dxsmpihgww9c8qs6i9ap67lsy30";
       type = "gem";
     };
-    version = "0.9.5";
+    version = "0.11.8";
   };
   cbor-packed = {
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1dijyj7rivi39h34f32fx7k4xvngldf569i0372n1z6w01nv761l";
+      sha256 = "0sbbz0p17m77xqmh4fv4rwly1cj799hapdsg4h43kwsw8h0rnk8n";
       type = "gem";
     };
-    version = "0.1.5";
+    version = "0.2.2";
   };
   cddl = {
     dependencies = [
@@ -103,10 +113,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1811vvf73jjcxifq8h2cyp0b2z2qwhkplmrc2javx7gwrxlgb2p4";
+      sha256 = "196j6ghznk83wvwxxdf5fcz9w1hycr3z5whqk0jcx4x8d8mrskfm";
       type = "gem";
     };
-    version = "0.12.9";
+    version = "0.12.13";
   };
   colorize = {
     groups = [ "default" ];
@@ -174,9 +184,9 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0adc8qblz8ii668r3rksjx83p675iryh52rvdvysimx2hkbasj7d";
+      sha256 = "1nl3q5ai7ikaa5sjdbspfa4njbrdvf7898zkplmalln6y4r3y153";
       type = "gem";
     };
-    version = "1.6.12";
+    version = "1.6.18";
   };
 }


### PR DESCRIPTION
`cddl` is broken on master. Every invocation crashes with `LoadError: cannot load such file -- base64` (Ruby 3.4 dropped it from default gems). Hydra missed it because cddl has no check that runs the binary. This bump fixes it.

I came from the failure of `compactor` package and this should also fix those (https://hydra.nixos.org/build/327832368)
ZHF: #516381 (Part of)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
