### PR TITLE
lpd8editor: 0.0.16 -> 0.0.18

### DIFF
--- a/pkgs/by-name/lp/lpd8editor/package.nix
+++ b/pkgs/by-name/lp/lpd8editor/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  qt5,
+  qt6Packages,
   stdenv,
   gitMinimal,
   fetchFromGitHub,
@@ -10,24 +10,26 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lpd8editor";
-  version = "0.0.16";
+  version = "0.0.18";
 
   src = fetchFromGitHub {
     owner = "charlesfleche";
     repo = "lpd8editor";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-lRp2RhNiIf1VrryfKqYFSbKG3pktw3M7B49fXVoj+C8=";
+    hash = "sha256-ru6uyoBWWab/D1YLfJ8qXlFOazSJXQER7jgOgjHYrvc=";
   };
 
   buildInputs = [
-    qt5.qttools
+    qt6Packages.qtbase
+    qt6Packages.qtsvg
+    qt6Packages.qttools
     alsa-lib
   ];
 
   nativeBuildInputs = [
     cmake
     gitMinimal
-    qt5.wrapQtAppsHook
+    qt6Packages.wrapQtAppsHook
   ];
 
   meta = {


### PR DESCRIPTION
Update to 0.0.18

update build to qt6

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
