### PR TITLE
herdr: init at 0.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14237,6 +14237,12 @@
     githubId = 8211181;
     name = "Kevin Kandlbinder";
   };
+  kevinpita = {
+    email = "gitkevin@pm.me";
+    github = "kevinpita";
+    githubId = 69063372;
+    name = "Kevin Pita";
+  };
   keyruu = {
     name = "Lucas";
     email = "me@keyruu.de";

--- a/pkgs/by-name/he/herdr/package.nix
+++ b/pkgs/by-name/he/herdr/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  zig_0_15,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "herdr";
+  version = "0.7.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "ogulcancelik";
+    repo = "herdr";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DjCSwhRMBRE9lSvjpX6m8IpoEgUbOP1jcmeXMlQlSQY=";
+  };
+
+  cargoHash = "sha256-NHVSdXlGsqhI/Mij28TvdW0f6IKOglNgpBNb2sFXocI=";
+
+  zigDeps = zig_0_15.fetchDeps {
+    inherit (finalAttrs) pname version;
+    src = "${finalAttrs.src}/vendor/libghostty-vt";
+    fetchAll = true;
+    hash = "sha256-pgGu8+NwvFcj6SrN4VaTHLeHdA7QY731ctyrHZwgFAc=";
+  };
+
+  nativeBuildInputs = [ zig_0_15.hook ];
+
+  # Upstream binary tests are renamed, added, or changed between releases and
+  # depend on host process details, so Nix-only patches for them are brittle.
+  doCheck = false;
+
+  dontUseZigBuild = true;
+  dontUseZigCheck = true;
+  dontUseZigInstall = true;
+
+  postConfigure = ''
+    export ZIG_GLOBAL_CACHE_DIR=$(mktemp -d)
+    cp -rL ${finalAttrs.zigDeps} "$ZIG_GLOBAL_CACHE_DIR/p"
+    chmod -R u+w "$ZIG_GLOBAL_CACHE_DIR/p"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Agent multiplexer that lives in your terminal";
+    homepage = "https://github.com/ogulcancelik/herdr";
+    changelog = "https://github.com/ogulcancelik/herdr/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ kevinpita ];
+    mainProgram = "herdr";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
# herdr: init at 0.7.0

Adds `herdr` at 0.7.0, an agent multiplexer that lives in your terminal.

Release: https://github.com/ogulcancelik/herdr/releases/tag/v0.7.0

The package builds the Rust CLI, uses Zig 0.15 for the vendored `libghostty-vt` dependency, and registers `kevinpita` as the package maintainer.

Checks are disabled because upstream binary tests spawn live `herdr` processes and assert host process details. Those tests are renamed, added, or changed between releases, so keeping Nix-only patches for them has been brittle.

AI assistance was used to help prepare this update. I reviewed the resulting changes.

Validation:
- `nix-build -A herdr`
- `nix-build lib/tests/maintainers.nix`
- `./result/bin/herdr --version` -> `herdr 0.7.0`
- `nixpkgs-review rev HEAD -b f60bf3d1ece330f80b3933c69912d376b8898f9d -p herdr --run "herdr --version" --print-result`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test