### PR TITLE
symlink symbols and footprint libraries into kicad-base so that kicad…

### DIFF
--- a/pkgs/by-name/ki/kicad/base.nix
+++ b/pkgs/by-name/ki/kicad/base.nix
@@ -62,6 +62,7 @@
   debug,
   sanitizeAddress,
   sanitizeThreads,
+  templateDir ? null,
 }:
 
 assert lib.assertMsg (
@@ -206,6 +207,14 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   dontStrip = debug;
+
+  # KiCad looks for the stock library tables at
+  # KICAD_LIBRARY_DATA/template/{sym,fp}-lib-table, where KICAD_LIBRARY_DATA is
+  # compiled in as $out/share/kicad. Those files live in separate library packages.
+  postInstall = optionalString (templateDir != null) ''
+    rm -rf $out/share/kicad/template
+    ln -s ${templateDir} $out/share/kicad/template
+  '';
 
   meta = {
     description = "Just the built source without the libraries";

--- a/pkgs/by-name/ki/kicad/package.nix
+++ b/pkgs/by-name/ki/kicad/package.nix
@@ -186,6 +186,7 @@ stdenv.mkDerivation rec {
     inherit wxGTK python wxPython;
     inherit withNgspice withScripting withI18n;
     inherit debug sanitizeAddress sanitizeThreads;
+    templateDir = template_dir;
   };
 
   inherit pname;


### PR DESCRIPTION
… 10 can discover it

This pr resolved #515658

By default the symbol library path points to: /nix/store/xxx-kicad-base-10.0.1/share/kicad/template/sym-lib-table, which currently does not exist, as the symbol library lives in its own derivation. This PR adds a symlink in that location so that kicad 10 can discover the symbol and footprint libraries.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
