### PR TITLE
gnome-shell: fix tecla path patch

### DIFF
--- a/pkgs/by-name/gn/gnome-shell/fix-paths.patch
+++ b/pkgs/by-name/gn/gnome-shell/fix-paths.patch
@@ -31,18 +31,6 @@ index 53fd92846..89533cedc 100644
          Gio.SubprocessFlags.NONE);
  
      try {
-diff --git a/js/ui/status/keyboard.js b/js/ui/status/keyboard.js
-index 1b43e1051..a31b0a304 100644
---- a/js/ui/status/keyboard.js
-+++ b/js/ui/status/keyboard.js
-@@ -1104,6 +1104,6 @@ class InputSourceIndicator extends PanelMenu.Button {
-     _showLayout() {
-         Main.overview.hide();
- 
--        Util.spawn(['tecla']);
-+        Util.spawn(['@tecla@']);
-     }
- });
 diff --git a/subprojects/extensions-tool/src/command-install.c b/subprojects/extensions-tool/src/command-install.c
 index 11fb4b6b7..e00e4807b 100644
 --- a/subprojects/extensions-tool/src/command-install.c

--- a/pkgs/by-name/gn/gnome-shell/package.nix
+++ b/pkgs/by-name/gn/gnome-shell/package.nix
@@ -56,7 +56,6 @@
   gnome-clocks,
   gnome-settings-daemon,
   gnome-autoar,
-  gnome-tecla,
   bash-completion,
   lcms2,
   libgbm,
@@ -91,7 +90,6 @@ stdenv.mkDerivation (finalAttrs: {
     (replaceVars ./fix-paths.patch {
       glib_compile_schemas = "${glib.dev}/bin/glib-compile-schemas";
       gsettings = "${glib.bin}/bin/gsettings";
-      tecla = "${lib.getBin gnome-tecla}/bin/tecla";
       unzip = "${lib.getBin unzip}/bin/unzip";
     })
 


### PR DESCRIPTION
The Tecla binary isn't hardcoded since:
https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/4c879d707f6012db7916e0fbc09b45ff48633c6f

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
