### PR TITLE
arti: 2.2.0 -> 2.3.0

### DIFF
--- a/pkgs/by-name/ar/arti/package.nix
+++ b/pkgs/by-name/ar/arti/package.nix
@@ -13,7 +13,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "arti";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.torproject.org";
@@ -21,10 +21,17 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "core";
     repo = "arti";
     tag = "arti-v${finalAttrs.version}";
-    hash = "sha256-yV+8P6V9QDDmIekJsa3kUt8Qv2Y/Zfeq2aqcQIGNubg=";
+    hash = "sha256-OEGKjYJ3p4g0ZfeK6k8IJJPjgSBMrSlKlxsCw1OwyaI=";
   };
 
-  cargoHash = "sha256-bqJ9beO+AZlz9GZkO5cAk45B4bxyfYq+pLMFWj8pWwg=";
+  # Working around a bug in cargo that appears with cargo-auditable, see
+  # https://github.com/rust-secure-code/cargo-auditable/issues/124.
+  postPatch = ''
+    substituteInPlace crates/arti/Cargo.toml \
+      --replace-fail '"tor-rpcbase"' '"dep:tor-rpcbase"'
+  '';
+
+  cargoHash = "sha256-OJgrIXL185W9rcQd7XZsgiqN4in74Oc2jDT1ZmcCC6E=";
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ pkg-config ];
 
@@ -68,7 +75,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   doInstallCheck = true;
 
   passthru = {
-    inherit (nixosTests) tor;
+    tests = { inherit (nixosTests) tor; };
     updateScript = nix-update-script { extraArgs = [ "--version-regex=^arti-v(.*)$" ]; };
   };
 


### PR DESCRIPTION
Release announcement: https://blog.torproject.org/arti_2_3_0_released/
Changelog: https://gitlab.torproject.org/tpo/core/arti/-/blob/arti-v2.3.0/CHANGELOG.md

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
