### PR TITLE
python3Packages.irc: fix tests on python 3.14

### DIFF
--- a/pkgs/development/python-modules/irc/default.nix
+++ b/pkgs/development/python-modules/irc/default.nix
@@ -24,6 +24,11 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-jdv9GfcSBM7Ount8cnJLFbP6h7q16B5Fp1vvc2oaPHY=";
   };
 
+  patches = [
+    # https://github.com/jaraco/irc/pull/236
+    ./python-3.14-event-loop.patch
+  ];
+
   nativeBuildInputs = [ setuptools-scm ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/irc/python-3.14-event-loop.patch
+++ b/pkgs/development/python-modules/irc/python-3.14-event-loop.patch
@@ -1,0 +1,33 @@
+--- a/irc/tests/test_client_aio.py
++++ b/irc/tests/test_client_aio.py
+@@ -1,6 +1,4 @@
+ import asyncio
+-import contextlib
+-import warnings
+ from unittest.mock import MagicMock
+
+ from irc import client_aio
+@@ -13,21 +11,14 @@ async def mock_create_connection(*args, **kwargs):
+     return mock_create_connection
+
+
+-@contextlib.contextmanager
+-def suppress_issue_197():
+-    with warnings.catch_warnings():
+-        warnings.filterwarnings('ignore', 'There is no current event loop')
+-        yield
+-
+-
+ def test_privmsg_sends_msg():
+     # create dummy transport, protocol
+     mock_transport = MagicMock()
+     mock_protocol = MagicMock()
+
+     # connect to dummy server
+-    with suppress_issue_197():
+-        loop = asyncio.get_event_loop()
++    loop = asyncio.new_event_loop()
++    asyncio.set_event_loop(loop)
+     loop.create_connection = make_mocked_create_connection(
+         mock_transport, mock_protocol
+     )


### PR DESCRIPTION
Borrowed the patch from unmerged PR at: https://github.com/jaraco/irc/pull/236
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327143320)](https://hydra.nixos.org/build/327143320)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test