### PR TITLE
cloudcompare: Add geospatial team

### DIFF
--- a/pkgs/by-name/cl/cloudcompare/package.nix
+++ b/pkgs/by-name/cl/cloudcompare/package.nix
@@ -157,6 +157,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://cloudcompare.org";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ nh2 ];
+    teams = [ lib.teams.geospatial ];
     mainProgram = "CloudCompare";
     platforms = with lib.platforms; linux; # only tested here; might work on others
   };


### PR DESCRIPTION
@NixOS/geospatial 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Meta-only change
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
