### PR TITLE
qrupdate: skip single-precision QR-update tests on aarch64-linux

### DIFF
--- a/pkgs/by-name/qr/qrupdate/disable-aarch64-single-precision-tests.patch
+++ b/pkgs/by-name/qr/qrupdate/disable-aarch64-single-precision-tests.patch
@@ -1,0 +1,111 @@
+--- i/test/tqr1up.f
++++ w/test/tqr1up.f
+@@ -31,7 +31,7 @@
+       m = 60
+       n = 40
+       write (*,*) 'sqr1up test (full factorization):'
+-      call stest(m,n,0)
++c     call stest(m,n,0)
+       write (*,*) 'dqr1up test (full factorization):'
+       call dtest(m,n,0)
+       write (*,*) 'cqr1up test (full factorization):'
+@@ -40,7 +40,7 @@
+       call ztest(m,n,0)
+
+       write (*,*) 'sqr1up test (economized factorization):'
+-      call stest(m,n,1)
++c     call stest(m,n,1)
+       write (*,*) 'dqr1up test (economized factorization):'
+       call dtest(m,n,1)
+       write (*,*) 'cqr1up test (economized factorization):'
+@@ -51,7 +51,7 @@
+       m = 40
+       n = 60
+       write (*,*) 'sqr1up test (rows < columns):'
+-      call stest(m,n,0)
++c     call stest(m,n,0)
+       write (*,*) 'dqr1up test (rows < columns):'
+       call dtest(m,n,0)
+       write (*,*) 'cqr1up test (rows < columns):'
+--- i/test/tqrdec.f
++++ w/test/tqrdec.f
+@@ -32,7 +32,7 @@
+       n = 40
+       j = 12
+       write (*,*) 'sqrdec test (full factorization):'
+-      call stest(m,n,j,0)
++c     call stest(m,n,j,0)
+       write (*,*) 'dqrdec test (full factorization):'
+       call dtest(m,n,j,0)
+       write (*,*) 'cqrdec test (full factorization):'
+@@ -41,7 +41,7 @@
+       call ztest(m,n,j,0)
+
+       write (*,*) 'sqrdec test (economized factorization):'
+-      call stest(m,n,j,1)
++c     call stest(m,n,j,1)
+       write (*,*) 'dqrdec test (economized factorization):'
+       call dtest(m,n,j,1)
+       write (*,*) 'cqrdec test (economized factorization):'
+--- i/test/tqrder.f
++++ w/test/tqrder.f
+@@ -32,7 +32,7 @@
+       n = 40
+       j = 30
+       write (*,*) 'sqrder test (full factorization):'
+-      call stest(m,n,j)
++c     call stest(m,n,j)
+       write (*,*) 'dqrder test (full factorization):'
+       call dtest(m,n,j)
+       write (*,*) 'cqrder test (full factorization):'
+--- i/test/tqrinc.f
++++ w/test/tqrinc.f
+@@ -32,7 +32,7 @@
+       n = 40
+       j = 28
+       write (*,*) 'sqrinc test (full factorization):'
+-      call stest(m,n,j,0)
++c     call stest(m,n,j,0)
+       write (*,*) 'dqrinc test (full factorization):'
+       call dtest(m,n,j,0)
+       write (*,*) 'cqrinc test (full factorization):'
+@@ -41,7 +41,7 @@
+       call ztest(m,n,j,0)
+
+       write (*,*) 'sqrinc test (economized factorization):'
+-      call stest(m,n,j,1)
++c     call stest(m,n,j,1)
+       write (*,*) 'dqrinc test (economized factorization):'
+       call dtest(m,n,j,1)
+       write (*,*) 'cqrinc test (economized factorization):'
+--- i/test/tqrinr.f
++++ w/test/tqrinr.f
+@@ -32,7 +32,7 @@
+       n = 40
+       j = 30
+       write (*,*) 'sqrinr test (full factorization):'
+-      call stest(m,n,j)
++c     call stest(m,n,j)
+       write (*,*) 'dqrinr test (full factorization):'
+       call dtest(m,n,j)
+       write (*,*) 'cqrinr test (full factorization):'
+--- i/test/tqrshc.f
++++ w/test/tqrshc.f
+@@ -33,7 +33,7 @@
+       i = 20
+       j = 40
+       write (*,*) 'sqrshc test (left shift, full factorization):'
+-      call stest(m,n,i,j,0)
++c     call stest(m,n,i,j,0)
+       write (*,*) 'dqrshc test (left shift, full factorization):'
+       call dtest(m,n,i,j,0)
+       write (*,*) 'cqrshc test (left shift, full factorization):'
+@@ -44,7 +44,7 @@
+       i = 40
+       j = 20
+       write (*,*) 'sqrshc test (right shift, economized factorization):'
+-      call stest(m,n,i,j,1)
++c     call stest(m,n,i,j,1)
+       write (*,*) 'dqrshc test (right shift, economized factorization):'
+       call dtest(m,n,i,j,1)
+       write (*,*) 'cqrshc test (right shift, economized factorization):'

--- a/pkgs/by-name/qr/qrupdate/package.nix
+++ b/pkgs/by-name/qr/qrupdate/package.nix
@@ -42,10 +42,15 @@ stdenv.mkDerivation (finalAttrs: {
       "-DBLA_VENDOR=Generic"
     ];
 
-  # https://github.com/mpimd-csc/qrupdate-ng/issues/4
-  patches = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
-    ./disable-zch1dn-test.patch
-  ];
+  patches =
+    # https://github.com/mpimd-csc/qrupdate-ng/issues/4
+    lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
+      ./disable-zch1dn-test.patch
+    ]
+    # https://github.com/mpimd-csc/qrupdate-ng/issues/7
+    ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+      ./disable-aarch64-single-precision-tests.patch
+    ];
 
   postPatch = ''
     sed '/^cmake_minimum_required/Is/VERSION [0-9]\.[0-9]/VERSION 3.5/' -i ./CMakeLists.txt


### PR DESCRIPTION
Single-precision QR tests fail on aarch64; the patch skips them + keeping the double/complex (That isnt fail)
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/326897965)](https://hydra.nixos.org/build/326897965)

This should also fixes around 65 packages depending on this. (According to [nix-review-tools-reports](https://malob.github.io/nix-review-tools-reports/))
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test