### PR TITLE
din: init at 64.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9259,6 +9259,12 @@
     githubId = 119691;
     name = "Michael Gough";
   };
+  fraggerfox = {
+    email = "santhosh.raju@gmail.com";
+    github = "fraggerfox";
+    githubId = 189939;
+    name = "Santhosh Raju";
+  };
   fraioveio = {
     email = "francesco@vecchia.lol";
     github = "FraioVeio";

--- a/pkgs/by-name/di/din/package.nix
+++ b/pkgs/by-name/di/din/package.nix
@@ -1,0 +1,120 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  autoreconfHook,
+  libsndfile,
+  freeglut,
+  libGL,
+  libGLU,
+  libjpeg,
+  SDL,
+  tcl,
+
+  # Audio backend — exactly one must be selected.
+  # ALSA is the upstream-recommended Linux backend; JACK is used elsewhere.
+  jackSupport ? !stdenv.hostPlatform.isLinux,
+  jack2,
+  alsaSupport ? stdenv.hostPlatform.isLinux,
+  alsa-lib,
+}:
+
+assert lib.assertMsg (
+  lib.count (x: x) [
+    jackSupport
+    alsaSupport
+  ] == 1
+) "din: exactly one audio backend must be selected (jackSupport or alsaSupport)";
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "din";
+  version = "64.2";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  # Darwin binary should NOT be available on the public cache; always build from source.
+  # https://dinisnoise.org/README/
+  allowSubstitutes = !stdenv.hostPlatform.isDarwin;
+
+  src = fetchurl {
+    url = "https://dinisnoise.org/files/din-${finalAttrs.version}.tar.gz";
+    hash = "sha256-YpaGOAVJmUMDkqvu9+fzW1RbNNSRO2Id8zg8DIblGXE=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    autoreconfHook
+  ];
+
+  buildInputs = [
+    libsndfile
+    libjpeg
+    SDL
+    tcl
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    freeglut
+    libGL
+    libGLU
+  ]
+  ++ lib.optionals jackSupport [ jack2 ]
+  ++ lib.optionals alsaSupport [ alsa-lib ];
+
+  # Makefile.am hard-codes /usr/include/tcl8.6 and unconditionally links
+  # -lasound. Strip both so Nix controls all flags via configureFlags.
+  # On Darwin, also strip -lGL and -lrt since OpenGL is provided as a framework
+  # and real-time extensions are built into the system library.
+  preConfigure = ''
+    substituteInPlace src/Makefile.am \
+      --replace-fail "-I /usr/include/tcl8.6" "-I${tcl}/include" \
+      --replace-fail " -lasound" ""
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace src/Makefile.am \
+      --replace-fail " -lGL" "" \
+      --replace-fail " -lrt" ""
+  '';
+
+  # Pass the backend macro and linker flags via configure, matching the
+  # upstream build scripts (o3-alsa / o3-jack).
+  # On Darwin, add -framework flags for OpenGL, GLUT, and Cocoa (needed by SDLmain),
+  # silence deprecation warnings, and link SDLmain (provides the main() wrapper for SDL apps on macOS).
+  configureFlags =
+    (
+      if jackSupport then
+        [
+          "CXXFLAGS=-D__UNIX_JACK__${lib.optionalString stdenv.hostPlatform.isDarwin " -DGL_SILENCE_DEPRECATION"}"
+        ]
+      else
+        [
+          "CXXFLAGS=-D__LINUX_ALSA__${lib.optionalString stdenv.hostPlatform.isDarwin " -DGL_SILENCE_DEPRECATION"}"
+        ]
+    )
+    ++ lib.optional jackSupport "LIBS=-ljack"
+    ++ lib.optional alsaSupport "LIBS=-lasound"
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      "LDFLAGS=-framework OpenGL -framework GLUT -framework Cocoa -lSDLmain"
+    ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "Open source cross-platform sound synthesizer";
+    longDescription = ''
+      DIN Is Noise is a program for making sound, music and noise. Use bezier
+      curves to edit waveforms, envelopes, modulators and FX components; use
+      the keyboard (computer and MIDI) to trigger notes (or noise), use the
+      mouse to sound like the theremin, create drones on microtones, launch,
+      orbit and drag them around; bounce balls on walls to trigger notes in a
+      mondrian inspired drawing and also make binaural beats. Supports MIDI
+      input and scripting through TCL.
+    '';
+    homepage = "https://dinisnoise.org/";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ fraggerfox ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    mainProgram = "din";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Import [DIN](https://dinisnoise.org/) into nixpkgs.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
