### PR TITLE
various: fix `meta.changelog` in orphaned packages, batch 5 and final

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/tekumara.typos-vscode/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/tekumara.typos-vscode/default.nix
@@ -31,7 +31,7 @@ let
     }
     .${system} or (throw "Unsupported system: ${system}");
 in
-vscode-utils.buildVscodeMarketplaceExtension {
+vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
   mktplcRef = {
     name = "typos-vscode";
     publisher = "tekumara";
@@ -57,7 +57,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
   passthru.updateScript = vscode-extension-update-script { };
 
   meta = {
-    changelog = "https://marketplace.visualstudio.com/items/tekumara.typos-vscode/changelog";
+    changelog = "https://github.com/tekumara/typos-lsp/blob/v${finalAttrs.version}/CHANGELOG.md";
     description = "VSCode extension for providing a low false-positive source code spell checker";
     downloadPage = "https://marketplace.visualstudio.com/items?itemName=tekumara.typos-vscode";
     homepage = "https://github.com/tekumara/typos-lsp";
@@ -70,4 +70,4 @@ vscode-utils.buildVscodeMarketplaceExtension {
     ];
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/sc/screentest/package.nix
+++ b/pkgs/by-name/sc/screentest/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Simple screen testing tool";
     mainProgram = "screentest";
     homepage = "https://github.com/TobiX/screentest";
-    changelog = "https://github.com/TobiX/screentest/blob/${finalAttrs.version}/NEWS";
+    changelog = "https://github.com/TobiX/screentest/blob/${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.gpl2Only;
     maintainers = [ ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/sy/syncstorage-rs/package.nix
+++ b/pkgs/by-name/sy/syncstorage-rs/package.nix
@@ -60,7 +60,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Mozilla Sync Storage built with Rust";
     homepage = "https://github.com/mozilla-services/syncstorage-rs";
-    changelog = "https://github.com/mozilla-services/syncstorage-rs/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/mozilla-services/syncstorage-rs/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.mpl20;
     maintainers = [ ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/up/uppy-companion/package.nix
+++ b/pkgs/by-name/up/uppy-companion/package.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     broken = stdenv.hostPlatform.isDarwin;
-    changelog = "https://github.com/transloadit/uppy/releases/tag/%2540uppy%252Fcompanion%2540${finalAttrs.version}";
+    changelog = "https://github.com/transloadit/uppy/releases/tag/%40uppy%2Fcompanion%40${finalAttrs.version}";
     description = "Server integration for Uppy file uploader";
     homepage = "https://uppy.io/";
     license = lib.licenses.mit;

--- a/pkgs/by-name/we/webpack-cli/package.nix
+++ b/pkgs/by-name/we/webpack-cli/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    changelog = "https://github.com/webpack/webpack-cli/blob/webpack-cli%2540${finalAttrs.version}/CHANGELOG.md";
+    changelog = "https://github.com/webpack/webpack-cli/blob/webpack-cli%40${finalAttrs.version}/CHANGELOG.md";
     description = "Webpack's Command Line Interface";
     homepage = "https://webpack.js.org/api/cli/";
     license = lib.licenses.mit;

--- a/pkgs/by-name/wg/wgnord/package.nix
+++ b/pkgs/by-name/wg/wgnord/package.nix
@@ -59,7 +59,6 @@ resholve.mkDerivation rec {
   meta = {
     description = "NordVPN Wireguard (NordLynx) client in POSIX shell";
     homepage = "https://github.com/phirecc/wgnord";
-    changelog = "https://github.com/phirecc/wgnord/releases/tag/v${version}";
     maintainers = [ ];
     license = lib.licenses.mit;
     mainProgram = "wgnord";

--- a/pkgs/by-name/zs/zsh-powerlevel10k/package.nix
+++ b/pkgs/by-name/zs/zsh-powerlevel10k/package.nix
@@ -43,7 +43,6 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    changelog = "https://github.com/romkatv/powerlevel10k/releases/tag/v${finalAttrs.version}";
     description = "Fast reimplementation of Powerlevel9k ZSH theme";
     longDescription = ''
       To make use of this derivation, use


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

part of #514132 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
