### PR TITLE
yt-dlp: Better support different JavaScript runtimes

### DIFF
--- a/pkgs/by-name/yt/yt-dlp/package.nix
+++ b/pkgs/by-name/yt/yt-dlp/package.nix
@@ -4,6 +4,9 @@
   python3Packages,
   atomicparsley,
   deno,
+  # Override jsRuntime with `nodejs`, `bun`, `quickjs`, or `quickjs-ng` if you want to use another default JS runtime.
+  # You still need to enable them in your yt-dlp config with `--js-runtimes [runtime]`.
+  jsRuntime ? deno,
   fetchFromGitHub,
   ffmpeg-headless,
   installShellFiles,
@@ -37,11 +40,11 @@ python3Packages.buildPythonApplication rec {
     substituteInPlace yt_dlp/version.py \
       --replace-fail "UPDATE_HINT = None" 'UPDATE_HINT = "Nixpkgs/NixOS likely already contain an updated version.\n       To get it run nix-channel --update or nix flake update in your config directory."'
     ${lib.optionalString javascriptSupport ''
-      # deno is required for full YouTube support (since 2025.11.12).
-      # This makes yt-dlp find deno even if it is used as a python dependency, i.e. in kodiPackages.sendtokodi.
-      # Crafted so people can replace deno with one of the other JS runtimes.
+      # A JavaScript runtime is required for full YouTube support (since 2025.11.12).
+      # This makes yt-dlp find `jsRuntime` even if it is used as a python dependency, i.e. in kodiPackages.sendtokodi.
+      # Crafted so people can replace the default deno with one of the other JS runtimes.
       substituteInPlace yt_dlp/utils/_jsruntime.py \
-        --replace-fail "path = _determine_runtime_path(self._path, '${deno.meta.mainProgram}')" "path = '${lib.getExe deno}'"
+        --replace-fail "path = _determine_runtime_path(self._path, '${jsRuntime.meta.mainProgram}')" "path = '${lib.getExe jsRuntime}'"
     ''}
   '';
 

--- a/pkgs/by-name/yt/yt-dlp/package.nix
+++ b/pkgs/by-name/yt/yt-dlp/package.nix
@@ -19,6 +19,12 @@
   withAlias ? false, # Provides bin/youtube-dl for backcompat
   withSecretStorage ? !stdenvNoCC.hostPlatform.isDarwin,
   nix-update-script,
+  # required for tests
+  yt-dlp,
+  nodejs,
+  bun,
+  quickjs,
+  quickjs-ng,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -139,6 +145,15 @@ python3Packages.buildPythonApplication rec {
 
   passthru = {
     updateScript = nix-update-script { };
+    # Try to build with each of the supported JS runtimes
+    tests = lib.genAttrs' [ nodejs bun quickjs quickjs-ng ] (
+      runtime:
+      lib.nameValuePair runtime.pname (
+        yt-dlp.override {
+          jsRuntime = runtime;
+        }
+      )
+    );
   };
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This was already there, but was made more apparent for people that want it.
Resolves https://github.com/NixOS/nixpkgs/issues/515927. Helps simplify this: https://www.reddit.com/r/NixOS/comments/1t13tp1/comment/ojdyk01/.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
