### PR TITLE
webkitgtk_6_0: Fix build on powerpc64

### DIFF
--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -255,6 +255,15 @@ clangStdenv.mkDerivation (finalAttrs: {
     moveToOutput "share/doc" "$devdoc"
   '';
 
+  env = {
+    # On powerpc64, clang seems to indicate target support for AltiVec SIMD extension by default (GCC requires explicit opt-in).
+    # WTF includes some libraries that try to use AltiVec & VSX when available, but they throw up issues on AltiVec without VSX. :(
+    # Explicitly tell clang to not expose AltiVec support. Fixes FTBFS, and matches target baseline.
+    NIX_CFLAGS_COMPILE = lib.optionalString (
+      clangStdenv.hostPlatform.isPower64 && clangStdenv.hostPlatform.isBigEndian
+    ) "-mno-altivec";
+  };
+
   requiredSystemFeatures = [ "big-parallel" ];
 
   passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;


### PR DESCRIPTION
Our baseline target for powerpc64 has no AltiVec. GCC requires passing `-maltivec` and `-mvsx` to enable extensions that some hardware doesn't have.

Clang indicates AltiVec support without passing any flags on my end. Whether that's due to some assumption inside LLVM/Clang (haven't been able to find anything about that there, except for powerpc64-darwin, which this is not support), or because the machine that I'm running this on does support AltiVec, I'm not sure. It's causing issues when building `webkitgtk_6_0` though.

Code in `Source/WTF/wtf/simdutf` checks if `<altivec.h>` is available, or if its define is… *defined*. If the check comes back as positive, then code that optimised certain functionalities via AltiVec is used. This code seems to *also* assume that VSX is available though, and building fails:

<details>
  <summary>Error from logs</summary>

```
[93/7939] Building CXX object Source/WTF/wtf/CMakeFiles/WTF.dir/SIMDUTF.cpp.o
FAILED: [code=1] Source/WTF/wtf/CMakeFiles/WTF.dir/SIMDUTF.cpp.o 
/nix/store/1amkbakh2cwfl1qhkikns5s1dgnpf3ip-clang-wrapper-21.1.8/bin/clang++ -DBUILDING_GTK__=1 -DBUILDING_WEBKIT=1 -DBUILDING_WITH_CMAKE=1 -DBUILDING_WTF -DBWRAP_EXECUTABLE=\"/nix/store/xdfmmr6cjnnbfycx8r92vmgk6x50n6hy-bubblewrap-0.11.0/bin/bwrap\" -DDBUS_PROXY_EXECUTABLE=
\"/nix/store/clz1sa37srgh8897h10jcsi1jd0w75lh-xdg-dbus-proxy-0.1.6/bin/xdg-dbus-proxy\" -DGETTEXT_PACKAGE=\"WebKitGTK-6.0\" -DHAVE_CONFIG_H=1 -DJSC_GLIB_API_ENABLED -DPAS_BMALLOC=1 -D_GLIBCXX_ASSERTIONS=1 -I/build/webkitgtk-2.52.1/build -I/build/webkitgtk-2.52.1/build/WTF/D
erivedSources -I/build/webkitgtk-2.52.1/Source/WTF -I/build/webkitgtk-2.52.1/Source/WTF/wtf -I/build/webkitgtk-2.52.1/Source/WTF/wtf/dtoa -I/build/webkitgtk-2.52.1/Source/WTF/wtf/fast_float -I/build/webkitgtk-2.52.1/Source/WTF/wtf/persistence -I/build/webkitgtk-2.52.1/Sourc
e/WTF/wtf/simdutf -I/build/webkitgtk-2.52.1/Source/WTF/wtf/text -I/build/webkitgtk-2.52.1/Source/WTF/wtf/text/icu -I/build/webkitgtk-2.52.1/Source/WTF/wtf/threads -I/build/webkitgtk-2.52.1/Source/WTF/wtf/unicode -isystem /nix/store/nrph8073fvfh2s9vkx1ygradmgsf07r8-glib-2.86
.3-dev/include/glib-2.0 -isystem /nix/store/xjd19khjh2w40md5pp6q0b8r63bh33q0-glib-2.86.3/lib/glib-2.0/include -isystem /nix/store/7rc0x44kpdd541i58l569k8n5rwjrvfg-libsysprof-capture-49.0/include/sysprof-6 -fdiagnostics-color=always -fcolor-diagnostics -Wextra -Wall -Wno-cha
racter-conversion -Werror=undefined-internal -Werror=undefined-inline -pipe -Wno-noexcept-type -Wno-nullability-completeness -Wno-psabi -Wno-misleading-indentation -Wno-parentheses-equality -Qunused-arguments -Wundef -Wpointer-arith -Wmissing-format-attribute -Wformat-secur
ity -Wcast-align -Wno-tautological-compare -fasynchronous-unwind-tables -fdebug-types-section -fno-strict-aliasing -fno-exceptions -fno-rtti -fcoroutines -ffunction-sections -fdata-sections -O3 -DNDEBUG -std=c++23 -fPIC -fvisibility=hidden -Wunsafe-buffer-usage -Wunsafe-buf
fer-usage-in-libc-call -fsafe-buffer-usage-suggestions -I/nix/store/nrph8073fvfh2s9vkx1ygradmgsf07r8-glib-2.86.3-dev/include -I/nix/store/nrph8073fvfh2s9vkx1ygradmgsf07r8-glib-2.86.3-dev/include/glib-2.0 -I/nix/store/xjd19khjh2w40md5pp6q0b8r63bh33q0-glib-2.86.3/lib/glib-2.0
/include -pthread -Wno-error=undef -Wno-undef -MD -MT Source/WTF/wtf/CMakeFiles/WTF.dir/SIMDUTF.cpp.o -MF Source/WTF/wtf/CMakeFiles/WTF.dir/SIMDUTF.cpp.o.d -o Source/WTF/wtf/CMakeFiles/WTF.dir/SIMDUTF.cpp.o -c /build/webkitgtk-2.52.1/Source/WTF/wtf/SIMDUTF.cpp
In file included from /build/webkitgtk-2.52.1/Source/WTF/wtf/SIMDUTF.cpp:36:
/build/webkitgtk-2.52.1/Source/WTF/wtf/simdutf/simdutf_impl.cpp.h:7882:37: error: use of 'long long' with '__vector' requires VSX support (available on POWER7 or later) to be enabled
 7882 | using vec_u64_t = __vector unsigned long long;
      |                                     ^
/build/webkitgtk-2.52.1/Source/WTF/wtf/simdutf/simdutf_impl.cpp.h:7883:35: error: use of 'long long' with '__vector' requires VSX support (available on POWER7 or later) to be enabled
 7883 | using vec_i64_t = __vector signed long long;
      |                                   ^
/build/webkitgtk-2.52.1/Source/WTF/wtf/simdutf/simdutf_impl.cpp.h:7931:34: error: use of undeclared identifier 'vec_vbpermq'
 7931 |   const auto result = (vec_u64_t)vec_vbpermq((vec_u8_t)vec, perm_mask);
      |                                  ^~~~~~~~~~~
[some warnings]
/build/webkitgtk-2.52.1/Source/WTF/wtf/simdutf/simdutf_impl.cpp.h:7989:12: error: no matching function for call to 'move_mask_u8'
 7989 |     return move_mask_u8(value);
      |            ^~~~~~~~~~~~
```

</details>

Building with `-mno-altivec` added via `NIX_CFLAGS_COMPILE` works, as simdutf8 then uses a fallback implementation.

---

This prolly needs to be a more general fix to clang (or its wrapper) instead, hence draft.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
