### PR TITLE
androidenv.ndk-bundle: use `${package.path}` instead of `ndk/${packag…

### DIFF
--- a/pkgs/development/mobile/androidenv/ndk-bundle/default.nix
+++ b/pkgs/development/mobile/androidenv/ndk-bundle/default.nix
@@ -76,8 +76,8 @@ deployAndroidPackage rec {
 
     # Ndk now has a prebuilt toolchains inside, the file layout has changed, we do a symlink
     # to still support the old standalone toolchains builds.
-    if [ -d $out/libexec/android-sdk/ndk ] && [ ! -d $out/libexec/android-sdk/ndk-bundle ]; then
-      ln -sf $out/libexec/android-sdk/ndk/${package.revision} $out/libexec/android-sdk/ndk-bundle
+    if [ -d $out/libexec/android-sdk/${package.path} ] && [ ! -d $out/libexec/android-sdk/ndk-bundle ]; then
+      ln -sf $out/libexec/android-sdk/${package.path} $out/libexec/android-sdk/ndk-bundle
     elif [ ! -d $out/libexec/android-sdk/ndk-bundle ]; then
       echo "The ndk-bundle layout has changed. The nix expressions have to be updated!"
       exit 1


### PR DESCRIPTION
…e.revision}`

Current implementation of the `ndk-bundle` symlink uses
`${package.revision}` to construct the source path. However, for Release
Candidate (RC) versions of the NDK (e.g., `30.0.14904198-rc1`), the
actual directory created matches `${package.path}`, not the raw revision
string. This leads to a dangling symlink and causes build failures for
these NDK versions.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
