### PR TITLE
nixos/modular-services: reload/restart on `configData` change

### DIFF
--- a/lib/services/config-data-item.nix
+++ b/lib/services/config-data-item.nix
@@ -51,6 +51,16 @@ in
       type = types.path;
       description = "Path of the source file.";
     };
+
+    applyChanges = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Whether a change in this file should be applied to the running service during activation.
+
+        `null` means to use the service's {option}`applyConfigDataChanges` setting.
+      '';
+    };
   };
 
   config = {

--- a/lib/services/config-data.nix
+++ b/lib/services/config-data.nix
@@ -43,5 +43,17 @@ in
 
       type = types.lazyAttrsOf (types.submodule (importApply ./config-data-item.nix pkgs));
     };
+
+    applyConfigDataChanges = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether the service manager should apply changes to this service's {option}`configData` when the configuration is activated, by reloading the service if it can be reloaded, or restarting it otherwise.
+
+        Set this to `false` for services that watch their own configuration files, or where interrupting the service is unacceptable.
+
+        Individual entries may override this with {option}`configData.<name>.applyChanges`.
+      '';
+    };
   };
 }

--- a/lib/services/test.nix
+++ b/lib/services/test.nix
@@ -91,10 +91,16 @@ let
     ];
   };
 
+  # Every service carries some assertions that hold; only the violated ones are of interest here.
+  failures = lib.filter (a: !a.assertion);
+
   filterEval =
     config:
     lib.optionalAttrs (config ? process) {
-      inherit (config) assertions warnings process;
+      inherit (config) warnings;
+      assertions = failures config.assertions;
+      # Only `argv` is relevant here; `process` also carries the reload options.
+      process = { inherit (config.process) argv; };
     }
     // {
       services = lib.mapAttrs (k: filterEval) config.services;
@@ -165,7 +171,7 @@ let
       ];
 
     assert
