### PR TITLE
python3Packages.kiosker-python-api: init at 1.2.9

### DIFF
--- a/pkgs/development/python-modules/kiosker-python-api/default.nix
+++ b/pkgs/development/python-modules/kiosker-python-api/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  httpx,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "kiosker-python-api";
+  version = "1.2.9";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Top-North";
+    repo = "kiosker-python";
+    tag = finalAttrs.version;
+    hash = "sha256-DGJ1lxi4pP4gyRWDpeUdyPGCKQmzpRaWw8bwHrFUKF0=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [ httpx ];
+
+  # Tests require a live Kiosker device (HOST/TOKEN env vars).
+  doCheck = false;
+
+  pythonImportsCheck = [ "kiosker" ];
+
+  meta = {
+    description = "Python wrapper for the Kiosker API";
+    homepage = "https://github.com/Top-North/kiosker-python";
+    changelog = "https://github.com/Top-North/kiosker-python/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -3250,7 +3250,8 @@
       ];
     "kiosker" =
       ps: with ps; [
-      ]; # missing inputs: kiosker-python-api
+        kiosker-python-api
+      ];
     "kira" =
       ps: with ps; [
         pykira
@@ -7912,6 +7913,7 @@
     "keenetic_ndms2"
     "kegtron"
     "keymitt_ble"
+    "kiosker"
     "kira"
     "kitchen_sink"
     "kmtronic"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8369,6 +8369,8 @@ self: super: with self; {
 
   kinparse = callPackage ../development/python-modules/kinparse { };
 
+  kiosker-python-api = callPackage ../development/python-modules/kiosker-python-api { };
+
   kiss-headers = callPackage ../development/python-modules/kiss-headers { };
 
   kitchen = callPackage ../development/python-modules/kitchen { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://www.home-assistant.io/integrations/kiosker/
- https://pypi.org/project/kiosker-python-api/
- https://github.com/Top-North/kiosker-python

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
