### PR TITLE
ac-library: fix tests on platforms where char is unsigned

### DIFF
--- a/pkgs/by-name/ac/ac-library/fix-char-signedness-tests.patch
+++ b/pkgs/by-name/ac/ac-library/fix-char-signedness-tests.patch
@@ -1,0 +1,24 @@
+diff --git i/test/unittest/type_traits_test.cpp w/test/unittest/type_traits_test.cpp
+index 164cc79..123b3a2 100644
+--- i/test/unittest/type_traits_test.cpp
++++ w/test/unittest/type_traits_test.cpp
+@@ -1,5 +1,6 @@
+ #include "atcoder/internal_type_traits"
+ 
++#include <climits>
+ #include <type_traits>
+ 
+ #include <gtest/gtest.h>
+@@ -44,7 +45,12 @@ static_assert(internal::is_unsigned_int<unsigned long long>::value, "");
+ static_assert(!internal::is_signed_int<A>::value, "");
+ static_assert(!internal::is_unsigned_int<A>::value, "");
+ 
++#if CHAR_MIN < 0
+ static_assert(is_same<unsigned char, internal::to_unsigned_t<char>>::value, "");
++#else
++static_assert(is_same<char, internal::to_unsigned_t<char>>::value, "");
++#endif
++
+ static_assert(
+     is_same<unsigned char, internal::to_unsigned_t<signed char>>::value,
+     "");

--- a/pkgs/by-name/ac/ac-library/package.nix
+++ b/pkgs/by-name/ac/ac-library/package.nix
@@ -18,7 +18,12 @@ stdenv.mkDerivation (finalAttrs: {
     fetchSubmodules = true;
     hash = "sha256-1wwzN/JPS6daj1vDFuEN5z20tMdLfMvEKti0sxCVlHA=";
   };
-
+  patches = [
+    # Fix type_traits_test assumptions about char signedness on platforms
+    # where char is unsigned by default (e.g. aarch64-linux).
+    # Reported upstream: https://github.com/atcoder/ac-library/issues/191
+    ./fix-char-signedness-tests.patch
+  ];
   outputs = [
     "dev"
     "out"
@@ -60,7 +65,6 @@ stdenv.mkDerivation (finalAttrs: {
   env = {
     NIX_CFLAGS_COMPILE = toString [
       "-Wno-error=array-bounds"
-      "-Wno-character-conversion"
     ];
   };
 


### PR DESCRIPTION
_Please apply the `0.kind: ZHF Fixes` label._

## Description

Fixes a long-standing build failure of `ac-library` on `aarch64-linux` (and any other platform where `char` is unsigned by default).

The unit test `type_traits_test.cpp` contains a `static_assert` that assumes `char` is signed:

```cpp
static_assert(is_same<unsigned char, internal::to_unsigned_t<char>>::value, "");
```

On platforms where `char` is unsigned (`aarch64-linux`, `ppc64`, etc.), `internal::is_signed_int<char>` is `false`, so `to_unsigned_t<char>` resolves to `char` rather than `unsigned char`, and the assertion fails to compile.

This PR adds a small patch that guards the assertion with `CHAR_MIN < 0`, so the correct relationship is checked on each platform. The library itself works fine on `aarch64`; only this one test assertion was platform-unsafe.

Also drops `-Wno-character-conversion` from `NIX_CFLAGS_COMPILE` because GCC 15 does not recognize the flag — it shows up as `unrecognized command-line option` in the build log.

## Hydra build

Failing build: https://hydra.nixos.org/build/326949471

## Upstream

Reported and fixed at:

- Issue: https://github.com/atcoder/ac-library/issues/191
- PR: https://github.com/atcoder/ac-library/pull/192

## Verification

Built locally on `aarch64-linux` (the same platform Hydra was failing on):

```
100% tests passed, 0 tests failed out of 126
installCheckPhase completed in 3 minutes 44 seconds
/nix/store/j8645c90mv4ywi3h54v1kyylrw3k07kx-ac-library-1.6-dev
```

ZHF: #516381

## Things done

- [x] Built on platform(s)
  - [x] aarch64-linux
  - [ ] x86_64-linux
  - [ ] aarch64-darwin
  - [ ] x86_64-darwin
- [x] Tested basic functionality (the `installCheckPhase` runs the upstream test suite, all 126 tests pass)
- [x] Fits CONTRIBUTING.md
