### PR TITLE
python3Packages.pyomie: init at 1.1.1

### DIFF
--- a/pkgs/development/python-modules/pyomie/default.nix
+++ b/pkgs/development/python-modules/pyomie/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  aiohttp,
+  aioresponses,
+  buildPythonPackage,
+  deepdiff,
+  fetchFromGitHub,
+  poetry-core,
+  pytest-asyncio,
+  pytest-cov-stub,
+  pytestCheckHook,
+  rich,
+  typer,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pyomie";
+  version = "1.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "luuuis";
+    repo = "pyomie";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-BOaOClTXeoRxWb2aJKN6+lQRCLAShvHPXsUZBbH0mno=";
+  };
+
+  build-system = [ poetry-core ];
+
+  pythonRelaxDeps = [ "typer" ];
+
+  dependencies = [
+    aiohttp
+    rich
+    typer
+  ];
+
+  nativeCheckInputs = [
+    aioresponses
+    deepdiff
+    pytest-asyncio
+    pytest-cov-stub
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pyomie" ];
+
+  meta = {
+    description = "Client for OMIE - Spain and Portugal electricity market data";
+    homepage = "https://github.com/luuuis/pyomie";
+    changelog = "https://github.com/luuuis/pyomie/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -4479,7 +4479,8 @@
       ];
     "omie" =
       ps: with ps; [
-      ]; # missing inputs: pyomie
+        pyomie
+      ];
     "omnilogic" =
       ps: with ps; [
         omnilogic
@@ -8100,6 +8101,7 @@
     "octoprint"
     "ohme"
     "ollama"
+    "omie"
     "omnilogic"
     "onboarding"
     "oncue"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14576,6 +14576,8 @@ self: super: with self; {
 
   pyombi = callPackage ../development/python-modules/pyombi { };
 
+  pyomie = callPackage ../development/python-modules/pyomie { };
+
   pyomo = callPackage ../development/python-modules/pyomo { };
 
   pyopen-wakeword = callPackage ../development/python-modules/pyopen-wakeword/default.nix { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://www.home-assistant.io/integrations/omie/
- https://pypi.org/project/pyomie/
- https://github.com/luuuis/pyomie

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
