### PR TITLE
mudlet: 4.19.1 -> 4.20.1

### DIFF
--- a/pkgs/by-name/mu/mudlet/package.nix
+++ b/pkgs/by-name/mu/mudlet/package.nix
@@ -7,161 +7,99 @@
   git,
   pkg-config,
   which,
+  assimp,
   boost,
+  discord-rpc,
   hunspell,
   libGLU,
-  libsForQt5,
   libsecret,
   libzip,
   lua5_1,
-  pcre,
+  pipewire,
   pugixml,
-  discord-rpc,
+  qt6Packages,
   yajl,
   withDiscordRpc ? false,
 }:
 
 let
-  overrideLua =
-    let
-      packageOverrides = self: super: {
-        # luasql-sqlite3 master branch broke compatibility with lua 5.1. Pin to
-        # an earlier commit.
-        # https://github.com/lunarmodules/luasql/issues/147
-        luasql-sqlite3 = super.luaLib.overrideLuarocks super.luasql-sqlite3 (drv: {
-          version = "2.6.0-1-custom";
-          src = fetchFromGitHub {
-            owner = "lunarmodules";
-            repo = "luasql";
-            rev = "8c58fd6ee32faf750daf6e99af015a31402578d1";
-            hash = "sha256-XlTB5O81yWCrx56m0cXQp7EFzeOyfNeqGbuiYqMrTUk=";
-          };
-        });
-      };
-    in
-    lua5_1.override { inherit packageOverrides; };
-
-  luaEnv = overrideLua.withPackages (
+  luaEnv = lua5_1.withPackages (
     ps: with ps; [
-      luazip
-      luafilesystem
-      lrexlib-pcre
-      luasql-sqlite3
+      lpeg
+      lrexlib-pcre2
       lua-yajl
+      luafilesystem
+      luasql-sqlite3
       luautf8
+      luazip
     ]
   );
+  libPathVar = if stdenv.hostPlatform.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "mudlet";
-  version = "4.19.1";
+  version = "4.20.1";
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "Mudlet";
     repo = "Mudlet";
     rev = "Mudlet-${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-I4RRIfHw9kZwxMlc9pvdtwPpq9EvNJU69WpGgZ+0uiw=";
+    hash = "sha256-o3f2ChQ7COql+WEe2diATx7wIR0fOlxkXcGWlL1AYkE=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "cmake4-fix.patch";
-      url = "https://github.com/Mudlet/Mudlet/commit/933f2551fe3084f0fad6d8b971c6176fe154d8d7.patch?full_index=1";
-      hash = "sha256-MElSRhTaT1a5r/Pz3e7MTrzq0krjdspgW0woAB2C8jc=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake
     git
     luaEnv
     pkg-config
-    libsForQt5.qttools
+    qt6Packages.qttools
+    qt6Packages.wrapQtAppsHook
     which
-    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [
+    assimp
     boost
     hunspell
     libGLU
-    libsForQt5.qtkeychain
     libsecret
     libzip
     luaEnv
-    pcre
     pugixml
-    libsForQt5.qtbase
-    libsForQt5.qtmultimedia
+    qt6Packages.qtbase
+    qt6Packages.qt5compat
+    qt6Packages.qtkeychain
+    qt6Packages.qtmultimedia
     yajl
   ]
   ++ lib.optional withDiscordRpc discord-rpc;
 
   cmakeFlags = [
     # RPATH of binary /nix/store/.../bin/... contains a forbidden reference to /build/
-    "-DCMAKE_SKIP_BUILD_RPATH=ON"
+    (lib.cmakeBool "CMAKE_SKIP_BUILD_RPATH" true)
+    (lib.cmakeBool "USE_FONTS" false)
+    (lib.cmakeBool "USE_OWN_QTKEYCHAIN" false)
+    (lib.cmakeBool "USE_UPDATER" false)
   ];
 
-  env = {
-    WITH_FONTS = "NO";
-    WITH_UPDATER = "NO";
-  };
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -pv $out/lib
-    cp 3rdparty/edbee-lib/edbee-lib/qslog/lib/libQsLog${stdenv.hostPlatform.extensions.sharedLibrary} $out/lib
-    mkdir -pv $out/share/mudlet
-    cp -r ../src/mudlet-lua/lua $out/share/mudlet/
-
-    mkdir -pv $out/share/pixmaps
-    cp -r ../mudlet.png $out/share/pixmaps/
-
-    cp -r ../translations $out/share/
-
-  ''
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+  installPhase = lib.optionalString stdenv.hostPlatform.isDarwin ''
     mkdir -p $out/Applications
     cp -r src/mudlet.app/ $out/Applications/mudlet.app
-    mv $out/Applications/mudlet.app/Contents/MacOS/mudlet $out/Applications/mudlet.app/Contents/MacOS/mudlet-unwrapped
-    makeQtWrapper $out/Applications/Mudlet.app/Contents/MacOS/mudlet-unwrapped $out/Applications/Mudlet.app/Contents/MacOS/mudlet \
-      --set LUA_CPATH "${luaEnv}/lib/lua/${lua5_1.luaversion}/?.so" \
-      --prefix LUA_PATH : "$NIX_LUA_PATH" \
-      --prefix DYLD_LIBRARY_PATH : "${
-        lib.makeLibraryPath (
-          [
-            libsForQt5.qtkeychain
-          ]
-          ++ lib.optional withDiscordRpc discord-rpc
-        )
-      }:$out/lib" \
-      --chdir "$out";
+  '';
 
