### PR TITLE
evtx: 0.10.0 -> 0.11.2

### DIFF
--- a/pkgs/by-name/ev/evtx/package.nix
+++ b/pkgs/by-name/ev/evtx/package.nix
@@ -6,21 +6,28 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "evtx";
-  version = "0.10.0";
+  version = "0.11.2";
 
   src = fetchFromGitHub {
     owner = "omerbenamram";
     repo = "evtx";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-v57lo1ggElGJD618ojuADspmhlZAMgmzD5DxEdtp2Ak=";
+    hash = "sha256-LVGw/u5xq+m96zSMPbQDpMnfMHq7FyQnzkmGMUMVgwM=";
   };
 
-  cargoHash = "sha256-qjlN10YS79S0JV2MPFB9SxPDUQnoVdqVf8kYpLt4w9g=";
+  cargoHash = "sha256-RnuWlfmzOZzOMfeKo8tv9I4elLQgpn9IbVa0EpYGnI0=";
 
   postPatch = ''
     # CLI tests will fail in the sandbox
     rm tests/test_cli_interactive.rs
   '';
+
+  checkFlags = [
+    "--skip=wevt_templates_research::wevt_dll_adtschema"
+    "--skip=wevt_templates_research::wevt_dll_lsasrv"
+    "--skip=wevt_templates_research::wevt_dll_services"
+    "--skip=wevt_templates_research::wevt_dll_wevtsvc"
+  ];
 
   meta = {
     description = "Parser for the Windows XML Event Log (EVTX) format";


### PR DESCRIPTION
Update to 0.11.2

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
