### PR TITLE
librewolf-unwrapped: 150.0.1-1 -> 150.0.2-1

### DIFF
--- a/pkgs/by-name/li/librewolf-unwrapped/src.json
+++ b/pkgs/by-name/li/librewolf-unwrapped/src.json
@@ -1,11 +1,11 @@
 {
-  "packageVersion": "150.0.1-1",
+  "packageVersion": "150.0.2-1",
   "source": {
-    "rev": "150.0.1-1",
-    "hash": "sha256-9+NiNv6uAxdj3zFurH3dBDWk4SJxdgJaHAm67aOmJAk="
+    "rev": "150.0.2-1",
+    "hash": "sha256-eEdLG9hBTRH8UIoclGJaJ4rNcTDrXbeUWZPM+Y6WXTw="
   },
   "firefox": {
-    "version": "150.0.1",
-    "hash": "sha512-s3EOGzUAIxK/JI6CJoEDm3XsEZb40BTIiwN3ybBvNHgEaRUqmK2WdEClGkoMpFQYumI5Q4+GmuVkzILAI2RReQ=="
+    "version": "150.0.2",
+    "hash": "sha512-4i/Gb3+uub70A20KkK9MJ9q8RaPcWccpBTa/5Gx2JNcziNKbNqiZnjZAZfoxpfoWdZZjIimwr5vBuvQTX6KaTQ=="
   }
 }


### PR DESCRIPTION
diff: https://codeberg.org/librewolf/source/compare/150.0.1-1...150.0.2-1
mfsa: https://www.mozilla.org/en-US/security/advisories/mfsa2026-40/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
