### PR TITLE
nixos/virtualisation/podman: add firewall.trustBridge option

### DIFF
--- a/nixos/modules/virtualisation/podman/default.nix
+++ b/nixos/modules/virtualisation/podman/default.nix
@@ -137,27 +137,36 @@ in
 
     firewall.trustBridge = mkOption {
       type = types.bool;
-      default = cfg.dockerCompat;
-      defaultText = lib.literalExpression "config.virtualisation.podman.dockerCompat";
+      default = false;
       description = ''
         Add the default podman bridge interface (typically `podman0`) to
         {option}`networking.firewall.trustedInterfaces`.
 
-        Without this, container-to-host traffic arrives on the bridge
-        interface and is filtered by the host firewall — services bound on
-        the host that are intentionally exposed to the LAN/VPN via
-        per-interface allow-lists (e.g. `networking.firewall.interfaces.<wg
-        / lan>.allowedTCPPorts`) are silently unreachable from containers,
-        because the rules don't match the bridge interface. Trusting the
-        bridge fixes this without forcing every host service to also open
-        ports on the bridge interface explicitly.
+        Container-to-host traffic terminating at a host-bound service
+        enters the host's `INPUT` chain on the bridge interface
+        (`podman0` for the default network, or whatever
+        {option}`virtualisation.podman.defaultNetwork.settings.network_interface`
+        names). Per-interface allow-lists scoped to other interfaces, e.g.
 
-        Defaults to the value of {option}`virtualisation.podman.dockerCompat`:
-        users opting into docker emulation expect docker-like permissive
-        container-to-host networking, while users running podman in its
-        stricter native mode keep the host firewall in front of the bridge.
+        ```nix
+        networking.firewall.interfaces.wg-home.allowedTCPPorts = [ 6379 ];
+        ```
 
-        Has no effect when the firewall backend is `firewalld`.
+        do not match this bridge ingress, so containers cannot reach
+        services that are only allow-listed on the LAN/VPN side. Setting
+        this option marks the bridge as trusted, accepting all
+        container-to-host traffic regardless of port allow-lists. The
+        alternative is to duplicate every relevant `allowedTCPPorts` /
+        `allowedUDPPorts` rule on the bridge interface, which is easy to
+        forget and grows unwieldy.
+
+        Defaults to `false` (opt-in only): trusting a bridge changes the
+        host's firewall surface, so users explicitly choose this rather
+        than inheriting it from an unrelated option.
+
+        Honored by both the iptables/nftables backend (via
+        {option}`networking.firewall.trustedInterfaces`) and the firewalld
+        backend (via the `trusted` zone, which consumes the same option).
       '';
     };
 
@@ -276,11 +285,21 @@ in
         source = json.generate "podman.json" networkConfig;
       };
 
-      # containers cannot reach aardvark-dns otherwise
-      networking.firewall = lib.mkIf (config.networking.firewall.backend != "firewalld") {
-        interfaces.${network_interface}.allowedUDPPorts = lib.mkIf dns_enabled [ 53 ];
-        trustedInterfaces = lib.optional cfg.firewall.trustBridge network_interface;
-      };
+      # `trustedInterfaces` is honored by every firewall backend — the
+      # iptables/nftables backends consume it directly, and the firewalld
+      # backend maps it to the `trusted` zone (see
+      # `nixos/modules/services/networking/firewall-firewalld.nix`).
+      # The aardvark-dns rule, on the other hand, is iptables/nftables-only;
+      # firewalld has its own DNS handling.
+      networking.firewall = lib.mkMerge [
+        {
+          trustedInterfaces = lib.optional cfg.firewall.trustBridge network_interface;
+        }
+        # containers cannot reach aardvark-dns otherwise
+        (lib.mkIf (config.networking.firewall.backend != "firewalld") {
+          interfaces.${network_interface}.allowedUDPPorts = lib.mkIf dns_enabled [ 53 ];
+        })
+      ];
 
       virtualisation.containers = {
         enable = true; # Enable common /etc/containers configuration

--- a/nixos/modules/virtualisation/podman/default.nix
+++ b/nixos/modules/virtualisation/podman/default.nix
@@ -135,6 +135,32 @@ in
       '';
     };
 
