### PR TITLE
nixos/iscsi-initiator: add option discoverType

### DIFF
--- a/nixos/modules/services/networking/iscsi/initiator.nix
+++ b/nixos/modules/services/networking/iscsi/initiator.nix
@@ -20,6 +20,24 @@ in
       default = null;
       description = "Portal to discover targets on";
     };
+
+    discoverType = mkOption {
+      description = ''
+        Target discovery type.
+        Change this if you want to discover your targes via an iSNS server
+        or use the targets provided via firmware settings.
+        See {manpage}`iscsiadm(8)`.
+      '';
+      default = "sendtargets";
+      example = "sendtargets";
+      type = enum [
+        "st"
+        "sendtargets"
+        "isns"
+        "fw"
+      ];
+    };
+
     name = mkOption {
       type = str;
       description = "Name of this iscsi initiator";
@@ -81,7 +99,7 @@ in
       wantedBy = [ "remote-fs.target" ];
       serviceConfig.ExecStartPre =
         mkIf (cfg.discoverPortal != null)
-          "${cfg.package}/bin/iscsiadm --mode discoverydb --type sendtargets --portal ${escapeShellArg cfg.discoverPortal} --discover";
+          "${cfg.package}/bin/iscsiadm --mode discoverydb --type ${cfg.discoverType} --portal ${escapeShellArg cfg.discoverPortal} --discover";
     };
 
     environment.systemPackages = [ cfg.package ];

--- a/nixos/modules/services/networking/iscsi/root-initiator.nix
+++ b/nixos/modules/services/networking/iscsi/root-initiator.nix
@@ -43,6 +43,23 @@ in
       type = nullOr str;
     };
 
+    discoverType = mkOption {
+      description = ''
+        Target discovery type.
+        Change this if you want to discover your targes via an iSNS server
+        or use the targets provided via firmware settings.
+        See {manpage}`iscsiadm(8)`.
+      '';
+      default = "sendtargets";
+      example = "sendtargets";
+      type = enum [
+        "st"
+        "sendtargets"
+        "isns"
+        "fw"
+      ];
+    };
+
     target = mkOption {
       description = ''
         Name of the iSCSI target to boot from.
@@ -168,7 +185,7 @@ in
 
           iscsid --foreground --no-pid-file --debug ${toString cfg.logLevel} &
           iscsiadm --mode discoverydb \
-            --type sendtargets \
+            --type ${cfg.discoverType} \
             --discover \
             --portal ${escapeShellArg cfg.discoverPortal} \
             --debug ${toString cfg.logLevel}


### PR DESCRIPTION
Add  option `discoverType` for selecting the discover type to `services.openiscsi` and `boot.iscsi-initiator`.
This allows discovering targets via iSNS.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
