### PR TITLE
pgformatter: 5.9 -> 5.10

### DIFF
--- a/pkgs/by-name/pg/pgformatter/package.nix
+++ b/pkgs/by-name/pg/pgformatter/package.nix
@@ -17,6 +17,9 @@ perlPackages.buildPerlPackage rec {
     hash = "sha256-OWw47okAs8x4Ri8+IJHPhy6YSkSN2sBlJ0v8h6GlhfU=";
   };
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   outputs = [ "out" ];
 
   makeMakerFlags = [ "INSTALLDIRS=vendor" ];

--- a/pkgs/by-name/pg/pgformatter/package.nix
+++ b/pkgs/by-name/pg/pgformatter/package.nix
@@ -54,10 +54,12 @@ perlPackages.buildPerlPackage rec {
       thunze
       mfairley
     ];
-    license = [
-      lib.licenses.postgresql
-      lib.licenses.artistic2
-    ];
+    license =
+      with lib.licenses;
+      AND [
+        postgresql
+        artistic2
+      ];
     mainProgram = "pg_format";
   };
 }

--- a/pkgs/by-name/pg/pgformatter/package.nix
+++ b/pkgs/by-name/pg/pgformatter/package.nix
@@ -8,13 +8,13 @@
 
 perlPackages.buildPerlPackage rec {
   pname = "pgformatter";
-  version = "5.9";
+  version = "5.10";
 
   src = fetchFromGitHub {
     owner = "darold";
     repo = "pgFormatter";
     tag = "v${version}";
-    hash = "sha256-G4Bbg8tNlwV8VCVKCamhlQ/pGf8hWCkABm6f8i5doos=";
+    hash = "sha256-OWw47okAs8x4Ri8+IJHPhy6YSkSN2sBlJ0v8h6GlhfU=";
   };
 
   outputs = [ "out" ];


### PR DESCRIPTION
Changelog: https://github.com/darold/pgFormatter/releases/tag/v5.10
Diff: https://github.com/darold/pgFormatter/compare/v5.9...v5.10

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
