### PR TITLE
happier: init at 0.2.1

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1225,6 +1225,7 @@
   ./services/networking/gvpe.nix
   ./services/networking/hans.nix
   ./services/networking/haproxy.nix
+  ./services/networking/happier-server.nix
   ./services/networking/harmonia.nix
   ./services/networking/headplane.nix
   ./services/networking/headscale.nix

--- a/nixos/modules/services/networking/happier-server.nix
+++ b/nixos/modules/services/networking/happier-server.nix
@@ -1,0 +1,192 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.happier-server;
+  inherit (lib)
+    getExe
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    optional
+    optionalString
+    types
+    ;
+
+  envFormat = pkgs.formats.keyValue { };
+  dataDir = "/var/lib/${cfg.stateDirectory}";
+  filesDir = "${dataDir}/files";
+  dbDir = "${dataDir}/db";
+  migrationsDir = "${cfg.package}/lib/happier-server/prisma/sqlite/migrations";
+  nodeModulesDir = "${cfg.package}/lib/happier-server/node_modules";
+  prismaEngine = "${cfg.package}/lib/happier-server/generated/sqlite-client/${
+    if pkgs.stdenv.hostPlatform.isAarch64 then
+      "libquery_engine-linux-arm64-openssl-3.0.x.so.node"
+    else
+      "libquery_engine-debian-openssl-3.0.x.so.node"
+  }";
+  settingsFile = envFormat.generate "happier-server-env" (
+    {
+      PORT = toString cfg.port;
+      HAPPIER_SERVER_HOST = cfg.host;
+      METRICS_ENABLED = false;
+      HAPPIER_DB_PROVIDER = "sqlite";
+      DATABASE_URL = "file:${dbDir}/happier-server-light.sqlite";
+      HAPPIER_FILES_BACKEND = "local";
+      NODE_PATH = nodeModulesDir;
+      PRISMA_CLIENT_ENGINE_TYPE = "library";
+      PRISMA_QUERY_ENGINE_LIBRARY = prismaEngine;
+      HAPPIER_SQLITE_AUTO_MIGRATE = true;
+      HAPPIER_SQLITE_MIGRATIONS_DIR = migrationsDir;
+      HAPPIER_SERVER_LIGHT_DATA_DIR = dataDir;
+      HAPPIER_SERVER_LIGHT_FILES_DIR = filesDir;
+      HAPPIER_SERVER_LIGHT_DB_DIR = dbDir;
+    }
+    // cfg.environment
+  );
+in
+{
+  meta.maintainers = with lib.maintainers; [ imalison ];
+
+  options.services.happier-server = {
+    enable = mkEnableOption "Happier relay server";
+
+    package = mkPackageOption pkgs "happier-server" { };
+
+    host = mkOption {
+      type = types.str;
+      default = "0.0.0.0";
+      description = "Address the Happier relay server listens on.";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 3000;
+      description = "Port the Happier relay server listens on.";
+    };
+
+    stateDirectory = mkOption {
+      type = types.str;
+      default = "happier-server";
+      description = ''
+        State directory managed by systemd under `/var/lib`.
+      '';
+    };
+
+    masterSecretFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/run/secrets/happier-server/master-secret";
+      description = ''
+        File containing `HANDY_MASTER_SECRET`. The service loads this through systemd credentials.
+      '';
+    };
+
+    environment = mkOption {
+      type = types.attrsOf (
+        types.oneOf [
+          types.str
+          types.int
+          types.bool
+        ]
+      );
+      default = { };
+      example = {
+        HAPPIER_PUBLIC_SERVER_URL = "https://happier.example.com";
+      };
+      description = ''
+        Environment variables passed to the Happier relay server.
+        This is written to the Nix store, so secrets should go in
+        `environmentFile` or `masterSecretFile`.
+      '';
+    };
+
+    environmentFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/run/secrets/happier-server/env";
+      description = ''
+        Environment file loaded by systemd. Use this for secrets and deployment-specific settings.
+      '';
+    };
+
+    extraArgs = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = "Additional command-line arguments passed to `happier-server`.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    warnings = optional (cfg.masterSecretFile == null) ''
+      `services.happier-server.masterSecretFile` is not set. Upstream self-hosting examples require `HANDY_MASTER_SECRET`; set it with `masterSecretFile` or provide it through `environmentFile`.
+    '';
+
+    systemd.services.happier-server = {
+      description = "Happier relay server";
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+      restartTriggers = [
+        cfg.package
+        settingsFile
+      ];
+
+      preStart = ''
+        mkdir -p "$HAPPIER_SERVER_LIGHT_FILES_DIR" "$HAPPIER_SERVER_LIGHT_DB_DIR"
+      '';
+
+      script = ''
+        ${optionalString (cfg.masterSecretFile != null) ''
+          export HANDY_MASTER_SECRET="$(${pkgs.systemd}/bin/systemd-creds cat HANDY_MASTER_SECRET)"
+        ''}
+        exec ${getExe cfg.package} ${lib.escapeShellArgs cfg.extraArgs}
+      '';
+
+      serviceConfig = {
+        DynamicUser = true;
+        EnvironmentFile = [ settingsFile ] ++ optional (cfg.environmentFile != null) cfg.environmentFile;
+        LoadCredential = optional (
+          cfg.masterSecretFile != null
+        ) "HANDY_MASTER_SECRET:${cfg.masterSecretFile}";
+        StateDirectory = cfg.stateDirectory;
+        StateDirectoryMode = "0700";
+        WorkingDirectory = dataDir;
+        Restart = "on-failure";
+
+        CapabilityBoundingSet = "";
+        LockPersonality = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = "~@clock @cpu-emulation @debug @module @mount @obsolete @privileged @raw-io @reboot @resources @swap";
+        UMask = "0077";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -708,6 +708,7 @@ in
     package = pkgs.hadoop_3_3;
   };
   haproxy = runTest ./haproxy.nix;
+  happier-server = runTest ./happier-server.nix;
   harmonia = runTest ./harmonia.nix;
   haste-server = runTest ./haste-server.nix;
   hbase2 = runTest {

--- a/nixos/tests/happier-server.nix
+++ b/nixos/tests/happier-server.nix
@@ -1,0 +1,26 @@
+{ pkgs, lib, ... }:
+
+{
+  name = "happier-server";
+  meta.maintainers = with lib.maintainers; [ imalison ];
+
+  nodes.machine =
+    { ... }:
+    {
+      services.happier-server = {
+        enable = true;
+        masterSecretFile = pkgs.writeText "happier-server-master-secret" "happier-server-test-secret";
+      };
+
+      environment.systemPackages = [ pkgs.sqlite ];
+    };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("happier-server.service")
+    machine.wait_for_open_port(3000)
+    machine.succeed("test -s /var/lib/happier-server/db/happier-server-light.sqlite")
+    machine.succeed("sqlite3 /var/lib/happier-server/db/happier-server-light.sqlite '.tables' | grep -w _prisma_migrations")
+  '';
+}

--- a/pkgs/by-name/ha/happier-server/package.nix
+++ b/pkgs/by-name/ha/happier-server/package.nix
@@ -1,0 +1,109 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  openssl,
+}:
+
+let
+  inherit (stdenv.hostPlatform) system;
+
+  pname = "happier-server";
+  version = "0.2.0";
+
+  sources = {
+    aarch64-darwin = fetchurl {
+      url = "https://github.com/happier-dev/happier/releases/download/server-v${version}/happier-server-v${version}-darwin-arm64.tar.gz";
+      hash = "sha256-TT1tZ0N5YvMPl4MuAz2gG5mOKZEBszVkpt74uHhwsbg=";
+    };
+    aarch64-linux = fetchurl {
+      url = "https://github.com/happier-dev/happier/releases/download/server-v${version}/happier-server-v${version}-linux-arm64.tar.gz";
+      hash = "sha256-EIRHvDL3GE+RgC18dWUo7v4gK/RhIbzcgnpWNa+jhjI=";
+    };
+    x86_64-darwin = fetchurl {
+      url = "https://github.com/happier-dev/happier/releases/download/server-v${version}/happier-server-v${version}-darwin-x64.tar.gz";
+      hash = "sha256-Cw9bWPlIccqcUkpvQKMe4kScuRHopmWxKhAYmT7EoHM=";
+    };
+    x86_64-linux = fetchurl {
+      url = "https://github.com/happier-dev/happier/releases/download/server-v${version}/happier-server-v${version}-linux-x64.tar.gz";
+      hash = "sha256-ZAg+3bsYHM1KERNnApWUVnDXvdMLhqNC7Pa5iI6gvvI=";
+    };
+  };
+  platforms = builtins.attrNames sources;
+  prismaEngineName =
+    if stdenv.hostPlatform.isAarch64 then
+      "libquery_engine-linux-arm64-openssl-3.0.x.so.node"
+    else
+      "libquery_engine-debian-openssl-3.0.x.so.node";
+in
+
+stdenv.mkDerivation {
+  inherit pname version;
+
+  strictDeps = true;
+
+  src =
+    if builtins.elem system platforms then
+      sources.${system}
+    else
+      throw "Source for happier-server is not available for ${system}";
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    openssl
+    stdenv.cc.cc.lib
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    tar --warning=no-unknown-keyword -xzf $src
+    sourceRoot=happier-server-v${version}-${stdenv.hostPlatform.parsed.kernel.name}-${
+      if stdenv.hostPlatform.isAarch64 then "arm64" else "x64"
+    }
+
+    runHook postUnpack
+  '';
+
+  # strip removes the payload embedded in Bun standalone executables.
+  dontStrip = true;
+
+  postPatch = ''
+    find . -name '._*' -delete
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/lib/happier-server
+    cp -r . $out/lib/happier-server/
+    ln -s $out/lib/happier-server/happier-server $out/bin/happier-server
+
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      for prismaClient in \
+        $out/lib/happier-server/generated/mysql-client \
+        $out/lib/happier-server/generated/sqlite-client \
+        $out/lib/happier-server/node_modules/.prisma/client
+      do
+        ln -s ${prismaEngineName} "$prismaClient/libquery_engine-linux-nixos.so.node"
+      done
+    ''}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Self-hostable relay server for Happier";
+    homepage = "https://github.com/happier-dev/happier";
+    changelog = "https://github.com/happier-dev/happier/releases/tag/server-v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ imalison ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    inherit platforms;
+    mainProgram = "happier-server";
+  };
+}

