### PR TITLE
media-downloader: add more extraPackages

### DIFF
--- a/pkgs/by-name/me/media-downloader/package.nix
+++ b/pkgs/by-name/me/media-downloader/package.nix
@@ -1,29 +1,47 @@
 {
-  aria2,
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  qt6,
   cmake,
   extraPackages ? [
-    aria2
-    ffmpeg
     python3
+    deno
+    ffmpeg
+    yt-dlp
+    gallery-dl
+    you-get
+    svtplay-dl
+    aria2
+    wget
   ],
-  fetchFromGitHub,
-  ffmpeg,
-  lib,
   python3,
-  qt6,
-  stdenv,
+  deno,
+  ffmpeg,
+  yt-dlp,
+  gallery-dl,
+  you-get,
+  svtplay-dl,
+  aria2,
+  wget,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "media-downloader";
-  version = "5.4.9";
+  version = "5.6.0";
 
   src = fetchFromGitHub {
     owner = "mhogomchungu";
     repo = "media-downloader";
     rev = finalAttrs.version;
-    hash = "sha256-afQ3Tra7hUjrG3vs4XBfmvSOBrhG7k5fkEMDr6WF+Fo=";
+    hash = "sha256-4mHSBeIbJzTUT24hlLPg1dH69ZNsFWcsReBIP5eu278=";
   };
+
+  postPatch = ''
+    substituteInPlace src/settings.cpp \
+      --replace-fail 'return this->getOption( "UseSystemEngine",false ) ;' \
+                     'return this->getOption( "UseSystemEngine",true ) ;'
+  '';
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/me/media-downloader/package.nix
+++ b/pkgs/by-name/me/media-downloader/package.nix
@@ -1,17 +1,29 @@
 {
-  aria2,
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  qt6,
   cmake,
   extraPackages ? [
-    aria2
-    ffmpeg
     python3
+    deno
+    ffmpeg
+    yt-dlp
+    gallery-dl
+    you-get
+    svtplay-dl
+    aria2
+    wget2
   ],
-  fetchFromGitHub,
-  ffmpeg,
-  lib,
   python3,
-  qt6,
-  stdenv,
+  deno,
+  ffmpeg,
+  yt-dlp,
+  gallery-dl,
+  you-get,
+  svtplay-dl,
+  aria2,
+  wget2,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -24,6 +36,12 @@ stdenv.mkDerivation (finalAttrs: {
     rev = finalAttrs.version;
     hash = "sha256-2Nn/XBU5mnrbITtwygAD1saZXRm1/2Y1mOL0SZkV6bA=";
   };
+
+  postPatch = ''
+    substituteInPlace src/settings.cpp \
+      --replace-fail 'return this->getOption( "UseSystemEngine",false ) ;' \
+                     'return this->getOption( "UseSystemEngine",true ) ;'
+  '';
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
- Add more engines to extraPackages to resolve the following dynamically linked executable error on NixOS:

```
[media-downloader] Cmd: ".local/share/media-downloader/bin/gallery-dl.bin" "--version"
[media-downloader] Exit Code: 127
[media-downloader] Exit Status: Normal Exit
[media-downloader] Std Out: Could not start dynamically linked executable: .local/share/media-downloader/bin/gallery-dl.bin
NixOS cannot run dynamically linked executables intended for generic
linux environments out of the box. For more information, see:
https://nix.dev/permalink/stub-ld
```

- Add postPatch to ensure engines are used from system instead of being downloaded at runtime.

- gallery-dl has a litte problem, user need to manually change gallery-dl.bin to gallery-dl in:

`~/.local/share/media-downloader/engines.v1/gallery-dl.json`

because it only download on running time, we cannot patch directly. 

```
[media-downloader] Downloading: https://raw.githubusercontent.com/mhogomchungu/media-downloader/d12d37e2f53b9fac0ac061f42cf36d46c3f01ab6/extensions/gallery-dl.json
[media-downloader] Start Downloading gallery-dl ... ... ... ...
[media-downloader] Downloading: https://codeberg.org/mikf/gallery-dl/releases/download/v1.32.1/gallery-dl.bin
```

- fix #276253 
referencing commit: https://github.com/mhogomchungu/media-downloader/commit/bf5373ddcaddd90aa6483cb49613aa38ab0aef27


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
