### PR TITLE
termirs: 0.2.5 -> 0.3.2

### DIFF
--- a/pkgs/by-name/te/termirs/package.nix
+++ b/pkgs/by-name/te/termirs/package.nix
@@ -8,16 +8,21 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "termirs";
-  version = "0.2.5";
+  version = "0.3.2";
 
   src = fetchFromGitHub {
     owner = "caelansar";
     repo = "termirs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-n9/rtPDf7wNAjumOetiLRPVHWLReAYHhntJ+BgJ7f10=";
+    hash = "sha256-Ae295u1qJLWrtWSYK+c9wMgjW6m3rvTJzVsm25BeXZo=";
   };
 
-  cargoHash = "sha256-Kkf20ljB2hm6e4hZXEGIg2l83ugxNlHUPpwxKEyBpdY=";
+  cargoHash = "sha256-klSZDK3s5X7qRopXVy3Qec3Dnuu9ov0bfuhwc6DwpIM=";
+
+  postPatch = ''
+    substituteInPlace ../termirs-0.3.2-vendor/source-git-0/wezterm-term-0.1.0/src/terminalstate/mod.rs \
+      --replace-fail 'include_bytes!("../../../termwiz/data/wezterm")' 'include_bytes!("../../../termwiz-0.24.0/data/wezterm")'
+  '';
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
Update to 0.3.2

Fix build issue with wezterm-term-0.1.0 including a file from a different dep ( termwiz-0.24.0 )

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
