### PR TITLE
professor: 2.4.2 -> 2.5.8

### DIFF
--- a/pkgs/by-name/pr/professor/package.nix
+++ b/pkgs/by-name/pr/professor/package.nix
@@ -7,15 +7,15 @@
   python3,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "professor";
-  version = "2.4.2";
+  version = "2.5.8";
 
   src = fetchFromGitLab {
     owner = "hepcedar";
     repo = "professor";
-    tag = "professor-2.4.2";
-    hash = "sha256-z2Ub7SUTz4Hj3ajnzOV/QXZ+cH2v6zJv9UZM2M2y1Hg=";
+    tag = "professor-${finalAttrs.version}";
+    hash = "sha256-q1OxYnsr4xE7NSZekQq9AeMFPv1B+/VMu6ZttKPQsBs=";
     # workaround unpacking to case-sensitive filesystems
     postFetch = ''
       rm -rf $out/[Dd]ocker
@@ -23,15 +23,24 @@ stdenv.mkDerivation {
   };
 
   postPatch = ''
+    substituteInPlace configure \
+      --replace-fail '$(which $PYTHON 2> /dev/null)' '$(command -v $PYTHON)' \
+      --replace-fail '$(which $CYTHON 2> /dev/null)' '$(command -v $CYTHON)' \
+      --replace-fail '$(which $ROOTCONFIG 2> /dev/null)' '$(command -v $ROOTCONFIG)'
     substituteInPlace Makefile \
-      --replace-fail 'pip install ' 'pip install --prefix $(out) '
+      --replace-fail 'pip wheel' 'pip wheel --no-build-isolation'
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace Makefile \
       --replace-fail '-shared -o' '-shared -install_name "$(out)/$@" -o'
   '';
 
+  configureFlags = [ "--with-eigen=${eigen}" ];
+
+  env.PYTHON = "python3";
+
   nativeBuildInputs = [
+    python3
     python3.pkgs.cython
     python3.pkgs.pip
     python3.pkgs.setuptools
@@ -49,11 +58,6 @@ stdenv.mkDerivation {
     yoda
   ];
 
-  env = {
-    CPPFLAGS = toString [ "-I${eigen}/include/eigen3" ];
-    PREFIX = placeholder "out";
-  };
-
   postInstall = ''
     for prog in "$out"/bin/*; do
       wrapProgram "$prog" --set PYTHONPATH "$PYTHONPATH:$(toPythonPath "$out")"
@@ -70,4 +74,4 @@ stdenv.mkDerivation {
     maintainers = [ lib.maintainers.veprbl ];
     platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
Release: https://gitlab.com/hepcedar/professor/-/tags/professor-2.5.8
Diff: https://gitlab.com/hepcedar/professor/-/compare/professor-2.4.2...professor-2.5.8
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327088160)](https://hydra.nixos.org/build/327088160)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test