### PR TITLE
zfs: support zfs-mount-generator

### DIFF
--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -843,10 +843,13 @@ in
           cfgZfs.package
           pkgs.coreutils
           pkgs.curl
+          pkgs.diffutils
+          pkgs.findutils
           pkgs.gawk
           pkgs.gnugrep
           pkgs.gnused
           pkgs.hostname-debian
+          pkgs.logger
           pkgs.util-linux
         ];
       };

--- a/nixos/tests/zfs.nix
+++ b/nixos/tests/zfs.nix
@@ -314,4 +314,47 @@ in
           exit(1)
       '';
   };
+
+  zfs-mount-generator = runTest {
+    name = "zfs-mount-generator";
+    nodes.machine =
+      { ... }:
+      {
+        boot.supportedFilesystems = [ "zfs" ];
+        networking.hostId = "00000000";
+        virtualisation = {
+          emptyDiskImages = [ 4096 ];
+        };
+      };
+
+    testScript = ''
+      from datetime import timedelta
+
+      machine.wait_for_unit("multi-user.target")
+
+      machine.succeed(
+          "zpool create -O mountpoint=none test /dev/vdb",
+
+          # Enable list caching for the test pool.
+          "mkdir /etc/zfs/zfs-list.cache",
+          "touch /etc/zfs/zfs-list.cache/test",
+
+          # Trigger the zedlet.
+          "zfs create -o mountpoint=/tmp/foo test/foo",
+      )
+
+      # Wait for the zedlet to update the cache with the new dataset.
+      machine.wait_until_succeeds(
+          "grep -F test/foo /etc/zfs/zfs-list.cache/test",
+          timeout=timedelta(seconds=120)
+      )
+
+      machine.succeed(
+          # Rerun systemd generators.
+          "systemctl daemon-reload",
+          "systemctl cat tmp-foo.mount | grep zfs-mount-generator",
+          "systemctl is-active tmp-foo.mount",
+      )
+    '';
+  };
 }

--- a/pkgs/os-specific/linux/zfs/generic.nix
+++ b/pkgs/os-specific/linux/zfs/generic.nix
@@ -205,7 +205,7 @@ let
         "--with-udevdir=$(out)/lib/udev"
         "--with-systemdunitdir=$(out)/etc/systemd/system"
         "--with-systemdpresetdir=$(out)/etc/systemd/system-preset"
-        "--with-systemdgeneratordir=$(out)/lib/systemd/system-generator"
+        "--with-systemdgeneratordir=$(out)/lib/systemd/system-generators"
         "--with-mounthelperdir=$(out)/bin"
         "--libexecdir=$(out)/libexec"
         "--sysconfdir=/etc"


### PR DESCRIPTION
I've been experimenting with zfs-mount-generator (which generates properly ordered systemd mount units for ZFS datasets) and NixOS and I had to make a few small changes to get it to work. In particular there were some packages missing from the `PATH` passed to zedlet scripts (for example the history state script which updates the dataset list cache file required diffutils), and the path for systemd generators was wrong (seems to be a typo).

I also had to symlink the `history_event-zfs-list-cacher.sh` zedlet under `/etc/zfs/zed.d`, but it looks like that's already the default in unstable (I'm on 25.11).


## Using zfs-mount-generator

For anyone interested, with these changes it was enough to follow the instructions in [zfs-mount-generator(8)](https://openzfs.github.io/openzfs-docs/man/master/8/zfs-mount-generator.8.html#EXAMPLES) to create the initial cache file for my pool. You can also do this during installation, after mounting everything by running a variation of the command from the zedlet (here, my ZFS pool is `zroot`):

```sh
cache_dir=/mnt/etc/zfs/zfs-list.cache
cache=$cache_dir/zroot
props="name,mountpoint,canmount,atime,relatime,devices,exec,readonly,setuid\
,nbmand,encroot,keylocation\
,org.openzfs.systemd:requires,org.openzfs.systemd:requires-mounts-for\
,org.openzfs.systemd:before,org.openzfs.systemd:after\
,org.openzfs.systemd:wanted-by,org.openzfs.systemd:required-by\
,org.openzfs.systemd:nofail,org.openzfs.systemd:ignore"
mkdir -p $cache_dir
zfs list -H -t filesystem -o $props -r zroot | sed 's|/mnt||g' >$cache
```

-this just avoids relying on ZED to create the initial cache file (as it won't be running during installation), but if you've already got a system set up then the official instructions are fine.

You can then remove all ZFS filesystems from `fileSystems` in `hardware-configuration.nix` except for `/` and `/nix` (if you have them) and systemd will automatically mount any of your datasets with `canmount=on` just like `zfs-mount.service` would, but without the potential race conditions on `/var/log`, etc.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
