### PR TITLE
various: fix `meta.changelog` in orphaned packages, batch 4 (and end of Python packages)

### DIFF
--- a/pkgs/development/python-modules/pymatreader/default.nix
+++ b/pkgs/development/python-modules/pymatreader/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
   meta = {
     description = "Python package to read all kinds and all versions of Matlab mat files";
     homepage = "https://gitlab.com/obob/pymatreader/";
-    changelog = "https://gitlab.com/obob/pymatreader/-/blob/${src.rev}/CHANGELOG.md";
+    changelog = "https://gitlab.com/obob/pymatreader/-/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.bsd2;
     maintainers = [ ];
   };

--- a/pkgs/development/python-modules/pynmea2/default.nix
+++ b/pkgs/development/python-modules/pynmea2/default.nix
@@ -35,7 +35,6 @@ buildPythonPackage rec {
   meta = {
     description = "Python library for the NMEA 0183 protcol";
     homepage = "https://github.com/Knio/pynmea2";
-    changelog = "https://github.com/Knio/pynmea2/releases/tag/${version}";
     license = lib.licenses.mit;
     maintainers = [ ];
   };

--- a/pkgs/development/python-modules/pyorc/default.nix
+++ b/pkgs/development/python-modules/pyorc/default.nix
@@ -71,7 +71,7 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    changelog = "https://github.com/noirello/pyorc/blob/${version}/CHANGELOG.rst";
+    changelog = "https://github.com/noirello/pyorc/blob/v${version}/CHANGELOG.rst";
     description = "Python module for Apache ORC file format";
     homepage = "https://github.com/noirello/pyorc";
     license = lib.licenses.asl20;

--- a/pkgs/development/python-modules/pyproject-metadata/default.nix
+++ b/pkgs/development/python-modules/pyproject-metadata/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
   meta = {
     description = "PEP 621 metadata parsing";
     homepage = "https://github.com/FFY00/python-pyproject-metadata";
-    changelog = "https://github.com/FFY00/python-pyproject-metadata/blob/${version}/CHANGELOG.rst";
+    changelog = "https://github.com/pypa/pyproject-metadata/releases/tag/${version}";
     license = lib.licenses.mit;
   };
 }

--- a/pkgs/development/python-modules/pysnmpcrypto/default.nix
+++ b/pkgs/development/python-modules/pysnmpcrypto/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
   meta = {
     description = "Strong crypto support for Python SNMP library";
     homepage = "https://github.com/lextudio/pysnmpcrypto";
-    changelog = "https://github.com/lextudio/pysnmpcrypto/blob/${version}/CHANGES.txt";
+    changelog = "https://github.com/lextudio/pysnmpcrypto/blob/v${version}/CHANGES.txt";
     license = lib.licenses.bsd2;
     maintainers = [ ];
   };

--- a/pkgs/development/python-modules/pythonocc-core/default.nix
+++ b/pkgs/development/python-modules/pythonocc-core/default.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Python wrapper for the OpenCASCADE 3D modeling kernel";
     homepage = "https://github.com/tpaviot/pythonocc-core";
-    changelog = "https://github.com/tpaviot/pythonocc-core/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/tpaviot/pythonocc-core/blob/${finalAttrs.src.rev}/NEWS";
     license = lib.licenses.lgpl3;
     platforms = lib.platforms.unix;
     maintainers = [ ];

