### PR TITLE
androidenv: fix emulator graphics acceleration

### DIFF
--- a/pkgs/development/mobile/androidenv/emulator.nix
+++ b/pkgs/development/mobile/androidenv/emulator.nix
@@ -22,7 +22,6 @@ deployAndroidPackage {
       [
         glibc
         libcxx
-        libGL
         libpulseaudio
         libtiff
         libuuid
@@ -78,10 +77,12 @@ deployAndroidPackage {
           lib.makeLibraryPath [
             pkgs.dbus
             pkgs.systemd
+            pkgs.libGL
           ]
         } \
         --set QT_XKB_CONFIG_ROOT ${pkgs.xkeyboard_config}/share/X11/xkb \
-        --set QTCOMPOSE ${pkgs.libx11.out}/share/X11/locale
+        --set QTCOMPOSE ${pkgs.libx11.out}/share/X11/locale \
+        --set-default VK_ADD_DRIVER_FILES /run/opengl-driver/share/vulkan/icd.d
     '')
     + ''
       mkdir -p $out/bin


### PR DESCRIPTION
Set a default value for VK_ADD_DRIVER_FILES so the SDK's vulkan-loader can load NixOS vulkan drivers.

libGL needs to be in LD_LIBRARY_PATH to get loaded successfully.

Tested using:
```nix
androidenv.emulateApp {
  name = "app";
  platformVersion = "36";
  abiVersion = "x86_64";
  systemImageType = "google_apis_playstore";
  configOptions = {
    "hw.gpu.mode" = "host";
    "hw.gpu.enabled" = "yes";
    "hw.keyboard" = "yes";
  };
}
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