-      portable-lib.getAssertions [ "service1" ] exampleEval.config.services.service1 == [
+      failures (portable-lib.getAssertions [ "service1" ] exampleEval.config.services.service1) == [
         {
           message = "in service1: you can't enable this for that reason";
           assertion = false;
@@ -177,7 +183,7 @@ let
         "in service3.services.exclacow: The `bar' service is deprecated and will go away soon!"
       ];
     assert
-      portable-lib.getAssertions [ "service3" ] exampleEval.config.services.service3 == [
+      failures (portable-lib.getAssertions [ "service3" ] exampleEval.config.services.service3) == [
         {
           message = "in service3.services.exclacow: you can't enable this for such reason";
           assertion = false;

--- a/nixos/modules/system/service/README.md
+++ b/nixos/modules/system/service/README.md
@@ -51,8 +51,12 @@ Many services implement automatic reloading or reloading on e.g. `SIGUSR1`, but 
   Fun fact: for the module system it is a completely normal module, despite its recursive definition.
   If we parameterize `/etc/system-services`, it will have to become an `importApply` style module nonetheless (function returning module).
 
-- **Simple attribute structure**: Unlike `environment.etc`, `configData` uses a simpler structure with just `enable`, `name`, `text`, `source`, and `path` attributes. Complex ownership options were omitted for simplicity and portability.
+- **Simple attribute structure**: Unlike `environment.etc`, `configData` uses a simpler structure with just `enable`, `name`, `text`, `source`, `path` and `applyChanges` attributes. Complex ownership options were omitted for simplicity and portability.
   Per-service user creation is still TBD.
+
+- **Apply-on-activation opt-out in the portable layer**: `applyConfigDataChanges` is declared next to `configData` rather than in the systemd implementation, because "this service applies configuration changes by itself" is a property of the program, not of the service manager.
+  It is a `bool` rather than a reload/restart enum: it says only *whether* changes should be applied, leaving *how* (systemd's reload versus restart) to the service manager.
+  Per-entry `configData.<name>.applyChanges` defaults to `null`, meaning it inherits the service-level setting, so a single noisy file can be excluded or re-included on its own.
 
 ## No `pkgs` module argument
 

--- a/nixos/modules/system/service/systemd/system.nix
+++ b/nixos/modules/system/service/systemd/system.nix
@@ -47,15 +47,60 @@ let
     in
     serviceConfigData // subServiceConfigData;
 
+  configDataSources =
+    service:
+    let
+      applyDefault = service.applyConfigDataChanges or true;
+    in
+    lib.mapAttrsToList (_: cfg: cfg.source) (
+      lib.filterAttrs (
+        _: cfg: cfg.enable && (if cfg.applyChanges == null then applyDefault else cfg.applyChanges)
+      ) (service.configData or { })
+    );
+
+  # Whether a unit declares a command to reload with. `serviceConfig.ExecReload` is always
+  # defined by ./service.nix, as `systemd.mainExecReload`, which is the empty string when the
+  # service has no `process.reloadCommand`. An empty entry resets systemd's command list
+  # rather than adding to it, so it does not make the unit reloadable.
+  hasExecReload =
+    unitConfig:
+    let
+      execReload = unitConfig.serviceConfig.ExecReload or null;
+    in
+    if execReload == null then
+      false
+    else if lib.isList execReload then
+      lib.any (cmd: cmd != "") execReload
+    else
+      execReload != "";
+
   makeUnits =
     unitType: prefix: service:
-    concatMapAttrs (unitName: unitModule: {
-      "${dash prefix unitName}" =
-        { ... }:
-        {
-          imports = [ unitModule ];
-        };
-    }) service.systemd.${unitType}
+    let
+      sources = configDataSources service;
+    in
+    concatMapAttrs (
+      unitName: unitModule:
+      let
+        extra = lib.optional (unitType == "services" && unitName == "" && sources != [ ]) (
+          { config, ... }:
+          {
+            # switch-to-configuration-ng does not fall back from reload to restart:
+            # X-Reload-Triggers on a unit without ExecReload= causes activation to
+            # exit with code 4. Use reloadTriggers only when ExecReload is declared.
+            reloadTriggers = lib.mkIf (hasExecReload config) sources;
+            restartTriggers = lib.mkIf (!hasExecReload config) sources;
+          }
+        );
+      in
+      {
+        "${dash prefix unitName}" =
+          { ... }:
+          {
+            imports = [ unitModule ] ++ extra;
+          };
+      }
+    ) service.systemd.${unitType}
     // concatMapAttrs (
       subServiceName: subService: makeUnits unitType (dash prefix subServiceName) subService
     ) service.services;

--- a/nixos/modules/system/service/systemd/test.nix
+++ b/nixos/modules/system/service/systemd/test.nix
@@ -91,6 +91,52 @@ let
             config.systemd.lib.escapeSystemdExecArgs config.process.argv + " --systemd-unit %n";
         };
 
+      # Test that configData sources are wired into restartTriggers on
+      # the primary unit (no ExecReload), including for sub-services,
+      # while disabled entries are excluded.
+      system.services.cfgtest = {
+        process.argv = [ hello' ];
+        configData."app.conf".text = "hello = world\n";
+        configData."disabled.conf" = {
+          text = "should not appear\n";
+          enable = false;
+        };
+        configData."noapply.conf" = {
+          text = "not applied on activation\n";
+          applyChanges = false;
+        };
+        services.sub = {
+          process.argv = [ hello' ];
+          configData."sub.conf".text = "sub = yes\n";
+        };
+      };
+
+      # Test that configData sources are wired into reloadTriggers when
+      # ExecReload is declared.
+      system.services.cfgtest-reload = {
+        process.argv = [ hello' ];
+        process.reloadCommand = "${hello}/bin/hello";
+        configData."reload.conf".text = "reload = me\n";
+      };
+
+      # Test that applyConfigDataChanges = false opts the whole service out.
+      system.services.cfgtest-noapply = {
+        process.argv = [ hello' ];
+        applyConfigDataChanges = false;
+        configData."skip.conf".text = "skip = yes\n";
+      };
+
+      # Test that a per-entry applyChanges overrides the service-level setting.
+      system.services.cfgtest-noapply-override = {
+        process.argv = [ hello' ];
+        applyConfigDataChanges = false;
+        configData."skip.conf".text = "skip = yes\n";
+        configData."forced.conf" = {
+          text = "forced = yes\n";
+          applyChanges = true;
+        };
+      };
+
       # irrelevant stuff
       system.stateVersion = "25.05";
       fileSystems."/" = {
@@ -140,6 +186,47 @@ runCommand "test-modular-service-systemd-units"
       [[ ! -e ${toplevel}/etc/systemd/system/foo.socket ]]
       [[ ! -e ${toplevel}/etc/systemd/system/bar.socket ]]
       [[ ! -e ${toplevel}/etc/systemd/system/bar-db.socket ]]
+
+      # cfgtest has no ExecReload, so configData sources go into restartTriggers
+      # (X-Restart-Triggers), not reloadTriggers.
+      grep -E '^X-Restart-Triggers=' ${toplevel}/etc/systemd/system/cfgtest.service >/dev/null
+      cfgtest_trigger=$(grep -oP '^X-Restart-Triggers=\K\S+' ${toplevel}/etc/systemd/system/cfgtest.service)
+      grep -F "service-configdata-app.conf" "$cfgtest_trigger" >/dev/null
+      ! grep -F "service-configdata-disabled.conf" "$cfgtest_trigger" >/dev/null
+      # Entries with applyChanges = false are excluded.
+      ! grep -F "service-configdata-noapply.conf" "$cfgtest_trigger" >/dev/null
+      ! grep -E '^X-Reload-Triggers=' ${toplevel}/etc/systemd/system/cfgtest.service >/dev/null
+
+      # Sub-service primary unit gets its own configData via restartTriggers, not the parent's.
+      grep -E '^X-Restart-Triggers=' ${toplevel}/etc/systemd/system/cfgtest-sub.service >/dev/null
+      cfgtest_sub_trigger=$(grep -oP '^X-Restart-Triggers=\K\S+' ${toplevel}/etc/systemd/system/cfgtest-sub.service)
+      grep -F "service-configdata-sub.conf" "$cfgtest_sub_trigger" >/dev/null
+      ! grep -F "service-configdata-app.conf" "$cfgtest_sub_trigger" >/dev/null
+      ! grep -E '^X-Reload-Triggers=' ${toplevel}/etc/systemd/system/cfgtest-sub.service >/dev/null
+
+      # cfgtest-reload declares ExecReload, so configData sources go into reloadTriggers.
+      grep -E '^X-Reload-Triggers=' ${toplevel}/etc/systemd/system/cfgtest-reload.service >/dev/null
+      cfgtest_reload_trigger=$(grep -oP '^X-Reload-Triggers=\K\S+' ${toplevel}/etc/systemd/system/cfgtest-reload.service)
+      grep -F "service-configdata-reload.conf" "$cfgtest_reload_trigger" >/dev/null
+      ! grep -E '^X-Restart-Triggers=' ${toplevel}/etc/systemd/system/cfgtest-reload.service >/dev/null
+
+      # applyConfigDataChanges = false opts the service out entirely.
+      ! grep -E '^X-Reload-Triggers=' ${toplevel}/etc/systemd/system/cfgtest-noapply.service >/dev/null
+      ! grep -E '^X-Restart-Triggers=' ${toplevel}/etc/systemd/system/cfgtest-noapply.service >/dev/null
+
+      # A per-entry applyChanges = true overrides applyConfigDataChanges = false.
+      grep -E '^X-Restart-Triggers=' ${toplevel}/etc/systemd/system/cfgtest-noapply-override.service >/dev/null
+      cfgtest_override_trigger=$(grep -oP '^X-Restart-Triggers=\K\S+' ${toplevel}/etc/systemd/system/cfgtest-noapply-override.service)
+      grep -F "service-configdata-forced.conf" "$cfgtest_override_trigger" >/dev/null
+      ! grep -F "service-configdata-skip.conf" "$cfgtest_override_trigger" >/dev/null
+
+      # Services without configData should have neither X-Reload-Triggers nor X-Restart-Triggers.
+      ! grep -E '^X-Reload-Triggers=' ${toplevel}/etc/systemd/system/bar.service >/dev/null
+      ! grep -E '^X-Restart-Triggers=' ${toplevel}/etc/systemd/system/bar.service >/dev/null
+      ! grep -E '^X-Reload-Triggers=' ${toplevel}/etc/systemd/system/bar-db.service >/dev/null
+      ! grep -E '^X-Restart-Triggers=' ${toplevel}/etc/systemd/system/bar-db.service >/dev/null
+      ! grep -E '^X-Reload-Triggers=' ${toplevel}/etc/systemd/system/foo.service >/dev/null
+      ! grep -E '^X-Restart-Triggers=' ${toplevel}/etc/systemd/system/foo.service >/dev/null
     )
     echo 🐬👍
     touch $out

--- a/nixos/tests/modular-service-etc/test.nix
+++ b/nixos/tests/modular-service-etc/test.nix
@@ -24,7 +24,10 @@
         system.services.webserver = {
           # The python web server is simple enough that it doesn't need a reload signal.
           # Other services may need to receive a signal in order to re-read what's in `configData`.
+          # It reads the files on every request, so the service manager must leave it alone when
+          # they change.
           imports = [ python-http-server ];
+          applyConfigDataChanges = false;
           python-http-server = {
             port = 8080;
           };
@@ -50,6 +53,7 @@
           # Add a sub-service
           services.api = {
             imports = [ python-http-server ];
+            applyConfigDataChanges = false;
             python-http-server = {
               port = 8081;
             };


### PR DESCRIPTION
Wire modular service's enabled `configData.<name>.source` paths into `reloadTriggers` if supported, `restartTriggers` otherwise, so a config change causes a reload (or fallback restart) on `nixos-rebuild switch`.

Blocked on #545732.

## Test plan
- `nix-build -A nixosTests.modularService`

Disclaimer: I used a coding agent in the creation of this patch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
