### PR TITLE
odp-dpdk: fix build with intel-ipsec-mb and gcc 15

### DIFF
--- a/pkgs/by-name/od/odp-dpdk/package.nix
+++ b/pkgs/by-name/od/odp-dpdk/package.nix
@@ -2,9 +2,11 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   autoreconfHook,
   pkg-config,
   dpdk,
+  intel-ipsec-mb,
   libbpf,
   libconfig,
   libpcap,
@@ -31,6 +33,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./odp-dpdk_25.03.patch
+    # Fix gcc 15 -Wunterminated-string-initialization errors in test code.
+    (fetchpatch2 {
+      url = "https://github.com/OpenDataPlane/odp-dpdk/commit/56c6bdbe8fe9db4c0441162ec269ef4e1ebd1a6a.patch";
+      hash = "sha256-aj4HuGb0BUxsKtFS3X3gXqBoRVRnKEBNxa/4heWhBlE=";
+    })
   ];
 
   nativeBuildInputs = [
@@ -44,6 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
         ./dpdk_25.03.patch
       ];
     })
+    intel-ipsec-mb
     libconfig
     libpcap
     numactl


### PR DESCRIPTION
GCC 15 Regression Tracking: #475479
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327061746)](https://hydra.nixos.org/build/327061746)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test