### PR TITLE
home-assistant: re-enable various component tests

### DIFF
--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -139,10 +139,6 @@ let
       # intent fixture mismatch
       "test_error_no_device_on_floor"
     ];
-    ecovacs = [
-      # Translation not found for vacuum
-      "test_raise_segment_changed_issue"
-    ];
     homeassistant_sky_connect = [
       # 2026.5.0: after reload device is in loaded state instead of retry state
       "test_usb_device_reactivity"
@@ -151,29 +147,9 @@ let
       # 2026.5.0: after reload device is in loaded state instead of retry state
       "test_usb_device_reactivity"
     ];
-    roborock = [
-      # Translation not found for vacuum
-      "test_clean_segments_mixed_maps"
-      "test_segments_changed_issue"
-    ];
-    sensor = [
-      # Failed: Translation not found for sensor
-      "test_validate_unit_change_convertible"
-      "test_validate_statistics_unit_change_no_device_class"
-      "test_validate_statistics_state_class_removed"
-      "test_validate_statistics_state_class_removed_issue_cleaned_up"
-      "test_validate_statistics_unit_change_no_conversion"
-      "test_validate_statistics_unit_change_equivalent_units_2"
-      "test_update_statistics_issues"
-      "test_validate_statistics_mean_type_changed"
-    ];
     shell_command = [
       # tries to retrieve file from github
       "test_non_text_stdout_capture"
-    ];
-    vacuum = [
-      # Translation not found for vacuum
-      "test_segments_changed_issue"
     ];
     zeroconf = [
       # multicast socket bind, not possible in the sandbox

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -114,10 +114,6 @@ let
       "tests/components/minecraft_server/test_init.py"
       "tests/components/minecraft_server/test_sensor.py"
     ];
-    overseerr = [
-      # imports broken future module
-      "tests/components/overseerr/test_event.py"
-    ];
     systemmonitor = [
       # sandbox doesn't grant access to /sys/class/power_supply
       "tests/components/systemmonitor/test_config_flow.py::test_add_and_remove_processes"

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -118,13 +118,6 @@ let
       "tests/components/minecraft_server/test_init.py"
       "tests/components/minecraft_server/test_sensor.py"
     ];
-    nzbget = [
-      # type assertion fails due to introduction of parameterized type
-      "tests/components/nzbget/test_config_flow.py::test_user_form"
-      "tests/components/nzbget/test_config_flow.py::test_user_form_show_advanced_options"
-      "tests/components/nzbget/test_config_flow.py::test_user_form_cannot_connect"
-      "tests/components/nzbget/test_init.py::test_async_setup_raises_entry_not_ready"
-    ];
     overseerr = [
       # imports broken future module
       "tests/components/overseerr/test_event.py"

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   home-assistant,
 }:
 
@@ -135,9 +136,13 @@ let
   };
 
   extraDisabledTests = {
-    conversation = [
-      # intent fixture mismatch
+    conversation = lib.optionals stdenv.hostPlatform.isAarch64 [
+      # intent fixture mismatch on aarch64
       "test_error_no_device_on_floor"
+    ];
+    ecovacs = [
+      # Translation not found for vacuum
+      "test_raise_segment_changed_issue"
     ];
     homeassistant_sky_connect = [
       # 2026.5.0: after reload device is in loaded state instead of retry state

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -94,10 +94,6 @@ let
   };
 
   extraDisabledTestPaths = {
-    hypontech = [
-      # outdated snapshot
-      "tests/components/hypontech/test_sensor.py::test_sensors"
-    ];
     influxdb = [
       # These tests fail because they check for the number of warnings in the
       # logs and there is an extra warning in the logs:

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -152,10 +152,6 @@ let
       # 2026.5.0: after reload device is in loaded state instead of retry state
       "test_usb_device_reactivity"
     ];
-    shell_command = [
-      # tries to retrieve file from github
-      "test_non_text_stdout_capture"
-    ];
     zeroconf = [
       # multicast socket bind, not possible in the sandbox
       "test_subscribe_discovery"

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -117,10 +117,6 @@ let
       "tests/components/minecraft_server/test_init.py"
       "tests/components/minecraft_server/test_sensor.py"
     ];
-    modem_callerid = [
-      # aioserial mock produces wrong state
-      "tests/components/modem_callerid/test_init.py::test_setup_entry"
-    ];
     nzbget = [
       # type assertion fails due to introduction of parameterized type
       "tests/components/nzbget/test_config_flow.py::test_user_form"


### PR DESCRIPTION
A handful of home-assistant component tests in `pkgs/servers/home-assistant/tests.nix` were disabled for upstream bugs that have since been fixed. Re-enabling them.

- `modem_callerid.test_setup_entry` home-assistant/core#167461
- `sensor`, `vacuum`, `ecovacs`, `roborock` home-assistant/core#167928
- `shell_command.test_non_text_stdout_capture` home-assistant/core#167466
- `nzbget` config_flow and init tests home-assistant/core#167456
- `hypontech.test_sensors` home-assistant/core#167273
- `overseerr.test_event` home-assistant/core#167458

`conversation.test_error_no_device_on_floor` is now only disabled on aarch64. It passes on x86_64 after the intents bump in home-assistant/core#162959.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
