### PR TITLE
python3Packages.pycyphal: fix doctests on python 3.14

### DIFF
--- a/pkgs/development/python-modules/pycyphal/default.nix
+++ b/pkgs/development/python-modules/pycyphal/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonAtLeast,
 
   # build system
   setuptools,
@@ -33,6 +34,9 @@ buildPythonPackage rec {
     hash = "sha256-yrGKmJW4W8bPazKHWkwgNWDPiQYg1KTEuI7hC3yOWek=";
     fetchSubmodules = true;
   };
+
+  # Set an event loop in the doctest helper; policy.get_event_loop no longer auto-creates one on 3.14.
+  patches = lib.optional (pythonAtLeast "3.14") ./python-3.14-asyncio-loop.patch;
 
   build-system = [ setuptools ];
 

--- a/pkgs/development/python-modules/pycyphal/python-3.14-asyncio-loop.patch
+++ b/pkgs/development/python-modules/pycyphal/python-3.14-asyncio-loop.patch
@@ -1,0 +1,10 @@
+--- a/tests/__init__.py
++++ b/tests/__init__.py
+@@ -37,6 +37,7 @@
+     This function shall be invoked per test, because the test suite undoes its effect before starting the next test.
+     """
+     _logger.info("asyncio_allow_event_loop_access_from_top_level()")
++    asyncio.set_event_loop(asyncio.new_event_loop())
+
+     def swap(mod: Any, name: str, new: Any) -> None:
+         restore = _PATCH_RESTORE_PREFIX + name


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/328693556)](https://hydra.nixos.org/build/328693556)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
