### PR TITLE
mrustc.bootstrap: fix build

### DIFF
--- a/pkgs/development/compilers/mrustc/bootstrap.nix
+++ b/pkgs/development/compilers/mrustc/bootstrap.nix
@@ -4,7 +4,7 @@
   fetchurl,
   mrustc,
   mrustc-minicargo,
-  #llvm_12,
+  llvm_20,
   libffi,
   cmake,
   perl,
@@ -18,11 +18,11 @@
 }:
 
 let
-  mrustcTargetVersion = "1.54";
-  rustcVersion = "1.54.0";
+  mrustcTargetVersion = "1.90";
+  rustcVersion = "1.90.0";
   rustcSrc = fetchurl {
     url = "https://static.rust-lang.org/dist/rustc-${rustcVersion}-src.tar.gz";
-    sha256 = "0xk9dhfff16caambmwij67zgshd8v9djw6ha0fnnanlv7rii31dc";
+    hash = "sha256-eZqfnLpO1TUeBxBIvPa1VgdV2QCWSN7zOkB91JYfm34=";
   };
   rustcDir = "rustc-${rustcVersion}-src";
   outputDir = "output-${rustcVersion}";
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
   ];
   buildInputs = [
     # for rustc
-    #llvm_12
+    llvm_20
     libffi
     zlib
     libxml2
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
     # Use shared mrustc/minicargo/llvm instead of rebuilding them
     "MRUSTC=${mrustc}/bin/mrustc"
     #"MINICARGO=${mrustc-minicargo}/bin/minicargo"  # FIXME: we need to rebuild minicargo locally so --manifest-overrides is applied
-    #"LLVM_CONFIG=${llvm_12.dev}/bin/llvm-config"
+    "LLVM_CONFIG=${llvm_20.dev}/bin/llvm-config"
     "RUSTC_TARGET=${stdenv.targetPlatform.rust.rustcTarget}"
   ];
 
@@ -153,24 +153,5 @@ stdenv.mkDerivation rec {
       asl20
     ];
     platforms = [ "x86_64-linux" ];
-    # rustc 1.54 only supports LLVM 12, which was removed from Nixpkgs.
-    # mrustc can bootstrap up to rustc 1.74, which supported LLVM 17,
-    # which has also been removed.
-    #
-    # 1.74 also shipped with the Cranelift backend, so perhaps that
-    # could be used instead? Alternatively, it may be possible to
-    # backport the upstream patches to support LLVM 18 to 1.74.
-    # Assuming LLVM 18 is still in Nixpkgs by the time you read this
-    # comment, anyway. But if not, then maybe mrustc has been updated
-    # to support newer rustc versions? Hope springs eternal.
-    #
-    # (Note that you still have to “draw the rest of the owl” to
-    # bootstrap the chain of rustc versions between this bootstrap
-    # and the version currently used in Nixpkgs, anyway, so this was
-    # already not useful for bootstrapping a Rust compiler for use with
-    # Nixpkgs without a lot of additional work. See Guix’s Rust
-    # bootstrap chain, or the non‐Rust minimal bootstrap in Guix and
-    # Nixpkgs, for inspiration.)
-    broken = true;
   };
 }


### PR DESCRIPTION
Upstream mrustc now supports building with 1.90, so we can get this working again. Tested full bootstrap build, appears to be functional.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
