### PR TITLE
python3Packages.python-tds: fix build by skipping live-server tests

### DIFF
--- a/pkgs/development/python-modules/python-tds/default.nix
+++ b/pkgs/development/python-modules/python-tds/default.nix
@@ -29,6 +29,11 @@ buildPythonPackage rec {
       --replace-fail "version.get_git_version()" '"${version}"'
   '';
 
+  preCheck = ''
+    # upstream conftest.py crashes without pytest-mypy installed
+    rm conftest.py
+  '';
+
   build-system = [ setuptools ];
 
   dependencies = [ six ];
@@ -40,6 +45,15 @@ buildPythonPackage rec {
     namedlist
     pydes
     cryptography
+  ];
+
+  disabledTestPaths = [
+    # requires live SQL Server / sqlalchemy fixtures
+    "tests/connected_test.py"
+    "tests/fedauth_test.py"
+    "tests/sqlalchemy_test.py"
+    "tests/transaction_test.py"
+    "tests/types_test.py"
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/python-tds/default.nix
+++ b/pkgs/development/python-modules/python-tds/default.nix
@@ -74,6 +74,8 @@ buildPythonPackage rec {
     "test_encrypted_socket"
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   pythonImportsCheck = [ "pytds" ];
 
   meta = {


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327157905)](https://hydra.nixos.org/build/327157905)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
