### PR TITLE
switch-to-configuration-ng: harden user-unit migration second pass

### DIFF
--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -322,6 +322,9 @@ in
         description = "Run user-specific NixOS activation";
         script = config.system.userActivationScripts.script;
         unitConfig.ConditionUser = "!@system";
+        # switch-to-configuration restarts this explicitly on every switch.
+        restartIfChanged = false;
+        serviceConfig.RemainAfterExit = true;
         serviceConfig.Type = "oneshot";
         wantedBy = [ "default.target" ];
       };

--- a/nixos/tests/switch-test.nix
+++ b/nixos/tests/switch-test.nix
@@ -739,6 +739,22 @@ in
             '';
           };
 
+          # As above, but with reloadIfChanged: pass 2 must reload, not
+          # restart.
+          userServiceMigratedToNixosReloadOnly.configuration = {
+            imports = [ userServiceMigratedToNixosNoStop.configuration ];
+            systemd.user.services.migrated = {
+              reloadIfChanged = true;
+              serviceConfig.ExecReload = "${pkgs.coreutils}/bin/true";
+            };
+          };
+
+          # As above, but with restartIfChanged = false: pass 2 must skip it.
+          userServiceMigratedToNixosNoRestart.configuration = {
+            imports = [ userServiceMigratedToNixosNoStop.configuration ];
+            systemd.user.services.migrated.restartIfChanged = false;
+          };
+
           no_inhibitors.configuration.system.switch.inhibitors = lib.mkForce { };
 
           inhibitors.configuration.system.switch.inhibitors = lib.mkForce {
@@ -1817,6 +1833,29 @@ in
           assert_contains(out, "/etc/systemd/user/migrated.service")
           out = machine.succeed(f"sudo -u usertest {user_env} cat /run/user/1001/migrated-owner")
           assert_contains(out, "nixos")
+
+          # Pass 2 must honour reloadIfChanged.
+          switch_to_specialisation("${machine}", "")
+          machine.fail(f"sudo -u usertest {user_env} systemctl --user is-active migrated.service")
+          seed_home_unit()
+          out = switch_to_specialisation("${machine}", "userServiceMigratedToNixosReloadOnly")
+          assert_lacks(out, "restarting (post-activation) the following user units: migrated.service")
+          assert_contains(out, "reloading (post-activation) the following user units: migrated.service")
+          user_systemctl("is-active migrated.service")
+          # Reloaded only, so the home ExecStart never re-ran.
+          out = machine.succeed(f"sudo -u usertest {user_env} cat /run/user/1001/migrated-owner")
+          assert_contains(out, "home")
+
+          # Pass 2 must honour restartIfChanged = false.
+          switch_to_specialisation("${machine}", "")
+          machine.fail(f"sudo -u usertest {user_env} systemctl --user is-active migrated.service")
+          seed_home_unit()
+          out = switch_to_specialisation("${machine}", "userServiceMigratedToNixosNoRestart")
+          assert_lacks(out, "\nrestarting (post-activation) the following user units: migrated.service")
+          assert_contains(out, "NOT restarting (post-activation) the following user units: migrated.service")
+          user_systemctl("is-active migrated.service")
+          out = machine.succeed(f"sudo -u usertest {user_env} cat /run/user/1001/migrated-owner")
+          assert_contains(out, "home")
 
           # Units that remain shadowed by ~/.config must be left alone in both
           # passes even though /etc now also defines them.

--- a/nixos/tests/switch-test.nix
+++ b/nixos/tests/switch-test.nix
@@ -1754,9 +1754,10 @@ in
           out = switch_to_specialisation("${machine}", "simpleUserService")
           user_systemctl("is-active usertest.service")
 
-          # No-op switch does nothing
+          # No-op switch leaves the test unit alone.
           out = switch_to_specialisation("${machine}", "simpleUserService")
-          assert_lacks(out, "user units:")
+          assert_lacks(out, "usertest.service")
+          assert_contains(out, "restarting the following user units: nixos-activation.service")
 
           # Modifying the unit stop-starts it (default stopIfChanged=true)
           out = switch_to_specialisation("${machine}", "simpleUserServiceModified")
@@ -1773,7 +1774,7 @@ in
           # reloadIfChanged=true reloads instead
           out = switch_to_specialisation("${machine}", "simpleUserServiceReload")
           assert_lacks(out, "stopping the following user units:")
-          assert_lacks(out, "restarting the following user units:")
+          assert_lacks(out, "restarting the following user units: usertest.service")
           assert_contains(out, "reloading the following user units: usertest.service")
           user_systemctl("is-active usertest.service")
 

--- a/nixos/tests/switch-test.nix
+++ b/nixos/tests/switch-test.nix
@@ -826,6 +826,15 @@ in
         RemainAfterExit=true
         ExecStart=${pkgs.runtimeShell} -c 'echo home > %t/migrated-owner'
       '';
+
+      # Unit file placed in ~/.local/share/systemd/user (lower priority than
+      # /etc) to simulate a package-shipped unit.
+      dataMigratedUnit = pkgs.writeText "migrated.service" ''
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        ExecStart=${pkgs.runtimeShell} -c 'echo data > %t/migrated-owner'
+      '';
     in
     # python
     ''
@@ -1856,6 +1865,36 @@ in
           user_systemctl("is-active migrated.service")
           out = machine.succeed(f"sudo -u usertest {user_env} cat /run/user/1001/migrated-owner")
           assert_contains(out, "home")
+
+          # Migration from a lower-priority search-path entry ($XDG_DATA_HOME
+          # here, standing in for ~/.nix-profile/share etc.). /etc outranks
+          # these, so pass 2 must restart onto the /etc definition.
+          switch_to_specialisation("${machine}", "")
+          machine.fail(f"sudo -u usertest {user_env} systemctl --user is-active migrated.service")
+          machine.succeed(
+              "sudo -u usertest mkdir -p ~usertest/.local/share/systemd/user",
+              "sudo -u usertest cp ${dataMigratedUnit} ~usertest/.local/share/systemd/user/migrated.service",
+          )
+          user_systemctl("daemon-reload")
+          user_systemctl("start migrated.service")
+          user_systemctl("is-active migrated.service")
+          out = machine.succeed(f"sudo -u usertest {user_env} cat /run/user/1001/migrated-owner")
+          assert_contains(out, "data")
+          out = user_systemctl("show -p FragmentPath migrated.service")
+          assert_contains(out, "/.local/share/systemd/user/migrated.service")
+          out = switch_to_specialisation("${machine}", "userServiceMigratedShadowed")
+          assert_contains(out, "restarting (post-activation) the following user units: migrated.service")
+          user_systemctl("is-active migrated.service")
+          out = user_systemctl("show -p FragmentPath migrated.service")
+          assert_contains(out, "/etc/systemd/user/migrated.service")
+          out = machine.succeed(f"sudo -u usertest {user_env} cat /run/user/1001/migrated-owner")
+          assert_contains(out, "nixos")
+          # Switching again must NOT touch it: /etc already had it, so it is
+          # not a candidate even though the lower-priority copy is still there.
+          out = switch_to_specialisation("${machine}", "userServiceMigratedShadowed")
+          assert_lacks(out, "migrated.service")
+          machine.succeed("sudo -u usertest rm -rf ~usertest/.local/share/systemd")
+          user_systemctl("daemon-reload")
 
           # Units that remain shadowed by ~/.config must be left alone in both
           # passes even though /etc now also defines them.

--- a/nixos/tests/user-activation-scripts.nix
+++ b/nixos/tests/user-activation-scripts.nix
@@ -13,6 +13,7 @@
       isNormalUser = true;
     };
     systemd.user.tmpfiles.users.alice.rules = [ "r %h/file-to-remove" ];
