### PR TITLE
deadbeefPlugins.vgmstream: init at 2026-05-09.1

### DIFF
--- a/pkgs/applications/audio/deadbeef/plugins/vgmstream.nix
+++ b/pkgs/applications/audio/deadbeef/plugins/vgmstream.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  deadbeef,
+  vgmstream,
+  mpg123,
+  libvorbis,
+  ffmpeg,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "deadbeef-vgmstream-plugin";
+  version = "2026-05-09.1";
+
+  src = fetchFromGitHub {
+    owner = "jchv";
+    repo = "deadbeef-vgmstream";
+    rev = finalAttrs.version;
+    hash = "sha256-dR1TEx61jnprEQokHRX/mi3WvbS+CVp4VIMlutX6uS8=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    deadbeef
+    mpg123
+    libvorbis
+    ffmpeg.dev
+  ];
+
+  enableParallelBuilding = true;
+
+  makeFlags = [ "DEADBEEF_ROOT=${deadbeef}" ];
+  installFlags = [ "DEADBEEF_ROOT=$(out)" ];
+
+  postUnpack = ''
+    rm -rf $sourceRoot/vgmstream
+    cp --no-preserve=mode,ownership -LR ${vgmstream.src} $sourceRoot/vgmstream
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Streaming video game music decoder plugin for the DeaDBeeF music player";
+    homepage = "https://github.com/jchv/deadbeef-vgmstream";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.jchw ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9114,6 +9114,7 @@ with pkgs;
     musical-spectrum = callPackage ../applications/audio/deadbeef/plugins/musical-spectrum.nix { };
     statusnotifier = callPackage ../applications/audio/deadbeef/plugins/statusnotifier.nix { };
     playlist-manager = callPackage ../applications/audio/deadbeef/plugins/playlist-manager.nix { };
+    vgmstream = callPackage ../applications/audio/deadbeef/plugins/vgmstream.nix { };
     waveform-seekbar = callPackage ../applications/audio/deadbeef/plugins/waveform-seekbar.nix { };
   };
 


### PR DESCRIPTION
This plugin brings an absolute ton of streaming video game music formats into DeaDBeeF.

I have been maintaining it continuously since 2014, and somewhat recently added it to the official plugins list. It doesn't really need too much maintenance; in all of this time I'm not sure the DeaDBeeF APIs have ever broken on me and the VGMStream APIs only broke on me once that I can recall. So, I expect it to be fairly stable with low maintenance (and to make it even more minimal, I have a `passthru.updateScript` as well.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
