### PR TITLE
Update linux-hardened

### DIFF
--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -1,12 +1,1 @@
-{
-    "6.12": {
-        "patch": {
-            "extra": "-hardened1",
-            "name": "linux-hardened-v6.12.85-hardened1.patch",
-            "sha256": "16hqi6nh53zxr8idpdib0m05hc213dijmn479ay06piwcm74j064",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.12.85-hardened1/linux-hardened-v6.12.85-hardened1.patch"
-        },
-        "sha256": "1v8a0z6znmr2m26l4744wndaimsh24zz6q4d7m4p8s0ayjcwjnp3",
-        "version": "6.12.85"
-    }
-}
+{}

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -1,1 +1,12 @@
-{}
+{
+    "6.12": {
+        "patch": {
+            "extra": "-hardened1",
+            "name": "linux-hardened-v6.12.87-hardened1.patch",
+            "sha256": "0kpsapx0zvg3wryjwfbmynnlpaan2fs62sbs4n28xms178scsa0p",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.12.87-hardened1/linux-hardened-v6.12.87-hardened1.patch"
+        },
+        "sha256": "0c4qidff0qs2x0mvba83cw3ksaz2af3xwabvc839xvsc9djaf4nc",
+        "version": "6.12.87"
+    }
+}


### PR DESCRIPTION
This fixes #518220 

As mentioned in that issue, the current version is vulnerable to https://nvd.nist.gov/vuln/detail/CVE-2026-43284 and other recently discovered vulnerabilities. That vulnerability is similar to copy fail and got the same score.

I'm not at all familiar with contributing here or even building the repo, but this is a very similar patch to #515585 therefore I think it is okay like this.

What I did to update:

```sh
cd ./os-specific/linux/kernel
# Set lts: false in kernels-org.json for 6.18 and set "6.12"."version": "6.12.87"
# This was necessary otherwise the script just tried switching to 6.18.
COMMIT=1 ./hardened/update.py
git reset --hard HEAD~1 # Because it has added 6.18 in the last commit
```

There is probably an easier way, but I'm not familiar enough with `nixpkgs` to determine that.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
