### PR TITLE
nodejs_26: 26.0.0 -> 26.1.0

### DIFF
--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -10,6 +10,7 @@
   c-ares,
   gtest,
   hdrhistogram_c,
+  libffiReal,
   libuv,
   lief,
   llhttp,
@@ -129,6 +130,7 @@ let
   # TODO: also handle MIPS flags (mips_arch, mips_fpu, mips_float_abi).
 
   useSharedAdaAndSimd = lib.versionAtLeast version "22.2";
+  useSharedFFI = lib.versionAtLeast version "26.1";
   useSharedGtestAndHistogram = lib.versionAtLeast version (
     if majorVersion == 24 then "24.14.0" else "25.4"
   );
@@ -169,6 +171,9 @@ let
   // (lib.optionalAttrs useSharedGtestAndHistogram {
     inherit gtest;
     hdr-histogram = hdrhistogram_c;
+  })
+  // (lib.optionalAttrs useSharedFFI {
+    ffi = libffiReal;
   })
   // (lib.optionalAttrs useSharedLief {
     inherit lief;
@@ -393,6 +398,7 @@ let
           "tooltest"
           "cctest"
         ]
+        ++ lib.optional useSharedFFI "build-ffi-tests"
         ++ lib.optionals (!stdenv.buildPlatform.isDarwin || lib.versionAtLeast version "20") [
           # There are some test failures on macOS before v20 that are not worth the
           # time to debug for a version that would be eventually removed in less

--- a/pkgs/development/web/nodejs/v26.nix
+++ b/pkgs/development/web/nodejs/v26.nix
@@ -23,8 +23,8 @@ let
       [ ];
 in
 buildNodejs {
-  version = "26.0.0";
-  sha256 = "fcb5e5c06a5c2ec9e669801248657aafaa2291f8760dac7bfb639f878318c592";
+  version = "26.1.0";
+  sha256 = "779a1364889575d44e0215adc381806bbd0d9437557b59893e172f5b9d35a990";
   patches =
     (
       if (stdenv.hostPlatform.emulatorAvailable buildPackages) then
@@ -58,27 +58,6 @@ buildNodejs {
       ./use-nix-codesign.patch
 
       ./fix-temporal-integration-with-shared-icu.patch
-      # TODO: remove when included in a next release
-      (fetchpatch2 {
-        url = "https://github.com/nodejs/node/commit/730fa6a16fa47406905b47540f3ab46ee10420c2.patch?full_index=1";
-        hash = "sha256-Ks9mT/7fcJ9nl8FWHq7HrVP+ZHF9AEOYV7xsN/NOWII=";
-      })
-
-      # Patch for nghttp2 1.69 support
-      # TODO: remove when included in a next release
-      (fetchpatch2 {
-        url = "https://github.com/nodejs/node/commit/4a32c00fb8dbe55c3bcf9ef43343968c9fe449e6.diff?full_index=1";
-        hash = "sha256-pex8ruwa4b/vWvfGA+nyN3JJP8NOturmwAQe4Rkd6nU=";
-        excludes = [ "tools/nix/*" ];
-      })
-
-      # https://github.com/NixOS/nixpkgs/pull/507974#issuecomment-4249433124
-      # OpenSSL reports different errors
-      # https://github.com/nodejs/node/pull/62629
-      (fetchpatch2 {
-        url = "https://github.com/nodejs/node/commit/dd25d8f29d3ddadcf5a5ebfdf98ece55f9df96c6.patch?full_index=1";
-        hash = "sha256-6cxRN7TyWmJgUZt3jp2YXbVIjrDb2BNep5LxBOtT3Q0=";
-      })
     ]
     ++ gypPatches;
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
