### PR TITLE
cdesktopenv: fix build by disabling fortify

### DIFF
--- a/pkgs/by-name/cd/cdesktopenv/package.nix
+++ b/pkgs/by-name/cd/cdesktopenv/package.nix
@@ -110,6 +110,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
+  # https://sourceforge.net/p/cdesktopenv/tickets/193/
+  hardeningDisable = [ "fortify" ];
+
   # Can probably remove after next release
   # https://sourceforge.net/p/cdesktopenv/code/ci/f0154141b1f1501490bac8e0235214bf8f00f715/
   env.NIX_CFLAGS_COMPILE = "-std=gnu17";


### PR DESCRIPTION
- #516381
- https://hydra.nixos.org/build/326783952

```
DTSRCREATE Successfully initialized database 'CDEDOC'.
dtsrload -dCDEDOC '-t
' CDEDOC
/build/cde-2.5.3/programs/dtsr/.libs/lt-dtsrload: Version 0.6.  Run Thursday, Apr 23 2026, 10:28 AM.
/build/cde-2.5.3/programs/dtsr/.libs/lt-dtsrload: cwd = '/build/cde-2.5.3/doc/en_US.UTF-8/cde.dti/CDEDOC/dtsearch', fzkfile = 'CDEDOC.fzk'
/build/cde-2.5.3/programs/dtsr/.libs/lt-dtsrload: 'CDEDOC' schema ver = 2.0, rec count = 0, last slot = 0.
/build/cde-2.5.3/programs/dtsr/.libs/lt-dtsrload: Each dot = 20 records processed.
*** buffer overflow detected ***: terminated
dtdocbook2infolib: command failed: dtsrload -dCDEDOC '-t
' CDEDOC
```

The underlying issue is in lib/DtSearch/isduprec.c where there is a structure defined as:

```
typedef struct hash_tag {
    struct hash_tag *link;
    char            recid[2];  /* actual array size varies */
}               HASHNODE;
```

The variable array member isn't defined in a C99 recognizable way, which requires the array size to be omitted.

Really an upstream issue. I thought to patch it but upon closer inspection there are multiple such usage throughout the codebase. I'd suppose most of these crashes if triggered are false positives. So I chose to report the issue to upstream and disable fortify here.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
