### PR TITLE
appleseed: reinit at 2.1.0-beta-unstable-2026-05-03

### DIFF
--- a/pkgs/by-name/ap/appleseed/bcd-use-system-eigen.patch
+++ b/pkgs/by-name/ap/appleseed/bcd-use-system-eigen.patch
@@ -1,0 +1,15 @@
+diff --git a/src/thirdparty/bcd/CMakeLists.txt b/src/thirdparty/bcd/CMakeLists.txt
+index b90d97e46..6ae960b5e 100644
+--- a/src/thirdparty/bcd/CMakeLists.txt
++++ b/src/thirdparty/bcd/CMakeLists.txt
+@@ -76,7 +76,9 @@ link_against_openexr (bcd)
+ # Include paths.
+ #--------------------------------------------------------------------------------------------------
+ 
+-target_include_directories (bcd PRIVATE ext/eigen)
++find_package(Eigen3 REQUIRED)
++
++target_link_libraries(bcd Eigen3::Eigen)
+ 
+ 
+ #--------------------------------------------------------------------------------------------------

--- a/pkgs/by-name/ap/appleseed/find-openimageio-tools.patch
+++ b/pkgs/by-name/ap/appleseed/find-openimageio-tools.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3db287170..d16ca74a5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -401,6 +401,8 @@ if (USE_FIND_PACKAGE_FOR_OIIO)
+     set(OPENIMAGEIO_INCLUDE_DIRS ${OpenImageIO_INCLUDES})
+     set(OPENIMAGEIO_LIBRARIES    ${OpenImageIO_LIB_DIR})
+     # TODO: use these vars (OpenImageIO_INCLUDES, OpenImageIO_LIB_DIR) created by OpenImageIOConfig.cmake itself.
++    find_program(OPENIMAGEIO_OIIOTOOL oiiotool HINTS ${OpenImageIO_LIB_DIR}/../bin ${OpenImageIO_INCLUDE_DIR}/../bin)
++    find_program(OPENIMAGEIO_IDIFF    idiff   HINTS ${OpenImageIO_LIB_DIR}/../bin ${OpenImageIO_INCLUDE_DIR}/../bin)
+ 
+     include_directories (${OPENIMAGEIO_INCLUDE_DIRS})
+     link_directories (${OPENIMAGEIO_LIBRARIES})

