### PR TITLE
hyprland-preview-share-picker: init at 0.2.1

### DIFF
--- a/pkgs/by-name/hy/hyprland-preview-share-picker/package.nix
+++ b/pkgs/by-name/hy/hyprland-preview-share-picker/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  glib,
+  gtk4,
+  gtk4-layer-shell,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "hyprland-preview-share-picker";
+  version = "0.2.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "WhySoBad";
+    repo = "hyprland-preview-share-picker";
+    tag = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-Zztb0soSN/NynWnBIGPuUNRKt2xSx/+f+QpYIPRyRdc=";
+  };
+
+  cargoHash = "sha256-AqX9jKj7JLEx1SLefyaWYGbRdk0c3H/NDTIsZy6B6hY=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    glib
+    gtk4
+    gtk4-layer-shell
+  ];
+
+  strictDeps = true;
+
+  postInstall = ''
+    $out/bin/hyprland-preview-share-picker schema > schema.json
+    install -Dm0644 schema.json -t $out/share/hyprland-preview-share-picker
+  '';
+
+  meta = {
+    description = "Alternative share picker for hyprland with window and monitor previews";
+    homepage = "https://github.com/WhySoBad/hyprland-preview-share-picker";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sophronesis ];
+    platforms = lib.platforms.linux;
+    mainProgram = "hyprland-preview-share-picker";
+  };
+})


### PR DESCRIPTION
An alternative share picker for hyprland with window and monitor previews. Launched by xdg-desktop-portal-hyprland (`screencopy.custom_picker_binary` in `xdph.conf`) to let the user pick a window or output when sharing the screen, with live thumbnails via the hyprland toplevel-export protocol.

Homepage: https://github.com/WhySoBad/hyprland-preview-share-picker

Tested on Framework 16 (Hyprland) - picker launches and renders monitor/window previews when triggered by xdph.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.