### PR TITLE
anydesk: fix broken updateScript, fix multi-arch hash update, update 8.0.2 -> 8.0.3

### DIFF
--- a/pkgs/by-name/an/anydesk/package.nix
+++ b/pkgs/by-name/an/anydesk/package.nix
@@ -4,8 +4,8 @@
   fetchurl,
   makeWrapper,
   makeDesktopItem,
-  genericUpdater,
   writeShellScript,
+  jq,
   atk,
   cairo,
   gdk-pixbuf,
@@ -164,24 +164,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    updateScript = genericUpdater {
-      versionLister =
-        let
-          arch =
-            if system == "x86_64-linux" then
-              "amd64"
-            else if system == "aarch64-linux" then
-              "arm64"
-            else
-              throw "cannot update AnyDesk on ${system}";
-        in
-        writeShellScript "anydesk-versionLister" ''
-          curl -s https://anydesk.com/en/downloads/linux \
-            | grep "https://[a-z0-9._/-]*-${arch}.tar.gz" -o \
-            | uniq \
-            | sed 's,.*/anydesk-\(.*\)-${arch}.tar.gz,\1,g'
-        '';
-    };
+    updateScript = ./update.sh;
   };
 
   meta = {

--- a/pkgs/by-name/an/anydesk/pin.json
+++ b/pkgs/by-name/an/anydesk/pin.json
@@ -1,5 +1,5 @@
 {
-  "version": "8.0.2",
-  "x86_64-linux": "sha256-6noMPfe0x6kx/whyd66qcmk7WhEivx3xK5q58Se9Ij0=",
-  "aarch64-linux": "sha256-wfY+OCx9OyLCmiA29RjnYzcg/pApMIXWT5UrcdcyRYM="
+  "version": "8.0.3",
+  "x86_64-linux": "sha256-Mjl17hh5A/pwRAi7giL1SJYlQ61O0SXX+KeH8STZ4bs=",
+  "aarch64-linux": "sha256-MhAj5cy81uBMoNeFPvOyhBOlJzBgNRHXyCXrpdvF8nE="
 }

--- a/pkgs/by-name/an/anydesk/update.sh
+++ b/pkgs/by-name/an/anydesk/update.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env -S nix shell nixpkgs#curl nixpkgs#jq nixpkgs#nix --command bash
+
+set -euo pipefail
+
+directory="$(dirname $0 | xargs realpath)"
+
+new_version=$(
+  curl -s https://rpm.anydesk.com/rhel/x86_64/Packages/ \
+    | grep -oP 'anydesk_\K[0-9]+\.[0-9]+\.[0-9]+(?=-[0-9]+_x86_64\.rpm)' \
+    | sort -V \
+    | tail -1
+)
+
+old_version=$(jq -r '.version' "$directory/pin.json")
+
+if [[ "$new_version" == "$old_version" ]]; then
+  echo "anydesk is already up to date ($old_version)"
+  exit 0
+fi
+
+echo "Updating anydesk: $old_version -> $new_version"
+
+hash_amd64=$(nix hash to-sri --type sha256 \
+  "$(nix-prefetch-url --type sha256 \
+    "https://download.anydesk.com/linux/anydesk-${new_version}-amd64.tar.gz")")
+
+hash_arm64=$(nix hash to-sri --type sha256 \
+  "$(nix-prefetch-url --type sha256 \
+    "https://download.anydesk.com/rpi/anydesk-${new_version}-arm64.tar.gz")")
+
+cat > "$directory/pin.json" << EOF
+{
+  "version": "$new_version",
+  "x86_64-linux": "$hash_amd64",
+  "aarch64-linux": "$hash_arm64"
+}
+EOF
+
+cat "$directory/pin.json"


### PR DESCRIPTION
The previous `updateScript` was broken for two reasons:

1. **Cloudflare protection**: it scraped `anydesk.com/en/downloads/linux` to find the latest version, which is protected by Cloudflare and fails in automated environments.
2. **Multi-arch hash update**: the script used `genericUpdater` which relies on `update-source-version`, which only updates the hash for the platform it runs on — leaving the other arch with a stale hash.

This rewrites the `updateScript` as a standalone `update.sh` following the pattern used by other packages in nixpkgs:
- Fetches the latest version from `rpm.anydesk.com/rhel/x86_64/Packages/`, a plain nginx directory listing with no Cloudflare protection
- Explicitly declares its dependencies via the `nix shell` shebang
- Updates both `x86_64-linux` and `aarch64-linux` hashes in `pin.json` in a single run, regardless of the host platform

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test