### PR TITLE
python3Packages.pyopen-wakeword: mark broken on aarch64-linux

### DIFF
--- a/pkgs/development/python-modules/pyopen-wakeword/default.nix
+++ b/pkgs/development/python-modules/pyopen-wakeword/default.nix
@@ -22,6 +22,7 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
+    # install pre-compiled libtensorflowlite
     python ./script/copy_lib
   '';
 
@@ -46,8 +47,12 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    # elftools.common.exceptions.ELFError: Magic number does not match
-    broken = stdenv.hostPlatform.isDarwin;
+    broken =
+      # elftools.common.exceptions.ELFError: Magic number does not match
+      stdenv.hostPlatform.isDarwin
+      ||
+        # segfaults when calling into libtensorflowlite
+        stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64;
     description = "Alternative Python library for openWakeWord";
     homepage = "https://github.com/rhasspy/pyopen-wakeword";
     changelog = "https://github.com/rhasspy/pyopen-wakeword/blob/${src.tag}/CHANGELOG.md";


### PR DESCRIPTION
Breaks in the tests when calling into libtensorflowlite.so.

https://cache.nixos.org/log/mzgmdnlmfpscpxfw7krxv6y9dpm23gz0-python3.13-pyopen-wakeword-1.1.0.drv

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
