### PR TITLE
botan3: 3.11.1 -> 3.12.0; haskellPackages.botan-low: 0.1.0.0 -> 0.2.0.1; haskellPackages.botan-bindings: 0.2.0.0 -> 0.3.0.0

### DIFF
--- a/pkgs/by-name/bo/botan3/package.nix
+++ b/pkgs/by-name/bo/botan3/package.nix
@@ -60,7 +60,7 @@ let
       '';
 in
 stdenv.mkDerivation (finalAttrs: {
-  version = "3.11.1";
+  version = "3.12.0";
   pname = "botan";
 
   __structuredAttrs = true;
@@ -82,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "randombit";
     repo = "botan";
     tag = finalAttrs.version;
-    hash = "sha256-AzQ/IblJF2atUXBTwI+84gmcceVQ6aMMElS3wOsfUDM=";
+    hash = "sha256-2ODTjqsWSmlornOKh5m6pOX7cNOBHS3+ALblRyC8lPw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -3359,6 +3359,14 @@ with haskellLib;
     revision = null;
     editedCabalFile = null;
   } (warnAfterVersion "0.2.0.1" super.botan-low);
+
+  # 2026-05-10: Remove again, when hackage bump is recent enough
+  botan-bindings = overrideCabal {
+    version = "0.3.0.0";
+    sha256 = "sha256-tsarIc3LcUKPgSWZ+xcGPWGO2f9OF6SWHB6nmX/vJYw=";
+    revision = null;
+    editedCabalFile = null;
+  } (warnAfterVersion "0.3.0.0" super.botan-bindings);
 }
 // import ./configuration-tensorflow.nix { inherit pkgs haskellLib; } self super
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -3351,6 +3351,14 @@ with haskellLib;
   stripe-concepts = doJailbreak super.stripe-concepts;
   stripe-signature = doJailbreak super.stripe-signature;
   stripe-wreq = doJailbreak super.stripe-wreq;
+
+  # 2026-05-10: Remove again, when hackage bump is recent enough
+  botan-low = overrideCabal {
+    version = "0.2.0.1";
+    sha256 = "sha256-yC+GJDNO58TIc197Mgn/vqpt4fY3YghLhJfmGkQjsxk=";
+    revision = null;
+    editedCabalFile = null;
+  } (warnAfterVersion "0.2.0.1" super.botan-low);
 }
 // import ./configuration-tensorflow.nix { inherit pkgs haskellLib; } self super
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
