### PR TITLE
nixos/version.nix: Do not define IMAGE_VERSION

### DIFF
--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -54,10 +54,12 @@ let
       BUG_REPORT_URL = optionalString isNixos "https://github.com/NixOS/nixpkgs/issues";
       ANSI_COLOR = optionalString isNixos "0;38;2;126;186;228";
       IMAGE_ID = optionalString (config.system.image.id != null) config.system.image.id;
-      IMAGE_VERSION = optionalString (config.system.image.version != null) config.system.image.version;
       VARIANT = optionalString (cfg.variantName != null) cfg.variantName;
       VARIANT_ID = optionalString (cfg.variant_id != null) cfg.variant_id;
       DEFAULT_HOSTNAME = config.system.nixos.distroId;
+    }
+    // lib.attrsets.optionalAttrs (config.system.image.version != null) {
+      IMAGE_VERSION = config.system.image.version;
     }
     // cfg.extraOSReleaseArgs;
 

--- a/pkgs/by-name/bi/biome/package.nix
+++ b/pkgs/by-name/bi/biome/package.nix
@@ -11,16 +11,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "biome";
-  version = "2.4.16";
+  version = "2.5.0";
 
   src = fetchFromGitHub {
     owner = "biomejs";
     repo = "biome";
     rev = "@biomejs/biome@${finalAttrs.version}";
-    hash = "sha256-YfPaSSNESFdGjJjB3C3rubydZW/U7NQ/HtTlXtH7VB4=";
+    hash = "sha256-d8MhD749rkLWeCKDBxhw2aF3G09h8kug5w2Q40JSkt4=";
   };
 
-  cargoHash = "sha256-N5rKXNrLs/J4uDHYVDMl+jSRowB8ipjvJdIHNvJvAUU=";
+  cargoHash = "sha256-z1KgScoH9retj0qNd6eOTjejjQypfVkha0ae71Z6TSg=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/by-name/fi/firefoxpwa-unwrapped/package.nix
+++ b/pkgs/by-name/fi/firefoxpwa-unwrapped/package.nix
@@ -16,13 +16,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "firefoxpwa-unwrapped";
-  version = "2.18.2";
+  version = "2.18.4";
 
   src = fetchFromGitHub {
     owner = "filips123";
     repo = "PWAsForFirefox";
     rev = "v${version}";
-    hash = "sha256-eNJKR6dmG4dDKwvWjC0Nbzk5ixNJtnRXjWJgxc9W5i8=";
+    hash = "sha256-Rz0H6dpeTnKHRnmBUZicjgzRSrcpamuGDJRw/lqD/7k=";
   };
 
   sourceRoot = "${src.name}/native";

--- a/pkgs/by-name/fo/fosrl-newt/package.nix
+++ b/pkgs/by-name/fo/fosrl-newt/package.nix
@@ -9,16 +9,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "newt";
-  version = "1.13.0";
+  version = "1.14.0";
 
   src = fetchFromGitHub {
     owner = "fosrl";
     repo = "newt";
     tag = finalAttrs.version;
-    hash = "sha256-Kt7YCxHQEv1DeASPJtjAwzmAiWBrkf+XNs7aJEZvb+M=";
+    hash = "sha256-WjjXtx2csUAzQ1h3Ey2axaYdsn8pTeyxYByiTfBURos=";
   };
 
-  vendorHash = "sha256-QJ70q53k4EvLpiMY+Nm70QqaZk14V0Q1CrwWVSowdUU=";
+  vendorHash = "sha256-JhNBJhj5YX3Wurv7r/JDu6YtHizOMLk+NCob7ISx+3c=";
 
   nativeInstallCheckInputs = [ versionCheckHook ];
 

--- a/pkgs/by-name/nu/nushell-plugin-hcl/package.nix
+++ b/pkgs/by-name/nu/nushell-plugin-hcl/package.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nu_plugin_hcl";
-  version = "0.113.1";
+  version = "0.114.0";
 
   src = fetchFromGitHub {
     owner = "Yethal";
     repo = "nu_plugin_hcl";
     tag = finalAttrs.version;
-    hash = "sha256-4rbYbyIYy3WEn2hSkreohVWJ8zhQHI/cdBN5xO4YKdY=";
+    hash = "sha256-3qUsEJIF91679W2mdU9eESTNmcp3TqmMxWoR7G5uUl8=";
   };
 
-  cargoHash = "sha256-lFlG86yGR61jgmKxTp2FYir2o0vEAVeoPk1owDGGWLM=";
+  cargoHash = "sha256-xAURId/OvgIGvbh5be4yS2dKmQObIpb4YYlRcjcHMeU=";
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
 

--- a/pkgs/by-name/sp/spi-tools/package.nix
+++ b/pkgs/by-name/sp/spi-tools/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "spi-tools";
-  version = "1.0.2";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "cpb-";
     repo = "spi-tools";
     tag = finalAttrs.version;
-    hash = "sha256-lrdoO4ZsZCf0pt1SSL5w4rXVuYzlkJZQpditYt61nUw=";
+    hash = "sha256-mlOpgzJ8YFX+2y8+V3A2WjsnOzzj+fF8lJHqzoEP30s=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/um/umu-launcher-unwrapped/package.nix
+++ b/pkgs/by-name/um/umu-launcher-unwrapped/package.nix
@@ -14,18 +14,18 @@
 }:
 python3Packages.buildPythonPackage rec {
   pname = "umu-launcher-unwrapped";
-  version = "1.4.0";
+  version = "1.4.1";
 
   src = fetchFromGitHub {
     owner = "Open-Wine-Components";
     repo = "umu-launcher";
     tag = version;
-    hash = "sha256-7BdA/iAAIn2NR/uLzxdvsIh5/1SZacSfkiXJVJBT3EQ=";
+    hash = "sha256-ZpYxoXux80QbmJUWyK5P9Om0iKNTWLrWH0RWDFXx5zE=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
-    hash = "sha256-CVcbktCBRZGnEuDVvl2iJpRgKh+ShFe5mjT6oMHIjtQ=";
+    hash = "sha256-f9Me1dCS5GxXN4mADS6Z20M7YnX5ck3JXOXUFhM+h5o=";
   };
 
   nativeCheckInputs = [

--- a/pkgs/desktops/lomiri/development/geonames/default.nix
+++ b/pkgs/desktops/lomiri/development/geonames/default.nix
@@ -69,7 +69,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # Tests need to be able to check locale
-  LC_ALL = lib.optionalString finalAttrs.finalPackage.doCheck "en_US.UTF-8";
+  env.LC_ALL = lib.optionalString finalAttrs.finalPackage.doCheck "en_US.UTF-8";
+
   nativeCheckInputs = [
     glibcLocales
   ];

--- a/pkgs/desktops/lomiri/development/libusermetrics/default.nix
+++ b/pkgs/desktops/lomiri/development/libusermetrics/default.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # Tests need to be able to check locale
-  LC_ALL = lib.optionalString finalAttrs.finalPackage.doCheck "en_US.UTF-8";
+  env.LC_ALL = lib.optionalString finalAttrs.finalPackage.doCheck "en_US.UTF-8";
 
   nativeCheckInputs = [
     dbus


### PR DESCRIPTION
On GNOME 49, if you go to Settings - System - System Details you will see a blank OS Build field. That is because IMAGE_VERSION is set to the empty string in /etc/os-release. Do not define osReleaseContents.IMAGE_VERSION if config.system.image.version is null.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test