### PR TITLE
pgcenter: update homepage

### DIFF
--- a/pkgs/by-name/pg/pgcenter/package.nix
+++ b/pkgs/by-name/pg/pgcenter/package.nix
@@ -34,7 +34,7 @@ buildGoModule (finalAttrs: {
   doCheck = false;
 
   meta = {
-    homepage = "https://pgcenter.org/";
+    homepage = "https://github.com/lesovsky/pgcenter";
     changelog = "https://github.com/lesovsky/pgcenter/raw/v${finalAttrs.version}/doc/Changelog";
     description = "Command-line admin tool for observing and troubleshooting PostgreSQL";
     license = lib.licenses.bsd3;


### PR DESCRIPTION
Update homepage to github page. Previous domain is expired.

## Things done


- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
