### PR TITLE
tor: 0.4.9.7 -> 0.4.9.8

### DIFF
--- a/pkgs/by-name/to/tor/package.nix
+++ b/pkgs/by-name/to/tor/package.nix
@@ -46,11 +46,11 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tor";
-  version = "0.4.9.7";
+  version = "0.4.9.8";
 
   src = fetchurl {
     url = "https://dist.torproject.org/tor-${finalAttrs.version}.tar.gz";
-    hash = "sha256-WnQPMvaIrInAZjRcOLR7ooawxDlNNRslH/SLalOUYY8=";
+    hash = "sha256-rB85Ti3Sqwh30n2Sj9DZ6GZi/jymr9/7n9m28PltBd4=";
   };
 
   outputs = [


### PR DESCRIPTION
Release notes: https://gitlab.torproject.org/tpo/core/tor/-/raw/tor-0.4.9.8/ReleaseNotes
Diff: https://gitlab.torproject.org/tpo/core/tor/-/compare/tor-0.4.9.7...tor-0.4.9.8

v0.4.9.7 had a CI/release engineering issue where the fallback directory list was not populated, so all clients will directly request the directory authorities to try to bootstrap. My understanding is that this will generally not affect visible client behavior, but *will* place undue load on the network itself.

Tested:
- Running a relay with the NixOS module
- Usage as a SOCKS5 proxy with curl
- Usage as a standalone instance with Tor Browser
- Running a full mini-network in the NixOS test

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---
## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 517728`
Commit: `7dcee78a4f6112f3e82d0af525dc53297b5517c9`

### `x86_64-linux`
<details>
  <summary>:white_check_mark: 18 packages built:</summary>
  <ul>
    <li>bisq2</li>
    <li>briar-desktop</li>
    <li>carburetor</li>
    <li>cwtch-ui</li>
    <li>cwtch-ui.debug</li>
    <li>cwtch-ui.pubcache</li>
    <li>feather</li>
    <li>onionshare</li>
    <li>onionshare-gui</li>
    <li>onionshare-gui.dist</li>
    <li>onionshare.dist</li>
    <li>sparrow</li>
    <li>tor</li>
    <li>tor.geoip</li>
    <li>tractor</li>
    <li>tractor.dist</li>
    <li>trezor-suite</li>
    <li>wahay</li>
  </ul>
</details>

### `aarch64-linux`
<details>
  <summary>:white_check_mark: 14 packages built:</summary>
  <ul>
    <li>bisq2</li>
    <li>carburetor</li>
    <li>feather</li>
    <li>onionshare</li>
    <li>onionshare-gui</li>
    <li>onionshare-gui.dist</li>
    <li>onionshare.dist</li>
    <li>sparrow</li>
    <li>tor</li>
    <li>tor.geoip</li>
    <li>tractor</li>
    <li>tractor.dist</li>
    <li>trezor-suite</li>
    <li>wahay</li>
  </ul>
</details>