### PR TITLE
taskhound: 1.0.0 -> 1.1.5

### DIFF
--- a/pkgs/by-name/ta/taskhound/package.nix
+++ b/pkgs/by-name/ta/taskhound/package.nix
@@ -2,18 +2,19 @@
   lib,
   python3,
   fetchFromGitHub,
+  writableTmpDirAsHomeHook,
 }:
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "taskhound";
-  version = "1.0.0";
+  version = "1.1.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "1r0BIT";
     repo = "TaskHound";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-qQ1OpJCgMcRKGkZCRjLiUO+u4SSIA/qExzq2K7m7BD8=";
+    hash = "sha256-OVCHdhfMkeFUgdvVY6uMBqWpJNIHE4cHFzy1XstvnyU=";
   };
 
   build-system = with python3.pkgs; [ setuptools ];
@@ -26,11 +27,20 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     neo4j
     pycryptodome
     requests
+    rich
+    rich-argparse
   ];
 
   nativeCheckInputs = with python3.pkgs; [
     pytest-cov-stub
     pytestCheckHook
+    writableTmpDirAsHomeHook
+  ];
+
+  disabledTests = [
+    # Flaky timing-dependent test
+    "test_rate_limit_accuracy"
+    "test_parallel_mode"
   ];
 
   pythonImportsCheck = [ "taskhound" ];


### PR DESCRIPTION
Update to 1.1.5

Add missing deps for new version (rich / rich-argparse)

Upstream changelog: https://github.com/1r0BIT/TaskHound/releases

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
