### PR TITLE
sublime4-dev: 4199 → 4205

### DIFF
--- a/pkgs/applications/editors/sublime/4/common.nix
+++ b/pkgs/applications/editors/sublime/4/common.nix
@@ -23,6 +23,7 @@
   common-updater-scripts,
   curl,
   openssl_1_1,
+  openssl_3_5,
   bzip2,
   sqlite,
 }:
@@ -33,7 +34,7 @@ let
   binaries = [
     "sublime_text"
     "plugin_host-3.3"
-    "plugin_host-3.8"
+    "plugin_host-3.${if lib.versionAtLeast buildVersion "4205" then "14" else "8"}"
     crashHandlerBinary
   ];
   primaryBinary = "sublime_text";
@@ -90,12 +91,20 @@ let
       for binary in ${builtins.concatStringsSep " " binaries}; do
         patchelf \
           --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-          --set-rpath ${lib.makeLibraryPath neededLibraries}:${lib.getLib stdenv.cc.cc}/lib${lib.optionalString stdenv.hostPlatform.is64bit "64"} \
+          --set-rpath ${lib.makeLibraryPath neededLibraries}:${lib.getLib stdenv.cc.cc}/lib${lib.optionalString stdenv.hostPlatform.is64bit "64"}:$out \
           $binary
       done
 
+      # Unable to get plugin_host-3.14 not crash with Python from Nixpkgs
+      ${lib.optionalString (lib.versionAtLeast buildVersion "4205") "patchelf --set-rpath ${
+        lib.makeLibraryPath [
+          sqlite
+          openssl_3_5
+        ]
+      } libpython3.14.so.1.0"}
+
       # Rewrite pkexec argument. Note that we cannot delete bytes in binary.
-      sed -i -e 's,/bin/cp\x00,cp\x00\x00\x00\x00\x00\x00,g' ${primaryBinary}
+      ${lib.optionalString (lib.versionOlder buildVersion "4205") "sed -i -e 's,/bin/cp\\x00,cp\\x00\\x00\\x00\\x00\\x00\\x00,g' ${primaryBinary}"}
 
       runHook postBuild
     '';
@@ -106,6 +115,7 @@ let
       # No need to patch these libraries, it works well with our own
       rm libcrypto.so.1.1 libssl.so.1.1
       ${lib.optionalString (lib.versionAtLeast buildVersion "4145") "rm libsqlite3.so"}
+      ${lib.optionalString (lib.versionAtLeast buildVersion "4205") "rm libcrypto.so.3 libssl.so.3"}
 
       mkdir -p $out
       cp -r * $out/
@@ -116,7 +126,7 @@ let
     dontWrapGApps = true; # non-standard location, need to wrap the executables manually
 
     postFixup = ''
-      sed -i 's#/usr/bin/pkexec#pkexec\x00\x00\x00\x00\x00\x00\x00\x00\x00#g' "$out/${primaryBinary}"
+      ${lib.optionalString (lib.versionOlder buildVersion "4205") "sed -i 's#/usr/bin/pkexec#pkexec\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00#g' \"$out/${primaryBinary}\""}
 
       wrapProgram $out/${primaryBinary} \
         --set LOCALE_ARCHIVE "${glibcLocales.out}/lib/locale/locale-archive" \

--- a/pkgs/applications/editors/sublime/4/packages.nix
+++ b/pkgs/applications/editors/sublime/4/packages.nix
@@ -11,9 +11,9 @@ in
   } { };
 
   sublime4-dev = common {
-    buildVersion = "4199";
+    buildVersion = "4205";
     dev = true;
-    x64sha256 = "Nrhwv+ox/SW21c8wZtuX9mzHQ+o9ghsI50dU2kDvCX0=";
-    aarch64sha256 = "3vCXj53f2Qlt/Ab3hNNng+Y4Ch85Dp0G8srTVBtd6zU=";
+    x64sha256 = "1Tg8m4FNrVOeHK6VSmlua30pW4Bu7Gz+sT0t/w01UyM=";
+    aarch64sha256 = "K94UipUVZRh8xJKYW35be0u9L/VHpZ+FYhC26v41b3U=";
   } { };
 }


### PR DESCRIPTION
- `/usr/bin/pkexec` no longer hardcoded – [does not seem to work](https://github.com/sublimehq/sublime_text/issues/3502#issuecomment-4407894124)
- Python 3.8 replaced with 3.14.4

Unfortunately, I was not able to use `python314` from Nixpkgs because `plugin_host-3.14` kept crashing in `PyConfig_SetWideStringList`.

Even though abidiff looks fine and I do not see anything in `include/python3.14/cpython/initconfig.h` that I would guess to be relevant to changing the layout of `PyConfig` struct, if I am not mistaken both appear to be compiled without Py_GIL_DISABLED, Py_STATS and Py_DEBUG. I even tried disabling LTO and bumping nixpkgs Python to 3.14.4.

So I kept the vendored variant, only unvendoring its OpenSSL 3 dependency. Using OpenSSL 3.5 since it is LTS.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
