### PR TITLE
python3Packages.serialx: disable racy tests; fix tests on darwin

### DIFF
--- a/pkgs/development/python-modules/serialx/default.nix
+++ b/pkgs/development/python-modules/serialx/default.nix
@@ -65,6 +65,8 @@ buildPythonPackage (finalAttrs: {
     socat
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   disabledTests = [
     # tries to access /sys/class/tty in sandbox
     "test_compat_tools_module"

--- a/pkgs/development/python-modules/serialx/default.nix
+++ b/pkgs/development/python-modules/serialx/default.nix
@@ -70,6 +70,9 @@ buildPythonPackage (finalAttrs: {
     "test_compat_tools_module"
     # connects to 192.0.2.1
     "test_async_socket_connect_timeout"
+    # racy
+    "test_sync_readexactly_total_timeout"
+    "test_sync_read_until_total_timeout"
   ];
 
   meta = {


### PR DESCRIPTION
https://cache.nixos.org/log/jv79mn10pdln0pv712s703mqs1hj9jvx-python3.13-serialx-1.7.0.drv
https://cache.nixos.org/log/j1vhr57kiyh5r2yv3rnrs9day0p7ra74-python3.13-serialx-1.7.0.drv

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
