### PR TITLE
sosreport: 4.9.1 -> 4.11.1

### DIFF
--- a/pkgs/by-name/so/sosreport/os-release.patch
+++ b/pkgs/by-name/so/sosreport/os-release.patch
@@ -1,0 +1,9 @@
+--- a/sos/policies/distros/__init__.py
++++ b/sos/policies/distros/__init__.py
+@@ -128,6 +128,8 @@
+             return True
+         # next check os-release for a NAME or ID value we expect
++        if not os.path.exists(OS_RELEASE):
++            return False
+         with open(OS_RELEASE, "r", encoding='utf-8') as f:
+             return _check_release(f.read())

--- a/pkgs/by-name/so/sosreport/package.nix
+++ b/pkgs/by-name/so/sosreport/package.nix
@@ -7,17 +7,21 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "sosreport";
-  version = "4.9.1";
+  version = "4.11.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "sosreport";
     repo = "sos";
     tag = version;
-    hash = "sha256-97S8b4PfjUN8uzvp01PGCLs4J3CbwpJsgBKtY8kI0HE=";
+    hash = "sha256-HKGGA9SHCJjAaCPduPx1plUJ10nt3JYAr10J/69Sm/0=";
   };
 
   build-system = [ python3Packages.setuptools ];
+
+  patches = [
+    ./os-release.patch
+  ];
 
   nativeBuildInputs = [
     gettext
@@ -26,6 +30,7 @@ python3Packages.buildPythonPackage rec {
   dependencies = with python3Packages; [
     packaging
     pexpect
+    python-magic
     pyyaml
   ];
 
@@ -43,5 +48,6 @@ python3Packages.buildPythonPackage rec {
     homepage = "https://github.com/sosreport/sos";
     license = lib.licenses.gpl2Plus;
     maintainers = [ ];
+    platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
Update to 4.11.1

Added patch fixing test
Added python-magic dep
Restrict to linux platforms: it collects linux logs and is not supported/working/useful on darwin

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
