### PR TITLE
sortmerna: fix build with gcc 15

### DIFF
--- a/pkgs/by-name/so/sortmerna/package.nix
+++ b/pkgs/by-name/so/sortmerna/package.nix
@@ -49,6 +49,10 @@ stdenv.mkDerivation (finalAttrs: {
     "-DZLIB_STATIC=off"
   ];
 
+  patches = [
+    ./ssw-stdbool.patch
+  ];
+
   postPatch = ''
     # Fix missing pthread dependency for the main binary.
     substituteInPlace src/sortmerna/CMakeLists.txt \

--- a/pkgs/by-name/so/sortmerna/ssw-stdbool.patch
+++ b/pkgs/by-name/so/sortmerna/ssw-stdbool.patch
@@ -1,0 +1,13 @@
+diff --git a/include/ssw.h b/include/ssw.h
+index 5259c95..32bb146 100644
+--- a/include/ssw.h
++++ b/include/ssw.h
+@@ -35,7 +35,7 @@ struct _profile;
+ typedef struct _profile s_profile;
+ 
+ #ifndef __cplusplus
+-typedef unsigned char bool;
++#include <stdbool.h>
+ static const bool False = 0;
+ static const bool True = 1;
+ #endif


### PR DESCRIPTION
GCC 15 Regression Tracking: #475479
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327184379)](https://hydra.nixos.org/build/327184379)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test