### PR TITLE
cgui: fix build with gcc15

### DIFF
--- a/pkgs/by-name/cg/cgui/fix-gcc15.patch
+++ b/pkgs/by-name/cg/cgui/fix-gcc15.patch
@@ -1,0 +1,15 @@
+diff --git a/examples/25viewer.c b/examples/25viewer.c
+index 37e4585..a0328f0 100644
+--- a/examples/25viewer.c
++++ b/examples/25viewer.c
+@@ -10,8 +10,9 @@
+ 
+ static const char *fname; /* stores name of file to open */
+ 
+-void quit()
++void quit(void *data)
+ {
++   (void)data;
+    exit(0);
+ }
+ 

--- a/pkgs/by-name/cg/cgui/package.nix
+++ b/pkgs/by-name/cg/cgui/package.nix
@@ -17,6 +17,10 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "1pp1hvidpilq37skkmbgba4lvzi01rasy04y0cnas9ck0canv00s";
   };
 
+  patches = [
+    ./fix-gcc15.patch
+  ];
+
   buildInputs = [
     texinfo
     allegro


### PR DESCRIPTION
- #475479 
- #516381
- https://hydra.nixos.org/build/326784121

```
examples/25viewer.c: In function 'GUI_start':
examples/25viewer.c:22:26: error: passing argument 4 of 'AddButton' from incompatible pointer type [-Wincompatible-pointer-types]
   22 |    AddButton(LEFT,"Quit",quit,NULL);
      |                          ^~~~
      |                          |
      |                          void (*)(void)
In file included from ./include/cgui.h:8,
                 from examples/25viewer.c:9:
./include/cgui.h:132:79: note: expected 'void (*)(void *)' but argument is of type 'void (*)(void)'
  132 | CGUI_FUNC(int, AddButton, (int x, int y, const char *label, CGUI_METHOD(void, CallBack, (void *data)), void *data));
      |                                                                         ~~~~~~^~~~~~~~~~~~~~~~~~~~~~
./include/cgui/cguicfg.h:325:62: note: in definition of macro 'CGUI_FUNC'
  325 |    #define CGUI_FUNC(type, name, args)             type name args
      |                                                              ^~~~
./include/cgui.h:132:61: note: in expansion of macro 'CGUI_METHOD'
  132 | CGUI_FUNC(int, AddButton, (int x, int y, const char *label, CGUI_METHOD(void, CallBack, (void *data)), void *data));
      |                                                             ^~~~~~~~~~~
examples/25viewer.c:13:6: note: 'quit' declared here
   13 | void quit()
      |      ^~~~
```

A really small problem in an example.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
