### PR TITLE
plover-lapwing-aio: init at 1.5.0

### DIFF
--- a/pkgs/development/python-modules/plover-dict-commands/default.nix
+++ b/pkgs/development/python-modules/plover-dict-commands/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  setuptools-scm,
+  plover,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "plover-dict-commands";
+  # See https://pypi.org/project/plover-dict-commands/
+  # and https://github.com/KoiOates/plover_dict_commands/issues/4
+  version = "0.2.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "KoiOates";
+    repo = "plover_dict_commands";
+    rev = "5dceddc0830fb5a72679d62995f27b2e49850998";
+    hash = "sha256-PXsYMqJz8sxgloEtiwxxt6Eo0hyFp5oW0homIAYPz6A=";
+  };
+
+  postPatch = ''
+    # See https://github.com/KoiOates/plover_dict_commands/issues/4
+    substituteInPlace setup.cfg \
+      --replace-fail "version = 0.2.4" "version = 0.2.5"
+  '';
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    plover
+  ];
+
+  pythonImportsCheck = [
+    "plover_dict_commands"
+  ];
+
+  meta = {
+    description = "Plover plugin for enabling, disabling, and changing the priority of dictionaries";
+    homepage = "https://github.com/KoiOates/plover_dict_commands";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [
+      pandapip1
+      ShamrockLee
+    ];
+  };
+})

--- a/pkgs/development/python-modules/plover-lapwing-aio/default.nix
+++ b/pkgs/development/python-modules/plover-lapwing-aio/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  plover-dict-commands,
+  plover-last-translation,
+  plover-modal-dictionary,
+  plover-python-dictionary,
+  plover-stitching,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "plover-lapwing-aio";
+  version = "1.5.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "aerickt";
+    repo = "plover-lapwing-aio";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+zXsbXwOtnj3feWdBujIYs7MdbB7VV3VWyio8CeJtB4=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace-fail "setuptools<77" "setuptools"
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    plover-dict-commands
+    plover-last-translation
+    plover-modal-dictionary
+    plover-python-dictionary
+    plover-stitching
+  ];
+
+  pythonImportsCheck = [
+    "plover_lapwing"
+  ];
+
+  meta = {
+    description = "Plover plugin to automatically install Lapwing dictionaries, dependent plugins, extra dictionaries, and fix the number key behaviour";
+    homepage = "https://github.com/aerickt/plover-lapwing-aio";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      pandapip1
+      ShamrockLee
+    ];
+  };
+})

--- a/pkgs/development/python-modules/plover-last-translation/default.nix
+++ b/pkgs/development/python-modules/plover-last-translation/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  plover,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "plover-last-translation";
+  version = "0.0.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "nsmarkop";
+    repo = "plover_last_translation";
+    tag = finalAttrs.version;
+    hash = "sha256-G6IvJ/xkayqFR4D3LTPJae2qxRnDpUI0yKTEbtRUxUg=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    plover
+  ];
+
+  pythonImportsCheck = [
+    "plover_last_translation"
+  ];
+
+  meta = {
+    description = "Plugins for Plover to repeat output";
+    homepage = "https://github.com/nsmarkop/plover_last_translation";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      pandapip1
+      ShamrockLee
+    ];
+  };
+})

--- a/pkgs/development/python-modules/plover-modal-dictionary/default.nix
+++ b/pkgs/development/python-modules/plover-modal-dictionary/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  plover,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "plover-modal-dictionary";
+  # See https://pypi.org/project/plover-modal-dictionary/#history
+  # and https://github.com/Kaoffie/plover_modal_dictionary/issues/3
+  version = "0.0.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Kaoffie";
+    repo = "plover_modal_dictionary";
+    rev = "086f9784377454ace45c333d21ea8ca2666b0a06";
+    hash = "sha256-d5BYkjeGXfoYQibjr5wQFUmXU69dNrewkJ/Gi4c9eEI=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    plover
+  ];
+
+  pythonImportsCheck = [
+    "plover_modal_dictionary"
+  ];
+
+  meta = {
+    description = "Modal Dictionaries for Plover";
+    homepage = "https://github.com/Kaoffie/plover_modal_dictionary";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      pandapip1
+      ShamrockLee
+    ];
+  };
+})

--- a/pkgs/development/python-modules/plover-python-dictionary/default.nix
+++ b/pkgs/development/python-modules/plover-python-dictionary/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  wheel,
+  pytestCheckHook,
+  plover,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "plover-python-dictionary";
+  version = "1.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "opensteno";
+    repo = "plover_python_dictionary";
+    tag = finalAttrs.version;
+    hash = "sha256-4li8WjriJdeLbu+JANuVOb9ejBGusHBm+AaLxyy91A0=";
+  };
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  dependencies = [
+    plover
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "plover_python_dictionary"
+  ];
+
+  meta = {
+    description = "Python dictionaries support for Plover";
+    homepage = "https://github.com/opensteno/plover_python_dictionary";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [
+      pandapip1
+      ShamrockLee
+    ];
+  };
+})

