### PR TITLE
xenia-canary: 0-unstable-2026-05-03 -> 0-unstable-2026-05-09

### DIFF
--- a/pkgs/by-name/xe/xenia-canary/package.nix
+++ b/pkgs/by-name/xe/xenia-canary/package.nix
@@ -33,14 +33,14 @@ let
 in
 llvmPackages_20.stdenv.mkDerivation {
   pname = "xenia-canary";
-  version = "0-unstable-2026-05-03";
+  version = "0-unstable-2026-05-09";
 
   src = fetchFromGitHub {
     owner = "xenia-canary";
     repo = "xenia-canary";
     fetchSubmodules = true;
-    rev = "9467c77f0825f3f8156038ef1a03e27b6c727393";
-    hash = "sha256-hGr8KJcvLkluup5FN+MW7+ciuztgGO+SyTvKXYSHeIk=";
+    rev = "3e1bff213d2d59c2b36239b9668d3298d99ca3e5";
+    hash = "sha256-bQgC8wVONKTUpsqNz8FOD0ACRy7zbC9lnxtJqPU6P6o=";
   };
 
   dontConfigure = true;
@@ -114,7 +114,10 @@ llvmPackages_20.stdenv.mkDerivation {
     description = "Xbox 360 Emulator Research Project";
     homepage = "https://github.com/xenia-canary/xenia-canary";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ tuxy ];
+    maintainers = with lib.maintainers; [
+      tuxy
+      reylak
+    ];
     mainProgram = "xenia_canary";
     platforms = [ "x86_64-linux" ];
   };


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.