### PR TITLE
fmit: 1.2.14 -> 1.3.3

### DIFF
--- a/pkgs/by-name/fm/fmit/package.nix
+++ b/pkgs/by-name/fm/fmit/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  libsForQt5,
+  qt6,
   fftw,
   itstool,
   alsaSupport ? true,
@@ -19,31 +19,34 @@ assert portaudioSupport -> portaudio != null;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fmit";
-  version = "1.2.14";
+  version = "1.3.3";
 
   src = fetchFromGitHub {
     owner = "gillesdegottex";
     repo = "fmit";
     rev = "v${finalAttrs.version}";
-    sha256 = "1q062pfwz2vr9hbfn29fv54ip3jqfd9r99nhpr8w7mn1csy38azx";
+    sha256 = "sha256-fi5/JCgum+TYexUuTRZNFWPPsR87P73gfYhozQYx3Rw=";
   };
 
   nativeBuildInputs = [
-    libsForQt5.qmake
+    qt6.qmake
     itstool
-    libsForQt5.wrapQtAppsHook
+    qt6.wrapQtAppsHook
   ];
   buildInputs = [
     fftw
-    libsForQt5.qtbase
-    libsForQt5.qtmultimedia
+    qt6.qtbase
+    qt6.qtmultimedia
+    qt6.qtsvg
   ]
   ++ lib.optionals alsaSupport [ alsa-lib ]
   ++ lib.optionals jackSupport [ libjack2 ]
   ++ lib.optionals portaudioSupport [ portaudio ];
 
   postPatch = ''
-    substituteInPlace fmit.pro --replace '$$FMITVERSIONGITPRO' '${finalAttrs.version}'
+    substituteInPlace fmit.pro \
+      --replace-fail 'FMITVERSIONPRO = $$system(git describe --tags --always)' 'FMITVERSIONPRO = ${finalAttrs.version}' \
+      --replace-fail 'FMITBRANCHGITPRO = $$system(git rev-parse --abbrev-ref HEAD)' 'FMITBRANCHGITPRO = master'
   '';
 
   qmakeFlags = [


### PR DESCRIPTION
Update to 1.3.3

Change qt dependency to qt6 to support the new version

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
