### PR TITLE
cargo-feature-combinations: init at 0.0.52

### DIFF
--- a/pkgs/by-name/ca/cargo-feature-combinations/package.nix
+++ b/pkgs/by-name/ca/cargo-feature-combinations/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "cargo-feature-combinations";
+  version = "0.0.52";
+
+  src = fetchFromGitHub {
+    owner = "romnn";
+    repo = "cargo-feature-combinations";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-e012XP2LsbcYC5oQYebvLzQvRzfjTSgIyngd/EpIYKY=";
+  };
+
+  cargoHash = "sha256-JcqVGS5EFED66e8BDXLqDz8OAjW3+/H4XkLb5mYV1Dc=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Cargo plugin to run commands against all combinations of features";
+    homepage = "https://github.com/romnn/cargo-feature-combinations";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      matthiasbeyer
+      pinage404
+    ];
+    mainProgram = "cargo-feature-combinations";
+  };
+})


### PR DESCRIPTION
Add new package [`cargo-feature-combinations`](https://github.com/romnn/cargo-feature-combinations)

This package help to run a `cargo` command with every feature combinations ; useful when a Rust package have several features, and we want to be sure that it is good in every cases
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
