### PR TITLE
replaySh: init at 0.2.2

### DIFF
--- a/pkgs/by-name/re/replaySh/package.nix
+++ b/pkgs/by-name/re/replaySh/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  installShellFiles,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "replaySh";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "Ra77a3l3-jar";
+    repo = "replaySh";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-nSOS6lCOCnsS0drD2GOBcm3r5OAhv/bE6gjhQA5zBIo=";
+  };
+
+  cargoHash = "sha256-aMaXnDNHHBtmbm9jFCM24sBzRA4z6DNLd1vJZBOYaSw=";
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  doCheck = true;
+
+  postInstall = ''
+    export HOME=$(mktemp -d)
+    $out/bin/replay completions --install bash
+    $out/bin/replay completions --install fish
+    $out/bin/replay completions --install zsh
+    installShellCompletion --bash "$HOME/.local/share/bash-completion/completions/replay"
+    installShellCompletion --fish "$HOME/.config/fish/completions/replay.fish"
+    installShellCompletion --zsh "$HOME/.local/share/zsh/site-functions/_replay"
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Record once, replay forever — a CLI workflow recorder and replayer";
+    homepage = "https://github.com/Ra77a3l3-jar/replaySh";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Ra77a3l3-jar ];
+    mainProgram = "replay";
+  };
+})

--- a/pkgs/by-name/re/replaySh/update.sh
+++ b/pkgs/by-name/re/replaySh/update.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -I nixpkgs=./. -i bash -p nix-update
+
+set -euo pipefail
+
+nix-update replaySh


### PR DESCRIPTION
## Changes

Adds replaySh, a CLI workflow recorder and replayer.
  - It lets you record sequences of shell commands as named workflows 
  -  Allows to replay the workflows on demand, making repetitive terminal tasks effortless.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
