### PR TITLE
porymap: init at 6.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3250,6 +3250,11 @@
     email = "close.line3633@fastmail.com";
     keys = [ { fingerprint = "FAD9F10819FA179515CD1B9FAFD359B057CEEE04"; } ];
   };
+  beauremus = {
+    github = "beauremus";
+    githubId = 3767966;
+    name = "Beau Harrison";
+  };
   beeb = {
     name = "Valentin Bersier";
     email = "hi@beeb.li";

--- a/pkgs/by-name/po/porymap/package.nix
+++ b/pkgs/by-name/po/porymap/package.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  qt6,
+  gtk3,
+  gsettings-desktop-schemas,
+  adwaita-icon-theme,
+  hicolor-icon-theme,
+  openssl,
+  imagemagick,
+  copyDesktopItems,
+  makeDesktopItem,
+  wrapGAppsHook3,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "porymap";
+  version = "6.3.1";
+
+  src = fetchFromGitHub {
+    owner = "huderlem";
+    repo = "porymap";
+    rev = finalAttrs.version;
+    hash = "sha256-EG09aOgJrIe5X+e/SKcZn+mxkZ2N4mBmRxlEV3LYvgo=";
+  };
+
+  nativeBuildInputs = [
+    qt6.qmake
+    qt6.wrapQtAppsHook
+    wrapGAppsHook3
+    imagemagick
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtcharts
+    qt6.qtdeclarative
+    qt6.qtwayland
+    gtk3
+    gsettings-desktop-schemas
+    adwaita-icon-theme
+    hicolor-icon-theme
+    openssl
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "porymap";
+      exec = "porymap";
+      icon = "porymap";
+      desktopName = "Porymap";
+      genericName = "Pokémon Map Editor";
+      categories = [ "Development" ];
+    })
+  ];
+
+  # This app doesn't have an install target in its qmake file
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 porymap $out/bin/porymap
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    magick resources/icons/porymap-icon-2.ico porymap.png
+    icon_file=$(ls porymap-*.png | sort -V | tail -n 1)
+    install -Dm644 "''${icon_file:-porymap.png}" $out/share/icons/hicolor/256x256/apps/porymap.png
+  '';
+
+  meta = {
+    description = "A map editor for the Pokémon generation 3 decompilation projects";
+    homepage = "https://github.com/huderlem/porymap";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ beauremus ];
+    platforms = lib.platforms.linux;
+    mainProgram = "porymap";
+  };
+})


### PR DESCRIPTION
Porymap is a custom map editor for the Pokémon generation 3 decompilation projects (pokeruby, pokeemerald, pokefirered).

https://github.com/huderlem/porymap

## Features:
- Built with Qt 6.
- Automatically extracts the application icon from project resources during build.
- Includes a desktop entry for application launchers.
- Wrapped with GTK 3 schemas to ensure native file dialogs work correctly on Linux.

## Things done

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [x] Manual verification of the GUI and file dialogs (fixed GIO/GTK schema errors).
- [ ] Ran `nixpkgs-review` on this PR. (Optional, but recommended if you have it installed).
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits `CONTRIBUTING.md`, `pkgs/README.md`, `maintainers/README.md` and other READMEs.