### PR TITLE
python3Packages.python-redis-lock: 4.0.0 -> 4.0.1

### DIFF
--- a/pkgs/development/python-modules/python-redis-lock/default.nix
+++ b/pkgs/development/python-modules/python-redis-lock/default.nix
@@ -4,8 +4,7 @@
   buildPythonPackage,
   setuptools,
   eventlet,
-  fetchPypi,
-  fetchpatch,
+  fetchFromGitHub,
   gevent,
   pkgs,
   process-tests,
@@ -16,13 +15,15 @@
 
 buildPythonPackage rec {
   pname = "python-redis-lock";
-  version = "4.0.0";
+  version = "4.0.1";
 
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-Sr0Lz0kTasrWZye/VIbdJJQHjKVeSe+mk/eUB3MZCRo=";
+  src = fetchFromGitHub {
+    owner = "ionelmc";
+    repo = "python-redis-lock";
+    tag = "v${version}";
+    hash = "sha256-KlmVRglglvj3EuX1m2sLqd/yZeU7CjeRxSUJ/cT4ww4=";
   };
 
   # Fix django tests
@@ -32,11 +33,6 @@ buildPythonPackage rec {
   '';
 
   patches = [
-    # https://github.com/ionelmc/python-redis-lock/pull/119
-    (fetchpatch {
-      url = "https://github.com/ionelmc/python-redis-lock/commit/ae404b7834990b833c1f0f703ec8fbcfecd201c2.patch";
-      hash = "sha256-Fo43+pCtnrEMxMdEEdo0YfJGkBlhhH0GjYNgpZeHF3U=";
-    })
     ./test_signal_expiration_increase_sleep.patch
   ];
 


### PR DESCRIPTION
Release: https://github.com/ionelmc/python-redis-lock/releases/tag/v4.0.1
Diff: https://github.com/ionelmc/python-redis-lock/compare/v4.0.0...v4.0.1
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327157808)](https://hydra.nixos.org/build/327157808)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
