### PR TITLE
yrba: init at 2.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14975,6 +14975,13 @@
     github = "lilioid";
     githubId = 12398140;
   };
+  lilith-roth = {
+    name = "Lilith Roth";
+    email = "lilith@roth.systems";
+    matrix = "@lily_squeaks:matrix.roth.systems";
+    github = "lilith-roth";
+    githubId = 96540347;
+  };
   LilleAila = {
     name = "Olai";
     email = "olai@olai.dev";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -468,6 +468,7 @@
   ./services/backup/syncoid.nix
   ./services/backup/tarsnap.nix
   ./services/backup/tsm.nix
+  ./services/backup/yrba.nix
   ./services/backup/zfs-replication.nix
   ./services/backup/znapzend.nix
   ./services/backup/zrepl.nix

--- a/nixos/modules/services/backup/yrba.nix
+++ b/nixos/modules/services/backup/yrba.nix
@@ -1,0 +1,82 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.yrba;
+
+  settingsFormat = pkgs.formats.toml { };
+  configFile = settingsFormat.generate "yrba.toml" cfg.extraConfig;
+in
+{
+  meta.maintainers = with lib.maintainers; [
+    lilith-roth
+  ];
+
+  options.services.yrba = {
+    enable = lib.mkEnableOption "Incremental remote backups made easy!";
+
+    package = lib.mkPackageOption pkgs "yrba" { };
+
+    schedule = {
+      enable = lib.mkEnableOption "Periodic backups with YRBA";
+
+      dates = lib.mkOption {
+        type = lib.types.singleLineStr;
+        default = "weekly";
+        description = ''
+          How often backups are created and uploaded/copied. Passed to systemd.time
+
+          The format is described in
+          {manpage}`systemd.time(7)`.
+        '';
+      };
+    };
+
+    extraConfig = lib.mkOption {
+      default = { };
+      description = "Extra configuration options for telegraf";
+      type = settingsFormat.type;
+    };
+  };
+
+  config = {
+    assertions = [
+      {
+        assertion = cfg.schedule.enable -> cfg.enable;
+        message = "programs.yrba.schedule.enable requires programs.yrba.enable";
+      }
+    ];
+
+    environment = lib.mkIf cfg.enable {
+      systemPackages = [ cfg.package ];
+    };
+
+    systemd = {
+      services.yrba = {
+        description = "Automatic incremental remote backups using YRBA";
+        startAt = cfg.schedule.dates;
+        path = [ config.nix.package ];
+        wants = [ "network-online.target" "remote-fs.target" "nss-lookup.target" ];
+        after = [ "network-online.target" "remote-fs.target" "nss-lookup.target" ];
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = "${lib.getExe cfg.package} -c /etc/yrba.toml";
+          ExecStartPre = (
+            pkgs.writeShellScript "pre-start" ''
+              umask 077
+              ${pkgs.envsubst}/bin/envsubst -i "${configFile}" > /etc/yrba.toml
+            ''
+          );
+        };
+      };
+      timers.yrba = {
+        timerConfig = {
+          Persistent = true;
+        };
+      };
+    };
+  };
+}

--- a/pkgs/by-name/yr/yrba/package.nix
+++ b/pkgs/by-name/yr/yrba/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  versionCheckHook,
+  pkg-config,
+  openssl,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "yrba";
+  version = "2.4.0";
+  src = fetchFromGitHub {
+      owner = "lilith-roth";
+      repo = "yrba";
+      tag = "v${version}";
+      hash = "sha256-yYPctHtAdRiSPJaYyZHcYTB76wpc2z7xBO5fCTRtBxs=";
+  };
+
+  cargoTestFlags = [
+    # Don't run integration tests, as they require other services to run which are configured in docker
+    "--bins"
+  ];
+  cargoHash = "sha256-/JG9X5nteBUXtngZSnbQ1v6HcuFceoBo7vG4UDbmz50=";
+  nativeBuildInputs = [
+      pkg-config
+  ];
+  buildInputs = [
+      openssl
+  ];
+  PKG_CONFIG_PATH = "${openssl.dev}/lib/pkgconfig";
+  meta = {
+    description = "Incremental remote backups made easy!";
+    homepage = "https://github.com/lilith-roth/yrba";
+    changelog = "https://github.com/lilith-roth/yrba/releases/tag/v${version}";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ lilith-roth ];
+    mainProgram = "yrba";
+  };
+}


### PR DESCRIPTION
Adding the automatic incremental backup tool YRBA.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
