### PR TITLE
ci/github-script/manual-file-edits: skip on PRs from one dev branch to another

### DIFF
--- a/ci/github-script/manual-file-edits.js
+++ b/ci/github-script/manual-file-edits.js
@@ -1,4 +1,5 @@
 // @ts-check
+const { classify } = require('../supportedBranches.js')
 const { getCommitDetailsForPR } = require('./get-pr-commit-details')
 
 /**
@@ -29,6 +30,27 @@ async function checkManualFileEdits({ github, context, core, repoPath, dry }) {
 
   if (pr.user.login.endsWith('[bot]')) {
     core.info('This is a bot, so these checks do not apply.')
+    return
+  }
+
+  const baseBranchType = classify(
+    pr.base.ref.replace(/^refs\/heads\//, ''),
+  ).type
+  const headBranchType = classify(
+    pr.head.ref.replace(/^refs\/heads\//, ''),
+  ).type
+
+  if (
+    baseBranchType.includes('development') &&
+    headBranchType.includes('development') &&
+    pr.base.repo.id === pr.head.repo?.id
+  ) {
+    // This matches, for example, PRs from NixOS:staging-next to NixOS:master, or vice versa.
+    // Ignore them: we should only care about PRs introducing *new* commits.
+    // We still want to run on PRs from, e.g., Someone:master to NixOS:master, though.
+    core.info(
+      'This PR is from one development branch to another. Skipping checks.',
+    )
     return
   }
 


### PR DESCRIPTION
Same logic as in lint-commits.

Fixes https://matrix.to/#/!EoslJfrUGMtQOAfnht:lassul.us/$govFR3OHnME2TZh7tcDSJfXAEfnMVUevnv4l5y4qFD0?via=nixos.org&via=matrix.org&via=catgirl.cloud


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested locally with CLI.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
