### PR TITLE
tree-sitter-grammars.tree-sitter-vcl: init at 0.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20084,6 +20084,12 @@
     githubId = 1839979;
     name = "Niklas Thörne";
   };
+  ntsk = {
+    email = "ntsk@ntsk.jp";
+    github = "ntsk";
+    githubId = 5681281;
+    name = "ntsk";
+  };
   nudelsalat = {
     email = "nudelsalat@clouz.de";
     name = "Fabian Dreßler";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20867,6 +20867,12 @@
     githubId = 1839979;
     name = "Niklas Thörne";
   };
+  ntsk = {
+    email = "ntsk@ntsk.jp";
+    github = "ntsk";
+    githubId = 5681281;
+    name = "ntsk";
+  };
   nudelsalat = {
     email = "nudelsalat@clouz.de";
     name = "Fabian Dreßler";

--- a/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
+++ b/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
@@ -2901,6 +2901,18 @@
     };
   };
 
+  vcl = rec {
+    version = "0.3.1";
+    url = "github:ntsk/tree-sitter-vcl?ref=v${version}";
+    hash = "sha256-aqEKHAb/ILoVAG2h/VuAn83HRZamrEgcjIGPatcQCfI=";
+    meta = {
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [
+        ntsk
+      ];
+    };
+  };
+
   vento = {
     version = "0-unstable-2026-02-23";
     url = "github:ventojs/tree-sitter-vento";

--- a/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
+++ b/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
@@ -2955,6 +2955,18 @@
     };
   };
 
+  vcl = rec {
+    version = "0.3.1";
+    url = "github:ntsk/tree-sitter-vcl?ref=v${version}";
+    hash = "sha256-aqEKHAb/ILoVAG2h/VuAn83HRZamrEgcjIGPatcQCfI=";
+    meta = {
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [
+        ntsk
+      ];
+    };
+  };
+
   vento = {
     version = "0-unstable-2026-02-23";
     url = "github:ventojs/tree-sitter-vento";

--- a/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
+++ b/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
@@ -2956,9 +2956,9 @@
   };
 
   vcl = rec {
-    version = "0.3.1";
+    version = "0.4.0";
     url = "github:ntsk/tree-sitter-vcl?ref=v${version}";
-    hash = "sha256-aqEKHAb/ILoVAG2h/VuAn83HRZamrEgcjIGPatcQCfI=";
+    hash = "sha256-qV+Ww5pzUHxmv9R6zIJDcLZnHLHL6xi3EZoRlhzgISQ=";
     meta = {
       license = lib.licenses.mit;
       maintainers = with lib.maintainers; [


### PR DESCRIPTION
Adds the [tree-sitter grammar](https://github.com/ntsk/tree-sitter-vcl) for VCL (Varnish Configuration Language).

It is included in the tree-sitter parser list on their wiki:
https://github.com/tree-sitter/tree-sitter/wiki/List-of-parsers


Grammar source: https://github.com/ntsk/tree-sitter-vcl
Release: https://github.com/ntsk/tree-sitter-vcl/releases/tag/v0.4.0

## Things done

- Built on platform:
  - [x] aarch64-darwin
- [x] Ran `nixpkgs-review` on this PR
- [x] Tested basic functionality of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md)

---

`nixpkgs-review` result on `aarch64-darwin`:

✅ 6 packages built, 0 failed:
- `tree-sitter-grammars.tree-sitter-vcl`
- `python313Packages.tree-sitter-grammars.tree-sitter-vcl` (and `.dist`)
- `python314Packages.tree-sitter-grammars.tree-sitter-vcl` (and `.dist`)
- `diffsitter`