### PR TITLE
macskk: 1.11.0 -> 2.14.0

### DIFF
--- a/pkgs/by-name/ma/macskk/package.nix
+++ b/pkgs/by-name/ma/macskk/package.nix
@@ -31,7 +31,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     7zz x $src
     xar -xf macSKK-${finalAttrs.version}.pkg
     cat app.pkg/Payload | gunzip -dc | cpio -i
-    cat dict.pkg/Payload | gunzip -dc | cpio -i
 
     runHook postUnpack
   '';
@@ -39,10 +38,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p "$out"/Library/{Containers,Input\ Methods}
+    mkdir -p "$out"/Library/Input\ Methods
     mkdir -p "$out/bin"
     cp -a "Library/Input Methods/macSKK.app" "$out/Library/Input Methods/"
-    cp -a "Library/Containers/net.mtgto.inputmethod.macSKK" "$out/Library/Containers/"
     ln -s "$out/Library/Input Methods/macSKK.app/Contents/MacOS/macSKK" "$out/bin/macSKK"
 
     runHook postInstall

--- a/pkgs/by-name/ma/macskk/package.nix
+++ b/pkgs/by-name/ma/macskk/package.nix
@@ -11,11 +11,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "macskk";
-  version = "1.11.0";
+  version = "2.14.0";
 
   src = fetchurl {
     url = "https://github.com/mtgto/macSKK/releases/download/${finalAttrs.version}/macSKK-${finalAttrs.version}.dmg";
-    hash = "sha256-CqtW6bfSuAo+9VRmRTgx0aKpBKBEDIxidOh7V5vD7ww=";
+    hash = "sha256-fjvrH/sd6A0d4ye7L/YMb+j4G6yxIZkxY4CN6z/n5JE=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixes the `macskk` 2.14.0 build on Darwin.

Since macSKK 2.0.0, the upstream installer no longer bundles the dictionary package. The 2.14.0 `.pkg` only contains `app.pkg`, so the existing derivation failed while trying to unpack `dict.pkg/Payload`. This removes the stale `dict.pkg` extraction and the now-missing `Library/Containers/net.mtgto.inputmethod.macSKK` copy.

Changelog: https://github.com/mtgto/macSKK/blob/2.14.0/CHANGELOG.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
