### PR TITLE
maintainers: remove tmountain

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27803,12 +27803,6 @@
     githubId = 3159881;
     name = "Tobias Markus";
   };
-  tmountain = {
-    email = "tinymountain@gmail.com";
-    github = "tmountain";
-    githubId = 135297;
-    name = "Travis Whitton";
-  };
   tmplt = {
     email = "v@tmplt.dev";
     github = "tmplt";

--- a/pkgs/by-name/ma/maelstrom/package.nix
+++ b/pkgs/by-name/ma/maelstrom/package.nix
@@ -51,6 +51,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "maelstrom";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ tmountain ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/uc/uchess/package.nix
+++ b/pkgs/by-name/uc/uchess/package.nix
@@ -33,7 +33,7 @@ buildGoModule (finalAttrs: {
     description = "Play chess against UCI engines in your terminal";
     mainProgram = "uchess";
     homepage = "https://tmountain.github.io/uchess/";
-    maintainers = with lib.maintainers; [ tmountain ];
+    maintainers = [ ];
     license = lib.licenses.mit;
   };
 })


### PR DESCRIPTION
## Reasons

- Last commented in [July 2021](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Atmountain)
- Hasn't created any PRs / Issues since [April 2021](https://github.com/NixOS/nixpkgs/issues?q=author%3Atmountain)
- About 0 [unanswered ](https://github.com/NixOS/nixpkgs/issues?q=involves%3Atmountain%20-commenter%3Atmountain%20-author%3Atmountain%20-reviewed-by%3Atmountain) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] maelstrom
- [ ] uchess