### PR TITLE
jrsonnet: 0.4.2 -> 0.5.0-pre98

### DIFF
--- a/pkgs/by-name/jr/jrsonnet/package.nix
+++ b/pkgs/by-name/jr/jrsonnet/package.nix
@@ -8,34 +8,28 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "jrsonnet";
-  version = "0.4.2";
+  version = "0.5.0-pre98";
 
   src = fetchFromGitHub {
-    rev = "v${finalAttrs.version}";
     owner = "CertainLach";
     repo = "jrsonnet";
-    sha256 = "sha256-OX+iJJ3vdCsWWr8x31psV9Vne6xWDZnJc83NbJqMK1A=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2dNzxZnvnw8TsKnnIlHGpuixrqe4z0a4faOBPv2N+ws=";
   };
 
-  cargoHash = "sha256-DA31NatwQyf3RPpaI38DdAujpRyZfJvoHgr2CZSjH3s=";
+  cargoHash = "sha256-QPJ1kVk/TftAROiBVBN6J4PZ1pwjtjldtgmJxSTC1Ao=";
 
   nativeBuildInputs = [ installShellFiles ];
 
-  # skip flaky tests
-  checkFlags = [
-    "--skip=tests::native_ext"
-  ];
-
   postInstall = ''
     ln -s $out/bin/jrsonnet $out/bin/jsonnet
-
   ''
   + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     for shell in bash zsh fish; do
       installShellCompletion --cmd jrsonnet \
-        --$shell <($out/bin/jrsonnet --generate $shell /dev/null)
+        --$shell <($out/bin/jrsonnet generate $shell)
       installShellCompletion --cmd jsonnet \
-        --$shell <($out/bin/jrsonnet --generate $shell /dev/null | sed s/jrsonnet/jsonnet/g)
+        --$shell <($out/bin/jrsonnet generate $shell | sed s/jrsonnet/jsonnet/g)
     done
   '';
 


### PR DESCRIPTION
Release: https://github.com/CertainLach/jrsonnet/releases/tag/v0.5.0-pre98
Diff: https://github.com/CertainLach/jrsonnet/compare/v0.4.2...v0.5.0-pre98
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327021106)](https://hydra.nixos.org/build/327021106)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
