### PR TITLE
ocamlPackages.rosetta: 0.3.0 -> 0.4.0

### DIFF
--- a/pkgs/development/ocaml-modules/rosetta/default.nix
+++ b/pkgs/development/ocaml-modules/rosetta/default.nix
@@ -9,11 +9,11 @@
 
 buildDunePackage (finalAttrs: {
   pname = "rosetta";
-  version = "0.3.0";
+  version = "0.4.0";
 
   src = fetchzip {
-    url = "https://github.com/mirage/rosetta/releases/download/v${finalAttrs.version}/rosetta-v${finalAttrs.version}.tbz";
-    sha256 = "1gzp3fbk8qd207cm25dgj9kj7b44ldqpjs63pl6xqvi9hx60m3ij";
+    url = "https://github.com/mirage/rosetta/releases/download/v${finalAttrs.version}/rosetta-${finalAttrs.version}.tbz";
+    hash = "sha256-LFdkwHBppDXE5q6mcDPWX1PreSVEsV9msq6rEmCWVwA=";
   };
 
   duneVersion = "3";


### PR DESCRIPTION
Update to 0.4.0

ocamlPackages.letters fails on x86_64-darwin since it can not build ocaml5.4.1-mirage-crypto-rng, but i think this is not related.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
