### PR TITLE
stdenv.mkDerivation: Optimise hardening flag handling

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -41,7 +41,6 @@ let
     optional
     optionalString
     optionals
-    pipe
     remove
     seq
     splitString
@@ -54,6 +53,7 @@ let
     unsafeGetAttrPos
     warnIf
     zipAttrsWith
+    any
     ;
 
   inherit (lib.generators) toPretty;
@@ -174,10 +174,6 @@ let
     "trivialautovarinit"
     "zerocallusedregs"
   ];
-
-  concretizeFlagImplications =
-    flag: impliesFlags: list:
-    if elem flag list then (list ++ impliesFlags) else list;
 
   removedOrReplacedAttrNames = [
     "checkInputs"
@@ -462,11 +458,6 @@ let
           actualValue;
       outputs' = if separateDebugInfo' then outputs ++ [ "debug" ] else outputs;
 
-      # hardeningDisable additionally supports "all".
-      erroneousHardeningFlags = subtractLists knownHardeningFlags (
-        hardeningEnable ++ remove "all" hardeningDisable
-      );
-
       checkDependencyList = checkDependencyList' [ ];
       checkDependencyList' =
         positions: name: deps:
@@ -488,9 +479,19 @@ let
                 concatMapStrings (ix: "element ${toString ix} of ") ([ index ] ++ positions)
               }${name} for ${attrs.name or attrs.pname}"
           ) 1 deps) deps;
+
+      isErroneous = flag: !elem flag knownHardeningFlags;
     in
-    if erroneousHardeningFlags != [ ] then
+    if
+      # Check if any hardening flag is erroneous
+      any isErroneous hardeningEnable || any (flag: flag != "all" && isErroneous flag) hardeningDisable
+    then
       abort (
+        let
+          erroneousHardeningFlags = subtractLists knownHardeningFlags (
+            hardeningEnable ++ remove "all" hardeningDisable
+          );
+        in
         "mkDerivation was called with unsupported hardening flags: "
         + toPretty { } {
           inherit
@@ -733,23 +734,21 @@ let
             else
               null
           } =
-            let
-              enabledHardeningOptions =
-                if elem "all" hardeningDisable then
-                  [ ]
-                else
-                  subtractLists (unique (
-                    pipe hardeningDisable [
-                      # disabling fortify implies fortify3 should also be disabled
-                      (concretizeFlagImplications "fortify" [ "fortify3" ])
-                      # disabling strictflexarrays1 implies strictflexarrays3 should also be disabled
-                      (concretizeFlagImplications "strictflexarrays1" [ "strictflexarrays3" ])
-                      # disabling libcxxhardeningfast implies libcxxhardeningextensive should also be disabled
-                      (concretizeFlagImplications "libcxxhardeningfast" [ "libcxxhardeningextensive" ])
-                    ]
-                  )) (defaultHardeningFlags ++ hardeningEnable);
-            in
-            concatStringsSep " " enabledHardeningOptions;
+            concatStringsSep " " (
+              if elem "all" hardeningDisable then
+                [ ]
+              else
+                filter (
+                  flag:
+                  !(elem flag hardeningDisable)
+                  # disabling fortify implies fortify3 should also be disabled
+                  && (flag == "fortify3" -> !elem "fortify" hardeningDisable)
+                  # disabling strictflexarrays1 implies strictflexarrays3 should also be disabled
+                  && (flag == "strictflexarrays3" -> !elem "strictflexarrays1" hardeningDisable)
+                  # disabling libcxxhardeningfast implies libcxxhardeningextensive should also be disabled
+                  && (flag == "libcxxhardeningextensive" -> !elem "libcxxhardeningfast" hardeningDisable)
+                ) (defaultHardeningFlags ++ hardeningEnable)
+            );
 
           # TODO: remove platform condition
           # Enabling this check could be a breaking change as it requires to edit nix.conf


### PR DESCRIPTION
## Things done

Very tiny optimisation, but much better readability.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
