### PR TITLE
lib.options: several small performance cleanups

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -516,18 +516,25 @@ rec {
     else if defs == [ ] then
       abort "This case should never happen."
     else
-      (foldl' (
-        first: def:
-        if def.value != first.value then
-          throw "The option `${showOption loc}' has conflicting definition values:${
-            showDefs [
-              first
-              def
-            ]
-          }\n${prioritySuggestion}"
-        else
-          first
-      ) (head defs) (tail defs)).value;
+      let
+        first = (head defs).value;
+      in
+      # Only fold to find the error if any of the values aren't equal
+      if all (def: def.value == first) (tail defs) then
+        first
+      else
+        (foldl' (
+          first: def:
+          if def.value != first.value then
+            throw "The option `${showOption loc}' has conflicting definition values:${
+              showDefs [
+                first
+                def
+              ]
+            }\n${prioritySuggestion}"
+          else
+            first
+        ) (head defs) (tail defs)).value;
 
   /**
     Extracts values of all `value` keys of the given list.

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -508,13 +508,13 @@ rec {
   */
   mergeEqualOption =
     loc: defs:
-    if defs == [ ] then
-      abort "This case should never happen."
     # Returns early if we only have one element
     # This also makes it work for functions, because the foldl' below would try
     # to compare the first element with itself, which is false for functions
-    else if length defs == 1 then
+    if length defs == 1 then
       (head defs).value
+    else if defs == [ ] then
+      abort "This case should never happen."
     else
       (foldl' (
         first: def:

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -324,17 +324,18 @@ rec {
       name' = if isList name then last name else name;
       default' = toList default;
       defaultText = showAttrPath default';
-      defaultValue = attrByPath default' (throw "${defaultText} cannot be found in ${pkgsText}") pkgs;
       defaults =
         if default != null then
           {
-            default = defaultValue;
+            default = attrByPath default' (throw "${defaultText} cannot be found in ${pkgsText}") pkgs;
             defaultText = literalExpression "${pkgsText}.${defaultText}";
           }
-        else
-          optionalAttrs nullable {
+        else if nullable then
+          {
             default = null;
-          };
+          }
+        else
+          { };
     in
     mkOption (
       defaults

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -184,12 +184,18 @@ rec {
     :::
   */
   mkEnableOption =
+    let
+      type = lib.types.bool;
+    in
     name:
-    mkOption {
+    # We inline the call to mkOption for performance, since mkEnableOption is
+    # used everywhere
+    {
+      _type = "option";
       default = false;
       example = true;
       description = "Whether to enable ${name}.";
-      type = lib.types.bool;
+      inherit type;
     };
 
   /**

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -6,6 +6,7 @@
 let
   inherit (lib)
     all
+    any
     collect
     concatLists
     concatMap
@@ -441,7 +442,7 @@ rec {
     else if all isAttrs list then
       foldl' lib.mergeAttrs { } list
     else if all isBool list then
-      foldl' lib."or" false list
+      any (x: x) list
     else if all isString list then
       lib.concatStrings list
     else if all isInt list && all (x: x == head list) list then

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -430,25 +430,26 @@ rec {
   */
   mergeDefaultOption =
     loc: defs:
-    let
-      list = getValues defs;
-    in
-    if length list == 1 then
-      head list
-    else if all isFunction list then
-      x: mergeDefaultOption loc (map (f: f x) list)
-    else if all isList list then
-      concatLists list
-    else if all isAttrs list then
-      foldl' lib.mergeAttrs { } list
-    else if all isBool list then
-      any (x: x) list
-    else if all isString list then
-      lib.concatStrings list
-    else if all isInt list && all (x: x == head list) list then
-      head list
+    if length defs == 1 then
+      (head defs).value
     else
-      throw "Cannot merge definitions of `${showOption loc}'. Definition values:${showDefs defs}";
+      let
+        list = getValues defs;
+      in
+      if all isFunction list then
+        x: mergeDefaultOption loc (map (f: f x) list)
+      else if all isList list then
+        concatLists list
+      else if all isAttrs list then
+        foldl' lib.mergeAttrs { } list
+      else if all isBool list then
+        any (x: x) list
+      else if all isString list then
+        lib.concatStrings list
+      else if all (x: isInt x && x == head list) list then
+        head list
+      else
+        throw "Cannot merge definitions of `${showOption loc}'. Definition values:${showDefs defs}";
 
   /**
     Require a single definition.

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -312,6 +312,9 @@ rec {
     :::
   */
   mkPackageOption =
+    let
+      inherit (lib.types) nullOr package;
+    in
     pkgs: name:
     {
       nullable ? false,
@@ -342,7 +345,7 @@ rec {
       // {
         description =
           "The ${name'} package to use." + (if extraDescription == "" then "" else " ") + extraDescription;
-        type = with lib.types; (if nullable then nullOr else lib.id) package;
+        type = if nullable then nullOr package else package;
         ${if example != null then "example" else null} = literalExpression (
           if isList example then "${pkgsText}.${showAttrPath example}" else example
         );

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -343,9 +343,7 @@ rec {
         description =
           "The ${name'} package to use." + (if extraDescription == "" then "" else " ") + extraDescription;
         type = with lib.types; (if nullable then nullOr else lib.id) package;
-      }
-      // optionalAttrs (example != null) {
-        example = literalExpression (
+        ${if example != null then "example" else null} = literalExpression (
           if isList example then "${pkgsText}.${showAttrPath example}" else example
         );
       }


### PR DESCRIPTION
I'm getting fast at this! Most of these are very small savings, but 0.1% of 4 million function calls is still 4 thousand function calls saved. Hash is the same before/after for both a minimal NixOS config and my own. Stats diff:
```sh
NIX_SHOW_STATS=1 \
nix-instantiate -I nixpkgs=. --eval -E '
  let nixos = import ./nixos/lib/eval-config.nix {
    modules = [
      ./nixos/modules/profiles/minimal.nix
      { 
        fileSystems."/" = { device = "/dev/sda1"; fsType = "ext4"; }; 
        boot.loader.grub.devices = ["/dev/sda"];
      }
    ];
  }; in nixos.config.system.build.toplevel.drvPath
'
```
```json
{
  "attrset": {
    "lookups": "-0.11%",
    "merges": "-0.69%",
    "mergeCopies": "-0.09%"
  },
  "list": {
    "concats": null
  },
  "parser": {
    "expressions": null
  },
  "memory": {
    "envs": "-0.25%",
    "list": "-0.1%",
    "sets": "-0.07%",
    "symbols": null,
    "values": false,
    "total": "-0.12%"
  },
  "speed": {
    "primops": "-0.07%",
    "functionCalls": "-0.1%",
    "thunksMade": "-0.1%",
    "thunksAvoided": "-0.22%"
  }
}
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
