### PR TITLE
adalanche: 2024.1.11 -> 2025.2.6

### DIFF
--- a/pkgs/by-name/ad/adalanche/package.nix
+++ b/pkgs/by-name/ad/adalanche/package.nix
@@ -7,25 +7,32 @@
 
 buildGoModule (finalAttrs: {
   pname = "adalanche";
-  version = "2024.1.11";
+  version = "2025.2.6";
 
   src = fetchFromGitHub {
     owner = "lkarlslund";
     repo = "adalanche";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-SJa2PQCXTYdv5jMucpJOD2gC7Qk2dNdINHW4ZvLXSLw=";
+    hash = "sha256-PEq0bIZTtaUoNUTPypq9OAzhwC2SM1KKtjfS9QZwo6c=";
   };
 
-  vendorHash = "sha256-3HulDSR6rWyxvImWBH1m5nfUwnUDQO9ALfyT2D8xmJc=";
+  vendorHash = "sha256-TTJ82l+oMGixQnpW0JxBndPuAuKe6TAjJnN0a1LPtSY=";
 
   buildInputs = [
     libpcap
   ];
 
+  # sonic dependency uses internal go APIs blocked in Go 1.23+
+  # See https://github.com/bytedance/sonic/issues/711
   ldflags = [
     "-s"
     "-w"
     "-X=github.com/lkarlslund/adalanche/modules/version.Version=${finalAttrs.version}"
+    "-checklinkname=0"
+  ];
+
+  checkFlags = [
+    "-skip=TestParseTestAQLQueries|TestParsePredefinedAQLQueries"
   ];
 
   meta = {


### PR DESCRIPTION
Update package.

Add -checklinkname=0 for compatibility with go > 1.223

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
