### PR TITLE
schedctl: init at 1.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14477,6 +14477,11 @@
     githubId = 361496;
     name = "Nikola Knežević";
   };
+  koalalorenzo = {
+    name = "Lorenzo Setale";
+    github = "koalalorenzo";
+    githubId = 33528;
+  };
   koffydrop = {
     github = "koffydrop";
     githubId = 67888720;

--- a/pkgs/by-name/sc/schedctl/package.nix
+++ b/pkgs/by-name/sc/schedctl/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  pkg-config,
+  btrfs-progs,
+  gpgme,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "schedctl";
+  version = "1.2.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "schedkit";
+    repo = "schedctl";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5LxD4420WCdHWcz7Yb0JV+ar4gSf/xsbkeHLPdLV1eY=";
+  };
+
+  vendorHash = "sha256-LMYJlvUmGejHk/AA/k2WwoI2Gtw3rNYgsklUcK+cB40=";
+  proxyVendor = true;
+
+  subPackages = [ "." ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    btrfs-progs
+    gpgme
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/schedkit/schedctl/releases/tag/v${finalAttrs.version}";
+    description = "OCI-packaged eBPF sched_ext plug and play schedulers for fun and profit";
+    homepage = "https://github.com/schedkit";
+    license = lib.licenses.asl20;
+    mainProgram = "schedctl";
+    maintainers = with lib.maintainers; [
+      koalalorenzo
+    ];
+  };
+})

--- a/pkgs/by-name/sc/schedctl/package.nix
+++ b/pkgs/by-name/sc/schedctl/package.nix
@@ -42,6 +42,7 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/schedkit";
     license = lib.licenses.asl20;
     mainProgram = "schedctl";
+    platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
       koalalorenzo
     ];


### PR DESCRIPTION
Adds [schedctl](https://github.com/schedkit/schedctl) command line. 

Ideally schedctl requires podman or containerd running. I think we would create a `programs.schedctl` option later on to help setting it up.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
