### PR TITLE
explain: fix build with gcc15

### DIFF
--- a/pkgs/by-name/ex/explain/package.nix
+++ b/pkgs/by-name/ex/explain/package.nix
@@ -4,6 +4,7 @@
   fetchurl,
   fetchpatch,
   libtool,
+  autoreconfHook,
   bison,
   groff,
   ghostscript,
@@ -24,7 +25,7 @@ stdenv.mkDerivation rec {
   patches =
     let
       debian-src = "https://sources.debian.org/data/main";
-      debian-ver = "${version}.D001-12";
+      debian-ver = "${version}.D001-17";
       debian-patch =
         fname: hash:
         fetchpatch {
@@ -35,14 +36,22 @@ stdenv.mkDerivation rec {
     in
     [
       (debian-patch "sanitize-bison.patch" "sha256-gU6JG32j2yIOwehZTUSvIr4TSDdlg+p1U3bhfZHMEDY=")
+      (debian-patch "01_termio.patch" "sha256-vLyhn1gqm6v+5e8jOiNyCUgEEY7dNSWKuxkUSoCZLxE=")
       (debian-patch "03_fsflags-4.5.patch" "sha256-ML7Qvf85vEBp+iwm6PSosMAn/frYdEOSHRToEggmR8M=")
       (debian-patch "linux5.11.patch" "sha256-N7WwnTfwOxBfIiKntcFOqHTH9r2gd7NMEzic7szzR+Y=")
       (debian-patch "termiox-no-more-exists-since-kernel-5.12.patch" "sha256-cocgEYKoDMDnGk9VNQDtgoVxMGnnNpdae0hzgUlacOw=")
+      (debian-patch "missing-prototypes.patch" "sha256-RbVLVqAfjRN4FDt116WlIw2rKpYuOUxDmA+I7SziAJk=")
       (debian-patch "gcc-10.patch" "sha256-YNcYGyOOqPUuwpUpXGcR7zsWbepVg8SAqcVKlxENSQk=")
+      (debian-patch "gcc-14.patch" "sha256-hoDEG6Yk9j8WOHkNYAipPOgPTux308YCBEbjcykmEtA=")
     ];
+
+  postPatch = ''
+    ln -s etc/configure.ac configure.ac
+  '';
 
   nativeBuildInputs = [
     libtool
+    autoreconfHook
     bison
     groff
     ghostscript
@@ -69,7 +78,5 @@ stdenv.mkDerivation rec {
     license = lib.licenses.lgpl3Plus;
     maintainers = with lib.maintainers; [ McSinyx ];
     platforms = lib.platforms.unix;
-    # never built on aarch64-linux since first introduction in nixpkgs
-    broken = stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64;
   };
 }

--- a/pkgs/by-name/ex/explain/package.nix
+++ b/pkgs/by-name/ex/explain/package.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation rec {
       (debian-patch "sanitize-bison.patch" "sha256-gU6JG32j2yIOwehZTUSvIr4TSDdlg+p1U3bhfZHMEDY=")
       (debian-patch "01_termio.patch" "sha256-vLyhn1gqm6v+5e8jOiNyCUgEEY7dNSWKuxkUSoCZLxE=")
       (debian-patch "03_fsflags-4.5.patch" "sha256-ML7Qvf85vEBp+iwm6PSosMAn/frYdEOSHRToEggmR8M=")
+      (debian-patch "06_sysctl.patch" "sha256-GY2alw3um+j2fxA7gp6029Baej25PFQFgGgNbplP/P0=")
       (debian-patch "linux5.11.patch" "sha256-N7WwnTfwOxBfIiKntcFOqHTH9r2gd7NMEzic7szzR+Y=")
       (debian-patch "termiox-no-more-exists-since-kernel-5.12.patch" "sha256-cocgEYKoDMDnGk9VNQDtgoVxMGnnNpdae0hzgUlacOw=")
       (debian-patch "missing-prototypes.patch" "sha256-RbVLVqAfjRN4FDt116WlIw2rKpYuOUxDmA+I7SziAJk=")


### PR DESCRIPTION
- #475479 
- #516381 
- https://hydra.nixos.org/build/327593827

```
libexplain/buffer/ipc_perm.c: In function 'explain_buffer_ipc_perm':
libexplain/buffer/ipc_perm.c:104:38: error: 'const struct ipc_perm' has no member named 'key'; did you mean '__key'?
  104 |         explain_buffer_int(sb, data->key);
      |                                      ^~~
      |                                      __key
libexplain/buffer/ipc_perm.c:128:41: error: 'const struct ipc_perm' has no member named 'seq'; did you mean '__seq'?
  128 |         explain_buffer_ushort(sb, data->seq);
      |                                         ^~~
      |                                         __seq
```

Fetched more debian patches to fix the issue. Doing autoreconf also seems to help generating better `configure` scripts.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
