### PR TITLE
cosmic-*: enable separateDebugInfo if not already enabled

### DIFF
--- a/pkgs/by-name/co/cosmic-applets/package.nix
+++ b/pkgs/by-name/co/cosmic-applets/package.nix
@@ -32,6 +32,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-gA+dpodk6u8dv9VaKNi/xzI8ys39iztQdia+eGkzXs4=";
 
+  separateDebugInfo = true;
+
   nativeBuildInputs = [
     just
     pkg-config

--- a/pkgs/by-name/co/cosmic-applibrary/package.nix
+++ b/pkgs/by-name/co/cosmic-applibrary/package.nix
@@ -23,6 +23,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-uR0wm2+zmcec3esfYwgq4pRqSHkZnd3O8XhgnANf/1Q=";
 
+  separateDebugInfo = true;
+
   nativeBuildInputs = [
     just
     libcosmicAppHook

--- a/pkgs/by-name/co/cosmic-bg/package.nix
+++ b/pkgs/by-name/co/cosmic-bg/package.nix
@@ -31,6 +31,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-xXq8Dckg3YOf2AT9uOZqVfq00FhZp/X5UU8hLmAln1U=";
 
+  separateDebugInfo = true;
+
   nativeBuildInputs = [
     just
     libcosmicAppHook

--- a/pkgs/by-name/co/cosmic-design-demo/package.nix
+++ b/pkgs/by-name/co/cosmic-design-demo/package.nix
@@ -23,6 +23,8 @@ rustPlatform.buildRustPackage {
 
   cargoHash = "sha256-czfDtiSEmzmcLfpqv0/8sP8zDAEKh+pkQkGXdd5NskM=";
 
+  separateDebugInfo = true;
+
   nativeBuildInputs = [
     just
     libcosmicAppHook

--- a/pkgs/by-name/co/cosmic-edit/package.nix
+++ b/pkgs/by-name/co/cosmic-edit/package.nix
@@ -28,6 +28,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-iWZRxn0puWwAibjbj/jdk4t6qgETEUJUv612RZSavMw=";
 
+  separateDebugInfo = true;
+
   postPatch = ''
     substituteInPlace justfile --replace-fail '#!/usr/bin/env' "#!$(command -v env)"
   '';

--- a/pkgs/by-name/co/cosmic-ext-tweaks/package.nix
+++ b/pkgs/by-name/co/cosmic-ext-tweaks/package.nix
@@ -25,6 +25,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-Zl7c/3q5J+9y1vRJdR77NJ6y62bV1bxaVMuiyxDbLX4=";
 
+  separateDebugInfo = true;
+
   nativeBuildInputs = [
     libcosmicAppHook
     just

--- a/pkgs/by-name/co/cosmic-files/package.nix
+++ b/pkgs/by-name/co/cosmic-files/package.nix
@@ -24,6 +24,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-tMSqyl75XK2rgqRtgHAPtr+KFotx61HGqzv0iqzakS8=";
 
+  separateDebugInfo = true;
+
   nativeBuildInputs = [
     just
     libcosmicAppHook

--- a/pkgs/by-name/co/cosmic-greeter/package.nix
+++ b/pkgs/by-name/co/cosmic-greeter/package.nix
@@ -31,6 +31,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-jhugV3eF7g6WU5ez3LzqKc/wP952Zpi8Hplg9SZflns=";
 
+  separateDebugInfo = true;
+
   env.VERGEN_GIT_SHA = finalAttrs.src.tag;
 
   cargoBuildFlags = [ "--all" ];

--- a/pkgs/by-name/co/cosmic-idle/package.nix
+++ b/pkgs/by-name/co/cosmic-idle/package.nix
@@ -28,6 +28,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-wAjFC6qAC3nllbnZf0KVaZTEztNYo6GTvwcp5FYmXLw=";
 
+  separateDebugInfo = true;
+
   nativeBuildInputs = [
     just
     libcosmicAppHook

--- a/pkgs/by-name/co/cosmic-initial-setup/package.nix
+++ b/pkgs/by-name/co/cosmic-initial-setup/package.nix
@@ -26,6 +26,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-DESnl5NjakU4++Ep6CHxDZzHn+o0Gi0eREpXk5BN5iY=";
 
+  separateDebugInfo = true;
+
   buildFeatures = [ "nixos" ];
 
   # cargo-auditable fails during the build when compiling the `crabtime::function`

--- a/pkgs/by-name/co/cosmic-launcher/package.nix
+++ b/pkgs/by-name/co/cosmic-launcher/package.nix
@@ -23,6 +23,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-wZgxlq9MVCeESH093MaQybVMyq50L7aYwj//2r/B0QM=";
 
+  separateDebugInfo = true;
+
   nativeBuildInputs = [
     just
     libcosmicAppHook

--- a/pkgs/by-name/co/cosmic-notifications/package.nix
+++ b/pkgs/by-name/co/cosmic-notifications/package.nix
@@ -24,6 +24,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-EIwYabYWSHTMnNFcammidn3bI4fc6JFdcVkGj7RmWqA=";
 
+  separateDebugInfo = true;
+
   nativeBuildInputs = [
     just
     which

--- a/pkgs/by-name/co/cosmic-osd/package.nix
+++ b/pkgs/by-name/co/cosmic-osd/package.nix
@@ -27,6 +27,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-1YRWWI2qhCI0GrxBAAkGT/AbtkTHgdbYsG8obriZ+zg=";
 
+  separateDebugInfo = true;
+
   nativeBuildInputs = [
     just
     libcosmicAppHook

--- a/pkgs/by-name/co/cosmic-panel/package.nix
+++ b/pkgs/by-name/co/cosmic-panel/package.nix
@@ -23,6 +23,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-vU++jreNHCRjxyyoj53LB2Sa7cdVUWGAvECcqoDofF8=";
 
+  separateDebugInfo = true;
+
   nativeBuildInputs = [
     just
     libcosmicAppHook

--- a/pkgs/by-name/co/cosmic-player/package.nix
+++ b/pkgs/by-name/co/cosmic-player/package.nix
@@ -30,6 +30,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-YPxbOSz/E3hoMT4dutk60jWJMpJHqOWpCSA91b+mHaE=";
 
+  separateDebugInfo = true;
+
   nativeBuildInputs = [
     just
     pkg-config

--- a/pkgs/by-name/co/cosmic-randr/package.nix
+++ b/pkgs/by-name/co/cosmic-randr/package.nix
@@ -24,6 +24,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-QWSPj7bxxWh5/KeNEtUsfDKg+JMONLjomrMcn57j6fw=";
 
+  separateDebugInfo = true;
+
   nativeBuildInputs = [
     just
     pkg-config

--- a/pkgs/by-name/co/cosmic-reader/package.nix
+++ b/pkgs/by-name/co/cosmic-reader/package.nix
@@ -30,6 +30,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-p0dg5RNXkzbi+/RB5k+jr34RNOp+Irahj0BiFUddfnk=";
 
+  separateDebugInfo = true;
+
   nativeBuildInputs = [
     just
     libcosmicAppHook

--- a/pkgs/by-name/co/cosmic-screenshot/package.nix
+++ b/pkgs/by-name/co/cosmic-screenshot/package.nix
@@ -23,6 +23,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-q0RJST1yeqPBjU5MseNZIrZw+brfDtQLKiw7wyViflE=";
 
+  separateDebugInfo = true;
+
   nativeBuildInputs = [
     just
     pkg-config

--- a/pkgs/by-name/co/cosmic-session/package.nix
+++ b/pkgs/by-name/co/cosmic-session/package.nix
@@ -24,6 +24,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-5dLG40X+yxJo566guyHqOCLNp+uNSE+HONS8GIDm58A=";
 
+  separateDebugInfo = true;
+
   postPatch = ''
     substituteInPlace data/start-cosmic \
       --replace-fail '/usr/bin/cosmic-session' "${placeholder "out"}/bin/cosmic-session" \

--- a/pkgs/by-name/co/cosmic-settings-daemon/package.nix
+++ b/pkgs/by-name/co/cosmic-settings-daemon/package.nix
@@ -35,6 +35,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-pvoCqFvMVqNTfdU5WidGijfFNsC9i2XNuNV33F8aKZw=";
 
+  separateDebugInfo = true;
+
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [

--- a/pkgs/by-name/co/cosmic-settings/package.nix
+++ b/pkgs/by-name/co/cosmic-settings/package.nix
@@ -39,6 +39,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-O6d47H+vcSn9G6EIMpSshfL+cBJWZMYXHHKsu2n/huk=";
 
+  separateDebugInfo = true;
+
   nativeBuildInputs = [
     cmake
     just

--- a/pkgs/by-name/co/cosmic-store/package.nix
+++ b/pkgs/by-name/co/cosmic-store/package.nix
@@ -27,6 +27,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-DCqEXoJ1qTwKemSCGe7AwQCdOFw7Qh3PoxbB9XdLfHk=";
 
+  separateDebugInfo = true;
+
   nativeBuildInputs = [
     just
     pkg-config

--- a/pkgs/by-name/co/cosmic-term/package.nix
+++ b/pkgs/by-name/co/cosmic-term/package.nix
@@ -27,6 +27,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-9iHcmImA2tscpRuRKE/nUrwhR5RU5xA2zxJpcDt+2sE=";
 
+  separateDebugInfo = true;
+
   nativeBuildInputs = [
     just
     pkg-config


### PR DESCRIPTION
At least `cosmic-settings`, `cosmic-launcher`, and `cosmic-osd` have core dumps listed in my `coredumpctl`. Other than "it takes up a few extra Mb in hydra's storage", there isn't a particularly compelling reason not to enable the debug output for all COSMIC applications, especially since they are relatively new and somewhat unstable


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
