### PR TITLE
Revert 'flameshot: 13.3.0 -> 14.0rc1'

### DIFF
--- a/pkgs/by-name/fl/flameshot/load-missing-deps.patch
+++ b/pkgs/by-name/fl/flameshot/load-missing-deps.patch
@@ -1,46 +1,46 @@
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -35,27 +35,7 @@
+--- a/CMakeLists.txt	2025-08-21 13:12:55
++++ b/CMakeLists.txt	2025-08-21 13:16:26
+@@ -24,28 +24,8 @@
  #Needed due to linker error with QtColorWidget
  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
- 
--
--# Dependency can be fetched via flatpak builder
--if(EXISTS "${CMAKE_SOURCE_DIR}/external/Qt-Color-Widgets/CMakeLists.txt")
--  add_subdirectory("${CMAKE_SOURCE_DIR}/external/Qt-Color-Widgets" EXCLUDE_FROM_ALL)
--else()
--  FetchContent_Declare(
--    qtColorWidgets
--    GIT_REPOSITORY https://gitlab.com/mattbas/Qt-Color-Widgets.git
--    GIT_TAG 5d52e907e50dc88cf969b41cea44665ff6c475b1
--  )
--  #Workaround for duplicate GUID in windows WIX installer
--  if(WIN32)
--    FetchContent_GetProperties(qtColorWidgets)
--    if(NOT qtcolorwidgets_POPULATED)
--      FetchContent_Populate(qtColorWidgets)
--      add_subdirectory(${qtcolorwidgets_SOURCE_DIR} ${qtcolorwidgets_BINARY_DIR} EXCLUDE_FROM_ALL)
--    endif()
--  else()
--    FetchContent_MakeAvailable(qtColorWidgets)
--  endif()
--endif()
+
 +find_package(QtColorWidgets REQUIRED)
  
+-# Dependency can be fetched via flatpak builder
+-if(EXISTS "${CMAKE_SOURCE_DIR}/external/Qt-Color-Widgets/CMakeLists.txt")
+-    add_subdirectory("${CMAKE_SOURCE_DIR}/external/Qt-Color-Widgets" EXCLUDE_FROM_ALL)
+-else()
+-    FetchContent_Declare(
+-        qtColorWidgets
+-        GIT_REPOSITORY https://gitlab.com/mattbas/Qt-Color-Widgets.git
+-        GIT_TAG 352bc8f99bf2174d5724ee70623427aa31ddc26a
+-    )
+-  #Workaround for duplicate GUID in windows WIX installer
+-  if (WIN32)
+-      FetchContent_GetProperties(qtColorWidgets)
+-      if(NOT qtcolorwidgets_POPULATED)
+-          FetchContent_Populate(qtColorWidgets)
+-          add_subdirectory(${qtcolorwidgets_SOURCE_DIR} ${qtcolorwidgets_BINARY_DIR} EXCLUDE_FROM_ALL)
+-      endif()
+-  else()
+-      FetchContent_MakeAvailable(qtColorWidgets)
+-  endif()
+-endif()
+-
  # This can be read from ${PROJECT_NAME} after project() is called
- if(APPLE)
-@@ -124,12 +104,7 @@
- # ToDo: Check if this is used anywhere
+ if (APPLE)
+   set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum OS X deployment version")
+@@ -133,12 +113,7 @@
  option(BUILD_STATIC_LIBS ON)
- 
- if(WIN32 OR APPLE)
+
+ if (APPLE)
 -  FetchContent_Declare(
--    qHotKey
--    GIT_REPOSITORY https://github.com/flameshot-org/QHotkey
--    GIT_TAG master
+-      qHotKey
+-      GIT_REPOSITORY https://github.com/flameshot-org/QHotkey
+-      GIT_TAG master
 -  )
 -  FetchContent_MakeAvailable(QHotKey)
 +  find_package(QHotKey REQUIRED)
  endif()
- 
+
  add_subdirectory(src)

--- a/pkgs/by-name/fl/flameshot/package.nix
+++ b/pkgs/by-name/fl/flameshot/package.nix
@@ -19,13 +19,13 @@ assert stdenv.hostPlatform.isDarwin -> (!enableWlrSupport);
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "flameshot";
-  version = "14.0.rc1";
+  version = "13.3.0";
 
   src = fetchFromGitHub {
     owner = "flameshot-org";
     repo = "flameshot";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-7YvmZ9oSYD3VepIml4ixj40IPfTAR0R3MF8DuhdkHUM=";
+    hash = "sha256-RyoLniRmJRinLUwgmaA4RprYAVHnoPxCP9LyhHfUPe0=";
   };
 
   cmakeFlags = [


### PR DESCRIPTION
Due to major change in screenshotting method, Flameshot reportedly works inconsistently for a variety of users. While in cases on Wayland this has been due to portal misconfiguration, for X11 users this has been more breaking without solutions. 

Considering the approaching release, it is best to revert the update. 