### PR TITLE
tracee: 0.23.2 -> 0.24.1

### DIFF
--- a/pkgs/by-name/tr/tracee/0001-fix-do-not-build-libbpf.patch
+++ b/pkgs/by-name/tr/tracee/0001-fix-do-not-build-libbpf.patch
@@ -11,7 +11,7 @@ diff --git a/Makefile b/Makefile
 index 0fce8de12..bb9937ed5 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -77,7 +77,7 @@ get_priv_reqs_recursive() { \
+@@ -94,7 +94,7 @@ get_priv_reqs_recursive() { \
  	fi; \
  	processed_libs="$$processed_libs $$lib"; \
  	if [ "$$lib" = "libbpf" ]; then \
@@ -20,16 +20,16 @@ index 0fce8de12..bb9937ed5 100644
  	else \
  		echo $$lib; \
  		priv_reqs=$$($(CMD_PKGCONFIG) --print-requires-private $$lib); \
-@@ -374,7 +374,7 @@ LIBBPF_DESTDIR = $(OUTPUT_DIR)/libbpf
+@@ -445,7 +445,7 @@ LIBBPF_DESTDIR = $(OUTPUT_DIR)/libbpf
  LIBBPF_OBJDIR = $(LIBBPF_DESTDIR)/obj
  LIBBPF_OBJ = $(LIBBPF_OBJDIR)/libbpf.a
  
--$(LIBBPF_OBJ): .build_libbpf .build_libbpf_fix
-+$(LIBBPF_OBJ):
+-$(LIBBPF_OBJ):: .build_libbpf .build_libbpf_fix
++$(LIBBPF_OBJ)::
  
- .build_libbpf: \
+ .build_libbpf:: \
  	$(LIBBPF_SRC) \
-@@ -413,7 +413,7 @@ LIBBPF_INCLUDE_UAPI = ./3rdparty/libbpf/include/uapi/linux
+@@ -483,7 +483,7 @@ LIBBPF_INCLUDE_UAPI = ./3rdparty/libbpf/include/uapi/linux
  	@$(CMD_TOUCH) $@
  
  
@@ -38,7 +38,7 @@ index 0fce8de12..bb9937ed5 100644
  
  .ONESHELL:
  .eval_goenv: $(LIBBPF_OBJ)
-@@ -430,7 +430,7 @@ endif
+@@ -500,7 +500,7 @@ endif
  		$(eval GO_ENV_EBPF += GOARCH=$(GO_ARCH))
  		$(eval CUSTOM_CGO_CFLAGS := "$(TRACEE_EBPF_CFLAGS)")
  		$(eval GO_ENV_EBPF += CGO_CFLAGS=$(CUSTOM_CGO_CFLAGS))
@@ -47,7 +47,7 @@ index 0fce8de12..bb9937ed5 100644
  		$(eval GO_ENV_EBPF := $(GO_ENV_EBPF) CGO_LDFLAGS=$(CUSTOM_CGO_LDFLAGS))
  		export GO_ENV_EBPF=$(GO_ENV_EBPF)
  		echo 'GO_ENV_EBPF := $(GO_ENV_EBPF)' > $(GOENV_MK)
-@@ -486,7 +486,6 @@ TRACEE_SRC_DIRS = ./cmd/ ./pkg/ ./signatures/
+@@ -633,7 +633,6 @@ TRACEE_SRC_DIRS = ./cmd/ ./pkg/ ./signatures/
  TRACEE_SRC = $(shell find $(TRACEE_SRC_DIRS) -type f -name '*.go' ! -name '*_test.go')
  GO_TAGS_EBPF = core,ebpf
  CGO_EXT_LDFLAGS_EBPF =
@@ -57,4 +57,3 @@ index 0fce8de12..bb9937ed5 100644
  TRACEE_PROTOS = ./api/v1beta1/*.proto
 -- 
 2.49.0
-

--- a/pkgs/by-name/tr/tracee/package.nix
+++ b/pkgs/by-name/tr/tracee/package.nix
@@ -19,17 +19,29 @@
 
 buildGoModule (finalAttrs: {
   pname = "tracee";
-  version = "0.23.2";
+  version = "0.24.1";
 
-  # src = /home/tim/repos/tracee;
   src = fetchFromGitHub {
     owner = "aquasecurity";
     repo = "tracee";
-    # project has branches and tags of the same name
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Rf1pa9e6t002ltg40xZZVpE5OL9Vl02Xcn2Ux0To408=";
+    hash = "sha256-TtSc5IfmDGu4BQv4HSumZEF5M2Gga/Svhri6tw3HybU=";
   };
-  vendorHash = "sha256-2+4UN9WB6eGzedogy5dMvhHj1x5VeUUkDM0Z28wKQgM=";
+  vendorHash = "sha256-c5w3lHReff5tD/l03moFfXOR7TzAG0OE/4ASYkjHUC4=";
+
+  proxyVendor = true;
+
+  preBuild = ''
+    go work init . cmd/traceectl api common types
+  '';
+
+  overrideModAttrs = (
+    _: {
+      preBuild = ''
+        go work init . cmd/traceectl api common types
+      '';
+    }
+  );
 
   patches = [
     ./0001-fix-do-not-build-libbpf.patch
@@ -83,7 +95,7 @@ buildGoModule (finalAttrs: {
 
     mkdir -p $out/bin $lib/lib/tracee $share/share/tracee
 
-    mv ./dist/{tracee,signatures} $out/bin/
+    mv ./dist/{tracee,traceectl,signatures} $out/bin/
     mv ./dist/tracee.bpf.o $lib/lib/tracee/
     mv ./cmd/tracee-rules/templates $share/share/tracee/
 


### PR DESCRIPTION
Update version
Fix go build
Update patch

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
