### PR TITLE
polyphone: 2.4.1 -> 2.5.1

### DIFF
--- a/pkgs/by-name/po/polyphone/package.nix
+++ b/pkgs/by-name/po/polyphone/package.nix
@@ -8,19 +8,20 @@
   libjack2,
   libogg,
   libvorbis,
+  libsndfile,
   rtmidi,
   kdePackages,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "2.4.1";
+  version = "2.5.1";
   pname = "polyphone";
 
   src = fetchFromGitHub {
     owner = "davy7125";
     repo = "polyphone";
     tag = finalAttrs.version;
-    hash = "sha256-43EswCgNJv11Ov+4vmj2vS/yJ2atyzkRmk/SoCKYD/0=";
+    hash = "sha256-zs8fdHC1/bR2m05+SEmsMPyxATE/KHcAj57DNYt63rQ=";
   };
 
   nativeBuildInputs = [
@@ -37,6 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     libjack2
     libogg
     libvorbis
+    libsndfile
     kdePackages.qtsvg
     kdePackages.qtwayland
     rtmidi


### PR DESCRIPTION
Update to 2.5.1

Add libsndfile dependency which is required in 2.5.1

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
