### PR TITLE
matrix-authentication-service: fix cross compilation

### DIFF
--- a/pkgs/by-name/ma/matrix-authentication-service/package.nix
+++ b/pkgs/by-name/ma/matrix-authentication-service/package.nix
@@ -14,6 +14,7 @@
   cctools,
   nix-update-script,
   versionCheckHook,
+  buildPackages,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -52,6 +53,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     zstd
   ];
 
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+
   env = {
     ZSTD_SYS_USE_PKG_CONFIG = true;
     VERGEN_GIT_DESCRIBE = finalAttrs.version;
@@ -74,23 +77,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   preBuild =
     let
-      rustTarget = stdenv.hostPlatform.rust.rustcTarget;
-      rustTargetUnderscore = builtins.replaceStrings [ "-" ] [ "_" ] rustTarget;
+      buildTarget = stdenv.buildPlatform.rust.rustcTarget;
+      buildTargetUnderscore = lib.replaceString "-" "_" buildTarget;
     in
     ''
       make -C policies
       (cd "$npmRoot" && npm run build)
 
-      # Fix aws-lc-sys cross-compilation:
-      # The cc crate looks for "aarch64-linux-gnu-gcc")
-      # when CC is unset and TARGET != HOST, but Nix's cross-compiler is
-      # named "aarch64-unknown-linux-gnu-gcc" (with vendor).
-      # We set the target-specific CC_<target> variable so the cc crate
-      # and aws-lc-sys find the correct cross-compiler, then unset the
-      # generic CC so aws-lc-sys doesn't misassign it.
-      export CC_${rustTargetUnderscore}=$CC
-      export CXX_${rustTargetUnderscore}=$CXX
-      unset CC CXX
+      # Fix aws-lc-sys cross-compilation
+      export CC_${buildTargetUnderscore}=$CC_FOR_BUILD
+      export CXX_${buildTargetUnderscore}=$CXX_FOR_BUILD
     '';
 
   # Adapted from https://github.com/element-hq/matrix-authentication-service/blob/v0.20.0/.github/workflows/build.yaml#L75-L84


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
# Description
Simply added host C/CXX compilers env vars to fix cross compilation

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
