### PR TITLE
cpeditor: 7.1.1 -> 7.1.1-unstable-2026-04-07

### DIFF
--- a/pkgs/by-name/cp/cpeditor/package.nix
+++ b/pkgs/by-name/cp/cpeditor/package.nix
@@ -2,7 +2,8 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  libsForQt5,
+  qt6,
+  kdePackages,
   pkg-config,
   cmake,
   ninja,
@@ -12,13 +13,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "cpeditor";
-  version = "7.1.1";
+  version = "7.1.1-unstable-2026-04-07";
 
   src = fetchFromGitHub {
     owner = "cpeditor";
     repo = "cpeditor";
-    tag = finalAttrs.version;
-    hash = "sha256-zEK3137DjQmuc7Y4c/HF0n37bdokj9ci2/agSaG7nZE=";
+    rev = "912784abcbfb38d70911c45d15a308c339894cec";
+    hash = "sha256-udpDsYve1QIQTT75Xk8HHBV1lTTTjauDMyfJKbShgEs=";
     fetchSubmodules = true;
   };
 
@@ -26,13 +27,15 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     ninja
     pkg-config
-    libsForQt5.wrapQtAppsHook
+    qt6.wrapQtAppsHook
     python3
   ];
+
   buildInputs = [
-    libsForQt5.qtbase
-    libsForQt5.qttools
-    libsForQt5.syntax-highlighting
+    qt6.qtbase
+    qt6.qttools
+    qt6.qt5compat
+    kdePackages.syntax-highlighting
   ];
 
   postPatch = ''


### PR DESCRIPTION
Since the KF5 syntax-highlighting dependency required by the Qt5 version is about to be removed, we are packaging the unreleased Qt6 branch instead.

cc @K900

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
