### PR TITLE
pywalfox-native: fix src for version 2.9.0

### DIFF
--- a/pkgs/by-name/py/pywalfox-native/package.nix
+++ b/pkgs/by-name/py/pywalfox-native/package.nix
@@ -3,7 +3,7 @@
   fetchFromGitHub,
   python3,
 }:
-python3.pkgs.buildPythonApplication {
+python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "pywalfox-native";
   version = "2.9.0";
   pyproject = true;
@@ -11,8 +11,8 @@ python3.pkgs.buildPythonApplication {
   src = fetchFromGitHub {
     owner = "Frewacom";
     repo = "pywalfox-native";
-    rev = "7ecbbb193e6a7dab424bf3128adfa7e2d0fa6ff9";
-    hash = "sha256-i1DgdYmNVvG+mZiFiBmVHsQnFvfDFOFTGf0GEy81lpE=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-8qMDwK4TgMqtGVGUnH3hyoyVlR3cQv28i7O4de+iuqU=";
   };
 
   build-system = with python3.pkgs; [ setuptools ];
@@ -26,4 +26,4 @@ python3.pkgs.buildPythonApplication {
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [ tsandrini ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Fixes the rev and hash for v2.9.0. Previous PR only updated the version.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
