### PR TITLE
python3Packages.prometheus-flask-exporter: skip test that breaks under prometheus-client 0.24

### DIFF
--- a/pkgs/development/python-modules/prometheus-flask-exporter/default.nix
+++ b/pkgs/development/python-modules/prometheus-flask-exporter/default.nix
@@ -27,6 +27,8 @@ buildPythonPackage rec {
     prometheus-client
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeCheckInputs = [ pytestCheckHook ];
 
   enabledTestPaths = [ "tests/" ];

--- a/pkgs/development/python-modules/prometheus-flask-exporter/default.nix
+++ b/pkgs/development/python-modules/prometheus-flask-exporter/default.nix
@@ -34,6 +34,8 @@ buildPythonPackage rec {
   disabledTests = [
     # AssertionError
     "test_group_by_lambda_is_not_supported"
+    # prometheus-client 0.24 moved CONTENT_TYPE_LATEST to version=1.0.0 while choose_encoder still defaults to 0.0.4
+    "test_default_format"
   ];
 
   meta = {


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327152485)](https://hydra.nixos.org/build/327152485)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
