### PR TITLE
sm64coopdx: Switch back to using `tag` instead of `rev` when fetching `src`

### DIFF
--- a/pkgs/by-name/sm/sm64coopdx/package.nix
+++ b/pkgs/by-name/sm/sm64coopdx/package.nix
@@ -45,8 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "coop-deluxe";
     repo = "sm64coopdx";
-    # Replace with `tag = "v${finalAttrs.version}";` in the next version. The upstream repository tagged the wrong commit.
-    rev = "6092488d1c4fc741b16a0789ef9c08ec0279333f";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-BIdKKIp6q9Vp2DByXzT9CJzOszFhjriiWBEqFwUT28M=";
   };
 


### PR DESCRIPTION
Before 1f2c3637d56ee36d6c05a498a69da6074d71087f, the sm64coopdx package fetched its source by doing this:

```nix
  src = fetchFromGitHub {
    owner = "coop-deluxe";
    repo = "sm64coopdx";
    tag = "v${finalAttrs.version}";
    hash = "<whatever>";
  };
```

1f2c3637d56ee36d6c05a498a69da6074d71087f made it so that the sm64coopdx package fetched its source by doing this:

```nix
  src = fetchFromGitHub {
    owner = "coop-deluxe";
    repo = "sm64coopdx";
    # Replace with `tag = "v${finalAttrs.version}";` in the next version. The upstream repository tagged the wrong commit.
    rev = "<whatever>";
    hash = "<whatever>;
  };
```

Switching from using `tag = "v${finalAttrs.version}";` to `rev = "<whatever>";` was only necessary because of [an upstream sm64coopdx bug](https://github.com/coop-deluxe/sm64coopdx/issues/1078). Now that that bug has been fixed, we can switch back to using `tag = "v${finalAttrs.version}";`

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `b6b9a78f416aab3fd882e6f4c64b54561dbddd83`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>tests.config-nix-unit</li>
  </ul>
</details>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
