### PR TITLE
bombsquad: 1.7.61 -> 1.7.62

### DIFF
--- a/pkgs/by-name/bo/bombsquad/package.nix
+++ b/pkgs/by-name/bo/bombsquad/package.nix
@@ -25,11 +25,11 @@ let
     {
       x86_64-linux = {
         name = "BombSquad_Linux_x86_64";
-        hash = "sha256-VHhDRzB7sSvb3Ou/Sg+PjTKFDG9sKsXueu2qLNfC06k=";
+        hash = "sha256-Su7xEVzgFBl+Q2iFWdIRbyO8lRs8Xd4KabFhycZUVjs=";
       };
       aarch64-linux = {
         name = "BombSquad_Linux_Arm64";
-        hash = "sha256-usrhPOsXkJZk0HCSBIGnc4qdIu2SW7STp6Y/e6RmZlM=";
+        hash = "sha256-Q87KbQqwEOaMiJ4uSgZ3eD8AYKQCoJWPzq7rt9Nu9Co=";
       };
     }
     .${stdenv.targetPlatform.system} or (throw "${stdenv.targetPlatform.system} is unsupported.");
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
   # Note: This version trails behind the latest version by one since the latest
   # version sometimes gets replaced for minor updates. The builds in /old/ are
   # stable.
-  version = "1.7.61";
+  version = "1.7.62";
 
   src = fetchurl {
     url = "https://files.ballistica.net/bombsquad/builds/old/${archive.name}_${finalAttrs.version}.tar.gz";
@@ -89,13 +89,17 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/bin $out/libexec $out/share/bombsquad/ba_data
 
     install -Dm555 -t $out/libexec ${finalAttrs.meta.mainProgram}
+    # x86_64 bundles Discord partner SDK; aarch64 currently does not.
+    if [ -e libdiscord_partner_sdk.so ]; then
+      install -Dm555 -t $out/libexec libdiscord_partner_sdk.so
+    fi
     cp -r ba_data $out/share/bombsquad
 
     makeWrapper "$out/libexec/${finalAttrs.meta.mainProgram}" "$out/bin/${finalAttrs.meta.mainProgram}" \
       --add-flags ${lib.escapeShellArg commandLineArgs} \
       --add-flags "-d $out/share/bombsquad"
 
-    install -Dm755 ${bombsquadIcon} $out/share/icons/bombsquad.png
+    install -Dm444 ${bombsquadIcon} $out/share/icons/bombsquad.png
 
     runHook postInstall
   '';


### PR DESCRIPTION
Opening this manually instead of waiting for the update bot because the game now ships with a new `libdiscord_partner_sdk.so`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