--- a/pkgs/by-name/ha/happier/package.nix
+++ b/pkgs/by-name/ha/happier/package.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  openssl,
+}:
+
+let
+  inherit (stdenv.hostPlatform) system;
+
+  pname = "happier";
+  version = "0.2.1";
+
+  sources = {
+    aarch64-darwin = fetchurl {
+      url = "https://github.com/happier-dev/happier/releases/download/cli-v${version}/happier-v${version}-darwin-arm64.tar.gz";
+      hash = "sha256-Sb4uQHnEzsm04ipwP/PaVMHQpTr4prBknt4Bn1+/fsg=";
+    };
+    aarch64-linux = fetchurl {
+      url = "https://github.com/happier-dev/happier/releases/download/cli-v${version}/happier-v${version}-linux-arm64.tar.gz";
+      hash = "sha256-gXLKHTEuTzuU4BlX56uuL4/IZDoVzofcrgbm/GQyKKU=";
+    };
+    x86_64-darwin = fetchurl {
+      url = "https://github.com/happier-dev/happier/releases/download/cli-v${version}/happier-v${version}-darwin-x64.tar.gz";
+      hash = "sha256-ymaKtVaYupPTmXHrTyuzJ34f62kkmnlXEytlJR5CfU4=";
+    };
+    x86_64-linux = fetchurl {
+      url = "https://github.com/happier-dev/happier/releases/download/cli-v${version}/happier-v${version}-linux-x64.tar.gz";
+      hash = "sha256-fH8EntUuvj6lXGEmqGqNfYnDC+Ng7o8pE2l5GdWpRnk=";
+    };
+  };
+  platforms = builtins.attrNames sources;
+in
+
+stdenv.mkDerivation {
+  inherit pname version;
+
+  strictDeps = true;
+
+  src =
+    if builtins.elem system platforms then
+      sources.${system}
+    else
+      throw "Source for happier is not available for ${system}";
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    openssl
+    stdenv.cc.cc.lib
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    tar --warning=no-unknown-keyword -xzf $src
+    sourceRoot=happier-v${version}-${stdenv.hostPlatform.parsed.kernel.name}-${
+      if stdenv.hostPlatform.isAarch64 then "arm64" else "x64"
+    }
+
+    runHook postUnpack
+  '';
+
+  autoPatchelfIgnoreMissingDeps = lib.optionals stdenv.hostPlatform.isLinux [
+    # Unused node-pty musl prebuild bundled in the upstream binary release.
+    "libc.musl-x86_64.so.1"
+  ];
+
+  # strip removes the payload embedded in Bun standalone executables.
+  dontStrip = true;
+
+  postPatch = ''
+    find . -name '._*' -delete
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/lib/happier
+    cp -r . $out/lib/happier/
+    ln -s $out/lib/happier/happier $out/bin/happier
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Mobile and web client for Claude Code, Codex, and other coding agents";
+    homepage = "https://github.com/happier-dev/happier";
+    changelog = "https://github.com/happier-dev/happier/releases/tag/cli-v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ imalison ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    inherit platforms;
+    mainProgram = "happier";
+  };
+}


