### PR TITLE
home-assistant-custom-components.pi-hole-v6: init at 1.17.0

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/pi-hole-v6/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/pi-hole-v6/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildHomeAssistantComponent,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "bastgau";
+  domain = "pi_hole_v6";
+  version = "1.17.0";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = "ha-pi-hole-v6";
+    tag = "v${version}";
+    hash = "sha256-C9QqdAFe1P5bzuMuYWCy8hQINAbc/yOIxdxp2jpM2N8=";
+  };
+
+  # has no tests
+  doCheck = false;
+
+  meta = {
+    changelog = "https://github.com/bastgau/ha-pi-hole-v6/releases/tag/${src.tag}";
+    description = "Pi-hole V6 Integration for Home Assistant";
+    longDescription = ''
+      This custom integration restored compatibility between Home Assistant and Pi-hole, which was no longer supported by the native integration.
+      Today, this integration offers additional and complementary features.
+    '';
+    homepage = "https://github.com/bastgau/ha-pi-hole-v6";
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+    license = lib.licenses.mit;
+  };
+}


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
