### PR TITLE
[25.11] istioctl: 1.28.0 -> 1.28.6

### DIFF
--- a/pkgs/by-name/is/istioctl/package.nix
+++ b/pkgs/by-name/is/istioctl/package.nix
@@ -7,15 +7,15 @@
 
 buildGoModule rec {
   pname = "istioctl";
-  version = "1.28.0";
+  version = "1.28.1";
 
   src = fetchFromGitHub {
     owner = "istio";
     repo = "istio";
     rev = version;
-    hash = "sha256-NLARp5Gw04UosyLw3TkEmtvSLKa+tYp4s60UKvcJOgw=";
+    hash = "sha256-Klew+aFwF4KmOud6GLqZ+H7HyydFGFa7oX79r7/ylGs=";
   };
-  vendorHash = "sha256-ge9aR3ZYOJaYp0D1UWzzg40nXlwM/Sl1Ep+u1CmdSV8=";
+  vendorHash = "sha256-Cv7wG8ws/wuMOT1JQFNemfNYxcJrcN0H+srQC2xNbMA=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/is/istioctl/package.nix
+++ b/pkgs/by-name/is/istioctl/package.nix
@@ -7,15 +7,15 @@
 
 buildGoModule rec {
   pname = "istioctl";
-  version = "1.28.1";
+  version = "1.28.2";
 
   src = fetchFromGitHub {
     owner = "istio";
     repo = "istio";
     rev = version;
-    hash = "sha256-Klew+aFwF4KmOud6GLqZ+H7HyydFGFa7oX79r7/ylGs=";
+    hash = "sha256-T3bhFAIsdnobcTYc80jY7mtIKRjBK6OcqGR59ko6q3s=";
   };
-  vendorHash = "sha256-Cv7wG8ws/wuMOT1JQFNemfNYxcJrcN0H+srQC2xNbMA=";
+  vendorHash = "sha256-QcPtQV3sO+B2NtxJvOi5x5hlAI1ace4LqWO84fAovGw=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/is/istioctl/package.nix
+++ b/pkgs/by-name/is/istioctl/package.nix
@@ -7,13 +7,13 @@
 
 buildGoModule rec {
   pname = "istioctl";
-  version = "1.28.2";
+  version = "1.28.3";
 
   src = fetchFromGitHub {
     owner = "istio";
     repo = "istio";
     rev = version;
-    hash = "sha256-T3bhFAIsdnobcTYc80jY7mtIKRjBK6OcqGR59ko6q3s=";
+    hash = "sha256-V8yG0Dj2/KevTiG9C68SlkLzo5xkblxMYhsZOq1ucgc=";
   };
   vendorHash = "sha256-QcPtQV3sO+B2NtxJvOi5x5hlAI1ace4LqWO84fAovGw=";
 

--- a/pkgs/by-name/is/istioctl/package.nix
+++ b/pkgs/by-name/is/istioctl/package.nix
@@ -7,15 +7,15 @@
 
 buildGoModule rec {
   pname = "istioctl";
-  version = "1.28.3";
+  version = "1.28.6";
 
   src = fetchFromGitHub {
     owner = "istio";
     repo = "istio";
     rev = version;
-    hash = "sha256-V8yG0Dj2/KevTiG9C68SlkLzo5xkblxMYhsZOq1ucgc=";
+    hash = "sha256-f+JuqJ8BtnAtGSsJu7zqWgrRNwekRf/LMr9jPM9BGLg=";
   };
-  vendorHash = "sha256-QcPtQV3sO+B2NtxJvOi5x5hlAI1ace4LqWO84fAovGw=";
+  vendorHash = "sha256-Pi9z3Ax4SL73iNsOlA+3SKYg8RwghErhlPRjyV9Gidc=";
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
diff: https://github.com/istio/istio/compare/1.28.0...1.28.6
news: https://istio.io/latest/news/

I can't find anything breaking in the changelog so this should be fine backporting. I can also target `1.28.6` if that's preferred though.

Closes #498851
Closes #498858
Closes #518018

Backports #467687
Backports #467687
Backports #481961

<details>
<summary>nixpkgs-review</summary>

## `nixpkgs-review` result

Generated using [`nixpkgs-review-gha`](https://github.com/Defelo/nixpkgs-review-gha)

Command: `nixpkgs-review pr 518708`
Commit: [`8432a9daf7d5ff361818bde9ca80bcac82fbf953`](https://github.com/NixOS/nixpkgs/commit/8432a9daf7d5ff361818bde9ca80bcac82fbf953) ([subsequent changes](https://github.com/NixOS/nixpkgs/compare/8432a9daf7d5ff361818bde9ca80bcac82fbf953..pull/518708/head))
Merge: [`16c671801a309e61632905bee0f5771fd8af23c8`](https://github.com/NixOS/nixpkgs/commit/16c671801a309e61632905bee0f5771fd8af23c8)

Logs: https://github.com/Hythera/nixpkgs-review-gha/actions/runs/25630705837


---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>istioctl</li>
  </ul>
</details>

---
### `aarch64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>istioctl</li>
  </ul>
</details>

---
### `x86_64-darwin` (sandbox = relaxed)
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>istioctl</li>
  </ul>
</details>

---
### `aarch64-darwin` (sandbox = relaxed)
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>istioctl</li>
  </ul>
</details>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
