### PR TITLE
noriskclient-launcher-unwrapped: 0.6.20 -> 0.6.21

### DIFF
--- a/pkgs/by-name/no/noriskclient-launcher-unwrapped/package.nix
+++ b/pkgs/by-name/no/noriskclient-launcher-unwrapped/package.nix
@@ -2,8 +2,6 @@
   cargo-tauri,
   desktop-file-utils,
   fetchFromGitHub,
-  fetchpatch,
-  fetchurl,
   fetchYarnDeps,
   glib,
   gtk3,
@@ -20,20 +18,17 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "noriskclient-launcher-unwrapped";
-  version = "0.6.20";
+  version = "0.6.21";
 
   src = fetchFromGitHub {
     owner = "NoRiskClient";
     repo = "noriskclient-launcher";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-VChMA6XXKgtytLFOORxnpNnTrunKaIJkFge2Xu4FjG0=";
+    hash = "sha256-RiKFSKHnyeiIcSaOltr4qv0pEBX5wctfztZ+8yrHjnE=";
   };
 
   yarnOfflineCache = fetchYarnDeps {
-    yarnLock = fetchurl {
-      url = "https://raw.githubusercontent.com/NoRiskClient/noriskclient-launcher/937b275341191552a08757c9b4e5eb7802d54945/yarn.lock";
-      hash = "sha256-IqhgDMthwEAd/rzat119Ajaf8p8LgTDEj/KrS2xVFuQ=";
-    };
+    yarnLock = "${finalAttrs.src}/yarn.lock";
     hash = "sha256-VWl6YqTiBRz85GICFKGwDZRBcITGQdWE7EUzW58wHdY=";
   };
 
@@ -43,13 +38,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
     # Make the launcher find java from PATH, instead of downloading its own, which is not going to work on NixOS.
     ./java-from-path.patch
-
-    # The version of tauri in Cargo.toml and in package.json aren't matching, causing the build to fail. Upstream PR is https://github.com/NoRiskClient/noriskclient-launcher/pull/222.
-    (fetchpatch {
-      name = "fix-tauri-version-mismatch";
-      url = "https://github.com/NoRiskClient/noriskclient-launcher/commit/937b275341191552a08757c9b4e5eb7802d54945.patch";
-      hash = "sha256-jI0KnvUpSJU739BfZeYFMhtZKjno1UrWWGwMLS3I6ag=";
-    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
changelog: https://github.com/NoRiskClient/noriskclient-launcher/blob/v3/changelogs/0.6.21.md
diff: https://github.com/NoRiskClient/noriskclient-launcher/compare/v0.6.20...v0.6.21

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