--- a/pkgs/development/python-modules/seaborn/default.nix
+++ b/pkgs/development/python-modules/seaborn/default.nix
@@ -84,7 +84,7 @@ buildPythonPackage rec {
   meta = {
     description = "Statistical data visualization";
     homepage = "https://seaborn.pydata.org/";
-    changelog = "https://github.com/mwaskom/seaborn/blob/master/doc/whatsnew/${src.rev}.rst";
+    changelog = "https://github.com/mwaskom/seaborn/blob/v${version}/doc/whatsnew/v${version}.rst";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/pkgs/development/python-modules/smpplib/default.nix
+++ b/pkgs/development/python-modules/smpplib/default.nix
@@ -34,7 +34,6 @@ buildPythonPackage rec {
   meta = {
     description = "SMPP library for Python";
     homepage = "https://github.com/python-smpplib/python-smpplib";
-    changelog = "https://github.com/python-smpplib/python-smpplib/releases/tag/${version}";
     license = lib.licenses.lgpl3Plus;
     maintainers = [ ];
   };

--- a/pkgs/development/python-modules/sqlalchemy/1_3.nix
+++ b/pkgs/development/python-modules/sqlalchemy/1_3.nix
@@ -76,7 +76,11 @@ buildPythonPackage (finalAttrs: {
   pythonImportsCheck = [ "sqlalchemy" ];
 
   meta = {
-    changelog = "https://github.com/sqlalchemy/sqlalchemy/releases/tag/${finalAttrs.src.tag})";
+    changelog =
+      let
+        shortVersion = lib.replaceString "." "" (lib.versions.majorMinor finalAttrs.version);
+      in
+      "https://github.com/sqlalchemy/sqlalchemy/blob/${finalAttrs.src.rev}/doc/build/changelog/changelog_${shortVersion}.rst";
     description = "Database Toolkit for Python";
     homepage = "https://github.com/sqlalchemy/sqlalchemy";
     license = lib.licenses.mit;

--- a/pkgs/development/python-modules/sqlalchemy/1_4.nix
+++ b/pkgs/development/python-modules/sqlalchemy/1_4.nix
@@ -100,9 +100,11 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "sqlalchemy" ];
 
   meta = {
-    changelog = "https://github.com/sqlalchemy/sqlalchemy/releases/tag/rel_${
-      builtins.replaceStrings [ "." ] [ "_" ] version
-    }";
+    changelog =
+      let
+        shortVersion = lib.replaceString "." "" (lib.versions.majorMinor version);
+      in
+      "https://github.com/sqlalchemy/sqlalchemy/blob/${src.rev}/doc/build/changelog/changelog_${shortVersion}.rst";
     description = "Database Toolkit for Python";
     homepage = "https://github.com/sqlalchemy/sqlalchemy";
     license = lib.licenses.mit;

--- a/pkgs/development/python-modules/starlette-wtf/default.nix
+++ b/pkgs/development/python-modules/starlette-wtf/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Simple tool for integrating Starlette and WTForms";
-    changelog = "https://github.com/muicss/starlette-wtf/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/amorey/starlette-wtf/releases/tag/${version}";
     homepage = "https://github.com/muicss/starlette-wtf";
     license = lib.licenses.mit;
   };

--- a/pkgs/development/python-modules/stm32loader/default.nix
+++ b/pkgs/development/python-modules/stm32loader/default.nix
@@ -59,7 +59,6 @@ buildPythonPackage rec {
     description = "Flash firmware to STM32 microcontrollers in Python";
     mainProgram = "stm32loader";
     homepage = "https://github.com/florisla/stm32loader";
-    changelog = "https://github.com/florisla/stm32loader/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.gpl3;
     maintainers = [ ];
   };

--- a/pkgs/development/python-modules/terminaltexteffects/default.nix
+++ b/pkgs/development/python-modules/terminaltexteffects/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   meta = {
     description = "Collection of visual effects that can be applied to terminal piped stdin text";
     homepage = "https://chrisbuilds.github.io/terminaltexteffects";
-    changelog = "https://chrisbuilds.github.io/terminaltexteffects/changeblog/";
+    changelog = "https://chrisbuilds.github.io/terminaltexteffects/changeblog/changeblog/";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     maintainers = [ ];

--- a/pkgs/development/python-modules/verspec/default.nix
+++ b/pkgs/development/python-modules/verspec/default.nix
@@ -31,7 +31,6 @@ buildPythonPackage rec {
   meta = {
     description = "Flexible version handling";
     homepage = "https://github.com/jimporter/verspec";
-    changelog = "https://github.com/jimporter/averspec/releases/tag/v${version}";
     license = with lib.licenses; [
       bsd2 # and
       asl20

--- a/pkgs/development/python-modules/yark/default.nix
+++ b/pkgs/development/python-modules/yark/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     description = "Module for YouTube archiving";
     mainProgram = "yark";
     homepage = "https://github.com/Owez/yark";
-    changelog = "https://github.com/Owez/yark/releases/tag/v${version}";
+    changelog = "https://github.com/Owez/yark/releases/tag/v${lib.versions.majorMinor version}";
     license = lib.licenses.mit;
     maintainers = [ ];
   };

--- a/pkgs/development/python-modules/zipfile2/default.nix
+++ b/pkgs/development/python-modules/zipfile2/default.nix
@@ -6,7 +6,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "zipfile2";
   version = "0.0.12-unstable-2024-09-28";
   pyproject = true;
@@ -33,7 +33,6 @@ buildPythonPackage rec {
   meta = {
     description = "Backwards-compatible improved zipfile class";
     homepage = "https://github.com/cournape/zipfile2";
-    changelog = "https://github.com/itziakos/zipfile2/releases/tag/v${version}";
     license = lib.licenses.psfl;
     maintainers = [ ];
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

part of #514132 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
