### PR TITLE
[staging-next] intel-llvm: reenable __structuredAttrs on symlinkJoin following #510526

### DIFF
--- a/pkgs/by-name/in/intel-llvm/package.nix
+++ b/pkgs/by-name/in/intel-llvm/package.nix
@@ -132,10 +132,7 @@ let
       inherit (self.unwrapped) pname version meta;
 
       strictDeps = true;
-      # Currently broken for symlinkJoin, can be removed once the following
-      # reaches branch master:
-      # https://github.com/NixOS/nixpkgs/pull/510526
-      __structuredAttrs = false;
+      __structuredAttrs = true;
 
       paths = with self; [
         # Order is important, we want files from the wrappers to take precedence


### PR DESCRIPTION
This reverts commit #511852 / 1ed85a36e880bdef4a2fbebf46d0df1dc042df83.

This is no longer needed, now that #510526 has been merged.

cc @doronbehar 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
