### PR TITLE
goimapnotify: 2.5.4 -> 2.5.5

### DIFF
--- a/pkgs/by-name/go/goimapnotify/package.nix
+++ b/pkgs/by-name/go/goimapnotify/package.nix
@@ -7,20 +7,20 @@
 
 buildGoModule (finalAttrs: {
   pname = "goimapnotify";
-  version = "2.5.4";
+  version = "2.5.5";
 
   src = fetchFromGitLab {
     owner = "shackra";
     repo = "goimapnotify";
     tag = finalAttrs.version;
-    hash = "sha256-6hsepgXdG+BSSKTVics2459qUxYPIHKNqm2yq8UJXks=";
+    hash = "sha256-kPyL6sObr1WvCjjGJZk2Rk4YsY4rH836OzXP/MEgpL0=";
   };
 
   vendorHash = "sha256-5cZzaCoOR1R7iST0q3GaJbYIbKKEigeWqhp87maOL04=";
 
   postPatch = ''
-    for f in command.go command_test.go; do
-      substituteInPlace $f --replace '"sh"' '"${runtimeShell}"'
+    for f in internal/util/command.go internal/util/command_test.go; do
+      substituteInPlace $f --replace-fail '"sh"' '"${runtimeShell}"'
     done
   '';
 


### PR DESCRIPTION
Update to 2.5.5

Adjust source file paths for substitutions.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
