### PR TITLE
[Backport staging-25.11] bubblewrap: 0.11.0 -> 0.11.2

### DIFF
--- a/pkgs/by-name/bu/bubblewrap/package.nix
+++ b/pkgs/by-name/bu/bubblewrap/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "bubblewrap";
-  version = "0.11.0";
+  version = "0.11.1";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = "bubblewrap";
     rev = "v${version}";
-    hash = "sha256-8IDMLQPeO576N1lizVudXUmTV6hNOiowjzRpEWBsZ+U=";
+    hash = "sha256-sp5XYkTuoL778p5xQRDtFbX0ocdJuRbVxJCkKbEUgZs=";
   };
 
   outputs = [

--- a/pkgs/by-name/bu/bubblewrap/package.nix
+++ b/pkgs/by-name/bu/bubblewrap/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "bubblewrap";
-  version = "0.11.1";
+  version = "0.11.2";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = "bubblewrap";
     rev = "v${version}";
-    hash = "sha256-sp5XYkTuoL778p5xQRDtFbX0ocdJuRbVxJCkKbEUgZs=";
+    hash = "sha256-MUjJMhJ8Q9sYQyGqA7zfMutYjMSZNmEHXs2H3WN4mbE=";
   };
 
   outputs = [


### PR DESCRIPTION
Fixes [CVE-2026-41163](https://nvd.nist.gov/vuln/detail/CVE-2026-41163)

https://github.com/containers/bubblewrap/security/advisories/GHSA-xq78-7hw4-5jvp

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
