### PR TITLE
lufus: repository moved

### DIFF
--- a/pkgs/by-name/lu/lufus/package.nix
+++ b/pkgs/by-name/lu/lufus/package.nix
@@ -11,7 +11,7 @@ python313Packages.buildPythonApplication (finalAttrs: {
   version = "1.0.0b1.1";
 
   src = fetchFromGitHub {
-    owner = "Hog185";
+    owner = "Hogjects";
     repo = "Lufus";
     tag = "v${finalAttrs.version}";
     sha256 = "sha256-3i0CnhGvLTXutz8CQoH5q4PwZ23lAwnUo8H5TRJx+KE=";
@@ -65,7 +65,7 @@ python313Packages.buildPythonApplication (finalAttrs: {
 
   meta = {
     description = "A rufus clone written in py and designed to work with linux";
-    homepage = "https://github.com/Hog185/Lufus";
+    homepage = "https://github.com/Hogjects/Lufus";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ Simon-Weij ];
     platforms = lib.platforms.linux;


### PR DESCRIPTION
Lufus moved from https://github.com/Hog185/Lufus to https://github.com/Hogjects/Lufus, currently github correctly redirects to the new location, but we should use the new location anyways


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
