### PR TITLE
jdupes: fix Darwin build

### DIFF
--- a/pkgs/by-name/jd/jdupes/package.nix
+++ b/pkgs/by-name/jd/jdupes/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromCodeberg,
+  fetchpatch2,
   libjodycode,
 }:
 
@@ -19,6 +20,14 @@ stdenv.mkDerivation (finalAttrs: {
     # directories have such files and will be removed.
     postFetch = "rm -r $out/testdir";
   };
+
+  patches = [
+    (fetchpatch2 {
+      name = "use-stat-time-macros-for-compatibility-reasons.patch";
+      url = "https://codeberg.org/jbruchon/jdupes/commit/464f72c82f2ce81dd33bfb5381f1bcf148da4091.patch";
+      hash = "sha256-/B6iNAG3Fsmot5MGSBMs99QnAc/bFZJjPtnbiq21QZg=";
+    })
+  ];
 
   buildInputs = [ libjodycode ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR fixes the `jdupes` package build on `aarch64-darwin` (broken since the bump to version 1.29.0 in #434233, caused by [this](https://codeberg.org/jbruchon/jdupes/commit/8a75e66f80bdf9fbc6eacacebab4cf7d285f8f0c) and [this](https://codeberg.org/jbruchon/jdupes/commit/de36869653f0ee692dbb20e93d5a37fe063eaa46)) by pulling in [an unreleased patch from upstream](https://codeberg.org/jbruchon/jdupes/commit/464f72c82f2ce81dd33bfb5381f1bcf148da4091).

Disclosure: I was assisted in finding the upstream commits by GPT-5.5 via Codex.

ZHF: #516381

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
