### PR TITLE
amnezia-vpn-bin: fix systemd service patch

### DIFF
--- a/pkgs/by-name/am/amnezia-vpn-bin/package.nix
+++ b/pkgs/by-name/am/amnezia-vpn-bin/package.nix
@@ -110,7 +110,7 @@ stdenv.mkDerivation (finalAttrs: {
       --set CQT_PKG_ROOT "$out/share/amnezia-vpn/service"
 
     substituteInPlace $out/share/amnezia-vpn/AmneziaVPN.service \
-      --replace-fail "ExecStart=/opt/AmneziaVPN/service/AmneziaVPN-service.sh" "AmneziaVPN-service" \
+      --replace-fail "/opt/AmneziaVPN/service/AmneziaVPN-service.sh" "AmneziaVPN-service" \
       --replace-fail "Environment=LD_LIBRARY_PATH=/opt/AmneziaVPN/client/lib" ""
     ln -s $out/share/amnezia-vpn/AmneziaVPN.service $out/lib/systemd/system/AmneziaVPN.service
 


### PR DESCRIPTION
## Things done
Fix systemd service patch (wrong ExecStart patching)

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
