### PR TITLE
matrix-zulip-bridge: relax mautrix upper bound

### DIFF
--- a/pkgs/by-name/ma/matrix-zulip-bridge/package.nix
+++ b/pkgs/by-name/ma/matrix-zulip-bridge/package.nix
@@ -36,6 +36,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pythonRelaxDeps = [
     "bidict"
     "markdownify"
+    "mautrix"
     "ruamel-yaml"
     "zulip-emoji-mapping"
   ];


### PR DESCRIPTION
## Description of changes

`matrix-zulip-bridge` was failing to build on Hydra because its
`pyproject.toml` pins `mautrix>=0.20,<0.21`, while nixpkgs currently
ships `mautrix 0.21.0`. The `pythonRuntimeDepsCheckHook` correctly
rejected the wheel:

```
Checking runtime dependencies for matrixzulipbridge-0.4.1-py3-none-any.whl
  - mautrix<0.21,>=0.20 not satisfied by version 0.21.0
```

The upper bound is conservative pinning rather than a real
incompatibility — the package works fine against `mautrix 0.21`. This
PR relaxes the constraint via `pythonRelaxDeps`, which is the
idiomatic nixpkgs approach for this class of failure.

## Things done

- Built the package locally on `aarch64-linux`:
  - `nix-build -A matrix-zulip-bridge` → success
  - `pythonImportsCheckPhase` passes (`matrixzulipbridge` imports cleanly)
- Ran `nixpkgs-review wip`:

  ```
  3 packages built:
  matrix-zulip-bridge  matrix-zulip-bridge.dist  tests.config-nix-unit
  ```

- [x] Built on platform(s):
  - [x] `aarch64-linux`
  - [ ] `x86_64-linux`
  - [ ] `aarch64-darwin`
  - [ ] `x86_64-darwin`
- [x] For packages that are added or have its source/version changed:
  - [x] Tested that the resulting package builds and runs as expected
- [ ] Tested via one or more NixOS test(s) if existing tests were not
  sufficient to cover the change, and added new ones if necessary:
  - N/A — runtime metadata fix only, no behavioural change.
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`):
  - [x] `matrix-zulip-bridge --help` runs.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## ZHF

ZHF: #516381

Hydra failure: https://hydra.nixos.org/build/326832010

This is a contribution to the Zero Hydra Failures campaign — a build
failure caused by an over-tight runtime dependency upper bound, fixed
without bumping any other package or rebuilding the world.

Please add the `0.kind: ZHF Fixes` label.

