### PR TITLE
fetchPnpmDeps: deprecate fetcherVersion = 2, schedule removal for 26.11

### DIFF
--- a/doc/languages-frameworks/javascript.section.md
+++ b/doc/languages-frameworks/javascript.section.md
@@ -503,9 +503,11 @@ Changes can include workarounds or bug fixes to existing PNPM issues.
 
 ##### Version history {#javascript-pnpm-fetcherVersion-versionHistory}
 
-- 1: Initial version, nothing special. **Deprecated: Scheduled for removal in the 26.11 release.**. New packages must not use this value.
+Version 3 is the recommended value for new packages. Versions 1 and 2 are deprecated and scheduled for removal in the 26.11 release; existing packages must migrate.
+
+- 1: Initial version, nothing special.
 - 2: [Ensure consistent permissions](https://github.com/NixOS/nixpkgs/pull/422975)
-- 3: [Build a reproducible tarball](https://github.com/NixOS/nixpkgs/pull/469950). **Recommended**
+- 3: [Build a reproducible tarball](https://github.com/NixOS/nixpkgs/pull/469950)
 
 ### Yarn {#javascript-yarn}
 

--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -330,11 +330,12 @@
 
 - `fetchPnpmDeps` and `pnpmConfigHook` were added as top-level attributes, replacing the now deprecated `pnpm.fetchDeps` and `pnpm.configHook` attributes.
 
-- `fetchPnpmDeps`' `fetcherVersion = 1` is deprecated and scheduled for removal
-  in the 26.11 release. A deprecation warning has been added. Packages still on
-  `fetcherVersion = 1` should migrate to `fetcherVersion = 3` and regenerate
-  their hashes. See the [pnpm `fetcherVersion`
-  section](#javascript-pnpm-fetcherVersion) of the manual for details.
+- `fetchPnpmDeps`' `fetcherVersion = 1` and `fetcherVersion = 2` are deprecated
+  and scheduled for removal in the 26.11 release. A deprecation warning has
+  been added. Packages still on `fetcherVersion = 1` or `fetcherVersion = 2`
+  should migrate to `fetcherVersion = 3` and regenerate their hashes. See the
+  [pnpm `fetcherVersion` section](#javascript-pnpm-fetcherVersion) of the
+  manual for details.
 
 - `buildNpmPackage` now supports `npmDepsFetcherVersion` (and `fetchNpmDeps` now supports `fetcherVersion`). Set to `2` to enable packument caching, which fixes builds for projects using npm workspaces.
 

--- a/pkgs/build-support/node/fetch-pnpm-deps/default.nix
+++ b/pkgs/build-support/node/fetch-pnpm-deps/default.nix
@@ -61,8 +61,8 @@ in
       "fetchPnpmDeps `fetcherVersion` is not set to a supported value (${lib.concatStringsSep ", " (map toString supportedFetcherVersions)}), see https://nixos.org/manual/nixpkgs/stable/#javascript-pnpm-fetcherVersion."
     ) true;
 
-    lib.warnIf (fetcherVersion == 1)
-      "fetchPnpmDeps: `fetcherVersion = 1` is deprecated and scheduled for removal in the 26.11 release. Please migrate `${pname}` to `fetcherVersion = 3` and regenerate the hash. See https://nixos.org/manual/nixpkgs/stable/#javascript-pnpm-fetcherVersion."
+    lib.warnIf (fetcherVersion < 3)
+      "fetchPnpmDeps: `fetcherVersion = ${toString fetcherVersion}` is deprecated and scheduled for removal in the 26.11 release. Please migrate `${pname}` to `fetcherVersion = 3` and regenerate the hash. See https://nixos.org/manual/nixpkgs/stable/#javascript-pnpm-fetcherVersion."
 
       stdenvNoCC.mkDerivation
       (


### PR DESCRIPTION
Depends on #514075 and #515082

Tracking #494184

## Things done
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.