### PR TITLE
python3Packages.aiosendspin: remove pytest-timeout

### DIFF
--- a/pkgs/development/python-modules/aiosendspin/default.nix
+++ b/pkgs/development/python-modules/aiosendspin/default.nix
@@ -18,7 +18,6 @@
   # test dependencies
   pytest-aiohttp,
   pytest-cov-stub,
-  pytest-timeout,
   pytest-xdist,
   pytestCheckHook,
 
@@ -44,6 +43,9 @@ buildPythonPackage (finalAttrs: {
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail 'version = "0.0.0"' 'version = "${finalAttrs.version}"'
+
+    # too narrow timeouts, so remove pytest-timeout
+    sed -i "/addopts/d" pyproject.toml
   '';
 
   build-system = [
@@ -63,7 +65,6 @@ buildPythonPackage (finalAttrs: {
   nativeCheckInputs = [
     pytest-aiohttp
     pytest-cov-stub
-    pytest-timeout
     pytest-xdist
     pytestCheckHook
   ];


### PR DESCRIPTION
The timeouts are often too narrow for busy builders making the tests flaky.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin (segfaults in python3.pkgs.av)
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
