### PR TITLE
cue: fix test

### DIFF
--- a/pkgs/by-name/cu/cue/package.nix
+++ b/pkgs/by-name/cu/cue/package.nix
@@ -7,6 +7,7 @@
   testers,
   tests,
   callPackage,
+  pkgs,
 }:
 
 buildGoModule (finalAttrs: {
@@ -49,7 +50,7 @@ buildGoModule (finalAttrs: {
 
       tests = {
         validation = tests.cue-validation.override {
-          callPackage = (path: attrs: callPackage path (attrs // { inherit writeCueValidator; }));
+          pkgs = pkgs.extend (_: _: { inherit writeCueValidator; });
         };
 
         test-001-all-good = callPackage ./tests/001-all-good.nix { inherit cue; };


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Fixes issue highlighted in #517565

This feels like there _should_ be a better way to do this but I don't believe there currently is.
I could overlay `cue` itself I suppose, and pass that to all the tests via callPackage... but that causes different overriding issues

CC @trofi for confirmation but I believe it should be correct now

```
$ nix-build -A cue.tests
/nix/store/sbym4krlyy6h4xpyrrd9n2jcrp1m2jv0-cue-test-001-all-good-0.16.1
/nix/store/4gq77a8i19nxksckgmq722238lnisnv0-cue-validation
/nix/store/1yaf1b1539jxrahjjq835vhk1633zzlp-cue-0.16.1-test-version
```


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
