### PR TITLE
libgsystemservice: init at 0.3.0

### DIFF
--- a/pkgs/by-name/li/libgsystemservice/package.nix
+++ b/pkgs/by-name/li/libgsystemservice/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  meson,
+  ninja,
+  pkg-config,
+  glib,
+  polkit,
+  gobject-introspection,
+  gi-docgen,
+  vala,
+  systemd,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libgsystemservice";
+  version = "0.3.0";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "pwithnall";
+    repo = "libgsystemservice";
+    rev = finalAttrs.version;
+    hash = "sha256-e7Wq/KCY/06bp+Ub8aK3LmJrKvj+UWbh0so6EatG8OQ=";
+  };
+
+  mesonFlags = [
+    "-Dgtk_doc=false"
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gobject-introspection
+    gi-docgen
+    vala
+  ];
+
+  buildInputs = [
+    polkit
+    systemd
+  ];
+
+  propagatedBuildInputs = [
+    glib
+  ];
+
+  meta = {
+    description = "LibGSystemService";
+    homepage = "https://gitlab.gnome.org/pwithnall/libgsystemservice";
+    license = lib.licenses.lgpl21Plus;
+    maintainers = with lib.maintainers; [ tbutter ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Adding libgsystemservice library. It is required for version 0.14 of malcontent .

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
