### PR TITLE
kbdd: unstable-2021-04-26 -> unstable-2025-08-10

### DIFF
--- a/pkgs/by-name/kb/kbdd/package.nix
+++ b/pkgs/by-name/kb/kbdd/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation {
   pname = "kbdd";
-  version = "unstable-2021-04-26";
+  version = "unstable-2025-08-10";
 
   src = fetchFromGitHub {
     owner = "qnikst";
     repo = "kbdd";
-    rev = "3145099e1fbbe65b27678be72465aaa5b5872874";
-    sha256 = "1gzcjnflgdqnjgphiqpzwbcx60hm0h2cprncm7i8xca3ln5q6ba1";
+    rev = "b87e44afd5859157245eee22b11827605bfa09b9";
+    sha256 = "sha256-cbMcB6jgssfMUjemBOiE06zJK2TbzOWt1Rvt41V33Mo=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update kbdd to latest master commit (date in the version chosen based on commit date).

Reason: current version doesn't compile:

```
error: Cannot build '/nix/store/5jba38nzaw1bn1zsgn9y7p7m1fjyhvxd-kbdd-unstable-2021-04-26.drv'.
       Reason: builder failed with exit code 2.
       Output paths:
         /nix/store/vm5hiry5f2vksrpwyz14rnn4kqp7rbab-kbdd-unstable-2021-04-26
       Last 25 log lines:
       > /nix/store/kw0yjwbvw6arwgwaa3p8rz46qsgy4626-glib-2.86.3-dev/include/glib-2.0/glib/deprecated/gthread.h:280:38: note: in expansion of macro 'GLIB_DEPRECATED_MACRO_IN_2_32'
       >   280 | #define g_thread_supported()     (1) GLIB_DEPRECATED_MACRO_IN_2_32
       >       |                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       > kbdd.c:305:11: note: in expansion of macro 'g_thread_supported'
       >   305 |     if ( !g_thread_supported () ) {
       >       |           ^~~~~~~~~~~~~~~~~~
       > kbdd.c:187:40: warning: '%s' directive argument is null [-Wformat-overflow=]
       >   187 |     printf(":main RequestName returned %s.\n", request_ret);
       >       |                                        ^~
       > gcc -DHAVE_CONFIG_H -I. -I..    -I/nix/store/kw0yjwbvw6arwgwaa3p8rz46qsgy4626-glib-2.86.3-dev/include/glib-2.0 -I/nix/store/zcmsivndca5wmam9nwnbjrm0zkgykwfz-glib-2.86.3/lib/glib-2.0/include -I/nix/store/zlbqxphazypj5gwqdb4a9x30j19lv9kx-dbus-glib-0.114-dev/include/dbus-1.0 -I/nix/store/6xzs85s04k598dchdp1jmyia35ajwn6l-dbus-1.16.2-dev/include/dbus-1.0 -I/nix/store/yanmwp5f435ing2nbhwa4v0gdmpl2an1-dbus-1.16.2-lib/lib/dbus-1.0/include -I/nix/store/kw0yjwbvw6arwgwaa3p8rz46qsgy4626-glib-2.86.3-dev/include -I/nix/store/kw0yjwbvw6arwgwaa3p8rz46qsgy4626-glib-2.86.3-dev/include/glib-2.0 -I/nix/store/zcmsivndca5wmam9nwnbjrm0zkgykwfz-glib-2.86.3/lib/glib-2.0/include -Idbus/ -I/nix/store/zlbqxphazypj5gwqdb4a9x30j19lv9kx-dbus-glib-0.114-dev/include/dbus-1.0 -I/nix/store/6xzs85s04k598dchdp1jmyia35ajwn6l-dbus-1.16.2-dev/include/dbus-1.0 -I/nix/store/yanmwp5f435ing2nbhwa4v0gdmpl2an1-dbus-1.16.2-lib/lib/dbus-1.0/include -I/nix/store/kw0yjwbvw6arwgwaa3p8rz46qsgy4626-glib-2.86.3-dev/include -I/nix/store/kw0yjwbvw6arwgwaa3p8rz46qsgy4626-glib-2.86.3-dev/include/glib-2.0 -I/nix/store/zcmsivndca5wmam9nwnbjrm0zkgykwfz-glib-2.86.3/lib/glib-2.0/include -g -O2 -c -o perwindow.o perwindow.c
       > gcc -DHAVE_CONFIG_H -I. -I..    -I/nix/store/kw0yjwbvw6arwgwaa3p8rz46qsgy4626-glib-2.86.3-dev/include/glib-2.0 -I/nix/store/zcmsivndca5wmam9nwnbjrm0zkgykwfz-glib-2.86.3/lib/glib-2.0/include -I/nix/store/zlbqxphazypj5gwqdb4a9x30j19lv9kx-dbus-glib-0.114-dev/include/dbus-1.0 -I/nix/store/6xzs85s04k598dchdp1jmyia35ajwn6l-dbus-1.16.2-dev/include/dbus-1.0 -I/nix/store/yanmwp5f435ing2nbhwa4v0gdmpl2an1-dbus-1.16.2-lib/lib/dbus-1.0/include -I/nix/store/kw0yjwbvw6arwgwaa3p8rz46qsgy4626-glib-2.86.3-dev/include -I/nix/store/kw0yjwbvw6arwgwaa3p8rz46qsgy4626-glib-2.86.3-dev/include/glib-2.0 -I/nix/store/zcmsivndca5wmam9nwnbjrm0zkgykwfz-glib-2.86.3/lib/glib-2.0/include -Idbus/ -I/nix/store/zlbqxphazypj5gwqdb4a9x30j19lv9kx-dbus-glib-0.114-dev/include/dbus-1.0 -I/nix/store/6xzs85s04k598dchdp1jmyia35ajwn6l-dbus-1.16.2-dev/include/dbus-1.0 -I/nix/store/yanmwp5f435ing2nbhwa4v0gdmpl2an1-dbus-1.16.2-lib/lib/dbus-1.0/include -I/nix/store/kw0yjwbvw6arwgwaa3p8rz46qsgy4626-glib-2.86.3-dev/include -I/nix/store/kw0yjwbvw6arwgwaa3p8rz46qsgy4626-glib-2.86.3-dev/include/glib-2.0 -I/nix/store/zcmsivndca5wmam9nwnbjrm0zkgykwfz-glib-2.86.3/lib/glib-2.0/include -g -O2 -c -o libkbdd.o libkbdd.c
       > libkbdd.c:223:1: error: conflicting types for 'kbdd_default_loop'; have 'void *(Display *)'
       >   223 | kbdd_default_loop(Display * display)
       >       | ^~~~~~~~~~~~~~~~~
       > In file included from libkbdd.c:29:
       > libkbdd.h:60:8: note: previous declaration of 'kbdd_default_loop' with type 'void *(void)'
       >    60 | void * kbdd_default_loop();
       >       |        ^~~~~~~~~~~~~~~~~
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
