### PR TITLE
e57inspector: init at 0.3.1

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -491,6 +491,7 @@ in
   drupal = runTest ./drupal.nix;
   dublin-traceroute = runTest ./dublin-traceroute.nix;
   dwl = runTestOn [ "x86_64-linux" "aarch64-linux" ] ./dwl.nix;
+  e57inspector = runTest ./e57inspector.nix;
   early-mount-options = runTest ./early-mount-options.nix;
   earlyoom = runTestOn [ "x86_64-linux" ] ./earlyoom.nix;
   easytier = runTest ./easytier.nix;

--- a/nixos/tests/e57inspector.nix
+++ b/nixos/tests/e57inspector.nix
@@ -1,0 +1,38 @@
+{ pkgs, ... }:
+{
+  name = "e57inspector";
+  meta.maintainers = with pkgs.lib.maintainers; [
+    nh2
+    chpatrick
+  ];
+
+  nodes.machine =
+    { ... }:
+    {
+      imports = [
+        ./common/x11.nix
+      ];
+
+      services.xserver.enable = true;
+      environment.systemPackages = [
+        pkgs.e57inspector
+        pkgs.xdotool
+      ];
+    };
+
+  testScript =
+    let
+      testFile = pkgs.fetchurl {
+        url = "https://raw.githubusercontent.com/asmaloney/libE57Format-test-data/bbcacec05d60f923869545c5eab33d94c390d50e/self/ColouredCubeFloat.e57";
+        hash = "sha256-bb95crNYvX3Qhkx4k6Sqe2GjOf1u4nxxswMfdjyXfTM=";
+      };
+    in
+    ''
+      start_all()
+      machine.wait_for_x()
+
+      machine.execute("e57inspector ${testFile} >&2 &")
+      machine.wait_until_succeeds("xdotool search --pid $(pidof .e57inspector-wrapped)")
+      machine.screenshot("screen")
+    '';
+}

--- a/pkgs/by-name/e5/e57inspector/package.nix
+++ b/pkgs/by-name/e5/e57inspector/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  qt6,
+  xercesc,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "e57inspector";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "sisakat";
+    repo = "e57inspector";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-McLPbvS7j+6UVEcQ34/ngGiCxsdF/Whs5wZt5cP2UkI=";
+    fetchSubmodules = true;
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  patches = [
+    # Support loading E57 files from CLI arguments,
+    # so we can use that in the NixOS VM test to load a sample file.
+    # Remove with next release (see https://github.com/sisakat/e57inspector/pull/8)
+    (fetchpatch {
+      name = "e57inspector-Allow-loading-file-from-CLI.patch";
+      url = "https://github.com/nh2/e57inspector/commit/a5a899ee58952ffc2971d18b3734ea405e0020f3.patch";
+      hash = "sha256-QRUv0CvX+OdH88CzI/6XjPXnAVIsf6N/Ix/qqCsSaRw=";
+    })
+  ];
+
+  postPatch = ''
+    # Fix cmake_minimum_required version compatibility with CMake >= 4.0
+    substituteInPlace app/cmake/gitversion.cmake \
+      --replace-fail "cmake_minimum_required(VERSION 3.0.0)" "cmake_minimum_required(VERSION 3.5)"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qttools
+    xercesc
+  ];
+
+  # Upstream CMakeLists.txt has no install() rules.
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 app/e57inspector -t $out/bin
+    install -Dm755 panorama/e57inspector_panorama -t $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Cross-platform E57 file viewer to list and view stored point clouds, images and metadata";
+    homepage = "https://github.com/sisakat/e57inspector";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      nh2
+      chpatrick
+    ];
+    teams = [ lib.teams.geospatial ];
+    platforms = lib.platforms.linux;
+    mainProgram = "e57inspector";
+  };
+})

--- a/pkgs/by-name/e5/e57inspector/package.nix
+++ b/pkgs/by-name/e5/e57inspector/package.nix
@@ -2,9 +2,11 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   qt6,
   xercesc,
+  nixosTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -59,6 +61,10 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru.tests = {
+    e57inspector = nixosTests.e57inspector;
+  };
 
   meta = {
     description = "Cross-platform E57 file viewer to list and view stored point clouds, images and metadata";


### PR DESCRIPTION

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
