### PR TITLE
nimlangserver: 1.12.0 -> 1.14.0

### DIFF
--- a/pkgs/by-name/ni/nimlangserver/lock.json
+++ b/pkgs/by-name/ni/nimlangserver/lock.json
@@ -184,11 +184,11 @@
     },
     {
       "method": "fetchzip",
-      "path": "/nix/store/2ksmfd7p93a1a7ibcv3qzsk8h3c3shz7-source",
-      "rev": "845b6af28b9f68f02d320e03ad18eccccea7ddb9",
-      "sha256": "1c55kl05pbavm9v5dv42n43sql9qcrblhh3hnp99p5xmlv20c9vf",
+      "path": "/nix/store/y97vkzpip50iy91xdgv7v7kg04afxn7x-source",
+      "rev": "8b51e99b4a57fcfb31689230e75595f024543024",
+      "sha256": "00bg4chz69hllj9ig3qd38ps9l3hcziwj9kgykhbdcavgw5llzbg",
       "srcDir": "",
-      "url": "https://github.com/status-im/nim-unittest2/archive/845b6af28b9f68f02d320e03ad18eccccea7ddb9.tar.gz",
+      "url": "https://github.com/status-im/nim-unittest2/archive/8b51e99b4a57fcfb31689230e75595f024543024.tar.gz",
       "subDir": "",
       "packages": [
         "unittest2"

--- a/pkgs/by-name/ni/nimlangserver/package.nix
+++ b/pkgs/by-name/ni/nimlangserver/package.nix
@@ -6,7 +6,7 @@
 buildNimPackage (
   final: prev: rec {
     pname = "nimlangserver";
-    version = "1.12.0";
+    version = "1.14.0";
 
     # nix build ".#nimlangserver.src"
     # nix run "github:daylinmorgan/nnl" -- result/nimble.lock -o:pkgs/by-name/ni/nimlangserver/lock.json --git,=,bearssl,zlib
@@ -16,7 +16,7 @@ buildNimPackage (
       owner = "nim-lang";
       repo = "langserver";
       rev = "v${version}";
-      hash = "sha256-yf3oiKwsJoQxRPhbEBMJN+TR7j58t6ggjq51DJ3ypGQ=";
+      hash = "sha256-IJbuM/AhPgyfe/1ONY8Nb46+gqjduVQOvkgGafgkhY4=";
     };
 
     doCheck = false;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Release Notes](https://github.com/nim-lang/langserver/releases/tag/v1.14.0)

Opened in favor of #518066 to also update the lock file.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
