### PR TITLE
python3Packages.migen: fix build with python 3.14

### DIFF
--- a/pkgs/development/python-modules/migen/default.nix
+++ b/pkgs/development/python-modules/migen/default.nix
@@ -20,6 +20,11 @@ buildPythonPackage {
     hash = "sha256-gRAvl5cUvrjq4t7htXsDBt4F8MEbHXFZoS0jbhrEs1I=";
   };
 
+  patches = [
+    # Add LOAD_FAST_BORROW to opcode tracer for python 3.14.
+    ./tracer-3.14.patch
+  ];
+
   nativeBuildInputs = [ setuptools ];
 
   propagatedBuildInputs = [ colorama ];

--- a/pkgs/development/python-modules/migen/tracer-3.14.patch
+++ b/pkgs/development/python-modules/migen/tracer-3.14.patch
@@ -1,0 +1,10 @@
+--- a/migen/fhdl/tracer.py
++++ b/migen/fhdl/tracer.py
+@@ -38,6 +38,7 @@ _load_build_opcodes = {
+     "BUILD_LIST" : _bytecode_length_version_guard(3),
+     "CACHE" : _bytecode_length_version_guard(3),
+     "COPY" : _bytecode_length_version_guard(3),
++    "LOAD_FAST_BORROW" : _bytecode_length_version_guard(3),
+ }
+
+


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327146592)](https://hydra.nixos.org/build/327146592)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
