### PR TITLE
godsvg: 1.0-alpha14 -> 1.0-alpha15

### DIFF
--- a/pkgs/by-name/go/godsvg/package.nix
+++ b/pkgs/by-name/go/godsvg/package.nix
@@ -5,16 +5,17 @@
   lib,
   fetchFromGitHub,
   nix-update-script,
+  enableWayland ? false,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "godsvg";
-  version = "1.0-alpha14";
+  version = "1.0-alpha15";
   src = fetchFromGitHub {
     owner = "MewPurPur";
     repo = "GodSVG";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Bo45Zu13RRPxf5tZhCxAulTe61o9kwqX1nEFJDaeBng=";
+    hash = "sha256-vEwkpYMIqiqCFVNE7UzEts/lSS9zR+AgvvSr+vj0Aas=";
   };
 
   nativeBuildInputs = [
@@ -53,11 +54,15 @@ stdenv.mkDerivation (finalAttrs: {
 
     makeWrapper ${godot_4_6}/bin/godot4 $out/bin/godsvg \
     --add-flag "--main-pack" \
-    --add-flag "$out/share/godsvg/godsvg.pck"
+    --add-flag "$out/share/godsvg/godsvg.pck" \
+    ${lib.optionalString enableWayland ''
+      --add-flag "--display-driver" \
+      --add-flag wayland
+    ''}
 
     install -Dm444 ./assets/logos/icon.svg $out/share/icons/hicolor/scalable/apps/godsvg.svg
     install -Dm444 ./assets/logos/icon.png $out/share/icons/hicolor/256x256/apps/godsvg.png
-    install -Dm444 ./assets/GodSVG.desktop $out/share/applications/GodSVG.desktop
+    install -Dm444 ./no_export/distribution/com.godsvg.GodSVG.desktop $out/share/applications/GodSVG.desktop
 
     runHook postInstall
   '';


### PR DESCRIPTION
Update bot failed because upstream moved `.desktop` file
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
