### PR TITLE
various: switch to python3Packages set #1

### DIFF
--- a/pkgs/by-name/aa/aab/package.nix
+++ b/pkgs/by-name/aa/aab/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
   fetchFromGitHub,
-  python3,
+  python3Packages,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "aab";
   version = "1.0.0-dev.5";
   pyproject = true;
@@ -22,9 +22,9 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     ./allow-manually-setting-modtime.patch
   ];
 
-  build-system = [ python3.pkgs.poetry-core ];
+  build-system = [ python3Packages.poetry-core ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     jsonschema
     whichcraft
     pyqt5
@@ -32,9 +32,9 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   ];
 
   nativeCheckInputs = [
-    python3.pkgs.pytestCheckHook
-    python3.pkgs.pyqt5
-    python3.pkgs.pyqt6
+    python3Packages.pytestCheckHook
+    python3Packages.pyqt5
+    python3Packages.pyqt6
   ];
 
   pythonImportsCheck = [ "aab" ];

--- a/pkgs/by-name/ab/above/package.nix
+++ b/pkgs/by-name/ab/above/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchFromGitHub,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "above";
   version = "2.8.1";
   pyproject = true;
@@ -16,9 +16,9 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     hash = "sha256-wyXWGfthzJeHZoJe4OKe9k2BIwLae/aOUtiJpT4SfHw=";
   };
 
-  build-system = with python3.pkgs; [ setuptools ];
+  build-system = with python3Packages; [ setuptools ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     colorama
     scapy
   ];

--- a/pkgs/by-name/ac/ac-library/package.nix
+++ b/pkgs/by-name/ac/ac-library/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   lib,
   python3,
+  python3Packages,
   nix-update-script,
   cmake,
 }:
