### PR TITLE
googler: init at 4.3.2

### DIFF
--- a/pkgs/by-name/go/googler/package.nix
+++ b/pkgs/by-name/go/googler/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  installShellFiles,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "googler";
+  version = "4.3.2";
+  pyproject = false;
+  __structuredAttrs = true;
+  src = fetchFromGitHub {
+    owner = "jarun";
+    repo = "googler";
+    rev = "v${version}";
+    hash = "sha256-PgWg396AQ15CAnfTXGDpSg1UXx7mNCtknEjJd/KV4MU=";
+  };
+  nativeBuildInputs = [ installShellFiles ];
+  dontBuild = true;
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 googler $out/bin/googler
+    installManPage googler.1
+    installShellCompletion --bash auto-completion/bash/googler-completion.bash
+    installShellCompletion --name _googler --zsh auto-completion/zsh/_googler
+    installShellCompletion --fish auto-completion/fish/googler.fish
+    runHook postInstall
+  '';
+  meta = {
+    description = "Google Search and Google Site Search from the terminal";
+    homepage = "https://github.com/jarun/googler";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "googler";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - `./bin/googler --help` succeeds
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
