### PR TITLE
nixos-render-docs: add --nix-shell-command-hint

### DIFF
--- a/doc/doc-support/package.nix
+++ b/doc/doc-support/package.nix
@@ -109,6 +109,7 @@ stdenvNoCC.mkDerivation (
       nixos-render-docs manual html \
         --manpage-urls ./manpage-urls.json \
         --redirects ./redirects.json \
+        --nix-shell-command-hint 'nix-shell doc' \
         --revision ${nixpkgs.rev or "master"} \
         --stylesheet style.css \
         --stylesheet highlightjs/mono-blue.css \

--- a/nixos/doc/manual/default.nix
+++ b/nixos/doc/manual/default.nix
@@ -192,7 +192,12 @@ rec {
 
         nixos-render-docs -j $NIX_BUILD_CORES manual html \
           --manpage-urls ${manpageUrls} \
-          ${if checkRedirects then "--redirects ${./redirects.json}" else ""} \
+          ${
+            if checkRedirects then
+              "--redirects ${./redirects.json} --nix-shell-command-hint 'nix-shell nixos/doc/manual'"
+            else
+              ""
+          } \
           --revision ${escapeShellArg revision} \
           --generator "nixos-render-docs ${pkgs.lib.version}" \
           --stylesheet style.css \

--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/manual.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/manual.py
@@ -763,6 +763,7 @@ def _build_cli_html(p: argparse.ArgumentParser) -> None:
     p.add_argument('--section-toc-depth', default=0, type=int)
     p.add_argument('--media-dir', default="media", type=Path)
     p.add_argument('--redirects', type=Path)
+    p.add_argument('--nix-shell-command-hint', type=str)
     p.add_argument('infile', type=Path)
     p.add_argument('outfile', type=Path)
 
@@ -771,7 +772,7 @@ def _run_cli_html(args: argparse.Namespace) -> None:
         redirects = None
         if args.redirects:
             with open(args.redirects) as raw_redirects:
-                redirects = Redirects(json.load(raw_redirects), redirects_script.read())
+                redirects = Redirects(json.load(raw_redirects), redirects_script.read(), args.nix_shell_command_hint)
 
         md = HTMLConverter(
             args.revision,

--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/redirects.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/redirects.py
@@ -12,13 +12,15 @@ class RedirectsError(Exception):
         divergent_redirects: set[str] = None,
         identifiers_missing_current_outpath: set[str] = None,
         identifiers_without_redirects: set[str] = None,
-        orphan_identifiers: set[str] = None
+        orphan_identifiers: set[str] = None,
+        nix_shell_command_hint: str = None
     ):
         self.conflicting_anchors = conflicting_anchors or set()
         self.divergent_redirects = divergent_redirects or set()
         self.identifiers_missing_current_outpath = identifiers_missing_current_outpath or set()
         self.identifiers_without_redirects = identifiers_without_redirects or set()
         self.orphan_identifiers = orphan_identifiers or set()
+        self.nix_shell_command_hint = nix_shell_command_hint
 
     def __str__(self):
         error_messages = []
@@ -36,7 +38,7 @@ All historical content locations must correspond to exactly one identifier.
     - {"\n    - ".join(self.divergent_redirects)}
 
     It leads to inconsistent behavior depending on which redirect is applied.
-    Please update doc/redirects.json or nixos/doc/manual/redirects.json!""")
+    Please update the redirects file!""")
         if self.identifiers_missing_current_outpath:
             error_messages.append(f"""
 The first element of an identifier's redirects list must denote its current location.
@@ -44,7 +46,7 @@ The first element of an identifier's redirects list must denote its current loca
     - {"\n    - ".join(self.identifiers_missing_current_outpath)}
 
     If you moved content, add its new location as the first element of the redirects mapping.
-    Please update doc/redirects.json or nixos/doc/manual/redirects.json!""")
+    Please update the redirects file!""")
         if self.identifiers_without_redirects:
             error_messages.append(f"""
 Identifiers present in the source must have a mapping in the redirects file.
@@ -54,6 +56,12 @@ Identifiers present in the source must have a mapping in the redirects file.
 Keys of the redirects mapping must correspond to some identifier in the source.
     - {"\n    - ".join(self.orphan_identifiers)}""")
         if self.identifiers_without_redirects or self.orphan_identifiers or self.identifiers_missing_current_outpath:
+            nix_shell_hint = ""
+            if self.nix_shell_command_hint:
+                nix_shell_hint = f"""
+    NOTE: Run the nix-shell to make this command available.
+        $ {self.nix_shell_command_hint}
+"""
             error_messages.append(f"""
 This can happen when an identifier was added, renamed, or removed.
 
@@ -70,13 +78,7 @@ This can happen when an identifier was added, renamed, or removed.
 
     Removed content? Redirect to alternatives or relevant release notes.
         $ redirects remove-and-redirect <identifier> <target-identifier>
-
-    NOTE: Run the right nix-shell to make this command available.
-        Nixpkgs:
-        $ nix-shell doc
-        NixOS:
-        $ nix-shell nixos/doc/manual
-""")
+{nix_shell_hint}""")
         error_messages.append("NOTE: If your build passes locally and you see this message in CI, you probably need a rebase.")
         return "\n".join(error_messages)
 
@@ -85,6 +87,7 @@ This can happen when an identifier was added, renamed, or removed.
 class Redirects:
     _raw_redirects: dict[str, list[str]]
     _redirects_script: str
+    _nix_shell_command_hint: str | None = None
 
     _xref_targets: dict[str, XrefTarget] = field(default_factory=dict)
 
@@ -155,7 +158,8 @@ class Redirects:
                 divergent_redirects=divergent_redirects,
                 identifiers_missing_current_outpath=identifiers_missing_current_outpath,
                 identifiers_without_redirects=identifiers_without_redirects,
-                orphan_identifiers=orphan_identifiers
+                orphan_identifiers=orphan_identifiers,
+                nix_shell_command_hint=self._nix_shell_command_hint
             )
 
         self._xref_targets = xref_targets


### PR DESCRIPTION
This way we can show the correct command.
Before this commit it would present both variations, which is annoying and a bit error prone.
(At least 2 people have got it wrong, including me :upside_down_face: )


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
