### PR TITLE
nixos/kernel: drop boot.vesa

### DIFF
--- a/nixos/doc/manual/configuration/profiles/headless.section.md
+++ b/nixos/doc/manual/configuration/profiles/headless.section.md
@@ -2,7 +2,7 @@
 
 Common configuration for headless machines (e.g., Amazon EC2 instances).
 
-Disables [vesa](#opt-boot.vesa), serial consoles,
+Disables serial consoles,
 [emergency mode](#opt-systemd.enableEmergencyMode),
 [grub splash images](#opt-boot.loader.grub.splashImage)
 and configures the kernel to reboot automatically on panic.

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -16,7 +16,7 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- Create the first release note entry in this section!
+- `boot.vesa` has been removed. It was deprecated in 2020 because Xorg now works better with kernel modesetting. If you still need the legacy VESA 800x600 fallback, set `boot.kernelParams = [ "vga=0x317" "nomodeset" ];` directly.
 
 ## Other Notable Changes {#sec-release-26.11-notable-changes}
 

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -35,6 +35,15 @@ in
 
 {
 
+  imports = [
+    (mkRemovedOptionModule [ "boot" "vesa" ] ''
+      The `boot.vesa` option has been removed. It was deprecated in 2020
+      because Xorg now works better with kernel modesetting. If you still
+      need the legacy VESA 800x600 fallback, set
+      `boot.kernelParams = [ "vga=0x317" "nomodeset" ];` directly.
+    '')
+  ];
+
   ###### interface
 
   options = {
@@ -178,19 +187,6 @@ in
       description = ''
         The kernel console `loglevel`. All Kernel Messages with a log level smaller
         than this setting will be printed to the console.
-      '';
-    };
-
-    boot.vesa = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        (Deprecated) This option, if set, activates the VESA 800x600 video
-        mode on boot and disables kernel modesetting. It is equivalent to
-        specifying `[ "vga=0x317" "nomodeset" ]` in the
-        {option}`boot.kernelParams` option. This option is
-        deprecated as of 2020: Xorg now works better with modesetting, and
-        you might want a different VESA vga setting, anyway.
       '';
     };
 
@@ -427,10 +423,6 @@ in
       # (so you don't need to reboot to have changes take effect).
       boot.kernelParams = [
         "loglevel=${toString config.boot.consoleLogLevel}"
-      ]
-      ++ optionals config.boot.vesa [
-        "vga=0x317"
-        "nomodeset"
       ];
 
       boot.kernel.sysctl."kernel.printk" = mkDefault config.boot.consoleLogLevel;


### PR DESCRIPTION
## Summary

`boot.vesa` was deprecated back in 2020 (commit message at the time: *"Xorg now works better with modesetting, and you might want a different VESA vga setting, anyway"*) but was never removed. The default of `false` means almost no one is depending on it, and the few who are can inline its expansion themselves.

This PR removes the option using `mkRemovedOptionModule`, so anyone who still has `boot.vesa = true;` set will get a clear evaluation error pointing at the replacement:

```
boot.kernelParams = [ "vga=0x317" "nomodeset" ];
```

The headless profile already inlines those kernel params directly and doesn't need touching.

## Things done

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [x] Verified eval: minimal NixOS config evaluates without warnings; setting `boot.vesa = true` now fails with the documented replacement instructions.
- NixOS Release Notes
  - [x] Module update: documented in `nixos/doc/manual/release-notes/rl-2605.section.md`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md