### PR TITLE
mutagen: 0.18.0 -> 0.18.1

### DIFF
--- a/pkgs/by-name/mu/mutagen/package.nix
+++ b/pkgs/by-name/mu/mutagen/package.nix
@@ -8,16 +8,16 @@
 
 buildGoModule rec {
   pname = "mutagen";
-  version = "0.18.0";
+  version = "0.18.1";
 
   src = fetchFromGitHub {
     owner = "mutagen-io";
     repo = "mutagen";
     rev = "v${version}";
-    hash = "sha256-/UigWQMk+VDMGna/ixctU8MR7VNPpOTOGNUtuYx8DS0=";
+    hash = "sha256-eT1B2ifs1BA2wcVyz9C9F8YoSbGcpGghu5Z3UrjfBOc=";
   };
 
-  vendorHash = "sha256-J92LzjIsLlBOhnkWrp8MRgoe+4NzXyBgqQRigse5GQk=";
+  vendorHash = "sha256-RVVUeNfp/HWd3/5uCyaDGw6bXFJvfomhu//829jO+qE=";
 
   agents = fetchzip {
     name = "mutagen-agents-${version}";
@@ -27,7 +27,7 @@ buildGoModule rec {
     postFetch = ''
       rm $out/mutagen # Keep only mutagen-agents.tar.gz.
     '';
-    hash = "sha256-EGMBsv6WjmWj/tOhtOORd6eqHmdfJb5pxPrb3zr/ynI=";
+    hash = "sha256-ltObD3MCSYE7IJaEDyB35CqmtUKintsaD0sMQdFAfYY=";
   };
 
   nativeBuildInputs = [ installShellFiles ];


### PR DESCRIPTION
Update to 0.18.1

Upstream changelog:

Fixed compatibility issue with Docker Engine (Moby) v28.0.0+ (thanks to @rfay for reporting)
Updated to Go 1.23.6 (does not apply to nix package)
Updated to Alpine 3.21 in Docker images  (does not apply to nix package)
Update golang.org/x/* dependencies

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
