### PR TITLE
still: init at 0.0.9

### DIFF
--- a/pkgs/by-name/st/still/package.nix
+++ b/pkgs/by-name/st/still/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  meson,
+  ninja,
+  pkg-config,
+  scdoc,
+  wayland,
+  wayland-protocols,
+  pixman,
+  wayland-scanner,
+  nix-update-script,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "still";
+  version = "0.0.9";
+
+  src = fetchFromGitHub {
+    owner = "faergeek";
+    repo = "still";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-bZo4SvBB5pSdvwxuE3+A2iz1um1kSZQ62chR0lOjpj8=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    scdoc
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    pixman
+    wayland
+    wayland-protocols
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  postInstall = ''
+    install -Dm644 $src/LICENSE $out/share/licenses/still/LICENSE
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Freeze the screen of a Wayland compositor until a provided command exits";
+    homepage = "https://github.com/faergeek/still";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "still";
+    maintainers = [ lib.maintainers.fazzi ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Adds the package `still`, a simple program which allows you to "Freeze the screen of a Wayland compositor until a provided command exits"

repo: https://github.com/faergeek/still

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
