### PR TITLE
amule-{web,gui,daemon}: move overrides to by-name

### DIFF
--- a/pkgs/by-name/am/amule-daemon/package.nix
+++ b/pkgs/by-name/am/amule-daemon/package.nix
@@ -1,0 +1,13 @@
+{
+  amule,
+  ...
+}@args:
+
+amule.override (
+  {
+    monolithic = false;
+    enableDaemon = true;
+    mainProgram = "amuled";
+  }
+  // removeAttrs args [ "amule" ]
+)

--- a/pkgs/by-name/am/amule-gui/package.nix
+++ b/pkgs/by-name/am/amule-gui/package.nix
@@ -1,0 +1,13 @@
+{
+  amule,
+  ...
+}@args:
+
+amule.override (
+  {
+    monolithic = false;
+    client = true;
+    mainProgram = "amulegui";
+  }
+  // removeAttrs args [ "amule" ]
+)

--- a/pkgs/by-name/am/amule-web/package.nix
+++ b/pkgs/by-name/am/amule-web/package.nix
@@ -1,0 +1,13 @@
+{
+  amule,
+  ...
+}@args:
+
+amule.override (
+  {
+    monolithic = false;
+    httpServer = true;
+    mainProgram = "amuleweb";
+  }
+  // removeAttrs args [ "amule" ]
+)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1446,12 +1446,6 @@ with pkgs;
 
   crystfel-headless = crystfel.override { withGui = false; };
 
-  amule-web = amule.override {
-    monolithic = false;
-    httpServer = true;
-    mainProgram = "amuleweb";
-  };
-
   inherit (callPackages ../tools/security/bitwarden-directory-connector { })
     bitwarden-directory-connector-cli
     bitwarden-directory-connector

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1446,12 +1446,6 @@ with pkgs;
 
   crystfel-headless = crystfel.override { withGui = false; };
 
-  amule-gui = amule.override {
-    monolithic = false;
-    client = true;
-    mainProgram = "amulegui";
-  };
-
   amule-web = amule.override {
     monolithic = false;
     httpServer = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1446,12 +1446,6 @@ with pkgs;
 
   crystfel-headless = crystfel.override { withGui = false; };
 
-  amule-daemon = amule.override {
-    monolithic = false;
-    enableDaemon = true;
-    mainProgram = "amuled";
-  };
-
   amule-gui = amule.override {
     monolithic = false;
     client = true;


### PR DESCRIPTION
This pull request refactors the packaging of the `amule-daemon`, `amule-gui`, and `amule-web` packages by moving their configuration from the central `all-packages.nix` file into dedicated `package.nix` files for each variant. This change improves maintainability and modularity by isolating the configuration for each package.

**Refactoring and modularization of amule package variants:**

* Moved the configuration for `amule-daemon` into its own `package.nix` file, using `amule.override` with the appropriate options and removing the direct definition from `all-packages.nix`.

* Moved the configuration for `amule-gui` into its own `package.nix` file, similarly using `amule.override` and cleaning up the central package list.

* Moved the configuration for `amule-web` into its own `package.nix` file, using `amule.override` and removing the previous definition from `all-packages.nix`.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
