### PR TITLE
[Backport release-25.11] Zabbix: Multiple versions

### DIFF
--- a/pkgs/servers/monitoring/zabbix/agent.nix
+++ b/pkgs/servers/monitoring/zabbix/agent.nix
@@ -48,6 +48,11 @@ import ./versions.nix (
     meta = {
       description = "Enterprise-class open source distributed monitoring solution (client-side agent)";
       homepage = "https://www.zabbix.com/";
+      knownVulnerabilities =
+        if (lib.versions.majorMinor version == "7.2") then
+          [ "Zabbix 7.2 has reached end-of-life on 2025-12-31" ]
+        else
+          [ ];
       license =
         if (lib.versions.major version >= "7") then lib.licenses.agpl3Only else lib.licenses.gpl2Plus;
       maintainers = with lib.maintainers; [

--- a/pkgs/servers/monitoring/zabbix/agent2.nix
+++ b/pkgs/servers/monitoring/zabbix/agent2.nix
@@ -81,6 +81,11 @@ import ./versions.nix (
     meta = {
       description = "Enterprise-class open source distributed monitoring solution (client-side agent)";
       homepage = "https://www.zabbix.com/";
+      knownVulnerabilities =
+        if (lib.versions.majorMinor version == "7.2") then
+          [ "Zabbix 7.2 has reached end-of-life on 2025-12-31" ]
+        else
+          [ ];
       license =
         if (lib.versions.major version >= "7") then lib.licenses.agpl3Only else lib.licenses.gpl2Plus;
       maintainers = with lib.maintainers; [

--- a/pkgs/servers/monitoring/zabbix/proxy.nix
+++ b/pkgs/servers/monitoring/zabbix/proxy.nix
@@ -119,6 +119,11 @@ import ./versions.nix (
     meta = {
       description = "Enterprise-class open source distributed monitoring solution (client-server proxy)";
       homepage = "https://www.zabbix.com/";
+      knownVulnerabilities =
+        if (lib.versions.majorMinor version == "7.2") then
+          [ "Zabbix 7.2 has reached end-of-life on 2025-12-31" ]
+        else
+          [ ];
       license =
         if (lib.versions.major version >= "7") then lib.licenses.agpl3Only else lib.licenses.gpl2Plus;
       maintainers = with lib.maintainers; [

--- a/pkgs/servers/monitoring/zabbix/server.nix
+++ b/pkgs/servers/monitoring/zabbix/server.nix
@@ -120,6 +120,11 @@ import ./versions.nix (
     meta = {
       description = "Enterprise-class open source distributed monitoring solution";
       homepage = "https://www.zabbix.com/";
+      knownVulnerabilities =
+        if (lib.versions.majorMinor version == "7.2") then
+          [ "Zabbix 7.2 has reached end-of-life on 2025-12-31" ]
+        else
+          [ ];
       license =
         if (lib.versions.major version >= "7") then lib.licenses.agpl3Only else lib.licenses.gpl2Plus;
       maintainers = with lib.maintainers; [

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -8,8 +8,8 @@ generic: {
     hash = "sha256-twEwY7nGJWoYX25gAe/31DuDGxg6o5Ez1u5STQVw6Fw=";
   };
   v70 = generic {
-    version = "7.0.22";
-    hash = "sha256-enR5SyEkYH2ANr42zBBNoFai+2U4EchKy+KfP22Xhgo=";
+    version = "7.0.23";
+    hash = "sha256-Q+pfyx5dsl50vcg+qJNtebgJO2FK9OiJQXSFvHTwYeI=";
   };
   v60 = generic {
     version = "6.0.43";

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -12,7 +12,7 @@ generic: {
     hash = "sha256-Q+pfyx5dsl50vcg+qJNtebgJO2FK9OiJQXSFvHTwYeI=";
   };
   v60 = generic {
-    version = "6.0.43";
-    hash = "sha256-FsRgW9sd1AYIIUjyz+eM8zV6uJuDdpVS4xfw+MB+HpY=";
+    version = "6.0.44";
+    hash = "sha256-TveW2ofMnm3PXUPwoklTPe48tI6dED/dAQKjwO2P4F4=";
   };
 }

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -1,7 +1,7 @@
 generic: {
   v74 = generic {
-    version = "7.4.6";
-    hash = "sha256-zMGw1psEFzsOeu7KlHi7b11JmccdTtUPgXNRvwEaaYs=";
+    version = "7.4.7";
+    hash = "sha256-FsOZQv6yg9euoX6Ccfy0/9usBpkVYVjcs3IZZ095m9g=";
   };
   v72 = generic {
     version = "7.2.15";

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -12,7 +12,7 @@ generic: {
     hash = "sha256-b4rpkLmyV2fk//vLXMfEVdZ04qOS3CFHhIil0cDn1Zc=";
   };
   v60 = generic {
-    version = "6.0.44";
-    hash = "sha256-TveW2ofMnm3PXUPwoklTPe48tI6dED/dAQKjwO2P4F4=";
+    version = "6.0.45";
+    hash = "sha256-duB2w2xDH9ZHEDh9iZ5Fr6RH0dI2lMCVvySA5dmSZcU=";
   };
 }

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -8,8 +8,8 @@ generic: {
     hash = "sha256-twEwY7nGJWoYX25gAe/31DuDGxg6o5Ez1u5STQVw6Fw=";
   };
   v70 = generic {
-    version = "7.0.23";
-    hash = "sha256-Q+pfyx5dsl50vcg+qJNtebgJO2FK9OiJQXSFvHTwYeI=";
+    version = "7.0.24";
+    hash = "sha256-b4rpkLmyV2fk//vLXMfEVdZ04qOS3CFHhIil0cDn1Zc=";
   };
   v60 = generic {
     version = "6.0.44";

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -1,7 +1,7 @@
 generic: {
   v74 = generic {
-    version = "7.4.7";
-    hash = "sha256-FsOZQv6yg9euoX6Ccfy0/9usBpkVYVjcs3IZZ095m9g=";
+    version = "7.4.8";
+    hash = "sha256-qbRStsV00igpziBpOhqpyriL8PWFt6oqajrUyxTdOxw=";
   };
   v72 = generic {
     version = "7.2.15";

--- a/pkgs/servers/monitoring/zabbix/web.nix
+++ b/pkgs/servers/monitoring/zabbix/web.nix
@@ -31,6 +31,11 @@ import ./versions.nix (
     meta = {
       description = "Enterprise-class open source distributed monitoring solution (web frontend)";
       homepage = "https://www.zabbix.com/";
+      knownVulnerabilities =
+        if (lib.versions.majorMinor version == "7.2") then
+          [ "Zabbix 7.2 has reached end-of-life on 2025-12-31" ]
+        else
+          [ ];
       license =
         if (lib.versions.major version >= "7") then lib.licenses.agpl3Only else lib.licenses.gpl2Plus;
       maintainers = with lib.maintainers; [


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/489460
zabbix: 6.0.43 -> 6.0.44
zabbix70: 7.0.22 -> 7.0.23
zabbix74: 7.4.6 -> 7.4.7
https://github.com/NixOS/nixpkgs/pull/500344
zabbix: 6.0.44 -> 6.0.45
zabbix70: 7.0.23 -> 7.0.24
zabbix74: 7.4.7 -> 7.4.8

Fixes #517662 ([CVE-2026-23926](https://nvd.nist.gov/vuln/detail/CVE-2026-23926))
Fixes #517656 ([CVE-2026-23927](https://nvd.nist.gov/vuln/detail/CVE-2026-23927))
Fixes #517658 ([CVE-2026-23928](https://nvd.nist.gov/vuln/detail/CVE-2026-23928))

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
