### PR TITLE
nikto: 2.5.0 -> 2.6.0

### DIFF
--- a/pkgs/by-name/ni/nikto/nix-wrapper-fix.patch
+++ b/pkgs/by-name/ni/nikto/nix-wrapper-fix.patch
@@ -2,25 +2,21 @@ diff --git a/program/nikto.pl b/program/nikto.pl
 index 2cb07f9..323e666 100755
 --- a/program/nikto.pl
 +++ b/program/nikto.pl
-@@ -243,7 +243,7 @@ sub config_init {
-     # Guess Nikto current directory
-     my $NIKTODIR = abs_path($0);
-     chomp($NIKTODIR);
--    $NIKTODIR =~ s#[\\/]nikto.pl$##;
-+    $NIKTODIR =~ s#[\\/]bin[\\/]\.nikto-wrapped$##;
+@@ -269,6 +269,7 @@
+     # Use RealBin to get absolute path even if script was invoked via symlink
+     my $NIKTODIR = $FindBin::RealBin || $FindBin::Bin;
+     $NIKTODIR = File::Spec->rel2abs($NIKTODIR) if defined $NIKTODIR;
++    $NIKTODIR =~ s#[\\/]bin$##;
  
      # Guess user's home directory -- to support Windows
      foreach my $var (split(/ /, "HOME USERPROFILE")) {
-@@ -251,10 +251,10 @@ sub config_init {
-     }
- 
-     # Read the conf files in order (previous values are over-written with each, if multiple found)
--    push(@CF, "$NIKTODIR/nikto.conf.default");
-+    push(@CF,"$NIKTODIR/etc/nikto.conf.default");
-     push(@CF, "/etc/nikto.conf");
-     push(@CF, "$home/nikto.conf");
--    push(@CF, "$NIKTODIR/nikto.conf");
-+    push(@CF,"$NIKTODIR/etc/nikto.conf");
+@@ -280,8 +281,8 @@
+     # Priority: --config option > local configs > user home > system-wide
+     push(@CF, "$VARIABLES{'configfile'}")
+       if defined $VARIABLES{'configfile'} && $VARIABLES{'configfile'} ne "";
+-    push(@CF, File::Spec->catfile($NIKTODIR, "nikto.conf"))         if defined $NIKTODIR;
+-    push(@CF, File::Spec->catfile($NIKTODIR, "nikto.conf.default")) if defined $NIKTODIR;
++    push(@CF, File::Spec->catfile($NIKTODIR, "etc", "nikto.conf"))         if defined $NIKTODIR;
++    push(@CF, File::Spec->catfile($NIKTODIR, "etc", "nikto.conf.default")) if defined $NIKTODIR;
      push(@CF, "nikto.conf");
-     push(@CF, "$VARIABLES{'configfile'}");
- 
+     push(@CF, File::Spec->catfile($home, "nikto.conf")) if defined $home;

--- a/pkgs/by-name/ni/nikto/package.nix
+++ b/pkgs/by-name/ni/nikto/package.nix
@@ -8,7 +8,7 @@
 }:
 
 let
-  version = "2.5.0";
+  version = "2.6.0";
 in
 stdenv.mkDerivation rec {
   pname = "nikto";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     owner = "sullo";
     repo = "nikto";
     rev = version;
-    sha256 = "sha256-lWiDbWc2BWAUgyaIm0tvZytja02WogYRoc7na4sHiNM=";
+    sha256 = "sha256-iHOdMlfcKhvQCsCjWge6K+0h8kkgXa0Uii9o3YRQP5w=";
   };
 
   # Nikto searches its configuration file based on its current path
@@ -29,8 +29,11 @@ stdenv.mkDerivation rec {
     # EXECDIR needs to be changed to the path where we copy the programs stuff
     # Forcing SSLeay is needed for SSL support (the auto mode doesn't seem to work otherwise)
     substituteInPlace program/nikto.conf.default \
-      --replace "# EXECDIR=/opt/nikto" "EXECDIR=$out/share" \
-      --replace "LW_SSL_ENGINE=auto" "LW_SSL_ENGINE=SSLeay"
+      --replace-fail "# EXECDIR=/opt/nikto" "EXECDIR=$out/share" \
+      --replace-fail "LW_SSL_ENGINE=auto" "LW_SSL_ENGINE=SSLeay"
+    # Disable update check which prompts you to do a git pull and is not applicable for nixpkg
+    substituteInPlace program/nikto.pl \
+      --replace-fail "check_updates()" ""
   '';
 
   nativeBuildInputs = [
@@ -41,6 +44,8 @@ stdenv.mkDerivation rec {
   buildInputs = [
     perlPackages.perl
     perlPackages.NetSSLeay
+    perlPackages.JSON
+    perlPackages.XMLWriter
   ];
 
   installPhase = ''

--- a/pkgs/by-name/ni/nikto/package.nix
+++ b/pkgs/by-name/ni/nikto/package.nix
@@ -70,6 +70,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Plus;
     homepage = "https://cirt.net/Nikto2";
     changelog = "https://github.com/sullo/nikto/releases/tag/${version}";
+    maintainers = with lib.maintainers; [ tbutter ];
     platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
Update to 2.6.0

Change the patch, add new dependencies and remove on-start update check.

Add myself as maintainer

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
