### PR TITLE
[Backport release-25.11] incus: 6.23.0 -> 7.0.0

### DIFF
--- a/nixos/modules/virtualisation/incus.nix
+++ b/nixos/modules/virtualisation/incus.nix
@@ -44,8 +44,6 @@ let
         libxfs
         lvm2
         lxcfs
-        minio
-        minio-client
         nftables
         qemu-utils
         qemu_kvm
@@ -67,6 +65,10 @@ let
       ]
       ++ lib.optionals (lib.versionAtLeast cfg.package.version "6.11.0") [
         lego
+      ]
+      ++ lib.optionals (lib.versionOlder cfg.package.version "7.0.0") [
+        minio
+        minio-client
       ]
       ++ lib.optionals config.security.apparmor.enable [
         apparmor-bin-utils

--- a/pkgs/by-name/in/incus/client.nix
+++ b/pkgs/by-name/in/incus/client.nix
@@ -9,14 +9,15 @@
   lib,
   buildGoModule,
   installShellFiles,
+  fetchpatch2,
 }:
 let
   pname = "incus${lib.optionalString lts "-lts"}-client";
+  evaluatedPatches = if lib.isFunction patches then patches fetchpatch2 else patches;
 in
 
 buildGoModule {
   inherit
-    patches
     pname
     src
     vendorHash
@@ -28,6 +29,8 @@ buildGoModule {
   nativeBuildInputs = [ installShellFiles ];
 
   subPackages = [ "cmd/incus" ];
+
+  patches = evaluatedPatches;
 
   postInstall = ''
     # Needed for builds on systems with auto-allocate-uids to pass.

--- a/pkgs/by-name/in/incus/generic.nix
+++ b/pkgs/by-name/in/incus/generic.nix
@@ -163,25 +163,27 @@ buildGoModule (finalAttrs: {
 
   doInstallCheck = true;
 
-  postInstall = ''
-    installShellCompletion --cmd incus \
-      --bash <($out/bin/incus completion bash) \
-      --fish <($out/bin/incus completion fish) \
-      --zsh <($out/bin/incus completion zsh)
+  postInstall =
+    lib.optionalString (stdenv.hostPlatform.canExecute stdenv.buildPlatform) ''
+      installShellCompletion --cmd incus \
+        --bash <($out/bin/incus completion bash) \
+        --fish <($out/bin/incus completion fish) \
+        --zsh <($out/bin/incus completion zsh)
+    ''
+    + ''
+      mkdir -p $agent_loader/bin $agent_loader/etc/systemd/system $agent_loader/lib/udev/rules.d
+      # the agent_loader output is used by virtualisation.incus.agent
+      cp internal/server/instance/drivers/agent-loader/incus-agent-linux $agent_loader/bin/incus-agent
+      cp internal/server/instance/drivers/agent-loader/incus-agent-setup-linux $agent_loader/bin/incus-agent-setup
+      chmod +x $agent_loader/bin/incus-agent{,-setup}
+      patchShebangs $agent_loader/bin/incus-agent{,-setup}
+      cp internal/server/instance/drivers/agent-loader/systemd/incus-agent.service $agent_loader/etc/systemd/system/
+      cp internal/server/instance/drivers/agent-loader/systemd/incus-agent.rules $agent_loader/lib/udev/rules.d/99-incus-agent.rules
+      substituteInPlace $agent_loader/etc/systemd/system/incus-agent.service --replace-fail 'TARGET/systemd' "$agent_loader/bin"
 
-    mkdir -p $agent_loader/bin $agent_loader/etc/systemd/system $agent_loader/lib/udev/rules.d
-    # the agent_loader output is used by virtualisation.incus.agent
-    cp internal/server/instance/drivers/agent-loader/incus-agent-linux $agent_loader/bin/incus-agent
-    cp internal/server/instance/drivers/agent-loader/incus-agent-setup-linux $agent_loader/bin/incus-agent-setup
-    chmod +x $agent_loader/bin/incus-agent{,-setup}
-    patchShebangs $agent_loader/bin/incus-agent{,-setup}
-    cp internal/server/instance/drivers/agent-loader/systemd/incus-agent.service $agent_loader/etc/systemd/system/
-    cp internal/server/instance/drivers/agent-loader/systemd/incus-agent.rules $agent_loader/lib/udev/rules.d/99-incus-agent.rules
-    substituteInPlace $agent_loader/etc/systemd/system/incus-agent.service --replace-fail 'TARGET/systemd' "$agent_loader/bin"
-
-    mkdir $doc
-    cp -R doc/html $doc/
-  '';
+      mkdir $doc
+      cp -R doc/html $doc/
+    '';
 
   passthru = {
     client = callPackage ./client.nix {

--- a/pkgs/by-name/in/incus/generic.nix
+++ b/pkgs/by-name/in/incus/generic.nix
@@ -14,6 +14,7 @@
   stdenv,
   buildGoModule,
   fetchFromGitHub,
+  fetchpatch2,
   acl,
   buildPackages,
   cowsql,
@@ -51,6 +52,7 @@ let
       sphinxext-opengraph
     ]
   );
+  evaluatedPatches = if lib.isFunction patches then patches fetchpatch2 else patches;
 in
 
 buildGoModule (finalAttrs: {
@@ -75,7 +77,7 @@ buildGoModule (finalAttrs: {
     // (if (rev == null) then { tag = "v${version}"; } else { inherit rev; })
   );
 
-  patches = [ ./docs.patch ] ++ patches;
+  patches = [ ./docs.patch ] ++ evaluatedPatches;
 
   excludedPackages = [
     # statically compile these

--- a/pkgs/by-name/in/incus/package.nix
+++ b/pkgs/by-name/in/incus/package.nix
@@ -1,8 +1,84 @@
 import ./generic.nix {
-  hash = "sha256-I+wwpsFGDX0W7pwzROGW1ZDHx+C7uc61ypO45BzOhoE=";
-  version = "6.23.0";
-  vendorHash = "sha256-R4q0FNu33qZrHrZQTqPCfw7FNUv6itl7y2AxdRF19CQ=";
-  patches = [ ];
+  hash = "sha256-7s2gc+78O8jKypVe1itaUrsLPa2mLjNgUUrR/cv7ITA=";
+  version = "7.0.0";
+  vendorHash = "sha256-6irMB3hpWcxDuMQBxWXnhMLAOwTAl63JX6JJZMQXf5E=";
+  patches = fetchpatch2: [
+    (fetchpatch2 {
+      name = "doc-devices-disk_Fix-broken-link.patch";
+      url = "https://github.com/lxc/incus/commit/faa636b70c05a5cca0346492a0586d5747e4b117.patch?full_index=1";
+      hash = "sha256-UsfzSeLJq0B9xDmd124ITzFBJzg2w1xXNK6TavQ5iMs=";
+    })
+    (fetchpatch2 {
+      name = "incusd-instance-qemu_Fix-version-detection-for-qemu-kvm.patch";
+      url = "https://github.com/lxc/incus/commit/a5f50d36eaa41580f2233b05936bd29fe1b15100.patch?full_index=1";
+      hash = "sha256-Qwu2oljB7COZB2m3W/9Y5wCCZyxvLj4ZUHcNqtoDGzk=";
+    })
+    (fetchpatch2 {
+      name = "incusd_Re-introduce-core-scheduling-detection.patch";
+      url = "https://github.com/lxc/incus/commit/1e6ce18e8cd92b5b3eb4346e7bd27fd4a7d1fb9b.patch?full_index=1";
+      hash = "sha256-RLy8bcod55g8vtXxChte4oalApw7d/gZg8No6BUZQS0=";
+    })
+    (fetchpatch2 {
+      name = "incusd-instance-lxc_Fix-swap=false-failure.patch";
+      url = "https://github.com/lxc/incus/commit/5f2cdf7545c5398290dc507313de9ee547fe803f.patch?full_index=1";
+      hash = "sha256-Ux6mm8Y4q68fj//hG7k+bXMjqhGDOxGNm64De1pwcYY=";
+    })
+    (fetchpatch2 {
+      name = "incusd-forknet_Persist-DHCPv6-client-DUID-across-restarts.patch";
+      url = "https://github.com/lxc/incus/commit/47377e345930e77d3fbce29d037fc7dbd6823dcf.patch?full_index=1";
+      hash = "sha256-CWaNaDYuBBLahxkqnM0FQZraVkvBSbrx1+8dcB8Vfbg=";
+    })
+    (fetchpatch2 {
+      name = "incusd-forknet_Include-FQDN-in-DHCPv6-INFO-requests.patch";
+      url = "https://github.com/lxc/incus/commit/d7f1c9d75ca33eb2ddb0bf10cec934fd6e352089.patch?full_index=1";
+      hash = "sha256-3zyADLiPUuiGLwdeISj5lUk3tkAayQGaRI+/yBHrvuM=";
+    })
+    (fetchpatch2 {
+      name = "incusd-forknet_Properly-renew-stateful-DHCPv6.patch";
+      url = "https://github.com/lxc/incus/commit/3b127758c17752302b3f4bf907f42e926ab664e4.patch?full_index=1";
+      hash = "sha256-+dcdeZwuyTWH7yfPEDqKOax/lS1Yqvwn9ooqJxKD3jA=";
+    })
+    (fetchpatch2 {
+      name = "incusd-forknet_Add-jitter-to-DHCPv6-renewal.patch";
+      url = "https://github.com/lxc/incus/commit/2b24a260b6177c033047f270286933563f05a999.patch?full_index=1";
+      hash = "sha256-grMspYyqn4Zl1Kn+hFeUfeIevdwszJc0x2YDC2JILKw=";
+    })
+    (fetchpatch2 {
+      name = "incusd-device-nic_bridged_Fix-swapped-IPv4-IPv6-DNS-record.patch";
+      url = "https://github.com/lxc/incus/commit/33ffcf71745e138dd4f3546839115c293e6be083.patch?full_index=1";
+      hash = "sha256-E8Plz9qdoTt3id9I5jbZYMKQt+kUrKmXmtMJ6IXlRJg=";
+    })
+    (fetchpatch2 {
+      name = "doc-authorization_Fix-reference-to-old-manager-relation.patch";
+      url = "https://github.com/lxc/incus/commit/c65ac0f4e6e94859b8565bce41bbf1595f4a8085.patch?full_index=1";
+      hash = "sha256-6wEz3uxWauIibBkH+OdB7+VsFySmugt6wk61qMayzYo=";
+    })
+    (fetchpatch2 {
+      name = "incusd-network-acl_Fix-issue-with-instances-in-different-project-than-ACL.patch";
+      url = "https://github.com/lxc/incus/commit/2a3584b6fccf152be42cf5614e54241bdb13e671.patch?full_index=1";
+      hash = "sha256-CXE5Bowk3ZPup6oVDEJb9ucsJoXhXu/kU7gGCghhtjQ=";
+    })
+    (fetchpatch2 {
+      name = "incusd-projects_Fix-targeting-on-project-delete.patch";
+      url = "https://github.com/lxc/incus/commit/3a104e4dc24897f0d6543136bb1043fcd4a33632.patch?full_index=1";
+      hash = "sha256-kTFkJqbjzdq5jvNxKw8YMPR04WRj4t5IS6ymoGyXDXE=";
+    })
+    (fetchpatch2 {
+      name = "test-network_acl_Add-test-for-ACL-used-by-instance-in-different-project.patch";
+      url = "https://github.com/lxc/incus/commit/41878729f06e9c31df9d4fac20fb8c384608577c.patch?full_index=1";
+      hash = "sha256-YR2Akus4vp3vNvHEmsJUh/3gbEf3R/cFUOVvt9u/wEU=";
+    })
+    (fetchpatch2 {
+      name = "incusd-instance-qemu_Remove-deprecated-QEMU-flag.patch";
+      url = "https://github.com/lxc/incus/commit/c1f18c78fc6bc4850df20574bdcc541e5eefc4ac.patch?full_index=1";
+      hash = "sha256-kbn4Yd/G23FCFA0Ch0+d81HUxCbcoiOzHfZ0MW+VlzE=";
+    })
+    (fetchpatch2 {
+      name = "incusd-cluster_Re-order-evacuations-to-happen-earlier-on-shutdown.patch";
+      url = "https://github.com/lxc/incus/commit/5b29ecc164ef28239d2e2a874a7c871a2e419083.patch?full_index=1";
+      hash = "sha256-jpyJYjiZvRw/aOGsykEx8uotRBF7p1q5O08PVhyQtvk=";
+    })
+  ];
   nixUpdateExtraArgs = [
     "--override-filename=pkgs/by-name/in/incus/package.nix"
   ];


### PR DESCRIPTION
Partial Backport of #515853 due to the security vulnerabilities.
The `incus-lts` package will get a seperate bump to 6.0.7 once that is tagged.

Announcement: https://discuss.linuxcontainers.org/t/incus-7-0-lts-has-been-released/26641

Patchsets:
- https://github.com/zabbly/incus/commit/cd1412344be5fc6dabb25b4f9095eee2ab7cd7bf
- https://github.com/zabbly/incus/commit/8b47b2222b3d5eb4b67417d3586b35ffae630752
- https://github.com/zabbly/incus/commit/6d3f94b0f5a3cef7bd9f20da4057769f07f63805

Advisories:
- https://github.com/lxc/incus/security/advisories/GHSA-8gw4-p4wq-4hcv (Moderate)
- https://github.com/lxc/incus/security/advisories/GHSA-gc7j-g665-rxr9 (Moderate)
  #517666
- https://github.com/lxc/incus/security/advisories/GHSA-r7w7-mmxr-47r9 (Moderate)
- https://github.com/lxc/incus/security/advisories/GHSA-4m88-wxj4-9qj6 (Moderate)
  #517664
- https://github.com/lxc/incus/security/advisories/GHSA-fwj8-62r8-8p8m (Moderate)
  https://github.com/NixOS/nixpkgs/issues/518012
- https://github.com/lxc/incus/security/advisories/GHSA-x5r6-jr56-89pv (Moderate)
  https://github.com/NixOS/nixpkgs/issues/518009
- https://github.com/lxc/incus/security/advisories/GHSA-98vh-x9cx-9cfp (Moderate)
  https://github.com/NixOS/nixpkgs/issues/518014
- https://github.com/lxc/incus/security/advisories/GHSA-c839-4qxr-j4x3 (Low)
  #517660
- https://github.com/lxc/incus/security/advisories/GHSA-67wx-r9xr-x75x (Low)
  https://github.com/NixOS/nixpkgs/issues/518342

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