--- a/pkgs/by-name/ap/appleseed/fix-cmake-cmp0043.patch
+++ b/pkgs/by-name/ap/appleseed/fix-cmake-cmp0043.patch
@@ -1,0 +1,46 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 82e1db50f..3db287170 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -547,16 +547,16 @@ set (preprocessor_definitions_ship
+ # A convenience macro to apply the preprocessor definitions to all configurations of a given target.
+ macro (apply_preprocessor_definitions target)
+     set_property (TARGET ${target} APPEND PROPERTY
+-        COMPILE_DEFINITIONS_DEBUG ${preprocessor_definitions_debug}
++        COMPILE_DEFINITIONS $<$<CONFIG:Debug>:${preprocessor_definitions_debug}>
+     )
+     set_property (TARGET ${target} APPEND PROPERTY
+-        COMPILE_DEFINITIONS_RELEASE ${preprocessor_definitions_release}
++        COMPILE_DEFINITIONS $<$<CONFIG:Release>:${preprocessor_definitions_release}>
+     )
+     set_property (TARGET ${target} APPEND PROPERTY
+-        COMPILE_DEFINITIONS_SHIP ${preprocessor_definitions_ship}
++        COMPILE_DEFINITIONS $<$<CONFIG:Ship>:${preprocessor_definitions_ship}>
+     )
+     set_property (TARGET ${target} APPEND PROPERTY
+-        COMPILE_DEFINITIONS_PROFILE ${preprocessor_definitions_profile}
++        COMPILE_DEFINITIONS $<$<CONFIG:Profile>:${preprocessor_definitions_profile}>
+     )
+ endmacro ()
+ 
+@@ -564,16 +564,16 @@ endmacro ()
+ macro (append_custom_preprocessor_definitions target first_definition)
+     set (definitions ${first_definition} ${ARGN})
+     set_property (TARGET ${target} APPEND PROPERTY
+-        COMPILE_DEFINITIONS_DEBUG ${definitions}
++        COMPILE_DEFINITIONS $<$<CONFIG:Debug>:${definitions}>
+     )
+     set_property (TARGET ${target} APPEND PROPERTY
+-        COMPILE_DEFINITIONS_RELEASE ${definitions}
++        COMPILE_DEFINITIONS $<$<CONFIG:Release>:${definitions}>
+     )
+     set_property (TARGET ${target} APPEND PROPERTY
+-        COMPILE_DEFINITIONS_SHIP ${definitions}
++        COMPILE_DEFINITIONS $<$<CONFIG:Ship>:${definitions}>
+     )
+     set_property (TARGET ${target} APPEND PROPERTY
+-        COMPILE_DEFINITIONS_PROFILE ${definitions}
++        COMPILE_DEFINITIONS $<$<CONFIG:Profile>:${definitions}>
+     )
+ endmacro ()
+ 

--- a/pkgs/by-name/ap/appleseed/fix-cmake-xercesc.patch
+++ b/pkgs/by-name/ap/appleseed/fix-cmake-xercesc.patch
@@ -1,0 +1,62 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 327ee229b..82e1db50f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -326,8 +326,7 @@ endif ()
+ 
+ if (USE_FIND_PACKAGE_FOR_XERCES)
+     add_definitions (-DAPPLESEED_WITH_EXTERNAL_XERCES)
+-    find_package (Xerces REQUIRED NAMES XercesC CONFIG)
+-    find_package_handle_standard_args(Xerces CONFIG_MODE)
++    find_package (XercesC REQUIRED)
+ endif ()
+ 
+ if (USE_FIND_PACKAGE_FOR_ZLIB)
+@@ -424,8 +423,6 @@ else ()
+ endif ()
+ 
+ if (USE_FIND_PACKAGE_FOR_XERCES)
+-    get_target_property (XERCES_LIBRARIES XercesC::XercesC INTERFACE_LINK_LIBRARIES) 
+-
+     include_directories (${XercesC_INCLUDE_DIRS})
+ else ()
+     include_directories (${APPLESEED_DEPS_STAGE_DIR}/xerces-c-debug/include)
+diff --git a/cmake/config/linux-gcc-clang.txt b/cmake/config/linux-gcc-clang.txt
+index 5f3289aa3..dd7c4e575 100644
+--- a/cmake/config/linux-gcc-clang.txt
++++ b/cmake/config/linux-gcc-clang.txt
+@@ -202,7 +202,7 @@ macro (link_against_osl target)
+ endmacro ()
+ 
+ macro (link_against_xercesc target)
+-    target_link_libraries (${target} ${XERCES_LIBRARIES})
++    target_link_libraries (${target} XercesC::XercesC)
+ endmacro ()
+ 
+ macro (link_against_zlib target)
+diff --git a/cmake/config/mac-clang.txt b/cmake/config/mac-clang.txt
+index 8f6393e5f..25eb4a00e 100644
+--- a/cmake/config/mac-clang.txt
++++ b/cmake/config/mac-clang.txt
+@@ -149,7 +149,7 @@ macro (link_against_osl target)
+ endmacro ()
+ 
+ macro (link_against_xercesc target)
+-    target_link_libraries (${target} ${XERCES_LIBRARIES})
++    target_link_libraries (${target} XercesC::XercesC)
+ endmacro ()
+ 
+ macro (link_against_zlib target)
+diff --git a/cmake/config/win-vs.txt b/cmake/config/win-vs.txt
+index c7bb60851..90888898b 100644
+--- a/cmake/config/win-vs.txt
++++ b/cmake/config/win-vs.txt
+@@ -353,7 +353,7 @@ endmacro ()
+ 
+ macro (link_against_xercesc target)
+     if (USE_FIND_PACKAGE_FOR_XERCES)
+-        target_link_libraries (${target} ${XERCES_LIBRARIES})
++        target_link_libraries (${target} XercesC::XercesC)
+     else ()
+         target_link_libraries (${target}
+             debug       ${APPLESEED_DEPS_STAGE_DIR}/xerces-c-debug/lib/xerces-c_3D.lib

--- a/pkgs/by-name/ap/appleseed/fix-cmake4.patch
+++ b/pkgs/by-name/ap/appleseed/fix-cmake4.patch
@@ -1,0 +1,65 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8108e5564..327ee229b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -42,18 +42,6 @@ cmake_policy (SET CMP0074 NEW)      # the find_package(<PackageName>) command no
+ 
+ cmake_policy (SET CMP0120 OLD)      # inclusion of the deprecated WriteCompilerDetectionHeader module
+ 
+-if (POLICY CMP0026)
+-    cmake_policy (SET CMP0026 OLD)  # disallow use of the LOCATION target property (CMake 3.0)
+-endif ()
+-
+-if (POLICY CMP0042)
+-    cmake_policy (SET CMP0042 OLD)  # MACOSX_RPATH is enabled by default (CMake 3.0)
+-endif ()
+-
+-if (POLICY CMP0043)
+-    cmake_policy (SET CMP0043 OLD)  # consume the content of the suffixed COMPILE_DEFINITIONS_<CONFIG>
+-endif ()
+-
+ set_property (GLOBAL PROPERTY USE_FOLDERS ON)
+ 
+ include (cmake/utilities.txt)
+diff --git a/cmake/config/linux-gcc-clang.txt b/cmake/config/linux-gcc-clang.txt
+index d28c69843..5f3289aa3 100644
+--- a/cmake/config/linux-gcc-clang.txt
++++ b/cmake/config/linux-gcc-clang.txt
+@@ -232,34 +232,31 @@ macro (get_relative_path_from_module_name path name)
+ endmacro ()
+ 
+ macro (add_copy_target_exe_to_sandbox_command target)
+-    get_target_property (target_path ${target} LOCATION)
+     get_sandbox_bin_path (bin_path)
+ 
+     add_custom_command (TARGET ${target} POST_BUILD
+         COMMAND mkdir -p ${bin_path}
+-        COMMAND cp ${target_path} ${bin_path}
++        COMMAND cp $<TARGET_FILE:${target}> ${bin_path}
+     )
+ endmacro ()
+ 
+ macro (add_copy_target_lib_to_sandbox_command target)
+-    get_target_property (target_path ${target} LOCATION)
+     get_sandbox_lib_path (lib_path)
+ 
+     add_custom_command (TARGET ${target} POST_BUILD
+         COMMAND mkdir -p ${lib_path}
+-        COMMAND cp ${target_path} ${lib_path}
++        COMMAND cp $<TARGET_FILE:${target}> ${lib_path}
+     )
+ endmacro ()
+ 
+ macro (add_copy_target_to_sandbox_py_module_command target module_name)
+-    get_target_property (target_path ${target} LOCATION)
+     get_sandbox_py_path (py_path)
+     get_relative_path_from_module_name (relative_module_path ${module_name})
+     set (module_path "${py_path}/${relative_module_path}")
+ 
+     add_custom_command (TARGET ${target} POST_BUILD
+         COMMAND mkdir -p ${module_path}
+-        COMMAND cp ${target_path} ${module_path}
++        COMMAND cp $<TARGET_FILE:${target}> ${module_path}
+     )
+ endmacro ()
+ 

--- a/pkgs/by-name/ap/appleseed/fix-python313.patch
+++ b/pkgs/by-name/ap/appleseed/fix-python313.patch
@@ -1,0 +1,84 @@
+diff --git a/src/appleseed.python/gillocks.cpp b/src/appleseed.python/gillocks.cpp
+index b40691838..5ae29c38a 100644
+--- a/src/appleseed.python/gillocks.cpp
++++ b/src/appleseed.python/gillocks.cpp
+@@ -31,27 +31,21 @@
+ #include "gillocks.h"
+ 
+ ScopedGILLock::ScopedGILLock()
+-  : m_threads_initialized(PyEval_ThreadsInitialized() ? true : false)
+ {
+-    if (m_threads_initialized)
+-        m_state = PyGILState_Ensure();
++    m_state = PyGILState_Ensure();
+ }
+ 
+ ScopedGILLock::~ScopedGILLock()
+ {
+-    if (m_threads_initialized)
+-        PyGILState_Release(m_state);
++    PyGILState_Release(m_state);
+ }
+ 
+ ScopedGILUnlock::ScopedGILUnlock()
+-  : m_threads_initialized(PyEval_ThreadsInitialized() ? true : false)
+ {
+-    if (m_threads_initialized)
+-        m_state = PyEval_SaveThread();
++    m_state = PyEval_SaveThread();
+ }
+ 
+ ScopedGILUnlock::~ScopedGILUnlock()
+ {
+-    if (m_threads_initialized)
+-        PyEval_RestoreThread(m_state);
+-}
++    PyEval_RestoreThread(m_state);
++}
+\ No newline at end of file
+diff --git a/src/appleseed.python/gillocks.h b/src/appleseed.python/gillocks.h
+index d680bc2ea..98cbc8505 100644
+--- a/src/appleseed.python/gillocks.h
++++ b/src/appleseed.python/gillocks.h
+@@ -43,7 +43,6 @@ class ScopedGILLock
+     ~ScopedGILLock();
+ 
+   private:
+-    bool                m_threads_initialized;
+     PyGILState_STATE    m_state;
+ };
+ 
+@@ -57,6 +56,5 @@ class ScopedGILUnlock
+     ~ScopedGILUnlock();
+ 
+   private:
+-    bool                m_threads_initialized;
+     PyThreadState*      m_state;
+ };
+diff --git a/src/appleseed.studio/python/studio/plugins.py b/src/appleseed.studio/python/studio/plugins.py
+index 73951fc53..ad0334193 100644
+--- a/src/appleseed.studio/python/studio/plugins.py
++++ b/src/appleseed.studio/python/studio/plugins.py
+@@ -27,7 +27,7 @@
+ #
+ 
+ import os
+-import imp
++import importlib.util
+ import traceback
+ 
+ 
+@@ -57,8 +57,11 @@ def load_plugin(plugin_path):
+     name, ext = os.path.splitext(name)
+ 
+     try:
+-        file, filename, data = imp.find_module(name, [path])
+-        plugin_module = imp.load_module(name, file, filename, data)
++        spec = importlib.util.find_spec(name, path)
++        if spec is None:
++            raise ImportError(f"No module named '{name}'")
++        plugin_module = importlib.util.module_from_spec(spec)
++        spec.loader.exec_module(plugin_module)
+     except ImportError as e:
+         print("Plugin '{0}' could not be imported: {1}".format(name, e))
+         return

