### PR TITLE
emmylua-formatter: init at 0.23.0

### DIFF
--- a/pkgs/by-name/em/emmylua-formatter/package.nix
+++ b/pkgs/by-name/em/emmylua-formatter/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  emmylua-ls,
+  rustPlatform,
+  versionCheckHook,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "emmylua_formatter";
+  inherit (emmylua-ls) version src cargoHash;
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  buildAndTestSubdir = "crates/emmylua_formatter";
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgram = "${placeholder "out"}/bin/luafmt";
+  doInstallCheck = true;
+
+  meta = {
+    description = "Lua and EmmyLua formatter used by the EmmyLua Analyzer Rust workspace.";
+    homepage = "https://github.com/EmmyLuaLs/emmylua-analyzer-rust";
+    changelog = "https://github.com/EmmyLuaLs/emmylua-analyzer-rust/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      mrcjkb
+    ];
+    platforms = lib.platforms.all;
+    mainProgram = "luafmt";
+  };
+})


### PR DESCRIPTION
https://github.com/EmmyLuaLs/emmylua-analyzer-rust/tree/main/crates/emmylua_formatter

Depends on: #518531

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
