### PR TITLE
nixos/forgejo-runner: init module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -509,6 +509,7 @@
   ./services/continuous-integration/buildbot/master.nix
   ./services/continuous-integration/buildbot/worker.nix
   ./services/continuous-integration/buildkite-agents.nix
+  ./services/continuous-integration/forgejo-runner.nix
   ./services/continuous-integration/gitea-actions-runner.nix
   ./services/continuous-integration/github-runners.nix
   ./services/continuous-integration/gitlab-runner/runner.nix

--- a/nixos/modules/services/continuous-integration/forgejo-runner.nix
+++ b/nixos/modules/services/continuous-integration/forgejo-runner.nix
@@ -14,6 +14,7 @@ let
     attrValues
     concatLists
     filterAttrs
+    getExe
     hasInfix
     hasSuffix
     literalExpression
@@ -82,16 +83,7 @@ let
     builtins.isAttrs server && server ? connections;
 
   allConnections = concatLists (
-    mapAttrsToList (
-      instanceName: instance:
-      mapAttrsToList (connectionName: connection: {
-        inherit
-          instanceName
-          connectionName
-          connection
-          ;
-      }) instance.connections
-    ) enabledInstances
+    mapAttrsToList (_: instance: attrValues instance.connections) enabledInstances
   );
 
   mkConnectionSettings =
@@ -111,6 +103,151 @@ let
     // optionalAttrs (connection.tokenFile != null) {
       token_url = "file:$CREDENTIALS_DIRECTORY/${credentialName connectionName}";
     };
