### PR TITLE
python3Packages.av: fix build

### DIFF
--- a/pkgs/development/python-modules/av/default.nix
+++ b/pkgs/development/python-modules/av/default.nix
@@ -1,8 +1,8 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
 
   # build-system
   cython,
@@ -34,6 +34,21 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-mz0VI72lqtur5HdCkPNxInk0pUWxji0boIZnfvdrxIs=";
   };
+
+  patches = [
+    # Upstream PR: https://github.com/PyAV-Org/PyAV/pull/2204
+    (fetchpatch {
+      name = "ffmpeg-8.1-compat-test_skip_samples_remux.patch";
+      url = "https://github.com/PyAV-Org/PyAV/commit/57d8f4d7215a7b7cc7d01415613fc6aa2831a8d3.patch";
+      hash = "sha256-bDp8p2Qy9tU1GD9YqxU3O0ozPxhX/Fu9p9Zy1BIlPXA=";
+    })
+    # Upstream PR: https://github.com/PyAV-Org/PyAV/pull/2205
+    (fetchpatch {
+      name = "ffmpeg-8.1-compat-test_reformat_pixel_format_align.patch";
+      url = "https://github.com/PyAV-Org/PyAV/commit/900e39b9f0f7df33c3ea192b6dc13736e0b1561c.patch";
+      hash = "sha256-5SDLg5kQl2XjKX73rEIVSTznWAbC1oHr6EXfcufwhNM=";
+    })
+  ];
 
   build-system = [
     cython


### PR DESCRIPTION
https://github.com/PyAV-Org/PyAV/pull/2204
https://github.com/PyAV-Org/PyAV/pull/2205

Hydra: https://hydra.nixos.org/build/328526004

Not bumping to 17.0.1 as that would be a breaking change and breaking changes are currently restricted.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `python3{13,14}Packages.av`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
