### PR TITLE
apftool-rs: 0-unstable-2024-01-05 -> 1.2.3

### DIFF
--- a/pkgs/by-name/ap/apftool-rs/package.nix
+++ b/pkgs/by-name/ap/apftool-rs/package.nix
@@ -4,18 +4,18 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "apftool-rs";
-  version = "0-unstable-2024-01-05";
+  version = "1.2.3";
 
   src = fetchFromGitHub {
     owner = "suyulin";
     repo = "apftool-rs";
-    rev = "92d8a1b88cb79a53f9e4a70fecee481710d3565b";
-    hash = "sha256-0+eKxaLKZBRLdydXxUbifFfFncAbthUn7AB8QieWaXM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-bcXZIY0CDyWE3vh04IU3kXRxi/uUm5TD8ifA0jq47rc=";
   };
 
-  cargoHash = "sha256-IJEEnNIW44kItB19U1lNGi1cHpVGaGHQZt2kgAJFkjU=";
+  cargoHash = "sha256-Ufe82fJALRlMjRSQ7Y2wFTOzXKtuwQyrWfxZjdEtuc0=";
 
   meta = {
     description = "About Tools for Rockchip image unpack tool";
@@ -25,4 +25,4 @@ rustPlatform.buildRustPackage {
     maintainers = with lib.maintainers; [ colemickens ];
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

Fixes Hydra build failure for `apftool-rs` on `aarch64-linux`.

The previous pin (`0-unstable-2024-01-05`) contained Rust source that hardcoded `as *const i8` casts when calling `CStr::from_ptr`. On `aarch64-linux`, `c_char` is `u8` (unsigned), so the casts produce `E0308: mismatched types` and the build fails. On `x86_64-linux` and Darwin, `c_char` happens to be `i8`, masking the bug.

Upstream fixed this in [PR #2](https://github.com/suyulin/apftool-rs/pull/2) (released in `v1.0.0`) by switching the casts to `*const c_char`. This PR bumps to the latest tagged release `v1.2.3` which includes the fix.


### ZHF

Part of the ZHF campaign — see #516381.

Hydra failure: https://hydra.nixos.org/build/326779525

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For new packages: please double-check the [licensing details](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md)
- [x] Tested compilation of all packages that depend on this change. N/A — leaf package.
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`): `./result/bin/afptool-rs --help` runs cleanly.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
