### PR TITLE
icon-lang: unstable-2020-02-05 -> 9.5.25a

### DIFF
--- a/pkgs/by-name/ic/icon-lang/package.nix
+++ b/pkgs/by-name/ic/icon-lang/package.nix
@@ -3,22 +3,24 @@
   stdenv,
   fetchFromGitHub,
   libx11,
+  libxpm,
   libxt,
   withGraphics ? true,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "icon-lang";
-  version = "unstable-2020-02-05";
+  version = "9.5.25a";
   src = fetchFromGitHub {
     owner = "gtownsend";
     repo = "icon";
-    rev = "829cff33de4a21546fb269de3ef5acd7b4f0c0c7";
-    sha256 = "1lj2f13pbaajcy4v3744bz46rghhw5sv4dwwfnzhsllbj5gnjsv2";
+    tag = "v${finalAttrs.version}";
+    sha256 = "sha256-COXB03j5keTaRP/ggOU4065NFk3bmK5NTSet4CBGFSM=";
   };
 
   buildInputs = lib.optionals withGraphics [
     libx11
+    libxpm
     libxt
   ];
 
@@ -57,4 +59,4 @@ stdenv.mkDerivation {
     license = lib.licenses.publicDomain;
     homepage = "https://www.cs.arizona.edu/icon/";
   };
-}
+})


### PR DESCRIPTION
- #475479 
- #516381
- Diff: https://github.com/gtownsend/icon/compare/829cff33de4a21546fb269de3ef5acd7b4f0c0c7...v9.5.25a
- https://hydra.nixos.org/build/324242343

```
ipp.c:88:17: error: initialization of 'char * (*)(void)' from incompatible pointer type 'char * (*)(char *)' [-Wincompatible-pointer-types]
   88 |    { "define",  define  },
      |                 ^~~~~~
ipp.c:88:17: note: (near initialization for 'pplist[0].func')
ipp.c:66:17: note: 'define' declared here
   66 | static  char *  define  (char *s);
      |                 ^~~~~~
...
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
