### PR TITLE
[Backport release-25.11] hyprland: 0.52.1 -> 0.52.2

### DIFF
--- a/pkgs/by-name/hy/hyprland/info.json
+++ b/pkgs/by-name/hy/hyprland/info.json
@@ -1,7 +1,7 @@
 {
-  "branch": "v0.52.1-b",
-  "commit_hash": "967c3c7404d4fa00234e29c70df3e263386d2597",
-  "commit_message": "version: bump to 0.52.1",
-  "date": "2025-11-09",
-  "tag": "v0.52.1"
+  "branch": "v0.52.2-b",
+  "commit_hash": "386376400119dd46a767c9f8c8791fd22c7b6e61",
+  "commit_message": "[gha] Nix: update inputs",
+  "date": "2025-12-03",
+  "tag": "v0.52.2"
 }

--- a/pkgs/by-name/hy/hyprland/package.nix
+++ b/pkgs/by-name/hy/hyprland/package.nix
@@ -91,14 +91,14 @@ assert assertMsg (
 
 customStdenv.mkDerivation (finalAttrs: {
   pname = "hyprland" + optionalString debug "-debug";
-  version = "0.52.1";
+  version = "0.52.2";
 
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = "hyprland";
     fetchSubmodules = true;
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Lr8kwriXtUxjYsi1sGRMIR2LZilgrxYQA1TTmbpSJ+g=";
+    hash = "sha256-R2Hm7XbW8CTLEIeYCAlSQ3U5bFhn76FC17hEy/ws8EM=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Backport of the following master PR that landed after 25.11 cut:

- hyprland: 0.52.1 -> 0.52.2 ([#467721](https://github.com/NixOS/nixpkgs/pull/467721))

No breaking changes; patch-level release with bug fixes. See [upstream changelog](https://github.com/hyprwm/Hyprland/releases/tag/v0.52.2) for details.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is sandboxing enabled in `nix.conf`?
- [x] Tested, as applicable:
  - [x] The package builds successfully (`nix-build -A hyprland`)
  - [x] Verified the binary works: `XDG_RUNTIME_DIR=/tmp ./result/bin/hyprland --version` returns `0.52.2`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Ran `nixpkgs-review wip --branch release-25.11` — 28 packages built, 0 failed
- [ ] 25.11 Release Notes (or backporting [25.05 release notes](...))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
