### PR TITLE
python3Packages.nodriver: fix non-utf-8 source byte for python 3.14

### DIFF
--- a/pkgs/development/python-modules/nodriver/default.nix
+++ b/pkgs/development/python-modules/nodriver/default.nix
@@ -18,6 +18,11 @@ buildPythonPackage rec {
     hash = "sha256-SsjNiLavEzwm3BV/t49asXRipZtKDaMwTjrxK75LQ0M=";
   };
 
+  patches = [
+    # https://github.com/ultrafunkamsterdam/nodriver/pull/36
+    ./python-3.14-network-py-encoding.patch
+  ];
+
   dependencies = [
     deprecated
     mss

--- a/pkgs/development/python-modules/nodriver/python-3.14-network-py-encoding.patch
+++ b/pkgs/development/python-modules/nodriver/python-3.14-network-py-encoding.patch
@@ -1,0 +1,11 @@
+--- a/nodriver/cdp/network.py
++++ b/nodriver/cdp/network.py
+@@ -1362,7 +1362,7 @@
+     #: Cookie expiration date as the number of seconds since the UNIX epoch.
+     #: The value is set to -1 if the expiry date is not set.
+     #: The value can be null for values that cannot be represented in
+-    #: JSON (±Inf).
++    #: JSON (Â±Inf).
+     expires: typing.Optional[float] = None
+ 
+     #: Cookie SameSite type.


### PR DESCRIPTION
Borrowed the patch from upstream's pr: https://github.com/ultrafunkamsterdam/nodriver/pull/36
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327149654)](https://hydra.nixos.org/build/327149654)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
](https://github.com/ultrafunkamsterdam/nodriver/pull/36)