### PR TITLE
maintainers: remove sitaaax

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25486,12 +25486,6 @@
     githubId = 74881555;
     name = "Fofanov Sergey";
   };
-  sitaaax = {
-    email = "johannes@kle1n.com";
-    github = "SitAAAx";
-    githubId = 74413170;
-    name = "Johannes Klein";
-  };
   sith-lord-vader = {
     email = "nixpkgs@xpertsre.rocks";
     github = "sith-lord-vader";

--- a/pkgs/by-name/pr/protoc-gen-prost-crate/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-prost-crate/package.nix
@@ -24,9 +24,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/neoeinstein/protoc-gen-prost";
     changelog = "https://github.com/neoeinstein/protoc-gen-prost/blob/main/CHANGELOG.md";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [
-      felschr
-      sitaaax
-    ];
+    maintainers = with lib.maintainers; [ felschr ];
   };
 })

--- a/pkgs/by-name/pr/protoc-gen-prost-serde/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-prost-serde/package.nix
@@ -24,9 +24,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/neoeinstein/protoc-gen-prost";
     changelog = "https://github.com/neoeinstein/protoc-gen-prost/blob/main/CHANGELOG.md";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [
-      felschr
-      sitaaax
-    ];
+    maintainers = with lib.maintainers; [ felschr ];
   };
 })

--- a/pkgs/by-name/pr/protoc-gen-prost/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-prost/package.nix
@@ -24,9 +24,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/neoeinstein/protoc-gen-prost";
     changelog = "https://github.com/neoeinstein/protoc-gen-prost/blob/main/CHANGELOG.md";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [
-      felschr
-      sitaaax
-    ];
+    maintainers = with lib.maintainers; [ felschr ];
   };
 })

--- a/pkgs/by-name/pr/protoc-gen-tonic/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-tonic/package.nix
@@ -24,9 +24,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/neoeinstein/protoc-gen-prost";
     changelog = "https://github.com/neoeinstein/protoc-gen-prost/blob/main/CHANGELOG.md";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [
-      felschr
-      sitaaax
-    ];
+    maintainers = with lib.maintainers; [ felschr ];
   };
 })


### PR DESCRIPTION
## Reasons

- Last commented in [August 2024](https://github.com/NixOS/nixpkgs/issues?q=commenter%3ASitAAAx)
- Hasn't created any PRs / Issues since [August 2024](https://github.com/NixOS/nixpkgs/issues?q=author%3ASitAAAx)
- About 8 [unanswered ](https://github.com/NixOS/nixpkgs/issues?q=involves%3ASitAAAx%20-commenter%3ASitAAAx%20-author%3ASitAAAx%20-reviewed-by%3ASitAAAx) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.