### PR TITLE
drumgizmo: fix non ascii characters rendering

### DIFF
--- a/pkgs/by-name/dr/drumgizmo/fix-non-ascii.patch
+++ b/pkgs/by-name/dr/drumgizmo/fix-non-ascii.patch
@@ -1,0 +1,42 @@
+From 17e4e901da64971cbbba4fb310a8cc10197f0ca3 Mon Sep 17 00:00:00 2001
+From: eymeric <hatchchien@protonmail.com>
+Date: Sun, 10 May 2026 20:24:17 +0200
+Subject: [PATCH] dggui: fix non-ASCII character rendering in drawText()
+
+Painter::drawText() was passing strings directly to font.render()
+which indexes the glyph bitmap by raw byte value (Latin-1).
+Strings coming from gettext .mo files (charset=ISO-8859-1) or
+embedded resource files (UTF-8) were not converted before rendering,
+causing multi-byte UTF-8 sequences to produce garbled/missing glyphs
+for accented characters (French, etc.).
+
+Fix: convert text to Latin-1 via UTF8::toLatin1() inside drawText()
+so all text rendering paths are correctly handled in one place.
+---
+ dggui/painter.cc | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/dggui/painter.cc b/dggui/painter.cc
+index c326601..1c4539e 100644
+--- a/dggui/painter.cc
++++ b/dggui/painter.cc
+@@ -29,6 +29,7 @@
+ #include <cmath>
+ #include <cassert>
+ 
++#include "utf8.h"
+ #include "pixelbuffer.h"
+ #include "font.h"
+ #include "drawable.h"
+@@ -177,7 +178,8 @@ void Painter::clear()
+ void Painter::drawText(int x0, int y0, const Font& font,
+                        const std::string& text, bool nocolour, bool rotate)
+ {
+-	PixelBufferAlpha* textbuf = font.render(text);
++	UTF8 utf8conv;
++	PixelBufferAlpha* textbuf = font.render(utf8conv.toLatin1(text));
+ 
+ 	if(!rotate)
+ 	{
+-- 
+2.53.0

--- a/pkgs/by-name/dr/drumgizmo/package.nix
+++ b/pkgs/by-name/dr/drumgizmo/package.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation rec {
       patch = "0005-fix_ftbfs_with_gcc13.patch";
       hash = "sha256-y5NDZ+3t6GkBeF/5UY8dwtH8k0cuM+5SGBGPSV7AX7M=";
     })
+    ./fix-non-ascii.patch
   ];
 
   configureFlags = [ "--enable-lv2" ];


### PR DESCRIPTION
DrumGizmo does not render non-ASCII characters correctly when using a French (or any non-English) locale:

<img width="750" height="786" alt="image" src="https://github.com/user-attachments/assets/1f8ab8cd-c352-4da5-8adf-06d15fda11c5" />

I was able to reproduce the issue on : archlinux, debian, ubuntustudio, opensuse leap.

I finally came to the conclusion that the issue was in the upstream code.
I made a simple patch and sent it to the DrumGizmo developer through email.
However, there has been no DrumGizmo release for a couple of years, so I would love to see this fix included directly in nixpkgs. 

Way better like this : 

<img width="1180" height="1105" alt="image" src="https://github.com/user-attachments/assets/ed13b2b2-85e5-42f4-8c0a-6a9c24e3b896" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
