### PR TITLE
{tor,mullvad}-browser: 15.0.11 -> 15.0.12

### DIFF
--- a/pkgs/by-name/mu/mullvad-browser/package.nix
+++ b/pkgs/by-name/mu/mullvad-browser/package.nix
@@ -97,7 +97,7 @@ let
     ++ lib.optionals mediaSupport [ ffmpeg_7 ]
   );
 
-  version = "15.0.11";
+  version = "15.0.12";
 
   sources = {
     x86_64-linux = fetchurl {
@@ -109,7 +109,7 @@ let
         "https://tor.eff.org/dist/mullvadbrowser/${version}/mullvad-browser-linux-x86_64-${version}.tar.xz"
         "https://tor.calyxinstitute.org/dist/mullvadbrowser/${version}/mullvad-browser-linux-x86_64-${version}.tar.xz"
       ];
-      hash = "sha256-+skGid5BYrptv3aHLPogxew28DNFArV6kEDhCTxD2Ic=";
+      hash = "sha256-Tqfa9f2q4bv2KpotoDKvklEmHa5AF4ARp/qKxlVBomE=";
     };
   };
 

--- a/pkgs/by-name/to/tor-browser/package.nix
+++ b/pkgs/by-name/to/tor-browser/package.nix
@@ -102,7 +102,7 @@ let
     ++ lib.optionals mediaSupport [ ffmpeg_7 ]
   );
 
-  version = "15.0.11";
+  version = "15.0.12";
 
   sources = {
     x86_64-linux = fetchurl {
@@ -112,7 +112,7 @@ let
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux-x86_64-${version}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux-x86_64-${version}.tar.xz"
       ];
-      hash = "sha256-+1ZpJcVkqqP2WE3kyAJ7Ip3CmM2JIpUos1wgvLjND24=";
+      hash = "sha256-PNGPJs25t+rG2TVLiWkLd96Iuq5XkOOEextnI+V1kJY=";
     };
 
     i686-linux = fetchurl {
@@ -122,7 +122,7 @@ let
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux-i686-${version}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux-i686-${version}.tar.xz"
       ];
-      hash = "sha256-dZeTAkmvI5+mu7u9DrUj/JTvLHE4hiNVqd5AyVbZptg=";
+      hash = "sha256-Kqg4UTr1IPZkB3caBKMJu2Cj0q0v8ttrhc4JNBuWDA0=";
     };
   };
 


### PR DESCRIPTION
Release announcement (TB): https://blog.torproject.org/new-release-tor-browser-15012/
Changelog (TB): https://gitlab.torproject.org/tpo/applications/tor-browser-build/-/raw/tbb-15.0.12-build1/projects/browser/Bundle-Data/Docs-TBB/ChangeLog.txt
Changelog (MB): https://gitlab.torproject.org/tpo/applications/tor-browser-build/-/raw/mb-15.0.12-build1/projects/browser/Bundle-Data/Docs-MB/ChangeLog.txt
Firefox ESR: https://www.firefox.com/en-US/firefox/140.10.2/releasenotes/
Firefox diff: https://gitlab.torproject.org/tpo/applications/tor-browser/-/compare/FIREFOX_140_10_1esr_BUILD1...FIREFOX_140_10_2esr_BUILD1

This release includes [security fixes to Firefox ESR](https://www.mozilla.org/en-US/security/advisories/mfsa2026-41/) as well as fixes for [TROVE-2026-006 through TROVE-2026-011](https://gitlab.torproject.org/tpo/core/team/-/wikis/NetworkTeam/TROVE) in Tor.

Note: Tor v0.4.9.7 has a minor (i.e. probably not blocking this PR) bug that clients will bootstrap against the directory authorities instead of against the fallback directories, placing undue load on the network. [v0.4.9.8 fixes this](https://gitlab.torproject.org/tpo/core/tor/-/raw/tor-0.4.9.8/ReleaseNotes), and we should get Tor Browser 15.0.13 with this update [within a few hours](https://gitlab.torproject.org/tpo/applications/tor-browser-build/-/work_items/41794).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] i686-linux (`tor-browser` only)
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
