### PR TITLE
lib.modules: small optimizations

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -565,7 +565,8 @@ let
         modulesPath:
         { disabled, modules }:
         let
-          keyFilter = filter (attrs: !isDisabled modulesPath disabled attrs);
+          isDisabledModule = isDisabled modulesPath disabled;
+          keyFilter = filter (attrs: !isDisabledModule attrs);
         in
         map (attrs: attrs.module) (genericClosure {
           startSet = keyFilter modules;

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1137,15 +1137,13 @@ let
       # Apply the 'apply' function to the merged value. This allows options to
       # yield a value computed from the definitions
       value = if opt ? apply then opt.apply res.mergedValue else res.mergedValue;
-
-      warnDeprecation =
-        if (opt.type.deprecationMessage != null) then
-          warn "The type `types.${opt.type.name}' of option `${showOption loc}' defined in ${showFiles opt.declarations} is deprecated. ${opt.type.deprecationMessage}"
-        else
-          x: x;
-
     in
-    warnDeprecation opt
+    (
+      if opt.type.deprecationMessage != null then
+        warn "The type `types.${opt.type.name}' of option `${showOption loc}' 'defined in ${showFiles opt.declarations} is deprecated. ${opt.type.deprecationMessage}" opt
+      else
+        opt
+    )
     // {
       value = addErrorContext "while evaluating the option `${showOption loc}':" value;
       inherit (res.defsFinal') highestPrio;

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1196,9 +1196,7 @@ let
           let
             d = head defs;
           in
-          addErrorContext "while evaluating definitions from `${d.file}':" (
-            !(isAttrs d.value && d.value ? _type)
-          )
+          addErrorContext "while evaluating definitions from `${d.file}':" (!d.value ? _type)
         )
       then
         {

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1036,7 +1036,7 @@ let
     : 2\. Function argument
   */
   mergeOptionDecls =
-    loc: opts:
+    loc:
     foldl'
       (
         res: opt:
@@ -1101,8 +1101,7 @@ let
         declarations = [ ];
         declarationPositions = [ ];
         options = [ ];
-      }
-      opts;
+      };
 
   /**
     Merge all the definitions of an option to produce the final

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1041,10 +1041,11 @@ let
       (
         res: opt:
         let
-          mergedType = res.type.typeMerge opt.options.type.functor;
-
           typeSet =
             if opt.options ? type && res ? type then
+              let
+                mergedType = res.type.typeMerge opt.options.type.functor;
+              in
               if mergedType != null then
                 {
                   type = mergedType;

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1184,40 +1184,12 @@ let
   # Merge definitions of a value of a given type.
   mergeDefinitions = loc: type: defs: rec {
     defsFinal' =
-      let
-        # Process mkMerge and mkIf properties.
-        defsNormalized = concatMap (
-          m:
-          map (
-            value:
-            if value._type or null == "definition" then
-              value
-            else
-              {
-                inherit (m) file;
-                inherit value;
-              }
-          ) (addErrorContext "while evaluating definitions from `${m.file}':" (dischargeProperties m.value))
-        ) defs;
-
-        # Process mkOverride properties.
-        defsFiltered = filterOverrides' defsNormalized;
-
-        # Sort mkOrder properties.
-        defsSorted =
-          # Avoid sorting if we don't have to.
-          if any (def: def.value._type or "" == "order") defsFiltered.values then
-            sortProperties defsFiltered.values
-          else
-            defsFiltered.values;
-      in
       # Fast path: the overwhelming majority of options have exactly one
       # definition whose value carries no property wrapper
       # (mkIf/mkMerge/mkOverride/mkOrder/definition). In that case the
-      # discharge/filter/sort pipeline above is a no-op but still allocates
-      # several intermediate lists and closures. Detect it up front and hand
-      # the original singleton straight to the type merge. The let-bindings
-      # above are lazy and thus never forced on this branch.
+      # discharge/filter/sort pipeline below is a no-op but still allocates
+      # several intermediate lists and closures. Detect it up front and hand the
+      # original singleton straight to the type merge.
       if
         length defs == 1
         && (
@@ -1234,6 +1206,33 @@ let
           highestPrio = defaultOverridePriority;
         }
       else
+        let
+          # Process mkMerge and mkIf properties.
+          defsNormalized = concatMap (
+            m:
+            map (
+              value:
+              if value._type or null == "definition" then
+                value
+              else
+                {
+                  inherit (m) file;
+                  inherit value;
+                }
+            ) (addErrorContext "while evaluating definitions from `${m.file}':" (dischargeProperties m.value))
+          ) defs;
+
+          # Process mkOverride properties.
+          defsFiltered = filterOverrides' defsNormalized;
+
+          # Sort mkOrder properties.
+          defsSorted =
+            # Avoid sorting if we don't have to.
+            if any (def: def.value._type or "" == "order") defsFiltered.values then
+              sortProperties defsFiltered.values
+            else
+              defsFiltered.values;
+        in
         {
           values = defsSorted;
           inherit (defsFiltered) highestPrio;

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -632,6 +632,28 @@ let
     : 3\. Function argument
   */
   unifyModuleSyntax =
+    let
+      attrsToRemove = [
+        "_class"
+        "_file"
+        "key"
+        "disabledModules"
+        "imports"
+        "options"
+        "config"
+        "meta"
+        "freeformType"
+      ];
+      shorthandAttrsToRemove = [
+        "_class"
+        "_file"
+        "key"
+        "disabledModules"
+        "require"
+        "imports"
+        "freeformType"
+      ];
+    in
     file: key: m:
     let
       addMeta =
@@ -655,17 +677,7 @@ let
     in
     if m ? config || m ? options then
       let
-        badAttrs = removeAttrs m [
-          "_class"
-          "_file"
-          "key"
-          "disabledModules"
-          "imports"
-          "options"
-          "config"
-          "meta"
-          "freeformType"
-        ];
+        badAttrs = removeAttrs m attrsToRemove;
       in
       if badAttrs != { } then
         throw "Module `${key}' has an unsupported attribute `${head (attrNames badAttrs)}'. This is caused by introducing a top-level `config' or `options' attribute. Add configuration attributes immediately on the top level instead, or move all of them (namely: ${toString (attrNames badAttrs)}) into the explicit `config' attribute."
@@ -688,17 +700,7 @@ let
         disabledModules = m.disabledModules or [ ];
         imports = m.require or [ ] ++ m.imports or [ ];
         options = { };
-        config = addFreeformType (
-          removeAttrs m [
-            "_class"
-            "_file"
-            "key"
-            "disabledModules"
-            "require"
-            "imports"
-            "freeformType"
-          ]
-        );
+        config = addFreeformType (removeAttrs m shorthandAttrsToRemove);
       };
 
   applyModuleArgsIfFunction =

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1154,10 +1154,6 @@ let
           throw "The option `${showOption loc}' is read-only, but it's set multiple times. Definition values:${showDefs separateDefs}"
         else
           mergeDefinitions loc opt.type defs';
-
-      # Apply the 'apply' function to the merged value. This allows options to
-      # yield a value computed from the definitions
-      value = if opt ? apply then opt.apply res.mergedValue else res.mergedValue;
     in
     (
       if opt.type.deprecationMessage != null then
@@ -1166,7 +1162,11 @@ let
         opt
     )
     // {
-      value = addErrorContext "while evaluating the option `${showOption loc}':" value;
+      value = addErrorContext "while evaluating the option `${showOption loc}':" (
+        # Apply the 'apply' function to the merged value. This allows options to
+        # yield a value computed from the definitions
+        if opt ? apply then opt.apply res.mergedValue else res.mergedValue
+      );
       inherit (res.defsFinal') highestPrio;
       definitions = map (def: def.value) res.defsFinal;
       files = map (def: def.file) res.defsFinal;

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1041,14 +1041,11 @@ let
       (
         res: opt:
         let
-          t = res.type;
-          t' = opt.options.type;
-          mergedType = t.typeMerge t'.functor;
-          typesMergeable = mergedType != null;
+          mergedType = res.type.typeMerge opt.options.type.functor;
 
           typeSet =
             if opt.options ? type && res ? type then
-              if typesMergeable then
+              if mergedType != null then
                 {
                   type = mergedType;
                 }

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -878,7 +878,6 @@ let
         # We're descending into attribute ‘name’.
         let
           loc = prefix ++ [ name ];
-          defns = pushedDownDefinitionsByName.${name} or [ ];
           defns' = rawDefinitionsByName.${name} or [ ];
           isOptionDecl =
             m:
@@ -948,7 +947,7 @@ let
               (head optionDecls).options.type.description or "<no description>"
             }' does not support nested options.\n${showRawDecls loc nonOptions}"
         else
-          mergeModules' loc decls defns
+          mergeModules' loc decls (pushedDownDefinitionsByName.${name} or [ ])
       ) declsByName;
 
       matchedOptions = mapAttrs (n: v: v.matchedOptions) resultsByName;

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1499,23 +1499,21 @@ let
   mergeAttrDefinitionsWithPrio =
     opt:
     let
-      defsByAttr = zipAttrs (
-        concatLists (
-          concatMap (
-            { value, ... }@def:
-            map (mapAttrsToList (
-              k: value: {
-                ${k} = def // {
-                  inherit value;
-                };
-              }
-            )) (pushDownProperties value)
-          ) opt.definitionsWithLocations
-        )
+      defsByAttr = concatLists (
+        concatMap (
+          { value, ... }@def:
+          map (mapAttrsToList (
+            k: value: {
+              ${k} = def // {
+                inherit value;
+              };
+            }
+          )) (pushDownProperties value)
+        ) opt.definitionsWithLocations
       );
     in
     assert opt.type.name == "attrsOf" || opt.type.name == "lazyAttrsOf";
