### PR TITLE
shopware-cli: update url

### DIFF
--- a/pkgs/by-name/sh/shopware-cli/package.nix
+++ b/pkgs/by-name/sh/shopware-cli/package.nix
@@ -14,7 +14,7 @@ buildGoModule (finalAttrs: {
   version = "0.14.8";
   src = fetchFromGitHub {
     repo = "shopware-cli";
-    owner = "FriendsOfShopware";
+    owner = "shopware";
     tag = finalAttrs.version;
     hash = "sha256-yN6yuGnZv6BsXoERUdA3aBGEmri1hqmPsbIYsX7HE5Q=";
   };
@@ -45,7 +45,7 @@ buildGoModule (finalAttrs: {
   ldflags = [
     "-s"
     "-w"
-    "-X 'github.com/FriendsOfShopware/shopware-cli/cmd.version=${finalAttrs.version}'"
+    "-X 'github.com/shopware/shopware-cli/cmd.version=${finalAttrs.version}'"
   ];
 
   __darwinAllowLocalNetworking = true;
@@ -53,8 +53,8 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Command line tool for Shopware 6";
     mainProgram = "shopware-cli";
-    homepage = "https://github.com/FriendsOfShopware/shopware-cli";
-    changelog = "https://github.com/FriendsOfShopware/shopware-cli/releases/tag/${finalAttrs.version}";
+    homepage = "https://github.com/shopware/shopware-cli";
+    changelog = "https://github.com/shopware/shopware-cli/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ shyim ];
   };


### PR DESCRIPTION
The project moved organisations from `FriendsOfShopware` to `shopware`, so the GitHub owner, homepage, changelog URL and the `-X cmd.version` ldflag's Go module path are updated accordingly. Source `hash` and `vendorHash` refreshed.

Release notes: https://github.com/shopware/shopware-cli/releases

I am the upstream maintainer of shopware-cli and the listed nixpkgs maintainer for this package.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (`shopware-cli --version` reports `0.14.7`.)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test