### PR TITLE
signal-desktop: 8.8.0 -> 8.9.1

### DIFF
--- a/pkgs/by-name/si/signal-desktop/libsignal-node.nix
+++ b/pkgs/by-name/si/signal-desktop/libsignal-node.nix
@@ -15,23 +15,23 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "libsignal-node";
-  version = "0.92.1";
+  version = "0.92.2";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "libsignal";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-gAXLt0e2k5PA6PgFRQa22oGuNLM7TGkOKQnYtFhn8I8=";
+    hash = "sha256-7VimtFjobM2EQl0cV0K1EIPeV015e+00ljfAfM4KNJI=";
   };
 
-  cargoHash = "sha256-TqYxkkzlbgrc7jkAubz3TsXhcU8Do5IFaLRqSPiZVR0=";
+  cargoHash = "sha256-HBrg//iKNo5/TuVtf9NuVbAyrhul2VVXwC0an7jGEgs=";
 
   npmRoot = "node";
   npmDeps = fetchNpmDeps {
     name = "${finalAttrs.pname}-npm-deps";
     inherit (finalAttrs) version src;
     sourceRoot = "${finalAttrs.src.name}/${finalAttrs.npmRoot}";
-    hash = "sha256-c6Alk2tyloaPAP2Qfgurle0ziVs8vbxb2klKJZaGlaQ=";
+    hash = "sha256-BV5E898u07LLoUVMVRJCHKhp4OJJl2fc5973n16T51k=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/si/signal-desktop/package.nix
+++ b/pkgs/by-name/si/signal-desktop/package.nix
@@ -11,6 +11,8 @@
   makeWrapper,
   callPackage,
   fetchFromGitHub,
+  fetchpatch,
+  fetchurl,
   jq,
   makeDesktopItem,
   copyDesktopItems,
@@ -38,34 +40,24 @@ let
   webrtc = callPackage ./webrtc.nix { };
   ringrtc = callPackage ./ringrtc.nix { inherit webrtc; };
 
-  # Noto Color Emoji PNG files for emoji replacement; see below.
-  noto-fonts-color-emoji-png = noto-fonts-color-emoji.overrideAttrs (prevAttrs: {
-    pname = "noto-fonts-color-emoji-png";
-
-    # The build produces 136×128 PNGs by default for arcane font
-    # reasons, but we want square PNGs.
-    buildFlags = prevAttrs.buildFlags or [ ] ++ [ "BODY_DIMENSIONS=128x128" ];
-
-    makeTargets = [ "compressed" ];
-
-    installPhase = ''
-      runHook preInstall
-
-      mkdir -p $out/share
-      mv build/compressed_pngs $out/share/noto-fonts-color-emoji-png
-      python3 add_aliases.py --srcdir=$out/share/noto-fonts-color-emoji-png
-
-      runHook postInstall
-    '';
-  });
-
-  version = "8.8.0";
+  version = "8.9.1";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "Signal-Desktop";
     tag = "v${version}";
-    hash = "sha256-moWEqKWZgqIfhK01RUROF4Waxbn5kcmxZQ94PGai4ww=";
+    hash = "sha256-HXxIjCVGh3JFAj0UUEAvmVnm7jMZdxRqWDILRDFCGw4=";
+    # Emoji font files will be added in `postFetch` if `withAppleEmojis` is enabled. They
+    # are fetched separately below.
+    postFetch = ''
+      rm $out/fonts/emoji.woff2
+    '';
+  };
+
+  apple-emoji = fetchurl {
+    url = "https://github.com/signalapp/Signal-Desktop/raw/refs/tags/v${version}/fonts/emoji.woff2";
+    hash = "sha256-yGdx5GZVnsmYn+SI9/yAfGhRyzO5Q5Bd0bW9AQyVzv8=";
+    meta.license = lib.licenses.unfree;
   };
 
   sticker-creator = stdenv.mkDerivation (finalAttrs: {
@@ -122,12 +114,20 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   patches = [
+    # Custom fonts currently don't work on windows other than the main one,
+    # which causes some of the text to look messed up. We want to include
+    # this patch since we are overriding the emoji font by default.
+    # Upstream PR: https://github.com/signalapp/Signal-Desktop/pull/7864
+    # This patch can be removed after `v8.11.0`.
+    (fetchpatch {
+      url = "https://github.com/signalapp/Signal-Desktop/commit/52ecd0d931e6071da79b016d2af1f508167b2a98.patch";
+      hash = "sha256-dtc0bwv9aLz92j5Zfm/SREWtQ43ljXN9Vm2VkeDbAx8=";
+    })
     ./force-90-days-expiration.patch
   ]
   ++ lib.optional (!withAppleEmojis) (
-    # Signal ships the Apple emoji set without a licence via an npm
-    # package and upstream does not seem terribly interested in fixing
-    # this; see:
+    # Signal ships the Apple emoji set without a licence and upstream
+    # does not seem terribly interested in fixing this; see:
     #
     # * <https://github.com/signalapp/Signal-Android/issues/5862>
     # * <https://whispersystems.discoursehosting.net/t/signal-is-likely-violating-apple-license-terms-by-using-apple-emoji-in-the-sticker-creator-and-android-and-desktop-apps/52883>
@@ -135,10 +135,10 @@ stdenv.mkDerivation (finalAttrs: {
     # We work around this by replacing it with the Noto Color Emoji
     # set, which is available under a FOSS licence and more likely to
     # be used on a NixOS machine anyway. The Apple emoji are removed
-    # before `fetchPnpmDeps` to ensure that the build doesn’t cache the
+    # in `postFetch` to ensure that the build doesn’t cache the
     # unlicensed emoji files.
     replaceVars ./replace-apple-emoji-with-noto-emoji.patch {
-      noto-emoji-pngs = "${noto-fonts-color-emoji-png}/share/noto-fonts-color-emoji-png";
+      inherit noto-fonts-color-emoji;
     }
   );
 
@@ -166,6 +166,9 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail '"afterPack": "scripts/after-pack.mjs",' "" \
       --replace-fail '"sign": "scripts/sign-macos.mjs",' "" \
       --replace-fail '"afterAllArtifactBuild": "scripts/after-all-artifact-build.mjs",' ""
+  ''
+  + lib.optionalString withAppleEmojis ''
+    cp ${apple-emoji} fonts/emoji.woff2
   '';
 
   pnpmDeps = fetchPnpmDeps {
@@ -177,17 +180,13 @@ stdenv.mkDerivation (finalAttrs: {
       ;
     inherit pnpm;
     fetcherVersion = 3;
-    hash =
-      if withAppleEmojis then
-        "sha256-Ib+NQbnCawbGgx45u27ubf1a6lHkrGde+m1DUT23w5Y="
-      else
-        "sha256-0HzY/4XHjc8uAIMy6OzgGcuDNGfqQVW2RHOtyeYPJaw=";
+    hash = "sha256-ls7DYPI5Dq06KI7WCdEkKHPsHTMJ3kO0qJDZsHZQHBQ=";
   };
 
   env = {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
     SIGNAL_ENV = "production";
-    SOURCE_DATE_EPOCH = 1777225303;
+    SOURCE_DATE_EPOCH = 1778260300;
   }
   // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
     # Disable code signing during local macOS builds.
@@ -321,6 +320,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     inherit
+      apple-emoji
       libsignal-node
       ringrtc
       webrtc
@@ -339,15 +339,12 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://signal.org/";
     changelog = "https://github.com/signalapp/Signal-Desktop/releases/tag/v${finalAttrs.version}";
-    license =
-      with lib.licenses;
-      [
-        agpl3Only
+    license = with lib.licenses; [
+      agpl3Only
 
-        # Various npm packages
-        free
-      ]
-      ++ lib.optional withAppleEmojis unfree;
+      # Various npm packages
+      free
+    ];
     maintainers = with lib.maintainers; [
       eclairevoyant
       iamanaws

--- a/pkgs/by-name/si/signal-desktop/replace-apple-emoji-with-noto-emoji.patch
+++ b/pkgs/by-name/si/signal-desktop/replace-apple-emoji-with-noto-emoji.patch
@@ -1,127 +1,126 @@
-diff --git a/ACKNOWLEDGMENTS.md b/ACKNOWLEDGMENTS.md
-index 273a9e097..ffb5b6eb6 100644
---- a/ACKNOWLEDGMENTS.md
-+++ b/ACKNOWLEDGMENTS.md
-@@ -3667,30 +3667,6 @@ Signal Desktop makes use of the following open source projects.
-     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-     SOFTWARE.
+diff --git a/app/AssetService.main.ts b/app/AssetService.main.ts
+index 33b20b8d5..c122f8c67 100644
+--- a/app/AssetService.main.ts
++++ b/app/AssetService.main.ts
+@@ -32,7 +32,6 @@ const LOCAL_ASSETS = new Set([
  
--## emoji-datasource-apple
--
--    The MIT License (MIT)
--
--    Copyright (c) 2013 Cal Henderson
--
--    Permission is hereby granted, free of charge, to any person obtaining a copy
--    of this software and associated documentation files (the "Software"), to deal
--    in the Software without restriction, including without limitation the rights
--    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
--    copies of the Software, and to permit persons to whom the Software is
--    furnished to do so, subject to the following conditions:
--
--    The above copyright notice and this permission notice shall be included in all
--    copies or substantial portions of the Software.
--
--    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
--    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
--    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
--    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
--    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
--    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
--    SOFTWARE.
--
- ## emoji-regex
+ // pathname to optional resource name
+ const OPTIONAL_ASSETS = new Map([
+-  ['optional-fonts/emoji-large.woff2', 'emoji-font.woff2'],
+ ]);
  
-     Copyright Mathias Bynens <https://mathiasbynens.be/>
+ export class AssetService {
 diff --git a/app/protocol_filter.node.ts b/app/protocol_filter.node.ts
-index 483d1c4e4..66609d9e9 100644
+index 17c68f0a4..4ed359de6 100644
 --- a/app/protocol_filter.node.ts
 +++ b/app/protocol_filter.node.ts
-@@ -62,6 +62,7 @@ function _createFileHandler({
+@@ -68,6 +68,7 @@ export function _createFileHandler({
    const allowedRoots = [
      userDataPath,
      installPath,
-+    "@noto-emoji-pngs@",
++    "@noto-fonts-color-emoji@",
      getAvatarsPath(userDataPath),
      getBadgesPath(userDataPath),
      getDraftPath(userDataPath),
-diff --git a/package.json b/package.json
-index dd87037e7..f16dd8d1f 100644
---- a/package.json
-+++ b/package.json
-@@ -240,7 +240,6 @@
-     "electron": "41.2.2",
-     "electron-builder": "26.0.14",
-     "electron-mocha": "13.1.0",
--    "emoji-datasource-apple": "16.0.0",
-     "emoji-regex": "10.6.0",
-     "enhanced-resolve": "5.20.1",
-     "enquirer": "2.4.1",
-diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
-index d659475fc..2f1e3cfdb 100644
---- a/pnpm-lock.yaml
-+++ b/pnpm-lock.yaml
-@@ -430,9 +430,6 @@ importers:
-       electron-mocha:
-         specifier: 13.1.0
-         version: 13.1.0
--      emoji-datasource-apple:
--        specifier: 16.0.0
--        version: 16.0.0
-       emoji-regex:
-         specifier: 10.6.0
-         version: 10.6.0
-@@ -6154,9 +6151,6 @@ packages:
-     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
-     engines: {node: '>=12'}
+diff --git a/stylesheets/_fontfaces.scss b/stylesheets/_fontfaces.scss
+index d9f558cd4..45a42ecd1 100644
+--- a/stylesheets/_fontfaces.scss
++++ b/stylesheets/_fontfaces.scss
+@@ -89,7 +89,8 @@ $protocol: 'asset://';
  
--  emoji-datasource-apple@16.0.0:
--    resolution: {integrity: sha512-dVYjsK0FnCry9F+PBtnivhG2K0xdwlmqYaSgiUtztUdAGPYiHYhZcVKvNBqC791g2qyEcFNTBO6utg4eQ3uLTw==}
--
-   emoji-datasource@16.0.0:
-     resolution: {integrity: sha512-/qHKqK5Nr3+8zhgO6kHmF43Fm5C8HNn0AaFRIpgw8HF3+uF0Vfc8jgLI1ZQS5ba1vBzksS8NBCjHejwLb2D/Sg==}
- 
-@@ -16387,8 +16381,6 @@ snapshots:
- 
-   emittery@0.13.1: {}
- 
--  emoji-datasource-apple@16.0.0: {}
--
-   emoji-datasource@16.0.0: {}
- 
-   emoji-regex@10.6.0: {}
-diff --git a/stylesheets/components/fun/FunEmoji.scss b/stylesheets/components/fun/FunEmoji.scss
-index 1cc4bb43c..a6444101a 100644
---- a/stylesheets/components/fun/FunEmoji.scss
-+++ b/stylesheets/components/fun/FunEmoji.scss
-@@ -5,19 +5,9 @@
- $emoji-sprite-sheet-grid-item-count: 62;
- 
- @mixin emoji-sprite($sheet, $margin, $scale) {
--  $size: calc($sheet * 1px * $scale);
--  $margin-start: calc($margin * $scale);
--  $margin-end: calc($margin * $scale);
--  $size-outer: calc($size + $margin-start + $margin-end);
--  $image: url('../images/emoji-sheet-#{$sheet}.webp');
--  background-image: $image;
--  background-size: calc($size-outer * $emoji-sprite-sheet-grid-item-count);
--  background-position-x: calc(
--    var(--fun-emoji-sheet-x) * ($size-outer * -1) + ($margin-start * -1)
--  );
--  background-position-y: calc(
--    var(--fun-emoji-sheet-y) * ($size-outer * -1) + ($margin-start * -1)
--  );
-+  background-image: var(--fun-emoji-jumbo-image);
-+  background-size: contain;
-+  background-position: center;
-   background-repeat: no-repeat;
+ @font-face {
+   font-family: 'Signal Emoji Small';
+-  src: url('#{$protocol}/fonts/emoji.woff2');
++  src: url('file://@noto-fonts-color-emoji@/share/fonts/noto/NotoColorEmoji.ttf');
++  size-adjust: 85%;
  }
  
+ $largeEmojiFont: 'asset:///optional-fonts/emoji-large.woff2';
+diff --git a/stylesheets/components/fun/FunEmoji.scss b/stylesheets/components/fun/FunEmoji.scss
+index f96218420..612538cd3 100644
+--- a/stylesheets/components/fun/FunEmoji.scss
++++ b/stylesheets/components/fun/FunEmoji.scss
+@@ -8,14 +8,12 @@
+ }
+ 
+ .FunStaticEmoji {
+-  contain: strict;
+   display: inline-flex;
+   align-items: center;
+   justify-content: center;
+   position: relative;
+   z-index: 0;
+   flex: none;
+-  content-visibility: auto;
+   vertical-align: top;
+   letter-spacing: inherit;
+ 
+@@ -24,15 +22,6 @@
+   color: hsl(from currentColor h s l / 100%);
+ }
+ 
+-.FunStaticEmoji__Text {
+-  padding-top: 1px;
+-
+-  // Emoji font images are slightly higher than optical center
+-  @media (resolution >= 2x) {
+-    padding-top: 0.5px;
+-  }
+-}
+-
+ .FunStaticEmoji--Blot {
+   display: inline-flex;
+   margin-bottom: round(-0.4em + 3px, 1px);
+@@ -133,7 +122,6 @@ $inline-emoji-container-name: inline-emoji;
+ 
+ .FunInlineEmoji {
+   z-index: 0;
+-  contain: strict;
+   container: $inline-emoji-container-name / inline-size;
+   display: inline-block;
+   flex: none;
+@@ -142,8 +130,7 @@ $inline-emoji-container-name: inline-emoji;
+   font-size: var(--fun-inline-emoji-size, round(1.4em, 1px));
+   line-height: var(--fun-inline-emoji-size, round(1em, 1px));
+   letter-spacing: inherit;
+-  content-visibility: auto;
+-  vertical-align: bottom;
++  vertical-align: text-bottom;
+ }
+ 
+ .FunInlineEmoji__Image {
+@@ -170,26 +157,6 @@ $inline-emoji-container-name: inline-emoji;
+   @container #{$inline-emoji-container-name} (width > 64px) {
+     display: none;
+   }
+-
+-  // Emoji font images are slightly higher than optical center
+-  @container #{$inline-emoji-container-name} (width > 16px) {
+-    padding-top: 0.5px;
+-  }
+-
+-  @container #{$inline-emoji-container-name} (width > 45px) {
+-    padding-top: 1px;
+-  }
+-
+-  @media (resolution >= 2x) {
+-    // Emoji font has images are slightly higher than optical center
+-    @container #{$inline-emoji-container-name} (width > 8px) {
+-      padding-top: 0.5px;
+-    }
+-
+-    @container #{$inline-emoji-container-name} (width > 40px) {
+-      padding-top: 1px;
+-    }
+-  }
+ }
+ 
+ .FunInlineEmoji__Jumbo {
 diff --git a/ts/components/fun/FunEmoji.dom.tsx b/ts/components/fun/FunEmoji.dom.tsx
-index ea031e9a8..3d760a43e 100644
+index 853f8b7cd..f4589f735 100644
 --- a/ts/components/fun/FunEmoji.dom.tsx
 +++ b/ts/components/fun/FunEmoji.dom.tsx
-@@ -20,13 +20,14 @@ function getEmojiJumboBackground(
+@@ -31,12 +31,6 @@ function getEmojiJumboUrl(
    emoji: EmojiVariantData,
    size: number | undefined
  ): string | null {
@@ -129,17 +128,8 @@ index ea031e9a8..3d760a43e 100644
 -    return null;
 -  }
 -  if (KNOWN_JUMBOMOJI.has(emoji.value)) {
--    return `url(emoji://jumbo?emoji=${encodeURIComponent(emoji.value)})`;
+-    return `emoji://jumbo?emoji=${encodeURIComponent(emoji.value)}`;
 -  }
--  return null;
-+  const emojiToNotoName = (emoji: string): string =>
-+    `emoji_u${
-+      [...emoji]
-+        .filter(c => c != "\ufe0f")
-+        .map(c => c.codePointAt(0)?.toString(16).padStart(4, "0"))
-+        .join("_")
-+    }.png`;
-+  return `url(file://@noto-emoji-pngs@/${emojiToNotoName(emoji.value)})`;
+   return null;
  }
  
- export type FunStaticEmojiSize =

--- a/pkgs/by-name/si/signal-desktop/update.sh
+++ b/pkgs/by-name/si/signal-desktop/update.sh
@@ -31,12 +31,10 @@ sed -E -i "s/(nodejs_)../\1$nodeVersion/" $SCRIPT_DIR/package.nix
 sed -E -i "s/(electron_)../\1$electronVersion/" $SCRIPT_DIR/package.nix
 sed -E -i "s/(SOURCE_DATE_EPOCH = )[0-9]+/\1$releaseEpoch/" $SCRIPT_DIR/package.nix
 
-sed -E -i "s/(withAppleEmojis \? )false/\1true/" $SCRIPT_DIR/package.nix
 nix-update signal-desktop --subpackage sticker-creator --version="$latestVersion"
-sed -E -i "s/(withAppleEmojis \? )true/\1false/" $SCRIPT_DIR/package.nix
 update-source-version signal-desktop \
   --ignore-same-version \
-  --source-key=pnpmDeps
+  --source-key=apple-emoji
 
 update-source-version signal-desktop.libsignal-node \
   "$libsignalClientVersion"


### PR DESCRIPTION
diff: https://github.com/signalapp/Signal-Desktop/compare/v8.8.0...v8.9.1
release: https://github.com/signalapp/Signal-Desktop/releases/tag/v8.9.1

I'm very unsure what to do with the Apple Emojis font right now. The Emoji fonts seem to be downloaded at runtime now since https://github.com/signalapp/Signal-Desktop/commit/bb07abb8b1a3681c10c7c8d052be9e0f76e7a637 but there are still some in-tree files like `fonts/emojis.woff2` which include all of the Apple Emojis. Keeping those files out of the main package is still a good idea in my opinion. The implementation isn't perfect right now (the Emojis still look a bit janky), so if there is any CSS wizzard, I'd be happy to push suggested changes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
