### PR TITLE
stdenv: deprecate is* aliases in favor of hostPlatform.is*

### DIFF
--- a/nixos/lib/test-driver/default.nix
+++ b/nixos/lib/test-driver/default.nix
@@ -60,7 +60,7 @@ buildPythonApplication {
     util-linux
     vde2
   ]
-  ++ lib.optionals stdenv.isLinux [
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     vhost-device-vsock
   ]
   ++ lib.optionals enableNspawn [

--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -482,7 +482,7 @@ in
               combineIcdPkgs =
                 icd: pkgs:
                 pkgs.symlinkJoin {
-                  name = "nvidia-egl-external-platforms${lib.optionalString pkgs.stdenv.is32bit "-x32"}";
+                  name = "nvidia-egl-external-platforms${lib.optionalString pkgs.stdenv.hostPlatform.is32bit "-x32"}";
                   paths = lib.attrVals icd pkgs;
                   # Remediate reversed priorities in pre-595 drivers,
                   # https://github.com/NixOS/nixpkgs/pull/497342#issuecomment-4034876793

--- a/pkgs/by-name/ar/arcanist/package.nix
+++ b/pkgs/by-name/ar/arcanist/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation {
     php
   ];
 
-  postPatch = lib.optionalString stdenv.isAarch64 ''
+  postPatch = lib.optionalString stdenv.hostPlatform.isAarch64 ''
     substituteInPlace support/xhpast/Makefile \
       --replace "-minline-all-stringops" ""
   '';

--- a/pkgs/by-name/bl/blast/package.nix
+++ b/pkgs/by-name/bl/blast/package.nix
@@ -105,7 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
     bzip2
     sqlite
   ]
-  ++ lib.optionals stdenv.isDarwin [
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     llvmPackages.openmp
   ];
 

--- a/pkgs/by-name/ch/chrony/package.nix
+++ b/pkgs/by-name/ch/chrony/package.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
         darwin
         illumos
       ];
-    broken = stdenv.isDarwin;
+    broken = stdenv.hostPlatform.isDarwin;
     maintainers = with lib.maintainers; [
       thoughtpolice
       vifino

--- a/pkgs/by-name/cp/cpond/package.nix
+++ b/pkgs/by-name/cp/cpond/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
     substituteInPlace Makefile \
       --replace-fail '$(eflags)$(ncursesw_macros)' '$(eflags) $(ncursesw_macros)'
   ''
-  + lib.optionalString stdenv.isDarwin ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace Makefile \
       --replace-fail '-lncursesw' '-lncurses'
   '';

--- a/pkgs/by-name/de/dejagnu/package.nix
+++ b/pkgs/by-name/de/dejagnu/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
   configureScript = "../configure";
 
-  doCheck = !(with stdenv; isDarwin && isAarch64);
+  doCheck = !(with stdenv.hostPlatform; isDarwin && isAarch64);
 
   # Note: The test-suite *requires* /dev/pts among the `build-chroot-dirs' of
   # the build daemon when building in a chroot.  See

--- a/pkgs/by-name/di/disko/package.nix
+++ b/pkgs/by-name/di/disko/package.nix
@@ -28,7 +28,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     cp -r install-cli.nix cli.nix default.nix disk-deactivate lib $out/share/disko
 
     scripts=(disko)
-    ${lib.optionalString (!stdenvNoCC.isDarwin) ''
+    ${lib.optionalString (!stdenvNoCC.hostPlatform.isDarwin) ''
       scripts+=(disko-install)
     ''}
 
@@ -44,7 +44,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
               coreutils
               xcp
             ]
-            ++ lib.optional (!stdenvNoCC.isDarwin) nixos-install
+            ++ lib.optional (!stdenvNoCC.hostPlatform.isDarwin) nixos-install
           )
         }
     done
@@ -54,7 +54,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   installCheckPhase = ''
     runHook preInstallCheck
     $out/bin/disko --help
