### PR TITLE
linuxHeaders: add updateScript

### DIFF
--- a/pkgs/os-specific/linux/kernel-headers/default.nix
+++ b/pkgs/os-specific/linux/kernel-headers/default.nix
@@ -9,6 +9,8 @@
   flex,
   rsync,
   writeTextFile,
+  nix-update-script,
+  linux_latest,
 }:
 
 let
@@ -42,6 +44,7 @@ let
       src,
       version,
       patches ? [ ],
+      passthru ? { },
     }:
     stdenvNoCC.mkDerivation {
       inherit src;
@@ -139,6 +142,8 @@ let
         echo "${version}-default" > $out/include/config/kernel.release
       '';
 
+      inherit passthru;
+
       meta = {
         description = "Header files and scripts for Linux kernel";
         license = lib.licenses.gpl2Only;
@@ -163,5 +168,11 @@ in
       patches = [
         ./no-relocs.patch # for building x86 kernel headers on non-ELF platforms
       ];
+      passthru.updateScript = nix-update-script {
+        extraArgs = [
+          "--version"
+          "${linux_latest.meta.branch}"
+        ];
+      };
     };
 }


### PR DESCRIPTION
This package doesn't seem to be updated consistently so adding an updateScript so the bot will create PRs when linux_latest is bumped to a new branch version.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
