### PR TITLE
nixos/test-driver: fix eval with noUserModules

### DIFF
--- a/nixos/lib/testing/nixos-test-base.nix
+++ b/nixos/lib/testing/nixos-test-base.nix
@@ -8,6 +8,7 @@ in
 {
   imports = [
     ../../modules/testing/test-instrumentation.nix # !!! should only get added for automated test runs
+    ../../modules/virtualisation/guest-networking-options.nix
     {
       key = "no-manual";
       documentation.nixos.enable = false;

--- a/nixos/lib/testing/nodes.nix
+++ b/nixos/lib/testing/nodes.nix
@@ -37,93 +37,94 @@ let
       in
       hostToGuest.${hostPlatform.system} or (throw message);
 
-  baseOS = import ../eval-config.nix {
-    inherit lib;
-    system = null; # use modularly defined system
-    inherit (config.node) specialArgs;
-    modules = [ config.defaults ];
-    baseModules = (import ../../modules/module-list.nix) ++ [
-      ./nixos-test-base.nix
-      {
-        key = "nodes";
-        _module.args = {
-          inherit (config) containers;
-          nodes = config.nodesCompat;
-        };
-      }
-      (
-        { options, ... }:
-        {
-          key = "nodes.nix-pkgs";
-          config = optionalAttrs (!config.node.pkgsReadOnly) (
-            mkIf (!options.nixpkgs.pkgs.isDefined) {
-              # TODO: switch to nixpkgs.hostPlatform and make sure containers-imperative test still evaluates.
-              nixpkgs.system = guestSystem;
+  baseOS =
+    extraBaseModules:
+    import ../eval-config.nix {
+      inherit lib;
+      system = null; # use modularly defined system
+      inherit (config.node) specialArgs;
+      modules = [ config.defaults ];
+      baseModules =
+        (import ../../modules/module-list.nix)
+        ++ [
+          ./nixos-test-base.nix
+          {
+            key = "nodes";
+            _module.args = {
+              inherit (config) containers;
+              nodes = config.nodesCompat;
+            };
+          }
+          (
+            { options, ... }:
+            {
+              key = "nodes.nix-pkgs";
+              config = optionalAttrs (!config.node.pkgsReadOnly) (
+                mkIf (!options.nixpkgs.pkgs.isDefined) {
+                  # TODO: switch to nixpkgs.hostPlatform and make sure containers-imperative test still evaluates.
+                  nixpkgs.system = guestSystem;
+                }
+              );
             }
-          );
-        }
-      )
-      testModuleArgs.config.extraBaseModules
-    ];
-  };
-  baseQemuOS = baseOS.extendModules {
-    modules = [
-      ../../modules/virtualisation/qemu-vm.nix
-      config.nodeDefaults
+          )
+          testModuleArgs.config.extraBaseModules
+        ]
+        ++ extraBaseModules;
+    };
+  baseQemuOS = baseOS [
+    ../../modules/virtualisation/qemu-vm.nix
+    testModuleArgs.config.extraBaseNodeModules
+    config.nodeDefaults
+    {
+      key = "base-qemu";
+      virtualisation.qemu = {
+        inherit (testModuleArgs.config.qemu) package forceAccel;
+      };
+      virtualisation.host.pkgs = hostPkgs;
+    }
+  ];
+  baseNspawnOS = baseOS [
+    ../../modules/virtualisation/nspawn-container
+    config.containerDefaults
+    (
+      { pkgs, ... }:
       {
-        key = "base-qemu";
-        virtualisation.qemu = {
-          inherit (testModuleArgs.config.qemu) package forceAccel;
+        key = "base-nspawn";
+
+        # PAM requires setuid and doesn't work in the build sandbox.
+        # https://github.com/NixOS/nix/blob/959c244a1265f4048390f3ad21679219d7b27a99/src/libstore/unix/build/linux-derivation-builder.cc#L63
+        services.openssh.settings.UsePAM = false;
+
+        # Networking for tests is statically configured by default.
+        # dhcpcd times out after blocking for a long time, which slows down tests.
+        # See https://github.com/NixOS/nixpkgs/pull/478109#discussion_r2867570799
+        networking.useDHCP = lib.mkDefault false;
+
+        # Disable Info manual directory generation to prevent build failures.
+        #
+        # Context: 'install-info' (from texinfo) is triggered during system-path
+        # generation to index manuals, but it requires 'gzip' in the $PATH to
+        # decompress them.
+        # When 'networking.useDHCP' is set to false, transitive dependencies
+        # (like dhcpcd or other network tools) that normally pull 'gzip' into
+        # the system environment are removed. This leaves 'install-info'
+        # stranded without 'gzip', causing the 'system-path' derivation to fail.
+        # Since nspawn containers are typically minimal, disabling 'info'
+        # is a cleaner fix than explicitly adding 'gzip' to systemPackages.
+        documentation.info.enable = lib.mkDefault false;
+
+        # Gross, insecure hack to make login work. See above.
+        security.pam.services.login = {
+          text = ''
+            auth sufficient ${pkgs.linux-pam}/lib/security/pam_permit.so
+            account sufficient ${pkgs.linux-pam}/lib/security/pam_permit.so
+            password sufficient ${pkgs.linux-pam}/lib/security/pam_permit.so
+            session sufficient ${pkgs.linux-pam}/lib/security/pam_permit.so
+          '';
         };
-        virtualisation.host.pkgs = hostPkgs;
       }
-      testModuleArgs.config.extraBaseNodeModules
-    ];
-  };
-  baseNspawnOS = baseOS.extendModules {
-    modules = [
-      ../../modules/virtualisation/nspawn-container
-      config.containerDefaults
-      (
-        { pkgs, ... }:
-        {
-          key = "base-nspawn";
-
-          # PAM requires setuid and doesn't work in the build sandbox.
-          # https://github.com/NixOS/nix/blob/959c244a1265f4048390f3ad21679219d7b27a99/src/libstore/unix/build/linux-derivation-builder.cc#L63
-          services.openssh.settings.UsePAM = false;
-
-          # Networking for tests is statically configured by default.
-          # dhcpcd times out after blocking for a long time, which slows down tests.
-          # See https://github.com/NixOS/nixpkgs/pull/478109#discussion_r2867570799
-          networking.useDHCP = lib.mkDefault false;
-
-          # Disable Info manual directory generation to prevent build failures.
-          #
-          # Context: 'install-info' (from texinfo) is triggered during system-path
-          # generation to index manuals, but it requires 'gzip' in the $PATH to
-          # decompress them.
-          # When 'networking.useDHCP' is set to false, transitive dependencies
-          # (like dhcpcd or other network tools) that normally pull 'gzip' into
-          # the system environment are removed. This leaves 'install-info'
-          # stranded without 'gzip', causing the 'system-path' derivation to fail.
-          # Since nspawn containers are typically minimal, disabling 'info'
-          # is a cleaner fix than explicitly adding 'gzip' to systemPackages.
-          documentation.info.enable = lib.mkDefault false;
-
-          # Gross, insecure hack to make login work. See above.
-          security.pam.services.login = {
-            text = ''
-              auth sufficient ${pkgs.linux-pam}/lib/security/pam_permit.so
-              account sufficient ${pkgs.linux-pam}/lib/security/pam_permit.so
-              password sufficient ${pkgs.linux-pam}/lib/security/pam_permit.so
-              session sufficient ${pkgs.linux-pam}/lib/security/pam_permit.so
-            '';
-          };
-        }
-      )
-    ];
-  };
+    )
+  ];
 
   # TODO (lib): Dedup with run.nix, add to lib/options.nix
   mkOneUp = opt: f: lib.mkOverride (opt.highestPrio - 1) (f opt.value);

--- a/nixos/modules/virtualisation/nspawn-container/default.nix
+++ b/nixos/modules/virtualisation/nspawn-container/default.nix
@@ -21,8 +21,6 @@ let
   cfg = config.virtualisation;
 in
 {
-  imports = [ ../guest-networking-options.nix ];
-
   options = {
 
     virtualisation.cmdline = lib.mkOption {

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -399,7 +399,6 @@ in
   imports = [
     ../profiles/qemu-guest.nix
     ./disk-size-option.nix
-    ./guest-networking-options.nix
     (mkRenamedOptionModule
       [
         "virtualisation"


### PR DESCRIPTION
When "non-user" modules are not placed in baseModules or extraModules (arguments of eval-config.nix), noUserModules.evalModules breaks if the options defined in those modules are consumed. In order to restore noUserModules functionality for NixOS VM (and now nspawn) tests, the modules implementing test behavior are moved to baseModules.

Among other places this fixes the `userborn-immutable-users` VM test:

```console
$ nix build github:nixos/nixpkgs/master#nixosTests.userborn-immutable-users
error:
       … while evaluating the attribute 'drvPath'
         at «github:nixos/nixpkgs/3911b8bd392062a8ce618d89bbea2a156b20473e»/lib/customisation.nix:428:7:
          427|     // {
          428|       drvPath =
             |       ^
          429|         assert condition;

       … while calling the 'derivationStrict' builtin
         at «nix-internal»/derivation-internal.nix:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating the option `driverConfigurationFile':

       … while evaluating the option `driverConfiguration.vms.machine.start_script':

       … while evaluating definitions from `/nix/store/b4m77v25r31j3n7m00wqdb4rcscjbf5y-source/nixos/lib/testing/driver-configuration.nix':

       … while evaluating the option `nodes.machine.system.systemBuilderCommands':

       … while evaluating definitions from `/nix/store/b4m77v25r31j3n7m00wqdb4rcscjbf5y-source/nixos/modules/system/activation/specialisation.nix':

       … while evaluating the option `nodes.machine.specialisation.new-generation.configuration':

       … while evaluating the option `nodes.machine.specialisation.new-generation.configuration.networking.interfaces':

       … while evaluating definitions from `/nix/store/b4m77v25r31j3n7m00wqdb4rcscjbf5y-source/nixos/lib/testing/network.nix, via option extraBaseModules':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'allInterfaces' missing
       at «github:nixos/nixpkgs/3911b8bd392062a8ce618d89bbea2a156b20473e»/nixos/lib/testing/network.nix:32:35:
           31|     let
           32|       interfaces = lib.attrValues config.virtualisation.allInterfaces;
             |                                   ^
           33|

$ nix build github:jmbaur/nixpkgs/nixos-test-no-user-modules#nixosTests.userborn-immutable-users
$ echo $?
0
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
