### PR TITLE
steelix: fix broken runtime path

### DIFF
--- a/pkgs/by-name/st/steelix/package.nix
+++ b/pkgs/by-name/st/steelix/package.nix
@@ -4,6 +4,7 @@
   installShellFiles,
   lib,
   rustPlatform,
+  makeBinaryWrapper,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -19,9 +20,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-6bu8sIM4So3AbnHHYbh8uu+rEB4IjMQjDgh7/AkLQs0=";
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [
+    installShellFiles
+    makeBinaryWrapper
+  ];
 
-  # Don't use cargo xtask steel since it needs network access
   cargoBuildFlags = [
     "--package"
     "helix-term"
@@ -30,9 +33,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   env = {
-    # Disable fetching and building of tree-sitter grammars in the helix-term build.rs
     HELIX_DISABLE_AUTO_GRAMMAR_BUILD = "1";
-    # Use tree-sitter grammars and runtime from the helix package
     HELIX_DEFAULT_RUNTIME = helix.runtime;
   };
 
@@ -41,6 +42,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mkdir -p $out/share/{applications,icons/hicolor/256x256/apps}
     cp contrib/Helix.desktop $out/share/applications
     cp contrib/helix.png $out/share/icons/hicolor/256x256/apps
+    wrapProgram $out/bin/hx --set HELIX_RUNTIME "${helix.runtime}"
   '';
 
   passthru.updateScript = ./update.sh;
@@ -48,7 +50,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Helix editor with Steel (Scheme) scripting support";
     longDescription = ''
-      Steelix is a fork of the Helix text editor with Steel (Scheme) scripting support.
+      Steelix is a fork of the Helix editor with Steel (Scheme) scripting support.
     '';
     homepage = "https://github.com/mattwparas/helix";
     changelog = "https://github.com/mattwparas/helix/blob/${finalAttrs.src.rev}/CHANGELOG.md";


### PR DESCRIPTION
 ## Changes

  - Update to latest commit on `steel-event-system` branch (2026-05-04)
  - Fix broken Tree-sitter grammar/theme lookup by wrapping the binary with
    `HELIX_RUNTIME` explicitly set to `helix.runtime`, preventing helix from
    falling back to the non-existent `bin/runtime` path at runtime
  - Add `makeBinaryWrapper` to `nativeBuildInputs`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
