### PR TITLE
python3Packages.sourmash: fix build by using system rocksdb

### DIFF
--- a/pkgs/development/python-modules/sourmash/default.nix
+++ b/pkgs/development/python-modules/sourmash/default.nix
@@ -4,6 +4,7 @@
   buildPythonPackage,
   stdenv,
   rustPlatform,
+  rocksdb_9_10,
   bitstring,
   cachetools,
   cffi,
@@ -18,6 +19,9 @@
   pyyaml,
   pytestCheckHook,
 }:
+let
+  rocksdb = rocksdb_9_10;
+in
 buildPythonPackage rec {
   pname = "sourmash";
   version = "4.9.4";
@@ -40,6 +44,11 @@ buildPythonPackage rec {
   ];
 
   buildInputs = [ iconv ];
+
+  env = {
+    ROCKSDB_INCLUDE_DIR = "${rocksdb}/include";
+    ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+  };
 
   propagatedBuildInputs = [
     bitstring

--- a/pkgs/development/python-modules/sourmash/default.nix
+++ b/pkgs/development/python-modules/sourmash/default.nix
@@ -2,6 +2,7 @@
   lib,
   fetchPypi,
   buildPythonPackage,
+  pythonAtLeast,
   stdenv,
   rustPlatform,
   rocksdb_9_10,
@@ -74,6 +75,16 @@ buildPythonPackage rec {
     "test_compare_no_such_file"
     "test_do_sourmash_index_multiscaled_rescale_fail"
     "test_metagenome_kreport_out_fail"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # argparse subparser usage prefix changed in 3.14
+    "test_cmd_3"
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
+    # rocksdb segfaults pytest workers
+    "rocksdb"
+    "disk_revindex"
+    "create_dataset_picklist"
   ];
 
   meta = {


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327161549)](https://hydra.nixos.org/build/327161549)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test