### PR TITLE
mustang-cli: init at 2.23.1

### DIFF
--- a/pkgs/by-name/mu/mustang-cli/package.nix
+++ b/pkgs/by-name/mu/mustang-cli/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  fetchFromGitHub,
+  maven,
+  jre_minimal,
+  jdk_headless,
+  makeWrapper,
+  stripJavaArchivesHook,
+  nix-update-script,
+}:
+let
+  jre = jre_minimal.override {
+    modules = [
+      "java.base"
+      "java.desktop"
+      "java.logging"
+    ];
+    jdk = jdk_headless;
+  };
+in
+maven.buildMavenPackage (finalAttrs: {
+  version = "2.23.1";
+  pname = "mustang-cli";
+
+  src = fetchFromGitHub {
+    owner = "ZUGFeRD";
+    repo = "mustangproject";
+    tag = "core-${finalAttrs.version}";
+    hash = "sha256-HhNcmXXwnR2u1hjSeNYfU+j9EdJ+tbXhgWHj1k4eSuw=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  mvnHash = "sha256-ekSgGKY3OMFAEM3bNByBXrU3tpbDcbJ0fmCTRz7NIkA=";
+
+  nativeBuildInputs = [
+    makeWrapper
+    stripJavaArchivesHook
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/Mustang-CLI
+
+    # Upstream hardcodes an incorrect version string in the generated JAR filename, use a glob to match it.
+    # Use correct version when https://github.com/ZUGFeRD/mustangproject/issues/1131 is fixed.
+    install -Dm644 Mustang-CLI/target/Mustang-CLI-*-SNAPSHOT.jar $out/share/Mustang-CLI/Mustang-CLI.jar
+
+    makeWrapper ${jre}/bin/java $out/bin/mustang-cli \
+      --add-flags "-jar $out/share/Mustang-CLI/Mustang-CLI.jar"
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex=core-(.*)"
+    ];
+  };
+
+  meta = {
+    mainProgram = "mustang-cli";
+    description = "Open Source Java e-Invoicing library, validator and tool (Factur-X/ZUGFeRD, UNCEFACT/CII XRechnung)";
+    homepage = "https://www.mustangproject.org";
+    changelog = "https://github.com/ZUGFeRD/mustangproject/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ angelodlfrtr ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add [Mustang Project](https://www.mustangproject.org), a tool to validate and manipulate Factur-X/ZUGFeRD invoices.

Factur-X will become mandatory for B2B invoicing in France in September 2026 and is already required in Germany.

https://github.com/ZUGFeRD/mustangproject

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
