### PR TITLE
hepmc3,pythia: migrate to by-name, modernize derivation

### DIFF
--- a/pkgs/by-name/he/hepmc3/package.nix
+++ b/pkgs/by-name/he/hepmc3/package.nix
@@ -17,13 +17,13 @@ let
   root_py = if enablePython then root.override { python3 = python; } else root;
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "hepmc3";
   version = "3.3.1";
 
   src = fetchurl {
-    url = "https://hepmc.web.cern.ch/hepmc/releases/HepMC3-${version}.tar.gz";
-    sha256 = "sha256-CCQBYLDyjcMpOqTWHOZeLWfNWXrPb6ykOfLkZiX355M=";
+    url = "https://hepmc.web.cern.ch/hepmc/releases/HepMC3-${finalAttrs.version}.tar.gz";
+    hash = "sha256-CCQBYLDyjcMpOqTWHOZeLWfNWXrPb6ykOfLkZiX355M=";
   };
 
   nativeBuildInputs = [
@@ -69,4 +69,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ veprbl ];
   };
-}
+})

--- a/pkgs/by-name/he/hepmc3/package.nix
+++ b/pkgs/by-name/he/hepmc3/package.nix
@@ -4,15 +4,17 @@
   fetchurl,
   cmake,
   coreutils,
-  python,
   root,
+  enablePython ? false,
+  python ? null,
 }:
+
+assert enablePython -> python != null;
 
 let
   pythonVersion = with lib.versions; "${major python.version}${minor python.version}";
-  withPython = python != null;
   # ensure that root is built with the same python interpreter, as it links against numpy
-  root_py = if withPython then root.override { python3 = python; } else root;
+  root_py = if enablePython then root.override { python3 = python; } else root;
 in
 
 stdenv.mkDerivation rec {
@@ -27,12 +29,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
   ]
-  ++ lib.optional withPython python.pkgs.pythonImportsCheckHook;
+  ++ lib.optional enablePython python.pkgs.pythonImportsCheckHook;
 
   buildInputs = [
     root_py
   ]
-  ++ lib.optional withPython python;
+  ++ lib.optional enablePython python;
 
   # error: invalid version number in 'MACOSX_DEPLOYMENT_TARGET=11.0'
   preConfigure =
@@ -44,9 +46,9 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DHEPMC3_CXX_STANDARD=17"
-    "-DHEPMC3_ENABLE_PYTHON=${if withPython then "ON" else "OFF"}"
+    "-DHEPMC3_ENABLE_PYTHON=${if enablePython then "ON" else "OFF"}"
   ]
-  ++ lib.optionals withPython [
+  ++ lib.optionals enablePython [
     "-DHEPMC3_PYTHON_VERSIONS=${if python.isPy3k then "3.X" else "2.X"}"
     "-DHEPMC3_Python_SITEARCH${pythonVersion}=${placeholder "out"}/${python.sitePackages}"
   ];

--- a/pkgs/by-name/py/pythia/package.nix
+++ b/pkgs/by-name/py/pythia/package.nix
@@ -5,11 +5,15 @@
   boost,
   fastjet,
   fixDarwinDylibNames,
-  hepmc,
+  hepmc2,
   lhapdf,
   rsync,
   zlib,
 }:
+
+let
+  hepmc = hepmc2;
+in
 
 stdenv.mkDerivation rec {
   pname = "pythia";

--- a/pkgs/by-name/py/pythia/package.nix
+++ b/pkgs/by-name/py/pythia/package.nix
@@ -15,15 +15,15 @@ let
   hepmc = hepmc2;
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "pythia";
   version = "8.317";
 
   src = fetchurl {
     url = "https://pythia.org/download/pythia83/pythia${
-      builtins.replaceStrings [ "." ] [ "" ] version
+      builtins.replaceStrings [ "." ] [ "" ] finalAttrs.version
     }.tgz";
-    sha256 = "sha256-GuVR0U2sSV3f5rNEeSA16+QQ/mxgBNRKM14Ozg50Wt8=";
+    hash = "sha256-GuVR0U2sSV3f5rNEeSA16+QQ/mxgBNRKM14Ozg50Wt8=";
   };
 
   nativeBuildInputs = [ rsync ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ fixDarwinDylibNames ];
@@ -60,4 +60,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ veprbl ];
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11642,10 +11642,6 @@ with pkgs;
     python = null;
   };
 
-  pythia = callPackage ../development/libraries/physics/pythia {
-    hepmc = hepmc2;
-  };
-
   yoda-with-root = lowPrio (
     yoda.override {
       withRootSupport = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11638,10 +11638,6 @@ with pkgs;
 
   ### SCIENCE / PHYSICS
 
-  hepmc3 = callPackage ../development/libraries/physics/hepmc3 {
-    python = null;
-  };
-
   yoda-with-root = lowPrio (
     yoda.override {
       withRootSupport = true;


### PR DESCRIPTION
This pull request refactors the packaging of the `hepmc3` and `pythia` libraries in Nixpkgs, improving maintainability and flexibility. The main changes include moving and updating the package files, improving Python integration for `hepmc3`, and simplifying the top-level package definitions.

**Refactoring and File Structure:**
- Renamed and moved `hepmc3` and `pythia` package files to the `pkgs/by-name` directory for better organization.

**Python Integration Improvements (`hepmc3`):**
- Replaced the fixed `python` argument with an optional `enablePython` flag and a configurable `python3` argument, allowing more flexible builds with or without Python support. Added assertions to ensure correctness.
- Updated CMake flags and build inputs to use the new Python integration logic, ensuring that Python-related build steps only occur when enabled.

**Code Modernization and Consistency:**
- Refactored derivations to use the `stdenv.mkDerivation (finalAttrs: { ... })` style for better consistency and future-proofing.

- Updated string interpolation to use `finalAttrs.version` for improved clarity and maintainability.

**Top-level Package Simplification:**
- Removed the old `hepmc3` and `pythia` definitions from `all-packages.nix`, as they are now handled through the new structure and do not require explicit top-level entries.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