-    ${lib.optionalString (!stdenvNoCC.isDarwin) ''
+    ${lib.optionalString (!stdenvNoCC.hostPlatform.isDarwin) ''
       $out/bin/disko-install --help
     ''}
     runHook postInstallCheck

--- a/pkgs/by-name/ee/eepers/package.nix
+++ b/pkgs/by-name/ee/eepers/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postBuild
   '';
 
-  postFixup = lib.optionalString stdenv.isLinux ''
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
     patchelf $out/bin/eepers \
       --add-needed libwayland-client.so \
       --add-needed libwayland-cursor.so \

--- a/pkgs/by-name/kr/krunkit/package.nix
+++ b/pkgs/by-name/kr/krunkit/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
   dontStrip = true;
 
   passthru = {
-    tests.boot = lib.optional stdenv.isDarwin (
+    tests.boot = lib.optional stdenv.hostPlatform.isDarwin (
       callPackage ./boot-test.nix { krunkit = finalAttrs.finalPackage; }
     );
     updateScript = nix-update-script { };

--- a/pkgs/by-name/li/libjxl/package.nix
+++ b/pkgs/by-name/li/libjxl/package.nix
@@ -173,7 +173,7 @@ stdenv.mkDerivation rec {
 
   # FIXME x86_64-darwin:
   # https://github.com/NixOS/nixpkgs/pull/204030#issuecomment-1352768690
-  doCheck = with stdenv; !(hostPlatform.isi686 || isDarwin && isx86_64);
+  doCheck = with stdenv.hostPlatform; !(isi686 || isDarwin && isx86_64);
 
   disabledTests = lib.optionals stdenv.hostPlatform.isBigEndian [
     # https://github.com/libjxl/libjxl/issues/3629

--- a/pkgs/by-name/li/limitcpu/package.nix
+++ b/pkgs/by-name/li/limitcpu/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-Wf/rGjUXr+RZmHFL6EGSYKQ2MvfOwI8LAmwezN/1fPw=";
   };
 
-  buildFlags = with stdenv; [
+  buildFlags = with stdenv.hostPlatform; [
     (
       if isDarwin then
         "osx"

--- a/pkgs/by-name/ma/mailspring/mailsync.nix
+++ b/pkgs/by-name/ma/mailspring/mailsync.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation {
     cmake
     pkg-config
   ]
-  ++ lib.optionals stdenv.isLinux [
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     autoPatchelfHook
   ];
 
@@ -64,7 +64,7 @@ stdenv.mkDerivation {
     xz
     zlib
   ]
-  ++ lib.optionals stdenv.isDarwin [
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     libiconv
   ];
 
@@ -99,7 +99,7 @@ stdenv.mkDerivation {
     # Transforms 'NAMES libfoo.a libfoo' into 'NAMES foo'
     sed -i -E 's/NAMES lib([a-zA-Z0-9]+)\.a lib\1/NAMES \1/g' CMakeLists.txt
   ''
-  + lib.optionalString stdenv.isDarwin ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
     # UUID_LIB is provided by system frameworks
     substituteInPlace CMakeLists.txt \
       --replace-fail "find_library(UUID_LIB NAMES uuid)" "set(UUID_LIB \"\")"

--- a/pkgs/by-name/nu/nusmv/package.nix
+++ b/pkgs/by-name/nu/nusmv/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.7.0";
 
   src =
-    with stdenv;
+    with stdenv.hostPlatform;
     fetchurl (
       if isx86_64 && isLinux then
         {

--- a/pkgs/by-name/on/onnxruntime/package.nix
+++ b/pkgs/by-name/on/onnxruntime/package.nix
@@ -25,7 +25,7 @@
   pythonSupport ? (stdenv.buildPlatform.canExecute stdenv.hostPlatform),
   cudaSupport ? config.cudaSupport,
   ncclSupport ? cudaSupport && cudaPackages.nccl.meta.available,
-  openvinoSupport ? stdenv.isLinux,
+  openvinoSupport ? stdenv.hostPlatform.isLinux,
   rocmSupport ? config.rocmSupport,
   coremlSupport ? stdenv.hostPlatform.isDarwin,
   withFullProtobuf ? false,

--- a/pkgs/by-name/pc/pcb2gcode/package.nix
+++ b/pkgs/by-name/pc/pcb2gcode/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "PCB2GCODE_COMPILE_WARNING_AS_ERROR" false)
   ];
 
-  preConfigure = lib.optionalString stdenv.isDarwin ''
+  preConfigure = lib.optionalString stdenv.hostPlatform.isDarwin ''
     export CXXFLAGS="$CXXFLAGS -fpermissive -Wno-error=c++20-extensions -Wno-error=invalid-constexpr"
   '';
 

--- a/pkgs/by-name/re/reprepro/package.nix
+++ b/pkgs/by-name/re/reprepro/package.nix
@@ -15,7 +15,7 @@
 }:
 
 let
-  theStdenv = if stdenv.isDarwin then gcc14Stdenv else stdenv;
+  theStdenv = if stdenv.hostPlatform.isDarwin then gcc14Stdenv else stdenv;
 in
 theStdenv.mkDerivation (finalAttrs: {
   pname = "reprepro";

--- a/pkgs/by-name/su/sundtek/package.nix
+++ b/pkgs/by-name/su/sundtek/package.nix
@@ -10,7 +10,7 @@ let
     "$out/bin"
   ];
   platform =
-    with stdenv;
+    with stdenv.hostPlatform;
     if isx86_64 then
       "64bit"
     else if isi686 then
@@ -18,7 +18,7 @@ let
     else
       throw "${system} not considered in build derivation. Might still be supported.";
   sha256 =
-    with stdenv;
+    with stdenv.hostPlatform;
     if isx86_64 then
       "1jfsng5n3phw5rqpkid9m5j7m7zgj5bifh7swvba7f97y6imdaax"
     else

--- a/pkgs/by-name/tu/turingdb/package.nix
+++ b/pkgs/by-name/tu/turingdb/package.nix
@@ -105,7 +105,7 @@ turingstdenv.mkDerivation (finalAttrs: {
     pugixml
     zlib
   ]
-  ++ lib.optionals turingstdenv.isDarwin [ llvmPackages_20.openmp ]
+  ++ lib.optionals turingstdenv.hostPlatform.isDarwin [ llvmPackages_20.openmp ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.cc.lib ]
   ++ lib.optionals cudaSupport [
     cudaPackages.cuda_cudart

--- a/pkgs/by-name/un/unblob/package.nix
+++ b/pkgs/by-name/un/unblob/package.nix
@@ -42,7 +42,7 @@ let
     zstd
     lz4
   ]
-  ++ lib.optional stdenvNoCC.isLinux partclone;
+  ++ lib.optional stdenvNoCC.hostPlatform.isLinux partclone;
 in
 python3.pkgs.buildPythonApplication rec {
   pname = "unblob";

--- a/pkgs/by-name/yb/yb/package.nix
+++ b/pkgs/by-name/yb/yb/package.nix
@@ -49,7 +49,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     installShellFiles
   ];
 
-  buildInputs = lib.optionals stdenv.isLinux [ pcsclite ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ pcsclite ];
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     # Bash completion: patch two clap_complete quirks:
@@ -107,7 +107,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
           pkg-config
           llvmPackages.libclang
         ];
-        buildInputs = lib.optionals stdenv.isLinux [ pcsclite ];
+        buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ pcsclite ];
 
         LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
         BINDGEN_EXTRA_CLANG_ARGS = "-I${llvmPackages.libclang.lib}/lib/clang/${lib.versions.major llvmPackages.release_version}/include";

--- a/pkgs/development/compilers/chicken/4/chicken.nix
+++ b/pkgs/development/compilers/chicken/4/chicken.nix
@@ -10,7 +10,7 @@
 let
   version = "4.13.0";
   platform =
-    with stdenv;
+    with stdenv.hostPlatform;
     if isDarwin then
       "macosx"
     else if isCygwin then

--- a/pkgs/development/compilers/chicken/5/chicken.nix
+++ b/pkgs/development/compilers/chicken/5/chicken.nix
@@ -10,7 +10,7 @@
 
 let
   platform =
-    with stdenv;
+    with stdenv.hostPlatform;
     if isDarwin then
       "macosx"
     else if isCygwin then

--- a/pkgs/development/compilers/dotnet/source/vmr.nix
+++ b/pkgs/development/compilers/dotnet/source/vmr.nix
@@ -43,11 +43,10 @@ let
   stdenv = llvmPackages.stdenv;
 
   inherit (stdenv)
-    isLinux
-    isDarwin
     buildPlatform
     targetPlatform
     ;
+  inherit (stdenv.hostPlatform) isLinux isDarwin;
   inherit (swiftPackages) swift;
 
   releaseManifest = lib.importJSON releaseManifestFile;

--- a/pkgs/development/compilers/llvm/common/flang-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/flang-rt/default.nix
@@ -15,7 +15,10 @@ let
 
   minDarwinVersion = "10.12";
   effectiveDarwinVersion =
-    if stdenv.isDarwin && lib.versionOlder stdenv.hostPlatform.darwinMinVersion minDarwinVersion then
+    if
+      stdenv.hostPlatform.isDarwin
+      && lib.versionOlder stdenv.hostPlatform.darwinMinVersion minDarwinVersion
+    then
       minDarwinVersion
     else
       stdenv.hostPlatform.darwinMinVersion;
@@ -57,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
     libllvm
   ];
 
-  env = lib.optionalAttrs stdenv.isDarwin {
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
     MACOSX_DEPLOYMENT_TARGET = effectiveDarwinVersion;
     NIX_CFLAGS_COMPILE = "-mmacosx-version-min=${effectiveDarwinVersion}";
   };
@@ -70,7 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "LLVM_DIR" "${libllvm.dev}/lib/cmake/llvm")
     (lib.cmakeFeature "LLVM_ENABLE_RUNTIMES" "flang-rt")
   ]
-  ++ lib.optionals stdenv.isDarwin [
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     (lib.cmakeFeature "CMAKE_OSX_DEPLOYMENT_TARGET" effectiveDarwinVersion)
   ];
 

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -70,20 +70,20 @@
   withDav1d ? withHeadlessDeps, # AV1 decoder (focused on speed and correctness)
   withDavs2 ? withFullDeps && withGPL, # AVS2 decoder
   withDc1394 ? withFullDeps && !stdenv.hostPlatform.isDarwin, # IIDC-1394 grabbing (ieee 1394)
-  withDrm ? withHeadlessDeps && (with stdenv; isLinux || isFreeBSD), # libdrm support
+  withDrm ? withHeadlessDeps && (with stdenv.hostPlatform; isLinux || isFreeBSD), # libdrm support
   withDvdnav ? withFullDeps && withGPL && lib.versionAtLeast version "7", # needed for DVD demuxing
   withDvdread ? withFullDeps && withGPL && lib.versionAtLeast version "7", # needed for DVD demuxing
   withFdkAac ? withFullDeps && (!withGPL || withUnfree), # Fraunhofer FDK AAC de/encoder
   withNvcodec ?
     withHeadlessDeps
     && (
-      with stdenv;
+      with stdenv.hostPlatform;
       !isDarwin
       && !isAarch32
-      && !hostPlatform.isLoongArch64
-      && !hostPlatform.isRiscV
-      && !(hostPlatform.isPower && hostPlatform.isBigEndian)
-      && hostPlatform == buildPlatform
+      && !isLoongArch64
+      && !isRiscV
+      && !(isPower && isBigEndian)
+      && stdenv.hostPlatform == stdenv.buildPlatform
     ), # dynamically linked Nvidia code
   withFlite ? withFullDeps, # Voice Synthesis
   withFontconfig ? withHeadlessDeps, # Needed for drawtext filter
@@ -152,8 +152,8 @@
   withUavs3d ? withFullDeps, # AVS3 decoder
   withV4l2 ? withHeadlessDeps && stdenv.hostPlatform.isLinux, # Video 4 Linux support
   withV4l2M2m ? withV4l2,
-  withVaapi ? withHeadlessDeps && (with stdenv; isLinux || isFreeBSD), # Vaapi hardware acceleration
-  withVdpau ? withSmallDeps && (with stdenv; isLinux || isFreeBSD), # Vdpau hardware acceleration
+  withVaapi ? withHeadlessDeps && (with stdenv.hostPlatform; isLinux || isFreeBSD), # Vaapi hardware acceleration
+  withVdpau ? withSmallDeps && (with stdenv.hostPlatform; isLinux || isFreeBSD), # Vdpau hardware acceleration
   withVidStab ? withHeadlessDeps && withGPL, # Video stabilization
   withVmaf ? withFullDeps && lib.versionAtLeast version "5", # Netflix's VMAF (Video Multi-Method Assessment Fusion)
   withVoAmrwbenc ? withFullDeps && withVersion3, # AMR-WB encoder

--- a/pkgs/development/libraries/fmt/default.nix
+++ b/pkgs/development/libraries/fmt/default.nix
@@ -106,7 +106,7 @@ in
     version = "12.2.0";
     hash = "sha256-Tc7PmNxUv7ajw6GaHPGEEtrD/fl6is7RB8TPestJa1o=";
 
-    patches = lib.optionals stdenv.is32bit [
+    patches = lib.optionals stdenv.hostPlatform.is32bit [
       # fix build on 32-bit targets
       # FIXME: remove in next update
       (fetchpatch {

--- a/pkgs/development/python-modules/django-health-check/default.nix
+++ b/pkgs/development/python-modules/django-health-check/default.nix
@@ -69,7 +69,7 @@ buildPythonPackage (finalAttrs: {
     "test_check_status__nonexistent_hostname"
     "test_check_status__no_answer"
   ]
-  ++ lib.optionals stdenv.isDarwin [
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # sensors_temperatures is not available on darwin: https://psutil.readthedocs.io/stable/index.html#psutil.sensors_temperatures
     "TestTemperature"
     # some metrics aren't available on darwin: https://psutil.readthedocs.io/stable/index.html#psutil.virtual_memory

--- a/pkgs/development/python-modules/otter-grader/default.nix
+++ b/pkgs/development/python-modules/otter-grader/default.nix
@@ -122,7 +122,7 @@ buildPythonPackage (finalAttrs: {
     # this R Markdown test, causing a partial credit output mismatch
     "test_rmd"
   ]
-  ++ lib.optionals stdenv.isDarwin [
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # socket.bind() fails under macOS sandbox
     "test_otter_example"
     "test_jupyterlite"

--- a/pkgs/development/python-modules/simple-pid/default.nix
+++ b/pkgs/development/python-modules/simple-pid/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage (finalAttrs: {
     "simple_pid"
   ];
 
-  doCheck = !stdenv.isDarwin;
+  doCheck = !stdenv.hostPlatform.isDarwin;
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/servers/sql/postgresql/ext/vectorchord/package.nix
+++ b/pkgs/servers/sql/postgresql/ext/vectorchord/package.nix
@@ -25,16 +25,18 @@ buildPgrxExtension (finalAttrs: {
 
   cargoHash = "sha256-IXOCzKJArNOcb/2TcJbLz1XdCquUpyF/cLHYU5vmlko=";
 
-  patches = lib.optional (lib.versionOlder rustc.llvm.version "22.0.0" && stdenv.isx86_64) [
-    # Due to a bug in LLVM 21, build fails on x86_64 with:
-    # `rustc-LLVM ERROR: Cannot select: intrinsic %llvm.x86.avx512.vpdpbusd.512`.
-    # This has been fixed in Rust's build of LLVM and LLVM 22 with https://github.com/rust-lang/llvm-project/commit/94e2c19f86a699d7a19ff0f4130b696699189c8d,
-    # but this is not reflected in nixpkgs' packaging of rustc.
-    # For this reason, we temporarily disable avx512vnni support until this is fixed in nixpkgs.
-    # This might cause a performance penalty, but should not affect correctness.
-    # See https://github.com/NixOS/nixpkgs/pull/537113#issuecomment-4846239887
-    ./0001-disable-avx512vnni.patch
-  ];
+  patches =
+    lib.optional (lib.versionOlder rustc.llvm.version "22.0.0" && stdenv.hostPlatform.isx86_64)
+      [
+        # Due to a bug in LLVM 21, build fails on x86_64 with:
+        # `rustc-LLVM ERROR: Cannot select: intrinsic %llvm.x86.avx512.vpdpbusd.512`.
+        # This has been fixed in Rust's build of LLVM and LLVM 22 with https://github.com/rust-lang/llvm-project/commit/94e2c19f86a699d7a19ff0f4130b696699189c8d,
+        # but this is not reflected in nixpkgs' packaging of rustc.
+        # For this reason, we temporarily disable avx512vnni support until this is fixed in nixpkgs.
+        # This might cause a performance penalty, but should not affect correctness.
+        # See https://github.com/NixOS/nixpkgs/pull/537113#issuecomment-4846239887
+        ./0001-disable-avx512vnni.patch
+      ];
 
   # Include upgrade scripts in the final package
   # https://github.com/supervc-stack/VectorChord/blob/0.5.0/crates/make/src/main.rs#L366

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -201,25 +201,35 @@ let
         extraSandboxProfile
         ;
 
-      # Utility flags to test the type of platform.
-      inherit (hostPlatform)
-        isDarwin
-        isLinux
-        isSunOS
-        isCygwin
-        isBSD
-        isFreeBSD
-        isOpenBSD
-        isi686
-        isx86_32
-        isx86_64
-        is32bit
-        is64bit
-        isAarch32
-        isAarch64
-        isMips
-        isBigEndian
-        ;
+    }
+    // lib.optionalAttrs config.allowAliases (
+      lib.mapAttrs
+        (
+          name: value: lib.warn "stdenv.${name} is deprecated, use stdenv.hostPlatform.${name} instead" value
+        )
+        {
+          # Added 2026-05-09
+          inherit (hostPlatform)
+            isDarwin
+            isLinux
+            isSunOS
+            isCygwin
+            isBSD
+            isFreeBSD
+            isOpenBSD
+            isi686
+            isx86_32
+            isx86_64
+            is32bit
+            is64bit
+            isAarch32
+            isAarch64
+            isMips
+            isBigEndian
+            ;
+        }
+    )
+    // {
 
       # Override `system` so that packages can get the system of the host
       # platform through `stdenv.system`. `system` is originally set to the

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3256,7 +3256,7 @@ with pkgs;
       ccWrapper.override (prev: {
         cc = prev.cc.override {
           reproducibleBuild = false;
-          profiledCompiler = with stdenv; (!isDarwin && hostPlatform.isx86);
+          profiledCompiler = with stdenv.hostPlatform; (!isDarwin && isx86);
         };
       })
     else


### PR DESCRIPTION
Co-authored by claude code

The `stdenv.is{Linux,Darwin,Aarch64,x86_64,...}` shorthands hide the platform distinction and are unfit for cross-compilation. PR #511765 mechanically migrates the remaining call sites to `stdenv.hostPlatform.is*`; this PR deprecates the aliases so the next round of drift gets surfaced at evaluation time.

- Each access to `stdenv.is*` now prints `stdenv.isFoo is deprecated, use stdenv.hostPlatform.isFoo instead` via `lib.warn`.

Mentioned by @siraben in https://github.com/NixOS/nixpkgs/pull/511765#issuecomment-4399886847; the original treewide #341407 also called out that "further replacements can be done in the PR where the warnings are added."

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.