### PR TITLE
maintainers: drop ewok

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8504,12 +8504,6 @@
     githubId = 92547295;
     email = "evysgarden@protonmail.com";
   };
-  ewok = {
-    email = "ewok@ewok.ru";
-    github = "ewok-old";
-    githubId = 454695;
-    name = "Artur Taranchiev";
-  };
   ewuuwe = {
     email = "ewu.uweq@pm.me";
     github = "EwuUwe";

--- a/pkgs/by-name/ca/carps-cups/package.nix
+++ b/pkgs/by-name/ca/carps-cups/package.nix
@@ -38,8 +38,7 @@ stdenv.mkDerivation {
     homepage = "https://www.canon.com/";
     license = lib.licenses.gpl3Plus;
     broken = stdenv.hostPlatform.isDarwin;
-    maintainers = with lib.maintainers; [
-      ewok
+    maintainers = [
     ];
   };
 }

--- a/pkgs/by-name/en/enpass/package.nix
+++ b/pkgs/by-name/en/enpass/package.nix
@@ -100,7 +100,7 @@ let
         "x86_64-linux"
         "i686-linux"
       ];
-      maintainers = with lib.maintainers; [ ewok ];
+      maintainers = [ ];
     };
 
     nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/by-name/to/todofi-sh/package.nix
+++ b/pkgs/by-name/to/todofi-sh/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "todofi.sh";
     homepage = "https://github.com/hugokernel/todofi.sh";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ewok ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/xk/xkb-switch-i3/package.nix
+++ b/pkgs/by-name/xk/xkb-switch-i3/package.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Switch your X keyboard layouts from the command line(i3 edition)";
     homepage = "https://github.com/Zebradil/xkb-switch-i3";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ ewok ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
     mainProgram = "xkb-switch";
   };


### PR DESCRIPTION
No [comments](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+commenter%3Aewok-old) since 2021 despite 7 [review requests](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+created%3A%3E%3D2022-01-01+involves%3Aewok-old). (Hasn't accepted org invitation so probably more.) Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/33954594ec46166510795930ba8ebf0856249d4e/maintainers/README.md#losing-maintainer-status).

@ewok-old if you object to being dropped please respond saying so within a week. Even if you don't make it, you are of course welcome back whenever you would like!





## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