+    firewall.trustBridge = mkOption {
+      type = types.bool;
+      default = cfg.dockerCompat;
+      defaultText = lib.literalExpression "config.virtualisation.podman.dockerCompat";
+      description = ''
+        Add the default podman bridge interface (typically `podman0`) to
+        {option}`networking.firewall.trustedInterfaces`.
+
+        Without this, container-to-host traffic arrives on the bridge
+        interface and is filtered by the host firewall — services bound on
+        the host that are intentionally exposed to the LAN/VPN via
+        per-interface allow-lists (e.g. `networking.firewall.interfaces.<wg
+        / lan>.allowedTCPPorts`) are silently unreachable from containers,
+        because the rules don't match the bridge interface. Trusting the
+        bridge fixes this without forcing every host service to also open
+        ports on the bridge interface explicitly.
+
+        Defaults to the value of {option}`virtualisation.podman.dockerCompat`:
+        users opting into docker emulation expect docker-like permissive
+        container-to-host networking, while users running podman in its
+        stricter native mode keep the host firewall in front of the bridge.
+
+        Has no effect when the firewall backend is `firewalld`.
+      '';
+    };
+
     autoPrune = {
       enable = mkOption {
         type = types.bool;
@@ -253,6 +279,7 @@ in
       # containers cannot reach aardvark-dns otherwise
       networking.firewall = lib.mkIf (config.networking.firewall.backend != "firewalld") {
         interfaces.${network_interface}.allowedUDPPorts = lib.mkIf dns_enabled [ 53 ];
+        trustedInterfaces = lib.optional cfg.firewall.trustBridge network_interface;
       };
 
       virtualisation.containers = {

--- a/nixos/tests/podman/default.nix
+++ b/nixos/tests/podman/default.nix
@@ -74,6 +74,50 @@ import ../make-test-python.nix (
             isNormalUser = true;
           };
         };
+
+      # Asserts that `firewall.trustBridge = true` lets a container reach a
+      # host service whose port is allow-listed only on the host's primary
+      # interface (not on the bridge). With `false` the same connection is
+      # dropped by the host firewall.
+      trustBridge =
+        { pkgs, ... }:
+        {
+          virtualisation.podman.enable = true;
+          virtualisation.podman.firewall.trustBridge = true;
+
+          # Per-interface allow-list: 12345 open on eth0, NOT on podman0
+          # (and not in the global allow-list). Without trustBridge=true,
+          # container-originated traffic to the host on this port is dropped.
+          networking.firewall.allowedTCPPorts = [ ];
+          networking.firewall.interfaces.eth0.allowedTCPPorts = [ 12345 ];
+
+          # Tiny host service bound to all interfaces; reachable only
+          # through the firewall hole on whichever interface the request
+          # arrives on.
+          systemd.services.host-probe = {
+            wantedBy = [ "multi-user.target" ];
+            after = [ "network-online.target" ];
+            wants = [ "network-online.target" ];
+            serviceConfig.ExecStart = "${pkgs.python3}/bin/python -m http.server --bind 0.0.0.0 12345";
+          };
+        };
+
+      noTrustBridge =
+        { pkgs, ... }:
+        {
+          virtualisation.podman.enable = true;
+          virtualisation.podman.firewall.trustBridge = false;
+
+          networking.firewall.allowedTCPPorts = [ ];
+          networking.firewall.interfaces.eth0.allowedTCPPorts = [ 12345 ];
+
+          systemd.services.host-probe = {
+            wantedBy = [ "multi-user.target" ];
+            after = [ "network-online.target" ];
+            wants = [ "network-online.target" ];
+            serviceConfig.ExecStart = "${pkgs.python3}/bin/python -m http.server --bind 0.0.0.0 12345";
+          };
+        };
     };
 
     testScript = ''
@@ -90,6 +134,8 @@ import ../make-test-python.nix (
       rootless.wait_for_unit("sockets.target")
       dns.wait_for_unit("sockets.target")
       docker.wait_for_unit("sockets.target")
+      trustBridge.wait_for_unit("sockets.target")
+      noTrustBridge.wait_for_unit("sockets.target")
       start_all()
 
       with subtest("Run container as root with runc"):
@@ -241,6 +287,34 @@ import ../make-test-python.nix (
           rootless.systemctl("start quadlet", "alice")
           rootless.wait_until_succeeds(su_cmd("podman ps | grep quadlet"), timeout=20)
           rootless.systemctl("stop quadlet", "alice")
+
+      with subtest("firewall.trustBridge=true allows container -> host on per-iface allow-listed port"):
+          trustBridge.wait_for_unit("host-probe.service")
+          trustBridge.wait_for_open_port(12345)
+
+          host_ip = trustBridge.succeed("ip -o -4 addr show eth0 | awk '{print $4}' | cut -d/ -f1").strip()
+
+          trustBridge.succeed("tar cv --files-from /dev/null | podman import - scratchimg")
+          # The default network puts the container on podman0; without
+          # trustBridge=true, the host's firewall would drop the SYN since
+          # 12345 is allow-listed only on eth0.
+          trustBridge.succeed(
+              "podman run --rm -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg "
+              f"${pkgs.curl}/bin/curl --max-time 5 --silent --fail http://{host_ip}:12345/"
+          )
+
+      with subtest("firewall.trustBridge=false (default) blocks the same connection"):
+          noTrustBridge.wait_for_unit("host-probe.service")
+          noTrustBridge.wait_for_open_port(12345)
+
+          host_ip = noTrustBridge.succeed("ip -o -4 addr show eth0 | awk '{print $4}' | cut -d/ -f1").strip()
+
+          noTrustBridge.succeed("tar cv --files-from /dev/null | podman import - scratchimg")
+          # Container's curl should fail with timeout/refused. We assert curl exits non-zero.
+          noTrustBridge.fail(
+              f"podman run --rm -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg "
+              f"${pkgs.curl}/bin/curl --max-time 5 --silent --fail http://{host_ip}:12345/"
+          )
 
       # TODO: add docker-compose test
 


### PR DESCRIPTION
## Summary

Adds `virtualisation.podman.firewall.trustBridge` so the podman default-bridge interface (`podman0`) can be added to `networking.firewall.trustedInterfaces` from the podman module itself.

### Why

Container-to-host traffic terminating at a host-bound service enters the host's `INPUT` chain on the bridge interface (`podman0` for the default network). Per-interface allow-lists scoped to other interfaces, e.g.

```nix
networking.firewall.interfaces.wg-home.allowedTCPPorts = [ 6379 ];
```

don't match this bridge ingress, so containers can't reach services that are only allow-listed on the LAN/VPN side. The current workaround is to either set `networking.firewall.trustedInterfaces = [ "podman0" ];` manually or duplicate every relevant `allowedTCPPorts` rule on the bridge interface — both unobvious and easy to miss when debugging "container can't reach Redis on the host" / "container can't reach a host-bound metrics endpoint" / etc.

### Default

`false` (opt-in). Trusting a bridge changes the host's firewall surface, so users explicitly choose this rather than inheriting it from an unrelated option.

### Backend coverage

Honored by both backends:

- **iptables/nftables**: consumed directly by `networking.firewall.trustedInterfaces`.
- **firewalld**: `nixos/modules/services/networking/firewall-firewalld.nix` maps `trustedInterfaces` to firewalld's `trusted` zone (line 57: `trusted.interfaces = cfg.trustedInterfaces;`). The aardvark-dns rule a few lines below stays guarded by `backend != "firewalld"` since firewalld has its own DNS handling.

The firewall block is now a `lib.mkMerge [...]` so `trustedInterfaces` and the firewalld-only DNS rule live in a single declaration (avoids the lint warning about duplicate `networking.firewall` attribute paths).

### Behavior matrix

Verified via `nix-instantiate --eval` on a minimal NixOS configuration:

| podman.enable | trustBridge | backend | `trustedInterfaces` |
|---------------|-------------|---------|---------------------|
| `true`        | `false` (default) | iptables (default) | `[ "lo" ]` |
| `true`        | `true`            | iptables            | `[ "podman0" "lo" ]` |
| `true`        | `true`            | `firewalld`         | `[ "podman0" "lo" ]` |

### Test

Added two nodes to `nixos/tests/podman/default.nix` exercising the actual behavioral delta:

- **`trustBridge`**: option enabled, host service on port 12345, `networking.firewall.allowedTCPPorts = [ ];` and `networking.firewall.interfaces.eth0.allowedTCPPorts = [ 12345 ];`. A container does `curl http://<eth0-ip>:12345/` and must succeed.
- **`noTrustBridge`**: same setup with the option disabled. Same curl must fail (firewall drops on bridge ingress).

`nix build .#nixosTests.podman` passes.

### Notes

- Uses `network_interface` from the same `networkConfig` block as the existing aardvark-dns rule, so users who customize the bridge name via `defaultNetwork.settings.network_interface` get the right interface trusted automatically.
- Default-network only. A future extension could generalize to non-default networks (`virtualisation.podman.networks.<name>.firewall.trustBridge`); deferring that until there's demand.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
