### PR TITLE
vgmtrans: 1.2 -> 1.3, fix future build failure due to minizip-ng

### DIFF
--- a/pkgs/by-name/vg/vgmtrans/package.nix
+++ b/pkgs/by-name/vg/vgmtrans/package.nix
@@ -2,35 +2,26 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch2,
   cmake,
   ninja,
   qt6,
   spdlog,
-  zlib-ng,
-  minizip-ng,
+  zlib,
   libbass,
   libbassmidi,
+  xz,
+  libchdr,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "vgmtrans";
-  version = "1.2";
+  version = "1.3";
 
   src = fetchFromGitHub {
     owner = "vgmtrans";
     repo = "vgmtrans";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-HVC45B1DFThZRkPVrroiay+9ufkOrTMUZoNIuC1CjjM=";
+    hash = "sha256-eI+AFZtw8+IND6bLytUZN7lPHe03LoqLnpP6SCnvQyQ=";
   };
-
-  patches = [
-    # https://github.com/vgmtrans/vgmtrans/pull/567
-    (fetchpatch2 {
-      name = "fix-version-string.patch";
-      url = "https://github.com/vgmtrans/vgmtrans/commit/5ad8a60a19476d2ae9a7c409b83ab6d5e1ff827f.patch?full_index=1";
-      hash = "sha256-I5ykYzj3tUBQ2e3TAnCm5Ry1Hmmi2IVneFQCe5/JV/A=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake
@@ -43,22 +34,30 @@ stdenv.mkDerivation (finalAttrs: {
     qt6.qtsvg
     libbass
     libbassmidi
+    xz
+    zlib
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "USE_SYSTEM_ZLIB" true)
   ];
 
   preConfigure = ''
-    rm -r lib/{spdlog,zlib-ng,minizip-ng}
+    rm -r lib/{spdlog,libchdr}
     ln -s ${spdlog.src} lib/spdlog
-    ln -s ${zlib-ng.src} lib/zlib-ng
-    ln -s ${minizip-ng.src} lib/minizip-ng
+    ln -s ${libchdr.src} lib/libchdr
+    tar xzf ${zlib.src} --strip-components=1 -C lib/zlib
   '';
 
   meta = {
     description = "Tool to convert proprietary, sequenced videogame music to industry-standard formats";
     homepage = "https://github.com/vgmtrans/vgmtrans";
-    license = with lib.licenses; [
-      zlib
-      libpng
-      bsd3 # oki_adpcm_state
+    license = [
+      # it has been previously observed that package inputs will override licenses with the same name
+      # it is imperative to not use `with lib.license` here.
+      lib.licenses.zlib
+      lib.licenses.libpng
+      lib.licenses.bsd3 # oki_adpcm_state
     ];
     # See CMakePresets.json
     platforms = [


### PR DESCRIPTION
Separating vgmtrans changes from https://github.com/NixOS/nixpkgs/pull/506086

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
