### PR TITLE
nixos/zswap: Address multiple issues with zswap configuration

### DIFF
--- a/nixos/modules/system/boot/zswap.nix
+++ b/nixos/modules/system/boot/zswap.nix
@@ -136,7 +136,7 @@ in
       zpool = cfg.zpool;
       max_pool_percent = cfg.maxPoolPercent;
       accept_threshold_percent = cfg.acceptThresholdPercent;
-      shrinker_enabled = true;
+      shrinker_enabled = cfg.shrinkerEnabled;
     };
 
     assertions = [

--- a/nixos/modules/system/boot/zswap.nix
+++ b/nixos/modules/system/boot/zswap.nix
@@ -20,6 +20,12 @@ let
 
   # Check if kernel supports zsmalloc as zswap backend (>= 6.3)
   zsmallocSupported = versionAtLeast kernelVersion "6.3";
+
+  # Check if kernel supports zbud and z3fold backends (< 6.15)
+  zbudSupported = versionOlder kernelVersion "6.15";
+
+  # Check if kernel supports zpool abstraction and configuration (< 6.18)
+  zpoolSupported = versionOlder kernelVersion "6.18";
 in
 {
   options.boot.zswap = {
@@ -54,6 +60,7 @@ in
       type = types.enum [
         "zsmalloc"
         "zbud"
+        "z3fold"
       ];
       default = if zsmallocSupported then "zsmalloc" else "zbud";
       defaultText = literalExpression "if kernel >= 6.3 then \"zsmalloc\" else \"zbud\"";
@@ -62,7 +69,7 @@ in
         'zsmalloc' is strongly recommended for kernels >= 6.3 as it offers the best density.
         For older kernels, 'zbud' is the fallback.
 
-        Note: 'z3fold' was removed from Linux kernel 6.8 and later.
+        Note: 'zbud' and 'z3fold' were removed from Linux kernel 6.15 and later.
       '';
     };
 
@@ -115,11 +122,11 @@ in
     boot.kernelParams = [
       "zswap.enabled=1"
       "zswap.compressor=${cfg.compressor}"
-      "zswap.zpool=${cfg.zpool}"
       "zswap.max_pool_percent=${toString cfg.maxPoolPercent}"
       "zswap.accept_threshold_percent=${toString cfg.acceptThresholdPercent}"
       "zswap.shrinker_enabled=${if cfg.shrinkerEnabled then "1" else "0"}"
-    ];
+    ]
+    ++ optional zpoolSupported "zswap.zpool=${cfg.zpool}";
 
     # 2. Dependency management: ensure required modules are included in initrd or kernel
     # This ensures Zswap is ready early in the boot process (before swap is mounted)
@@ -133,11 +140,11 @@ in
     boot.kernel.sysfs.module.zswap.parameters = {
       enabled = true;
       compressor = cfg.compressor;
-      zpool = cfg.zpool;
       max_pool_percent = cfg.maxPoolPercent;
       accept_threshold_percent = cfg.acceptThresholdPercent;
       shrinker_enabled = cfg.shrinkerEnabled;
-    };
+    }
+    // optionalAttrs zpoolSupported { zpool = cfg.zpool; };
 
     assertions = [
       {
@@ -173,6 +180,15 @@ in
           Support for zsmalloc in Zswap was added in Linux 6.3.
 
           Please use 'zbud' instead: boot.zswap.zpool = "zbud";
+        '';
+      }
+      {
+        assertion = (cfg.zpool != "zsmalloc") -> zbudSupported;
+        message = ''
+          Zswap allocators 'zbud' and 'z3fold' are not supported on kernel version ${kernelVersion}.
+          Support for zbud and z3fold in Zswap was removed in Linux 6.15 in favor of zsmalloc.
+
+          Please use 'zsmalloc' instead: boot.zswap.zpool = "zsmalloc";
         '';
       }
     ];

--- a/nixos/modules/system/boot/zswap.nix
+++ b/nixos/modules/system/boot/zswap.nix
@@ -115,6 +115,22 @@ in
         on systems with limited memory.
       '';
     };
+
+    dynamicSwap = mkOption {
+      type = types.bool;
+      default = config.services.swapspace.enable;
+      defaultText = literalExpression "config.services.swapspace.enable";
+      visible = false;
+      description = ''
+        Zswap requires a swap device to work properly. By default, the zswap
+        module checks for an entry in 'swapDevices' to ensure this condition
+        is met. However, some setups add swap devices dynamically, such as with
+        GPT partition auto discovery or 'services.swapspace'.
+
+        Set this value to true to assert that a swap device will be added
+        dynamically, and bypass the check for a 'swapDevices' entry.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -161,7 +177,7 @@ in
         '';
       }
       {
-        assertion = config.swapDevices != [ ];
+        assertion = config.swapDevices != [ ] || cfg.dynamicSwap;
         message = ''
           Zswap requires at least one physical swap device to function as a backing store.
 
@@ -171,6 +187,9 @@ in
             device = "/var/lib/swapfile";
             size = 16 * 1024; # 16GB
           } ];
+
+          If swap devices will be added dynamically (eg. by GPT partition auto discovery),
+          set 'boot.zswap.dynamicSwap = true' to bypass this check.
         '';
       }
       {


### PR DESCRIPTION
This addresses multiple issues with the new `boot.zswap` config options

* Fixes the value for `boot.kernel.sysfs.module.zswap.parameters.shrinker_enabled ` not respecting the value set for `boot.zswap.shrinkerEnabled`, which prevented that value from being applied correctly (addresses [this comment](https://github.com/NixOS/nixpkgs/pull/470366#discussion_r3195571095))
* The description for `boot.zswap.zpool` states that `z3fold` was removed in Linux 6.8, but I wasn't able to corroborate that. Instead, I found that **both** zbud and z3fold were removed in Linux 6.15 ([zbud](https://github.com/torvalds/linux/commit/6df8bae8e851eacf2acf2237860213e002aba74f) and [z3fold](https://github.com/torvalds/linux/commit/58ba73e521b3d3a7a7612fc200beba1544a5100c) commits), and the entire zpool abstraction layer and configuration option were removed in 6.18 ([commit](https://github.com/torvalds/linux/commit/2ccd9fecd9163f168761d4398564c81554f636ef)). While it might be worth completely removing the `boot.zswap.zpool` option, I *think* it's a little late to do that for 26.05, and therefore would need a deprecation plan. Instead, I opted for a more permissive option. I added "z3fold" as a valid value, and added an assert that `boot.zswap.zpool == "zsmalloc"` if the kernel is >= 6.15. I also added handling to avoid specifying the zpool type in the kernel params and sysfs if the kernel is >= 6.18 to avoid any warnings or errors from the parameter being missing.
* Add an option `boot.zswap.dynamicSwap` as a bypass for the assert that checks for an entry in `swapDevices`. This is intended to address situations where the swap is handled dynamically, such as with GPT partition auto discovery (suggested by [this comment](https://github.com/NixOS/nixpkgs/pull/470366#issuecomment-4225593994)) and using the swapspace service (replacing #517619). Setting this value to true only causes the assert to pass, and is intended as a mechanism for configs to bypass the check if they know a swap will be present. The default value exclusively checks if swapspace is enabled, as swapspace ensures that swap files should be generated, whereas enabling GPT partition auto discovery only adds a swap if a swap partition already exists. This default can be adjusted for other potential sources of dynamic swap devices, but these are the two I'm aware of.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
