### PR TITLE
d-seams: fix missing cstdint include

### DIFF
--- a/pkgs/by-name/d-/d-seams/cxxopts-cstdint.patch
+++ b/pkgs/by-name/d-/d-seams/cxxopts-cstdint.patch
@@ -1,0 +1,11 @@
+diff --git a/src/include/external/cxxopts.hpp b/src/include/external/cxxopts.hpp
+--- a/src/include/external/cxxopts.hpp
++++ b/src/include/external/cxxopts.hpp
+@@ -26,6 +26,7 @@ THE SOFTWARE.
+ #define CXXOPTS_HPP_INCLUDED
+
+ #include <cctype>
++#include <cstdint>
+ #include <cstring>
+ #include <exception>
+ #include <iostream>

--- a/pkgs/by-name/d-/d-seams/package.nix
+++ b/pkgs/by-name/d-/d-seams/package.nix
@@ -36,6 +36,8 @@ clangStdenv.mkDerivation rec {
       url = "https://github.com/d-SEAMS/seams-core/commit/f6156057e43d0aa1a0df9de67d8859da9c30302d.patch";
       hash = "sha256-PLbT1lqdw+69lIHH96MPcGRjfIeZyb88vc875QLYyqw=";
     })
+    # Add missing <cstdint> include for uint8_t in vendored cxxopts.
+    ./cxxopts-cstdint.patch
   ];
   postPatch = ''
     substituteInPlace CMakeLists.txt \


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/326967267)](https://hydra.nixos.org/build/326967267)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test