### PR TITLE
python3Packages.adb-enhanced: patch dependencies to fix build

### DIFF
--- a/pkgs/development/python-modules/adb-enhanced/default.nix
+++ b/pkgs/development/python-modules/adb-enhanced/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   docopt,
   fetchFromGitHub,
+  fetchpatch,
   setuptools,
   jdk11,
   psutil,
@@ -19,6 +20,13 @@ buildPythonPackage (finalAttrs: {
     tag = finalAttrs.version;
     hash = "sha256-YuQgz3WeN50hg/IgdoNV61St9gpu6lcgFfKCfI/ENl0=";
   };
+  patches = [
+    # psutil==7.2.1 -> psutil==7.2.2
+    (fetchpatch {
+      url = "https://github.com/ashishb/adb-enhanced/pull/337.patch";
+      hash = "sha256-BRpdgLS6CNkmyj+OwnIaqfkmz1jzZg/qtoiN32jUIog=";
+    })
+  ];
 
   build-system = [ setuptools ];
 


### PR DESCRIPTION
given how infrequently psutil releases, I've decided not to use `pythonRelaxDeps` in case the pin is actually relevant (or becomes relevant in the future)

ZHF: #516381


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
