### PR TITLE
ocamlPackages.bytesrw: 0.2.0 → 0.3.0

### DIFF
--- a/pkgs/development/ocaml-modules/bytesrw/default.nix
+++ b/pkgs/development/ocaml-modules/bytesrw/default.nix
@@ -1,35 +1,75 @@
 {
   lib,
   fetchzip,
-  libblake3,
-  libmd,
-  xxhash,
-  zlib,
-  zstd,
+  topkg,
   buildTopkgPackage,
+  withBlake3 ? true,
+  libblake3,
+  withLibmd ? true,
+  libmd,
+  withMbedtls ? true,
+  mbedtls_4,
+  withXxh ? true,
+  xxhash,
+  withZlib ? true,
+  zlib,
+  withZstd ? true,
+  zstd,
+  withCmdliner ? false,
+  cmdliner,
 }:
 
 buildTopkgPackage rec {
   pname = "bytesrw";
-  version = "0.2.0";
+  version = "0.3.0";
 
   minimalOCamlVersion = "4.14.0";
 
   src = fetchzip {
     url = "https://erratique.ch/software/bytesrw/releases/bytesrw-${version}.tbz";
-    hash = "sha256-DMQXclJV5uz/2a6XVHVnBkYgXpGRI83uzmzeed3fDxQ=";
+    hash = "sha256-EFdHKBH4VrWvOqs+I6tiRW9D2s6lY8Pol4YyuB7fqh8=";
   };
 
-  # docs say these are optional, but buildTopkgPackage doesn’t handle missing
-  # dependencies
+  buildInputs =
+    lib.optional withBlake3 libblake3
+    ++ lib.optional withLibmd libmd
+    ++ lib.optional withMbedtls mbedtls_4
+    ++ lib.optional withXxh xxhash
+    ++ lib.optional withZlib zlib
+    ++ lib.optional withZstd zstd
+    ++ lib.optional withCmdliner cmdliner;
 
-  buildInputs = [
-    libblake3
-    libmd
-    xxhash
-    zlib
-    zstd
-  ];
+  # certown is a CA utility that uses missing b0 APIs (Os.name, Os.Name).
+  # …but this is only need if enabling Cmdliner
+  postPatch = lib.optionalString withCmdliner ''
+    substituteInPlace pkg/pkg.ml --replace-fail \
+      'Pkg.bin ~cond:(b0 && cmdliner && mbedtls) "test/certown";' ""
+  '';
+
+  buildPhase = "${topkg.run} build ${
+    lib.escapeShellArgs [
+      "--with-conf-libblake3"
+      (lib.boolToString withBlake3)
+
+      "--with-conf-libmd"
+      (lib.boolToString withLibmd)
+
+      "--with-conf-mbedtls"
+      (lib.boolToString withMbedtls)
+
+      "--with-conf-xxhash"
+      (lib.boolToString withXxh)
+
+      "--with-conf-zlib"
+      (lib.boolToString withZlib)
+
+      "--with-conf-zstd"
+      (lib.boolToString withZstd)
+
+      "--with-cmdliner"
+      (lib.boolToString withCmdliner)
+    ]
+  }";
 
   meta = {
     description = "Composable, memory efficient, byte stream readers and writers compatible with effect-based concurrency";
@@ -37,8 +77,8 @@ buildTopkgPackage rec {
       Bytesrw extends the OCaml Bytes module with composable, memory efficient,
       byte stream readers and writers compatible with effect-based concurrency.
 
-      Except for byte slice life-times, these abstractions intentionnaly
-      separate away ressource management and the specifics of reading and
+      Except for byte slice life-times, these abstractions intentionally
+      separate away resource management and the specifics of reading and
       writing bytes.
     '';
     homepage = "https://erratique.ch/software/bytesrw";


### PR DESCRIPTION
post #509801

Fixed typos in description & made all the arguments option borrowing from `jsont`.

I am done fighting what is needed to get the certown test to run with these `b0` issues, so here’s a version that skips that specific test phase.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.