### PR TITLE
maintainers: remove hedning

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10687,12 +10687,6 @@
     githubId = 2427959;
     name = "Hector Jusforgues";
   };
-  hedning = {
-    email = "torhedinbronner@gmail.com";
-    github = "hedning";
-    githubId = 71978;
-    name = "Tor Hedin Brønner";
-  };
   heel = {
     email = "parizhskiy@gmail.com";
     github = "HeeL";

--- a/pkgs/by-name/eg/egl-wayland/package.nix
+++ b/pkgs/by-name/eg/egl-wayland/package.nix
@@ -70,9 +70,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/NVIDIA/egl-wayland/";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux ++ lib.platforms.freebsd;
-    maintainers = with lib.maintainers; [
-      hedning
-      ccicnce113424
-    ];
+    maintainers = with lib.maintainers; [ ccicnce113424 ];
   };
 })

--- a/pkgs/by-name/eg/eglexternalplatform/package.nix
+++ b/pkgs/by-name/eg/eglexternalplatform/package.nix
@@ -40,9 +40,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/NVIDIA/eglexternalplatform";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux ++ lib.platforms.freebsd;
-    maintainers = with lib.maintainers; [
-      hedning
-      ccicnce113424
-    ];
+    maintainers = with lib.maintainers; [ ccicnce113424 ];
   };
 })

--- a/pkgs/by-name/ni/nix-bash-completions/package.nix
+++ b/pkgs/by-name/ni/nix-bash-completions/package.nix
@@ -60,10 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Bash completions for Nix, NixOS, and NixOps";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [
-      hedning
-      ncfavier
-    ];
+    maintainers = with lib.maintainers; [ ncfavier ];
     # Set a lower priority such that Nix wins in case of conflicts.
     priority = 10;
   };

--- a/pkgs/by-name/ni/nix-zsh-completions/package.nix
+++ b/pkgs/by-name/ni/nix-zsh-completions/package.nix
@@ -37,7 +37,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [
       olejorgenb
-      hedning
       ma27
     ];
   };


### PR DESCRIPTION
## Reasons

- Last commented in [November 2020](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Ahedning)
- Hasn't created any PRs / Issues since [November 2020](https://github.com/NixOS/nixpkgs/issues?q=author%3Ahedning)
- About 2600 [unanswered ](https://github.com/NixOS/nixpkgs/issues?q=involves%3Ahedning%20-commenter%3Ahedning%20-author%3Ahedning%20-reviewed-by%3Ahedning) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Extra

~~Hedning would also have to be manually removed from the `GNOME` team.~~ Done