### PR TITLE
nixos/virtualisation.kvmgt: explain explicitly it is meant for host

### DIFF
--- a/nixos/modules/virtualisation/kvmgt.nix
+++ b/nixos/modules/virtualisation/kvmgt.nix
@@ -25,9 +25,9 @@ in
     virtualisation.kvmgt = {
       enable = mkEnableOption ''
         KVMGT (iGVT-g) VGPU support.
-        Allows Qemu/KVM guests to share host's Intel integrated graphics card.
+        When enabled on a host, allows Qemu/KVM guests to share host's Intel integrated graphics card.
         Currently only one graphical device can be shared.
-        To allow users to access the device without root add them to the kvm group: `users.extraUsers.<yourusername>.extraGroups = [ "kvm" ];`
+        To allow host users to access the device without root add them to the kvm group: `users.extraUsers.<yourusername>.extraGroups = [ "kvm" ];`
       '';
       # multi GPU support is under the question
       device = mkOption {
@@ -39,7 +39,7 @@ in
         default = { };
         type = with types; attrsOf (submodule [ { options = vgpuOptions; } ]);
         description = ''
-          Virtual GPUs to be used in Qemu.
+          Virtual GPUs of the host to be used in Qemu.
           You can find devices via {command}`ls /sys/bus/pci/devices/*/mdev_supported_types` and find info about device via {command}`cat /sys/bus/pci/devices/*/mdev_supported_types/i915-GVTg_V5_4/description`
         '';
         example = {

--- a/nixos/modules/virtualisation/kvmgt.nix
+++ b/nixos/modules/virtualisation/kvmgt.nix
@@ -24,9 +24,10 @@ in
   options = {
     virtualisation.kvmgt = {
       enable = mkEnableOption ''
-        KVMGT (iGVT-g) VGPU support. Allows Qemu/KVM guests to share host's Intel integrated graphics card.
-        Currently only one graphical device can be shared. To allow users to access the device without root add them
-        to the kvm group: `users.extraUsers.<yourusername>.extraGroups = [ "kvm" ];`
+        KVMGT (iGVT-g) VGPU support.
+        Allows Qemu/KVM guests to share host's Intel integrated graphics card.
+        Currently only one graphical device can be shared.
+        To allow users to access the device without root add them to the kvm group: `users.extraUsers.<yourusername>.extraGroups = [ "kvm" ];`
       '';
       # multi GPU support is under the question
       device = mkOption {
@@ -38,8 +39,8 @@ in
         default = { };
         type = with types; attrsOf (submodule [ { options = vgpuOptions; } ]);
         description = ''
-          Virtual GPUs to be used in Qemu. You can find devices via {command}`ls /sys/bus/pci/devices/*/mdev_supported_types`
-          and find info about device via {command}`cat /sys/bus/pci/devices/*/mdev_supported_types/i915-GVTg_V5_4/description`
+          Virtual GPUs to be used in Qemu.
+          You can find devices via {command}`ls /sys/bus/pci/devices/*/mdev_supported_types` and find info about device via {command}`cat /sys/bus/pci/devices/*/mdev_supported_types/i915-GVTg_V5_4/description`
         '';
         example = {
           i915-GVTg_V5_8.uuid = [ "a297db4a-f4c2-11e6-90f6-d3b88d6c9525" ];


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test