### PR TITLE
nixos/dms-greeter: added mango and miracle-wm as supported compositor…

### DIFF
--- a/nixos/modules/services/display-managers/dms-greeter.nix
+++ b/nixos/modules/services/display-managers/dms-greeter.nix
@@ -4,7 +4,6 @@
   pkgs,
   ...
 }:
-
 let
   inherit (lib)
     types
@@ -24,13 +23,27 @@ let
   cfgAutoLogin = config.services.displayManager.autoLogin;
   sessionData = config.services.displayManager.sessionData;
 
+  # Miracle WM is nested under `programs.wayland.miracle-wm` unlike the rest
+  compositorOption =
+    if cfg.compositor.name == "miracle-wm" then "wayland.miracle-wm" else "${cfg.compositor.name}";
   cacheDir = "/var/lib/dms-greeter";
+
+  # Not all compositor packages match the name they use and Miracle does not have a package option
+  compositorPkg =
+    if cfg.compositor.name == "miracle-wm" then
+      pkgs.miracle-wm
+    else
+      lib.attrByPath [
+        "programs"
+        cfg.compositor.name
+        "package"
+      ] null config;
 
   greeterScript = pkgs.writeShellScriptBin "dms-greeter-start" ''
     export PATH=$PATH:${
       makeBinPath [
         cfg.quickshell.package
-        config.programs.${cfg.compositor.name}.package
+        compositorPkg
       ]
     }
     ${
@@ -123,6 +136,9 @@ in
           "niri"
           "hyprland"
           "sway"
+          "mangowc"
+          "miracle-wm"
+          "labwc"
         ];
         example = "niri";
         description = ''
@@ -135,6 +151,9 @@ in
           - niri: A scrollable-tiling Wayland compositor
           - hyprland: A dynamic tiling Wayland compositor
           - sway: An i3-compatible Wayland compositor
+          - mango: A dwm-inspired Wayland compositor with modern config options and multiple layouts
+          - miracle-wm: A keyboard-driven Wayland compositor with smooth animations and extensibility
+          - labwc: Lightweight stacking Wayland compositor inspired by Openbox
         '';
       };
 
@@ -242,12 +261,16 @@ in
   config = mkIf cfg.enable {
     assertions = [
       {
-        assertion = config.programs.${cfg.compositor.name}.enable or false;
+        assertion =
+          # Assemble the full attribute structure because miracle-wm is not nested in the same location as the others
+          lib.attrByPath (
+            [ "programs" ] ++ lib.splitString "." compositorOption ++ [ "enable" ]
+          ) false config;
         message = ''
           DankMaterialShell greeter: The compositor "${cfg.compositor.name}" is not enabled.
 
           Please enable the compositor via:
-            programs.${cfg.compositor.name}.enable = true;
+            programs.${compositorOption}.enable = true;
         '';
       }
       {


### PR DESCRIPTION
Updated the `dms-greeter` module to include MangoWC and Miracle WM as valid compositor options for the DMS Greeter. This brings the NixOS implementation in line with the current documentation for valid compositors.

I ran and tested the greeter for basic setups on existing and new modules and they launched correctly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
