### PR TITLE
nextinspace: 2.0.5 -> 3.0.1

### DIFF
--- a/pkgs/by-name/ne/nextinspace/package.nix
+++ b/pkgs/by-name/ne/nextinspace/package.nix
@@ -6,28 +6,28 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "nextinspace";
-  version = "2.0.5";
+  version = "3.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "not-stirred";
     repo = "nextinspace";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-CrhzCvIA3YAFsWvdemvK1RLMacsM5RtgMjLeiqz5MwY=";
+    hash = "sha256-oEvRxaxx1pIco2+jm/3HUN0a0nqdo2VosCisM0MWTjU=";
   };
 
-  nativeBuildInputs = with python3.pkgs; [
+  build-system = with python3.pkgs; [
     poetry-core
   ];
 
-  pythonPath = with python3.pkgs; [
+  dependencies = with python3.pkgs; [
     requests
     tzlocal
     colorama
   ];
 
   nativeCheckInputs = with python3.pkgs; [
-    pytest-lazy-fixture
+    pytest-lazy-fixtures
     pytestCheckHook
     requests-mock
   ];


### PR DESCRIPTION
Update to 3.0.1 and adapt build to new version

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
