### PR TITLE
hunk: init at 0.10.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7347,6 +7347,12 @@
     github = "dsluijk";
     githubId = 8537327;
   };
+  dsp = {
+    email = "nixos@experimentalworks.net";
+    github = "dsp";
+    githubId = 14013;
+    name = "David Soria Parra";
+  };
   dstathis = {
     email = "dylan.stephano-shachter@canonical.com";
     github = "dstathis";

--- a/pkgs/by-name/hu/hunk/package.nix
+++ b/pkgs/by-name/hu/hunk/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchurl,
+  autoPatchelfHook,
+}:
+
+let
+  version = "0.10.0";
+
+  source = fetchFromGitHub {
+    owner = "modem-dev";
+    repo = "hunk";
+    tag = "v${version}";
+    hash = "sha256-S2EuZW5vzyk3FGhUQbyanE3hdlnb9F6GQMtu2k8pjrM=";
+  };
+
+  sources = {
+    x86_64-linux = fetchurl {
+      url = "https://registry.npmjs.org/hunkdiff-linux-x64/-/hunkdiff-linux-x64-${version}.tgz";
+      hash = "sha256-ICkeeCq8X7czMDtVBH3P5lPDhSrgueZMeQb0QwTcfSA=";
+    };
+    aarch64-linux = fetchurl {
+      url = "https://registry.npmjs.org/hunkdiff-linux-arm64/-/hunkdiff-linux-arm64-${version}.tgz";
+      hash = "sha256-+1/uVxcmkyqYSTDz9gk+aZOgTKUzcypgichFfMwnGF4=";
+    };
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hunk";
+  inherit version;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src =
+    sources.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  buildInputs = [
+    (lib.getLib stdenv.cc.cc)
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D bin/hunk -t $out/bin
+    install -D LICENSE -t $out/share/licenses/hunk
+    install -D ${source}/skills/hunk-review/SKILL.md -t $out/bin/skills/hunk-review
+
+    runHook postInstall
+  '';
+
+  dontBuild = true;
+  dontStrip = true;
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $out/bin/hunk --version
+    $out/bin/hunk skill path
+
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    description = "Review-first terminal diff viewer for agent-authored changesets";
+    homepage = "https://github.com/modem-dev/hunk";
+    changelog = "https://github.com/modem-dev/hunk/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "hunk";
+    maintainers = with lib.maintainers; [ dsp ];
+    platforms = lib.attrNames sources;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform(s):
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [x] `nix-build -A hunk`
  - [x] `result/bin/hunk --version`
  - [x] `result/bin/hunk skill path`
  - [x] `nix-build lib/tests/maintainers.nix`
  - [x] `git diff --check`
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` (not applicable; new leaf package)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (new package)
- [x] Ensured that relevant documentation is up to date (not applicable)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Notes:

This package uses upstream Linux npm binary artifacts and marks `sourceProvenance = [ binaryNativeCode ]`. Upstream is Bun-based and this avoids vendoring Bun dependencies without a nixpkgs Bun lockfile packaging helper.

Disclosure: I have used AI assistance (Codex and Claude Code) to prepare this package, but tested the nix evaluations manually.