### PR TITLE
nixos/dawarich: add Prometheus exporter configuration

### DIFF
--- a/nixos/modules/services/web-apps/dawarich.nix
+++ b/nixos/modules/services/web-apps/dawarich.nix
@@ -51,6 +51,10 @@ let
     SMTP_FROM = cfg.smtp.fromAddress;
     SMTP_USERNAME = cfg.smtp.user;
     PORT = toString cfg.webPort;
+
+    PROMETHEUS_EXPORTER_ENABLED = toString cfg.prometheus.enable;
+    PROMETHEUS_EXPORTER_HOST = toString cfg.prometheus.listenAddress;
+    PROMETHEUS_EXPORTER_PORT = toString cfg.prometheus.port;
   }
   // redisEnv
   // cfg.environment;
@@ -127,7 +131,8 @@ let
   commonUnits =
     lib.optional cfg.redis.createLocally "redis-dawarich.service"
     ++ lib.optional cfg.database.createLocally "postgresql.target"
-    ++ lib.optional cfg.automaticMigrations "dawarich-init-db.service";
+    ++ lib.optional cfg.automaticMigrations "dawarich-init-db.service"
+    ++ lib.optional cfg.prometheus.enable "dawarich-prometheus-exporter.service";
 
   defaultSecretKeyBaseFile = "${dataDir}/secrets/secret-key-base";
   needsGenCredentialsUnit = cfg.secretKeyBaseFile == null;
@@ -508,6 +513,32 @@ in
         type = lib.types.bool;
         default = true;
       };
+
+      prometheus = {
+        enable = lib.mkOption {
+          description = "Whether to enable the Prometheus metrics exporter";
+          type = lib.types.bool;
+          default = false;
+        };
+
+        listenAddress = lib.mkOption {
+          description = "Host address to bind the metrics exporter to";
+          type = lib.types.str;
+          default = "127.0.0.1";
+        };
+
+        port = lib.mkOption {
+          description = "Port number to bind the metrics exporter to";
+          type = lib.types.port;
+          default = 9394;
+        };
+
+        metricPrefix = lib.mkOption {
+          description = "Prefix prepended to the exported metrics";
+          type = lib.types.str;
+          default = "ruby_";
+        };
+      };
     };
   };
 
@@ -620,6 +651,27 @@ in
             # Runtime directory and mode
             RuntimeDirectory = "dawarich-web";
             RuntimeDirectoryMode = "0750";
+          }
+          // cfgService;
+        };
+
+        # Prometheus exporter should not need runtime directory or credentials
+        systemd.services.dawarich-prometheus-exporter = lib.mkIf cfg.prometheus.enable {
+          after = [ "network.target" ];
+          wantedBy = [ "dawarich.target" ];
+          description = "Dawarich Prometheus exporter";
+          environment = env;
+          serviceConfig = {
+            ExecStart = lib.concatStringsSep [
+              "${lib.getExe' cfg.package "prometheus_exporter"}"
+              "--bind ${cfg.prometheus.listenAddress}"
+              "--port ${cfg.prometheus.port}"
+              "--prefix ${cfg.prometheus.metricPrefix}"
+            ];
+
+            Restart = "always";
+            RestartSec = 20;
+            WorkingDirectory = cfg.package;
           }
           // cfgService;
         };


### PR DESCRIPTION
Add options for the Dawarich Prometheus exporter.
References:
- https://dawarich.app/docs/self-hosting/monitoring/prometheus/
- The exporter itself is a different project with documentation available here: https://github.com/discourse/prometheus_exporter

I'm looking for feedback on whether to change the default metric prefix from "ruby_" (used by upstream as far as I can tell) to something like "dawarich_". This would mean we'd deviate from the expected metric naming, but on the other hand "ruby_" will collide with other Ruby services also using the Prometheus exporter with default settings. If in doubt, I'd probably keep the "ruby_" default.

TODO: I've tested a previous iteration of this on my deployment without any issues, and I'll shortly begin testing this PR on my deployment.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
