### PR TITLE
amnezia-vpn-bin: init at 4.8.15.4

### DIFF
--- a/pkgs/by-name/am/amnezia-vpn-bin/package.nix
+++ b/pkgs/by-name/am/amnezia-vpn-bin/package.nix
@@ -1,0 +1,140 @@
+{
+  stdenv,
+  fetchzip,
+  lib,
+  libarchive,
+  makeWrapper,
+  autoPatchelfHook,
+  libxkbcommon,
+  libxcb-cursor,
+  libxcb-wm,
+  libxcb-util,
+  libxcb-image,
+  libxcb-keysyms,
+  libxcb-render-util,
+  krb5,
+  brotli,
+  fontconfig,
+  freetype,
+  gtk3,
+  pango,
+  at-spi2-atk,
+  unixodbc,
+  firebird,
+  libdrm,
+  openldap,
+  bash,
+  kdePackages,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "amnezia-vpn-bin";
+  version = "4.8.15.4";
+
+  __structuredAttrs = true;
+
+  src = fetchzip {
+    url = "https://github.com/amnezia-vpn/amnezia-client/releases/download/${finalAttrs.version}/AmneziaVPN_${finalAttrs.version}_linux_x64.tar";
+    hash = "sha256-Dr8zuzgwMAPXOTh69URFvA7EzGMnfBFO6kPhjhtjr6A=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    libarchive
+    makeWrapper
+  ];
+
+  buildInputs = [
+    stdenv.cc.cc
+    bash
+    libxkbcommon
+    libxcb-cursor
+    libxcb-wm
+    libxcb-util
+    libxcb-image
+    libxcb-keysyms
+    libxcb-render-util
+    krb5.lib
+    brotli.lib
+    fontconfig.lib
+    freetype
+    gtk3
+    pango
+    at-spi2-atk
+    unixodbc
+    firebird
+    libdrm
+    openldap
+    kdePackages.wayland
+  ];
+
+  # These libraries are not available in nixpkgs. They are Oracle Instant Client
+  # (libclntsh.so.23.1) and UCanAccess/Mimer SQL (libmimerapi.so) drivers that
+  # are bundled with Qt's SQlite database plugins (libqsqlora, libqsqlmimer).
+  # The Amnezia VPN binary ships pre-linked against these Qt database drivers
+  # even though it does not use them. Without ignoring these missing deps,
+  # autoPatchelfHook would fail the build.
+  autoPatchelfIgnoreMissingDeps = [
+    "libclntsh.so.23.1"
+    "libmimerapi.so"
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/amnezia-vpn $out/bin $out/share/applications $out/lib/systemd/system $out/share/icons/hicolor/512x512/apps
+
+    bsdtar -xf AmneziaVPN_Linux_Installer.bin -C $out/share/amnezia-vpn
+
+    makeWrapper "$out/share/amnezia-vpn/client/bin/AmneziaVPN" "$out/bin/AmneziaVPN" \
+      --prefix LD_LIBRARY_PATH : "$out/share/amnezia-vpn/client/lib" \
+      --set QML_IMPORT_PATH "$out/share/amnezia-vpn/client/qml" \
+      --set QML2_IMPORT_PATH "$out/share/amnezia-vpn/client/qml" \
+      --set QT_PLUGIN_PATH "$out/share/amnezia-vpn/client/plugins" \
+      --set QT_QPA_PLATFORM_PLUGIN_PATH "$out/share/amnezia-vpn/client/plugins/platforms" \
+      --set QTDIR "$out/share/amnezia-vpn/client" \
+      --set CQT_PKG_ROOT "$out/share/amnezia-vpn/client"
+
+    makeWrapper "$out/share/amnezia-vpn/service/bin/AmneziaVPN-service" "$out/bin/AmneziaVPN-service" \
+      --prefix LD_LIBRARY_PATH : "$out/share/amnezia-vpn/client/lib" \
+      --prefix LD_LIBRARY_PATH : "$out/share/amnezia-vpn/service/lib" \
+      --set QML_IMPORT_PATH "$out/share/amnezia-vpn/service/qml" \
+      --set QML2_IMPORT_PATH "$out/share/amnezia-vpn/service/qml" \
+      --set QT_PLUGIN_PATH "$out/share/amnezia-vpn/service/plugins" \
+      --set QT_QPA_PLATFORM_PLUGIN_PATH "$out/share/amnezia-vpn/service/plugins/platforms" \
+      --set QTDIR "$out/share/amnezia-vpn/service" \
+      --set CQT_PKG_ROOT "$out/share/amnezia-vpn/service"
+
+    substituteInPlace $out/share/amnezia-vpn/AmneziaVPN.service \
+      --replace-fail "ExecStart=/opt/AmneziaVPN/service/AmneziaVPN-service.sh" "AmneziaVPN-service" \
+      --replace-fail "Environment=LD_LIBRARY_PATH=/opt/AmneziaVPN/client/lib" ""
+    ln -s $out/share/amnezia-vpn/AmneziaVPN.service $out/lib/systemd/system/AmneziaVPN.service
+
+    substituteInPlace $out/share/amnezia-vpn/AmneziaVPN.desktop \
+      --replace-fail "/usr/share/pixmaps/AmneziaVPN.png" "AmneziaVPN"
+    ln -s $out/share/amnezia-vpn/AmneziaVPN.desktop $out/share/applications/AmneziaVPN.desktop
+
+    ln -s $out/share/amnezia-vpn/AmneziaVPN.png $out/share/icons/hicolor/512x512/apps/AmneziaVPN.png
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Amnezia VPN Client (binary release)";
+    downloadPage = "https://amnezia.org/en/downloads";
+    homepage = "https://github.com/amnezia-vpn/amnezia-client";
+    license = lib.licenses.gpl3;
+    mainProgram = "AmneziaVPN";
+    maintainers = with lib.maintainers; [ sund3RRR ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
## Things done
Added the AmneziaVPN binary release from vendor. Probably this should fix all Amnezia Premium related issues (https://github.com/NixOS/nixpkgs/issues/474746) at least for `x86_64-linux` because original build has `PROD_AGW_PUBLIC_KEY` and `PROD_S3_ENDPOINT` which is needed for premium API interaction.

Package is fully compatible with `amnezia-vpn`, means it can be used as a replacement in module:
```nix
programs.amnezia-vpn = {
  enable = true;
  package = pkgs.amnezia-vpn-bin;
};
```

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
