### PR TITLE
haskellPackages.botan-low: fix `base64Decode` against botan 3.12.0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -3351,6 +3351,17 @@ with haskellLib;
   stripe-concepts = doJailbreak super.stripe-concepts;
   stripe-signature = doJailbreak super.stripe-signature;
   stripe-wreq = doJailbreak super.stripe-wreq;
+
+  # 2026-05-08: fix `base64Decode` failing against botan 3.12.0, which now rejects
+  # a NULL output pointer in `botan_base64_decode`. Drop once upstream releases
+  # a botan-low containing the fix.
+  # https://github.com/haskell-cryptography/botan/pull/126
+  botan-low = appendPatch (pkgs.fetchpatch2 {
+    url = "https://github.com/haskell-cryptography/botan/commit/95c9befcdd9aaecae87396398afcb8c88e7550c4.patch";
+    relative = "botan-low";
+    excludes = [ "CHANGELOG.md" ];
+    hash = "sha256-EO/9KRLarGiE38iV1hf4a1eU6EtxQ46U0kPUgFsN5iQ=";
+  }) super.botan-low;
 }
 // import ./configuration-tensorflow.nix { inherit pkgs haskellLib; } self super
 


### PR DESCRIPTION
## Things done

Botan 3.12.0 update breaks the base64Decode functionality of the botan-low package, patching it.
(Related: https://github.com/NixOS/nixpkgs/pull/517674 )

Upstream PR here: https://github.com/haskell-cryptography/botan/pull/126

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
