### PR TITLE
python3Packages.tkinterdnd2: init at 0.4.3

### DIFF
--- a/pkgs/development/python-modules/tkinterdnd2/default.nix
+++ b/pkgs/development/python-modules/tkinterdnd2/default.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  replaceVars,
+
+  setuptools,
+
+  tcl8Packages,
+  tkinter,
+
+  unittestCheckHook,
+  libxcursor,
+  xvfb,
+}:
+buildPythonPackage rec {
+  pname = "tkinterdnd2";
+  version = "0.4.3";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Eliav2";
+    repo = "tkinterdnd2";
+    tag = version;
+    hash = "sha256-7+W+H0a6LUmh3822eUk+jTElEV6DGdNqIGF4mH+1AWU=";
+  };
+
+  patches = [
+    (replaceVars ./fix-paths.patch {
+      tkdnd = "${tcl8Packages.tkdnd}/lib";
+    })
+  ];
+
+  postPatch = ''
+    touch tests/__init__.py
+    substituteInPlace tests/test_tkinterdnd2.py \
+      --replace-fail '2.9.2' '${tcl8Packages.tkdnd.version}'
+  '';
+
+  build-system = [ setuptools ];
+  dependencies = [ tkinter ];
+
+  nativeCheckInputs = [
+    unittestCheckHook
+    xvfb
+  ];
+
+  env.LD_LIBRARY_PATH = lib.makeLibraryPath [ libxcursor ];
+
+  preCheck = ''
+    export DISPLAY=:$((2000 + $RANDOM % 1000))
+    Xvfb $DISPLAY -screen 5 1024x768x8 &
+    xvfb_pid=$!
+  '';
+
+  postCheck = ''
+    sleep 0.5
+    kill $xvfb_pid
+  '';
+
+  meta = {
+    description = "Fork of wrapper for George Petasis' tkDnD Tk extension version 2";
+    homepage = "https://github.com/Eliav2/tkinterdnd2";
+    changelog = "https://github.com/Eliav2/tkinterdnd2/raw/refs/tags/${version}/changelog.txt";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.ryand56 ];
+  };
+}

--- a/pkgs/development/python-modules/tkinterdnd2/fix-paths.patch
+++ b/pkgs/development/python-modules/tkinterdnd2/fix-paths.patch
@@ -1,0 +1,47 @@
+diff --git a/tkinterdnd2/TkinterDnD.py b/tkinterdnd2/TkinterDnD.py
+index 5395278..a1ad3a8 100755
+--- a/tkinterdnd2/TkinterDnD.py
++++ b/tkinterdnd2/TkinterDnD.py
+@@ -30,41 +30,7 @@ def _require(tkroot):
+     '''Internal function.'''
+     global TkdndVersion
+     try:
+-        import os
+-        import platform
+-
+-        # On Windows, platform.machine() returns the identifier of the
+-        # *host* architecture, which does not necessarily match the
+-        # architecture of the running python process. For example, when
+-        # running x86 python under x64 Windows, the return value is AMD64;
+-        # when running either x86 or x64 python under arm64 Windows, the
+-        # return value is ARM64. The architecture of the running process
+-        # can be obtained from the PROCESSOR_ARCHITECTURE environment variable,
+-        # which is automatically set by Windows / WOW subsystem.
+-        system = platform.system()
+-        if system=="Windows":
+-            machine = os.environ.get('PROCESSOR_ARCHITECTURE', platform.machine())
+-        else:
+-            machine = platform.machine()
+-
+-        if system=="Darwin" and machine=="arm64":
+-            tkdnd_platform_rep = "osx-arm64"
+-        elif system=="Darwin" and machine=="x86_64":
+-            tkdnd_platform_rep = "osx-x64"
+-        elif system=="Linux" and machine=="aarch64":
+-            tkdnd_platform_rep = "linux-arm64"
+-        elif system=="Linux" and machine=="x86_64":
+-            tkdnd_platform_rep = "linux-x64"
+-        elif system=="Windows" and machine=="ARM64":
+-            tkdnd_platform_rep = "win-arm64"
+-        elif system=="Windows" and machine=="AMD64":
+-            tkdnd_platform_rep = "win-x64"
+-        elif system=="Windows" and machine=="x86":
+-            tkdnd_platform_rep = "win-x86"
+-        else:
+-            raise RuntimeError('Plaform not supported.')
+-
+-        module_path = os.path.join(os.path.dirname(__file__), 'tkdnd', tkdnd_platform_rep)
++        module_path = "@tkdnd@"
+         tkroot.tk.call('lappend', 'auto_path', module_path)
+         TkdndVersion = tkroot.tk.call('package', 'require', 'tkdnd')
+     except tkinter.TclError:

--- a/pkgs/development/tcl-modules/by-name/tk/tkdnd/package.nix
+++ b/pkgs/development/tcl-modules/by-name/tk/tkdnd/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  mkTclDerivation,
+  fetchFromGitHub,
+
+  tk,
+
+  libx11,
+  libxcursor,
+}:
+mkTclDerivation rec {
+  pname = "tkdnd";
+  version = "2.9.5";
+
+  src = fetchFromGitHub {
+    owner = "petasis";
+    repo = "tkdnd";
+    tag = "tkdnd-release-test-v${version}";
+    hash = "sha256-VF1f9HSEThyFy3u7d3Kvo7EIpoosz6KpLOiHkf89PQI=";
+  };
+
+  configureFlags = [
+    "--with-tk=${tk}/lib"
+    "--with-tkinclude=${lib.getDev tk}/include"
+  ];
+
+  buildInputs = [
+    libx11
+    libxcursor
+  ];
+
+  meta = {
+    description = "Extension to the Tk toolkit that adds native drag and drop support";
+    homepage = "https://github.com/petasis/tkdnd";
+    changelog = "https://github.com/petasis/tkdnd/raw/refs/tags/${src.tag}/Changelog";
+    license = lib.licenses.tcltk;
+    maintainers = [ lib.maintainers.ryand56 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19551,6 +19551,8 @@ self: super: with self; {
 
   tkinter-gl = callPackage ../development/python-modules/tkinter-gl { };
 
+  tkinterdnd2 = callPackage ../development/python-modules/tkinterdnd2 { };
+
   tld = callPackage ../development/python-modules/tld { };
 
   tldextract = callPackage ../development/python-modules/tldextract { };


### PR DESCRIPTION
Depends on #518225

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
