### PR TITLE
ffsubsync: switch to python3Packages set, fix formatting

### DIFF
--- a/pkgs/by-name/ff/ffsubsync/package.nix
+++ b/pkgs/by-name/ff/ffsubsync/package.nix
@@ -1,11 +1,11 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchFromGitHub,
   ffmpeg,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "ffsubsync";
   version = "0.4.31";
   pyproject = true;
@@ -17,9 +17,11 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     hash = "sha256-j9E4h2de2EOtYpuxKFbPOxZ5FBRO0EkbZhJdx5RiPn8=";
   };
 
-  build-system = with python3.pkgs; [ setuptools ];
+  build-system = with python3Packages; [
+    setuptools
+  ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     auditok
     charset-normalizer
     faust-cchardet
@@ -36,9 +38,13 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     webrtcvad
   ];
 
-  nativeCheckInputs = with python3.pkgs; [ pytestCheckHook ];
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+  ];
 
-  pythonImportsCheck = [ "ffsubsync" ];
+  pythonImportsCheck = [
+    "ffsubsync"
+  ];
 
   makeWrapperArgs = [
     "--prefix"


### PR DESCRIPTION
This pull request refactors the `ffsubsync` package definition to use `python3Packages` instead of `python3.pkgs` throughout the file. This change improves consistency with Nixpkgs best practices and simplifies dependency management.

Dependency management improvements:

* Switched from using `python3.pkgs` to `python3Packages` for all Python-related functions and dependencies, including `buildPythonApplication`, `build-system`, `dependencies`, and `nativeCheckInputs` in `pkgs/by-name/ff/ffsubsync/package.nix`.

Code style and consistency:

* Reformatted list definitions for `build-system`, `dependencies`, `nativeCheckInputs`, and `pythonImportsCheck` to use one item per line, improving readability.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
