### PR TITLE
pixiecore: Fix preBuild hook check for go-modules vs main build stages

### DIFF
--- a/pkgs/by-name/pi/pixiecore/package.nix
+++ b/pkgs/by-name/pi/pixiecore/package.nix
@@ -48,7 +48,7 @@ buildGoModule rec {
   env.NIX_CFLAGS_COMPILE = toString [ "-Wno-error" ];
   preBuild = lib.optionalString rebuildIpxe ''
     # don't run in our go-modules phase but only in the normal build phase
-    if echo $NIX_CFLAGS_COMPILE | grep -q xz; then
+    if echo "$name" | grep -qv go-modules; then
       rm -rf ./third_party/ipxe
       cp -r ${ipxe.src} ./third_party/ipxe
       chmod -R u+w ./third_party/ipxe


### PR DESCRIPTION
The preBuild hook is invoked in both stages of the two-stage Go package build process, i.e. both the main derivation and the intermediate pixiecore-go-modules derivation.

On x86_64, we rebuild ipxe in the preBuild hook, but this must only be done in the main build phase. In the go-modules phase, the build fails as we don't have xz as an input.

The hook detects which phase it's in by grepping NIX_CFLAGS_COMPILE for "xz", and compiling ipxe if there is a match.

Unfortunately, this fails if the string "xz" appears anywhere else in NIX_CFLAGS_COMPILE, which can happen if, for example, cc-wrapper adds an include directory from a derivation whose hash includes xz, e.g.:
```
-isystem /nix/store/fcn7j45ia0vf1x6cjbmmff725xza1l4b-libxcrypt-4.5.2/include
```
When this happens, the hook will incorrectly try to build ipxe in the go-modules stage, and the build will fail:
```
util/zbin.c:7:10: fatal error: lzma.h: No such file or directory
7 | #include <lzma.h>
  |          ^~~~~~~~
compilation terminated.
make[2]: *** [Makefile.housekeeping:1451: util/zbin32] Error 1
```
Fix this by checking whether the derivation name contains "go-modules" instead, which should be more reliable.

Closes: #518420 ("Build failure: pixiecore")


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
