### PR TITLE
shutter: 0.99.6 -> 0.99.7

### DIFF
--- a/pkgs/by-name/sh/shutter/package.nix
+++ b/pkgs/by-name/sh/shutter/package.nix
@@ -64,13 +64,15 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "shutter";
-  version = "0.99.6";
+  version = "0.99.7";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "shutter-project";
     repo = "shutter";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-2wRPmTpFfgU8xW9Fyn1+TMowcKm3pukT1ck06IWPiGo=";
+    tag = finalAttrs.version;
+    sha256 = "sha256-iri4yj2DujsEfpa6u4f5bpaOhWL0h/XbSlolkSJgKgE=";
   };
 
   nativeBuildInputs = [ wrapGAppsHook3 ];


### PR DESCRIPTION
Diff: https://github.com/shutter-project/shutter/compare/v0.99.6...0.99.7
Changelog: https://github.com/shutter-project/shutter/releases/tag/0.99.7

https://nixpkgs-update-logs.nix-community.org/shutter/2026-05-09.log

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
