### PR TITLE
p4v: 2024.2/2606884 -> 2026.1/2933292

### DIFF
--- a/pkgs/by-name/p4/p4v/libs.patch
+++ b/pkgs/by-name/p4/p4v/libs.patch
@@ -1,0 +1,54 @@
+diff -ru bin-before/p4admin bin-after/p4admin
+--- before/bin/p4admin	2026-05-05 13:38:26.865099841 -0700
++++ after/bin/p4admin	2026-05-05 13:40:01.377761574 -0700
+@@ -43,14 +43,6 @@
+             progname=`basename "$realfullprogname"`
+               prefix=`topdir   "$realfullprogname"`
+ 
+-    # check for symbolic links for libssl.so and libcrypto.so
+-    if [ ! -f $prefix/lib/libssl.so ]; then
+-        p4vlibssl=$( find $prefix/lib/libssl.so.* )
+-        ln -s $p4vlibssl $prefix/lib/libssl.so;
+-        p4vlibcrypto=$( find $prefix/lib/libcrypto.so.* )
+-        ln -s $p4vlibcrypto $prefix/lib/libcrypto.so;
+-    fi
+-
+     XDG_SESSION_TYPE=
+     QT_QPA_PLATFORM=xcb
+     P4VRES=$prefix/lib/P4VResources
+diff -ru bin-before/p4merge bin-after/p4merge
+--- before/bin/p4merge	2026-05-05 13:38:26.865161794 -0700
++++ after/bin/p4merge	2026-05-05 13:39:51.100750813 -0700
+@@ -43,14 +43,6 @@
+             progname=`basename "$realfullprogname"`
+               prefix=`topdir   "$realfullprogname"`
+ 
+-    # check for symbolic links for libssl.so and libcrypto.so
+-    if [ ! -f $prefix/lib/libssl.so ]; then
+-        p4vlibssl=$( find $prefix/lib/libssl.so.* )
+-        ln -s $p4vlibssl $prefix/lib/libssl.so;
+-        p4vlibcrypto=$( find $prefix/lib/libcrypto.so.* )
+-        ln -s $p4vlibcrypto $prefix/lib/libcrypto.so;
+-    fi
+-
+     XDG_SESSION_TYPE=
+     QT_QPA_PLATFORM=xcb
+     P4VRES=$prefix/lib/P4VResources
+diff -ru bin-before/p4v bin-after/p4v
+--- before/bin/p4v	2026-05-05 13:38:26.865192103 -0700
++++ after/bin/p4v	2026-05-05 13:39:20.028718286 -0700
+@@ -43,14 +43,6 @@
+             progname=`basename "$realfullprogname"`
+               prefix=`topdir   "$realfullprogname"`
+ 
+-    # check for symbolic links for libssl.so and libcrypto.so
+-    if [ ! -f $prefix/lib/libssl.so ]; then
+-        p4vlibssl=$( find $prefix/lib/libssl.so.* )
+-        ln -s $p4vlibssl $prefix/lib/libssl.so;
+-        p4vlibcrypto=$( find $prefix/lib/libcrypto.so.* )
+-        ln -s $p4vlibcrypto $prefix/lib/libcrypto.so;
+-    fi
+-
+     XDG_SESSION_TYPE=
+     QT_QPA_PLATFORM=xcb
+     P4VRES=$prefix/lib/P4VResources

--- a/pkgs/by-name/p4/p4v/linux.nix
+++ b/pkgs/by-name/p4/p4v/linux.nix
@@ -77,6 +77,10 @@ let
     # Don't wrap the Qt apps; upstream has its own wrapper scripts.
     dontWrapQtApps = true;
 
+    patches = [
+      ./libs.patch # Fixes issues with bundled libraries that we've stripped out
+    ];
+
     postPatch = ''
       rm -r lib/plugins lib/libQt6* lib/libssl* lib/libicu* lib/libcrypto*
     '';

--- a/pkgs/by-name/p4/p4v/package.nix
+++ b/pkgs/by-name/p4/p4v/package.nix
@@ -10,12 +10,12 @@ let
   # Upstream replaces minor versions, so use archived URLs.
   srcs = rec {
     x86_64-linux = fetchurl {
-      url = "https://web.archive.org/web/20240612193642id_/https://ftp.perforce.com/perforce/r24.2/bin.linux26x86_64/p4v.tgz";
-      sha256 = "sha256-HA99fHcmgli/vVnr0M8ZJEsaZ2ZLzpG3M8S77oDYJyE=";
+      url = "https://web.archive.org/web/20260414052921/https://filehost.perforce.com/perforce/r26.1/bin.linux26x86_64/p4v.tgz";
+      sha256 = "sha256-89Xz9dxAeLGOOr90K0CdlxjrfIf9vUmyZV3tzWspWdQ=";
     };
     aarch64-darwin = fetchurl {
-      url = "https://web.archive.org/web/20240612194532id_/https://ftp.perforce.com/perforce/r24.2/bin.macosx12u/P4V.dmg";
-      sha256 = "sha256-PS7gfDdWspyL//YWLkrsGi5wh6SIeAry2yef1/V0d6o=";
+      url = "https://web.archive.org/web/20260414052748/https://filehost.perforce.com/perforce/r26.1/bin.macosx12u/P4V.dmg";
+      sha256 = "sha256-8MBLS6EQOVenxZ1Uv75kPzU8aO2AldmxkwOz+JcBRpY=";
     };
     # this is universal
     x86_64-darwin = aarch64-darwin;
@@ -29,7 +29,7 @@ let
 in
 mkDerivation {
   pname = "p4v";
-  version = "2024.2/2606884";
+  version = "2026.1/2933292";
 
   src =
     srcs.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");


### PR DESCRIPTION
P4V was very out of date, and it seems like time to do something about it.

Based on a cursory check, not too much that's relevant to packaging seems to have changed. The upstream wrapper scripts did have some symlinking behavior for bundled libraries that doesn't work so well with our removal of those libraries, so I've patched around that.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (**Linux only**)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test