### PR TITLE
honggfuzz: 2.6 -> 2.6-unstable-2026-04-13

### DIFF
--- a/pkgs/by-name/ho/honggfuzz/package.nix
+++ b/pkgs/by-name/ho/honggfuzz/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch2,
   makeWrapper,
   clang,
   llvm,
@@ -10,26 +9,19 @@
   libopcodes,
   libunwind,
   libblocksruntime,
+  unstableGitUpdater,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "honggfuzz";
-  version = "2.6";
+  version = "2.6-unstable-2026-04-13";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "honggfuzz";
-    rev = finalAttrs.version;
-    sha256 = "sha256-/ra6g0qjjC8Lo8/n2XEbwnZ95yDHcGhYd5+TTvQ6FAc=";
+    rev = "48790f7b18f30ba4a95272ea290b720662ed56c9";
+    hash = "sha256-RHNOZF5ttqdh3daGGVRHkvL9g2aZFDGDmmW056ohI6w=";
   };
-
-  patches = [
-    # [PATCH] mangle: support gcc-15 with __attribute__((nonstring))
-    (fetchpatch2 {
-      url = "https://github.com/google/honggfuzz/commit/4cfa62f4fdb56e3027c1cb3aecf04812e786f0fd.patch?full_index=1";
-      hash = "sha256-79/GZfqTH1o/21P7At5ZPmvcCSYWAsVakSv5dNCT+XI=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace hfuzz_cc/hfuzz-cc.c \
@@ -65,6 +57,10 @@ stdenv.mkDerivation (finalAttrs: {
     cp libhfcommon/libhfcommon.a $out/lib
     cp libhfnetdriver/libhfnetdriver.a $out/lib
   '';
+
+  passthru.updateScript = unstableGitUpdater {
+    tagFormat = "[0-9]*";
+  };
 
   meta = {
     description = "Security oriented, feedback-driven, evolutionary, easy-to-use fuzzer";


### PR DESCRIPTION
`honggfuzz` stopped doing tagged releases. Let's use latest `master` instead.

This update fixes the build fialure against latest `binutils` in `master`: https://hydra.nixos.org/build/327016208

```
linux/bfd.c: In function 'arch_bfdDisasm':
linux/bfd.c:233:51: error: incompatible type for argument 1 of 'disassembler'
  233 |     disassembler_ftype disassemble = disassembler(bfdh);
      |                                                   ^~~~
      |                                                   |
      |                                                   bfd *
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

ZHF: #516381

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
