### PR TITLE
python3Packages.plover: reference to `python3Packages.plover_5` instead of `python3Packages.plover_4`

### DIFF
--- a/pkgs/by-name/pl/plover/package.nix
+++ b/pkgs/by-name/pl/plover/package.nix
@@ -3,7 +3,7 @@
   config,
   python3Packages,
   # For aliases
-  plover,
+  plover_4,
 }:
 python3Packages.toPythonApplication python3Packages.plover
 # Aliases to now-dropped plover.stable and plover.dev
@@ -11,7 +11,8 @@ python3Packages.toPythonApplication python3Packages.plover
 # TODO(@ShamrockLee): remove after Nixpkgs 25.11 EOL
 // lib.optionalAttrs (config.allowAliases && !(lib.oldestSupportedReleaseIsAtLeast 2605)) {
   dev =
-    lib.throwIf (lib.oldestSupportedReleaseIsAtLeast 2511) "plover.dev was renamed. Use plover instead."
-      plover; # Added 2026-04-26
+    lib.throwIf (lib.oldestSupportedReleaseIsAtLeast 2511)
+      "plover.dev was renamed. Use plover, plover_5, or plover_4 instead."
+      plover_4; # Added 2026-05-07
   stable = throw "plover.stable was renamed. Use plover instead."; # Added 2022-06-05; updated 2026-04-26
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12701,7 +12701,7 @@ self: super: with self; {
   plotpy = callPackage ../development/python-modules/plotpy { };
 
   # Plover 5 moves from PyQt5 to PySide6,
-  # which is a backward-incompatible change to praphical plugins.
+  # which is a backward-incompatible change to graphical plugins.
   # Use Plover 4 for now (2026-04-26),
   # as the upstream still warns about this in every Plover 5 release,
   # List of unsupported plugins:

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12700,13 +12700,16 @@ self: super: with self; {
 
   plotpy = callPackage ../development/python-modules/plotpy { };
 
+  # Use Plover 5 as Plover 4 depends on setuptool's pkg_resources to discover plugins,
+  # which the setuptools upstream deprecated at version 81.0.0 and removed at version 82.0.0
+  # Plover 5 has addressed this issue by switching to importlib.meta.distributions()
+  #
+  # NOTE:
   # Plover 5 moves from PyQt5 to PySide6,
   # which is a backward-incompatible change to graphical plugins.
-  # Use Plover 4 for now (2026-04-26),
-  # as the upstream still warns about this in every Plover 5 release,
   # List of unsupported plugins:
   # https://github.com/opensteno/plover_plugins_registry/blob/master/unsupported.json
-  plover = plover_4;
+  plover = plover_5;
 
   plover-stroke = callPackage ../development/python-modules/plover-stroke { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Use Plover 5 as `python3Packages.plover`.

Plover 4 depends on setuptool's `pkg_resources` to discover plugins, which the setuptools upstream deprecated at version 81.0.0 and removed at version 82.0.0. Plover 5 has addressed this issue by switching to `importlib.meta.distributions()`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