@@ -29,12 +30,12 @@ stdenv.mkDerivation (finalAttrs: {
     "out"
   ];
 
-  buildInputs = [
+  nativeBuildInputs = [
     python3
   ];
 
   nativeInstallCheckInputs = [
-    python3.pkgs.pytest
+    python3Packages.pytest
     cmake
   ];
 

--- a/pkgs/by-name/ac/accerciser/package.nix
+++ b/pkgs/by-name/ac/accerciser/package.nix
@@ -10,14 +10,14 @@
   wrapGAppsHook3,
   gobject-introspection,
   itstool,
-  python3,
+  python3Packages,
   at-spi2-core,
   gettext,
   libwnck,
   librsvg,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "accerciser";
   version = "3.48.0";
 
@@ -46,7 +46,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     librsvg
   ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  propagatedBuildInputs = with python3Packages; [
     dbus-python
     ipython
     pyatspi

--- a/pkgs/by-name/ad/ad-miner/package.nix
+++ b/pkgs/by-name/ad/ad-miner/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchFromGitHub,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "ad-miner";
   version = "1.8.1";
   pyproject = true;
@@ -19,9 +19,9 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   # All requirements are pinned
   pythonRelaxDeps = true;
 
-  build-system = with python3.pkgs; [ poetry-core ];
+  build-system = with python3Packages; [ poetry-core ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     neo4j
     numpy
     pytz

--- a/pkgs/by-name/ad/adafruit-ampy/package.nix
+++ b/pkgs/by-name/ad/adafruit-ampy/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchPypi,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "adafruit-ampy";
   version = "1.1.0";
   pyproject = true;
@@ -14,11 +14,11 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     sha256 = "f4cba36f564096f2aafd173f7fbabb845365cc3bb3f41c37541edf98b58d3976";
   };
 
-  build-system = with python3.pkgs; [
+  build-system = with python3Packages; [
     setuptools
   ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     click
     python-dotenv
     pyserial

--- a/pkgs/by-name/ad/adcskiller/package.nix
+++ b/pkgs/by-name/ad/adcskiller/package.nix
@@ -1,11 +1,11 @@
 {
   lib,
   fetchFromGitHub,
-  python3,
+  python3Packages,
   coercer,
 }:
 
-python3.pkgs.buildPythonApplication {
+python3Packages.buildPythonApplication {
   pname = "adcskiller";
   version = "0-unstable-2024-05-19";
   pyproject = false;
@@ -21,7 +21,7 @@ python3.pkgs.buildPythonApplication {
     coercer
   ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  propagatedBuildInputs = with python3Packages; [
     ldap3
     certipy
   ];

--- a/pkgs/by-name/ad/adenum/package.nix
+++ b/pkgs/by-name/ad/adenum/package.nix
@@ -2,10 +2,10 @@
   lib,
   fetchFromGitHub,
   john,
-  python3,
+  python3Packages,
 }:
 
-python3.pkgs.buildPythonApplication {
+python3Packages.buildPythonApplication {
   pname = "adenum";
   version = "0-unstable-2022-04-01";
   pyproject = false;
@@ -18,7 +18,7 @@ python3.pkgs.buildPythonApplication {
   };
 
   propagatedBuildInputs =
-    with python3.pkgs;
+    with python3Packages;
     [
       impacket
       pwntools

--- a/pkgs/by-name/ad/adidnsdump/package.nix
+++ b/pkgs/by-name/ad/adidnsdump/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
   fetchFromGitHub,
-  python3,
+  python3Packages,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "adidnsdump";
   version = "1.4.0";
   pyproject = true;
@@ -16,9 +16,9 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     hash = "sha256-gKOIZuXYm8ltaajmOZXulPX5dI4fWz4xiZ8W0kPpcRk=";
   };
 
-  build-system = with python3.pkgs; [ setuptools ];
+  build-system = with python3Packages; [ setuptools ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     impacket
     ldap3
   ];

--- a/pkgs/by-name/ai/aiodnsbrute/package.nix
+++ b/pkgs/by-name/ai/aiodnsbrute/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
   fetchFromGitHub,
-  python3,
+  python3Packages,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "aiodnsbrute";
   version = "0.3.3";
   pyproject = true;
@@ -16,11 +16,11 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     hash = "sha256-cEpk71VoQJZfKeAZummkk7yjtXKSMndgo0VleYiMlWE=";
   };
 
-  build-system = with python3.pkgs; [
+  build-system = with python3Packages; [
     setuptools
   ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     aiodns
     click
     tqdm

--- a/pkgs/by-name/ai/airlift/package.nix
+++ b/pkgs/by-name/ai/airlift/package.nix
@@ -1,13 +1,13 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchPypi,
   kubernetes-helm,
   kind,
   docker,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
 
   pname = "airlift";
   pyproject = true;
@@ -27,7 +27,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   ];
 
   nativeBuildInputs = [
-    python3.pkgs.poetry-core
+    python3Packages.poetry-core
   ];
 
   buildInputs = [
@@ -36,7 +36,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     docker
   ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  propagatedBuildInputs = with python3Packages; [
     halo
     pyyaml
     hiyapyco

--- a/pkgs/by-name/al/alacarte/package.nix
+++ b/pkgs/by-name/al/alacarte/package.nix
@@ -2,6 +2,7 @@
   lib,
   fetchFromGitLab,
   python3,
+  python3Packages,
   autoconf,
   automake,
   gettext,
@@ -15,7 +16,7 @@
   docbook_xsl,
   nix-update-script,
 }:
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "alacarte";
   version = "3.58.0";
 
@@ -46,7 +47,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     gtk3
   ];
 
-  propagatedBuildInputs = with python3.pkgs; [ pygobject3 ];
+  propagatedBuildInputs = with python3Packages; [ pygobject3 ];
 
   configureScript = "./autogen.sh";
 

--- a/pkgs/by-name/al/alerta-server/package.nix
+++ b/pkgs/by-name/al/alerta-server/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchPypi,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "alerta-server";
   version = "9.0.1";
   format = "setuptools";
@@ -14,7 +14,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     hash = "sha256-v4+0l5Sx9RTxmNFnKCoKrWFl1xu1JIRZ/kiI6zi/y0I=";
   };
 
-  propagatedBuildInputs = with python3.pkgs; [
+  propagatedBuildInputs = with python3Packages; [
     bcrypt
     blinker
     cryptography

--- a/pkgs/by-name/al/alerta/package.nix
+++ b/pkgs/by-name/al/alerta/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchPypi,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "alerta";
   version = "8.5.3";
   pyproject = true;
@@ -14,9 +14,9 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     hash = "sha256-ePvT2icsgv+io5aDDUr1Zhfodm4wlqh/iqXtNkFhS10=";
   };
 
-  build-system = with python3.pkgs; [ setuptools ];
+  build-system = with python3Packages; [ setuptools ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     click
     requests
     requests-hawk
@@ -28,7 +28,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   pythonImportsCheck = [ "alertaclient" ];
 
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = with python3Packages; [
     pytestCheckHook
     requests-mock
   ];

--- a/pkgs/by-name/al/almonds/package.nix
+++ b/pkgs/by-name/al/almonds/package.nix
@@ -1,11 +1,11 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchFromGitHub,
   ncurses,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "almonds";
   version = "1.25b";
   pyproject = true;
@@ -17,13 +17,13 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     sha256 = "0j8d8jizivnfx8lpc4w6sbqj5hq35nfz0vdg7ld80sc5cs7jr3ws";
   };
 
-  build-system = with python3.pkgs; [ setuptools ];
+  build-system = with python3Packages; [ setuptools ];
 
-  dependencies = with python3.pkgs; [ pillow ];
+  dependencies = with python3Packages; [ pillow ];
 
   buildInputs = [ ncurses ];
 
-  nativeCheckInputs = with python3.pkgs; [ pytestCheckHook ];
+  nativeCheckInputs = with python3Packages; [ pytestCheckHook ];
 
   meta = {
     description = "Terminal Mandelbrot fractal viewer";

--- a/pkgs/by-name/am/amoco/package.nix
+++ b/pkgs/by-name/am/amoco/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
   fetchFromGitHub,
-  python3,
+  python3Packages,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "amoco";
   version = "2.9.8";
   pyproject = true;
@@ -16,11 +16,11 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     hash = "sha256-3+1ssFyU7SKFJgDYBQY0kVjmTHOD71D2AjnH+4bfLXo=";
   };
 
-  build-system = with python3.pkgs; [
+  build-system = with python3Packages; [
     setuptools
   ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     blessed
     click
     crysp
@@ -31,7 +31,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   ];
 
   optional-dependencies = {
-    app = with python3.pkgs; [
+    app = with python3Packages; [
       # ccrawl
       ipython
       prompt-toolkit
@@ -41,7 +41,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     ];
   };
 
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = with python3Packages; [
     pytestCheckHook
   ];
 

--- a/pkgs/by-name/an/annextimelog/package.nix
+++ b/pkgs/by-name/an/annextimelog/package.nix
@@ -1,11 +1,11 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchFromGitLab,
   fetchPypi,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "annextimelog";
   version = "0.15.0";
   pyproject = true;
@@ -19,7 +19,7 @@ python3.pkgs.buildPythonApplication rec {
 
   pythonRelaxDeps = [ "rich" ];
 
-  nativeBuildInputs = with python3.pkgs; [
+  nativeBuildInputs = with python3Packages; [
     unittestCheckHook
     setuptools
     wheel
@@ -29,7 +29,7 @@ python3.pkgs.buildPythonApplication rec {
 
   unittestFlags = [ "-vb" ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  propagatedBuildInputs = with python3Packages; [
     rich
   ];
 

--- a/pkgs/by-name/an/antimony/package.nix
+++ b/pkgs/by-name/an/antimony/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   libpng,
   python3,
+  python3Packages,
   libGLU,
   libGL,
   libsForQt5,
@@ -47,7 +48,7 @@ stdenv.mkDerivation {
   buildInputs = [
     libpng
     python3
-    python3.pkgs.boost
+    python3Packages.boost
     libGLU
     libGL
     libsForQt5.qtbase

--- a/pkgs/by-name/ap/apachetomcatscanner/package.nix
+++ b/pkgs/by-name/ap/apachetomcatscanner/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
   fetchFromGitHub,
-  python3,
+  python3Packages,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "apachetomcatscanner";
   version = "3.8.2";
   pyproject = true;
@@ -27,9 +27,9 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     "urllib3"
   ];
 
-  build-system = with python3.pkgs; [ setuptools ];
+  build-system = with python3Packages; [ setuptools ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  propagatedBuildInputs = with python3Packages; [
     requests
     sectools
     urllib3

--- a/pkgs/by-name/ap/apkid/package.nix
+++ b/pkgs/by-name/ap/apkid/package.nix
@@ -2,9 +2,10 @@
   lib,
   fetchFromGitHub,
   python3,
+  python3Packages,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "apkid";
   version = "3.1.0";
   pyproject = true;
@@ -22,11 +23,11 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
       --replace "yara-python-dex>=1.0.1" "yara-python"
   '';
 
-  build-system = with python3.pkgs; [ setuptools ];
+  build-system = with python3Packages; [ setuptools ];
 
-  dependencies = with python3.pkgs; [ yara-python ];
+  dependencies = with python3Packages; [ yara-python ];
 
-  nativeCheckInputs = with python3.pkgs; [ pytestCheckHook ];
+  nativeCheckInputs = with python3Packages; [ pytestCheckHook ];
 
   preBuild = ''
     # Prepare the YARA rules

--- a/pkgs/by-name/ap/apkleaks/package.nix
+++ b/pkgs/by-name/ap/apkleaks/package.nix
@@ -2,10 +2,10 @@
   lib,
   fetchFromGitHub,
   jadx,
-  python3,
+  python3Packages,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "apkleaks";
   version = "2.6.3";
   pyproject = true;
@@ -17,9 +17,9 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     hash = "sha256-8P4LZsyq0mSVdE6QhnW3QaaA3UAg4UDBS3jSg7Kg/oY=";
   };
 
-  build-system = with python3.pkgs; [ setuptools ];
+  build-system = with python3Packages; [ setuptools ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     jadx
     pyaxmlparser
     setuptools

--- a/pkgs/by-name/ap/apksigcopier/package.nix
+++ b/pkgs/by-name/ap/apksigcopier/package.nix
@@ -5,10 +5,10 @@
   fetchFromGitHub,
   installShellFiles,
   pandoc,
-  python3,
+  python3Packages,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "apksigcopier";
   version = "1.1.1";
   pyproject = true;
@@ -25,11 +25,11 @@ python3.pkgs.buildPythonApplication rec {
     pandoc
   ];
 
-  build-system = with python3.pkgs; [
+  build-system = with python3Packages; [
     setuptools
   ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     click
   ];
 

--- a/pkgs/by-name/ap/appgate-sdp/package.nix
+++ b/pkgs/by-name/ap/appgate-sdp/package.nix
@@ -33,6 +33,7 @@
   openssl,
   pango,
   python3,
+  python3Packages,
   stdenv,
   systemd,
   xdg-utils,
@@ -113,7 +114,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     python3
-    python3.pkgs.dbus-python
+    python3Packages.dbus-python
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ar/arcanechat-tui/package.nix
+++ b/pkgs/by-name/ar/arcanechat-tui/package.nix
@@ -1,12 +1,13 @@
 {
   lib,
   python3,
+  python3Packages,
   fetchFromGitHub,
   testers,
   arcanechat-tui,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "arcanechat-tui";
   version = "0.12.0";
   pyproject = true;
@@ -25,7 +26,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   pythonRelaxDeps = true;
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     appdirs
     deltachat2
     urwid

--- a/pkgs/by-name/ar/arjun/package.nix
+++ b/pkgs/by-name/ar/arjun/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchFromGitHub,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "arjun";
   version = "2.2.7-unstable-2025-02-20";
   pyproject = true;
@@ -16,9 +16,9 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     hash = "sha256-z6YGCwypp69+98KSC1YUzJETfwb3V4Qp1sV5V3N9zMI=";
   };
 
-  build-system = with python3.pkgs; [ setuptools ];
+  build-system = with python3Packages; [ setuptools ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     dicttoxml
     ratelimit
     requests

--- a/pkgs/by-name/ar/arsenal/package.nix
+++ b/pkgs/by-name/ar/arsenal/package.nix
@@ -1,11 +1,11 @@
 {
   lib,
   fetchFromGitHub,
-  python3,
+  python3Packages,
   versionCheckHook,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "arsenal";
   version = "1.2.7";
   pyproject = true;
@@ -17,11 +17,11 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     sha256 = "sha256-C8DEB/xojU7vGvmeBF+PBD6KWMaJgwa7PpRS5+YzQ6c=";
   };
 
-  build-system = with python3.pkgs; [
+  build-system = with python3Packages; [
     setuptools
   ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     libtmux
     docutils
     pyfzf

--- a/pkgs/by-name/as/asahi-fwextract/package.nix
+++ b/pkgs/by-name/as/asahi-fwextract/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchFromGitHub,
   gzip,
   gnutar,
@@ -8,7 +8,7 @@
   nix-update-script,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "asahi-fwextract";
   version = "0.8.0";
   pyproject = true;
@@ -28,7 +28,7 @@ python3.pkgs.buildPythonApplication rec {
       --replace-fail '"xf"' '"-x", "-I", "${gzip}/bin/gzip", "-f"'
   '';
 
-  build-system = [ python3.pkgs.setuptools ];
+  build-system = [ python3Packages.setuptools ];
 
   passthru = {
     updateScript = nix-update-script { };

--- a/pkgs/by-name/as/asciidoc/package.nix
+++ b/pkgs/by-name/as/asciidoc/package.nix
@@ -3,6 +3,7 @@
   lib,
   stdenv,
   python3,
+  python3Packages,
   fetchFromGitHub,
   autoreconfHook,
   installShellFiles,
@@ -56,7 +57,7 @@
 }:
 
 let
-  inherit (python3.pkgs)
+  inherit (python3Packages)
     pygments
     matplotlib
     numpy
@@ -140,7 +141,7 @@ let
   };
 
 in
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname =
     "asciidoc"
     + lib.optionalString enableStandardFeatures "-full"
@@ -307,7 +308,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     installManPage doc/asciidoc.1 doc/a2x.1 doc/testasciidoc.1
   '';
 
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = with python3Packages; [
     pytest
     pytest-mock
   ];

--- a/pkgs/by-name/as/asn1editor/package.nix
+++ b/pkgs/by-name/as/asn1editor/package.nix
@@ -1,11 +1,11 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchFromGitHub,
   wrapGAppsHook3,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "asn1editor";
   version = "0.8.0";
   pyproject = true;
@@ -17,12 +17,12 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     hash = "sha256-mgluhC2DMS4OyS/BoWqBdVf7GcxquOtOKTHZ/hbiHQM=";
   };
 
-  build-system = with python3.pkgs; [
+  build-system = with python3Packages; [
     setuptools
     wrapGAppsHook3
   ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     asn1tools
     coverage
     wxpython

--- a/pkgs/by-name/at/atomic-operator/package.nix
+++ b/pkgs/by-name/at/atomic-operator/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
   fetchFromGitHub,
-  python3,
+  python3Packages,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "atomic-operator";
   version = "0.8.5";
   pyproject = true;
@@ -16,7 +16,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     hash = "sha256-DyNqu3vndyLkmfybCfTbgxk3t/ALg7IAkAMg4kBkH7Q=";
   };
 
-  build-system = with python3.pkgs; [
+  build-system = with python3Packages; [
     setuptools
   ];
 
@@ -25,7 +25,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     "urllib3"
   ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     attrs
     certifi
     chardet
@@ -40,7 +40,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     urllib3
   ];
 
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = with python3Packages; [
     pytestCheckHook
   ];
 

--- a/pkgs/by-name/at/atop/package.nix
+++ b/pkgs/by-name/at/atop/package.nix
@@ -9,6 +9,7 @@
   findutils,
   systemd,
   python3,
+  python3Packages,
   nixosTests,
   # makes the package unfree via pynvml
   withAtopgpu ? false,
@@ -27,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ]
   ++ lib.optionals withAtopgpu [
-    python3.pkgs.wrapPython
+    python3Packages.wrapPython
   ];
 
   buildInputs = [
@@ -40,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   pythonPath = lib.optionals withAtopgpu [
-    python3.pkgs.pynvml
+    python3Packages.pynvml
   ];
 
   makeFlags = [

--- a/pkgs/by-name/au/audiness/package.nix
+++ b/pkgs/by-name/au/audiness/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
   fetchFromGitHub,
-  python3,
+  python3Packages,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "audiness";
   version = "1.0.0";
   pyproject = true;
@@ -21,15 +21,15 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     "validators"
   ];
 
-  build-system = with python3.pkgs; [ poetry-core ];
+  build-system = with python3Packages; [ poetry-core ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     pytenable
     typer
     validators
   ];
 
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = with python3Packages; [
     pytest-mock
     pytestCheckHook
   ];

--- a/pkgs/by-name/au/autobloody/package.nix
+++ b/pkgs/by-name/au/autobloody/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchFromGitHub,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "autobloody";
   version = "1.1.0";
   pyproject = true;
@@ -16,11 +16,11 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     hash = "sha256-iv2Al5FQMZNVrAxvrwYjglPBxEUUZ9Jn1wFd5B4b9WY=";
   };
 
-  nativeBuildInputs = with python3.pkgs; [
+  nativeBuildInputs = with python3Packages; [
     hatchling
   ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  propagatedBuildInputs = with python3Packages; [
     bloodyad
     neo4j
   ];
@@ -28,7 +28,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   # Tests require a test file which is not available in the current release
   doCheck = false;
 
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = with python3Packages; [
     pytestCheckHook
   ];
 

--- a/pkgs/by-name/au/autorandr/package.nix
+++ b/pkgs/by-name/au/autorandr/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchFromGitHub,
   systemd,
   xrandr,
@@ -9,7 +9,7 @@
   udevCheckHook,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "autorandr";
   version = "1.15";
   pyproject = false;
@@ -26,7 +26,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     desktop-file-utils
     udevCheckHook
   ];
-  propagatedBuildInputs = with python3.pkgs; [ packaging ];
+  propagatedBuildInputs = with python3Packages; [ packaging ];
 
   buildPhase = ''
     substituteInPlace autorandr.py \

--- a/pkgs/by-name/au/autosuspend/package.nix
+++ b/pkgs/by-name/au/autosuspend/package.nix
@@ -3,13 +3,13 @@
   dbus,
   fetchFromGitHub,
   nixosTests,
-  python3,
+  python3Packages,
   sphinxHook,
   withDocs ? true,
   withMan ? true,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "autosuspend";
   version = "10.1.0";
   pyproject = true;
@@ -42,11 +42,11 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   sphinxBuilders = lib.optionals withDocs [ "html" ] ++ lib.optionals withMan [ "man" ];
 
-  build-system = with python3.pkgs; [
+  build-system = with python3Packages; [
     setuptools
   ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     dbus-python
     icalendar
     jsonpath-ng
@@ -62,7 +62,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   ];
 
   optional-dependencies = {
-    docs = with python3.pkgs; [
+    docs = with python3Packages; [
       furo
       recommonmark
       sphinx-autodoc-typehints
@@ -71,7 +71,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     ];
   };
 
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = with python3Packages; [
     dbus
     freezegun
     pytest-cov-stub

--- a/pkgs/by-name/au/autotools-language-server/package.nix
+++ b/pkgs/by-name/au/autotools-language-server/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchFromGitHub,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "autotools-language-server";
   version = "0.0.23";
   pyproject = true;
@@ -17,16 +17,16 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   };
 
   build-system = [
-    python3.pkgs.setuptools-generate
-    python3.pkgs.setuptools-scm
+    python3Packages.setuptools-generate
+    python3Packages.setuptools-scm
   ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     tree-sitter-make
     lsp-tree-sitter
   ];
   nativeCheckInputs = [
-    python3.pkgs.pytestCheckHook
+    python3Packages.pytestCheckHook
   ];
 
   meta = {

--- a/pkgs/by-name/aw/aws-sam-cli/package.nix
+++ b/pkgs/by-name/aw/aws-sam-cli/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchFromGitHub,
   git,
   testers,
@@ -9,7 +9,7 @@
   enableTelemetry ? false,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "aws-sam-cli";
   version = "1.160.0";
   pyproject = true;
@@ -21,7 +21,7 @@ python3.pkgs.buildPythonApplication rec {
     hash = "sha256-IBxnBIgTSpPUNb/4yx3OqA7WFzudzRKgkKCFsJeyx08=";
   };
 
-  build-system = with python3.pkgs; [ setuptools ];
+  build-system = with python3Packages; [ setuptools ];
 
   pythonRelaxDeps = [
     "aws_lambda_builders"
@@ -43,7 +43,7 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   dependencies =
-    with python3.pkgs;
+    with python3Packages;
     [
       aws-lambda-builders
       aws-sam-translator
@@ -69,7 +69,7 @@ python3.pkgs.buildPythonApplication rec {
       watchdog
     ]
     ++ (
-      with python3.pkgs.boto3-stubs.optional-dependencies;
+      with python3Packages.boto3-stubs.optional-dependencies;
       lib.concatLists [
         apigateway
         cloudformation
@@ -95,7 +95,7 @@ python3.pkgs.buildPythonApplication rec {
       --prefix PATH : $out/bin:${lib.makeBinPath [ git ]}
   '';
 
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = with python3Packages; [
     filelock
     flaky
     jaraco-text

--- a/pkgs/by-name/aw/awslimitchecker/package.nix
+++ b/pkgs/by-name/aw/awslimitchecker/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
   fetchFromGitHub,
-  python3,
+  python3Packages,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "awslimitchecker";
   version = "12.0.0";
   pyproject = true;
@@ -21,9 +21,9 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     ./version.patch
   ];
 
-  build-system = with python3.pkgs; [ setuptools ];
+  build-system = with python3Packages; [ setuptools ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     boto3
     botocore
     pytz
@@ -31,7 +31,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     versionfinder
   ];
 
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = with python3Packages; [
     freezegun
     onetimepass
     pyotp

--- a/pkgs/by-name/aw/awslogs/package.nix
+++ b/pkgs/by-name/aw/awslogs/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
   fetchFromGitHub,
-  python3,
+  python3Packages,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "awslogs";
   version = "0.15.0";
   pyproject = true;
@@ -16,7 +16,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     sha256 = "sha256-o6xZqwlqAy01P+TZ0rB5rpEddWNUBzzHp7/cycpcwes=";
   };
 
-  propagatedBuildInputs = with python3.pkgs; [
+  propagatedBuildInputs = with python3Packages; [
     boto3
     termcolor
     python-dateutil
@@ -30,7 +30,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
       --replace "boto3>=1.34.75" "boto3>=1.34.58"
   '';
 
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = with python3Packages; [
     pytestCheckHook
   ];
 


### PR DESCRIPTION
This pull request refactors several Python package definitions to consistently use the `python3Packages` attribute set instead of the older `python3.pkgs` and `python3` references. This change helps standardize package definitions and improves maintainability across the codebase. All affected files in the `pkgs/by-name` directory now use `python3Packages` for build functions, dependencies, and native inputs.

**Refactoring to use `python3Packages`:**

* Updated all occurrences of `python3.pkgs.buildPythonApplication` and `python3.pkgs.buildPythonPackage` to use `python3Packages.buildPythonApplication` and `python3Packages.buildPythonPackage` respectively.

* Updated all dependency, build-system, native input, and propagated input references from `python3.pkgs` to `python3Packages`.

**Other related improvements:**

* In `pkgs/by-name/ac/ac-library/package.nix`, updated `nativeBuildInputs` and `nativeInstallCheckInputs` to use `python3Packages` instead of `python3.pkgs`.

* Added `python3Packages` to the argument list where necessary for consistency.

This refactor ensures all Python package expressions use the modern and consistent `python3Packages` attribute set, which is the recommended approach in Nixpkgs.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
