### PR TITLE
 python314Packages.pyobjc-framework-* share source with pyobjc-core 

### DIFF
--- a/pkgs/development/python-modules/pyobjc-framework-Quartz/default.nix
+++ b/pkgs/development/python-modules/pyobjc-framework-Quartz/default.nix
@@ -1,6 +1,5 @@
 {
   buildPythonPackage,
-  fetchFromGitHub,
   setuptools,
   darwin,
   pyobjc-core,
@@ -10,15 +9,9 @@
 
 buildPythonPackage rec {
   pname = "pyobjc-framework-Quartz";
-  version = "11.1";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "ronaldoussoren";
-    repo = "pyobjc";
-    tag = "v${version}";
-    hash = "sha256-2qPGJ/1hXf3k8AqVLr02fVIM9ziVG9NMrm3hN1de1Us=";
-  };
+  inherit (pyobjc-core) version src;
 
   sourceRoot = "${src.name}/pyobjc-framework-Quartz";
 

--- a/pkgs/development/python-modules/pyobjc-framework-Security/default.nix
+++ b/pkgs/development/python-modules/pyobjc-framework-Security/default.nix
@@ -1,6 +1,5 @@
 {
   buildPythonPackage,
-  fetchFromGitHub,
   setuptools,
   darwin,
   pyobjc-core,
@@ -10,15 +9,9 @@
 
 buildPythonPackage rec {
   pname = "pyobjc-framework-Security";
-  version = "11.1";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "ronaldoussoren";
-    repo = "pyobjc";
-    tag = "v${version}";
-    hash = "sha256-2qPGJ/1hXf3k8AqVLr02fVIM9ziVG9NMrm3hN1de1Us=";
-  };
+  inherit (pyobjc-core) version src;
 
   sourceRoot = "${src.name}/pyobjc-framework-Security";
 

--- a/pkgs/development/python-modules/pyobjc-framework-WebKit/default.nix
+++ b/pkgs/development/python-modules/pyobjc-framework-WebKit/default.nix
@@ -1,6 +1,5 @@
 {
   buildPythonPackage,
-  fetchFromGitHub,
   setuptools,
   darwin,
   pyobjc-core,
@@ -10,15 +9,9 @@
 
 buildPythonPackage rec {
   pname = "pyobjc-framework-WebKit";
-  version = "11.1";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "ronaldoussoren";
-    repo = "pyobjc";
-    tag = "v${version}";
-    hash = "sha256-2qPGJ/1hXf3k8AqVLr02fVIM9ziVG9NMrm3hN1de1Us=";
-  };
+  inherit (pyobjc-core) version src;
 
   sourceRoot = "${src.name}/pyobjc-framework-WebKit";
 


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
