### PR TITLE
ivpn{,-service,-ui}: 3.15.0 -> 3.15.6

### DIFF
--- a/pkgs/by-name/iv/ivpn-service/package.nix
+++ b/pkgs/by-name/iv/ivpn-service/package.nix
@@ -17,7 +17,7 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "ivpn-service";
-  version = "3.15.0";
+  version = "3.15.6";
 
   buildInputs = [ wirelesstools ];
   nativeBuildInputs = [ makeWrapper ];
@@ -26,14 +26,15 @@ buildGoModule (finalAttrs: {
     owner = "ivpn";
     repo = "desktop-app";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Y+oW/2WDkH/YydR+xSzEHPdCNKTmmsV4yEsju+OmDYE=";
+    hash = "sha256-C24klcr10i0lki74eNfJ4bappdIttp3S4FGg1wkAGcY=";
   };
 
   strictDeps = true;
   __structuredAttrs = true;
 
   modRoot = "daemon";
-  vendorHash = "sha256-DVKSCcEeE7vI8aOYuEwk22n0wtF7MMDOyAgYoXYadwI=";
+  subPackages = [ "." ];
+  vendorHash = "sha256-YDvZVmResoieSBIp/yuZDvI9GSz3M6Bi5KksHOljuR0=";
 
   proxyVendor = true; # .c file
 

--- a/pkgs/by-name/iv/ivpn-ui/package.nix
+++ b/pkgs/by-name/iv/ivpn-ui/package.nix
@@ -11,18 +11,18 @@
 }:
 buildNpmPackage (finalAttrs: {
   pname = "ivpn-ui";
-  version = "3.15.0";
+  version = "3.15.6";
 
   src = fetchFromGitHub {
     owner = "ivpn";
     repo = "desktop-app";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Y+oW/2WDkH/YydR+xSzEHPdCNKTmmsV4yEsju+OmDYE=";
+    hash = "sha256-C24klcr10i0lki74eNfJ4bappdIttp3S4FGg1wkAGcY=";
   };
 
   sourceRoot = "source/ui";
 
-  npmDepsHash = "sha256-OOBBUDJwTP2T/KqzJPRV+A9ncRmb14KBoAXqa0T6c58=";
+  npmDepsHash = "sha256-S/fB3MxEDLVEZ762EkBkyemYW2rgBGtCH5y/6p6nqgE=";
 
   nativeBuildInputs = [
     copyDesktopItems

--- a/pkgs/by-name/iv/ivpn/package.nix
+++ b/pkgs/by-name/iv/ivpn/package.nix
@@ -7,7 +7,7 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "ivpn";
-  version = "3.15.0";
+  version = "3.15.6";
 
   buildInputs = [ wirelesstools ];
 
@@ -15,13 +15,13 @@ buildGoModule (finalAttrs: {
     owner = "ivpn";
     repo = "desktop-app";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Y+oW/2WDkH/YydR+xSzEHPdCNKTmmsV4yEsju+OmDYE=";
+    hash = "sha256-C24klcr10i0lki74eNfJ4bappdIttp3S4FGg1wkAGcY=";
   };
 
   __structuredAttrs = true;
 
   modRoot = "cli";
-  vendorHash = "sha256-xZ1tMiv06fE2wtpDagKjHiVTPYWpj32hM6n/v9ZcgrE=";
+  vendorHash = "sha256-Qm3OZq3W8GyfkYP674Jzse7wDPWgXfc0bi8ZpYl4T1I=";
 
   proxyVendor = true; # .c file
 


### PR DESCRIPTION
https://github.com/ivpn/desktop-app/releases/tag/v3.15.6

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
