### PR TITLE
kdePackages.rememberwindowpositions: init at 6.0.0

### DIFF
--- a/pkgs/kde/third-party/rememberwindowpositions/default.nix
+++ b/pkgs/kde/third-party/rememberwindowpositions/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+
+  zip,
+  kwin,
+  kpackage,
+  ...
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "rememberwindowpositions";
+  version = "6.0.0";
+
+  src = fetchFromGitHub {
+    owner = "rxappdev";
+    repo = "RememberWindowPositions";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dZGwtW9IGAsXj6mbek6oYNWquv6Da6vXw03a1wAPAzo=";
+  };
+
+  buildInputs = [
+    kpackage
+    zip
+  ];
+
+  nativeBuildInputs = [
+    kwin
+  ];
+
+  buildFlags = [ "build" ];
+  dontWrapQtApps = true;
+
+  installPhase = ''
+    runHook preInstall
+    kpackagetool6 --type=KWin/Script --install rememberwindowpositions.kwinscript --packageroot=$out/share/kwin/scripts
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Remember window positions for apps in KDE Plasma 6+. Especially useful for multi-window applications such as browsers.";
+    homepage = "https://github.com/rxappdev/RememberWindowPositions";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ nukdokplex ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Added awesome KWin script to nixpkgs 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
