### PR TITLE
workflows/backport: Label failed backports

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,7 +11,7 @@ on:
 
 permissions:
   contents: read
-  issues: write # adding the 'has: port to stable' label
+  issues: write # adding the 'has: port to stable' and 'has: backport failed' label
   pull-requests: write # creating backport pull requests
 
 defaults:
@@ -81,4 +81,17 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
               labels: [ '8.has: port to stable' ]
+            })
+
+      - name: "Add 'has: failed backport' label"
+        if: steps.backport.outputs.was_successful == 'false'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          # Not using the app on purpose to avoid triggering another workflow run after adding this label.
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: [ '8.has: failed backport' ]
             })


### PR DESCRIPTION
The intent behind this new label is to allow filtering on the label, which can then allow Nixpkgs contributors to *act* on such failures.

The label **must** be removed *only* when a PR was then successfully made, or the change has been verified to not need a backport.

Removing the label is intended to make the list of PRs with the label actionable.

The following search query could be used to ensure no security changes that were marked for being backported are left behind:

 - https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+label%3A%221.severity%3A+security%22+label%3A%228.has%3A+failed+backport%22+

(Obviously not right now. The label does not exist and isn't used.)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

> [!NOTE]
> This PR does not affect Nixpkgs at all, which is why most checkboxes are left unchecked.

The change was verified to apply a label on failure here:

 - https://github.com/samueldr-at-cyberus/gha-testing/actions/runs/25507357299/job/74856567414

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
