### PR TITLE
Revert "gnutls: fix cross-compilation failure since 3.8.12"

### DIFF
--- a/pkgs/by-name/gn/gnutls/package.nix
+++ b/pkgs/by-name/gn/gnutls/package.nix
@@ -112,13 +112,6 @@ stdenv.mkDerivation rec {
   # https://gitlab.com/gnutls/gnutls/-/issues/1721
   + ''
     sed '2iexit 77' -i tests/system-override-compress-cert.sh
-  ''
-  # Upstream packaging bug: stamp_error_codes is missing from EXTRA_DIST in
-  # the release tarball, causing the build to try regenerating it by compiling
-  # and running `errcodes` — which fails when cross-compiling since the binary
-  # is for the target architecture. https://gitlab.com/gnutls/gnutls/-/issues/1797
-  + lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
-    touch doc/stamp_error_codes
   '';
 
   preConfigure = "patchShebangs .";


### PR DESCRIPTION
This reverts commit https://github.com/NixOS/nixpkgs/commit/34e34f6971444724542f921764a525efd2323bd7.

No longer needed with gnutls 3.8.13.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
