### PR TITLE
nixos/zswap: Allow enabling zswap without any explicit swap devices if swapspace is enabled

### DIFF
--- a/nixos/modules/system/boot/zswap.nix
+++ b/nixos/modules/system/boot/zswap.nix
@@ -154,7 +154,7 @@ in
         '';
       }
       {
-        assertion = config.swapDevices != [ ];
+        assertion = config.swapDevices != [ ] || config.services.swapspace.enable;
         message = ''
           Zswap requires at least one physical swap device to function as a backing store.
 


### PR DESCRIPTION
This is perhaps a bit of a niche situation, but I noticed it while looking at the newly-merged zswap config code. The module includes an assert that if zswap is enabled, there's also a swap device added to the config. This makes sense, given that zswap doesn't work unless there's a swap device for Linux to try and swap into. *However*, it's possible for a user to use `services.swapspace` to have the system automatically manage swap files *instead*, which can work in conjunction with zswap. This is *arguably* not an ideal setup (since it requires zswap to wait for swapspace to decide to generate a swap file), but this setup is functional. However, the assert prevents users from using this setup. This PR simply modifies the assert to accept an empty `swapDevices` list if `services.swapspace.enable` is true to allow for this use-case.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
