### PR TITLE
subjack: init at 3.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9473,6 +9473,11 @@
     name = "Faye Chun";
     keys = [ { fingerprint = "ACB8 DB1F E88D A908 6332  BDB1 5A71 B010 2FD7 3FC0"; } ];
   };
+  fxai = {
+    github = "fxai";
+    githubId = 44463990;
+    name = "fxai";
+  };
   fxfactorial = {
     email = "edgar.factorial@gmail.com";
     github = "fxfactorial";

--- a/pkgs/by-name/su/subjack/package.nix
+++ b/pkgs/by-name/su/subjack/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "subjack";
+  version = "3.0.0";
+
+  src = fetchFromGitHub {
+    owner = "haccer";
+    repo = "subjack";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-AHzBPtMpXy8ZG+lh7PpcvkJkdUal3ONhEQIhMVFSx+A=";
+  };
+
+  vendorHash = "sha256-Ma4kAcMfYm1ltOaAX39j78lxaAnWq03FYyB6rnKv9y8=";
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "DNS Takeover Scanner written in Go";
+    mainProgram = "subjack";
+    homepage = "https://github.com/haccer/subjack";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ fxai ];
+  };
+})


### PR DESCRIPTION
`subjack` is a Hostile Subdomain Takeover Scanner written in Go.
Homepage: https://github.com/haccer/subjack

This PR:
1. Packages `subjack` v3.0.0 using `buildGoModule` via the `by-name` structure.
2. Adds myself to the `maintainers` list.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