+    specialisation.changed.configuration.system.userActivationScripts.bar = "true";
   };
 
   testScript = ''
@@ -36,5 +37,12 @@
     machine.succeed("/run/current-system/bin/switch-to-configuration test")
     verify_user_activation_run_count(2)
     machine.succeed("[[ ! -f /home/alice/file-to-remove ]] || false")
+    # Activation must not be killed while running.
+    machine.fail("journalctl -b _SYSTEMD_USER_UNIT=nixos-activation.service | grep -q 'code=killed'")
+
+    # Changed activation script: still exactly one run.
+    machine.succeed("/run/current-system/specialisation/changed/bin/switch-to-configuration test")
+    verify_user_activation_run_count(3)
+    machine.fail("journalctl -b _SYSTEMD_USER_UNIT=nixos-activation.service | grep -q 'code=killed'")
   '';
 }

--- a/nixos/tests/user-activation-scripts.nix
+++ b/nixos/tests/user-activation-scripts.nix
@@ -18,8 +18,9 @@
 
   testScript = ''
     def verify_user_activation_run_count(n):
-        machine.succeed(
-            '[[ "$(find /home/alice/ -name user-activation-ran.\\* | wc -l)" == %s ]]' % n
+        t.assertEqual(
+            n,
+            int(machine.succeed('find /home/alice/ -name user-activation-ran.\\* | wc -l').rstrip())
         )
 
 

--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
@@ -1395,26 +1395,79 @@ fn do_user_switch(parent_exe: String) -> anyhow::Result<()> {
 
     let current_active_units = get_active_units(&systemd)?;
 
+    let old_unit_dir = old_toplevel.join(scope.etc_dir());
     let new_unit_dir = toplevel.join(scope.etc_dir());
-    let fragment_prefix = scope
-        .current_dir()
-        .to_str()
-        .expect("scope dir is valid UTF-8");
+    let fragment_dir = scope.current_dir();
 
-    // Units that are currently running from a non-/etc location (typically
-    // ~/.config/systemd/user, i.e. home-manager) but that the new NixOS
-    // configuration also defines. Pass 1 will skip these because of the
-    // FragmentPath filter; if the per-user activation (sd-switch) later drops
-    // its copy, we need a second pass to bring the NixOS-owned definition up.
+    // Determine $XDG_CONFIG_HOME/systemd/user from the user manager's own
+    // environment (we are spawned with env_clear()).
+    let user_config_unit_dir: Option<PathBuf> = match systemd.environment() {
+        Err(err) => {
+            log::debug!("Failed to read user manager environment: {err}");
+            None
+        }
+        Ok(env) => {
+            let lookup = |key: &str| {
+                env.iter().find_map(|kv| {
+                    kv.strip_prefix(key)
+                        .and_then(|rest| rest.strip_prefix('='))
+                        .filter(|v| Path::new(v).is_absolute())
+                        .map(PathBuf::from)
+                })
+            };
+            let config_home =
+                lookup("XDG_CONFIG_HOME").or_else(|| lookup("HOME").map(|h| h.join(".config")));
+            if config_home.is_none() {
+                log::debug!(
+                    "Neither $XDG_CONFIG_HOME nor $HOME is set in the user manager's environment"
+                );
+            }
+            config_home.map(|config_home| config_home.join("systemd/user"))
+        }
+    };
+
+    if user_config_unit_dir.is_none() {
+        log::debug!(
+            "Could not determine $XDG_CONFIG_HOME/systemd/user; \
+             units shadowed by ~/.config will not be considered for migration"
+        );
+    }
+
+    // Units active from a non-/etc location that the new generation defines
+    // in /etc/systemd/user. Pass 1 skips these (FragmentPath filter); pass 2
+    // brings the /etc definition into effect once /etc has won. Two cases:
+    //   * ~/.config/systemd/user (home-manager): shadows /etc, so wait for
+    //     the per-user activation (sd-switch) to remove its copy.
+    //   * anywhere else outside /etc ($XDG_DATA_HOME, $XDG_DATA_DIRS, ...):
+    //     /etc outranks these, so only act when /etc is gaining the unit;
+    //     if the previous generation already had it, leave it alone.
+    // Pass 2's `now_etc` check verifies /etc actually won before acting.
     let migration_candidates: Vec<String> = current_active_units
         .iter()
         .filter(|(unit, _)| new_unit_dir.join(unit).exists())
-        .filter(|(_, unit_state)| {
-            !unit_state
+        .filter(|(unit, unit_state)| {
+            let Ok(fragment_path) = unit_state
                 .proxy
-                .get("org.freedesktop.systemd1.Unit", "FragmentPath")
-                .map(|p: String| p.starts_with(fragment_prefix))
-                .unwrap_or(false)
+                .get::<String>("org.freedesktop.systemd1.Unit", "FragmentPath")
+            else {
+                return false;
+            };
+            let fragment_parent = Path::new(&fragment_path).parent();
+
+            // Already in /etc: handled by pass 1.
+            if fragment_parent == Some(fragment_dir) {
+                return false;
+            }
+
+            // Loaded from ~/.config/systemd/user, which shadows /etc.
+            if let Some(dir) = &user_config_unit_dir {
+                if fragment_parent == Some(dir.as_path()) {
+                    return true;
+                }
+            }
+
+            // Elsewhere: only act if /etc is gaining the unit this switch.
+            !old_unit_dir.join(unit).exists()
         })
         .map(|(unit, _)| unit.clone())
         .collect();
@@ -1422,7 +1475,7 @@ fn do_user_switch(parent_exe: String) -> anyhow::Result<()> {
     collect_unit_changes(
         &toplevel,
         scope,
-        &old_toplevel.join(scope.etc_dir()),
+        &old_unit_dir,
         &new_unit_dir,
         &current_active_units,
         &mut units_to_stop,
@@ -1577,7 +1630,7 @@ fn do_user_switch(parent_exe: String) -> anyhow::Result<()> {
                     let now_etc = unit_state
                         .proxy
                         .get("org.freedesktop.systemd1.Unit", "FragmentPath")
-                        .map(|p: String| p.starts_with(fragment_prefix))
+                        .map(|p: String| Path::new(&p).parent() == Some(fragment_dir))
                         .unwrap_or(false);
                     if !now_etc {
                         // Still shadowed (or read error); leave it alone.

--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
@@ -1486,6 +1486,9 @@ fn do_user_switch(parent_exe: String) -> anyhow::Result<()> {
         &mut units_to_filter,
     )?;
 
+    // Restarted unconditionally below; don't list it as skipped.
+    units_to_skip.remove("nixos-activation.service");
+
     let print_units = |verb: &str, units: &HashMap<String, ()>| {
         if units.is_empty() {
             return;
@@ -1586,6 +1589,7 @@ fn do_user_switch(parent_exe: String) -> anyhow::Result<()> {
     // Toplevels with system.activatable = false do not ship this unit; mirror
     // the system scope's tolerance for a missing activate script.
     if new_unit_dir.join("nixos-activation.service").exists() {
+        eprintln!("restarting the following user units: nixos-activation.service");
         match systemd.restart_unit("nixos-activation.service", "replace") {
             Ok(_) => {
                 log::debug!("waiting for nixos activation to finish");

--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
@@ -688,12 +688,7 @@ fn handle_modified_unit(
     let reload_list = scope.reload_list_file();
     let use_restart_as_stop_and_start = new_unit_info.is_none();
 
-    if matches!(
-        unit,
-        "sysinit.target" | "basic.target" | "multi-user.target" | "graphical.target"
-    ) || unit.ends_with(".unit")
-        || unit.ends_with(".slice")
-    {
+    if cannot_be_restarted_directly(unit) {
         // Do nothing.  These cannot be restarted directly.
 
         // Slices and Paths don't have to be restarted since properties (resource limits and
@@ -940,6 +935,17 @@ fn parse_fstab(fstab: impl BufRead) -> (HashMap<String, Filesystem>, HashMap<Str
     (filesystems, swaps)
 }
 
+/// Whether a unit cannot be (re)started directly. Special targets are pulled
+/// in by their dependents; slices and paths get their properties applied on
+/// daemon-reload.
+fn cannot_be_restarted_directly(unit: &str) -> bool {
+    matches!(
+        unit,
+        "sysinit.target" | "basic.target" | "multi-user.target" | "graphical.target"
+    ) || unit.ends_with(".path")
+        || unit.ends_with(".slice")
+}
+
 // Returns a HashMap containing the same contents as the passed in `units`, minus the units in
 // `units_to_filter`.
 fn filter_units(
@@ -955,6 +961,50 @@ fn filter_units(
     }
 
     res
+}
+
+/// Action to take on a unit that migrated to NixOS ownership during the
+/// post-activation pass. Honours the same X-* directives as
+/// `handle_modified_unit`.
+#[derive(Debug, PartialEq)]
+enum MigrationAction {
+    Skip,
+    Reload,
+    Restart,
+    Start,
+}
+
+impl MigrationAction {
+    /// Action to take on a migrated unit that is still active.
+    fn for_active_unit(unit: &str, new_unit_info: &UnitInfo) -> Self {
+        if cannot_be_restarted_directly(unit) {
+            return Self::Skip;
+        }
+
+        if parse_systemd_bool(Some(new_unit_info), "Service", "X-ReloadIfChanged", false) {
+            return Self::Reload;
+        }
+
+        if !parse_systemd_bool(Some(new_unit_info), "Service", "X-RestartIfChanged", true)
+            || parse_systemd_bool(Some(new_unit_info), "Unit", "RefuseManualStop", false)
+            || parse_systemd_bool(Some(new_unit_info), "Unit", "X-OnlyManualStart", false)
+        {
+            return Self::Skip;
+        }
+
+        Self::Restart
+    }
+
+    /// Action to take on a migrated unit that the previous owner stopped.
+    fn for_stopped_unit(new_unit_info: &UnitInfo) -> Self {
+        if parse_systemd_bool(Some(new_unit_info), "Unit", "RefuseManualStart", false)
+            || parse_systemd_bool(Some(new_unit_info), "Unit", "X-OnlyManualStart", false)
+        {
+            return Self::Skip;
+        }
+
+        Self::Start
+    }
 }
 
 fn unit_is_active(conn: &LocalConnection, unit: &str) -> Result<bool> {
@@ -1510,29 +1560,40 @@ fn do_user_switch(parent_exe: String) -> anyhow::Result<()> {
 
         let active_after = get_active_units(&systemd)?;
 
+        let mut to_reload = HashMap::new();
         let mut to_restart = HashMap::new();
         let mut to_start = HashMap::new();
+        let mut to_skip = HashMap::new();
 
         for unit in &migration_candidates {
-            match active_after.get(unit) {
+            // Honour X-* directives so reloadIfChanged/restartIfChanged hold.
+            let new_unit_file = new_unit_dir.join(unit);
+            let new_unit_info = parse_unit(&new_unit_file, &new_unit_file)?;
+
+            let action = match active_after.get(unit) {
                 Some(unit_state) => {
+                    // Only act if /etc now wins (i.e. the higher-priority
+                    // copy is gone). Read errors are treated as "leave alone".
                     let now_etc = unit_state
                         .proxy
                         .get("org.freedesktop.systemd1.Unit", "FragmentPath")
                         .map(|p: String| p.starts_with(fragment_prefix))
                         .unwrap_or(false);
-                    if now_etc {
-                        // Still running with the previous manager's binary;
-                        // restart so the /etc definition takes effect.
-                        to_restart.insert(unit.clone(), ());
+                    if !now_etc {
+                        // Still shadowed (or read error); leave it alone.
+                        continue;
                     }
-                    // else: still shadowed by ~/.config, leave it alone.
+                    MigrationAction::for_active_unit(unit, &new_unit_info)
                 }
-                None => {
-                    // Stopped by the previous manager; start the /etc copy.
-                    to_start.insert(unit.clone(), ());
-                }
-            }
+                // Stopped by the previous manager; start the /etc copy.
+                None => MigrationAction::for_stopped_unit(&new_unit_info),
+            };
+            match action {
+                MigrationAction::Skip => to_skip.insert(unit.clone(), ()),
+                MigrationAction::Reload => to_reload.insert(unit.clone(), ()),
+                MigrationAction::Restart => to_restart.insert(unit.clone(), ()),
+                MigrationAction::Start => to_start.insert(unit.clone(), ()),
+            };
         }
 
         // Re-start active targets so any other newly-unmasked dependencies are
@@ -1542,6 +1603,24 @@ fn do_user_switch(parent_exe: String) -> anyhow::Result<()> {
                 to_start.insert(unit.clone(), ());
             }
         }
+
+        if !to_skip.is_empty() {
+            print_units("NOT restarting (post-activation)", &to_skip);
+        }
+
+        print_units("reloading (post-activation)", &to_reload);
+        for unit in to_reload.keys() {
+            match systemd.reload_unit(unit, "replace") {
+                Ok(job_path) => {
+                    submitted_jobs.borrow_mut().insert(job_path, Job::Reload);
+                }
+                Err(err) => {
+                    eprintln!("Failed to reload user unit {unit}: {err}");
+                    exit_code = 4;
+                }
+            }
+        }
+        block_on_jobs(&dbus_conn, &submitted_jobs);
 
         print_units("restarting (post-activation)", &to_restart);
         for unit in to_restart.keys() {
@@ -2862,5 +2941,108 @@ After=dev-disk-by\x2dlabel-root.device
                 "dev-disk-by\\x2dlabel-root.device"
             );
         }
+    }
+
+    fn unit_info(
+        sections: &[(&str, &[(&str, &str)])],
+    ) -> HashMap<String, HashMap<String, Vec<String>>> {
+        sections
+            .iter()
+            .map(|(section, kvs)| {
+                (
+                    section.to_string(),
+                    kvs.iter()
+                        .map(|(k, v)| (k.to_string(), vec![v.to_string()]))
+                        .collect(),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn migration_action_for_active_unit() {
+        use super::MigrationAction;
+
+        // Plain service: restart.
+        assert_eq!(
+            MigrationAction::for_active_unit("foo.service", &unit_info(&[])),
+            MigrationAction::Restart
+        );
+
+        // reloadIfChanged must reload, not restart.
+        assert_eq!(
+            MigrationAction::for_active_unit(
+                "foo.service",
+                &unit_info(&[("Service", &[("X-ReloadIfChanged", "true")])])
+            ),
+            MigrationAction::Reload
+        );
+
+        // X-RestartIfChanged=false (restartIfChanged = false) must skip.
+        assert_eq!(
+            MigrationAction::for_active_unit(
+                "foo.service",
+                &unit_info(&[("Service", &[("X-RestartIfChanged", "false")])])
+            ),
+            MigrationAction::Skip
+        );
+
+        // RefuseManualStop must skip.
+        assert_eq!(
+            MigrationAction::for_active_unit(
+                "foo.service",
+                &unit_info(&[("Unit", &[("RefuseManualStop", "yes")])])
+            ),
+            MigrationAction::Skip
+        );
+
+        // X-OnlyManualStart must skip.
+        assert_eq!(
+            MigrationAction::for_active_unit(
+                "foo.service",
+                &unit_info(&[("Unit", &[("X-OnlyManualStart", "yes")])])
+            ),
+            MigrationAction::Skip
+        );
+
+        // Units that cannot be restarted directly must skip.
+        for unit in [
+            "sysinit.target",
+            "basic.target",
+            "multi-user.target",
+            "graphical.target",
+            "foo.path",
+            "bar.slice",
+        ] {
+            assert_eq!(
+                MigrationAction::for_active_unit(unit, &unit_info(&[])),
+                MigrationAction::Skip,
+                "{unit}"
+            );
+        }
+    }
+
+    #[test]
+    fn migration_action_for_stopped_unit() {
+        use super::MigrationAction;
+
+        assert_eq!(
+            MigrationAction::for_stopped_unit(&unit_info(&[])),
+            MigrationAction::Start
+        );
+        assert_eq!(
+            MigrationAction::for_stopped_unit(&unit_info(&[(
+                "Unit",
+                &[("RefuseManualStart", "true")]
+            )])),
+            MigrationAction::Skip
+        );
+        assert_eq!(
+            MigrationAction::for_stopped_unit(&unit_info(&[(
+                "Unit",
+                &[("X-OnlyManualStart", "true")]
+            )])),
+            MigrationAction::Skip
+        );
     }
 }


### PR DESCRIPTION
The post-activation pass added in 5cc82c4922f8 to handle units migrating from a per-user manager (home-manager) to NixOS unconditionally restarts or starts any candidate. dbus-broker.service explicitly opts out of restarts via reloadIfChanged because restarting the session bus kills running clients; the second pass ignored that and restarted it anyway.

Honour the same X-* directives `handle_modified_unit` checks in the second pass.
Also tighten the candidate set: only consider units whose pre-activation FragmentPath is exactly under $XDG_CONFIG_HOME/systemd/user.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]: `nixosTests.switchTest` (added `userServiceMigratedToNixosReloadOnly` and `userServiceMigratedToNixosNoRestart` specialisations).
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
