### PR TITLE
joycond-cemuhook: 0-unstable-2023-08-09 -> 0-unstable-2024-12-27

### DIFF
--- a/pkgs/by-name/jo/joycond-cemuhook/package.nix
+++ b/pkgs/by-name/jo/joycond-cemuhook/package.nix
@@ -6,31 +6,35 @@
 
 python3Packages.buildPythonApplication {
   pname = "joycond-cemuhook";
-  version = "0-unstable-2023-08-09";
+  version = "0-unstable-2024-12-27";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "joaorb64";
     repo = "joycond-cemuhook";
-    rev = "3c0e07374ff431a0f8ae70dbb0b5a62fb3de06ee";
-    hash = "sha256-K24CEmYWhgkvVX4geg2bylH8TSvHIpsWjsPwY5BpquI=";
+    rev = "fc2f29e22640b6615a32941cbdc03d41e3ee6f26";
+    hash = "sha256-ud9X+GfVzoPQM4bSDzczgrn8rJRmXy7tT6mBY3BNnFA=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail 'setuptools-git-versioning<2' 'setuptools-git-versioning'
+      --replace-fail 'setuptools-git-versioning<2' "setuptools-git-versioning"
   '';
 
   build-system = with python3Packages; [
     setuptools
+    wheel
     setuptools-git-versioning
   ];
 
   dependencies = with python3Packages; [
-    dbus-python
     evdev
     pyudev
+    dbus-python
     termcolor
+    pygobject-stubs
+    # Not explicitly stated, but required
+    pygobject3
   ];
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
