### PR TITLE
haskellPackages.qhs: fix dependency bounds and tests

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -832,6 +832,15 @@ with haskellLib;
   # Tests require a Kafka broker running locally
   haskakafka = dontCheck super.haskakafka;
 
+  # https://github.com/itchyny/qhs/issues/8
+  qhs = overrideSrc {
+    version = "0.4.3";
+    src = pkgs.fetchzip {
+      url = "mirror://hackage/qhs-0.4.3/qhs-0.4.3.tar.gz";
+      sha256 = "191015m47qdxzi8w5pvadgv95g8vk7v2gr76jzfgglyjy6zhb5wb";
+    };
+  } (warnAfterVersion "0.4.2" super.qhs);
+
   # Fix build with time >= 1.10 while retaining compat with time < 1.9
   mbox = appendPatch ./patches/mbox-time-1.10.patch (
     overrideCabal {

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -5160,7 +5160,6 @@ broken-packages:
   - qc-oi-testgenerator # failure in job https://hydra.nixos.org/build/233197822 at 2023-09-02
   - qd # failure in job https://hydra.nixos.org/build/233213936 at 2023-09-02
   - qed # failure in job https://hydra.nixos.org/build/233249635 at 2023-09-02
-  - qhs # failure in job https://hydra.nixos.org/build/315099159 at 2025-11-29
   - qhull-simple # failure in job https://hydra.nixos.org/build/233248108 at 2023-09-02
   - qif # failure in job https://hydra.nixos.org/build/233227609 at 2023-09-02
   - QIO # failure in job https://hydra.nixos.org/build/233233009 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -134,6 +134,18 @@ builtins.intersectAttrs super {
   ### END HASKELL-LANGUAGE-SERVER SECTION ###
   ###########################################
 
+  qhs = lib.pipe super.qhs [
+    # Package does not declare tool dependency hspec-discover
+    (addTestToolDepends [ self.hspec-discover ])
+    # tests depend on executable
+    (overrideCabal (drv: {
+      preCheck = ''
+        ${drv.preCheck or ""}
+        export PATH="$PWD/dist/build/qhs:$PATH"
+      '';
+    }))
+  ];
+
   # Test suite needs executable
   agda2lagda = overrideCabal (drv: {
     preCheck = ''


### PR DESCRIPTION
Fix `qhs` by relaxing stale Cabal bounds and making its test suite use the
newly built executable.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

Test details:

- `nix-build --option sandbox true -A haskellPackages.qhs`
  - upstream Hspec suite: `70 examples, 0 failures`
- `nixpkgs-review wip --no-shell --print-result --build-args '--option sandbox true'`
  - `aarch64-darwin`: built `haskellPackages.qhs`
- `./result/bin/qhs --version`
- Basic stdin query through `./result/bin/qhs`

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
