### PR TITLE
asciinema-agg: 1.7.0 -> 1.8.1

### DIFF
--- a/pkgs/by-name/as/asciinema-agg/package.nix
+++ b/pkgs/by-name/as/asciinema-agg/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   rustPlatform,
   fetchFromGitHub,
   versionCheckHook,
@@ -7,24 +8,28 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "agg";
-  version = "1.7.0";
+  version = "1.8.1";
 
   src = fetchFromGitHub {
     owner = "asciinema";
     repo = "agg";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-6UenPE6mmmvliaIuGdQj/FrlmoJvmBJgfo0hW+uRaxM=";
+    hash = "sha256-64VyCTGjzey6AHEAfk5V/Qoffe5+sDaDNve54M7tmf4=";
   };
 
   strictDeps = true;
 
-  cargoHash = "sha256-VpbjvrMhzS1zrcMNWBjTLda6o3ea2cwpnEDUouwyp8w=";
+  cargoHash = "sha256-/WS5nAFKnP/CsU5+Pf5rtNN4LWaXVjlidLzH7DWYds0=";
+
+  __impureHostDeps = lib.optionals stdenv.hostPlatform.isDarwin [
+    "/System/Library/Fonts"
+  ];
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
 
   meta = {
-    description = "Command-line tool for generating animated GIF files from asciicast v2 files produced by asciinema terminal recorder";
+    description = "Command-line tool for generating animated GIF files from asciicast files produced by asciinema terminal recorder";
     homepage = "https://github.com/asciinema/agg";
     changelog = "https://github.com/asciinema/agg/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;


### PR DESCRIPTION
- Manual PR based on https://github.com/NixOS/nixpkgs/pull/517398
- Updates the description
- Fixes macos test failures

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core"
        functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in
      `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and
      other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
