### PR TITLE
wabt: 1.0.40 -> 1.0.41

### DIFF
--- a/pkgs/by-name/wa/wabt/package.nix
+++ b/pkgs/by-name/wa/wabt/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wabt";
-  version = "1.0.40";
+  version = "1.0.41";
 
   src = fetchFromGitHub {
     owner = "WebAssembly";
     repo = "wabt";
     tag = finalAttrs.version;
-    hash = "sha256-Lrdmx/JOiWJdzZeyP6HdZH1SEHJ0N5VfSCYxtMBCF74=";
+    hash = "sha256-WcSFrVrZBr6ITskBUuD7rQvIPOiAW6VCrhXr1QroFHg=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/wa/wabt/package.nix
+++ b/pkgs/by-name/wa/wabt/package.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wabt";
-  version = "1.0.40";
+  version = "1.0.41";
 
   src = fetchFromGitHub {
     owner = "WebAssembly";


### PR DESCRIPTION
Brings in [WebAssembly/wabt#2744](https://github.com/WebAssembly/wabt/pull/2744) (`return_call_indirect` validator under `table64`), released upstream as 1.0.41 today.

Three packages rebuild: `diffoscope`, `wabt`, plus its closure.

## Things done

- Built on platform:
  - [x] aarch64-darwin
- [ ] Ran `nixpkgs-review`
- [x] Tested basic functionality (`wasm-validate --enable-tail-call --enable-memory64` against a memory64 binary using `return_call_indirect`)