### PR TITLE
python3Packages.qcs-sdk-python: 0.26.0 -> 0.26.1

### DIFF
--- a/pkgs/development/python-modules/qcs-sdk-python/default.nix
+++ b/pkgs/development/python-modules/qcs-sdk-python/default.nix
@@ -15,19 +15,19 @@
 
 buildPythonPackage rec {
   pname = "qcs-sdk-python";
-  version = "0.26.0";
+  version = "0.26.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "rigetti";
     repo = "qcs-sdk-rust";
     tag = "lib/v${version}";
-    hash = "sha256-A404lYKGAigzsnqWO4BAphOK/Juj4Fa2EHXQO8N1U9I=";
+    hash = "sha256-ZxfDOcfTMyBvS5IRU2c61TOxwnM8hW4hTTjI4JlbBJk=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-NAcCZks5N1KPqeA5v72NAcJqHGexRU99yXQHg21vkPA=";
+    hash = "sha256-Tx3qmBXUZZWNrkQybKNc/gmF/3Jfip+bgF9PSTEXntM=";
   };
 
   buildAndTestSubdir = "crates/lib";


### PR DESCRIPTION
Diff: https://github.com/rigetti/qcs-sdk-rust/compare/lib/v0.26.0...lib/v0.26.1

Changelog: https://github.com/rigetti/qcs-sdk-rust/blob/lib/v0.26.1/crates/lib/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
