### PR TITLE
various: clarify usage of GPL and derivatives (batch 1 of ?)

### DIFF
--- a/pkgs/by-name/ao/ao3downloader/package.nix
+++ b/pkgs/by-name/ao/ao3downloader/package.nix
@@ -50,7 +50,7 @@ python312Packages.buildPythonApplication (finalAttrs: {
     changelog = "https://github.com/nianeyna/ao3downloader/releases/tag/v${finalAttrs.version}";
     mainProgram = "ao3downloader";
     homepage = "https://nianeyna.dev/ao3downloader";
-    license = lib.licenses.gpl3;
+    license = lib.licenses.gpl3Only;
     maintainers = [ lib.maintainers.samasaur ];
   };
 })

--- a/pkgs/kde/third-party/koi/default.nix
+++ b/pkgs/kde/third-party/koi/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
       - Hide application to system tray
       - Toggle between LIGHT/DARK themes by clicking mouse wheel
     '';
-    license = lib.licenses.lgpl3;
+    license = lib.licenses.lgpl3Only;
     platforms = lib.platforms.linux;
     changelog = "https://github.com/baduhai/Koi/releases/tag/${finalAttrs.version}";
     homepage = "https://github.com/baduhai/Koi";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Since `lib.licenses.?gpl?` values are deprecated, they better be replaced with `?gpl?Only|Plus` for accurate representation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
