### PR TITLE
codex-auth: init at 0.2.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23295,6 +23295,12 @@
     githubId = 988098;
     name = "Richard Palethorpe";
   };
+  richienb = {
+    email = "richiebendall@gmail.com";
+    github = "Richienb";
+    githubId = 29491356;
+    name = "Richie Bendall";
+  };
   rick68 = {
     email = "rick68@gmail.com";
     github = "rick68";

--- a/pkgs/by-name/co/codex-auth/package.nix
+++ b/pkgs/by-name/co/codex-auth/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  makeWrapper,
+  nodejs_24,
+  versionCheckHook,
+  zig_0_15,
+}:
+
+let
+  zig = zig_0_15;
+in
+stdenv.mkDerivation rec {
+  pname = "codex-auth";
+  version = "0.2.8";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Loongphy";
+    repo = "codex-auth";
+    rev = "v${version}";
+    hash = "sha256-J1aq5ieWkHqze4HF/7Lw+VIa+FxO7vmsXaDJc7VH+Wk=";
+  };
+
+  nativeBuildInputs = [
+    zig
+    makeWrapper
+  ]
+  ++ lib.optional (zig ? hook) zig.hook;
+
+  dontUseZigBuild = true;
+  dontUseZigCheck = true;
+  dontAddPrefix = true;
+
+  zigInstallFlags = [
+    "-Doptimize=ReleaseSafe"
+    "--prefix"
+    (builtins.placeholder "out")
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/codex-auth \
+      --prefix PATH : ${lib.makeBinPath [ nodejs_24 ]}
+  '';
+
+  doInstallCheck = true;
+  versionCheckProgramArg = "--version";
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "CLI for switching and managing Codex accounts";
+    homepage = "https://github.com/Loongphy/codex-auth";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ richienb ];
+    mainProgram = "codex-auth";
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
