### PR TITLE
python3Packages.pytest-flake8: drop deprecated py.path.local hook arg

### DIFF
--- a/pkgs/development/python-modules/pytest-flake8/default.nix
+++ b/pkgs/development/python-modules/pytest-flake8/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
   setuptools-scm,
   flake8,
   pytestCheckHook,
@@ -18,6 +19,14 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-uc5DOqqdoLfhzI2ogDOqhbJOHzdu+uqSOojIH+S1LZI=";
   };
+
+  patches = [
+    # Drop deprecated `path` arg from pytest_collect_file hook. (https://github.com/coherent-oss/pytest-flake8/issues/5)
+    (fetchpatch2 {
+      url = "https://raw.githubusercontent.com/OpenIndiana/oi-userland/0d06abedf17256d1f2c89086acc05cfa53dbc647/components/python/pytest-flake8/patches/02-deprecated-path.patch";
+      hash = "sha256-mHGRKaMmDTJdj6ajWS0Dts1ZTbT1bNLMjOOZAP156Jg=";
+    })
+  ];
 
   build-system = [ setuptools-scm ];
 


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327156682)](https://hydra.nixos.org/build/327156682)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
