### PR TITLE
python3Packages.denon-rs232: init at 4.1.0

### DIFF
--- a/pkgs/development/python-modules/denon-rs232/default.nix
+++ b/pkgs/development/python-modules/denon-rs232/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytest-asyncio,
+  pytest-timeout,
+  pytestCheckHook,
+  pythonOlder,
+  serialx,
+  uv-build,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "denon-rs232";
+  version = "4.1.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.12";
+
+  src = fetchFromGitHub {
+    owner = "home-assistant-libs";
+    repo = "denon-rs232";
+    tag = finalAttrs.version;
+    hash = "sha256-SkfxUen1F5cakQao68uYz5uxAkzJfZtVtuIoFGH6mOU=";
+  };
+
+  build-system = [ uv-build ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'version = "0.0.0"' 'version = "${finalAttrs.version}"' \
+      --replace-fail '"uv_build>=0.8.4,<0.9.0"' '"uv_build>=0.8.4"'
+  '';
+
+  dependencies = [ serialx ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-timeout
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "denon_rs232" ];
+
+  meta = {
+    description = "Async library to control Denon receivers over RS232";
+    homepage = "https://github.com/home-assistant-libs/denon-rs232";
+    changelog = "https://github.com/home-assistant-libs/denon-rs232/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -1236,8 +1236,9 @@
     "denon_rs232" =
       ps: with ps; [
         aiousbwatcher
+        denon-rs232
         serialx
-      ]; # missing inputs: denon-rs232
+      ];
     "denonavr" =
       ps: with ps; [
         denonavr
@@ -7611,6 +7612,7 @@
     "default_config"
     "deluge"
     "demo"
+    "denon_rs232"
     "denonavr"
     "derivative"
     "devialet"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3842,6 +3842,8 @@ self: super: with self; {
 
   dendropy = callPackage ../development/python-modules/dendropy { };
 
+  denon-rs232 = callPackage ../development/python-modules/denon-rs232 { };
+
   denonavr = callPackage ../development/python-modules/denonavr { };
 
   dep-logic = callPackage ../development/python-modules/dep-logic { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://www.home-assistant.io/integrations/denon_rs232/
- https://pypi.org/project/denon-rs232/
- https://github.com/home-assistant-libs/denon-rs232

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
