### PR TITLE
ssh-tpm-agent: install man pages, adopt

### DIFF
--- a/pkgs/by-name/ss/ssh-tpm-agent/package.nix
+++ b/pkgs/by-name/ss/ssh-tpm-agent/package.nix
@@ -53,7 +53,10 @@ buildGoModule (finalAttrs: {
     changelog = "https://github.com/Foxboron/ssh-tpm-agent/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ sgo ];
+    maintainers = with lib.maintainers; [
+      sgo
+      defelo
+    ];
     mainProgram = "ssh-tpm-agent";
   };
 })

--- a/pkgs/by-name/ss/ssh-tpm-agent/package.nix
+++ b/pkgs/by-name/ss/ssh-tpm-agent/package.nix
@@ -3,6 +3,8 @@
   buildGoModule,
   fetchFromGitHub,
   nix-update-script,
+  installShellFiles,
+  asciidoctor,
   openssh,
   openssl,
 }:
@@ -22,19 +24,25 @@ buildGoModule (finalAttrs: {
 
   vendorHash = "sha256-N7JuMUy5Z+HVhxsqESlBkHcHVipRYM8ncx/wR77k1fw=";
 
-  buildInputs = [
-    openssl
+  nativeBuildInputs = [
+    installShellFiles
+    asciidoctor
   ];
 
-  nativeCheckInputs = [
-    openssh
-  ];
+  buildInputs = [ openssl ];
+
+  nativeCheckInputs = [ openssh ];
 
   # disable broken tests, see https://github.com/NixOS/nixpkgs/pull/394097
   preCheck = ''
     rm cmd/scripts_test.go
     substituteInPlace internal/keyring/keyring_test.go --replace-fail ENOKEY ENOENT
     substituteInPlace internal/keyring/threadkeyring_test.go --replace-fail ENOKEY ENOENT
+  '';
+
+  postInstall = ''
+    make man
+    installManPage man/*.1
   '';
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
