### PR TITLE
weechat-matrix-rs: fix build with newer Rust

### DIFF
--- a/pkgs/by-name/we/weechat-matrix-rs/increase-recursion-limit.patch
+++ b/pkgs/by-name/we/weechat-matrix-rs/increase-recursion-limit.patch
@@ -1,0 +1,10 @@
+diff --git a/src/lib.rs b/src/lib.rs
+index 2f1090a..205d90d 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,3 +1,5 @@
++#![recursion_limit = "256"]
++
+ mod bar_items;
+ mod commands;
+ mod completions;

--- a/pkgs/by-name/we/weechat-matrix-rs/package.nix
+++ b/pkgs/by-name/we/weechat-matrix-rs/package.nix
@@ -13,26 +13,34 @@
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "weechat-matrix-rs";
   version = "0-unstable-2025-10-09";
+
   src = fetchFromGitHub {
     owner = "poljar";
     repo = "weechat-matrix-rs";
     rev = "4cc5777b630ba4d6a9c964248531f283178a4717";
     hash = "sha256-CF4xDoRYey9F8/XSW/euNb8IjZXyP6k0Nj61shsmyEo=";
   };
+
+  patches = [ ./increase-recursion-limit.patch ];
+
   cargoHash = "sha256-jAlBCmLJfWWAUHd3ySB930iqAVXMh6ueba7xS///Rt0=";
+
   nativeBuildInputs = [
     pkg-config
     rustPlatform.bindgenHook
   ];
+
   buildInputs = [
     weechat
     openssl
     sqlite
   ];
+
   postInstall = ''
     mkdir -p $out/lib/weechat/plugins
     mv $out/lib/libmatrix${stdenv.hostPlatform.extensions.sharedLibrary} $out/lib/weechat/plugins/matrix${stdenv.hostPlatform.extensions.sharedLibrary}
   '';
+
   passthru.tests.load-plugin =
     runCommand "${finalAttrs.pname}-test-load"
       {
@@ -50,6 +58,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
           exit 1
         fi
       '';
+
   meta = {
     description = "Rust plugin for WeeChat to communicate over Matrix";
     homepage = "https://github.com/poljar/weechat-matrix-rs";


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327225989)](https://hydra.nixos.org/build/327225989)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test