### PR TITLE
python3Packages.schedula: skip form-extras test that lacks proper guard

### DIFF
--- a/pkgs/development/python-modules/schedula/default.nix
+++ b/pkgs/development/python-modules/schedula/default.nix
@@ -79,6 +79,8 @@ buildPythonPackage rec {
     # ERROR tests/utils/test_form.py::TestDispatcherForm::test_form1 - ModuleNotFoundError: No module named 'chromedriver_autoinstaller'
     # ERROR tests/utils/test_form.py::TestDispatcherForm::test_form_stripe - ModuleNotFoundError: No module named 'chromedriver_autoinstaller'
     "tests/utils/test_form.py"
+    # requires schedula[form] extras
+    "tests/utils/test_form_items.py"
   ];
 
   pythonImportsCheck = [ "schedula" ];

--- a/pkgs/development/python-modules/schedula/default.nix
+++ b/pkgs/development/python-modules/schedula/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildPythonPackage,
+  pythonAtLeast,
   fetchFromGitHub,
 
   # build-system
@@ -81,6 +82,19 @@ buildPythonPackage rec {
     "tests/utils/test_form.py"
     # requires schedula[form] extras
     "tests/utils/test_form_items.py"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # itertools iterators no longer picklable in 3.14 (cpython#101588)
+    "tests/test_dispatcher.py::TestAsyncParallel"
+    "tests/test_dispatcher.py::TestCopyDispatcher::test_copy"
+    "tests/utils/test_blue.py::TestBlueDispatcher::test_blue_io"
+    "tests/utils/test_io.py::TestReadWrite::test_load_dispatcher"
+    "tests/utils/test_io.py::TestReadWrite::test_save_dispatcher"
+    # exception repr format changed in 3.14
+    "tests/test_dispatcher.py::TestDispatch::test_raises"
+    # doctest output drift on 3.14
+    "tests/test_dispatcher.py::TestDoctest::runTest"
+    "tests/utils/test_io.py::TestDoctest::runTest"
   ];
 
   pythonImportsCheck = [ "schedula" ];


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327160237)](https://hydra.nixos.org/build/327160237)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test