### PR TITLE
liborbispkg-pkgtool: 0.3-unstable-2024-10-12 -> 0.3-unstable-2025-11-13

### DIFF
--- a/pkgs/by-name/li/liborbispkg-pkgtool/package.nix
+++ b/pkgs/by-name/li/liborbispkg-pkgtool/package.nix
@@ -5,13 +5,13 @@
 }:
 buildDotnetModule {
   pname = "liborbispkg-pkgtool";
-  version = "0.3-unstable-2024-10-12";
+  version = "0.3-unstable-2025-11-13";
 
   src = fetchFromGitHub {
     owner = "OpenOrbis";
     repo = "LibOrbisPkg";
-    rev = "75616a28de0f49f05eeff872211e806fb6de3818";
-    hash = "sha256-ySlMzUfJ0IXi/NWbj53jqCRDNm9Xh4TuffyKhNh4wuM=";
+    rev = "c1caa3ba25097fe602c0d842a0357bf7037b0838";
+    hash = "sha256-bCnaWooLHmUK5Say4fQINUuzTAmXr8qULmkD8bVVUjU=";
   };
 
   projectFile = "PkgTool.Core/PkgTool.Core.csproj";
@@ -21,7 +21,7 @@ buildDotnetModule {
   '';
 
   meta = {
-    description = "Library, GUI, CLI for creating, inspecting, and modifying PS4 PKG, SFO, PFS, and related filetypes";
+    description = "CLI for creating, inspecting, and modifying PS4 PKG, SFO, PFS, and related filetypes";
     homepage = "https://github.com/OpenOrbis/LibOrbisPkg";
     license = lib.licenses.lgpl3Plus;
     maintainers = [ lib.maintainers.ryand56 ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
