### PR TITLE
secretfinder: init 0-unstable-2024-05-26

### DIFF
--- a/pkgs/by-name/se/secretfinder/package.nix
+++ b/pkgs/by-name/se/secretfinder/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "secretfinder";
+  version = "0-unstable-2024-05-26";
+  pyproject = false;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "m4ll0k";
+    repo = "SecretFinder";
+    rev = "d06119dedd9c1505137d1ec4792d5d5b65c7425d";
+    hash = "sha256-PXmW8t7g6JC12R/xDTi6MN5R2XM3b2zzHH6GVeZfBxk=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    requests
+    jsbeautifier
+    lxml
+    requests-file
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 SecretFinder.py $out/bin/secretfinder
+    runHook postInstall
+  '';
+
+  doCheck = false;
+
+  meta = {
+    description = "Discover sensitive data in JavaScript files";
+    homepage = "https://github.com/m4ll0k/SecretFinder";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "secretfinder";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - `echo 'var key = "AKIA1234567890ABCDEF";' > /tmp/sf-test.js`
  - `./result/bin/secretfinder -i /tmp/sf-test.js -o cli`
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