--- a/pkgs/development/python-modules/plover-stitching/default.nix
+++ b/pkgs/development/python-modules/plover-stitching/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+  plover,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "plover-stitching";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "panathea";
+    repo = "plover_stitching";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Md3LIQ73CAJlA91hfVdZZp9RJElINHYfiFFBBOYrIgs=";
+  };
+
+  patches = [
+    # Make plover-stitching's blackbox test use the current blackbox_test from Plover.
+    # https://github.com/panathea/plover_stitching/pull/1
+    ./plover_stitching_pr-1_test-blackbox_modernise_and_fix_build.patch
+  ];
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    plover
+  ];
+
+  pythonImportsCheck = [
+    "plover_stitching"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "S-t-i-t-c-h-i-n-g support for Plover";
+    homepage = "https://github.com/panathea/plover_stitching";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      pandapip1
+      ShamrockLee
+    ];
+  };
+})

--- a/pkgs/development/python-modules/plover-stitching/plover_stitching_pr-1_test-blackbox_modernise_and_fix_build.patch
+++ b/pkgs/development/python-modules/plover-stitching/plover_stitching_pr-1_test-blackbox_modernise_and_fix_build.patch
@@ -1,0 +1,31 @@
+From 2751875916f23d42c81602d082fa2fd06a396fb1 Mon Sep 17 00:00:00 2001
+From: Yueh-Shun Li <shamrocklee@posteo.net>
+Date: Tue, 5 May 2026 16:34:28 +0800
+Subject: [PATCH] test_blackbox: modernize to fix build
+
+Use `@blackbox_test` (decorator) from `plover_build_utils.testing`
+instead of the historical `BlackboxTester`.
+---
+ test/test_blackbox.py | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/test/test_blackbox.py b/test/test_blackbox.py
+index 71eb6d0676e39e4e916b04ae9cc290dff3de9e02..e746705fe21174ac05ee3c6087f9a19171f68189 100644
+--- a/test/test_blackbox.py
++++ b/test/test_blackbox.py
+@@ -1,12 +1,12 @@
+-from plover_build_utils.testing import BlackboxTester
++from plover_build_utils.testing import blackbox_test
+ from plover.registry import registry
+ from plover import system
+ 
+-class TestsBlackbox(BlackboxTester):
++@blackbox_test
++class TestsBlackbox:
+ 
+     @classmethod
+     def setup_class(cls):
+-        super().setup_class()
+         registry.update()
+         system.setup('English Stenotype')
+ 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12676,6 +12676,8 @@ self: super: with self; {
 
   plover-python-dictionary = callPackage ../development/python-modules/plover-python-dictionary { };
 
+  plover-stitching = callPackage ../development/python-modules/plover-stitching { };
+
   plover-stroke = callPackage ../development/python-modules/plover-stroke { };
 
   plover_4 = callPackage ../development/python-modules/plover/4.nix {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12670,6 +12670,8 @@ self: super: with self; {
 
   plover-dict-commands = callPackage ../development/python-modules/plover-dict-commands { };
 
+  plover-last-translation = callPackage ../development/python-modules/plover-last-translation { };
+
   plover-stroke = callPackage ../development/python-modules/plover-stroke { };
 
   plover_4 = callPackage ../development/python-modules/plover/4.nix {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12670,6 +12670,8 @@ self: super: with self; {
 
   plover-dict-commands = callPackage ../development/python-modules/plover-dict-commands { };
 
+  plover-lapwing-aio = callPackage ../development/python-modules/plover-lapwing-aio { };
+
   plover-last-translation = callPackage ../development/python-modules/plover-last-translation { };
 
   plover-modal-dictionary = callPackage ../development/python-modules/plover-modal-dictionary { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12668,6 +12668,8 @@ self: super: with self; {
   # https://github.com/opensteno/plover_plugins_registry/blob/master/unsupported.json
   plover = plover_4;
 
+  plover-dict-commands = callPackage ../development/python-modules/plover-dict-commands { };
+
   plover-stroke = callPackage ../development/python-modules/plover-stroke { };
 
   plover_4 = callPackage ../development/python-modules/plover/4.nix {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12674,6 +12674,8 @@ self: super: with self; {
 
   plover-modal-dictionary = callPackage ../development/python-modules/plover-modal-dictionary { };
 
+  plover-python-dictionary = callPackage ../development/python-modules/plover-python-dictionary { };
+
   plover-stroke = callPackage ../development/python-modules/plover-stroke { };
 
   plover_4 = callPackage ../development/python-modules/plover/4.nix {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12672,6 +12672,8 @@ self: super: with self; {
 
   plover-last-translation = callPackage ../development/python-modules/plover-last-translation { };
 
+  plover-modal-dictionary = callPackage ../development/python-modules/plover-modal-dictionary { };
+
   plover-stroke = callPackage ../development/python-modules/plover-stroke { };
 
   plover_4 = callPackage ../development/python-modules/plover/4.nix {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR packages `python3Packages.plover-lapwing-aio` and its dependencies. `python3Packages.plover-lapwing-aio` is a plugin of Plover (`python3Packages.plover`) the stenography software.

Simply make an Python environment containing both packages, and you'll have Plover with Lapwing plugin installed.

```nix
let
  lib = import ./lib;
  pkgs = import ./. { };
in
(pkgs.python3.override {
  packageOverrides = final: previous: { plover = final.plover_4; };
}).withPackages (ps: with ps; [ plover plover-lapwing-aio ])
```
```nix
let
  lib = import ./lib;
  pkgs = import ./. { };
in
(pkgs.python3.override {
  packageOverrides = final: previous: { plover = final.plover_5; };
}).withPackages (ps: with ps; [ plover plover-lapwing-aio ])
```

Fixes #89341
- #89341

Surpasses PRs #110658 and #119702
- #110658
- #119702

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
