### PR TITLE
netmask: 2.4.4 -> 2.5.0

### DIFF
--- a/pkgs/by-name/ne/netmask/package.nix
+++ b/pkgs/by-name/ne/netmask/package.nix
@@ -3,22 +3,33 @@
   stdenv,
   fetchFromGitHub,
   autoreconfHook,
+  autoconf-archive,
+  pkg-config,
   texinfo,
+  check,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "netmask";
-  version = "2.4.4";
+  version = "2.5.0";
 
   src = fetchFromGitHub {
     owner = "tlby";
     repo = "netmask";
     rev = "v${finalAttrs.version}";
-    sha256 = "1269bmdvl534wr0bamd7cqbnr76pnb14yn8ly4qsfg29kh7hrds6";
+    hash = "sha256-BXCZsk+52nygxtY1s4C79WCwy/iOSwgRnQYnauWGipQ=";
   };
 
   buildInputs = [ texinfo ];
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [
+    autoreconfHook
+    autoconf-archive
+    pkg-config
+  ];
+
+  nativeCheckInputs = [ check ];
+
+  doCheck = true;
 
   meta = {
     homepage = "https://github.com/tlby/netmask";


### PR DESCRIPTION
Update netmask to 2.5.0


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
