### PR TITLE
maintainers: remove emattiza

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7971,12 +7971,6 @@
     github = "EmanuelM153";
     githubId = 134736553;
   };
-  emattiza = {
-    email = "nix@mattiza.dev";
-    github = "emattiza";
-    githubId = 11719476;
-    name = "Evan Mattiza";
-  };
   embr = {
     email = "hi@liclac.eu";
     github = "liclac";

--- a/pkgs/by-name/ot/otel-cli/package.nix
+++ b/pkgs/by-name/ot/otel-cli/package.nix
@@ -43,9 +43,7 @@ buildGoModule (finalAttrs: {
     description = "Command-line tool for sending OpenTelemetry traces";
     changelog = "https://github.com/equinix-labs/otel-cli/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [
-      emattiza
-    ];
+    maintainers = [ ];
     mainProgram = "otel-cli";
   };
 })

--- a/pkgs/development/python-modules/result/default.nix
+++ b/pkgs/development/python-modules/result/default.nix
@@ -35,6 +35,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/rustedpy/result";
     changelog = "https://github.com/rustedpy/result/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ emattiza ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
## Reasons

- Last commented in [July 2024](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Aemattiza)
- Hasn't created any PRs / Issues since [July 2024](https://github.com/NixOS/nixpkgs/issues?q=author%3Aemattiza)
- About 2 [unanswered ](https://github.com/NixOS/nixpkgs/issues?q=involves%3Aemattiza%20-commenter%3Aemattiza%20-author%3Aemattiza%20-reviewed-by%3Aemattiza) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] otel-cli
- [ ] pythonPackages.result