### PR TITLE
nixos/qbittorrent: pre-seed QueueingSystemEnabled to prevent legacy mode

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -162,6 +162,21 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- `services.qbittorrent`: when `serverConfig` is non-empty, the module now
+  pre-seeds `BitTorrent/Session/QueueingSystemEnabled = false` to match
+  qBittorrent's documented default. Previously, writing any `serverConfig`
+  caused qBittorrent to misclassify the install as an upgrade from a pre-4.3
+  version and inject the historical default (`true`), enabling torrent
+  queueing silently. Users who currently have queueing enabled (whether
+  intentionally or through the previous incorrect behavior) must set it
+  explicitly to retain it after upgrading:
+  ```nix
+  {
+    services.qbittorrent.serverConfig.BitTorrent.Session.QueueingSystemEnabled =
+      true;
+  }
+  ```
+
 - `systemd.coredump.extraConfig` has been removed in favor of the structured [](#opt-systemd.coredump.settings.Coredump) option. Use `systemd.coredump.settings.Coredump` to set any `coredump.conf(5)` option directly. For example, replace `systemd.coredump.extraConfig = "Storage=journal";` with `systemd.coredump.settings.Coredump.Storage = "journal";`.
 
 - `services.home-assistant.config.lovelace.mode` has been renamed to `lovelace.dashboards` and `lovelace.resource_mode` to match the [configuration format](https://www.home-assistant.io/dashboards/dashboards/) required by Home Assistant 2026.8. Users who explicitly set `lovelace.mode` should remove it; the module generates the correct entries automatically.

--- a/nixos/modules/services/torrent/qbittorrent.nix
+++ b/nixos/modules/services/torrent/qbittorrent.nix
@@ -11,7 +11,9 @@ let
   inherit (lib)
     literalExpression
     getExe
+    mkDefault
     mkEnableOption
+    mkMerge
     mkOption
     mkPackageOption
     mkIf
@@ -116,6 +118,20 @@ in
         }
         ];
         ```
+
+        ::: {.note}
+        When this option is non-empty, the module pre-seeds
+        `BitTorrent/Session/QueueingSystemEnabled = false` to match the
+        current qBittorrent upstream default. This prevents qBittorrent's
+        legacy-mode detection from silently overriding it for declarative
+        configurations. Users who want torrent queuing enabled must set it
+        explicitly:
+        ```nix
+        {
+          services.qbittorrent.serverConfig.BitTorrent.Session.QueueingSystemEnabled = true;
+        }
+        ```
+        :::
       '';
       example = literalExpression ''
         {
@@ -142,102 +158,113 @@ in
       ];
     };
   };
-  config = mkIf cfg.enable {
-    systemd = {
-      tmpfiles.settings = {
-        qbittorrent = {
-          "${cfg.profileDir}/qBittorrent/"."d" = {
-            mode = "755";
-            inherit (cfg) user group;
-          };
-          "${cfg.profileDir}/qBittorrent/config/"."d" = {
-            mode = "755";
-            inherit (cfg) user group;
+  config = mkIf cfg.enable (mkMerge [
+    # Mirror of upstream qBittorrent's changedDefaults[] table:
+    # https://github.com/qbittorrent/qBittorrent/blob/master/src/app/upgrade.cpp
+    # Currently contains only QueueingSystemEnabled. If upstream adds entries,
+    # this seed needs to be expanded.
+    # Context: https://github.com/NixOS/nixpkgs/issues/516998
+    (mkIf (cfg.serverConfig != { }) {
+      services.qbittorrent.serverConfig.BitTorrent.Session.QueueingSystemEnabled = mkDefault false;
+    })
+
+    {
+      systemd = {
+        tmpfiles.settings = {
+          qbittorrent = {
+            "${cfg.profileDir}/qBittorrent/"."d" = {
+              mode = "755";
+              inherit (cfg) user group;
+            };
+            "${cfg.profileDir}/qBittorrent/config/"."d" = {
+              mode = "755";
+              inherit (cfg) user group;
+            };
           };
         };
-      };
-      services.qbittorrent = {
-        description = "qbittorrent BitTorrent client";
-        wants = [ "network-online.target" ];
-        after = [
-          "local-fs.target"
-          "network-online.target"
-          "nss-lookup.target"
-        ];
-        wantedBy = [ "multi-user.target" ];
-        restartTriggers = optionals (cfg.serverConfig != { }) [ configFile ];
-
-        serviceConfig = {
-          Type = "simple";
-          User = cfg.user;
-          Group = cfg.group;
-
-          # the config file has to be writable, so we have to do this weird dance
-          ExecStartPre = lib.mkIf (cfg.serverConfig != { }) ''
-            ${pkgs.coreutils}/bin/install -Dm600 ${configFile} "${cfg.profileDir}/qBittorrent/config/qBittorrent.conf"
-          '';
-
-          ExecStart = utils.escapeSystemdExecArgs (
-            [
-              (getExe cfg.package)
-              "--profile=${cfg.profileDir}"
-            ]
-            ++ optionals (cfg.webuiPort != null) [ "--webui-port=${toString cfg.webuiPort}" ]
-            ++ optionals (cfg.torrentingPort != null) [ "--torrenting-port=${toString cfg.torrentingPort}" ]
-            ++ cfg.extraArgs
-          );
-          TimeoutStopSec = 1800;
-
-          # https://github.com/qbittorrent/qBittorrent/pull/6806#discussion_r121478661
-          PrivateTmp = false;
-
-          PrivateNetwork = false;
-          RemoveIPC = true;
-          NoNewPrivileges = true;
-          PrivateDevices = true;
-          PrivateUsers = true;
-          ProtectHome = "yes";
-          ProtectProc = "invisible";
-          ProcSubset = "pid";
-          ProtectSystem = "full";
-          ProtectClock = true;
-          ProtectHostname = true;
-          ProtectKernelLogs = true;
-          ProtectKernelModules = true;
-          ProtectKernelTunables = true;
-          ProtectControlGroups = true;
-          RestrictAddressFamilies = [
-            "AF_INET"
-            "AF_INET6"
-            "AF_NETLINK"
+        services.qbittorrent = {
+          description = "qbittorrent BitTorrent client";
+          wants = [ "network-online.target" ];
+          after = [
+            "local-fs.target"
+            "network-online.target"
+            "nss-lookup.target"
           ];
-          RestrictNamespaces = true;
-          RestrictRealtime = true;
-          RestrictSUIDSGID = true;
-          LockPersonality = true;
-          MemoryDenyWriteExecute = true;
-          SystemCallArchitectures = "native";
-          CapabilityBoundingSet = "";
-          SystemCallFilter = [ "@system-service" ];
+          wantedBy = [ "multi-user.target" ];
+          restartTriggers = optionals (cfg.serverConfig != { }) [ configFile ];
+
+          serviceConfig = {
+            Type = "simple";
+            User = cfg.user;
+            Group = cfg.group;
+
+            # the config file has to be writable, so we have to do this weird dance
+            ExecStartPre = lib.mkIf (cfg.serverConfig != { }) ''
+              ${pkgs.coreutils}/bin/install -Dm600 ${configFile} "${cfg.profileDir}/qBittorrent/config/qBittorrent.conf"
+            '';
+
+            ExecStart = utils.escapeSystemdExecArgs (
+              [
+                (getExe cfg.package)
+                "--profile=${cfg.profileDir}"
+              ]
+              ++ optionals (cfg.webuiPort != null) [ "--webui-port=${toString cfg.webuiPort}" ]
+              ++ optionals (cfg.torrentingPort != null) [ "--torrenting-port=${toString cfg.torrentingPort}" ]
+              ++ cfg.extraArgs
+            );
+            TimeoutStopSec = 1800;
+
+            # https://github.com/qbittorrent/qBittorrent/pull/6806#discussion_r121478661
+            PrivateTmp = false;
+
+            PrivateNetwork = false;
+            RemoveIPC = true;
+            NoNewPrivileges = true;
+            PrivateDevices = true;
+            PrivateUsers = true;
+            ProtectHome = "yes";
+            ProtectProc = "invisible";
+            ProcSubset = "pid";
+            ProtectSystem = "full";
+            ProtectClock = true;
+            ProtectHostname = true;
+            ProtectKernelLogs = true;
+            ProtectKernelModules = true;
+            ProtectKernelTunables = true;
+            ProtectControlGroups = true;
+            RestrictAddressFamilies = [
+              "AF_INET"
+              "AF_INET6"
+              "AF_NETLINK"
+            ];
+            RestrictNamespaces = true;
+            RestrictRealtime = true;
+            RestrictSUIDSGID = true;
+            LockPersonality = true;
+            MemoryDenyWriteExecute = true;
+            SystemCallArchitectures = "native";
+            CapabilityBoundingSet = "";
+            SystemCallFilter = [ "@system-service" ];
+          };
         };
       };
-    };
 
-    users = {
-      users = mkIf (cfg.user == "qbittorrent") {
-        qbittorrent = {
-          inherit (cfg) group;
-          isSystemUser = true;
+      users = {
+        users = mkIf (cfg.user == "qbittorrent") {
+          qbittorrent = {
+            inherit (cfg) group;
+            isSystemUser = true;
+          };
         };
+        groups = mkIf (cfg.group == "qbittorrent") { qbittorrent = { }; };
       };
-      groups = mkIf (cfg.group == "qbittorrent") { qbittorrent = { }; };
-    };
 
-    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall (
-      optionals (cfg.webuiPort != null) [ cfg.webuiPort ]
-      ++ optionals (cfg.torrentingPort != null) [ cfg.torrentingPort ]
-    );
-  };
+      networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall (
+        optionals (cfg.webuiPort != null) [ cfg.webuiPort ]
+        ++ optionals (cfg.torrentingPort != null) [ cfg.torrentingPort ]
+      );
+    }
+  ]);
   meta.maintainers = with maintainers; [
     fsnkty
     undefined-landmark

--- a/nixos/tests/qbittorrent.nix
+++ b/nixos/tests/qbittorrent.nix
@@ -65,6 +65,19 @@
           serverConfig.Preferences.WebUI.Port = "7171";
         };
       };
+
+      # Verify fix for https://github.com/NixOS/nixpkgs/issues/516998:
+      # A non-empty serverConfig must not cause qBittorrent to inject extra
+      # entries from its changedDefaults[] legacy table beyond what we seed.
+      specialisation.legacyDefaultsBlocked.configuration = {
+        services.qbittorrent = {
+          enable = true;
+          webuiPort = null;
+          serverConfig.LegalNotice.Accepted = true;
+          # QueueingSystemEnabled is intentionally NOT set here;
+          # the module seeds mkDefault false to block legacy injection.
+        };
+      };
     };
   };
 
@@ -77,6 +90,7 @@
       openPorts = "${simpleSpecPath}/openPorts";
       serverConfig = "${simpleSpecPath}/serverConfig";
       serverConfigChange = "${declarativeSpecPath}/serverConfigChange";
+      legacyDefaultsBlocked = "${declarativeSpecPath}/legacyDefaultsBlocked";
     in
     ''
       simple.start(allow_reboot=True)
@@ -189,5 +203,47 @@
       with subtest("changes in serverConfig are applied correctly"):
           declarative.succeed("${serverConfigChange}/bin/switch-to-configuration test")
           test_webui(declarative, 7171)
+
+      with subtest("legacy defaults are blocked when serverConfig is non-empty"):
+          # Differential test for https://github.com/NixOS/nixpkgs/issues/516998.
+          # The bug: qBittorrent detects a non-empty on-disk config at startup,
+          # activates "legacy mode", and injects changedDefaults[] values (e.g.
+          # QueueingSystemEnabled=true) regardless of the current upstream default.
+          # The fix: the module pre-seeds those values via mkDefault so qBittorrent
+          # sees them already present and does not inject legacy overrides.
+          #
+          # Baseline (fresh install): restart simple with a clean config so qBit
+          # writes only its current defaults with no legacy mode activated.
+          simple.stop_job("qbittorrent.service")
+          simple.succeed("rm -f /var/lib/qBittorrent/qBittorrent/config/qBittorrent.conf")
+          simple.start_job("qbittorrent.service")
+          simple.wait_for_unit("qbittorrent.service")
+          simple.wait_until_succeeds(
+              "test -s /var/lib/qBittorrent/qBittorrent/config/qBittorrent.conf"
+          )
+          fresh_conf = simple.succeed(
+              "cat /var/lib/qBittorrent/qBittorrent/config/qBittorrent.conf"
+          )
+
+          # Declarative install: switch to a config that has a non-empty serverConfig
+          # (only LegalNotice.Accepted is set; QueueingSystemEnabled is intentionally
+          # absent so the module's mkDefault seed is the only source of that key).
+          declarative.succeed("${legacyDefaultsBlocked}/bin/switch-to-configuration test")
+          declarative.wait_for_unit("qbittorrent.service")
+          seeded_conf = declarative.succeed(
+              "cat /var/lib/qBittorrent/qBittorrent/config/qBittorrent.conf"
+          )
+
+          # Differential assertion: the legacy-mode bug would make QueueingSystemEnabled
+          # appear as true only in seeded_conf (non-empty on-disk config path) but not
+          # in fresh_conf (fresh install, current defaults). Our seed must prevent that.
+          assert "QueueingSystemEnabled=true" not in fresh_conf, (
+              "Unexpected: fresh install wrote QueueingSystemEnabled=true\n"
+              f"fresh_conf:\n{fresh_conf}"
+          )
+          assert "QueueingSystemEnabled=true" not in seeded_conf, (
+              "Legacy mode was triggered: QueueingSystemEnabled was injected as true.\n"
+              f"fresh_conf:\n{fresh_conf}\n\nseeded_conf:\n{seeded_conf}"
+          )
     '';
 }


### PR DESCRIPTION
Fixes #516998

## Problem

When `services.qbittorrent.serverConfig` is non-empty, qBittorrent reads
a non-empty on-disk config at first start and activates its "legacy default
mode". This silently sets `BitTorrent/Session/QueueingSystemEnabled=true`
regardless of the current upstream default (`false` since qBittorrent 4.3.0,
[upstream PR](https://github.com/qbittorrent/qBittorrent/pull/11847),
merged 2020-02-11, shipped in release-4.3.0 on 2020-10-18).

The root cause: qBittorrent checks whether the in-memory config is empty on
load — if non-empty → old user → legacy defaults. The NixOS module writes
the config file *before* qBittorrent starts via `ExecStartPre`, so qBittorrent
always sees a non-empty config and applies legacy defaults.

## Fix

Pre-seed `BitTorrent/Session/QueueingSystemEnabled = lib.mkDefault false`
when `serverConfig != {}`. This mirrors the current upstream default and
prevents the legacy-mode override. Users who want queueing enabled must set
it explicitly.

Only applied when `serverConfig` is non-empty (users who do not use
declarative config are unaffected).

## Changes

- `nixos/modules/services/torrent/qbittorrent.nix`: `mkIf cfg.enable (mkMerge
  [...])` structure with a `mkIf (serverConfig != {})` block pre-seeding
  `QueueingSystemEnabled = mkDefault false`; comment links upstream
  `changedDefaults[]` table in `upgrade.cpp`; option description updated
- `nixos/tests/qbittorrent.nix`: differential `legacyDefaultsBlocked`
  subtest — restarts `simple` (no serverConfig) to get a fresh-install
  baseline config, then switches `declarative` to a non-empty serverConfig,
  and asserts `QueueingSystemEnabled=true` is absent in both
- `nixos/doc/manual/release-notes/rl-2605.section.md`: backward
  incompatibility note

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test