### PR TITLE
nixos/reframe: fix module

### DIFF
--- a/nixos/modules/services/networking/reframe.nix
+++ b/nixos/modules/services/networking/reframe.nix
@@ -173,7 +173,7 @@ in
       description = "ReFrame Remote Desktop";
     };
     users.groups.reframe = { };
-    environment.etc = builtins.mapAttrs' (
+    environment.etc = lib.mapAttrs' (
       name: value:
       lib.nameValuePair "reframe/${name}.conf" {
         mode = "0644";

--- a/nixos/modules/services/networking/reframe.nix
+++ b/nixos/modules/services/networking/reframe.nix
@@ -113,7 +113,7 @@ in
                   "cpu"
                   "gpu"
                 ];
-                default = true;
+                default = "cpu";
                 description = ''
                   Set to `gpu` to use GPU damage region detection, which may be more efficiency but may cause artifacts depending on GPU vendors.
                   Set to `cpu` to use CPU damage region detection if you get bugs with `gpu`.

--- a/nixos/modules/services/networking/reframe.nix
+++ b/nixos/modules/services/networking/reframe.nix
@@ -9,7 +9,7 @@ let
   iniFmt = pkgs.formats.ini { };
 in
 {
-  options.programs.reframe = {
+  options.services.reframe = {
     enable = lib.mkEnableOption "DRM/KMS based remote desktop for Linux that supports Wayland/NVIDIA/headless/login…";
     package = lib.mkPackageOption pkgs "reframe" { };
     configs = lib.mkOption {


### PR DESCRIPTION
Messed up when writing the module, put config.services.reframe as cfg but options.programs.reframe in module. 🙁

Also fixes `damage` default.

Will remember to test new modules next time. Sorry!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
