### PR TITLE
zfs-replicate: 4.0.0 -> 4.1.0

### DIFF
--- a/pkgs/by-name/zf/zfs-replicate/package.nix
+++ b/pkgs/by-name/zf/zfs-replicate/package.nix
@@ -8,14 +8,15 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "zfs_replicate";
-  version = "4.0.0";
+  version = "4.1.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "alunduil";
     repo = "zfs-replicate";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-VajMSoFZ4SQXpuF1Lo6S9IhxvspCfUwpNw5zg16uA3M=";
+    hash = "sha256-7UoFx2XtadsQqavR5BTwbylaDksWSRxy5o+2hCOzfBw=";
   };
 
   # For compression to work, both local and remote systems must have lz4 installed.
@@ -41,8 +42,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     pytest-cov-stub
     pytestCheckHook
   ];
-
-  doCheck = true;
 
   disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
     # AssertionError: Expected SystemExit or FileNotFoundError


### PR DESCRIPTION
## Things done

Diff: https://github.com/alunduil/zfs-replicate/compare/v4.0.0...v4.1.0
Changelog: https://github.com/alunduil/zfs-replicate/blob/v4.1.0/CHANGELOG.md

cc @alunduil

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test