### PR TITLE
helium-browser: init at 0.11.3.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30884,5 +30884,11 @@
     githubId = 59917878;
     name = "Mathias Zhang";
   };
+  nilsritter = {
+    email = "ritter.nils@protonmail.com";
+    github = "Nils-Ritter";
+    githubId = 282257734;
+    name = "Nils Ritter";
+  };
   # keep-sorted end
 }

--- a/pkgs/applications/networking/browsers/helium-browser/default.nix
+++ b/pkgs/applications/networking/browsers/helium-browser/default.nix
@@ -1,0 +1,49 @@
+{ lib, stdenv, fetchurl, appimageTools, makeWrapper
+, gtk3, libdrm, libxshmfence, mesa, nspr, nss, libGL, xorg
+, alsa-lib, at-spi2-atk, atk, cairo, cups, dbus, expat, fontconfig
+, freetype, gdk-pixbuf, glib, gnome2, libnotify, libX11, libXcomposite
+, libXcursor, libXdamage, libXext, libXfixes, libXi, libXrandr
+, libXrender, libXScrnSaver, libXtst, pango, systemd, udev, xdg-utils
+, autoPatchelfHook }:
+
+let
+  pname = "helium-browser";
+  version = "0.11.3.2";
+  src = fetchurl {
+    url = "https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage";
+    hash = "sha256-5gdyKg12ZV2hpf0RL+eoJnawuW/J8NobiG+zEA0IOHA=";
+};
+in appimageTools.wrapType2 rec {
+  inherit pname version src;
+  extraPkgs = pkgs: with pkgs; [
+    gtk3 libdrm libxshmfence mesa nspr nss
+    alsa-lib at-spi2-atk atk cairo cups dbus expat
+    fontconfig freetype gdk-pixbuf glib gnome2.GConf
+    libnotify libX11 libXcomposite libXcursor libXdamage
+    libXext libXfixes libXi libXrandr libXrender libXScrnSaver
+    libXtst pango systemd udev xdg-utils
+  ];
+
+  # Extract desktop item
+  desktopItem = appimageTools.extractDesktopItem {
+    inherit pname version;
+    src = src;
+    name = "${pname}";
+    exec = "${placeholder "out"}/bin/${pname}";
+    comment = meta.description;
+    desktopName = lib.strings.capitalize pname;
+    genericName = "Web Browser";
+    categories = [ "Network" "WebBrowser" ];
+    mimeTypes = [ "text/html" "text/xml" "application/xhtml+xml" "application/vnd.mozilla.xul+xml" ];
+  };
+
+  meta = with lib; {
+    description = "Private, fast, and honest web browser based on Chromium";
+    homepage = "https://helium.computer";
+    license = licenses.gpl3;
+    maintainers =  with maintainers; [ nilsritter ];
+    platforms = platforms.linux;
+    mainProgram = pname;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12176,4 +12176,6 @@ with pkgs;
   gpac-unstable = callPackage ../by-name/gp/gpac/package.nix {
     releaseChannel = "unstable";
   };
+
+  helium-browser = callPackage ../applications/networking/browsers/helium-browser {};
 }


### PR DESCRIPTION
###### Description of changes

Adds Helium Browser, a privacy-focused Chromium-based web browser with built-in ad-blocking, tracker protection, and zero telemetry. It is packaged as an AppImage wrapped with Nix dependencies.

- Homepage: [helium.computer](https://helium.computer/)
- Upstream: [imputnet/helium-linux](https://github.com/imputnet/helium-linux/)

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] Tested with `nix-shell -p helium-browser --run "helium-browser"`: launches correctly and supports basic browsing
- [X] Tested with `nix build`: builds successfully
- [X] Added `meta.maintainers` for myself

###### Existing packages

No existing Helium package in nixpkgs.