### PR TITLE
river-tag-overlay: fix build with gcc 15

### DIFF
--- a/pkgs/by-name/ri/river-tag-overlay/package.nix
+++ b/pkgs/by-name/ri/river-tag-overlay/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromSourcehut,
   fetchpatch,
+  fetchpatch2,
   wayland,
   pixman,
   pkg-config,
@@ -25,6 +26,11 @@ stdenv.mkDerivation (finalAttrs: {
     (fetchpatch {
       url = "https://git.sr.ht/~leon_plickat/river-tag-overlay/commit/791eaadf46482121a4c811ffba13d03168d74d8f.patch";
       sha256 = "CxSDcweHGup1EF3oD/2vhP6RFoeYorj0BwmlgA3tbPE=";
+    })
+    # Specify argument types for C23 compatibility (gcc 15).
+    (fetchpatch2 {
+      url = "https://git.sr.ht/~leon_plickat/river-tag-overlay/commit/b7d9232f9106c6d2c3ecce802495f14069ce3406.patch";
+      hash = "sha256-/fNpVPY09zwwymS/VNaonqX7jtdflC3Iot5R26VsTTw=";
     })
   ];
 


### PR DESCRIPTION
GCC 15 Regression Tracking: #475479
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327171212)](https://hydra.nixos.org/build/327171212)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test