### PR TITLE
python3Packages.pyteleinfo: init at 0.4.0

### DIFF
--- a/pkgs/development/python-modules/pyteleinfo/default.nix
+++ b/pkgs/development/python-modules/pyteleinfo/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  pydantic-settings,
+  pyserial,
+  pyserial-asyncio-fast,
+  pyhamcrest,
+  pytest-asyncio,
+  pytest-cov-stub,
+  pytest-mock,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pyteleinfo";
+  version = "0.4.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "esciara";
+    repo = "pyteleinfo";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-uNkCunWlFoGmg80t69z2PXyPL1pGDsezTc8heec97VI=";
+  };
+
+  build-system = [ hatchling ];
+
+  pythonRelaxDeps = [ "pydantic-settings" ];
+
+  dependencies = [
+    pydantic-settings
+    pyserial
+    pyserial-asyncio-fast
+  ];
+
+  nativeCheckInputs = [
+    pyhamcrest
+    pytest-asyncio
+    pytest-cov-stub
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "teleinfo" ];
+
+  meta = {
+    description = "Python library for decoding and encoding ENEDIS teleinfo frames";
+    homepage = "https://github.com/esciara/pyteleinfo";
+    changelog = "https://github.com/esciara/pyteleinfo/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -6346,8 +6346,9 @@
     "teleinfo" =
       ps: with ps; [
         aiousbwatcher
+        pyteleinfo
         serialx
-      ]; # missing inputs: pyteleinfo
+      ];
     "tellduslive" =
       ps: with ps; [
         tellduslive
@@ -8376,6 +8377,7 @@
     "tedee"
     "telegram"
     "telegram_bot"
+    "teleinfo"
     "tellduslive"
     "teltonika"
     "temper"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15295,6 +15295,8 @@ self: super: with self; {
 
   pytelegrambotapi = callPackage ../development/python-modules/pyTelegramBotAPI { };
 
+  pyteleinfo = callPackage ../development/python-modules/pyteleinfo { };
+
   pytenable = callPackage ../development/python-modules/pytenable { };
 
   pytensor = callPackage ../development/python-modules/pytensor { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://www.home-assistant.io/integrations/teleinfo/
- https://pypi.org/project/pyteleinfo/
- https://github.com/esciara/pyteleinfo

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
