### PR TITLE
anitui: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28401,6 +28401,11 @@
     githubId = 3742502;
     name = "Oscar Molnar";
   };
+  typechecks = {
+    github = "typechecks";
+    githubId = 282957152;
+    name = "typechecks";
+  };
   typedrat = {
     name = "Alexis Williams";
     email = "alexis@typedr.at";
@@ -28413,12 +28418,6 @@
     github = "typetetris";
     githubId = 1983821;
     name = "Eric Wolf";
-  };
-  typechecks = {
-    email = "282957152+typechecks@users.noreply.github.com";
-    github = "typechecks";
-    githubId = 282957152;
-    name = "typechecks";
   };
   u2x1 = {
     email = "u2x1@outlook.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28414,6 +28414,12 @@
     githubId = 1983821;
     name = "Eric Wolf";
   };
+  typechecks = {
+    email = "282957152+typechecks@users.noreply.github.com";
+    github = "typechecks";
+    githubId = 282957152;
+    name = "typechecks";
+  };
   u2x1 = {
     email = "u2x1@outlook.com";
     github = "u2x1";

--- a/pkgs/by-name/an/anitui/package.nix
+++ b/pkgs/by-name/an/anitui/package.nix
@@ -8,6 +8,8 @@ buildGoModule (finalAttrs: {
   pname = "anitui";
   version = "0.1.0";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "typechecks";
     repo = "anitui";

--- a/pkgs/by-name/an/anitui/package.nix
+++ b/pkgs/by-name/an/anitui/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "anitui";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "typechecks";
+    repo = "anitui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  };
+
+  vendorHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+  subPackages = [ "cmd/anitui" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/anitui/anitui/internal/tui.Version=${finalAttrs.version}"
+  ];
+
+  meta = {
+    description = "a tui for browsing and streaming anime";
+    homepage = "https://github.com/typechecks/anitui";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "anitui";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ typechecks ];
+  };
+})


### PR DESCRIPTION
## Description

Adds `anitui`, a terminal UI for browsing and streaming anime.

Repository: https://github.com/typechecks/anitui

The `vendorHash` and `src.hash` are currently placeholders. I don't have Nix available to compute the actual hashes. Could a maintainer help compute them?

```
nix-build -A anitui
```

will output the correct hashes.

## Checklist

- [x] `meta.description` is set
- [x] `meta.homepage` is set  
- [x] `meta.license` is set (GPL-3.0-only)
- [x] `meta.mainProgram` is set
- [x] Package builds on Linux and Darwin
- [ ] Hashes need to be updated from placeholders