+
+  connectionOptions = {
+    options = {
+      url = mkOption {
+        type = types.str;
+        example = "https://codeberg.org/";
+        description = ''
+          Base URL of the Forgejo instance.
+        '';
+      };
+
+      uuid = mkOption {
+        type = types.str;
+        example = "33834eef-e758-48c4-a676-1745426747aa";
+        description = ''
+          UUID identifying this runner towards the Forgejo instance.
+        '';
+      };
+
+      token = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Plain runner token for this connection.
+
+          This is copied into the Nix store. Use
+          [](#opt-services.forgejo-runner.instances._name_.connections._name_.tokenFile)
+          for secrets.
+        '';
+      };
+
+      tokenFile = mkOption {
+        type = types.nullOr (types.either types.str types.path);
+        default = null;
+        description = ''
+          Path to a file containing the runner token for this connection.
+          The file is passed to the service with `LoadCredential`.
+        '';
+      };
+
+      labels = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = literalExpression ''
+          [
+            "debian-latest:docker://node:22-bookworm"
+            "ubuntu-latest:docker://node:22-bookworm"
+            "native:host"
+          ]
+        '';
+        description = ''
+          Labels used to map jobs to their runtime environment.
+
+          If empty, the runner falls back to labels declared in
+          `settings.runner.labels`.
+        '';
+      };
+
+      fetchInterval = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "30s";
+        description = ''
+          How often Forgejo Runner should ask this connection for pending jobs.
+        '';
+      };
+    };
+  };
+
+  instanceOptions =
+    { name, ... }:
+    {
+      options = {
+        enable = mkEnableOption "Forgejo Runner instance";
+
+        settings = mkOption {
+          description = ''
+            Configuration for `forgejo-runner daemon`.
+
+            The `server.connections` section is generated from the
+            [](#opt-services.forgejo-runner.instances._name_.connections)
+            option.
+
+            See <https://code.forgejo.org/forgejo/runner/src/branch/main/internal/pkg/config/config.example.yaml>
+            for an example configuration.
+          '';
+          type = types.submodule {
+            freeformType = settingsFormat.type;
+          };
+          default = {
+            runner.name = name;
+          };
+          defaultText = literalExpression ''
+            {
+              runner.name = "<instance name>";
+            }
+          '';
+          example = literalExpression ''
+            {
+              log.level = "info";
+              runner.capacity = 2;
+              container.network = "bridge";
+              cache.enabled = true;
+            }
+          '';
+        };
+
+        connections = mkOption {
+          default = { };
+          description = ''
+            Forgejo server connections for this runner instance.
+          '';
+          type = types.attrsOf (types.submodule connectionOptions);
+        };
+
+        hostPackages = mkOption {
+          type = types.listOf types.package;
+          default = with pkgs; [
+            bash
+            coreutils
+            curl
+            gawk
+            gitMinimal
+            gnused
+            nodejs
+            wget
+          ];
+          defaultText = literalExpression ''
+            with pkgs; [
+              bash
+              coreutils
+              curl
+              gawk
+              gitMinimal
+              gnused
+              nodejs
+              wget
+            ]
+          '';
+          description = ''
+            Packages available to actions when this runner has a host execution label.
+          '';
+        };
+      };
+    };
 in
 {
   meta.maintainers = lib.teams.forgejo.members;
@@ -123,155 +260,11 @@ in
       description = ''
         Forgejo Runner instances.
       '';
-      type = attrsOf (
-        submodule (
-          { name, ... }:
-          {
-            options = {
-              enable = mkEnableOption "Forgejo Runner instance";
-
-              settings = mkOption {
-                description = ''
-                  Configuration for `forgejo-runner daemon`.
-
-                  The `server.connections` section is generated from the
-                  [](#opt-services.forgejo-runner.instances._name_.connections)
-                  option.
-
-                  See <https://code.forgejo.org/forgejo/runner/src/branch/main/internal/pkg/config/config.example.yaml>
-                  for an example configuration.
-                '';
-                type = submodule {
-                  freeformType = settingsFormat.type;
-                };
-                default = {
-                  runner.name = name;
-                };
-                defaultText = literalExpression ''
-                  {
-                    runner.name = "<instance name>";
-                  }
-                '';
-                example = literalExpression ''
-                  {
-                    log.level = "info";
-                    runner.capacity = 2;
-                    container.network = "bridge";
-                    cache.enabled = true;
-                  }
-                '';
-              };
-
-              connections = mkOption {
-                default = { };
-                description = ''
-                  Forgejo server connections for this runner instance.
-                '';
-                type = attrsOf (submodule {
-                  options = {
-                    url = mkOption {
-                      type = str;
-                      example = "https://codeberg.org/";
-                      description = ''
-                        Base URL of the Forgejo instance.
-                      '';
-                    };
-
-                    uuid = mkOption {
-                      type = str;
-                      example = "33834eef-e758-48c4-a676-1745426747aa";
-                      description = ''
-                        UUID identifying this runner towards the Forgejo instance.
-                      '';
-                    };
-
-                    token = mkOption {
-                      type = nullOr str;
-                      default = null;
-                      description = ''
-                        Plain runner token for this connection.
-
-                        This is copied into the Nix store. Use
-                        [](#opt-services.forgejo-runner.instances._name_.connections._name_.tokenFile)
-                        for secrets.
-                      '';
-                    };
-
-                    tokenFile = mkOption {
-                      type = nullOr (either str path);
-                      default = null;
-                      description = ''
-                        Path to a file containing the runner token for this connection.
-                        The file is passed to the service with `LoadCredential`.
-                      '';
-                    };
-
-                    labels = mkOption {
-                      type = listOf str;
-                      default = [ ];
-                      example = literalExpression ''
-                        [
-                          "debian-latest:docker://node:22-bookworm"
-                          "ubuntu-latest:docker://node:22-bookworm"
-                          "native:host"
-                        ]
-                      '';
-                      description = ''
-                        Labels used to map jobs to their runtime environment.
-
-                        If empty, the runner falls back to labels declared in
-                        `settings.runner.labels`.
-                      '';
-                    };
-
-                    fetchInterval = mkOption {
-                      type = nullOr str;
-                      default = null;
-                      example = "30s";
-                      description = ''
-                        How often Forgejo Runner should ask this connection for pending jobs.
-                      '';
-                    };
-                  };
-                });
-              };
-
-              hostPackages = mkOption {
-                type = listOf package;
-                default = with pkgs; [
-                  bash
-                  coreutils
-                  curl
-                  gawk
-                  gitMinimal
-                  gnused
-                  nodejs
-                  wget
-                ];
-                defaultText = literalExpression ''
-                  with pkgs; [
-                    bash
-                    coreutils
-                    curl
-                    gawk
-                    gitMinimal
-                    gnused
-                    nodejs
-                    wget
-                  ]
-                '';
-                description = ''
-                  Packages available to actions when this runner has a host execution label.
-                '';
-              };
-            };
-          }
-        )
-      );
+      type = attrsOf (submodule instanceOptions);
     };
   };
 
-  config = mkIf (cfg.instances != { }) {
+  config = mkIf (enabledInstances != { }) {
     assertions = [
       {
         assertion = all (instance: !instance.enable || instance.connections != { }) (
@@ -280,7 +273,7 @@ in
         message = "Enabled instances of forgejo-runner must define at least one connection.";
       }
       {
-        assertion = all ({ connection, ... }: tokenXorTokenFile connection) allConnections;
+        assertion = all tokenXorTokenFile allConnections;
         message = "Connections of forgejo-runner instances must have `token` or `tokenFile`, not both.";
       }
       {
@@ -298,6 +291,7 @@ in
         mkRunnerService =
           name: instance:
           let
+            escapedName = escapeSystemdPath name;
             wantsDockerScheme = hasDockerScheme instance;
             wantsHost = hasHostScheme instance;
             wantsDocker = wantsDockerScheme && hasDocker;
@@ -307,7 +301,7 @@ in
             };
             configFile = settingsFormat.generate "forgejo-runner-${name}.yaml" settings;
           in
-          nameValuePair "forgejo-runner-${escapeSystemdPath name}" {
+          nameValuePair "forgejo-runner-${escapedName}" {
             inherit (instance) enable;
             description = "Forgejo Runner";
             wants = [ "network-online.target" ];
@@ -326,7 +320,7 @@ in
                 DOCKER_HOST = "unix:///run/podman/podman.sock";
               }
               // {
-                HOME = "/var/lib/forgejo-runner/${name}";
+                HOME = "/var/lib/forgejo-runner/${escapedName}";
               };
             path = [
               pkgs.coreutils
@@ -335,13 +329,13 @@ in
             serviceConfig = {
               DynamicUser = true;
               User = "forgejo-runner";
-              StateDirectory = "forgejo-runner";
-              WorkingDirectory = "-/var/lib/forgejo-runner/${name}";
+              StateDirectory = "forgejo-runner/${escapedName}";
+              WorkingDirectory = "-/var/lib/forgejo-runner/${escapedName}";
 
               Restart = "on-failure";
               RestartSec = 2;
 
-              ExecStart = "${cfg.package}/bin/forgejo-runner daemon --config ${configFile}";
+              ExecStart = "${getExe cfg.package} daemon --config ${configFile}";
               SupplementaryGroups =
                 optionals wantsDocker [
                   "docker"

--- a/nixos/modules/services/continuous-integration/forgejo-runner.nix
+++ b/nixos/modules/services/continuous-integration/forgejo-runner.nix
@@ -1,0 +1,364 @@
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+
+let
+  inherit (lib)
+    all
+    any
+    attrByPath
+    attrValues
+    concatLists
+    filterAttrs
+    hasInfix
+    hasSuffix
+    literalExpression
+    mapAttrs
+    mapAttrs'
+    mapAttrsToList
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    nameValuePair
+    optionalAttrs
+    optionals
+    recursiveUpdate
+    types
+    ;
+
+  inherit (utils) escapeSystemdPath;
+
+  cfg = config.services.forgejo-runner;
+
+  settingsFormat = pkgs.formats.yaml { };
+
+  enabledInstances = filterAttrs (_: instance: instance.enable) cfg.instances;
+
+  credentialName = connectionName: "${escapeSystemdPath connectionName}-token";
+
+  runnerLabels =
+    instance:
+    let
+      labels =
+        attrByPath
+          [
+            "runner"
+            "labels"
+          ]
+          [ ]
+          instance.settings;
+    in
+    if builtins.isList labels then labels else [ ];
+
+  connectionLabels =
+    instance: concatLists (mapAttrsToList (_: connection: connection.labels) instance.connections);
+
+  instanceLabels = instance: runnerLabels instance ++ connectionLabels instance;
+
+  hasDockerScheme = instance: any (label: hasInfix ":docker://" label) (instanceLabels instance);
+
+  hasHostScheme = instance: any (label: hasSuffix ":host" label) (instanceLabels instance);
+
+  hasDocker = config.virtualisation.docker.enable;
+  hasPodman = config.virtualisation.podman.enable;
+
+  wantsContainerRuntime = any hasDockerScheme (attrValues enabledInstances);
+
+  tokenXorTokenFile =
+    connection:
+    (connection.token == null && connection.tokenFile != null)
+    || (connection.token != null && connection.tokenFile == null);
+
+  serverConnectionsInSettings =
+    instance:
+    let
+      server = instance.settings.server or { };
+    in
+    builtins.isAttrs server && server ? connections;
+
+  allConnections = concatLists (
+    mapAttrsToList (
+      instanceName: instance:
+      mapAttrsToList (connectionName: connection: {
+        inherit
+          instanceName
+          connectionName
+          connection
+          ;
+      }) instance.connections
+    ) enabledInstances
+  );
+
+  mkConnectionSettings =
+    connectionName: connection:
+    {
+      inherit (connection) url uuid;
+    }
+    // optionalAttrs (connection.labels != [ ]) {
+      inherit (connection) labels;
+    }
+    // optionalAttrs (connection.fetchInterval != null) {
+      fetch_interval = connection.fetchInterval;
+    }
+    // optionalAttrs (connection.token != null) {
+      inherit (connection) token;
+    }
+    // optionalAttrs (connection.tokenFile != null) {
+      token_url = "file:$CREDENTIALS_DIRECTORY/${credentialName connectionName}";
+    };
+in
+{
+  meta.maintainers = lib.teams.forgejo.members;
+
+  options.services.forgejo-runner = with types; {
+    package = mkPackageOption pkgs "forgejo-runner" { };
+
+    instances = mkOption {
+      default = { };
+      description = ''
+        Forgejo Runner instances.
+      '';
+      type = attrsOf (
+        submodule (
+          { name, ... }:
+          {
+            options = {
+              enable = mkEnableOption "Forgejo Runner instance";
+
+              settings = mkOption {
+                description = ''
+                  Configuration for `forgejo-runner daemon`.
+
+                  The `server.connections` section is generated from the
+                  [](#opt-services.forgejo-runner.instances._name_.connections)
+                  option.
+
+                  See <https://code.forgejo.org/forgejo/runner/src/branch/main/internal/pkg/config/config.example.yaml>
+                  for an example configuration.
+                '';
+                type = submodule {
+                  freeformType = settingsFormat.type;
+                };
+                default = {
+                  runner.name = name;
+                };
+                defaultText = literalExpression ''
+                  {
+                    runner.name = "<instance name>";
+                  }
+                '';
+                example = literalExpression ''
+                  {
+                    log.level = "info";
+                    runner.capacity = 2;
+                    container.network = "bridge";
+                    cache.enabled = true;
+                  }
+                '';
+              };
+
+              connections = mkOption {
+                default = { };
+                description = ''
+                  Forgejo server connections for this runner instance.
+                '';
+                type = attrsOf (submodule {
+                  options = {
+                    url = mkOption {
+                      type = str;
+                      example = "https://codeberg.org/";
+                      description = ''
+                        Base URL of the Forgejo instance.
+                      '';
+                    };
+
+                    uuid = mkOption {
+                      type = str;
+                      example = "33834eef-e758-48c4-a676-1745426747aa";
+                      description = ''
+                        UUID identifying this runner towards the Forgejo instance.
+                      '';
+                    };
+
+                    token = mkOption {
+                      type = nullOr str;
+                      default = null;
+                      description = ''
+                        Plain runner token for this connection.
+
+                        This is copied into the Nix store. Use
+                        [](#opt-services.forgejo-runner.instances._name_.connections._name_.tokenFile)
+                        for secrets.
+                      '';
+                    };
+
+                    tokenFile = mkOption {
+                      type = nullOr (either str path);
+                      default = null;
+                      description = ''
+                        Path to a file containing the runner token for this connection.
+                        The file is passed to the service with `LoadCredential`.
+                      '';
+                    };
+
+                    labels = mkOption {
+                      type = listOf str;
+                      default = [ ];
+                      example = literalExpression ''
+                        [
+                          "debian-latest:docker://node:22-bookworm"
+                          "ubuntu-latest:docker://node:22-bookworm"
+                          "native:host"
+                        ]
+                      '';
+                      description = ''
+                        Labels used to map jobs to their runtime environment.
+
+                        If empty, the runner falls back to labels declared in
+                        `settings.runner.labels`.
+                      '';
+                    };
+
+                    fetchInterval = mkOption {
+                      type = nullOr str;
+                      default = null;
+                      example = "30s";
+                      description = ''
+                        How often Forgejo Runner should ask this connection for pending jobs.
+                      '';
+                    };
+                  };
+                });
+              };
+
+              hostPackages = mkOption {
+                type = listOf package;
+                default = with pkgs; [
+                  bash
+                  coreutils
+                  curl
+                  gawk
+                  gitMinimal
+                  gnused
+                  nodejs
+                  wget
+                ];
+                defaultText = literalExpression ''
+                  with pkgs; [
+                    bash
+                    coreutils
+                    curl
+                    gawk
+                    gitMinimal
+                    gnused
+                    nodejs
+                    wget
+                  ]
+                '';
+                description = ''
+                  Packages available to actions when this runner has a host execution label.
+                '';
+              };
+            };
+          }
+        )
+      );
+    };
+  };
+
+  config = mkIf (cfg.instances != { }) {
+    assertions = [
+      {
+        assertion = all (instance: !instance.enable || instance.connections != { }) (
+          attrValues cfg.instances
+        );
+        message = "Enabled instances of forgejo-runner must define at least one connection.";
+      }
+      {
+        assertion = all ({ connection, ... }: tokenXorTokenFile connection) allConnections;
+        message = "Connections of forgejo-runner instances must have `token` or `tokenFile`, not both.";
+      }
+      {
+        assertion = all (instance: !serverConnectionsInSettings instance) (attrValues enabledInstances);
+        message = "Configure Forgejo Runner server connections with `services.forgejo-runner.instances.<name>.connections`, not `settings.server.connections`.";
+      }
+      {
+        assertion = wantsContainerRuntime -> hasDocker || hasPodman;
+        message = "Docker labels on forgejo-runner instances require either Docker or Podman.";
+      }
+    ];
+
+    systemd.services =
+      let
+        mkRunnerService =
+          name: instance:
+          let
+            wantsDockerScheme = hasDockerScheme instance;
+            wantsHost = hasHostScheme instance;
+            wantsDocker = wantsDockerScheme && hasDocker;
+            wantsPodman = wantsDockerScheme && hasPodman;
+            settings = recursiveUpdate instance.settings {
+              server.connections = mapAttrs mkConnectionSettings instance.connections;
+            };
+            configFile = settingsFormat.generate "forgejo-runner-${name}.yaml" settings;
+          in
+          nameValuePair "forgejo-runner-${escapeSystemdPath name}" {
+            inherit (instance) enable;
+            description = "Forgejo Runner";
+            wants = [ "network-online.target" ];
+            after = [
+              "network-online.target"
+            ]
+            ++ optionals wantsDocker [
+              "docker.service"
+            ]
+            ++ optionals wantsPodman [
+              "podman.service"
+            ];
+            wantedBy = [ "multi-user.target" ];
+            environment =
+              optionalAttrs wantsPodman {
+                DOCKER_HOST = "unix:///run/podman/podman.sock";
+              }
+              // {
+                HOME = "/var/lib/forgejo-runner/${name}";
+              };
+            path = [
+              pkgs.coreutils
+            ]
+            ++ optionals wantsHost instance.hostPackages;
+            serviceConfig = {
+              DynamicUser = true;
+              User = "forgejo-runner";
+              StateDirectory = "forgejo-runner";
+              WorkingDirectory = "-/var/lib/forgejo-runner/${name}";
+
+              Restart = "on-failure";
+              RestartSec = 2;
+
+              ExecStart = "${cfg.package}/bin/forgejo-runner daemon --config ${configFile}";
+              SupplementaryGroups =
+                optionals wantsDocker [
+                  "docker"
+                ]
+                ++ optionals wantsPodman [
+                  "podman"
+                ];
+            }
+            //
+              optionalAttrs (any (connection: connection.tokenFile != null) (attrValues instance.connections))
+                {
+                  LoadCredential = mapAttrsToList (
+                    connectionName: connection: "${credentialName connectionName}:${connection.tokenFile}"
+                  ) (filterAttrs (_: connection: connection.tokenFile != null) instance.connections);
+                };
+          };
+      in
+      mapAttrs' mkRunnerService enabledInstances;
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -607,6 +607,7 @@ in
     inherit runTest;
     forgejoPackage = pkgs.forgejo-lts;
   };
+  forgejo-runner = runTest ./forgejo-runner.nix;
   freenet = runTest ./freenet.nix;
   freeswitch = runTest ./freeswitch.nix;
   freetube = discoverTests (import ./freetube.nix);

--- a/nixos/tests/forgejo-runner.nix
+++ b/nixos/tests/forgejo-runner.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  ...
+}:
+
+{
+  name = "forgejo-runner";
+  meta.maintainers = lib.teams.forgejo.members;
+
+  nodes.machine = {
+    virtualisation.podman = {
+      enable = true;
+      dockerSocket.enable = true;
+    };
+
+    environment.etc."forgejo-runner-token".text = "0123456789abcdef0123456789abcdef01234567";
+
+    services.forgejo-runner.instances.codeberg = {
+      enable = true;
+      settings = {
+        log.level = "info";
+        runner = {
+          name = "test-runner";
+          capacity = 2;
+        };
+        container.network = "bridge";
+        cache.enabled = true;
+      };
+      connections.codeberg = {
+        url = "https://codeberg.org/";
+        uuid = "33834eef-e758-48c4-a676-1745426747aa";
+        tokenFile = "/etc/forgejo-runner-token";
+        labels = [
+          "ubuntu-latest:docker://ghcr.io/catthehacker/ubuntu:act-latest"
+        ];
+        fetchInterval = "30s";
+      };
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+
+    unit = machine.succeed("systemctl cat forgejo-runner-codeberg.service")
+    assert "LoadCredential=codeberg-token:/etc/forgejo-runner-token" in unit
+    assert "DOCKER_HOST=unix:///run/podman/podman.sock" in unit
+    assert "SupplementaryGroups=podman" in unit
+
+    config_path = machine.succeed(
+        "systemctl show forgejo-runner-codeberg.service -p ExecStart --value "
+        "| sed -n 's/.* --config \\([^ ;]*\\).*/\\1/p'"
+    ).strip()
+    config = machine.succeed(f"cat {config_path}")
+
+    assert "server:" in config
+    assert "connections:" in config
+    assert "codeberg:" in config
+    assert "url: https://codeberg.org/" in config
+    assert "uuid: 33834eef-e758-48c4-a676-1745426747aa" in config
+    assert "token_url: file:$CREDENTIALS_DIRECTORY/codeberg-token" in config
+    assert "fetch_interval: 30s" in config
+    assert "token: " not in config
+  '';
+}

--- a/nixos/tests/forgejo-runner.nix
+++ b/nixos/tests/forgejo-runner.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  pkgs,
   ...
 }:
 
@@ -8,6 +9,14 @@
   meta.maintainers = lib.teams.forgejo.members;
 
   nodes.machine = {
+    services.forgejo-runner.package = pkgs.writeShellScriptBin "forgejo-runner" ''
+      if [ "$1" = daemon ]; then
+        sleep infinity
+      else
+        echo "forgejo-runner test"
+      fi
+    '';
+
     virtualisation.podman = {
       enable = true;
       dockerSocket.enable = true;
@@ -40,11 +49,14 @@
 
   testScript = ''
     machine.wait_for_unit("multi-user.target")
+    machine.wait_for_unit("forgejo-runner-codeberg.service")
 
     unit = machine.succeed("systemctl cat forgejo-runner-codeberg.service")
     assert "LoadCredential=codeberg-token:/etc/forgejo-runner-token" in unit
     assert "DOCKER_HOST=unix:///run/podman/podman.sock" in unit
     assert "SupplementaryGroups=podman" in unit
+    assert "StateDirectory=forgejo-runner/codeberg" in unit
+    assert "WorkingDirectory=-/var/lib/forgejo-runner/codeberg" in unit
 
     config_path = machine.succeed(
         "systemctl show forgejo-runner-codeberg.service -p ExecStart --value "


### PR DESCRIPTION
Adds a dedicated NixOS module for Forgejo Runner using declarative server.connections configuration. This avoids the deprecated imperative register flow and supports credential-backed tokens through systemd LoadCredential.

Review notes:
- Local x86_64-linux validation passed: nixosTests.forgejo-runner, forgejo-runner package build, updateScript eval, updater run, and forgejo-runner --version.
- nixpkgs-review-gha passed for the current head: https://github.com/caniko/nixpkgs-review-gha/actions/runs/25597185446.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test