### PR TITLE
endless-sky: 0.11.0 -> 0.11.1

### DIFF
--- a/pkgs/by-name/en/endless-sky/package.nix
+++ b/pkgs/by-name/en/endless-sky/package.nix
@@ -16,17 +16,18 @@
   libmad,
   libuuid,
   minizip,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "endless-sky";
-  version = "0.11.0";
+  version = "0.11.1";
 
   src = fetchFromGitHub {
     owner = "endless-sky";
     repo = "endless-sky";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-zeLM3n6pm5FxT+GO3dtJwDFKHs8boUuQBShU/PDCeFA=";
+    hash = "sha256-QXLIHAAdpK6lvKv0471KsiB+B06RKUfYoUNYKi8NAlg=";
   };
 
   patches = [
@@ -62,6 +63,8 @@ stdenv.mkDerivation (finalAttrs: {
     libuuid
     minizip
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Sandbox-style space exploration game similar to Elite, Escape Velocity, or Star Control";


### PR DESCRIPTION
https://github.com/endless-sky/endless-sky/releases/tag/v0.11.1

I updated Endless Sky to version 0.11.1 and tested the game by starting a new game and traveling to a new location on the map. I was not sure what ship to start with, so I picked the shuttle.

Added updateScript so that automatic updates (hopefully) work when the next version is released.

This PR probably doesn't need nixpkgs-review run on it as grepping nixpkgs for endless-sky only gives one result, this package.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
