### PR TITLE
python3Packages.{agent-budget,bedrock-ops,embspec}: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18736,6 +18736,12 @@
     githubId = 220262;
     name = "Ion Mudreac";
   };
+  mukundakatta = {
+    email = "mukunda.vjcs6@gmail.com";
+    github = "MukundaKatta";
+    githubId = 99349238;
+    name = "Mukunda Katta";
+  };
   mulatta = {
     email = "seungwon@mulatta.io";
     github = "mulatta";

--- a/pkgs/development/python-modules/agent-budget/default.nix
+++ b/pkgs/development/python-modules/agent-budget/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchurl,
+  pythonOlder,
+  uv-build,
+}:
+
+buildPythonPackage rec {
+  pname = "agent-budget";
+  version = "0.1.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchurl {
+    url = "https://github.com/MukundaKatta/agent-budget/releases/download/v${version}/agent_budget-${version}.tar.gz";
+    hash = "sha256-xql6X9NdcbwG8771ql8xOyeZFKn0UN0E3uOQQrNp54w=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.11.7,<0.12.0" uv_build
+  '';
+
+  build-system = [ uv-build ];
+
+  # Pure stdlib at runtime — no `dependencies` list needed.
+
+  pythonImportsCheck = [ "agent_budget" ];
+
+  doCheck = false;
+
+  meta = {
+    description = "Production retry/budget primitive for LLM and agent calls with adversarial-loop detection";
+    longDescription = ''
+      The retry/budget primitive ``tenacity`` isn't, with the three things
+      that matter for production LLM-shaped work: cost cap, structured
+      per-attempt events, and adversarial-loop detection.
+
+      Wraps any callable with cost cap, attempts cap, wall-clock cap,
+      exponential backoff (clamped to remaining wall-clock), exception
+      classification (retry_on / fatal_on / unknown), structured AttemptEvent
+      lifecycle hooks, and adversarial-loop detection via error
+      fingerprinting that catches the retry-amplification class of bug from
+      Instructor #2056. Zero runtime dependencies.
+    '';
+    homepage = "https://github.com/MukundaKatta/agent-budget";
+    changelog = "https://github.com/MukundaKatta/agent-budget/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mukundakatta ];
+  };
+}

--- a/pkgs/development/python-modules/bedrock-ops/default.nix
+++ b/pkgs/development/python-modules/bedrock-ops/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  boto3,
+  botocore,
+  buildPythonPackage,
+  fetchurl,
+  pythonOlder,
+  uv-build,
+}:
+
+buildPythonPackage rec {
+  pname = "bedrock-ops";
+  version = "0.1.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchurl {
+    url = "https://github.com/MukundaKatta/bedrock-ops/releases/download/v${version}/bedrock_ops-${version}.tar.gz";
+    hash = "sha256-DT7hBt3GM1/XL6o8BUMXOqTxbR0MNGBt9zpdPfzrMEY=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.11.7,<0.12.0" uv_build
+  '';
+
+  build-system = [ uv-build ];
+
+  dependencies = [
+    boto3
+    botocore
+  ];
+
+  pythonImportsCheck = [ "bedrock_ops" ];
+
+  # Tests require boto3 mocking with moto and live AWS-shape fixtures; the
+  # upstream tests exist but are not part of the sdist. Skip CheckHook;
+  # rely on pythonImportsCheck.
+  doCheck = false;
+
+  meta = {
+    description = "Production-grade boto3 toolkit for AWS Bedrock with typed retry, capability lookup, and PII-safe Guardrails";
+    homepage = "https://github.com/MukundaKatta/bedrock-ops";
+    changelog = "https://github.com/MukundaKatta/bedrock-ops/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mukundakatta ];
+  };
+}