-  ''
-  + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
-    mkdir -pv $out/bin
-    cp src/mudlet $out/bin/mudlet-unwrapped
-    makeQtWrapper $out/bin/mudlet-unwrapped $out/bin/mudlet \
-      --set LUA_CPATH "${luaEnv}/lib/lua/${lua5_1.luaversion}/?.so" \
-      --prefix LUA_PATH : "$NIX_LUA_PATH" \
-      --prefix LD_LIBRARY_PATH : "${
-        lib.makeLibraryPath (
-          [
-            libsForQt5.qtkeychain
-          ]
-          ++ lib.optional withDiscordRpc discord-rpc
-        )
-      }" \
-      --chdir "$out";
-
-    mkdir -pv $out/share/applications
-    cp ../mudlet.desktop $out/share/applications/
-
-  ''
-  + ''
-    runHook postInstall
+  preFixup = ''
+    qtWrapperArgs+=(--set LUA_CPATH "${luaEnv}/lib/lua/${lua5_1.luaversion}/?.so")
+    qtWrapperArgs+=(--prefix LUA_PATH : "$NIX_LUA_PATH")
+    qtWrapperArgs+=(--prefix ${libPathVar} : "${
+      lib.makeLibraryPath (
+        lib.optional stdenv.hostPlatform.isLinux pipewire ++ lib.optional withDiscordRpc discord-rpc
+      )
+    }")
+    qtWrapperArgs+=(--chdir "$out")
   '';
 
   meta = {
@@ -173,7 +111,6 @@ stdenv.mkDerivation (finalAttrs: {
       felixalbrigtsen
     ];
     platforms = with lib.platforms; linux ++ darwin;
-    broken = stdenv.hostPlatform.isDarwin;
     license = lib.licenses.gpl2Plus;
     mainProgram = "mudlet";
   };


### PR DESCRIPTION
- #475479 
- #516381
- #356387
- Changelogs:
  - https://github.com/Mudlet/Mudlet/releases/tag/Mudlet-4.20.0
  - https://github.com/Mudlet/Mudlet/releases/tag/Mudlet-4.20.1
- Diff: https://hydra.nixos.org/build/326833971

```
/build/source/3rdparty/edbee-lib/vendor/onig/regparse.c: In function 'onig_st_init_strend_table_with_size':
/build/source/3rdparty/edbee-lib/vendor/onig/regparse.c:409:5: error: initialization of 'int (*)(void)' from incompatible pointer type 'int (*)(st_data_t,  st_data_t)' {aka 'int (*)(long unsigned int,  long unsigned int)'} [-Wincompatible-pointer-types]
  409 |     str_end_cmp,
      |     ^~~~~~~~~~~
/build/source/3rdparty/edbee-lib/vendor/onig/regparse.c:409:5: note: (near initialization for 'hashType.compare')
/build/source/3rdparty/edbee-lib/vendor/onig/regparse.c:367:1: note: 'str_end_cmp' declared here
  367 | str_end_cmp(st_data_t xp, st_data_t yp)
      | ^~~~~~~~~~~
/build/source/3rdparty/edbee-lib/vendor/onig/regparse.c:410:5: error: initialization of 'st_index_t (*)(void)' {aka 'long unsigned int (*)(void)'} from incompatible pointer type 'st_index_t (*)(st_data_t)' {aka 'long unsigned int (*)(long unsigned int)'} [-Wincompatible-pointer-types]
  410 |     str_end_hash,
      |     ^~~~~~~~~~~~
/build/source/3rdparty/edbee-lib/vendor/onig/regparse.c:410:5: note: (near initialization for 'hashType.hash')
/build/source/3rdparty/edbee-lib/vendor/onig/regparse.c:391:1: note: 'str_end_hash' declared here
  391 | str_end_hash(st_data_t xp)
      | ^~~~~~~~~~~~
...
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
