### PR TITLE
python3Packages.typer: 0.25.1 -> 0.26.8

### DIFF
--- a/pkgs/development/python-modules/typer/default.nix
+++ b/pkgs/development/python-modules/typer/default.nix
@@ -9,7 +9,6 @@
 
   # dependencies
   annotated-doc,
-  click,
 
   # optional-dependencies
   rich,
@@ -22,17 +21,19 @@
   procps,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "typer";
-  version = "0.25.1";
+  version = "0.26.8";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "fastapi";
     repo = "typer";
-    tag = version;
-    hash = "sha256-HIvXseuR7zUXFuTWzntDfHhAp8BcFjxo35gn0i4+03w=";
+    tag = finalAttrs.version;
+    hash = "sha256-VkqvlWLzmtbQPaplx/YRdSNN1xq/UMRl8EZVIEm97Lk=";
   };
+
+  patches = [ ./fix-binary-stderr-test.patch ];
 
   postPatch = ''
     for f in $(find tests -type f -print); do
@@ -47,7 +48,6 @@ buildPythonPackage rec {
 
   dependencies = [
     annotated-doc
-    click
     rich
     shellingham
   ];
@@ -62,13 +62,14 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
+    # Flaky sometimes
+    "test_file_error"
+
     "test_scripts"
+
     # Likely related to https://github.com/sarugaku/shellingham/issues/35
     # fails also on Linux
     "test_show_completion"
-    "test_install_completion"
-  ]
-  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
     "test_install_completion"
   ];
 
@@ -77,8 +78,8 @@ buildPythonPackage rec {
   meta = {
     description = "Library for building CLI applications";
     homepage = "https://typer.tiangolo.com/";
-    changelog = "https://github.com/tiangolo/typer/releases/tag/${version}";
+    changelog = "https://github.com/tiangolo/typer/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ winpat ];
   };
-}
+})

--- a/pkgs/development/python-modules/typer/fix-binary-stderr-test.patch
+++ b/pkgs/development/python-modules/typer/fix-binary-stderr-test.patch
@@ -1,0 +1,14 @@
+diff --git a/tests/test_types_file.py b/tests/test_types_file.py
+index 3fb7d82f69..1265899334 100644
+--- a/tests/test_types_file.py
++++ b/tests/test_types_file.py
+@@ -142,7 +142,8 @@
+             "-m",
+             "coverage",
+             "run",
+-            __file__,
++            "-m",
++            "tests.test_types_file",
+             "write-binary-stderr",
+         ],
+         capture_output=True,


### PR DESCRIPTION
https://github.com/fastapi/typer/releases/tag/0.26.8
Diff: https://github.com/fastapi/typer/compare/0.25.1...0.26.8

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
