### PR TITLE
thcrap-steam-proton-wrapper: 0-unstable-2024-04-03 -> 0-unstable-2026-02-11

### DIFF
--- a/pkgs/by-name/th/thcrap-steam-proton-wrapper/package.nix
+++ b/pkgs/by-name/th/thcrap-steam-proton-wrapper/package.nix
@@ -5,7 +5,6 @@
   makeWrapper,
   bash,
   subversion,
-  zenity,
 }:
 stdenv.mkDerivation {
   pname = "thcrap-proton";
@@ -37,7 +36,6 @@ stdenv.mkDerivation {
         lib.makeBinPath [
           bash
           subversion
-          zenity
         ]
       }
   '';

--- a/pkgs/by-name/th/thcrap-steam-proton-wrapper/package.nix
+++ b/pkgs/by-name/th/thcrap-steam-proton-wrapper/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   version = "0-unstable-2024-04-03";
 
   src = fetchFromGitHub {
-    owner = "tactikauan";
+    owner = "nerusuki";
     repo = "thcrap-steam-proton-wrapper";
     rev = "2b636c3f5f1ce1b9b41f731aa9397aa68d2ce66b";
     hash = "sha256-J2O8F75NMdsxSaNVr8zLf+vLEJE6CHqWQIIscuuJZ3o=";
@@ -44,7 +44,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Wrapper script for launching the official Touhou games on Steam with patches through Proton on GNU/Linux";
-    homepage = "https://github.com/tactikauan/thcrap-steam-proton-wrapper";
+    homepage = "https://github.com/nerusuki/thcrap-steam-proton-wrapper";
     license = lib.licenses.unlicense;
     maintainers = with lib.maintainers; [ ashuramaruzxc ];
     platforms = [

--- a/pkgs/by-name/th/thcrap-steam-proton-wrapper/package.nix
+++ b/pkgs/by-name/th/thcrap-steam-proton-wrapper/package.nix
@@ -8,13 +8,13 @@
 }:
 stdenv.mkDerivation {
   pname = "thcrap-proton";
-  version = "0-unstable-2024-04-03";
+  version = "0-unstable-2026-02-11";
 
   src = fetchFromGitHub {
     owner = "nerusuki";
     repo = "thcrap-steam-proton-wrapper";
-    rev = "2b636c3f5f1ce1b9b41f731aa9397aa68d2ce66b";
-    hash = "sha256-J2O8F75NMdsxSaNVr8zLf+vLEJE6CHqWQIIscuuJZ3o=";
+    rev = "a5edfe44ead2df2e6bca54bd738ae0dc3284e679";
+    hash = "sha256-4RTVfcwlYW+KPyPIon0X1d4SPsF6cFkRSXBfe4yzAyQ=";
   };
 
   buildInputs = [ subversion ];


### PR DESCRIPTION
- Update to 0-unstable-2026-02-11
- Update repo owner
- Remove zenity dependency (see nerusuki/thcrap-steam-proton-wrapper#14)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
