### PR TITLE
nixos/oauth2-proxy: add trustedProxyIP option and warning when it is not set in combination with reverseProxy

### DIFF
--- a/nixos/modules/services/security/oauth2-proxy.nix
+++ b/nixos/modules/services/security/oauth2-proxy.nix
@@ -55,6 +55,7 @@ let
       pass-basic-auth = passBasicAuth;
       pass-host-header = passHostHeader;
       reverse-proxy = reverseProxy;
+      trusted-proxy-ip = trustedProxyIP;
       proxy-prefix = proxyPrefix;
       profile-url = profileURL;
       oidc-issuer-url = oidcIssuerUrl;
@@ -495,6 +496,16 @@ in
       '';
     };
 
+    trustedProxyIP = lib.mkOption {
+      type = with lib.types; listOf str;
+      default = [ ];
+      description = ''
+        List of IPs or CIDR ranges allowed to supply X-Forwarded-* headers when reverseProxy is enabled.
+        If not set, OAuth2 Proxy preserves backwards compatibility by trusting all source IPs (0.0.0.0/0, ::/0) and logs a warning at startup.
+        Configure this to your reverse proxy addresses to prevent forwarded header spoofing.
+      '';
+    };
+
     proxyPrefix = lib.mkOption {
       type = lib.types.str;
       default = "/oauth2";
@@ -616,6 +627,13 @@ in
         assertion = cfg.clientID != null || cfg.keyFile != null;
         message = "Either services.oauth2-proxy.clientID or services.oauth2-proxy.keyFile must be specified.";
       }
+    ];
+
+    warnings = lib.mkIf (cfg.reverseProxy -> cfg.trustedProxyIP == [ ]) [
+      ''
+        When config.services.oauth2-proxy.reverseProxy is enabled, configure config.services.oauth2-proxy.trustedProxyIP to the IPs or CIDR range(s) of the reverse proxies that are allowed to send X-Forwarded-* headers.
+        If you leave it unset, OAuth2 Proxy currently trusts all source IPs for backwards compatibility, which means a client that can reach OAuth2 Proxy directly may be able to spoof forwarded headers.
+      ''
     ];
 
     users.users.oauth2-proxy = {


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
