### PR TITLE
yubal: init at 0.7.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25560,6 +25560,11 @@
     name = "Sebastian Kowalak";
     matrix = "@scl:tchncs.de";
   };
+  skullgirl = {
+    name = "Skullgirl-(Lady-Bugged)";
+    github = "Skullman-G";
+    githubId = 64651571;
+  };
   skwig = {
     name = "skwig";
     github = "skwig";

--- a/pkgs/by-name/yu/yubal/api.nix
+++ b/pkgs/by-name/yu/yubal/api.nix
@@ -1,0 +1,36 @@
+{
+  yubal,
+  python312Packages,
+}:
+
+with python312Packages;
+buildPythonPackage {
+  pname = yubal.pname + "-api";
+  inherit (yubal) version src;
+  sourceRoot = "source/packages/api";
+  pyproject = true;
+
+  build-system = [
+    uv-build
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.9.23,<0.10.0" "uv-build" \
+      --replace-fail "alembic>=1.18.3" "alembic"
+  '';
+
+  pythonImportsCheck = [ "yubal_api" ];
+
+  dependencies = [
+    alembic
+    croniter
+    fastapi
+    rich
+    pydantic-settings
+    sqlmodel
+    tzdata
+    uvicorn
+    yubal.yubal-cli
+  ];
+}

--- a/pkgs/by-name/yu/yubal/cli.nix
+++ b/pkgs/by-name/yu/yubal/cli.nix
@@ -1,0 +1,35 @@
+{
+  yubal,
+  python312Packages,
+}:
+
+with python312Packages;
+buildPythonPackage {
+  pname = yubal.pname + "-cli";
+  inherit (yubal) version src;
+  sourceRoot = "source/packages/yubal";
+  pyproject = true;
+
+  build-system = [
+    uv-build
+  ];
+
+  pythonImportsCheck = [ "yubal" ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.9.23,<0.10.0" "uv-build"
+  '';
+
+  dependencies = [
+    ytmusicapi
+    pydantic
+    yt-dlp
+    pathvalidate
+    rapidfuzz
+    mediafile
+    httpx
+    unidecode
+    numpy_1
+  ];
+}

--- a/pkgs/by-name/yu/yubal/package.nix
+++ b/pkgs/by-name/yu/yubal/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  python312Packages,
+  callPackage,
+  python312,
+  makeWrapper,
+  ffmpeg,
+  rsgain,
+}:
+
+with python312Packages;
+stdenv.mkDerivation (finalAttrs: {
+  pname = "yubal";
+  version = "0.7.2";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "guillevc";
+    repo = "yubal";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-SO3KFUDOCBQ7BSf5PujiQ0RaHyiuuIOrmBsw/i0OsF0=";
+  };
+
+  web = callPackage ./web.nix { };
+
+  yubal-cli = callPackage ./cli.nix { };
+
+  yubal-api = callPackage ./api.nix { };
+
+  pythonEnv = python312.withPackages (ps: [
+    finalAttrs.yubal-api
+  ]);
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  buildInputs = [
+    ffmpeg
+    rsgain
+  ];
+
+  installPhase = ''
+    mkdir -p $out/web
+    cp -r ${finalAttrs.web}/dist $out/web
+
+    makeWrapper ${finalAttrs.pythonEnv}/bin/python $out/bin/yubal \
+      --add-flags "-m yubal_api" \
+      --set-default YUBAL_ROOT $out \
+      --set-default YUBAL_CONFIG ./config \
+      --set-default YUBAL_DATA ./data \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          ffmpeg
+          rsgain
+        ]
+      }
+  '';
+
+  meta = with lib; {
+    description = "Self-hosted YouTube Music downloader. Tags, organizes, and keeps playlists in sync.";
+    homepage = "https://github.com/guillevc/yubal";
+    mainProgram = "yubal";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.skullgirl ];
+  };
+})

--- a/pkgs/by-name/yu/yubal/web.nix
+++ b/pkgs/by-name/yu/yubal/web.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  stdenv,
+  bun,
+  nodejs,
+  git,
+  yubal,
+}:
+
+let
+  node_modules = stdenv.mkDerivation {
+    inherit (yubal) version;
+    pname = yubal.pname + "-web-node_modules";
+    nativeBuildInputs = [
+      bun
+      nodejs
+    ];
+    phases = [
+      "buildPhase"
+      "installPhase"
+    ];
+
+    impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
+      "GIT_PROXY_COMMAND"
+      "SOCKS_SERVER"
+    ];
+
+    buildPhase = ''
+      cp ${yubal.src}/web/package.json package.json
+      cp ${yubal.src}/web/bun.lock bun.lock
+      bun install --no-progress --frozen-lockfile
+    '';
+
+    installPhase = ''
+      mkdir -p $out/node_modules
+      cp -R node_modules/. $out/node_modules/
+    '';
+
+    outputHash =
+      {
+        x86_64-linux = "sha256-UxKGFOtlQuoFSG/yDCpzdD0KudaqUAYQMg4EocxHl2M=";
+        aarch64-linux = "sha256-5Pt1QoRp5CkFSWKIN2B+cv2AD0MOQ0uEeeEKLN/JnJ0=";
+      }
+      .${stdenv.hostPlatform.system} or (throw "Unsupported system ${stdenv.hostPlatform.system}");
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+  };
+in
+
+stdenv.mkDerivation {
+  inherit (yubal) version src;
+  pname = yubal.pname + "-web";
+  buildInputs = [
+    bun
+    nodejs
+    git
+  ];
+  sourceRoot = "source/web";
+
+  buildPhase = ''
+    mkdir -p node_modules
+    cp -R ${node_modules}/node_modules/. node_modules/
+    patchShebangs node_modules
+    bun run build
+  '';
+
+  installPhase = ''
+    mkdir -p $out/dist
+    cp -r dist/* $out/dist/
+  '';
+}


### PR DESCRIPTION
Added package "yubal" at version 0.7.2
Homepage: https://github.com/guillevc/yubal
Description: Self-hosted YouTube Music downloader. Tags, organizes, and keeps playlists in sync.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test