### PR DESCRIPTION
Adds Happier packages and a NixOS module for the Happier relay server.

Happier is a mobile/web client for coding agents such as Claude Code and Codex:
https://github.com/happier-dev/happier

This PR adds:

- `happier` CLI at 0.2.1
- `happier-server` relay server at 0.2.0
- `services.happier-server` NixOS module using systemd credentials for `HANDY_MASTER_SECRET`
- a NixOS VM test that checks service startup and SQLite migration state

The upstream binary releases are Bun standalone executables, so the derivations keep `dontStrip = true` and declare `sourceProvenance = [ binaryNativeCode ]`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

Validation run:

- `git fetch origin master --prune`
- `npm view @happier-dev/cli version dist-tags --json`
- `npm view @happier-dev/relay-server version dist-tags --json`
- `gh search prs --repo NixOS/nixpkgs 'happier-dev OR "happier-server" OR "@happier-dev"' --limit 20 --json number,title,state,url,author`
- `nix run nixpkgs#nixfmt -- pkgs/by-name/ha/happier/package.nix pkgs/by-name/ha/happier-server/package.nix nixos/modules/services/networking/happier-server.nix nixos/modules/module-list.nix nixos/tests/all-tests.nix nixos/tests/happier-server.nix`
- `git diff --check -- pkgs/by-name/ha/happier/package.nix pkgs/by-name/ha/happier-server/package.nix nixos/modules/services/networking/happier-server.nix nixos/modules/module-list.nix nixos/tests/all-tests.nix nixos/tests/happier-server.nix`
- `nix-build -A happier --no-out-link`
- `nix-build -A happier-server --no-out-link`
- `nix-instantiate --eval --strict -E 'let pkgs = import ./. {}; in { happier = pkgs.happier.meta.mainProgram; server = pkgs.happier-server.meta.mainProgram; test = pkgs.nixosTests.happier-server.name; }'`
- `happier --help`
- `happier-server` smoke test with SQLite auto-migration, confirming startup on configured `PORT` and `_prisma_migrations` table creation

The full VM test was not run locally because it attempted to build a fresh kernel on this machine.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
