### PR TITLE
tor-browser: 15.0.12 -> 15.0.13

### DIFF
--- a/pkgs/by-name/to/tor-browser/package.nix
+++ b/pkgs/by-name/to/tor-browser/package.nix
@@ -102,7 +102,7 @@ let
     ++ lib.optionals mediaSupport [ ffmpeg_7 ]
   );
 
-  version = "15.0.12";
+  version = "15.0.13";
 
   sources = {
     x86_64-linux = fetchurl {
@@ -112,7 +112,7 @@ let
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux-x86_64-${version}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux-x86_64-${version}.tar.xz"
       ];
-      hash = "sha256-PNGPJs25t+rG2TVLiWkLd96Iuq5XkOOEextnI+V1kJY=";
+      hash = "sha256-v21pvipaEPj3WzDybQkDxHLefl14ZMCOJDQAvJatSSU=";
     };
 
     i686-linux = fetchurl {
@@ -122,7 +122,7 @@ let
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux-i686-${version}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux-i686-${version}.tar.xz"
       ];
-      hash = "sha256-Kqg4UTr1IPZkB3caBKMJu2Cj0q0v8ttrhc4JNBuWDA0=";
+      hash = "sha256-RPJUoRZlY1upYivnnDxSLJI2hoVII56PY7BeCN87lOc=";
     };
   };
 


### PR DESCRIPTION
Release announcement: https://blog.torproject.org/new-release-tor-browser-15013/
Changelog: https://gitlab.torproject.org/tpo/applications/tor-browser-build/-/raw/tbb-15.0.13-build1/projects/browser/Bundle-Data/Docs-TBB/ChangeLog.txt
Tor Changelog: https://gitlab.torproject.org/tpo/core/tor/-/raw/tor-0.4.9.8/ReleaseNotes

Tor Browser 15.0.13 is the same as 15.0.12, except for updating Tor to 0.4.9.8 in order to fix a bug where clients would only fetch from the directory authorities, not the fallback directories, due to a CI issue. There is thus no corresponding Mullvad Browser release.

cc @SigmaSquadron, since you asked to be notified in #517715

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] i686-linux
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
