### PR TITLE
dragmap: fix build issues #517580

### DIFF
--- a/pkgs/by-name/dr/dragmap/cstdint.patch
+++ b/pkgs/by-name/dr/dragmap/cstdint.patch
@@ -58,3 +58,16 @@ index eefb9ae..623a77f 100644
  class ReadGroupList {
  public:
    const std::string &getReadGroupName(const uint16_t idx) const {
+
+diff --git a/stubs/dragen/src/host/metrics/public/run_stats.hpp b/stubs/dragen/src/host/metrics/public/run_stats.hpp
+index 998fe4e..9561b0b 100644
+--- a/stubs/dragen/src/host/metrics/public/run_stats.hpp
++++ b/stubs/dragen/src/host/metrics/public/run_stats.hpp
+@@ -10,6 +10,7 @@
+ #include <string>
+ #include <vector>
+ #include <memory>
++#include <cstdint>
+ //
+ // RP: HA! HA! HA! That's what you get when you write code logging to cout all
+ // over the place!

--- a/pkgs/by-name/dr/dragmap/getHostVersion.patch
+++ b/pkgs/by-name/dr/dragmap/getHostVersion.patch
@@ -1,0 +1,11 @@
+diff --git a/thirdparty/dragen/src/common/hash_generation/gen_hash_table.c b/thirdparty/dragen/src/common/hash_generation/gen_hash_table.c
+index cdca3df..5a55699 100644
+--- a/thirdparty/dragen/src/common/hash_generation/gen_hash_table.c
++++ b/thirdparty/dragen/src/common/hash_generation/gen_hash_table.c
+@@ -249,7 +249,7 @@ void setDefaultHashParams(hashTableConfig_t* defConfig, const char* destDir, Has
+     free(dir);
+   }
+
+-  defConfig->hostVersion = (char*)getHostVersion(0);
++  defConfig->hostVersion = (char*)getHostVersion();
+ }

--- a/pkgs/by-name/dr/dragmap/package.nix
+++ b/pkgs/by-name/dr/dragmap/package.nix
@@ -19,13 +19,21 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-f1jsOErriS1I/iUS4CzJ3+Dz8SMUve/ccb3KaE+L7U8=";
   };
 
-  nativebuildInputs = [ boost ];
+  nativeBuildInputs = [ boost ];
   buildInputs = [
     gtest
     zlib
   ];
 
+  # Latest boost do not need system as a linking flag
+  postPatch = ''
+    sed -i 's/system filesystem/filesystem/' config.mk
+  '';
+
   patches = [
+    # getHostVersion use an empty parameter list. This is now an error for GC
+    ./getHostVersion.patch
+
     # pclose is called on a NULL value. This is no longer allowed since
     #  https://github.com/bminor/glibc/commit/64b1a44183a3094672ed304532bedb9acc707554
     ./stdio-pclose.patch


### PR DESCRIPTION
Now compatible with latest boost and GCC with additional include headers and a fix for link flags.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
