### PR TITLE
zabbix: Multiple versions

### DIFF
--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -1,7 +1,7 @@
 generic: {
   v74 = generic {
-    version = "7.4.9";
-    hash = "sha256-+X7YkyghpR9kUQCt99SA6HWA606DhJwQT0T9VWrxr88=";
+    version = "7.4.10";
+    hash = "sha256-hVdgC5Nmby+JsQjpmYl3dA4I7DXyoCXaMLdggi6Wa/o=";
   };
   v70 = generic {
     version = "7.0.25";

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -4,8 +4,8 @@ generic: {
     hash = "sha256-hVdgC5Nmby+JsQjpmYl3dA4I7DXyoCXaMLdggi6Wa/o=";
   };
   v70 = generic {
-    version = "7.0.25";
-    hash = "sha256-OkLoXanL2KrdEb/L4CHw+cbKpRD1ZON/OsEEaYSstyk=";
+    version = "7.0.26";
+    hash = "sha256-PCepe1LHXi7M+kPexeP9fVKHb1/dlBcklbAl7J8qE6g=";
   };
   v60 = generic {
     version = "6.0.45";

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -8,7 +8,7 @@ generic: {
     hash = "sha256-PCepe1LHXi7M+kPexeP9fVKHb1/dlBcklbAl7J8qE6g=";
   };
   v60 = generic {
-    version = "6.0.45";
-    hash = "sha256-duB2w2xDH9ZHEDh9iZ5Fr6RH0dI2lMCVvySA5dmSZcU=";
+    version = "6.0.46";
+    hash = "sha256-WwI1cv8iHXyOBhzBis/n0Wom9GQgFnCZoJrbOcpc4Ao=";
   };
 }


### PR DESCRIPTION
zabbix74: 7.4.9 -> 7.4.10 https://www.zabbix.com/rn/rn7.4.10
zabbix70: 7.0.25 -> 7.0.26 https://www.zabbix.com/rn/rn7.0.26
zabbix: 6.0.45 -> 6.0.46 https://www.zabbix.com/rn/rn6.0.46

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
