### PR TITLE
om: init at 0.1.6

### DIFF
--- a/pkgs/by-name/om/om/package.nix
+++ b/pkgs/by-name/om/om/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromCodeberg,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "om";
+  version = "0.1.6";
+
+  src = fetchFromCodeberg {
+    owner = "undltd";
+    repo = "om";
+    tag = finalAttrs.version;
+    hash = "sha256-hlGwpvEG0W6BwtdYkkz9I3BKO875B2+z0JYlVEw+OAc=";
+  };
+
+  cargoHash = "sha256-pO139mVjFAi0NgiUqpJM+hG99uxGFBD6rU+X8kflrh4=";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Command line tool to conveniently mount, unmount, (un)lock and safely power off storage devices on Linux with as few keystrokes as possible";
+    homepage = "https://codeberg.org/undltd/om";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ phijor ];
+    mainProgram = "om";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Package the `om` CLI for interactively (un)mounting disks on Linux.

https://codeberg.org/undltd/om/

The derivation...

* includes `passthru.updateScript` for automated updates
* has minimal package tests (currently a version check)
* is Linux-specific (the package uses `udisks`)
* sets `__structuredAttrs = true` (took me a while to figure out what **NPV-166** was, cf. https://github.com/NixOS/nixpkgs-vet/issues/234)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
