### PR TITLE
nim.nim.nimTarget: fix the eval

### DIFF
--- a/pkgs/by-name/ni/nim-unwrapped-2_2/package.nix
+++ b/pkgs/by-name/ni/nim-unwrapped-2_2/package.nix
@@ -98,7 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     nimHost = lib.warn "nimHost is deprecated, please use stdenv.hostPlatform.nim.os instead." stdenv.hostPlatform.nim.os;
-    nimTarget = lib.warn "nimTarget is deprecated, please use stdenv.hostPlatform.nim.cpu instead." stdenv.hostPlatform.cpu;
+    nimTarget = lib.warn "nimTarget is deprecated, please use stdenv.hostPlatform.nim.cpu instead." stdenv.hostPlatform.nim.cpu;
   };
 
   meta = {


### PR DESCRIPTION
Without the chnage the eval fails as:

```
$ nix eval --impure --expr 'with import ./. {}; nim.nim.nimTarget'
evaluation warning: nimTarget is deprecated, please use stdenv.hostPlatform.nim.cpu instead.
error:
       … while evaluating the attribute 'nim.nimTarget'
         at pkgs/by-name/ni/nim-unwrapped-2_2/package.nix:101:5:
          100|     nimHost = lib.warn "nimHost is deprecated, please use stdenv.hostPlatform.nim.os instead." stdenv.hostPlatform.nim.os;
          101|     nimTarget = lib.warn "nimTarget is deprecated, please use stdenv.hostPlatform.nim.cpu instead." stdenv.hostPlatform.cpu;
             |     ^
          102|   };

       … while calling the 'warn' builtin
         at pkgs/by-name/ni/nim-unwrapped-2_2/package.nix:101:17:
          100|     nimHost = lib.warn "nimHost is deprecated, please use stdenv.hostPlatform.nim.os instead." stdenv.hostPlatform.nim.os;
          101|     nimTarget = lib.warn "nimTarget is deprecated, please use stdenv.hostPlatform.nim.cpu instead." stdenv.hostPlatform.cpu;
             |                 ^
          102|   };

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'cpu' missing
       at pkgs/by-name/ni/nim-unwrapped-2_2/package.nix:101:101:
          100|     nimHost = lib.warn "nimHost is deprecated, please use stdenv.hostPlatform.nim.os instead." stdenv.hostPlatform.nim.os;
          101|     nimTarget = lib.warn "nimTarget is deprecated, please use stdenv.hostPlatform.nim.cpu instead." stdenv.hostPlatform.cpu;
             |                                                                                                     ^
          102|   };
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
