### PR TITLE
[release-25.11] weblate: mark as vulnerable

### DIFF
--- a/pkgs/by-name/we/weblate/package.nix
+++ b/pkgs/by-name/we/weblate/package.nix
@@ -189,5 +189,22 @@ python.pkgs.buildPythonApplication rec {
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ erictapen ];
     mainProgram = "weblate";
+    knownVulnerabilities = [
+      "CVE-2026-24126: 6.6 Medium https://github.com/NixOS/nixpkgs/issues/510510"
+      "CVE-2026-27457: 4.3 Medium https://github.com/NixOS/nixpkgs/issues/494757"
+      "CVE-2026-33212: 3.1 Low https://github.com/NixOS/nixpkgs/issues/510512"
+      "CVE-2026-33214: 4.3 Medium https://github.com/NixOS/nixpkgs/issues/510520"
+      "CVE-2026-33220: 6.8 Medium https://github.com/NixOS/nixpkgs/issues/510519"
+      "CVE-2026-33435: 8.1 High https://github.com/NixOS/nixpkgs/issues/510516"
+      "CVE-2026-33440: 5.0 Medium https://github.com/NixOS/nixpkgs/issues/510517"
+      "CVE-2026-34242: 7.7 High https://github.com/NixOS/nixpkgs/issues/510511"
+      "CVE-2026-34244: 5.0 Medium https://github.com/NixOS/nixpkgs/issues/510515"
+      "CVE-2026-34393: 8.8 High https://github.com/NixOS/nixpkgs/issues/510513"
+      "CVE-2026-39845: 4.1 Medium https://github.com/NixOS/nixpkgs/issues/510509"
+      "CVE-2026-40256: 5.0 Medium https://github.com/NixOS/nixpkgs/issues/510518"
+      "CVE-2026-41519: 4.2 Medium https://github.com/NixOS/nixpkgs/issues/518006"
+      "CVE-2026-44263: 4.3 Medium https://github.com/NixOS/nixpkgs/issues/518008"
+      "CVE-2026-44264: 4.3 Medium https://github.com/NixOS/nixpkgs/issues/518015"
+    ];
   };
 }


### PR DESCRIPTION
Most of these issues are fixed on 5.17 (which we have on unstable).

Closes https://github.com/NixOS/nixpkgs/issues/510510
Closes https://github.com/NixOS/nixpkgs/issues/494757
Closes https://github.com/NixOS/nixpkgs/issues/510512
Closes https://github.com/NixOS/nixpkgs/issues/510520
Closes https://github.com/NixOS/nixpkgs/issues/510519
Closes https://github.com/NixOS/nixpkgs/issues/510516
Closes https://github.com/NixOS/nixpkgs/issues/510517
Closes https://github.com/NixOS/nixpkgs/issues/510511
Closes https://github.com/NixOS/nixpkgs/issues/510515
Closes https://github.com/NixOS/nixpkgs/issues/510513
Closes https://github.com/NixOS/nixpkgs/issues/510509
Closes https://github.com/NixOS/nixpkgs/issues/510518

The last three need to be fixed addressed on unstable as well.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