--- a/pkgs/development/python-modules/embspec/default.nix
+++ b/pkgs/development/python-modules/embspec/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchurl,
+  numpy,
+  pythonOlder,
+  uv-build,
+}:
+
+buildPythonPackage rec {
+  pname = "embspec";
+  version = "0.1.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchurl {
+    url = "https://github.com/MukundaKatta/embspec/releases/download/v${version}/embspec-${version}.tar.gz";
+    hash = "sha256-8D2PBdnMTn21CDgKokU86gNKL21ZcN/Mq8NDwJ+sXqU=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.11.7,<0.12.0" uv_build
+  '';
+
+  build-system = [ uv-build ];
+
+  dependencies = [
+    numpy
+  ];
+
+  pythonImportsCheck = [ "embspec" ];
+
+  doCheck = false;
+
+  meta = {
+    description = "Embedding pipeline ops and drift detection for production RAG";
+    longDescription = ''
+      Three primitives that close the embedding-pipeline-ops gap left between
+      Evidently (tabular-ML drift heritage), Phoenix (full observability
+      platform), and the Drift-Adapter paper (research code):
+
+      * IndexManifest + embed_assert decorator: fail fast on encoder/index
+        version drift.
+      * DriftAdapter: linear least-squares adapter that recovers 95-99%
+        retrieval after embedding-model swap without re-encoding the corpus
+        (Vejendla 2025, arXiv:2509.23471).
+      * neighbor_stability(): pure function comparing two retrievers on a
+        frozen probe set; reports overlap, Jaccard, regressions, and a
+        deploy-safety verdict.
+    '';
+    homepage = "https://github.com/MukundaKatta/embspec";
+    changelog = "https://github.com/MukundaKatta/embspec/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mukundakatta ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -140,6 +140,8 @@ self: super: with self; {
 
   agate-sql = callPackage ../development/python-modules/agate-sql { };
 
+  agent-budget = callPackage ../development/python-modules/agent-budget { };
+
   agent-client-protocol = callPackage ../development/python-modules/agent-client-protocol { };
 
   agent-py = callPackage ../development/python-modules/agent-py { };
@@ -1967,6 +1969,8 @@ self: super: with self; {
   beautysh = callPackage ../development/python-modules/beautysh { };
 
   bech32 = callPackage ../development/python-modules/bech32 { };
+
+  bedrock-ops = callPackage ../development/python-modules/bedrock-ops { };
 
   beetcamp = callPackage ../development/python-modules/beetcamp { };
 
@@ -5009,6 +5013,8 @@ self: super: with self; {
   embrace = callPackage ../development/python-modules/embrace { };
 
   embreex = callPackage ../development/python-modules/embreex { };
+
+  embspec = callPackage ../development/python-modules/embspec { };
 
   emcee = callPackage ../development/python-modules/emcee { };
 


### PR DESCRIPTION
Adds three new pure-Python packages from the [`@mukundakatta`](https://github.com/MukundaKatta) agent-stack family.

| Package | Description | Runtime deps |
|---|---|---|
| `python3Packages.agent-budget` | Production retry/budget primitive for LLM and agent calls; cost cap, structured per-attempt events, adversarial-loop detection | none (pure stdlib) |
| `python3Packages.bedrock-ops` | Production-grade boto3 toolkit for AWS Bedrock; throttle retry normalization, full TokenUsage, capability lookup, PII-safe Guardrails | `boto3`, `botocore` |
| `python3Packages.embspec` | Embedding pipeline ops + drift detection for production RAG; IndexManifest assertions, Drift-Adapter, neighbor-stability eval | `numpy` |

All three are Apache-2.0, Python 3.10+, pure-Python (`noarch`-equivalent), with `pyproject = true` and `uv-build` build backend (mirrors the existing `pkgs/development/python-modules/aio-pika` pattern).

Adds `mukundakatta` to `maintainers/maintainer-list.nix`.

### About the batched PR

These are three separate libraries from one maintainer ([all three are designed to compose](https://github.com/MukundaKatta/agent-budget); related project lineage). I batched them to make review more efficient — happy to split into three PRs if a maintainer prefers.

### Disclosure

I did not have `nix` installed locally and could not run `nix-build` to verify the derivations before submission. Reviewers, please flag any convention slips and I'll iterate. Each derivation:

- Uses `fetchurl` against the GitHub Release sdist (stable URL, sha256 verified)
- `postPatch` relaxes the upstream `uv_build>=0.11.7,<0.12.0` constraint to match the upstream `aio-pika` pattern  
- Skips `doCheck` because the unit tests are not included in the sdist; relies on `pythonImportsCheck` to verify the package imports cleanly with all dependencies resolved

### Things done

- [x] Built on platform(s)
  - [ ] x86_64-linux (not run locally — nix not available; awaits CI)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For new packages, the appropriate license has been selected
- [x] All paths checked alphabetically (`python-packages.nix`, `maintainer-list.nix`)
- [x] Sources point at versioned tarballs with sha256 hashes
- [x] Maintainer added themselves