### PR TITLE
furmark: 2.3.0.0 -> 2.10.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29218,6 +29218,11 @@
     githubId = 115360611;
     name = "Wölfchen";
   };
+  w1lldu = {
+    name = "William Du";
+    github = "w1lldu";
+    githubId = 70287641;
+  };
   waelwindows = {
     email = "waelwindows9922@gmail.com";
     github = "Waelwindows";

--- a/pkgs/by-name/fu/furmark/package.nix
+++ b/pkgs/by-name/fu/furmark/package.nix
@@ -20,7 +20,7 @@ let
 
   versions = {
     "x86_64-linux" = "2.10.2";
-    "aarch64-linux" = "2.3.0.0";
+    "aarch64-linux" = "2.10.1";
     "i686-linux" = "2.0.16";
   };
 
@@ -30,8 +30,8 @@ let
       hash = "sha256-s9AEj9r7kBhPGPU365HgxS9tEyrm7UjLtoxD21pCrts=";
     };
     "aarch64-linux" = {
-      url = "https://gpumagick.com/downloads/files/2024/furmark2/FurMark_${versions.x86_64-linux}_rpi64.zip";
-      hash = "sha256-az4prQbg9I+6rt2y1OTy3t21/VHyZS++57r4Ahe3fcQ=";
+      url = "https://gpumagick.com/downloads/files/2025/fm2/2_10_dbc69dd0a08da5ff09169a4fc759ddaa/FurMark_${versions.aarch64-linux}_arm64.7z";
+      hash = "sha256-XQuK6UgZOjwqpENkHVYsoiG9zyZAbNjR+65hj9dvAY8=";
     };
     "i686-linux" = {
       url = "https://gpumagick.com/downloads/files/2024/furmark2/FurMark_${versions.i686-linux}_linux32.zip";
@@ -39,9 +39,11 @@ let
     };
   };
 
-  is7z = stdenv.hostPlatform.system == "x86_64-linux";
+  is7z =
+    (stdenv.hostPlatform.system == "x86_64-linux") || (stdenv.hostPlatform.system == "aarch64-linux");
 
-  linkLogs = stdenv.hostPlatform.system == "x86_64-linux";
+  linkLogs =
+    (stdenv.hostPlatform.system == "x86_64-linux") || (stdenv.hostPlatform.system == "aarch64-linux");
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "furmark";

--- a/pkgs/by-name/fu/furmark/package.nix
+++ b/pkgs/by-name/fu/furmark/package.nix
@@ -103,7 +103,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.geeks3d.com/furmark/v2/";
     license = lib.licenses.unfree;
     mainProgram = "FurMark_GUI";
-    maintainers = with lib.maintainers; [ surfaceflinger ];
+    maintainers = with lib.maintainers; [
+      surfaceflinger
+      w1lldu
+    ];
     platforms = [
       "aarch64-linux"
       "i686-linux"

--- a/pkgs/by-name/fu/furmark/package.nix
+++ b/pkgs/by-name/fu/furmark/package.nix
@@ -9,6 +9,7 @@
   libxcrypt-legacy,
   makeDesktopItem,
   makeWrapper,
+  p7zip,
   stdenv,
   testers,
   vulkan-loader,
@@ -18,15 +19,15 @@ let
   description = "OpenGL and Vulkan Benchmark and Stress Test";
 
   versions = {
-    "x86_64-linux" = "2.3.0.0";
+    "x86_64-linux" = "2.10.2";
     "aarch64-linux" = "2.3.0.0";
     "i686-linux" = "2.0.16";
   };
 
   sources = {
     "x86_64-linux" = {
-      url = "https://gpumagick.com/downloads/files/2024/furmark2/FurMark_${versions.x86_64-linux}_linux64.zip";
-      hash = "sha256-9xwnOo8gh6XlX2uTwvEorXsx9FafaeCyCPPPJLJGeuE=";
+      url = "https://gpumagick.com/downloads/files/2025/fm2/2_10_dbc69dd0a08da5ff09169a4fc759ddaa/FurMark_${versions.x86_64-linux}_linux64.7z";
+      hash = "sha256-s9AEj9r7kBhPGPU365HgxS9tEyrm7UjLtoxD21pCrts=";
     };
     "aarch64-linux" = {
       url = "https://gpumagick.com/downloads/files/2024/furmark2/FurMark_${versions.x86_64-linux}_rpi64.zip";
@@ -37,6 +38,10 @@ let
       hash = "sha256-yXd90FgL3WbTga5x0mXT40BonA2NQtqLzRVzn4s4lLc=";
     };
   };
+
+  is7z = stdenv.hostPlatform.system == "x86_64-linux";
+
+  linkLogs = stdenv.hostPlatform.system == "x86_64-linux";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "furmark";
@@ -44,12 +49,13 @@ stdenv.mkDerivation (finalAttrs: {
     versions.${stdenv.hostPlatform.system}
       or (throw "Furmark is not available on ${stdenv.hostPlatform.system}");
 
-  src = fetchzip sources.${stdenv.hostPlatform.system};
+  src = fetchurl sources.${stdenv.hostPlatform.system};
 
   nativeBuildInputs = [
     autoPatchelfHook
     copyDesktopItems
     makeWrapper
+    p7zip
   ];
 
   buildInputs = [
@@ -58,12 +64,29 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isAarch64 [ libxcrypt-legacy ];
 
+  unpackPhase = ''
+    runHook preUnpack
+    7z x $src
+  ''
+  + lib.optionalString is7z ''
+    mv FurMark_linux64/* .
+    rmdir FurMark_linux64
+  ''
+  + ''
+    runHook postUnpack
+  '';
+
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/share/furmark
     cp -rp * $out/share/furmark
-
+  ''
+  + lib.optionalString linkLogs ''
+    ln -sf /tmp/furmark-geexlab.log $out/share/furmark/_geexlab_log.txt
+    ln -sf /tmp/furmark-furmark.log $out/share/furmark/_furmark_log.txt
+  ''
+  + ''
     mkdir -p $out/bin
     for i in $(find $out/share/furmark -maxdepth 1 -type f -executable); do
       ln -s "$i" "$out/bin/$(basename "$i")"


### PR DESCRIPTION
links log files to tmp since the store is read-only
[changelog](https://www.geeks3d.com/furmark/changelog/)

Closes https://github.com/NixOS/nixpkgs/issues/391384

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test