### PR TITLE
maintainers: remove vizanto

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28966,12 +28966,6 @@
     githubId = 59029586;
     name = "Vitor Pavan";
   };
-  vizanto = {
-    email = "danny@prime.vc";
-    github = "vizanto";
-    githubId = 326263;
-    name = "Danny Wilson";
-  };
   vizid = {
     email = "mail@vizqq.cc";
     github = "ViZiD";

--- a/pkgs/by-name/st/storm/package.nix
+++ b/pkgs/by-name/st/storm/package.nix
@@ -79,9 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Distributed realtime computation system";
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [
-      vizanto
-    ];
+    maintainers = [ ];
     platforms = with lib.platforms; unix;
   };
 })


### PR DESCRIPTION
## Reasons

- Last commented in [February 2016](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Avizanto)
- Hasn't created any PRs / Issues since [February 2016](https://github.com/NixOS/nixpkgs/issues?q=author%3Avizanto)
- About 29 [unanswered ](https://github.com/NixOS/nixpkgs/issues?q=involves%3Avizanto%20-commenter%3Avizanto%20-author%3Avizanto%20-reviewed-by%3Avizanto) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] storm