### PR TITLE
ryubing: migrate to forgejo

### DIFF
--- a/pkgs/by-name/ry/ryubing/package.nix
+++ b/pkgs/by-name/ry/ryubing/package.nix
@@ -4,7 +4,7 @@
   cctools,
   darwin,
   dotnetCorePackages,
-  fetchFromGitLab,
+  fetchFromForgejo,
   libx11,
   libgdiplus,
   moltenvk,
@@ -34,10 +34,10 @@ buildDotnetModule rec {
   pname = "ryubing";
   version = "1.3.3";
 
-  src = fetchFromGitLab {
+  src = fetchFromForgejo {
     domain = "git.ryujinx.app";
-    owner = "Ryubing";
-    repo = "Ryujinx";
+    owner = "projects";
+    repo = "Ryubing";
     tag = version;
     hash = "sha256-LhQaXxmj5HIgfmrsDN8GhhVXlXHpDO2Q8JtNLaCq0mk=";
   };

--- a/pkgs/by-name/ry/ryubing/updater.sh
+++ b/pkgs/by-name/ry/ryubing/updater.sh
@@ -6,7 +6,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 # If NEW_VERSION or COMMIT are not set, fetch the latest version
 if [ -z ${NEW_VERSION+x} ] && [ -z ${COMMIT+x} ]; then
-    RELEASE_DATA=$(curl -s "https://git.ryujinx.app/api/v4/projects/1/repository/tags?order_by=updated&sort=desc")
+    RELEASE_DATA=$(curl -s "https://git.ryujinx.app/api/v1/repos/projects/Ryubing/tags")
     if [ -z "$RELEASE_DATA" ] || [[ $RELEASE_DATA =~ "imposed ratelimits" ]]; then
         echo "failed to get release job data" >&2
         exit 1
@@ -27,7 +27,7 @@ fi
 cd ../../../..
 
 if [[ "${1-default}" != "--deps-only" ]]; then
-    SHA="$(nix-prefetch-git https://git.ryujinx.app/ryubing/ryujinx --rev "$NEW_VERSION" --quiet | jq -r '.sha256')"
+    SHA="$(nix-prefetch-git https://git.ryujinx.app/projects/Ryubing --rev "$NEW_VERSION" --quiet | jq -r '.sha256')"
     SRI=$(nix --experimental-features nix-command hash to-sri "sha256:$SHA")
     update-source-version ryubing "$NEW_VERSION" "$SRI"
 fi


### PR DESCRIPTION
[Ryubing has migrated from Gitlab to Forgejo](https://blog.ryujinx.app/migration-to-forgejo/)

This PR switches out FetchFromGithub to FetchFromForgejo, and changes the updater script to fit with the Forgejo API and new repository name.

The hash didn't change, so I believe the package should still work as it did before, but I tested it a bit anyway, and it was fine.

Currently, the updater script doesn't work. It only fetches the previous 50 tagged commits (gitlab only fetched 20), and the most recent non-canary version was over 140 tags ago, however I have tested both commands outside of the script, and they work.

The next release of Ryubing will need to be manually updated anyway due to updating dotnet and SDL major versions.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
