### PR TITLE
music-assistant: 2.8.6 -> 2.8.7

### DIFF
--- a/pkgs/by-name/mu/music-assistant/package.nix
+++ b/pkgs/by-name/mu/music-assistant/package.nix
@@ -38,14 +38,14 @@ assert
 
 python.pkgs.buildPythonApplication rec {
   pname = "music-assistant";
-  version = "2.8.6";
+  version = "2.8.7";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "music-assistant";
     repo = "server";
     tag = version;
-    hash = "sha256-//SR7UhaDgT6zNBZ6/B0tBQ88fWkHtrr9Ds0KwH6xzs=";
+    hash = "sha256-m91q/8XYoZ5Azu79fKD0euRCuf29w3vj5cxdFheDsmI=";
   };
 
   patches = [
@@ -176,12 +176,15 @@ python.pkgs.buildPythonApplication rec {
       pytestCheckHook
     ]
     ++ lib.concatAttrValues optional-dependencies
-    ++ (providerPackages.audible python.pkgs)
-    ++ (providerPackages.dlna python.pkgs)
-    ++ (providerPackages.jellyfin python.pkgs)
-    ++ (providerPackages.opensubsonic python.pkgs)
-    ++ (providerPackages.sendspin python.pkgs)
-    ++ (providerPackages.tidal python.pkgs);
+    ++ (map (provider: providerPackages.${provider} python.pkgs) [
+      "audible"
+      "dlna"
+      "jellyfin"
+      "opensubsonic"
+      "sendspin"
+      "snapcast"
+      "tidal"
+    ]);
 
   disabledTestPaths = [
     # no multicast support in build sandbox:

--- a/pkgs/by-name/mu/music-assistant/providers.nix
+++ b/pkgs/by-name/mu/music-assistant/providers.nix
@@ -1,7 +1,7 @@
 # Do not edit manually, run ./update-providers.py
 
 {
-  version = "2.8.6";
+  version = "2.8.7";
   providers = {
     airplay =
       ps: with ps; [


### PR DESCRIPTION
https://github.com/music-assistant/server/releases/tag/2.8.7


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
