### PR TITLE
tirith: 0.2.12 -> 0.3.1

### DIFF
--- a/pkgs/by-name/ti/tirith/package.nix
+++ b/pkgs/by-name/ti/tirith/package.nix
@@ -8,20 +8,25 @@
 }:
 rustPlatform.buildRustPackage (final: {
   pname = "tirith";
-  version = "0.2.12";
+  version = "0.3.1";
   src = fetchFromGitHub {
     owner = "sheeki03";
     repo = "tirith";
     tag = "v${final.version}";
-    hash = "sha256-O0IRWiNib7sc6y17NdHcFfxKW5M37l/87kBEAJiTMWs=";
+    hash = "sha256-RdStW5ubqypdmFqNk9DHtUp5jHnZdXiWW/lAlSaBb3c=";
   };
 
-  cargoHash = "sha256-mIQ1zvAh+a7EyyNoYEZFdYUaQ9drIE2WfHmFHvgFUFM=";
+  cargoHash = "sha256-/V2vv02x0zSsJCcJMSttG9eekRZMK7KTk6m2VYePFa8=";
 
   cargoBuildFlags = [
     "-p"
     "tirith"
   ];
+
+  postPatch = ''
+    # The bash_preexec_enforce tests require a shell with job control
+    rm crates/tirith/tests/bash_preexec_enforce.rs
+  '';
 
   checkFlags = [
     # requires a fully functional shell environment, generating init scripts needs a patch under nix to work at build time
@@ -34,6 +39,7 @@ rustPlatform.buildRustPackage (final: {
   ];
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
+  __darwinAllowLocalNetworking = true;
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd tirith \


### PR DESCRIPTION
Update to 0.3.1

Remove a test that is not working in sandbox

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
