### PR TITLE
i2pd-tools: 2.56.0 -> 2.58.0-unstable-2026-04-29

### DIFF
--- a/pkgs/by-name/i2/i2pd-tools/package.nix
+++ b/pkgs/by-name/i2/i2pd-tools/package.nix
@@ -9,15 +9,13 @@
 
 stdenv.mkDerivation {
   pname = "i2pd-tools";
-  version = "2.56.0";
-
-  #tries to access the network during the tests, which fails
+  version = "2.58.0-unstable-2026-04-29";
 
   src = fetchFromGitHub {
     owner = "PurpleI2P";
     repo = "i2pd-tools";
-    rev = "33fce4b087d92ee90653460bbe7a07cdc0c7b121";
-    hash = "sha256-mmCs8AHHKhx1/rDp/Vc1p2W3pufoTa4FcJyJwD919zw=";
+    rev = "34944bbd5d0bab34694b1f57edba4b5a783f8b7b";
+    hash = "sha256-W0khA1uVHmMBQdUwPMo/q64P9I6t6Eatf/KPaamJg7I=";
     fetchSubmodules = true;
   };
 
@@ -26,13 +24,15 @@ stdenv.mkDerivation {
     openssl
     boost
   ];
+
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/bin
     for bin in \
         routerinfo keygen vain keyinfo regaddr \
-        regaddr_3ld regaddralias x25519 famtool autoconf;
+        regaddr_3ld regaddralias x25519 famtool autoconf_i2pd \
+        verifyhost offlinekeys b33address i2pbase64;
     do
       install -Dm755 $bin -t $out/bin
     done
@@ -45,6 +45,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/PurpleI2P/i2pd-tools";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ MulliganSecurity ];
-    mainProgram = "i2pd-tools";
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/i2/i2pd-tools/package.nix
+++ b/pkgs/by-name/i2/i2pd-tools/package.nix
@@ -44,7 +44,10 @@ stdenv.mkDerivation {
     description = "Toolsuite to work with keys and eepsites";
     homepage = "https://github.com/PurpleI2P/i2pd-tools";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ MulliganSecurity ];
+    maintainers = with lib.maintainers; [
+      MulliganSecurity
+      ryand56
+    ];
     platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
ZHF: #516381
Diff: https://github.com/PurpleI2P/i2pd-tools/compare/33fce4b087d92ee90653460bbe7a07cdc0c7b121...34944bbd5d0bab34694b1f57edba4b5a783f8b7b
https://hydra.nixos.org/build/327017861

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
