### PR TITLE
simplex-chat-desktop: fix updates for aarch64-linux

### DIFF
--- a/pkgs/by-name/si/simplex-chat-desktop/package.nix
+++ b/pkgs/by-name/si/simplex-chat-desktop/package.nix
@@ -2,7 +2,6 @@
   lib,
   appimageTools,
   fetchurl,
-  gitUpdater,
   stdenv,
 }:
 
@@ -13,7 +12,7 @@ let
   sources = {
     "aarch64-linux" = fetchurl {
       url = "https://github.com/simplex-chat/simplex-chat/releases/download/v${version}/simplex-desktop-aarch64.AppImage";
-      hash = "sha256-CvHwYKbieRYbBKUCoKAa11rTy5Opdfb7FKS4poantKs=";
+      hash = "sha256-VrPNKXgVO/9yvGqseOVkYKMFVqhtExL2PCJb6stn3ko=";
     };
     "x86_64-linux" = fetchurl {
       url = "https://github.com/simplex-chat/simplex-chat/releases/download/v${version}/simplex-desktop-x86_64.AppImage";
@@ -46,11 +45,9 @@ appimageTools.wrapType2 {
     cp -r ${appimageContents}/usr/share/icons $out/share
   '';
 
-  passthru.updateScript = gitUpdater {
-    url = "https://github.com/simplex-chat/simplex-chat";
-    rev-prefix = "v";
-    # skip tags that does not correspond to official releases, like vX.Y.Z-(beta,fdroid,armv7a).
-    ignoredVersions = "-";
+  passthru = {
+    inherit sources;
+    updateScript = ./update.sh;
   };
 
   meta = {

--- a/pkgs/by-name/si/simplex-chat-desktop/update.sh
+++ b/pkgs/by-name/si/simplex-chat-desktop/update.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq common-updater-scripts
+
+set -euo pipefail
+
+attr="simplex-chat-desktop"
+
+# Get the latest non-prerelease tag from GitHub.
+latest=$(curl -fsSL ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} \
+  "https://api.github.com/repos/simplex-chat/simplex-chat/releases/latest" \
+  | jq -r '.tag_name')
+
+# Strip the leading "v".
+version="${latest#v}"
+
+# Current version in nixpkgs (so we can short-circuit if unchanged).
+current=$(nix-instantiate --eval -E "with import ./. {}; ${attr}.version" \
+  | tr -d '"')
+
+if [[ "$version" == "$current" ]]; then
+  echo "${attr} is already at ${version}"
+  exit 0
+fi
+
+# Update each per-system source independently.
+update-source-version "$attr" "$version" \
+    --source-key=sources.x86_64-linux
+
+# --ignore-same-version flag silences warning because previous invocation bumped version
+update-source-version "$attr" "$version" \
+    --ignore-same-version \
+    --source-key=sources.aarch64-linux


### PR DESCRIPTION
Replace gitUpdater with a shell script that invokes update-source-version once per system using --source-key, so both per-arch AppImage hashes are refreshed on each version bump.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
