### PR TITLE
nixos/rustnet: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -308,6 +308,7 @@
   ./programs/rog-control-center.nix
   ./programs/rush.nix
   ./programs/rust-motd.nix
+  ./programs/rustnet.nix
   ./programs/ryzen-monitor-ng.nix
   ./programs/schroot.nix
   ./programs/screen.nix

--- a/nixos/modules/programs/rustnet.nix
+++ b/nixos/modules/programs/rustnet.nix
@@ -1,0 +1,43 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.rustnet;
+
+in
+{
+  options = {
+    programs.rustnet = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether to add rustnet to the global environment and configure a
+          setcap wrapper for it. The wrapper grants the capabilities
+          required for read-only packet capture (`cap_net_raw`) and for
+          eBPF-enhanced process tracking (`cap_bpf`, `cap_perfmon`),
+          allowing any user to run rustnet without sudo.
+        '';
+      };
+
+      package = lib.mkPackageOption pkgs "rustnet" { };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    security.wrappers.rustnet = {
+      owner = "root";
+      group = "root";
+      capabilities = "cap_net_raw,cap_bpf,cap_perfmon+eip";
+      source = lib.getExe cfg.package;
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ dvaerum ];
+}


### PR DESCRIPTION
## Description

Follow-up to #445289 (which added the `rustnet` package). This adds a NixOS module so users get the equivalent of `setcap 'cap_net_raw,cap_bpf,cap_perfmon+eip'` automatically: enabling the module installs rustnet and configures a `security.wrappers` entry, allowing any user to run rustnet without sudo.

Direct `setcap` on the binary is not viable on NixOS because `/nix/store` is read-only, so the standard pattern is to wrap the binary via `security.wrappers`, the same approach used by `programs.mtr` and `programs.wireshark`.

Capabilities follow rustnet's documented minimum-privilege set:

* `cap_net_raw`: raw socket access for read-only, non-promiscuous packet capture.
* `cap_bpf`, `cap_perfmon`: load eBPF programs and attach kprobes for process tracking on Linux 5.8+.

`cap_net_admin` is intentionally not granted, since rustnet does not require promiscuous mode. rustnet itself drops the elevated capabilities after pcap and eBPF init via its built-in landlock sandbox.

Usage:

```nix
programs.rustnet.enable = true;
```

## Things done

* Built on platform:
  * [x] x86_64-linux
  * [x] aarch64-linux
* Tested, as applicable:
  * Confirmed `nix run nixpkgs#rustnet -- --version` and `--help` work on aarch64-linux (binary substituted from `cache.nixos.org`).
  * Confirmed the module evaluates against a minimal NixOS configuration: `nix-instantiate '<nixpkgs/nixos>' -A config.security.wrappers.rustnet --arg configuration '{ programs.rustnet.enable = true; ... }'` yields the expected wrapper with `capabilities = "cap_net_raw,cap_bpf,cap_perfmon+eip"` and `source = \${pkgs.rustnet}/bin/rustnet`.
* [x] `nix fmt` reports no changes.