### PR TITLE
toppra: init at 0.6.9

### DIFF
--- a/pkgs/by-name/to/toppra/package.nix
+++ b/pkgs/by-name/to/toppra/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  # nativeBuildInputs
+  cmake,
+  python3Packages,
+
+  # buildInputs
+  eigen,
+  glpk,
+  msgpack-cxx,
+  pinocchio,
+  qpoases,
+
+  # checkInputs
+  gtest,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "toppra";
+  version = "0.6.9";
+
+  src = fetchFromGitHub {
+    owner = "hungpham2511";
+    repo = "toppra";
+    tag = finalAttrs.version;
+    hash = "sha256-MD3m8vLLW3AUXXp5z5i8svEkvXMtDZH5kRDHhgHd4po=";
+  };
+
+  sourceRoot = "source/cpp";
+
+  # fix ld: cannot open output file
+  # /build/source/toppra/toppra/cpp/toppra_int.cpython-313-x86_64-linux-gnu.so:
+  # No such file or directory
+  postPatch = ''
+    substituteInPlace bindings/CMakeLists.txt --replace-fail \
+      "LIBRARY_OUTPUT_DIRECTORY $""{TOPPRA_PYTHON_SOURCE_DIR}" \
+      "LIBRARY_OUTPUT_DIRECTORY $""{CMAKE_CURRENT_BINARY_DIR}"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    python3Packages.pybind11
+  ];
+
+  buildInputs = [
+    python3Packages.boost
+    eigen
+    glpk
+    msgpack-cxx
+    pinocchio
+    qpoases
+  ];
+
+  checkInputs = [
+    gtest
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_TESTS" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "BUILD_WITH_PINOCCHIO" true)
+    (lib.cmakeBool "BUILD_WITH_PINOCCHIO_PYTHON" true)
+    (lib.cmakeBool "BUILD_WITH_qpOASES" true)
+    (lib.cmakeBool "BUILD_WITH_GLPK" true)
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "OPT_MSGPACK" true)
+    (lib.cmakeBool "PYTHON_BINDINGS" true)
+    (lib.cmakeFeature "PYTHON_VERSION" (lib.versions.majorMinor python3Packages.python.version))
+  ];
+
+  doCheck = true;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Robotic motion planning library";
+    homepage = "https://github.com/hungpham2511/toppra";
+    changelog = "https://github.com/hungpham2511/toppra/blob/${finalAttrs.src.tag}/HISTORY.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nim65s ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/development/python-modules/toppra/default.nix
+++ b/pkgs/development/python-modules/toppra/default.nix
@@ -1,0 +1,42 @@
+{
+  buildPythonPackage,
+  cython,
+  setuptools,
+  numpy,
+  matplotlib,
+  scipy,
+  pkgs,
+}:
+buildPythonPackage (finalAttrs: {
+  inherit (pkgs.toppra) pname version src;
+
+  pyproject = true;
+
+  sourceRoot = "${finalAttrs.src.name}/python";
+
+  build-system = [
+    cython
+    setuptools
+  ];
+
+  dependencies = [
+    numpy
+    matplotlib
+    scipy
+  ];
+
+  pythonImportsCheck = [
+    "toppra"
+  ];
+
+  meta = {
+    inherit (pkgs.toppra.meta)
+      changelog
+      description
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19609,6 +19609,8 @@ self: super: with self; {
 
   toposort = callPackage ../development/python-modules/toposort { };
 
+  toppra = callPackage ../development/python-modules/toppra { };
+
   toptica-lasersdk = callPackage ../development/python-modules/toptica-lasersdk { };
 
   torch = callPackage ../development/python-modules/torch/source { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
