### PR TITLE
linkfinder: init at 0-unstable-2024-04-13

### DIFF
--- a/pkgs/by-name/li/linkfinder/package.nix
+++ b/pkgs/by-name/li/linkfinder/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  python3,
+  python3Packages,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "linkfinder";
+  version = "0-unstable-2024-04-13";
+  pyproject = false;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "GerbenJavado";
+    repo = "LinkFinder";
+    rev = "1debac5dace4724fd6187c06f133578dae51c86f";
+    hash = "sha256-B1mP2twGjuQC09GZodBl/8R2JhUKkU0q3ZQkPSXZbNI=";
+  };
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  propagatedBuildInputs = with python3Packages; [ jsbeautifier ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm644 linkfinder.py $out/share/linkfinder/linkfinder.py
+    install -Dm644 template.html $out/share/linkfinder/template.html
+    makeWrapper ${lib.getExe python3} $out/bin/linkfinder \
+      --prefix PYTHONPATH : "$PYTHONPATH" \
+      --add-flags "$out/share/linkfinder/linkfinder.py"
+    runHook postInstall
+  '';
+
+  doCheck = false; # no test suite
+
+  meta = {
+    description = "Discover endpoints and parameters in JavaScript files";
+    homepage = "https://github.com/GerbenJavado/LinkFinder";
+    license = lib.licenses.mit;
+    mainProgram = "linkfinder";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - `curl -s https://code.jquery.com/jquery-3.7.1.min.js -o /tmp/jq.js && ./result/bin/linkfinder -i /tmp/jq.js -o cli`
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
