### PR TITLE
cambrinary: migrate to by-name, use PEP517 format

### DIFF
--- a/pkgs/by-name/ca/cambrinary/package.nix
+++ b/pkgs/by-name/ca/cambrinary/package.nix
@@ -16,11 +16,11 @@ python3Packages.buildPythonApplication {
     hash = "sha256-wDcvpKAY/6lBjO5h3qKH3+Y2G2gm7spcKCXFMt/bAtE=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     python3Packages.flit
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     python3Packages.aiohttp
     python3Packages.beautifulsoup4
   ];

--- a/pkgs/by-name/ca/cambrinary/package.nix
+++ b/pkgs/by-name/ca/cambrinary/package.nix
@@ -1,13 +1,10 @@
 {
   lib,
-  buildPythonApplication,
+  python3Packages,
   fetchFromGitHub,
-  flit,
-  aiohttp,
-  beautifulsoup4,
 }:
 
-buildPythonApplication {
+python3Packages.buildPythonApplication {
   pname = "cambrinary";
   version = "unstable-2023-07-16";
   pyproject = true;
@@ -20,12 +17,12 @@ buildPythonApplication {
   };
 
   nativeBuildInputs = [
-    flit
+    python3Packages.flit
   ];
 
   propagatedBuildInputs = [
-    aiohttp
-    beautifulsoup4
+    python3Packages.aiohttp
+    python3Packages.beautifulsoup4
   ];
 
   pythonImportsCheck = [ "cambrinary" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1661,8 +1661,6 @@ with pkgs;
 
   intelLlvmStdenv = intel-llvm.stdenv;
 
-  cambrinary = python3Packages.callPackage ../applications/misc/cambrinary { };
-
   cplex = callPackage ../applications/science/math/cplex (config.cplex or { });
 
   cot = with python3Packages; toPythonApplication cot;


### PR DESCRIPTION
This pull request refactors the packaging of the `cambrinary` Python application to align with current Nixpkgs best practices and to simplify dependency management. The package definition is moved, updated to use the `python3Packages` namespace for dependencies, and its registration in the package set is removed, likely in preparation for a new inclusion method.

**Packaging refactor and dependency updates:**

* Moved the package definition for `cambrinary` from `pkgs/applications/misc/cambrinary/default.nix` to `pkgs/by-name/ca/cambrinary/package.nix`, following the new directory structure for Python packages.
* Updated the packaging to use `python3Packages.buildPythonApplication` and referenced dependencies via `python3Packages`, replacing the previous direct references and `buildPythonApplication`.
* Changed the way build and runtime dependencies are specified, using `build-system` and `dependencies` instead of `nativeBuildInputs` and `propagatedBuildInputs` for better compatibility with modern Python packaging in Nix.

**Package set registration:**

* Removed the registration of `cambrinary` from `pkgs/top-level/all-packages.nix`, suggesting it will now be included via the new package set mechanism.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
