### PR TITLE
nixos/home-assistant: complete components that need binaries in PATH

### DIFF
--- a/nixos/modules/services/home-automation/home-assistant.nix
+++ b/nixos/modules/services/home-automation/home-assistant.nix
@@ -982,7 +982,8 @@ in
           UMask = "0077";
         };
       path =
-        lib.optional (useComponent "picotts") pkgs.picotts
+        lib.optional (useComponent "go2rtc") pkgs.go2rtc
+        ++ lib.optional (useComponent "picotts") pkgs.picotts
         ++ lib.optional (any useComponent componentsUsingPing) pkgs.unixtools.ping;
     };
 

--- a/nixos/modules/services/home-automation/home-assistant.nix
+++ b/nixos/modules/services/home-automation/home-assistant.nix
@@ -981,9 +981,7 @@ in
           ];
           UMask = "0077";
         };
-      path = [
-        pkgs.unixtools.ping # needed for ping
-      ];
+      path = lib.optional (any useComponent componentsUsingPing) pkgs.unixtools.ping;
     };
 
     systemd.targets.home-assistant = rec {

--- a/nixos/modules/services/home-automation/home-assistant.nix
+++ b/nixos/modules/services/home-automation/home-assistant.nix
@@ -149,6 +149,120 @@ let
       type = "module";
     }) cfg.customLovelaceModules;
   };
+
+  componentsUsingBluetooth = [
+    # Components that require the AF_BLUETOOTH address family
+    "august"
+    "august_ble"
+    "airthings_ble"
+    "aranet"
+    "bluemaestro"
+    "bluetooth"
+    "bluetooth_adapters"
+    "bluetooth_le_tracker"
+    "bluetooth_tracker"
+    "bthome"
+    "default_config"
+    "eufylife_ble"
+    "esphome"
+    "fjaraskupan"
+    "gardena_bluetooth"
+    "govee_ble"
+    "homekit_controller"
+    "inkbird"
+    "improv_ble"
+    "keymitt_ble"
+    "ld2410_ble"
+    "leaone"
+    "led_ble"
+    "medcom_ble"
+    "melnor"
+    "moat"
+    "mopeka"
+    "motionblinds_ble"
+    "oralb"
+    "private_ble_device"
+    "qingping"
+    "rapt_ble"
+    "ruuvi_gateway"
+    "ruuvitag_ble"
+    "sensirion_ble"
+    "sensorpro"
+    "sensorpush"
+    "shelly"
+    "snooz"
+    "switchbot"
+    "thermobeacon"
+    "thermopro"
+    "tilt_ble"
+    "xiaomi_ble"
+    "yalexs_ble"
+  ];
+  componentsUsingPing = [
+    # Components that require the capset syscall for the ping wrapper
+    "ping"
+    "wake_on_lan"
+  ];
+  componentsUsingSerialDevices = [
+    # Components that require access to serial devices (/dev/tty*)
+    # List generated from home-assistant documentation:
+    #   git clone https://github.com/home-assistant/home-assistant.io/
+    #   cd source/_integrations
+    #   rg "/dev/tty" -l | cut -d'/' -f3 | cut -d'.' -f1 | sort
+    # And then extended by references found in the source code, these
+    # mostly the ones using config flows already.
+    "acer_projector"
+    "alarmdecoder"
+    "aurora_abb_powerone"
+    "blackbird"
+    "bryant_evolution"
+    "crownstone"
+    "deconz"
+    "dsmr"
+    "edl21"
+    "elkm1"
+    "elv"
+    "enocean"
+    "homeassistant_hardware"
+    "homeassistant_yellow"
+    "firmata"
+    "flexit"
+    "gpsd"
+    "insteon"
+    "kwb"
+    "lacrosse"
+    "landisgyr_heat_meter"
+    "modbus"
+    "modem_callerid"
+    "mysensors"
+    "nad"
+    "numato"
+    "nut"
+    "opentherm_gw"
+    "otbr"
+    "rainforst_raven"
+    "rflink"
+    "rfxtrx"
+    "scsgate"
+    "serial"
+    "serial_pm"
+    "sms"
+    "upb"
+    "usb"
+    "velbus"
+    "w800rf32"
+    "zha"
+    "zwave"
+    "zwave_js"
+
+    # Custom components, maintained manually.
+    "amshan"
+    "benqprojector"
+  ];
+  componentsUsingInputDevices = [
+    # Components that require access to input devices (/dev/input/*)
+    "keyboard_remote"
+  ];
 in
 {
   imports = [
@@ -769,119 +883,6 @@ in
               "CAP_NET_RAW"
             ]
           );
