### PR TITLE
lokinet: fix build, 0.9.13 -> 0.9.14

### DIFF
--- a/pkgs/by-name/lo/lokinet/package.nix
+++ b/pkgs/by-name/lo/lokinet/package.nix
@@ -18,14 +18,14 @@
 
 stdenv.mkDerivation rec {
   pname = "lokinet";
-  version = "0.9.13";
+  version = "0.9.14";
 
   src = fetchFromGitHub {
     owner = "oxen-io";
     repo = "lokinet";
     tag = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-6TVMuT4O8zJj97873BTsR1PJU8NaBgYr/nBkc/EfQuQ=";
+    hash = "sha256-Gmc3h3J19tn2UMvhHApoKsUwbBnudmkLA+9EhC1NDqs=";
   };
 
   patches = [
@@ -36,6 +36,51 @@ stdenv.mkDerivation rec {
       hash = "sha256-yCy4WXs6p67TMe4uPNAuQyJvtP3IbpJS81AeomNu9lU=";
     })
   ];
+
+  postPatch = ''
+        # Fix fmt compatibility: format() must be const in custom formatters
+        substituteInPlace llarp/util/aligned.hpp \
+          --replace-fail 'FormatContext& ctx)' 'FormatContext& ctx) const'
+
+        substituteInPlace external/oxen-mq/oxenmq/fmt.h \
+          --replace-fail 'format_context& ctx)' 'format_context& ctx) const'
+
+        substituteInPlace external/oxen-logging/include/oxen/log/color.hpp \
+          --replace-fail 'FormatContext& ctx)' 'FormatContext& ctx) const'
+
+        # Fix spdlog/fmt compatibility by avoiding fmt/ranges.h and its conflict with AlignedBuffer.
+
+        substituteInPlace llarp/util/str.hpp \
+          --replace-fail 'return fmt::format("{}", fmt::join(delimiter, begin, end));' \
+                         'std::string s; for (auto it = begin; it != end; ++it) { if (it != begin) s += delimiter; s += fmt::format("{}", *it); } return s;'
+
+        substituteInPlace llarp/net/interface_info.cpp \
+          --replace-fail '#include "interface_info.hpp"' '#include "interface_info.hpp"
+    #include <llarp/util/str.hpp>' \
+          --replace-fail 'fmt::join(addrs, ",")' 'llarp::join(",", addrs)'
+
+        substituteInPlace llarp/service/intro_set.cpp \
+          --replace-fail '#include "intro_set.hpp"' '#include "intro_set.hpp"
+    #include <llarp/util/str.hpp>' \
+          --replace-fail 'fmt::join(intros, ",")' 'llarp::join(",", intros)'
+
+        substituteInPlace llarp/router_contact.cpp \
+          --replace-fail '#include "router_contact.hpp"' '#include "router_contact.hpp"
+    #include <llarp/util/str.hpp>' \
+          --replace-fail 'fmt::join(addrs, ",")' 'llarp::join(",", addrs)'
+
+        substituteInPlace llarp/dns/message.cpp \
+          --replace-fail '#include "message.hpp"' '#include "message.hpp"
+    #include <llarp/util/str.hpp>' \
+          --replace-fail 'fmt::join(questions, ",")' 'llarp::join(",", questions)' \
+          --replace-fail 'fmt::join(answers, ",")' 'llarp::join(",", answers)' \
+          --replace-fail 'fmt::join(authorities, ",")' 'llarp::join(",", authorities)' \
+          --replace-fail 'fmt::join(additional, ",")' 'llarp::join(",", additional)'
+
+        substituteInPlace llarp/router/router.cpp \
+          --replace-fail 'fmt::format_to(out, "v{}", fmt::join(llarp::VERSION, "."));' \
+                         'fmt::format_to(out, "v{}.{}.{}", llarp::VERSION[0], llarp::VERSION[1], llarp::VERSION[2]);'
+  '';
 
   nativeBuildInputs = [
     cmake
@@ -61,10 +106,6 @@ stdenv.mkDerivation rec {
   ];
 
   meta = {
-    # Upstream has received reports of incompatibilities with fmt, and other
-    # dependencies, see: https://github.com/oxen-io/lokinet/issues/2200.
-    # But our version of spdlog doesn't support fmt_9
-    broken = true;
     description = "Anonymous, decentralized and IP based overlay network for the internet";
     homepage = "https://lokinet.org/";
     changelog = "https://github.com/oxen-io/lokinet/releases/tag/v${version}";


### PR DESCRIPTION
Fix the build by updating 0.9.14 and patchting to make it spdlog/fmt 12 compatible


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
