### PR TITLE
sbb-tui: 1.13.4 -> 1.14.2

### DIFF
--- a/pkgs/by-name/sb/sbb-tui/package.nix
+++ b/pkgs/by-name/sb/sbb-tui/package.nix
@@ -8,13 +8,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "sbb-tui";
-  version = "1.13.4";
+  version = "1.14.2";
   __structuredAttrs = true;
   src = fetchFromGitHub {
     owner = "Necrom4";
     repo = "sbb-tui";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-JLjAhs5UbqgNYqpA3cDucrAS6ell+0JiDJNf7G33Nhs=";
+    hash = "sha256-kmT8wVkmAmVQLtSkRRIGInCjXiLfsYd9OrixYcDofS4=";
   };
 
   vendorHash = "sha256-K4DOu3rfSlKAa5JNKCzWWpnWZlXXxtN5Po7p1Spqe1w=";


### PR DESCRIPTION
[Changelog](https://github.com/Necrom4/sbb-tui/blob/master/CHANGELOG.md)

## [1.14.1](https://github.com/Necrom4/sbb-tui/compare/v1.14.0...v1.14.1) (2026-05-09)


### Bug Fixes

* **ui.animation:** adapt animation colors to the terminal background ([2206f36](https://github.com/Necrom4/sbb-tui/commit/2206f36b552babb35b20fab8b52b057638d990f0))
* **ui.animation:** gate build cells with spaces while still fading from the bg ([dd10bad](https://github.com/Necrom4/sbb-tui/commit/dd10badae42cbf60d4f76e166542f727c80754cf))

# [1.14.0](https://github.com/Necrom4/sbb-tui/compare/v1.13.4...v1.14.0) (2026-05-09)


### Bug Fixes

* **ui.shine:** blend toward neutral in Lab to avoid saturated logo shines ([9a25185](https://github.com/Necrom4/sbb-tui/commit/9a25185c6427b4bc017e1180994b49ebd1f4c178)), closes [#E9F7](https://github.com/Necrom4/sbb-tui/issues/E9F7)
* **ui.shine:** synchronize logo and tagline shines on a shared cycle ([c16a568](https://github.com/Necrom4/sbb-tui/commit/c16a568f41a10f9e7197185d0d37c0a27ddd1607))


### Features

* **config:** add 'animations' setting and flag ([1d18bef](https://github.com/Necrom4/sbb-tui/commit/1d18befa619edca3cb3ffe9f976ba32214c9dd2c))
* **ui.animation:** loop logo shine while on the start screen ([a7f3739](https://github.com/Necrom4/sbb-tui/commit/a7f3739c8db8017d98fa034cc5a341ff72fba126))
* **ui:** add animations ([3f7c8e2](https://github.com/Necrom4/sbb-tui/commit/3f7c8e2e96a97efa0671078c04819a7ca38d1a15)), closes [#61](https://github.com/Necrom4/sbb-tui/issues/61)
* **ui:** add logo shine startup animation ([cabc976](https://github.com/Necrom4/sbb-tui/commit/cabc9765437248497a8c8e52805e418e17c3fc2e))
* **ui:** add tagline shine on the start screen ([6781c0c](https://github.com/Necrom4/sbb-tui/commit/6781c0cda6258f69eaf676152f2c039ca145de6c))
* **ui:** build the logo from the center outward on startup ([c7a523a](https://github.com/Necrom4/sbb-tui/commit/c7a523ae89ffc07c9188003d1e9048f3d73b91b6))
* **ui:** replace ellipsis with a Braille spinner while loading ([5dd26c9](https://github.com/Necrom4/sbb-tui/commit/5dd26c9f40303f6521e64bea625467c520bd7739))
* **ui:** set typewriter effect for the welcome message on startup ([c79e56d](https://github.com/Necrom4/sbb-tui/commit/c79e56d7088d6e5d3f07d8de767deb19038fd5ba))
* **ui:** start the typewriter effect only after the logo build finishes ([58edfa6](https://github.com/Necrom4/sbb-tui/commit/58edfa66b39a8c4500470f0f2b556ae917a96301))

Note: initially this PR was for version 1.14.1, but it got updated during this PR.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
