### PR TITLE
hashlink: remove unused pcre dependency

### DIFF
--- a/pkgs/by-name/ha/hashlink/package.nix
+++ b/pkgs/by-name/ha/hashlink/package.nix
@@ -12,7 +12,6 @@
   libvorbis,
   mbedtls,
   openal,
-  pcre,
   SDL2,
   sqlite,
 }:
@@ -45,7 +44,6 @@ stdenv.mkDerivation rec {
     libvorbis
     mbedtls
     openal
-    pcre
     SDL2
     sqlite
   ];


### PR DESCRIPTION
- #356387 

Upstream has migrated to vendor PCRE2 years ago: https://github.com/HaxeFoundation/hashlink/commit/2206f8c074960f79cc79cab2b7b7e609320e232c

Upstream also merged a commit recently to allow unvendoring PCRE2: https://github.com/HaxeFoundation/hashlink/commit/86d15f389f2a46249bc809d5ccade38e9dbc7eb8
We should utilize this after next release.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
