### PR TITLE
nixosTests.systemd-initrd-swraid: test RAID auto-detection

### DIFF
--- a/nixos/tests/systemd-initrd-swraid.nix
+++ b/nixos/tests/systemd-initrd-swraid.nix
@@ -23,12 +23,7 @@
         mdadm
         e2fsprogs
       ]; # for mdadm and mkfs.ext4
-      boot.swraid = {
-        enable = true;
-        mdadmConf = ''
-          ARRAY /dev/md0 devices=/dev/vdb,/dev/vdc
-        '';
-      };
+      boot.swraid.enable = true;
       environment.etc."mdadm.conf".text = ''
         MAILADDR test@example.com
       '';
@@ -64,12 +59,12 @@
     assert "hello" in machine.succeed("cat /test")
     assert "md0" in machine.succeed("cat /proc/mdstat")
 
-    expected_config = """MAILADDR test@example.com
+    # Verify the RAID array was properly auto-detected and assembled
+    detail = machine.succeed("mdadm --detail /dev/md0")
+    assert "raid1" in detail, f"Expected raid1 in mdadm detail output: {detail}"
+    assert "/dev/vdb" in detail, f"Expected /dev/vdb in array: {detail}"
+    assert "/dev/vdc" in detail, f"Expected /dev/vdc in array: {detail}"
 
-    ARRAY /dev/md0 devices=/dev/vdb,/dev/vdc
-    """
-    got_config = machine.execute("cat /etc/mdadm.conf")[1]
-    assert expected_config == got_config, repr((expected_config, got_config))
     machine.wait_for_unit("mdmonitor.service")
   '';
 }


### PR DESCRIPTION
I implemented this to verify whether or not #210210 was still an issue and it turns out it had already been fixed. After a lot of investigating I figured out that it was unintentionally fixed by #333643.

I tested this by duplicating this commit on top of the commit before that PR and the commit after that PR to verify that PR actually fixed the issue.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test