### PR TITLE
formats/plist: support base64 encoded binary data

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -407,6 +407,8 @@ gnuradioMinimal.override {
 
 ### Additions and Improvements {#sec-nixpkgs-release-26.05-lib-additions-improvements}
 
+- `pkgs.formats.plist` now supports emitting binary data (base64 encoded inside `<data>` tags) via the new constructor `lib.mkPlistData` and matching option type `lib.types.plistData`.
+
 - The builder `php.buildComposerProject2` for PHP applications has been improved for better reliability and stability.
 
 - The `services.drupal` module has a few improvements aimed at making it better for installing custom Drupal instances, namely a new `webRoot` option for identifying custom webroots in source code, a new `configRoot` option for identifying and synchronizing config yamls onto NixOS, and a some new settings for managing variable content and filepaths.

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -426,7 +426,7 @@ let
         addDrvOutputDependencies
         unsafeDiscardOutputDependency
         ;
-      inherit (self.generators) mkLuaInline;
+      inherit (self.generators) mkLuaInline mkPlistData;
       inherit (self.meta)
         addMetaAttrs
         dontDistribute

--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -614,6 +614,10 @@ rec {
   /**
     Translate a simple Nix expression to [Plist notation](https://en.wikipedia.org/wiki/Property_list).
 
+    Binary data can be represented by wrapping a base64-encoded
+    string with `mkPlistData`; `toPlist` emits these as `<data>`
+    elements.
+
     # Inputs
 
     Structured function argument
@@ -642,6 +646,8 @@ rec {
           str ind x
         else if isList x then
           list ind x
+        else if x ? _type && x._type == "plistData" then
+          data ind x.base64
         else if isAttrs x then
           attrs ind x
         else if isPath x then
@@ -660,6 +666,7 @@ rec {
       str = ind: x: literal ind "<string>${maybeEscapeXML x}</string>";
       key = ind: x: literal ind "<key>${maybeEscapeXML x}</key>";
       float = ind: x: literal ind "<real>${toString x}</real>";
+      data = ind: x: literal ind "<data>${x}</data>";
 
       indent = ind: expr "\t${ind}";
 
@@ -885,6 +892,26 @@ rec {
   mkLuaInline = expr: {
     _type = "lua-inline";
     inherit expr;
+  };
+
+  /**
+    Mark a string as base64-encoded binary data to be emitted inside a `<data>` tag by `toPlist`.
+
+    # Inputs
+
+    `base64`
+
+    : 1\. Function argument
+
+    # Type
+
+    ```
+    mkPlistData :: String -> { _type = "plistData"; base64 :: String; }
+    ```
+  */
+  mkPlistData = base64: {
+    _type = "plistData";
+    inherit base64;
   };
 }
 // {

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -2946,6 +2946,7 @@ runTests {
           int = 42;
           float = 0.1337;
           bool = true;
+          data = generators.mkPlistData "SGVsbG8gV29ybGQ=";
           emptystring = "";
           string = "fn\${o}\"r\\d";
           newlinestring = "\n";
@@ -2978,6 +2979,7 @@ runTests {
           int = 42;
           float = 0.1337;
           bool = true;
+          data = generators.mkPlistData "SGVsbG8gV29ybGQ=";
           emptystring = "";
           string = "fn\${o}\"r\\d";
           newlinestring = "\n";

--- a/lib/tests/test-to-plist-escaped-expected.plist
+++ b/lib/tests/test-to-plist-escaped-expected.plist
@@ -13,6 +13,8 @@
 			</dict>
 			<key>bool</key>
 			<true/>
+			<key>data</key>
+			<data>SGVsbG8gV29ybGQ=</data>
 			<key>emptyattrs</key>
 			<dict>
 

--- a/lib/tests/test-to-plist-unescaped-expected.plist
+++ b/lib/tests/test-to-plist-unescaped-expected.plist
@@ -13,6 +13,8 @@
 			</dict>
 			<key>bool</key>
 			<true/>
+			<key>data</key>
+			<data>SGVsbG8gV29ybGQ=</data>
 			<key>emptyattrs</key>
 			<dict>
 

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1043,6 +1043,15 @@ rec {
     merge = mergeEqualOption;
   };
 
+  # A value produced by `lib.generators.mkPlistData`
+  plistData = mkOptionType {
+    name = "plistData";
+    description = "plist <data> value";
+    descriptionClass = "noun";
+    check = x: x._type or null == "plistData" && isString (x.base64 or null);
+    merge = mergeEqualOption;
+  };
+
   uniq = unique { message = ""; };
 
   unique =

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -270,6 +270,12 @@ Users must still be careful about how they reference these paths.
 :   A string wrapped using `lib.mkLuaInline`. Allows embedding lua expressions
     inline within generated lua. Multiple definitions cannot be merged.
 
+`types.plistData`
+
+:   A base64-encoded string wrapped using `lib.mkPlistData`. Allows embedding
+    binary data as a `<data>` element within generated plists. Multiple
+    definitions cannot be merged.
+
 ## Submodule types {#sec-option-types-submodule}
 
 Submodules are detailed in [Submodule](#section-option-types-submodule).

--- a/nixos/doc/manual/development/settings-options.section.md
+++ b/nixos/doc/manual/development/settings-options.section.md
@@ -376,6 +376,8 @@ have a predefined type and string generator already declared under
 
     It returns a set with Property list (plist) specific attributes `type` and `generate` as specified [below](#pkgs-formats-result).
 
+    Binary `<data>` values can be produced with `lib.mkPlistData "<base64>"`.
+
 `pkgs.formats.pythonVars` { }
 
 :   A function taking an empty attribute set (for future extensibility)

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -55,6 +55,7 @@ let
     nullOr
     oneOf
     path
+    plistData
     str
     submodule
     ;
@@ -1037,6 +1038,9 @@ optionalAttrs allowAliases aliases
         let
           valueType =
             nullOr (oneOf [
+              # Must precede attrsOf so a tagged plistData attrset matches as
+              # the marker rather than as a generic attrset.
+              plistData
               bool
               int
               float

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -1116,6 +1116,30 @@ runBuildTests {
       </plist>'';
   };
 
+  PlistData = shouldPass {
+    format = formats.plist { };
+    input = {
+      holdShortcut = {
+        secureData = lib.mkPlistData "YnBsaXN0MDA=";
+        string = "⌘";
+      };
+    };
+    expected = ''
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+      <dict>
+      ''\t<key>holdShortcut</key>
+      ''\t<dict>
+      ''\t''\t<key>secureData</key>
+      ''\t''\t<data>YnBsaXN0MDA=</data>
+      ''\t''\t<key>string</key>
+      ''\t''\t<string>⌘</string>
+      ''\t</dict>
+      </dict>
+      </plist>'';
+  };
+
   hcl1Atoms = shouldPass {
     format = formats.hcl1 { };
     input = {


### PR DESCRIPTION
This PR adds `lib.mkPlistData "<base64>"` which allows users to generate Plists with binary data inside of them which then gets transformed into the Plist XML `<data>{base64}</data>`.

Based on #390120

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
