### PR TITLE
geph, gephgui-wry: support aarch64 and darwin

### DIFF
--- a/pkgs/by-name/ge/geph/package.nix
+++ b/pkgs/by-name/ge/geph/package.nix
@@ -24,16 +24,16 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "geph5";
-  version = "0.2.99";
+  version = "0.2.102";
 
   src = fetchFromGitHub {
     owner = "geph-official";
     repo = "geph5";
     rev = "geph5-client-v${finalAttrs.version}";
-    hash = "sha256-AWdVFpIP+LIZz6zqcx0GJxDs4ZWGR6JgpHDVAg0mHaU=";
+    hash = "sha256-E3msw4yG5RxKapHBvhGEVlsJiLgysCgjAtOrJ8fGES0=";
   };
 
-  cargoHash = "sha256-zFCq29vtsbwbo6JBRdX+CziKZVoxwpt6y3BYVlIqZfc=";
+  cargoHash = "sha256-w+1JLxvflb8PQqNi5MnxoEcWctuaC6Ux3oNYJzB6oaE=";
 
   postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
     substituteInPlace binaries/geph5-client/src/vpn/*.sh \

--- a/pkgs/by-name/ge/geph/package.nix
+++ b/pkgs/by-name/ge/geph/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   rustPlatform,
   fetchFromGitHub,
   makeBinaryWrapper,
@@ -34,13 +35,17 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-zFCq29vtsbwbo6JBRdX+CziKZVoxwpt6y3BYVlIqZfc=";
 
-  postPatch = ''
+  postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
     substituteInPlace binaries/geph5-client/src/vpn/*.sh \
       --replace-fail 'PATH=' 'PATH=${binPath}:'
 
     substituteInPlace binaries/geph5-client/src/vpn/linux.rs \
       --replace-fail 'Command::new("sh")' 'Command::new("${bash}/bin/sh")' \
       --replace-fail '/usr/bin/env ' '${lib.getExe' coreutils "env"} '
+  '';
+
+  postInstall = ''
+    rm -rf "$out/lib"
   '';
 
   nativeBuildInputs = [
@@ -61,7 +66,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   buildFeatures = [
     "aws_lambda"
-    "windivert"
+    # "windivert" # Only on Windows
   ];
 
   checkFlags = [
@@ -74,9 +79,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--skip=tests::test_blind_sign"
     "--skip=tests::test_generate_secret_key"
     "--skip=tests::ping_pong"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # Cannot connect to the internet within the macOS sandbox
+    "--skip=tests::test_successful_ping"
+    "--skip=tests::test_failed_ping"
   ];
 
-  postFixup = ''
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
     for program in $out/bin/*; do
       wrapProgram "$program" --prefix PATH : ${binPath}
     done
@@ -94,7 +104,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/geph-official/geph5";
     changelog = "https://github.com/geph-official/geph5/releases/tag/geph5-client-v${finalAttrs.version}";
     mainProgram = "geph5-client";
-    platforms = lib.platforms.unix;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin; # VPN mode is not yet available on macOS.
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [
       penalty1083

--- a/pkgs/by-name/ge/gephgui-wry/package.nix
+++ b/pkgs/by-name/ge/gephgui-wry/package.nix
@@ -59,13 +59,13 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "gephgui-wry";
-  version = "5.5.0";
+  version = "5.7.0";
 
   src = fetchFromGitHub {
     owner = "geph-official";
     repo = "gephgui-pkg";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-NxtE26GPG2EvgtMa6eEOZmOcqu4yYr3zioF1CmrxLRk=";
+    hash = "sha256-f6IC9dRQ3CW3P0TRuOe1mmG3jOAvyMPBpylHJ82AUpM=";
     fetchSubmodules = true;
   };
 
@@ -74,7 +74,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     inherit (finalAttrs) version src;
 
     sourceRoot = "${finalAttrs.src.name}/gephgui-wry/gephgui";
-    npmDepsHash = "sha256-dGzmdvzKp/JHCgDf3NJb0oolgW4Y/spagzpeVpMF28w=";
+    npmDepsHash = "sha256-GFeHowIv+TiejSNK6kAGAgYcwc2DHu3c4UBEeTScIPk=";
 
     installPhase = ''
       runHook preInstall
@@ -87,7 +87,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   sourceRoot = "${finalAttrs.src.name}/gephgui-wry";
-  cargoHash = "sha256-Dh1WuxU1rRDNu2cF9GCo1CIiph1sLc5j0GSPb7b7kJA=";
+  cargoHash = "sha256-Ekl03CvM32E3Q86YZL8eBFYAzDcpAXq8yVi2Fg3t5yc=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/ge/gephgui-wry/package.nix
+++ b/pkgs/by-name/ge/gephgui-wry/package.nix
@@ -3,6 +3,7 @@
   rustPlatform,
   webkitgtk_4_1,
   pkg-config,
+  openssl,
   buildNpmPackage,
   makeDesktopItem,
   fetchFromGitHub,
@@ -12,7 +13,6 @@
   glib,
   copyDesktopItems,
   wrapGAppsHook4,
-  nodejs_22,
 }:
 let
   pac-cmd = stdenv.mkDerivation {
@@ -28,11 +28,18 @@ let
 
     postPatch = ''
       rm binaries/*/pac
