### PR TITLE
jetbrains-jdk: 25.0.2b329.72 -> 25.0.2b432.48

### DIFF
--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -21,19 +21,20 @@ let
       url = "https://raw.githubusercontent.com/GNOME/gtk/${rev}/gdk/wayland/protocol/gtk-shell.xml";
       hash = hash;
     };
+  # To get the new tag:
+  # git clone https://github.com/jetbrains/jetbrainsruntime
+  # cd jetbrainsruntime
+  # git tag --points-at [revision]
+  # Look for the line that starts with jbr-
+  javaVersion = "25.0.2";
+  build = "329.72";
 in
 callPackage ./common.nix
   {
     inherit jdk debugBuild withJcef;
   }
   {
-    # To get the new tag:
-    # git clone https://github.com/jetbrains/jetbrainsruntime
-    # cd jetbrainsruntime
-    # git tag --points-at [revision]
-    # Look for the line that starts with jbr-
-    javaVersion = "25.0.2";
-    build = "329.72";
+    inherit javaVersion build;
     # run `git log -1 --pretty=%ct` in jdk repo for new value on update
     sourceDateEpoch = 1769205294;
     srcHash = "sha256-K4Izbij+1YO4UERHS0mwGKZX/VtIaxyNPZD068Vf99Q=";

--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -27,7 +27,7 @@ let
   # git tag --points-at [revision]
   # Look for the line that starts with jbr-
   javaVersion = "25.0.2";
-  build = "329.72";
+  build = "432.48";
 in
 callPackage ./common.nix
   {
@@ -36,14 +36,14 @@ callPackage ./common.nix
   {
     inherit javaVersion build;
     # run `git log -1 --pretty=%ct` in jdk repo for new value on update
-    sourceDateEpoch = 1769205294;
-    srcHash = "sha256-K4Izbij+1YO4UERHS0mwGKZX/VtIaxyNPZD068Vf99Q=";
+    sourceDateEpoch = 1777242155;
+    srcHash = "sha256-BKyvBUKtg+JbZNuH/RZY87eJng6Eyd6L3cOwcOgOx/Y=";
     homePath = "${jetbrains.jdk}/lib/openjdk";
     jcefPackage = jetbrains.jcef;
     extraBuildPhase = ''
       cp -r ${gtk-protocols.out} gtk-shell.xml
     '';
-    vendorVersionString = "nix/JBR-25.0.2-b329.72${if withJcef then "-jcef" else ""}";
+    vendorVersionString = "nix/JBR-${javaVersion}-b${build}${if withJcef then "-jcef" else ""}";
     extraConfigureFlags = [
       "--with-wayland-protocols=${wayland-protocols.out}/share/wayland-protocols"
     ];

--- a/pkgs/development/compilers/jetbrains-jdk/jcef.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/jcef.nix
@@ -92,11 +92,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "jcef-jetbrains";
-  rev = "a492f5c1bbe877d2f58d4b066d0a1c89ab579b84";
+  rev = "97d05cdf1720586ebfff5d4bc6e15a6a533eb21e";
   # This is the commit number
   # Currently from the branch: https://github.com/JetBrains/jcef/tree/261
   # Run `git rev-list --count HEAD`
-  version = "1131";
+  version = "1156";
 
   nativeBuildInputs = [
     cmake
@@ -126,7 +126,7 @@ stdenv.mkDerivation rec {
     owner = "jetbrains";
     repo = "jcef";
     inherit rev;
-    hash = "sha256-c1gJu6gogALx3viLi9saLvqOn+zS9jCpWizB2g1Xa/g=";
+    hash = "sha256-31WV6vYp0zIf6EkccQTeiggCRtQnDOg8/4J2q6axiGs=";
   };
 
   # Find the hash in tools/buildtools/linux64/clang-format.sha1


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Jetbrains jdk update. 

<img width="739" height="142" alt="image" src="https://github.com/user-attachments/assets/58374773-ed93-42ed-a0f6-50ced8cca9a0" />


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
