### PR TITLE
lib.types: small performance improvements

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1440,13 +1440,20 @@ let
         def: if def.value._type or "" == "override" then def // { value = def.value.content; } else def;
     in
     defs:
-    let
-      highestPrio = foldl' (prio: def: min (getPrio def) prio) 9999 defs;
-    in
-    {
-      values = concatMap (def: if getPrio def == highestPrio then [ (strip def) ] else [ ]) defs;
-      inherit highestPrio;
-    };
+    # Optimize for the singleton case, equivalent to the `else` clause.
+    if length defs == 1 then
+      {
+        values = map strip defs;
+        highestPrio = getPrio (head defs);
+      }
+    else
+      let
+        highestPrio = foldl' (prio: def: min (getPrio def) prio) 9999 defs;
+      in
+      {
+        values = concatMap (def: if getPrio def == highestPrio then [ (strip def) ] else [ ]) defs;
+        inherit highestPrio;
+      };
 
   /**
     Sort a list of properties.  The sort priority of a property is

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1433,16 +1433,18 @@ let
   filterOverrides = defs: (filterOverrides' defs).values;
 
   filterOverrides' =
-    defs:
     let
       getPrio =
         def: if def.value._type or "" == "override" then def.value.priority else defaultOverridePriority;
-      highestPrio = foldl' (prio: def: min (getPrio def) prio) 9999 defs;
       strip =
         def: if def.value._type or "" == "override" then def // { value = def.value.content; } else def;
     in
+    defs:
+    let
+      highestPrio = foldl' (prio: def: min (getPrio def) prio) 9999 defs;
+    in
     {
-      values = map strip (filter (def: getPrio def == highestPrio) defs);
+      values = concatMap (def: if getPrio def == highestPrio then [ (strip def) ] else [ ]) defs;
       inherit highestPrio;
     };
 

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -26,7 +26,6 @@ let
     ;
   inherit (lib.lists)
     concatLists
-    count
     elemAt
     filter
     foldl'
@@ -1085,14 +1084,14 @@ rec {
       merge =
         loc: defs:
         let
-          nrNulls = count (def: def.value == null) defs;
+          nulls = filter (def: def.value == null) defs;
         in
-        if nrNulls == length defs then
+        if nulls == [ ] then
+          elemType.merge loc defs
+        else if length nulls == length defs then
           null
-        else if nrNulls != 0 then
-          throw "The option `${showOption loc}` is defined both null and not null, in ${showFiles (getFiles defs)}."
         else
-          elemType.merge loc defs;
+          throw "The option `${showOption loc}` is defined both null and not null, in ${showFiles (getFiles defs)}.";
       emptyValue = {
         value = null;
       };

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -17,6 +17,7 @@ let
     isPath
     isStorePath
     isString
+    substring
     throwIf
     toDerivation
     toList
@@ -74,6 +75,7 @@ let
     unions
     empty
     ;
+  inherit (lib.path) hasStorePathPrefix;
 
   inAttrPosSuffix =
     v: name:
@@ -713,15 +715,15 @@ rec {
         check =
           x:
           let
-            isInStore = lib.path.hasStorePathPrefix (
-              if builtins.isPath x then
+            isInStore = hasStorePathPrefix (
+              if isPath x then
                 x
               # Discarding string context is necessary to convert the value to
               # a path and safe as the result is never used in any derivation.
               else
                 /. + builtins.unsafeDiscardStringContext x
             );
-            isAbsolute = builtins.substring 0 1 (toString x) == "/";
+            isAbsolute = substring 0 1 (toString x) == "/";
             isExpectedType = (
               if inStore == null || inStore then isStringLike x else isString x # Do not allow a true path, which could be copied to the store later on.
             );

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -4,6 +4,7 @@
 
 let
   inherit (lib)
+    all
     elem
     flip
     hasContext
@@ -111,10 +112,15 @@ let
 
   checkDefsForError =
     check: loc: defs:
-    let
-      invalidDefs = filter (def: !check def.value) defs;
-    in
-    if invalidDefs != [ ] then { message = "Definition values: ${showDefs invalidDefs}"; } else null;
+    if all (def: check def.value) defs then
+      null
+    else
+      let
+        invalidDefs = filter (def: !check def.value) defs;
+      in
+      {
+        message = "Definition values: ${showDefs invalidDefs}";
+      };
 
   # Check that a type with v2 merge has a coherent check attribute.
   # Throws an error if the type uses an ad-hoc `type // { check }` override.

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1518,11 +1518,11 @@ rec {
           self: loc: defs:
           (self.v2 { inherit loc defs; }).value;
         v2 =
-          { loc, defs }:
+          { loc, defs }@args:
           let
             t1CheckedAndMerged =
               if t1.merge ? v2 then
-                checkV2MergeCoherence loc t1 (t1.merge.v2 { inherit loc defs; })
+                checkV2MergeCoherence loc t1 (t1.merge.v2 args)
               else
                 {
                   value = t1.merge loc defs;
@@ -1531,7 +1531,7 @@ rec {
                 };
             t2CheckedAndMerged =
               if t2.merge ? v2 then
-                checkV2MergeCoherence loc t2 (t2.merge.v2 { inherit loc defs; })
+                checkV2MergeCoherence loc t2 (t2.merge.v2 args)
               else
                 {
                   value = t2.merge loc defs;
@@ -1688,9 +1688,9 @@ rec {
             self: loc: defs:
             (self.v2 { inherit loc defs; }).value;
           v2 =
-            { loc, defs }:
+            { loc, defs }@args:
             let
-              orig = checkV2MergeCoherence loc elemType (elemType.merge.v2 { inherit loc defs; });
+              orig = checkV2MergeCoherence loc elemType (elemType.merge.v2 args);
               headError' = if orig.headError != null then orig.headError else checkDefsForError check loc defs;
             in
             orig

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1585,9 +1585,8 @@ rec {
     let
       head' =
         if ts == [ ] then throw "types.oneOf needs to get at least one type in its argument" else head ts;
-      tail' = tail ts;
     in
-    foldl' either head' tail';
+    foldl' either head' (tail ts);
 
   # Either value of type `coercedType` or `finalType`, the former is
   # converted to `finalType` using `coerceFunc`.

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -8,6 +8,7 @@ let
     elem
     flip
     hasContext
+    functionArgs
     isAttrs
     isBool
     isDerivation
@@ -1115,9 +1116,7 @@ rec {
       check = isFunction;
       merge = loc: defs: {
         # An argument attribute has a default when it has a default in all definitions
-        __functionArgs = lib.zipAttrsWith (_: lib.all (x: x)) (
-          lib.map (fn: lib.functionArgs fn.value) defs
-        );
+        __functionArgs = zipAttrsWith (_: all (x: x)) (map (fn: functionArgs fn.value) defs);
         __functor =
           _: callerArgs:
           (mergeDefinitions (loc ++ [ "<function body>" ]) elemType (

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1617,19 +1617,15 @@ rec {
                 def
                 // {
                   value =
-                    let
-                      merged =
-                        if coercedType.merge ? v2 then
-                          checkV2MergeCoherence loc coercedType (
-                            coercedType.merge.v2 {
-                              inherit loc;
-                              defs = [ def ];
-                            }
-                          )
-                        else
-                          null;
-                    in
                     if coercedType.merge ? v2 then
+                      let
+                        merged = checkV2MergeCoherence loc coercedType (
+                          coercedType.merge.v2 {
+                            inherit loc;
+                            defs = [ def ];
+                          }
+                        );
+                      in
                       if merged.headError == null then coerceFunc def.value else def.value
                     else if coercedType.check def.value then
                       coerceFunc def.value

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -6,6 +6,7 @@ let
   inherit (lib)
     elem
     flip
+    hasContext
     isAttrs
     isBool
     isDerivation
@@ -13,8 +14,9 @@ let
     isFunction
     isInt
     isList
-    isString
+    isPath
     isStorePath
+    isString
     throwIf
     toDerivation
     toList
@@ -653,10 +655,7 @@ rec {
       let
         res = mergeOneOption loc defs;
       in
-      if builtins.isPath res || (builtins.isString res && !builtins.hasContext res) then
-        toDerivation res
-      else
-        res;
+      if isPath res || (isString res && !hasContext res) then toDerivation res else res;
   };
 
   shellPackage = package // {

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1565,7 +1565,7 @@ rec {
       typeMerge =
         f':
         let
-          mt1 = t1.typeMerge (elemAt f'.payload.elemType 0).functor;
+          mt1 = t1.typeMerge (head f'.payload.elemType).functor;
           mt2 = t2.typeMerge (elemAt f'.payload.elemType 1).functor;
         in
         if (name == f'.name) && (mt1 != null) && (mt2 != null) then functor.type mt1 mt2 else null;


### PR DESCRIPTION
Another day, another look through a core file, looking for easy pickings. Stats diff with a minimal NixOS config:
```json
{
  "attrset": {
    "lookups": "-0.39%",
    "merges": null,
    "mergeCopies": null
  },
  "list": {
    "concats": null
  },
  "parser": {
    "expressions": null
  },
  "memory": {
    "envs": "-0.61%",
    "list": null,
    "sets": "-0.01%",
    "symbols": "+0%",
    "values": false,
    "total": "-0.16%"
  },
  "speed": {
    "primops": "-0.27%",
    "functionCalls": "-0.72%",
    "thunksMade": "-0.29%",
    "thunksAvoided": "-0.6%"
  }
}
```
And stats diff with my own config:
```json
{
  "attrset": {
    "lookups": "-0.46%",
    "merges": null,
    "mergeCopies": null
  },
  "list": {
    "concats": null
  },
  "parser": {
    "expressions": null
  },
  "memory": {
    "envs": "-0.64%",
    "list": null,
    "sets": "-0.01%",
    "symbols": "+0%",
    "values": false,
    "total": "-0.16%"
  },
  "speed": {
    "primops": "-0.4%",
    "functionCalls": "-0.8%",
    "thunksMade": "-0.3%",
    "thunksAvoided": "-0.66%"
  }
}
```
Hashes for the final drv stay the same for both.	
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
