### PR TITLE
managarr: 0.7.1 -> 0.7.2

### DIFF
--- a/pkgs/by-name/ma/managarr/package.nix
+++ b/pkgs/by-name/ma/managarr/package.nix
@@ -3,31 +3,39 @@
   fetchFromGitHub,
   rustPlatform,
   perl,
+  cacert,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "managarr";
-  version = "0.7.1";
+  version = "0.7.2";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "Dark-Alex-17";
     repo = "managarr";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-bKW67cpLbnBxF5gbpwfCNe2QkxKYvooWEM3yKrbj7Q8=";
+    hash = "sha256-10wM6OI3XqFQKyspJU6fqnE3GyzxNaquQlPjn3nS774=";
   };
 
-  cargoHash = "sha256-CDhFj7lP65wlLkSWGcQ8YBK4umSyQsBGF/Sn85gy5hE=";
+  cargoHash = "sha256-7myysFoBYTosHPZ3gzSzXhN8+wbHHF/73b6wQqdlKe8=";
 
   nativeBuildInputs = [ perl ];
+
+  env.SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+
+  __darwinAllowLocalNetworking = true;
 
   meta = {
     description = "TUI and CLI to manage your Servarrs";
     homepage = "https://github.com/Dark-Alex-17/managarr";
     license = lib.licenses.mit;
-    maintainers = [
-      lib.maintainers.IncredibleLaser
-      lib.maintainers.darkalex
-      lib.maintainers.nindouja
+    maintainers = with lib.maintainers; [
+      IncredibleLaser
+      darkalex
+      nindouja
+      kybe236
     ];
     mainProgram = "managarr";
   };


### PR DESCRIPTION
Diff: https://github.com/Dark-Alex-17/managarr/compare/v0.7.1...v0.7.2
Changelog: https://github.com/Dark-Alex-17/managarr/releases/tag/v0.7.2

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