-    mapAttrs (
+    zipAttrsWith (
       k: v:
       let
         merging = mergeDefinitions (opt.loc ++ [ k ]) opt.type.nestedTypes.elemType v;

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -31,7 +31,6 @@ let
     length
     mapAttrs
     mapAttrsToList
-    mapAttrsRecursiveCond
     min
     optional
     optionalAttrs
@@ -280,7 +279,11 @@ let
         let
 
           # For definitions that have an associated option
-          declaredConfig = mapAttrsRecursiveCond (v: !isOption v) (_: v: v.value) options;
+          declaredConfig =
+            let
+              recurse = mapAttrs (n: v: if isOption v then v.value else recurse v);
+            in
+            recurse options;
 
           # If freeformType is set, this is for definitions that don't have an associated option
           freeformConfig =

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1506,7 +1506,7 @@ let
   fixupOptionType =
     loc: opt:
     if opt.type.getSubModules or null == null then
-      opt // { type = opt.type or types.unspecified; }
+      if opt ? type then opt else opt // { type = types.unspecified; }
     else
       opt
       // {

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -568,10 +568,20 @@ let
           isDisabledModule = isDisabled modulesPath disabled;
           keyFilter = filter (attrs: !isDisabledModule attrs);
         in
-        map (attrs: attrs.module) (genericClosure {
-          startSet = keyFilter modules;
-          operator = attrs: keyFilter attrs.modules;
-        });
+        map (attrs: attrs.module) (
+          genericClosure (
+            if disabled == [ ] then
+              {
+                startSet = modules;
+                operator = attrs: attrs.modules;
+              }
+            else
+              {
+                startSet = keyFilter modules;
+                operator = attrs: keyFilter attrs.modules;
+              }
+          )
+        );
 
       toGraph =
         modulesPath:

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -880,13 +880,12 @@ let
           loc = prefix ++ [ name ];
           defns = pushedDownDefinitionsByName.${name} or [ ];
           defns' = rawDefinitionsByName.${name} or [ ];
-          optionDecls = filter (
+          isOptionDecl =
             m:
             m.options ? _type
-            && (m.options._type == "option" || throwDeclarationTypeError loc m.options._type m._file)
-          ) decls;
+            && (m.options._type == "option" || throwDeclarationTypeError loc m.options._type m._file);
         in
-        if length optionDecls == length decls then
+        if all isOptionDecl decls then
           let
             opt = fixupOptionType loc (mergeOptionDecls loc decls);
           in
@@ -894,7 +893,34 @@ let
             matchedOptions = evalOptionValue loc opt defns';
             unmatchedDefns = [ ];
           }
-        else if optionDecls != [ ] then
+        # this may look like duplicate computations are performed, but testing
+        # with a minimal NixOS config (defined below):
+        #
+        # 1. in 97.61% of cases, the above `all isOptionDecl decls` passes
+        # 2. In 1.19% of the cases, there's only one decl and we short-circuit
+        # 3. in another 1.19% of the cases, we have to loop again, to check if
+        # any of the decls were options
+        # 4. In the final case, we pass the `any` and have to refilter. This
+        # only triggers in 1 of the 42500 calls to this function.
+        #
+        # The minimal config was defined with this expression:
+        #
+        # let nixos = import ./nixos/lib/eval-config.nix {
+        #   modules = [
+        #     ./nixos/modules/profiles/minimal.nix
+        #     {
+        #       fileSystems."/" = {
+        #         device = "/dev/sda1";
+        #         fsType = "ext4";
+        #       };
+        #       boot.loader.grub.devices = [ "/dev/sda" ];
+        #     }
+        #   ];
+        # }; in nixos.config.system.build.toplevel'
+        else if length decls > 1 && any isOptionDecl decls then
+          let
+            optionDecls = filter isOptionDecl decls;
+          in
           if
             all (x: x.options.type.name or null == "submodule") optionDecls
           # Raw options can only be merged into submodules. Merging into

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1055,7 +1055,7 @@ let
         res: opt:
         let
           typeSet =
-            if opt.options ? type && res ? type then
+            if res ? type && opt.options ? type then
               let
                 mergedType = res.type.typeMerge opt.options.type.functor;
               in
@@ -1070,7 +1070,7 @@ let
             else
               { };
 
-          bothHave = k: opt.options ? ${k} && res ? ${k};
+          bothHave = k: res ? ${k} && opt.options ? ${k};
         in
         if bothHave "default" || bothHave "example" || bothHave "description" || bothHave "apply" then
           # Keep in sync with the same error above!

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1192,11 +1192,8 @@ let
       # original singleton straight to the type merge.
       if
         length defs == 1
-        && (
-          let
-            d = head defs;
-          in
-          addErrorContext "while evaluating definitions from `${d.file}':" (!d.value ? _type)
+        && addErrorContext "while evaluating definitions from `${(head defs).file}':" (
+          !(head defs).value ? _type
         )
       then
         {

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1375,13 +1375,16 @@ let
           val;
     in
     cfg:
-    if cfg._type or "" == "merge" then
-      concatMap pushDownProperties cfg.contents
-    else if cfg._type or "" == "if" then
-      map (mapAttrsIfAttrs (n: v: mkIf cfg.condition v)) (pushDownProperties cfg.content)
-    else if cfg._type or "" == "override" then
-      map (mapAttrsIfAttrs (n: v: mkOverride cfg.priority v)) (pushDownProperties cfg.content)
-    # FIXME: handle mkOrder?
+    if cfg ? _type then
+      if cfg._type == "if" then
+        map (mapAttrsIfAttrs (n: v: mkIf cfg.condition v)) (pushDownProperties cfg.content)
+      else if cfg._type == "merge" then
+        concatMap pushDownProperties cfg.contents
+      else if cfg._type == "override" then
+        map (mapAttrsIfAttrs (n: v: mkOverride cfg.priority v)) (pushDownProperties cfg.content)
+      # FIXME: handle mkOrder?
+      else
+        [ cfg ]
     else
       [ cfg ];
 
@@ -1404,13 +1407,16 @@ let
   */
   dischargeProperties =
     def:
-    if def._type or "" == "merge" then
-      concatMap dischargeProperties def.contents
-    else if def._type or "" == "if" then
-      if isBool def.condition then
-        if def.condition then dischargeProperties def.content else [ ]
+    if def ? _type then
+      if def._type == "if" then
+        if isBool def.condition then
+          if def.condition then dischargeProperties def.content else [ ]
+        else
+          throw "‘mkIf’ called with a non-Boolean condition"
+      else if def._type == "merge" then
+        concatMap dischargeProperties def.contents
       else
-        throw "‘mkIf’ called with a non-Boolean condition"
+        [ def ]
     else
       [ def ];
 

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1500,23 +1500,21 @@ let
   mergeAttrDefinitionsWithPrio =
     opt:
     let
-      defsByAttr = zipAttrs (
-        concatLists (
-          concatMap (
-            { value, ... }@def:
-            map (mapAttrsToList (
-              k: value: {
-                ${k} = def // {
-                  inherit value;
-                };
-              }
-            )) (pushDownProperties value)
-          ) opt.definitionsWithLocations
-        )
+      defsByAttr = concatLists (
+        concatMap (
+          { value, ... }@def:
+          map (mapAttrsToList (
+            k: value: {
+              ${k} = def // {
+                inherit value;
+              };
+            }
+          )) (pushDownProperties value)
+        ) opt.definitionsWithLocations
       );
     in
     assert opt.type.name == "attrsOf" || opt.type.name == "lazyAttrsOf";
-    mapAttrs (
+    zipAttrsWith (
       k: v:
       let
         merging = mergeDefinitions (opt.loc ++ [ k ]) opt.type.nestedTypes.elemType v;

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -31,7 +31,6 @@ let
     length
     mapAttrs
     mapAttrsToList
-    mapAttrsRecursiveCond
     min
     optional
     optionalAttrs
@@ -279,7 +278,11 @@ let
         let
 
           # For definitions that have an associated option
-          declaredConfig = mapAttrsRecursiveCond (v: !isOption v) (_: v: v.value) options;
+          declaredConfig =
+            let
+              recurse = mapAttrs (n: v: if isOption v then v.value else recurse v);
+            in
+            recurse options;
 
           # If freeformType is set, this is for definitions that don't have an associated option
           freeformConfig =

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1043,14 +1043,11 @@ let
       (
         res: opt:
         let
-          t = res.type;
-          t' = opt.options.type;
-          mergedType = t.typeMerge t'.functor;
-          typesMergeable = mergedType != null;
+          mergedType = res.type.typeMerge opt.options.type.functor;
 
           typeSet =
             if opt.options ? type && res ? type then
-              if typesMergeable then
+              if mergedType != null then
                 {
                   type = mergedType;
                 }

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1043,10 +1043,11 @@ let
       (
         res: opt:
         let
-          mergedType = res.type.typeMerge opt.options.type.functor;
-
           typeSet =
             if opt.options ? type && res ? type then
+              let
+                mergedType = res.type.typeMerge opt.options.type.functor;
+              in
               if mergedType != null then
                 {
                   type = mergedType;

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1057,7 +1057,7 @@ let
         res: opt:
         let
           typeSet =
-            if opt.options ? type && res ? type then
+            if res ? type && opt.options ? type then
               let
                 mergedType = res.type.typeMerge opt.options.type.functor;
               in
@@ -1072,7 +1072,7 @@ let
             else
               { };
 
-          bothHave = k: opt.options ? ${k} && res ? ${k};
+          bothHave = k: res ? ${k} && opt.options ? ${k};
         in
         if bothHave "default" || bothHave "example" || bothHave "description" || bothHave "apply" then
           # Keep in sync with the same error above!

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1377,13 +1377,16 @@ let
           val;
     in
     cfg:
-    if cfg._type or "" == "merge" then
-      concatMap pushDownProperties cfg.contents
-    else if cfg._type or "" == "if" then
-      map (mapAttrsIfAttrs (n: v: mkIf cfg.condition v)) (pushDownProperties cfg.content)
-    else if cfg._type or "" == "override" then
-      map (mapAttrsIfAttrs (n: v: mkOverride cfg.priority v)) (pushDownProperties cfg.content)
-    # FIXME: handle mkOrder?
+    if cfg ? _type then
+      if cfg._type == "if" then
+        map (mapAttrsIfAttrs (n: v: mkIf cfg.condition v)) (pushDownProperties cfg.content)
+      else if cfg._type == "merge" then
+        concatMap pushDownProperties cfg.contents
+      else if cfg._type == "override" then
+        map (mapAttrsIfAttrs (n: v: mkOverride cfg.priority v)) (pushDownProperties cfg.content)
+      # FIXME: handle mkOrder?
+      else
+        [ cfg ]
     else
       [ cfg ];
 
@@ -1406,13 +1409,16 @@ let
   */
   dischargeProperties =
     def:
-    if def._type or "" == "merge" then
-      concatMap dischargeProperties def.contents
-    else if def._type or "" == "if" then
-      if isBool def.condition then
-        if def.condition then dischargeProperties def.content else [ ]
+    if def ? _type then
+      if def._type == "if" then
+        if isBool def.condition then
+          if def.condition then dischargeProperties def.content else [ ]
+        else
+          throw "‘mkIf’ called with a non-Boolean condition"
+      else if def._type == "merge" then
+        concatMap dischargeProperties def.contents
       else
-        throw "‘mkIf’ called with a non-Boolean condition"
+        [ def ]
     else
       [ def ];
 

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1185,40 +1185,12 @@ let
   # Merge definitions of a value of a given type.
   mergeDefinitions = loc: type: defs: rec {
     defsFinal' =
-      let
-        # Process mkMerge and mkIf properties.
-        defsNormalized = concatMap (
-          m:
-          map (
-            value:
-            if value._type or null == "definition" then
-              value
-            else
-              {
-                inherit (m) file;
-                inherit value;
-              }
-          ) (addErrorContext "while evaluating definitions from `${m.file}':" (dischargeProperties m.value))
-        ) defs;
-
-        # Process mkOverride properties.
-        defsFiltered = filterOverrides' defsNormalized;
-
-        # Sort mkOrder properties.
-        defsSorted =
-          # Avoid sorting if we don't have to.
-          if any (def: def.value._type or "" == "order") defsFiltered.values then
-            sortProperties defsFiltered.values
-          else
-            defsFiltered.values;
-      in
       # Fast path: the overwhelming majority of options have exactly one
       # definition whose value carries no property wrapper
       # (mkIf/mkMerge/mkOverride/mkOrder/definition). In that case the
-      # discharge/filter/sort pipeline above is a no-op but still allocates
-      # several intermediate lists and closures. Detect it up front and hand
-      # the original singleton straight to the type merge. The let-bindings
-      # above are lazy and thus never forced on this branch.
+      # discharge/filter/sort pipeline below is a no-op but still allocates
+      # several intermediate lists and closures. Detect it up front and hand the
+      # original singleton straight to the type merge.
       if
         length defs == 1
         && (
@@ -1235,6 +1207,33 @@ let
           highestPrio = defaultOverridePriority;
         }
       else
+        let
+          # Process mkMerge and mkIf properties.
+          defsNormalized = concatMap (
+            m:
+            map (
+              value:
+              if value._type or null == "definition" then
+                value
+              else
+                {
+                  inherit (m) file;
+                  inherit value;
+                }
+            ) (addErrorContext "while evaluating definitions from `${m.file}':" (dischargeProperties m.value))
+          ) defs;
+
+          # Process mkOverride properties.
+          defsFiltered = filterOverrides' defsNormalized;
+
+          # Sort mkOrder properties.
+          defsSorted =
+            # Avoid sorting if we don't have to.
+            if any (def: def.value._type or "" == "order") defsFiltered.values then
+              sortProperties defsFiltered.values
+            else
+              defsFiltered.values;
+        in
         {
           values = defsSorted;
           inherit (defsFiltered) highestPrio;

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1156,10 +1156,6 @@ let
           throw "The option `${showOption loc}' is read-only, but it's set multiple times. Definition values:${showDefs separateDefs}"
         else
           mergeDefinitions loc opt.type defs';
-
-      # Apply the 'apply' function to the merged value. This allows options to
-      # yield a value computed from the definitions
-      value = if opt ? apply then opt.apply res.mergedValue else res.mergedValue;
     in
     (
       if opt.type.deprecationMessage != null then
@@ -1168,7 +1164,11 @@ let
         opt
     )
     // {
-      value = addErrorContext "while evaluating the option `${showOption loc}':" value;
+      value = addErrorContext "while evaluating the option `${showOption loc}':" (
+        # Apply the 'apply' function to the merged value. This allows options to
+        # yield a value computed from the definitions
+        if opt ? apply then opt.apply res.mergedValue else res.mergedValue
+      );
       inherit (res.defsFinal') highestPrio;
       definitions = catAttrs "value" res.defsFinal;
       files = catAttrs "file" res.defsFinal;

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -631,6 +631,28 @@ let
     : 3\. Function argument
   */
   unifyModuleSyntax =
+    let
+      attrsToRemove = [
+        "_class"
+        "_file"
+        "key"
+        "disabledModules"
+        "imports"
+        "options"
+        "config"
+        "meta"
+        "freeformType"
+      ];
+      shorthandAttrsToRemove = [
+        "_class"
+        "_file"
+        "key"
+        "disabledModules"
+        "require"
+        "imports"
+        "freeformType"
+      ];
+    in
     file: key: m:
     let
       addMeta =
@@ -654,17 +676,7 @@ let
     in
     if m ? config || m ? options then
       let
-        badAttrs = removeAttrs m [
-          "_class"
-          "_file"
-          "key"
-          "disabledModules"
-          "imports"
-          "options"
-          "config"
-          "meta"
-          "freeformType"
-        ];
+        badAttrs = removeAttrs m attrsToRemove;
       in
       if badAttrs != { } then
         throw "Module `${key}' has an unsupported attribute `${head (attrNames badAttrs)}'. This is caused by introducing a top-level `config' or `options' attribute. Add configuration attributes immediately on the top level instead, or move all of them (namely: ${toString (attrNames badAttrs)}) into the explicit `config' attribute."
@@ -690,17 +702,7 @@ let
         disabledModules = m.disabledModules or [ ];
         imports = m.require or [ ] ++ m.imports or [ ];
         options = { };
-        config = addFreeformType (
-          removeAttrs m [
-            "_class"
-            "_file"
-            "key"
-            "disabledModules"
-            "require"
-            "imports"
-            "freeformType"
-          ]
-        );
+        config = addFreeformType (removeAttrs m shorthandAttrsToRemove);
       };
 
   applyModuleArgsIfFunction =

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1138,15 +1138,13 @@ let
       # Apply the 'apply' function to the merged value. This allows options to
       # yield a value computed from the definitions
       value = if opt ? apply then opt.apply res.mergedValue else res.mergedValue;
-
-      warnDeprecation =
-        if (opt.type.deprecationMessage != null) then
-          warn "The type `types.${opt.type.name}' of option `${showOption loc}' defined in ${showFiles opt.declarations} is deprecated. ${opt.type.deprecationMessage}"
-        else
-          x: x;
-
     in
-    warnDeprecation opt
+    (
+      if opt.type.deprecationMessage != null then
+        warn "The type `types.${opt.type.name}' of option `${showOption loc}' 'defined in ${showFiles opt.declarations} is deprecated. ${opt.type.deprecationMessage}" opt
+      else
+        opt
+    )
     // {
       value = addErrorContext "while evaluating the option `${showOption loc}':" value;
       inherit (res.defsFinal') highestPrio;

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1038,7 +1038,7 @@ let
     : 2\. Function argument
   */
   mergeOptionDecls =
-    loc: opts:
+    loc:
     foldl'
       (
         res: opt:
@@ -1103,8 +1103,7 @@ let
         declarations = [ ];
         declarationPositions = [ ];
         options = [ ];
-      }
-      opts;
+      };
 
   /**
     Merge all the definitions of an option to produce the final

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -879,7 +879,6 @@ let
         # We're descending into attribute ‘name’.
         let
           loc = prefix ++ [ name ];
-          defns = pushedDownDefinitionsByName.${name} or [ ];
           defns' = rawDefinitionsByName.${name} or [ ];
           isOptionDecl =
             m:
@@ -950,7 +949,7 @@ let
               (head optionDecls).options.type.description or "<no description>"
             }' does not support nested options.\n${showRawDecls loc nonOptions}"
         else
-          mergeModules' loc decls defns
+          mergeModules' loc decls (pushedDownDefinitionsByName.${name} or [ ])
       ) declsByName;
 
       matchedOptions = mapAttrs (n: v: v.matchedOptions) resultsByName;

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -881,13 +881,12 @@ let
           loc = prefix ++ [ name ];
           defns = pushedDownDefinitionsByName.${name} or [ ];
           defns' = rawDefinitionsByName.${name} or [ ];
-          optionDecls = filter (
+          isOptionDecl =
             m:
             m.options ? _type
-            && (m.options._type == "option" || throwDeclarationTypeError loc m.options._type m._file)
-          ) decls;
+            && (m.options._type == "option" || throwDeclarationTypeError loc m.options._type m._file);
         in
-        if length optionDecls == length decls then
+        if all isOptionDecl decls then
           let
             opt = fixupOptionType loc (mergeOptionDecls loc decls);
           in
@@ -895,7 +894,35 @@ let
             matchedOptions = evalOptionValue loc opt defns';
             unmatchedDefns = [ ];
           }
-        else if optionDecls != [ ] then
+        # this may look like duplicate computations are performed, but testing
+        # with a minimal NixOS config (defined below):
+        #
+        # 1. in 87% of cases, the above `all isOptionDecl decls` passes and we
+        # short-circuit
+        # 2. In 12% of cases, there's only one decl and we short-circuit
+        # 3. in another 1% of cases, we loop again and short-circuit when
+        # `any isOptionDecl decls` fails
+        # 4. In the final case, we pass the `any` and have to refilter. This
+        # only triggers in 1 of the 48000 calls to this function.
+        #
+        # The minimal config was defined with this expression:
+        #
+        # let nixos = import ./nixos/lib/eval-config.nix {
+        #   modules = [
+        #     ./nixos/modules/profiles/minimal.nix
+        #     {
+        #       fileSystems."/" = {
+        #         device = "/dev/sda1";
+        #         fsType = "ext4";
+        #       };
+        #       boot.loader.grub.devices = [ "/dev/sda" ];
+        #     }
+        #   ];
+        # }; in nixos.config.system.build.toplevel
+        else if length decls != 1 && any isOptionDecl decls then
+          let
+            optionDecls = filter isOptionDecl decls;
+          in
           if
             all (x: x.options.type.name or null == "submodule") optionDecls
           # Raw options can only be merged into submodules. Merging into

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1508,7 +1508,7 @@ let
   fixupOptionType =
     loc: opt:
     if opt.type.getSubModules or null == null then
-      opt // { type = opt.type or types.unspecified; }
+      if opt ? type then opt else opt // { type = types.unspecified; }
     else
       opt
       // {

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -567,10 +567,20 @@ let
           isDisabledModule = isDisabled modulesPath disabled;
           keyFilter = filter (attrs: !isDisabledModule attrs);
         in
-        catAttrs "module" (genericClosure {
-          startSet = keyFilter modules;
-          operator = attrs: keyFilter attrs.modules;
-        });
+        catAttrs "module" (
+          genericClosure (
+            if disabled == [ ] then
+              {
+                startSet = modules;
+                operator = attrs: attrs.modules;
+              }
+            else
+              {
+                startSet = keyFilter modules;
+                operator = attrs: keyFilter attrs.modules;
+              }
+          )
+        );
 
       toGraph =
         modulesPath:

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1193,11 +1193,8 @@ let
       # original singleton straight to the type merge.
       if
         length defs == 1
-        && (
-          let
-            d = head defs;
-          in
-          addErrorContext "while evaluating definitions from `${d.file}':" (!d.value ? _type)
+        && addErrorContext "while evaluating definitions from `${(head defs).file}':" (
+          !(head defs).value ? _type
         )
       then
         {

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1197,9 +1197,7 @@ let
           let
             d = head defs;
           in
-          addErrorContext "while evaluating definitions from `${d.file}':" (
-            !(isAttrs d.value && d.value ? _type)
-          )
+          addErrorContext "while evaluating definitions from `${d.file}':" (!d.value ? _type)
         )
       then
         {

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -564,7 +564,8 @@ let
         modulesPath:
         { disabled, modules }:
         let
-          keyFilter = filter (attrs: !isDisabled modulesPath disabled attrs);
+          isDisabledModule = isDisabled modulesPath disabled;
+          keyFilter = filter (attrs: !isDisabledModule attrs);
         in
         catAttrs "module" (genericClosure {
           startSet = keyFilter modules;


### PR DESCRIPTION
Stats difference for my personal config:
```json
{
  "attrset": {
    "lookups": "-10.96%",
    "merges": "-5.15%",
    "mergeCopies": "-0.26%"
  },
  "list": {
    "concats": null
  },
  "parser": {
    "expressions": "+0%"
  },
  "memoryBytes": {
    "envs": "-5.24%",
    "list": "-9.5%",
    "sets": "-0.59%",
    "symbols": "+0%",
    "values": "-4.14%",
    "total": "-2.73%"
  },
  "speed": {
    "primops": "-8.71%",
    "functionCalls": "-4.59%",
    "thunksMade": "-6.09%",
    "thunksAvoided": "-6.83%"
  }
}
```
Hash stays the same.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
