### PR TITLE
stumpwm: migrate to by-name, switch from rev to tag

### DIFF
--- a/pkgs/by-name/st/stumpwm/package.nix
+++ b/pkgs/by-name/st/stumpwm/package.nix
@@ -24,7 +24,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "stumpwm";
     repo = "stumpwm";
-    rev = "${finalAttrs.version}";
+    tag = "${finalAttrs.version}";
     hash = "sha256-Ba2HcAmNcZvnqU0jpLTxsBe8L+4aHbO/oM4Bp/IYEC0=";
   };
 

--- a/pkgs/by-name/st/stumpwm/package.nix
+++ b/pkgs/by-name/st/stumpwm/package.nix
@@ -1,5 +1,5 @@
 {
-  stdenv,
+  stdenvNoCC,
   lib,
   fetchFromGitHub,
   autoreconfHook,
@@ -7,7 +7,17 @@
   texinfo,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+let
+  sbclWithPkgs = sbcl.withPackages (
+    ps: with ps; [
+      alexandria
+      cl-ppcre
+      clx
+      fiasco
+    ]
+  );
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "stumpwm";
   version = "24.11";
 
@@ -20,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     autoreconfHook
-    sbcl
+    sbclWithPkgs
     texinfo
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10227,18 +10227,6 @@ with pkgs;
 
   inherit (ocaml-ng.ocamlPackages) stog;
 
-  stumpwm = callPackage ../applications/window-managers/stumpwm {
-    stdenv = stdenvNoCC;
-    sbcl = sbcl.withPackages (
-      ps: with ps; [
-        alexandria
-        cl-ppcre
-        clx
-        fiasco
-      ]
-    );
-  };
-
   stumpwm-unwrapped = sbcl.pkgs.stumpwm;
 
   sublime3Packages = recurseIntoAttrs (


### PR DESCRIPTION
This pull request refactors how the `stumpwm` package is defined and included in the package set. The package definition has been moved and simplified, and redundant code has been removed from the top-level package list.

**Refactoring and simplification of `stumpwm` packaging:**

- Moved and renamed the package definition file from `pkgs/applications/window-managers/stumpwm/default.nix` to `pkgs/by-name/st/stumpwm/package.nix`, updating it to use `stdenvNoCC` and inlining the `sbcl.withPackages` logic. The `rev` attribute was also replaced with `tag` for fetching sources.
- Removed the explicit `stumpwm` package definition from `pkgs/top-level/all-packages.nix`, as it is now handled by the new package location and logic.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
