### PR TITLE
abc-verifier: 0.62 -> 0.64 and use cmake

### DIFF
--- a/pkgs/by-name/ab/abc-verifier/cmake.patch
+++ b/pkgs/by-name/ab/abc-verifier/cmake.patch
@@ -1,0 +1,42 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bbb153e64..4d5a3093c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -117,14 +117,13 @@ set_property(TARGET libabc-pic PROPERTY OUTPUT_NAME abc-pic)
+ 
+ if(NOT DEFINED ABC_SKIP_TESTS)
+     enable_testing()
+-    include(FetchContent)
+-    FetchContent_Declare(
+-    googletest
+-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+-    # Specify the commit you depend on and update it regularly.
+-    URL "https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip"
+-    )
+-    FetchContent_MakeAvailable(googletest)
++    find_package(GTest REQUIRED)
+     include(GoogleTest)
+     add_subdirectory(test)
+-endif()
+\ No newline at end of file
++endif()
++
++include(GNUInstallDirs)
++install(TARGETS abc libabc
++    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++)
+\ No newline at end of file
+diff --git a/test/gia/CMakeLists.txt b/test/gia/CMakeLists.txt
+index e4dffd475..dd8bcb9bd 100644
+--- a/test/gia/CMakeLists.txt
++++ b/test/gia/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ add_executable(gia_test gia_test.cc)
+ 
+ target_link_libraries(gia_test
+-    gtest_main
++    GTest::gtest_main
+     libabc
+ )
+ 

--- a/pkgs/by-name/ab/abc-verifier/package.nix
+++ b/pkgs/by-name/ab/abc-verifier/package.nix
@@ -26,11 +26,12 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     # This prevents CMake from trying to download googletest during the build
     (lib.cmakeBool "ABC_SKIP_TESTS" true)
+    (lib.cmakeBool "BUILD_SHARED_LIBS" true)
   ];
 
   installPhase = ''
     runHook preInstall
-    install -Dm755 'abc' "$out/bin/abc"
+    cmake --install .
     runHook postInstall
   '';
 

--- a/pkgs/by-name/ab/abc-verifier/package.nix
+++ b/pkgs/by-name/ab/abc-verifier/package.nix
@@ -9,7 +9,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "abc-verifier";
-  version = "0.62";
+  version = "0.64";
 
   src = fetchFromGitHub {
     owner = "yosyshq";

--- a/pkgs/by-name/ab/abc-verifier/package.nix
+++ b/pkgs/by-name/ab/abc-verifier/package.nix
@@ -20,6 +20,9 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ readline ];
 
+  # thank you to the Arch Linux developers
+  patches = [ ./cmake.patch ];
+
   cmakeFlags = [
     # This prevents CMake from trying to download googletest during the build
     (lib.cmakeBool "ABC_SKIP_TESTS" true)

--- a/pkgs/by-name/ab/abc-verifier/package.nix
+++ b/pkgs/by-name/ab/abc-verifier/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   readline,
+  gtest,
   cmake,
 }:
 
@@ -20,14 +21,17 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ readline ];
 
+  doCheck = true;
+  checkInputs = [ gtest ];
+
   # thank you to the Arch Linux developers
   patches = [ ./cmake.patch ];
 
   cmakeFlags = [
-    # This prevents CMake from trying to download googletest during the build
-    (lib.cmakeBool "ABC_SKIP_TESTS" true)
     (lib.cmakeBool "BUILD_SHARED_LIBS" true)
-  ];
+  ]
+  # ABC CMake switches on definition not value
+  ++ lib.optional (!finalAttrs.doCheck) (lib.cmakeBool "ABC_SKIP_TESTS" true);
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
I adopted a patch from the Arch repos ([0BSD license](https://gitlab.archlinux.org/archlinux/packaging/packages/abc/-/blob/bc679da052f9717c6f19c23fec2bf435cc9ea68a/LICENSE)) which allows us to run the disabled checks, ships the shared library which is useful and I updated abc in the process.

I apologize but I don't have the resources right now to run nixpkgs-review as ACL2's book tests depend on abc apparently. And those take a long time.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
