### PR TITLE
home-assistant-custom-components.blueprints-updater: init at 2.4.0

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/blueprints-updater/allow-symlinked-blueprints.diff
+++ b/pkgs/servers/home-assistant/custom-components/blueprints-updater/allow-symlinked-blueprints.diff
@@ -1,0 +1,26 @@
+diff --git a/custom_components/blueprints_updater/coordinator.py b/custom_components/blueprints_updater/coordinator.py
+index 9cbbe32..92a5ab5 100644
+--- a/custom_components/blueprints_updater/coordinator.py
++++ b/custom_components/blueprints_updater/coordinator.py
+@@ -3234,21 +3234,6 @@ def scan_blueprints(
+                         continue
+ 
+                     full_path = os.path.join(root, file)
+-                    real_full_path = os.path.realpath(full_path)
+-                    try:
+-                        if (
+-                            os.path.commonpath([real_full_path, real_blueprint_path])
+-                            != real_blueprint_path
+-                        ):
+-                            _LOGGER.warning(
+-                                "Security alert: Ignoring blueprint symlink outside root: %s",
+-                                full_path,
+-                            )
+-                            continue
+-                    except (ValueError, OSError):
+-                        _LOGGER.warning("Skipping blueprint with invalid path: %s", full_path)
+-                        continue
+-
+                     if relative_path := get_blueprint_relative_path(hass, full_path):
+                         try:
+                             with open(full_path, encoding="utf-8") as f:

--- a/pkgs/servers/home-assistant/custom-components/blueprints-updater/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/blueprints-updater/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  h2,
+  home-assistant,
+  pytest-cov-stub,
+  pytest-homeassistant-custom-component,
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "luuquangvu";
+  domain = "blueprints_updater";
+  version = "2.4.0";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = "blueprints-updater";
+    tag = version;
+    hash = "sha256-O5HGjnj9fz+RrCq6sgdYlU1r9qFJhmUdfYWdFrwFngw=";
+  };
+
+  patches = [
+    # Do not skip blueprints symlinked from the nix store.
+    # They cannot be updated, but users probably still want to be notified if they have an update.
+    ./allow-symlinked-blueprints.diff
+  ];
+
+  postPatch = ''
+    # avoid dependency on rather big pytest-timeout
+    substituteInPlace pyproject.toml \
+      --replace-fail '"--timeout=60"' ""
+  '';
+
+  dependencies = [
+    h2
+  ];
+
+  nativeCheckInputs = [
+    home-assistant
+    pytest-asyncio
+    pytest-cov-stub
+    pytest-homeassistant-custom-component
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # pytest-homeassistant-custom-component tries to create temporary directories inside the nix store
+    "test_async_fetch_content_forum_invalid_json_sets_fetch_error"
+    "test_full_update_lifecycle"
+    "test_restore_blueprint_service"
+    "test_update_all_service"
+  ];
+
+  meta = {
+    description = "Automatically update Home Assistant blueprints via native update entities";
+    homepage = "https://github.com/luuquangvu/blueprints-updater/";
+    changelog = "https://github.com/luuquangvu/blueprints-updater/releases/tag/${src.tag}";
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+    license = lib.licenses.mit;
+  };
+}


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
