### PR TITLE
ghui: vendor package-lock.json and auto-regenerate via nix-update

### DIFF
--- a/pkgs/by-name/gh/ghui/package-lock.json
+++ b/pkgs/by-name/gh/ghui/package-lock.json
@@ -1,0 +1,1539 @@
+{
+	"name": "@kitlangton/ghui",
+	"version": "0.4.6",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "@kitlangton/ghui",
+			"version": "0.4.6",
+			"license": "MIT",
+			"workspaces": [
+				".",
+				"packages/*"
+			],
+			"dependencies": {
+				"@effect/atom-react": "4.0.0-beta.59",
+				"@opentui/core": "0.2.1",
+				"@opentui/react": "0.2.1",
+				"effect": "4.0.0-beta.59",
+				"react": "19.2.5",
+				"scheduler": "0.27.0"
+			},
+			"bin": {
+				"ghui": "bin/ghui.js"
+			},
+			"devDependencies": {
+				"@effect/language-service": "0.85.1",
+				"@ghui/keymap": "workspace:*",
+				"@types/bun": "1.3.12",
+				"@types/react": "19.2.14",
+				"oxfmt": "0.47.0",
+				"oxlint": "1.62.0",
+				"typescript": "6.0.2"
+			}
+		},
+		"node_modules/@effect/atom-react": {
+			"version": "4.0.0-beta.59",
+			"resolved": "https://registry.npmjs.org/@effect/atom-react/-/atom-react-4.0.0-beta.59.tgz",
+			"integrity": "sha512-VkznQz5c+Z/BLxX+hQNPzPOyUnLQjnbppFSNP7tbPru7HKR4ihzCDC6Xjbx87156MOrZ+JOa6shTMbmvGT5W0w==",
+			"license": "MIT",
+			"peerDependencies": {
+				"effect": "^4.0.0-beta.59",
+				"react": "^19.2.4",
+				"scheduler": "*"
+			}
+		},
+		"node_modules/@effect/language-service": {
+			"version": "0.85.1",
+			"resolved": "https://registry.npmjs.org/@effect/language-service/-/language-service-0.85.1.tgz",
+			"integrity": "sha512-EXnJjIy6zQ3nUO/MZ+ynWUb8B895KZPotd1++oTs9JjDkplwM7cb6zo8Zq2zU6piwq+KflO7amXbEfj1UMpHkw==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"effect-language-service": "cli.js"
+			}
+		},
+		"node_modules/@ghui/keymap": {
+			"resolved": "packages/keymap",
+			"link": true
+		},
+		"node_modules/@kitlangton/ghui": {
+			"resolved": "",
+			"link": true
+		},
+		"node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
+			"integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+			"integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+			"integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+			"integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+			"integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+			"integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@opentui/core": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@opentui/core/-/core-0.2.1.tgz",
+			"integrity": "sha512-tXFD2NeznXzZa02yOsQ/D0o/06GBqVrPR7VdmgqI+ZChcS7NY/QgNQGgAZUditW2vezFcxlgTqoCgQaZFqRfGQ==",
+			"license": "MIT",
+			"dependencies": {
+				"bun-ffi-structs": "0.1.2",
+				"diff": "9.0.0",
+				"marked": "17.0.1",
+				"string-width": "7.2.0",
+				"strip-ansi": "7.1.2",
+				"yoga-layout": "3.2.1"
+			},
+			"optionalDependencies": {
+				"@opentui/core-darwin-arm64": "0.2.1",
+				"@opentui/core-darwin-x64": "0.2.1",
+				"@opentui/core-linux-arm64": "0.2.1",
+				"@opentui/core-linux-x64": "0.2.1",
+				"@opentui/core-win32-arm64": "0.2.1",
+				"@opentui/core-win32-x64": "0.2.1"
+			},
+			"peerDependencies": {
+				"web-tree-sitter": "0.25.10"
+			}
+		},
+		"node_modules/@opentui/core-darwin-arm64": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@opentui/core-darwin-arm64/-/core-darwin-arm64-0.2.1.tgz",
+			"integrity": "sha512-vT8rgeNdkzD84wCcS5zmrSVFgR/SjeVr+2FNM/icTjwKh9Jq3cY6UY7/EFck3PRjrmanNu4zw7W5lFKSpMxnPQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@opentui/core-darwin-x64": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@opentui/core-darwin-x64/-/core-darwin-x64-0.2.1.tgz",
+			"integrity": "sha512-HAH1KeTejs0Z+RChNsNImI1eOlYJabKeAEvLtnn1aiHxvJFpzdAi6d/VrG5WFcxAem6TVRtnKN46gXff26lkig==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@opentui/core-linux-arm64": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@opentui/core-linux-arm64/-/core-linux-arm64-0.2.1.tgz",
+			"integrity": "sha512-447FI6xolsKbG1eH3hpNGQhQ/8M6FDJIgpiJhX9XXvZGO7vEyN6efyqqIzRF+quafqF69+rT3qK70S1svjwVKA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@opentui/core-linux-x64": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@opentui/core-linux-x64/-/core-linux-x64-0.2.1.tgz",
+			"integrity": "sha512-Xdds+HnAbFiylTdxyYhRxPFPnrHm75KTi7QCA1JHU3lb8Sfwrxv3nlYtFhEV798y4osafsghL20Nq5mqVPjizQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@opentui/core-win32-arm64": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@opentui/core-win32-arm64/-/core-win32-arm64-0.2.1.tgz",
+			"integrity": "sha512-VEuqX9OSFpw960mibe4OXVmnE43V/VYwB61zoxD5uw7L3jgCiOfrf+W2TuFbcRAgtTD35MypJ53fYxmUcVZc8g==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@opentui/core-win32-x64": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@opentui/core-win32-x64/-/core-win32-x64-0.2.1.tgz",
+			"integrity": "sha512-ywwRbyjPPEbNe3da+ez4NxIaJWQ79sA2gdepuHKUVdmdxsevdRpAxOHkEpJNtiVvphPc/On9EsP25Hmn5gjYxg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@opentui/core/node_modules/bun-ffi-structs": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/bun-ffi-structs/-/bun-ffi-structs-0.1.2.tgz",
+			"integrity": "sha512-Lh1oQAYHDcnesJauieA4UNkWGXY9hYck7OA5IaRwE3Bp6K2F2pJSNYqq+hIy7P3uOvo3km3oxS8304g5gDMl/w==",
+			"license": "MIT",
+			"peerDependencies": {
+				"typescript": "^5"
+			}
+		},
+		"node_modules/@opentui/core/node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/@opentui/react": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@opentui/react/-/react-0.2.1.tgz",
+			"integrity": "sha512-kHxNHqukauhf1StjuGV36DoR42dBPxU3YVj1wo/V2SOumC/enF6zxBnnsWC3EUWqxLKnMkufh38AvHL3EJ1Taw==",
+			"license": "MIT",
+			"dependencies": {
+				"@opentui/core": "0.2.1",
+				"react-reconciler": "^0.32.0"
+			},
+			"peerDependencies": {
+				"react": ">=19.0.0",
+				"react-devtools-core": "^7.0.1",
+				"ws": "^8.18.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-android-arm-eabi": {
+			"version": "0.47.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.47.0.tgz",
+			"integrity": "sha512-KrMQRdMi/upr81qT4ijK6X6BNp6jqpMY7FwILQnwIy9QLc3qpnhUx5rsCLGzn4ewsCQ0CNAspN2ogmP1GXLyLw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-android-arm64": {
+			"version": "0.47.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.47.0.tgz",
+			"integrity": "sha512-r4ixS/PeUpAFKgrpDoZ5pSkthjZzVzKd95525Aazj+aOv9H4ulK5zYHGb7wFY5n5kZxHK8TbOJUZgoEb1ohddQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-darwin-arm64": {
+			"version": "0.47.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.47.0.tgz",
+			"integrity": "sha512-CLWxiKpMl+195cm09CuaWEhJK0CirRkoMa07aR9+9AFPat2LfIKtwx1JqxZM0MTvcMe6+adlJNdVL6jdInvq3g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-darwin-x64": {
+			"version": "0.47.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.47.0.tgz",
+			"integrity": "sha512-Xq5fjTYDC50faUeLSm0rZdBqoTgleXEdD7NpJdARtQIczkCJn3xNjMUSQQkUmh4CtxkKTNL68lytcOK3e/osgg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-freebsd-x64": {
+			"version": "0.47.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.47.0.tgz",
+			"integrity": "sha512-QOU9ZIJ52p5askcEC0QJvvr8trHAWoonul8bgISo6gYUL3s50zkqafBYcNAr9LJZQbsZtPfIWHk9+5+nUp1qJQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
+			"version": "0.47.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.47.0.tgz",
+			"integrity": "sha512-oJxDM1aBhPvz9gmElBv8UpxyiqhwfjcbrSxT5F0xtuUzY6dQI27/AQPIt3eu3Z5Yvn0kQl5R7MA3Z+MbnRvCBw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-linux-arm-musleabihf": {
+			"version": "0.47.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.47.0.tgz",
+			"integrity": "sha512-g8Lh50VS4ibGz2q6v7r9UZY4D0dM16SdrFYOMzhqIoCwGcai8VMIRUAcqn1/jlCsOOzUXJ741+kCeJt0cofakQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-linux-arm64-gnu": {
+			"version": "0.47.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.47.0.tgz",
+			"integrity": "sha512-YrNT1vQ0asaXoRbrvYENPqmBfOQ9Xr8enPNOULeYfg44VjCcrUowFy5QZr+WawE0zyP8cH9e9Gxxg0fDEFzhcg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-linux-arm64-musl": {
+			"version": "0.47.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.47.0.tgz",
+			"integrity": "sha512-IxtQC/sbBi4ubbY+MdwdanRWrG9InQJVZqyMsBa5IUaQcnSg86gQme574HxXMC1p4bo4YhV99zQ+wNnGCvEgzw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-linux-ppc64-gnu": {
+			"version": "0.47.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.47.0.tgz",
+			"integrity": "sha512-EWXEhOMbWO0q6eJSbu0QLkU8cKi0ljlYLngeDs2Ocu/pm1rrLwyQiYzlFbdnMRURI4w9ndr1sI9rSbhlJ5o23Q==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-linux-riscv64-gnu": {
+			"version": "0.47.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.47.0.tgz",
+			"integrity": "sha512-tZrjS11TUiDuEpRaqdk8K9F9xETRyKXfuZKmdeW+Gj7coBnm7+8sBEfyt033EAFEQSlkniAXvBLh+Qja2ioGBQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-linux-riscv64-musl": {
+			"version": "0.47.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.47.0.tgz",
+			"integrity": "sha512-KBFy+2CFKUCZzYwX2ZOPQKck1vjQbz+hextuc19G4r0WRJwadfAeuQMQRQvB+Ivc8brlbOVg7et8K7E467440g==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-linux-s390x-gnu": {
+			"version": "0.47.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.47.0.tgz",
+			"integrity": "sha512-REUPFKVGSiK99B+9eaPhluEVglzaoj/SMykNC5SUiV2RSsBfV5lWN7Y0iCIc251Wz3GaeAGZsJ/zj3gjarxdFg==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-linux-x64-gnu": {
+			"version": "0.47.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.47.0.tgz",
+			"integrity": "sha512-KVftVSVEDeIfRW3TIeLe3aNI/iY4m1fu5mDwHcisKMZSCMKLkrhFsjowC7o9RoqNPxbbglm2+/6KAKBIts2t0Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-linux-x64-musl": {
+			"version": "0.47.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.47.0.tgz",
+			"integrity": "sha512-DTsmGEaA2860Aq5VUyDO8/MT9NFxwVL93RnRYmpMwK6DsSkThmvEpqoUDDljziEpAedMRG19SCogrNbINSbLUQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-openharmony-arm64": {
+			"version": "0.47.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.47.0.tgz",
+			"integrity": "sha512-8r5BDro7fLOBoq1JXHLVSs55OlrxQhEso4HVo0TcY7OXJUPYfjPoOaYL5us+yIwqyP9rQwN+rxuiNFSmaxSuOQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-win32-arm64-msvc": {
+			"version": "0.47.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.47.0.tgz",
+			"integrity": "sha512-qtz/gzm8IjSPUlseZ0ofW8zyHLoZsuP5HTfcGGkWkUblB89JT8GNYH3ICqjbDsqsGqXum0/ZndXTFplSdXFIcg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-win32-ia32-msvc": {
+			"version": "0.47.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.47.0.tgz",
+			"integrity": "sha512-5vIcdcIDE7nCx+MXN6sm8kbC4zajDB31E86rez4i45iHNH/2NjdKlJ720xcHTr3eeiMcttCGPHPhE1TjtBDGZw==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-win32-x64-msvc": {
+			"version": "0.47.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.47.0.tgz",
+			"integrity": "sha512-Sr59Y5ms54ONBjxFeWhVlGyQcHXxcl9DxC23f6yXlRkcos7LXBLoO+KDfxexjHIOZh7cWqrWduzvUjJ+pHp8cQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-android-arm-eabi": {
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.62.0.tgz",
+			"integrity": "sha512-pKsthNECyvJh8lPTICz6VcwVy2jOqdhhsp1rlxCkhgZR47aKvXPmaRWQDv+zlXpRae4qm1MaaTnutkaOk5aofg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-android-arm64": {
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.62.0.tgz",
+			"integrity": "sha512-b1AUNViByvgmR2xJDubvLIr+dSuu3uraG7bsAoKo+xrpspPvu6RIn6Fhr2JUhobfep3jwUTy18Huco6GkwdvGQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-darwin-arm64": {
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.62.0.tgz",
+			"integrity": "sha512-iG+Tvf70UJ6otfwFYIHk36Sjq9cpPP5YLxkoggANNRtzgi3Tj3g8q6Ybqi6AtkU3+yg9QwF7bDCkCS6bbL4PCg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-darwin-x64": {
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.62.0.tgz",
+			"integrity": "sha512-oOWI6YPPr5AJUx+yIDlxmuUbQjS5gZX3OH3QisawYvsZgLiQVvZtR0rPBcJTxLWqt2ClrWg0DlSrlUiG5SQNHg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-freebsd-x64": {
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.62.0.tgz",
+			"integrity": "sha512-dLP33T7VLCmLVv4cvjkVX+rmkcwNk2UfxmsZPNur/7BQHoQR60zJ7XLiRvNUawlzn0u8ngCa3itjEG73MAMa/w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-arm-gnueabihf": {
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.62.0.tgz",
+			"integrity": "sha512-fl//LWNks6qo9chNY60UDYyIwtp7a5cEx4Y/rHPjaarhuwqx6jtbzEpD5V5AqmdL4a6Y5D8zeXg5HF2Cr0QmSQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-arm-musleabihf": {
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.62.0.tgz",
+			"integrity": "sha512-i5vkAuxvueTODV3J2dL61/TXewDHhMFKvtD156cIsk7GsdfiAu7zW7kY0NJXhKeFHeiMZIh7eFNjkPYH6J47HQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-arm64-gnu": {
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.62.0.tgz",
+			"integrity": "sha512-QwN19LLuIGuOjEflSeJkZmOTfBdBMlTmW8xbMf8TZhjd//cxVNYQPq75q7oKZBJc6hRx3gY7sX0Egc8cEIFZYg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-arm64-musl": {
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.62.0.tgz",
+			"integrity": "sha512-8eCy3FCDuWUM5hWujAv6heMvfZPbcCOU3SdQUAkixZLu5bSzOkNfirJiLGoQFO943xceOKkiQRMQNzH++jM3WA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-ppc64-gnu": {
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.62.0.tgz",
+			"integrity": "sha512-NjQ7K7tpTPDe9J+yq8p/s/J0E7lRCkK2uDBDqvT4XIT6f4Z0tlnr59OBg/WcrmVHER1AbrcfyxhGTXgcG8ytWg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-riscv64-gnu": {
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.62.0.tgz",
+			"integrity": "sha512-oKZed9gmSwze29dEt3/Wnsv6l/Ygw/FUst+8Kfpv2SGeS/glEoTGZAMQw37SVyzFV76UTHJN2snGgxK2t2+8ow==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-riscv64-musl": {
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.62.0.tgz",
+			"integrity": "sha512-gBjBxQ+9lGpAYq+ELqw0w8QXsBnkZclFc7GRX2r0LnEVn3ZTEqeIKpKcGjucmp76Q53bvJD0i4qBWBhcfhSfGA==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-s390x-gnu": {
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.62.0.tgz",
+			"integrity": "sha512-Ew2Kxs9EQ9/mbAIJ2hvocMC0wsOu6YKzStI2eFBDt+Td5O8seVC/oxgRIHqCcl5sf5ratA1nozQBAuv7tphkHg==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-x64-gnu": {
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.62.0.tgz",
+			"integrity": "sha512-5z25jcAA0gfKyVwz71A0VXgaPlocPoTAxhlv/hgoK6tlCrfoNuw7haWbDHvGMfjXhdic4EqVXGRv5XsTqFnbRQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-x64-musl": {
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.62.0.tgz",
+			"integrity": "sha512-IWpHmMB6ZDllPvqWDkG6AmXrN7JF5e/c4g/0PuURsmlK+vHoYZPB70rr4u1bn3I4LsKCSpqqfveyx6UCOC8wdg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-openharmony-arm64": {
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.62.0.tgz",
+			"integrity": "sha512-fjlSxxrD5pA594vkyikCS9MnPRjQawW6/BLgyTYkO+73wwPlYjkcZ7LSd974l0Q2zkHQmu4DPvJFLYA7o8xrxQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-win32-arm64-msvc": {
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.62.0.tgz",
+			"integrity": "sha512-EiFXr8loNS0Ul3Gu80+9nr1T8jRmnKocqmHHg16tj5ZqTgUXyb97l2rrspVHdDluyFn9JfR4PoJFdNzw4paHww==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-win32-ia32-msvc": {
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.62.0.tgz",
+			"integrity": "sha512-IgOFvL73li1bFgab+hThXYA0N2Xms2kV2MvZN95cebV+fmrZ9AVui1JSxfeeqRLo3CpPxKZlzhyq4G0cnaAvIw==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-win32-x64-msvc": {
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.62.0.tgz",
+			"integrity": "sha512-6hMpyDWQ2zGA1OXFKBrdYMUveUCO8UJhkO6JdwZPd78xIdHZNhjx+pib+4fC2Cljuhjyl0QwA2F3df/bs4Bp6A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"license": "MIT"
+		},
+		"node_modules/@types/bun": {
+			"version": "1.3.12",
+			"resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.12.tgz",
+			"integrity": "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bun-types": "1.3.12"
+			}
+		},
+		"node_modules/@types/node": {
+			"version": "25.9.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+			"integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": ">=7.24.0 <7.24.7"
+			}
+		},
+		"node_modules/@types/react": {
+			"version": "19.2.14",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+			"integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"csstype": "^3.2.2"
+			}
+		},
+		"node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/bun-types": {
+			"version": "1.3.12",
+			"resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.12.tgz",
+			"integrity": "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/csstype": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/detect-libc": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+			"license": "Apache-2.0",
+			"optional": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/diff": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+			"integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/effect": {
+			"version": "4.0.0-beta.59",
+			"resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.59.tgz",
+			"integrity": "sha512-xyUDLeHSe8d6lWGOvR6Fgn2HL6gYeTZ/S4Jzk9uc4ZUxMPPsNZlNXrvk0C7/utQFzeX7uAWcVnG2BjbA0SRoAA==",
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"fast-check": "^4.6.0",
+				"find-my-way-ts": "^0.1.6",
+				"ini": "^6.0.0",
+				"kubernetes-types": "^1.30.0",
+				"msgpackr": "^1.11.9",
+				"multipasta": "^0.2.7",
+				"toml": "^4.1.1",
+				"uuid": "^13.0.0",
+				"yaml": "^2.8.3"
+			}
+		},
+		"node_modules/emoji-regex": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+			"license": "MIT"
+		},
+		"node_modules/fast-check": {
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+			"integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/dubzzz"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fast-check"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"pure-rand": "^8.0.0"
+			},
+			"engines": {
+				"node": ">=12.17.0"
+			}
+		},
+		"node_modules/find-my-way-ts": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+			"integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+			"license": "MIT"
+		},
+		"node_modules/get-east-asian-width": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ini": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+			"integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/kubernetes-types": {
+			"version": "1.30.0",
+			"resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
+			"integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/marked": {
+			"version": "17.0.1",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
+			"integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/msgpackr": {
+			"version": "1.11.12",
+			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.12.tgz",
+			"integrity": "sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg==",
+			"license": "MIT",
+			"optionalDependencies": {
+				"msgpackr-extract": "^3.0.2"
+			}
+		},
+		"node_modules/msgpackr-extract": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
+			"integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"node-gyp-build-optional-packages": "5.2.2"
+			},
+			"bin": {
+				"download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+			},
+			"optionalDependencies": {
+				"@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
+				"@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
+				"@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
+				"@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
+				"@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
+				"@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+			}
+		},
+		"node_modules/multipasta": {
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
+			"integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
+			"license": "MIT"
+		},
+		"node_modules/node-gyp-build-optional-packages": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+			"integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"detect-libc": "^2.0.1"
+			},
+			"bin": {
+				"node-gyp-build-optional-packages": "bin.js",
+				"node-gyp-build-optional-packages-optional": "optional.js",
+				"node-gyp-build-optional-packages-test": "build-test.js"
+			}
+		},
+		"node_modules/oxfmt": {
+			"version": "0.47.0",
+			"resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.47.0.tgz",
+			"integrity": "sha512-OFbkbzxKCpooQEnRmpTDnuwTX8KHXzZTQ4Df/hz85fpS67Pl+lxPEFvUtin56HIIS0B1k4X8oIzTXRZPufA2CA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinypool": "2.1.0"
+			},
+			"bin": {
+				"oxfmt": "bin/oxfmt"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			},
+			"optionalDependencies": {
+				"@oxfmt/binding-android-arm-eabi": "0.47.0",
+				"@oxfmt/binding-android-arm64": "0.47.0",
+				"@oxfmt/binding-darwin-arm64": "0.47.0",
+				"@oxfmt/binding-darwin-x64": "0.47.0",
+				"@oxfmt/binding-freebsd-x64": "0.47.0",
+				"@oxfmt/binding-linux-arm-gnueabihf": "0.47.0",
+				"@oxfmt/binding-linux-arm-musleabihf": "0.47.0",
+				"@oxfmt/binding-linux-arm64-gnu": "0.47.0",
+				"@oxfmt/binding-linux-arm64-musl": "0.47.0",
+				"@oxfmt/binding-linux-ppc64-gnu": "0.47.0",
+				"@oxfmt/binding-linux-riscv64-gnu": "0.47.0",
+				"@oxfmt/binding-linux-riscv64-musl": "0.47.0",
+				"@oxfmt/binding-linux-s390x-gnu": "0.47.0",
+				"@oxfmt/binding-linux-x64-gnu": "0.47.0",
+				"@oxfmt/binding-linux-x64-musl": "0.47.0",
+				"@oxfmt/binding-openharmony-arm64": "0.47.0",
+				"@oxfmt/binding-win32-arm64-msvc": "0.47.0",
+				"@oxfmt/binding-win32-ia32-msvc": "0.47.0",
+				"@oxfmt/binding-win32-x64-msvc": "0.47.0"
+			}
+		},
+		"node_modules/oxlint": {
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.62.0.tgz",
+			"integrity": "sha512-1uFkg6HakjsGIpW9wNdeW4/2LOHW9MEkoWjZUTUfQtIHyLIZPYt00w3Sg+H3lH+206FgBPHBbW5dVE5l2ExECQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"oxlint": "bin/oxlint"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			},
+			"optionalDependencies": {
+				"@oxlint/binding-android-arm-eabi": "1.62.0",
+				"@oxlint/binding-android-arm64": "1.62.0",
+				"@oxlint/binding-darwin-arm64": "1.62.0",
+				"@oxlint/binding-darwin-x64": "1.62.0",
+				"@oxlint/binding-freebsd-x64": "1.62.0",
+				"@oxlint/binding-linux-arm-gnueabihf": "1.62.0",
+				"@oxlint/binding-linux-arm-musleabihf": "1.62.0",
+				"@oxlint/binding-linux-arm64-gnu": "1.62.0",
+				"@oxlint/binding-linux-arm64-musl": "1.62.0",
+				"@oxlint/binding-linux-ppc64-gnu": "1.62.0",
+				"@oxlint/binding-linux-riscv64-gnu": "1.62.0",
+				"@oxlint/binding-linux-riscv64-musl": "1.62.0",
+				"@oxlint/binding-linux-s390x-gnu": "1.62.0",
+				"@oxlint/binding-linux-x64-gnu": "1.62.0",
+				"@oxlint/binding-linux-x64-musl": "1.62.0",
+				"@oxlint/binding-openharmony-arm64": "1.62.0",
+				"@oxlint/binding-win32-arm64-msvc": "1.62.0",
+				"@oxlint/binding-win32-ia32-msvc": "1.62.0",
+				"@oxlint/binding-win32-x64-msvc": "1.62.0"
+			},
+			"peerDependencies": {
+				"oxlint-tsgolint": ">=0.18.0"
+			},
+			"peerDependenciesMeta": {
+				"oxlint-tsgolint": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/pure-rand": {
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+			"integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/dubzzz"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fast-check"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/react": {
+			"version": "19.2.5",
+			"resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+			"integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/react-devtools-core": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-7.0.1.tgz",
+			"integrity": "sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"shell-quote": "^1.6.1",
+				"ws": "^7"
+			}
+		},
+		"node_modules/react-devtools-core/node_modules/ws": {
+			"version": "7.5.10",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+			"integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8.3.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/react-reconciler": {
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.32.0.tgz",
+			"integrity": "sha512-2NPMOzgTlG0ZWdIf3qG+dcbLSoAc/uLfOwckc3ofy5sSK0pLJqnQLpUFxvGcN2rlXSjnVtGeeFLNimCQEj5gOQ==",
+			"license": "MIT",
+			"dependencies": {
+				"scheduler": "^0.26.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"peerDependencies": {
+				"react": "^19.1.0"
+			}
+		},
+		"node_modules/react-reconciler/node_modules/scheduler": {
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+			"integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+			"license": "MIT"
+		},
+		"node_modules/scheduler": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+			"integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+			"license": "MIT"
+		},
+		"node_modules/shell-quote": {
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+			"integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/tinypool": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-2.1.0.tgz",
+			"integrity": "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.0.0 || >=22.0.0"
+			}
+		},
+		"node_modules/toml": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/toml/-/toml-4.1.1.tgz",
+			"integrity": "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+			"integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "7.24.6",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+			"integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/uuid": {
+			"version": "13.0.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+			"integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist-node/bin/uuid"
+			}
+		},
+		"node_modules/web-tree-sitter": {
+			"version": "0.25.10",
+			"resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.25.10.tgz",
+			"integrity": "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==",
+			"license": "MIT",
+			"peer": true,
+			"peerDependencies": {
+				"@types/emscripten": "^1.40.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/emscripten": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/ws": {
+			"version": "8.20.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+			"integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/yaml": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"node_modules/yoga-layout": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+			"integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+			"license": "MIT"
+		},
+		"packages/keymap": {
+			"name": "@ghui/keymap",
+			"version": "0.0.0",
+			"peerDependencies": {
+				"react": "*"
+			}
+		}
+	}
+}

--- a/pkgs/by-name/gh/ghui/package.nix
+++ b/pkgs/by-name/gh/ghui/package.nix
@@ -2,11 +2,9 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
-  fetchNpmDeps,
   bun,
   gh,
   git,
-  nodejs,
   nix-update-script,
   runtimeShell,
   versionCheckHook,
@@ -25,32 +23,18 @@ buildNpmPackage (finalAttrs: {
     hash = "sha256-jMi2Pc2VTpj0cZ2zXqtunG0FxcglCNEt9WzWnwxq+Js=";
   };
 
-  npmDeps = fetchNpmDeps {
-    name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
-    inherit (finalAttrs) src;
-    fetcherVersion = finalAttrs.npmDepsFetcherVersion;
-    hash = "sha256-GYGegGw80M5T2wETreP95OrCn7F7XxlZcZWy9TjbCHY=";
-    nativeBuildInputs = [ nodejs ];
-    prePatch = ''
-      export HOME=$TMPDIR
-      npm pkg set 'dependencies.@ghui/keymap=file:packages/keymap'
-      npm pkg delete 'devDependencies.@ghui/keymap'
-      npm install --package-lock-only --ignore-scripts --no-audit --no-fund
-    '';
-  };
-
-  prePatch = ''
-    export HOME=$TMPDIR
-    # prefetch-npm-deps --map-cache reads npmDeps from the process environment.
-    export npmDeps
-    npm pkg set 'dependencies.@ghui/keymap=file:packages/keymap'
-    npm pkg delete 'devDependencies.@ghui/keymap'
-    cp ${finalAttrs.npmDeps}/package-lock.json package-lock.json
+  # Upstream ghui is a Bun project and ships only `bun.lock`. We vendor an
+  # npm `package-lock.json` next to this file so `buildNpmPackage` has a
+  # deterministic, cross-OS-stable FOD input; `passthru.updateScript` below
+  # keeps it in sync via `nix-update --generate-lockfile`.
+  postPatch = ''
+    cp ${./package-lock.json} package-lock.json
   '';
 
-  nativeBuildInputs = [ bun ];
-
+  npmDepsHash = "sha256-pg+USHnvcxaXG/floNItLXNFJOPvuDltQCcN1qT/nng=";
   npmDepsFetcherVersion = 3;
+
+  nativeBuildInputs = [ bun ];
 
   npmFlags = [
     "--no-audit"
@@ -81,6 +65,12 @@ buildNpmPackage (finalAttrs: {
     runHook preInstall
 
     npm prune --omit=dev --no-save --no-audit --no-fund
+    # `@ghui/keymap` is declared as a `workspace:*` devDependency upstream but
+    # imported at runtime (see postInstallCheck). `npm prune --omit=dev` may
+    # strip the `node_modules/@ghui/keymap` workspace symlink; restore it
+    # idempotently so the Bun runtime can resolve it after install. `ln -sf`
+    # is safe whether or not prune actually removed the link.
+    ln -sf ../../packages/keymap node_modules/@ghui/keymap
 
     mkdir -p $out/lib/ghui $out/bin
     cp -r dist node_modules packages package.json README.md LICENSE .env.example $out/lib/ghui/
@@ -127,7 +117,9 @@ buildNpmPackage (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--generate-lockfile" ];
+  };
 
   meta = {
     description = "Terminal UI for GitHub pull requests";


### PR DESCRIPTION
The current `npmDeps.prePatch` runs `npm install --package-lock-only` to regenerate `package-lock.json` inside the fetchNpmDeps FOD. That regeneration produces different bytes per build environment (different node/npm versions, transitive resolution variance), so the resulting `npmDepsHash` diverges across platforms and `@ofborg` fails with hash mismatches on Linux while passing on darwin.

This switches ghui to the standard nixpkgs vendored-lockfile pattern used by eslint, i18next-cli, and markdownlint-cli2:

- `pkgs/by-name/gh/ghui/package-lock.json` is vendored, generated via `nix-update --generate-lockfile` (the same mechanism r-ryantm uses, so the committed bytes are exactly what the bot will reproduce on future version bumps).
- The explicit `npmDeps = fetchNpmDeps { ... prePatch ... }` block is removed; `buildNpmPackage` builds the default `npmDeps` FOD from the pinned `npmDepsHash`, and `postPatch = '' cp ${./package-lock.json} package-lock.json ''` copies the vendored file into both the deps FOD and the main build.
- The `npm pkg set/delete` rewrite (which promoted `@ghui/keymap` from a `workspace:*` devDep to a `file:` runtime dep, and forced the lockfile regeneration) is dropped. Instead, `installPhase` restores the workspace symlink after `npm prune --omit=dev`: `ln -sf ../../packages/keymap node_modules/@ghui/keymap`.
- `passthru.updateScript` is now `nix-update-script { extraArgs = [ "--generate-lockfile" ]; }` so the vendored lockfile auto-updates on version bumps.

Cross-OS hash stability rests on `prefetch-npm-deps` fetching every tarball the lockfile lists (no `cpu`/`os`/`optional` filtering); the committed lockfile contains all-platform native-binary entries.

**Drift gate verified locally:** a second `nix-update --generate-lockfile` run produces a byte-identical lockfile (`git diff` empty), so the committed file matches what the update bot will reproduce.

Supersedes the earlier cacert approach (no longer needed — the in-FOD `npm install` step that needed cacert is gone).

Fixes #518315.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Disclosure: this PR was prepared with the help of Claude Code. Both the diagnosis and the fix were verified locally before pushing.