--- a/pkgs/by-name/ap/appleseed/openimageio/default.nix
+++ b/pkgs/by-name/ap/appleseed/openimageio/default.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  boost,
+  dcmtk,
+  ffmpeg,
+  fmt,
+  freetype,
+  giflib,
+  libheif,
+  libjpeg_turbo,
+  libpng,
+  libraw,
+  libtiff,
+  libwebp,
+  onetbb,
+  opencolorio,
+  opencv,
+  openexr,
+  openjpeg,
+  openvdb,
+  ptex,
+  robin-map,
+  zlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "openimageio";
+  version = "2.5.19.1";
+
+  src = fetchFromGitHub {
+    owner = "AcademySoftwareFoundation";
+    repo = "OpenImageIO";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+KreH4JoyX64Z3LMfTiyf96YL1msXpiELvcpiCziGNs=";
+  };
+
+  outputs = [
+    "bin"
+    "out"
+    "dev"
+    "doc"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    boost
+    dcmtk
+    ffmpeg
+    freetype
+    giflib
+    libheif
+    libjpeg_turbo
+    libpng
+    libraw
+    libtiff
+    libwebp
+    onetbb
+    opencolorio
+    opencv
+    openexr
+    openjpeg
+    openvdb
+    ptex
+    robin-map
+    zlib
+  ];
+
+  propagatedBuildInputs = [
+    fmt
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "USE_PYTHON" false)
+    (lib.cmakeBool "USE_QT" false)
+    (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib") # needs relative path for pkg-config
+    (lib.cmakeBool "INTERNALIZE_FMT" false) # Do not install a copy of fmt header files
+  ];
+
+  postFixup = ''
+    substituteInPlace $dev/lib/cmake/OpenImageIO/OpenImageIOTargets-*.cmake \
+      --replace "\''${_IMPORT_PREFIX}/lib/lib" "$out/lib/lib"
+  '';
+
+  meta = {
+    description = "Library and tools for reading and writing images";
+    homepage = "https://openimageio.org";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      wishstudio
+    ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/ap/appleseed/package.nix
+++ b/pkgs/by-name/ap/appleseed/package.nix
@@ -1,0 +1,146 @@
+{
+  pkgs,
+  lib,
+  stdenv,
+  callPackage,
+  fetchFromGitHub,
+  fetchpatch,
+  cmake,
+  pkg-config,
+  boost,
+  eigen,
+  embree,
+  libGL,
+  libpng,
+  libtiff,
+  lz4,
+  opencolorio,
+  openexr,
+  openshadinglanguage,
+  python3,
+  qt5,
+  xercesc,
+  enablePython ? false,
+  enableQt5 ? true,
+  sse42Support ? stdenv.hostPlatform.sse4_2Support,
+  avxSupport ? stdenv.hostPlatform.avxSupport,
+  avx2Support ? stdenv.hostPlatform.avx2Support,
+}:
+let
+  boost_python = boost.override {
+    enablePython = enablePython;
+    python = python3;
+  };
+  happly_src = fetchFromGitHub {
+    owner = "MarcusTU";
+    repo = "happly";
+    rev = "1e74cc732e039df91d617072a8b4503806907673";
+    hash = "sha256-05rqtyATIn/iDYMp5eb0Osc3quxNYcOLKW26aYgYGbs=";
+  };
+  # does not compile with openimageio v3 yet
+  openimageio2 = callPackage ./openimageio { };
+  openshadinglanguage_openimageio2 = openshadinglanguage.override {
+    openimageio = openimageio2;
+  };
+  embree_openimageio2 = embree.override {
+    openimageio = openimageio2;
+  };
+  buildStudio = enablePython && enableQt5;
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "appleseed";
+  version = "2.1.0-beta-unstable-2026-05-03";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "appleseedhq";
+    repo = "appleseed";
+    rev = "01206dc8fa1c3a0e1a7e5acbced874c9a71b40f0";
+    hash = "sha256-cyoUT2ig9BhGnN3N2Oq58PlRBh9P/tYQHh/oE6a1tws=";
+  };
+
+  patches = [
+    ./fix-cmake4.patch
+    ./fix-cmake-cmp0043.patch
+    ./fix-cmake-xercesc.patch
+    ./bcd-use-system-eigen.patch
+    ./find-openimageio-tools.patch
+    ./fix-python313.patch
+  ];
+
+  postPatch = ''
+    # boost 1.89
+    substituteInPlace CMakeLists.txt --replace-fail \
+      "find_package (Boost 1.86.00 REQUIRED COMPONENTS atomic chrono date_time filesystem regex system thread wave)" \
+      "find_package (Boost 1.86.00 REQUIRED COMPONENTS atomic chrono date_time filesystem regex thread wave)"
+    # remove vendored eigen
+    rm -rv src/thirdparty/bcd/ext/eigen
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    openshadinglanguage_openimageio2
+  ]
+  ++ lib.optionals enablePython [
+    python3
+    python3.pkgs.wrapPython
+  ]
+  ++ lib.optionals enableQt5 [
+    qt5.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    boost_python
+    eigen
+    embree_openimageio2
+    libGL
+    libpng
+    libtiff
+    lz4
+    opencolorio
+    openimageio2
+    openexr
+    openshadinglanguage_openimageio2
+    xercesc
+  ]
+  ++ lib.optionals enablePython [
+    python3
+  ]
+  ++ lib.optionals enableQt5 [
+    qt5.qtbase
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "WARNINGS_AS_ERRORS" false)
+    (lib.cmakeBool "USE_STATIC_BOOST" false)
+    (lib.cmakeBool "WITH_STUDIO" buildStudio)
+    (lib.cmakeBool "WITH_BENCH" false) # file INSTALL can not find appleseed.bench.xml
+    (lib.cmakeBool "WITH_PYTHON2_BINDINGS" false)
+    (lib.cmakeBool "WITH_PYTHON3_BINDINGS" enablePython)
+    (lib.cmakeBool "WITH_EMBREE" true)
+    (lib.cmakeBool "USE_SSE" true)
+    (lib.cmakeBool "USE_SSE42" sse42Support)
+    (lib.cmakeBool "USE_AVX" avxSupport)
+    (lib.cmakeBool "USE_AVX2" avx2Support)
+    (lib.cmakeFeature "happly_ROOT" "${happly_src}")
+  ];
+
+  dontWrapQtApps = true;
+  preFixup = lib.optionalString buildStudio ''
+    wrapQtApp "$out/bin/appleseed.studio" --set PYTHONHOME "${python3}"
+  '';
+
+  meta = {
+    description = "Open source, physically-based global illumination rendering engine";
+    homepage = "https://appleseedhq.net";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      wishstudio
+    ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
- Is a standalone application and can also be used by #515775

WIP. Working on submitting the patches to upstream and seeing if I can make CUDA to work.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