-      substituteInPlace Makefile --replace-fail 'uname -p' 'uname -m'
+       substituteInPlace Makefile \
+        --replace-fail 'uname -p' 'uname -m' \
+        --replace-fail 'ifneq ($(filter arm%,$(UNAME_P)),)' 'ifneq ($(filter aarch64 arm%,$(UNAME_P)),)'
     '';
 
     nativeBuildInputs = [ pkg-config ];
     buildInputs = [ glib ];
+
+    preBuild = ''
+      mkdir -p binaries/linux_arm
+    '';
+
     installPhase = ''
       runHook preInstall
 
@@ -69,9 +76,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     sourceRoot = "${finalAttrs.src.name}/gephgui-wry/gephgui";
     npmDepsHash = "sha256-dGzmdvzKp/JHCgDf3NJb0oolgW4Y/spagzpeVpMF28w=";
 
-    # npm dependency install fails with nodejs_24: https://github.com/NixOS/nixpkgs/issues/474535
-    nodejs = nodejs_22;
-
     installPhase = ''
       runHook preInstall
 
@@ -88,27 +92,39 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeBuildInputs = [
     pkg-config
     perl
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     copyDesktopItems
     wrapGAppsHook4
   ];
 
-  buildInputs = [ webkitgtk_4_1 ];
+  buildInputs =
+    lib.optionals stdenv.hostPlatform.isLinux [ webkitgtk_4_1 ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ openssl ];
 
   preBuild = ''
     cp -r ${finalAttrs.gephgui}/ gephgui/dist/
   '';
 
-  postInstall = ''
-    install -m 444 -D gephgui/public/gephlogo.png $out/share/icons/hicolor/512x512/apps/geph.png
-  '';
+  postInstall =
+    lib.optionalString stdenv.hostPlatform.isLinux ''
+      install -m 444 -D gephgui/public/gephlogo.png $out/share/icons/hicolor/512x512/apps/geph.png
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      mkdir -p "$out/Applications"
+      cp -a ../macos/template.app "$out/Applications/Geph.app"
+      chmod -R u+w "$out/Applications/Geph.app"
+      install -Dm755 "$out/bin/gephgui-wry" "$out/Applications/Geph.app/Contents/MacOS/bin/gephgui-wry"
+      ln -s "$out/Applications/Geph.app/Contents/MacOS/entrypoint" "$out/bin/Geph"
+    '';
 
-  preFixup = ''
+  preFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
     gappsWrapperArgs+=(
       --suffix PATH : ${lib.makeBinPath [ pac-cmd ]}
     )
   '';
 
-  desktopItems = [
+  desktopItems = lib.optionals stdenv.hostPlatform.isLinux [
     (makeDesktopItem {
       name = "Geph";
       desktopName = "Geph";
@@ -133,8 +149,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Modular Internet censorship circumvention system designed specifically to deal with national filtering";
     homepage = "https://github.com/geph-official/gephgui-wry";
-    mainProgram = "gephgui-wry";
-    platforms = lib.platforms.linux;
+    mainProgram = if stdenv.hostPlatform.isDarwin then "Geph" else "gephgui-wry";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [
       penalty1083


### PR DESCRIPTION
Added support for `aarch64-linux` and `aarch64-darwin` to geph and gephgui-wry. Additionally, the final output of geph no longer includes the unnecessary lib/ directory.
I don't have an Apple device with a GUI on hand, so I'm not sure if gephgui-wry will work properly. Apple users are welcome to submit feedback.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
