### PR TITLE
emmylua-{ls,check,doc-cli}: enable `__structuredAttrs` and `strictDeps`

### DIFF
--- a/pkgs/by-name/em/emmylua-check/package.nix
+++ b/pkgs/by-name/em/emmylua-check/package.nix
@@ -11,6 +11,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "emmylua_check";
   inherit (emmylua-ls) version src cargoHash;
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   nativeBuildInputs = [
     pkg-config
   ];

--- a/pkgs/by-name/em/emmylua-doc-cli/package.nix
+++ b/pkgs/by-name/em/emmylua-doc-cli/package.nix
@@ -8,6 +8,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "emmylua_doc_cli";
   inherit (emmylua-ls) version src cargoHash;
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   buildAndTestSubdir = "crates/emmylua_doc_cli";
 
   nativeInstallCheckInputs = [

--- a/pkgs/by-name/em/emmylua-ls/package.nix
+++ b/pkgs/by-name/em/emmylua-ls/package.nix
@@ -18,6 +18,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-Zj5nLeTH/4sVElYP+erg6bSTX8jFqF7sqiXfaMam8pE=";
   };
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   nativeBuildInputs = [
     pkg-config
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