-          componentsUsingBluetooth = [
-            # Components that require the AF_BLUETOOTH address family
-            "august"
-            "august_ble"
-            "airthings_ble"
-            "aranet"
-            "bluemaestro"
-            "bluetooth"
-            "bluetooth_adapters"
-            "bluetooth_le_tracker"
-            "bluetooth_tracker"
-            "bthome"
-            "default_config"
-            "eufylife_ble"
-            "esphome"
-            "fjaraskupan"
-            "gardena_bluetooth"
-            "govee_ble"
-            "homekit_controller"
-            "inkbird"
-            "improv_ble"
-            "keymitt_ble"
-            "ld2410_ble"
-            "leaone"
-            "led_ble"
-            "medcom_ble"
-            "melnor"
-            "moat"
-            "mopeka"
-            "motionblinds_ble"
-            "oralb"
-            "private_ble_device"
-            "qingping"
-            "rapt_ble"
-            "ruuvi_gateway"
-            "ruuvitag_ble"
-            "sensirion_ble"
-            "sensorpro"
-            "sensorpush"
-            "shelly"
-            "snooz"
-            "switchbot"
-            "thermobeacon"
-            "thermopro"
-            "tilt_ble"
-            "xiaomi_ble"
-            "yalexs_ble"
-          ];
-          componentsUsingPing = [
-            # Components that require the capset syscall for the ping wrapper
-            "ping"
-            "wake_on_lan"
-          ];
-          componentsUsingSerialDevices = [
-            # Components that require access to serial devices (/dev/tty*)
-            # List generated from home-assistant documentation:
-            #   git clone https://github.com/home-assistant/home-assistant.io/
-            #   cd source/_integrations
-            #   rg "/dev/tty" -l | cut -d'/' -f3 | cut -d'.' -f1 | sort
-            # And then extended by references found in the source code, these
-            # mostly the ones using config flows already.
-            "acer_projector"
-            "alarmdecoder"
-            "aurora_abb_powerone"
-            "blackbird"
-            "bryant_evolution"
-            "crownstone"
-            "deconz"
-            "dsmr"
-            "edl21"
-            "elkm1"
-            "elv"
-            "enocean"
-            "homeassistant_hardware"
-            "homeassistant_yellow"
-            "firmata"
-            "flexit"
-            "gpsd"
-            "insteon"
-            "kwb"
-            "lacrosse"
-            "landisgyr_heat_meter"
-            "modbus"
-            "modem_callerid"
-            "mysensors"
-            "nad"
-            "numato"
-            "nut"
-            "opentherm_gw"
-            "otbr"
-            "rainforst_raven"
-            "rflink"
-            "rfxtrx"
-            "scsgate"
-            "serial"
-            "serial_pm"
-            "sms"
-            "upb"
-            "usb"
-            "velbus"
-            "w800rf32"
-            "zha"
-            "zwave"
-            "zwave_js"
-
-            # Custom components, maintained manually.
-            "amshan"
-            "benqprojector"
-          ];
-          componentsUsingInputDevices = [
-            # Components that require access to input devices (/dev/input/*)
-            "keyboard_remote"
-          ];
         in
         {
           ExecStart = escapeSystemdExecArgs (

--- a/nixos/modules/services/home-automation/home-assistant.nix
+++ b/nixos/modules/services/home-automation/home-assistant.nix
@@ -981,7 +981,9 @@ in
           ];
           UMask = "0077";
         };
-      path = lib.optional (any useComponent componentsUsingPing) pkgs.unixtools.ping;
+      path =
+        lib.optional (useComponent "picotts") pkgs.picotts
+        ++ lib.optional (any useComponent componentsUsingPing) pkgs.unixtools.ping;
     };
 
     systemd.targets.home-assistant = rec {


### PR DESCRIPTION
Should be all usages https://github.com/search?q=repo%3Ahome-assistant%2Fcore%20shutil.which&type=code , or at least the ones who use `shutil.which`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
