### PR TITLE
tclPackages.tkdnd: init at 2.9.5

### DIFF
--- a/pkgs/development/tcl-modules/by-name/tk/tkdnd/package.nix
+++ b/pkgs/development/tcl-modules/by-name/tk/tkdnd/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  mkTclDerivation,
+  fetchFromGitHub,
+
+  cmake,
+  xvfb,
+
+  tk,
+  libx11,
+  libxcursor,
+}:
+mkTclDerivation (finalAttrs: {
+  pname = "tkdnd";
+  version = "2.9.5";
+
+  src = fetchFromGitHub {
+    owner = "petasis";
+    repo = "tkdnd";
+    tag = "tkdnd-release-test-v${finalAttrs.version}";
+    hash = "sha256-VF1f9HSEThyFy3u7d3Kvo7EIpoosz6KpLOiHkf89PQI=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    xvfb
+  ];
+
+  buildInputs = [
+    tk
+    libx11
+    libxcursor
+  ];
+
+  postInstall = ''
+    mkdir -p $out/lib
+    mv $out/tkdnd${finalAttrs.version} $out/lib
+  '';
+
+  # Requires X server for tclRequiresCheck
+  postFixup = ''
+    export DISPLAY=:$((2000 + $RANDOM % 1000))
+    Xvfb $DISPLAY -screen 5 1024x768x8 &
+    xvfb_pid=$!
+  '';
+
+  tclRequiresCheck = [ "tkdnd" ];
+
+  postDist = ''
+    kill $xvfb_pid
+  '';
+
+  meta = {
+    description = "Extension to the Tk toolkit that adds native drag and drop support";
+    homepage = "https://github.com/petasis/tkdnd";
+    changelog = "https://github.com/petasis/tkdnd/raw/refs/tags/${finalAttrs.src.tag}/Changelog";
+    license = lib.licenses.tcltk;
+    maintainers = [ lib.maintainers.ryand56 ];
+  };
+})


### PR DESCRIPTION
Adds [tkdnd](https://github.com/petasis/tkdnd), an extension to the Tk toolkit that adds native drag and drop support.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
