### PR TITLE
sonar: init at v0.3.0

### DIFF
--- a/pkgs/by-name/so/sonar/package.nix
+++ b/pkgs/by-name/so/sonar/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "sonar";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "raskrebs";
+    repo = "sonar";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ucOIFws3fo94o5ziJDn8ldgWkpAuiUqW8A+MQdPNy3c=";
+  };
+
+  vendorHash = "sha256-komX1AmHt2NoF1x6xsNa2RFkfVzOXfYEMPhT0zwMxjw=";
+
+  ldflags = [
+    "-s -w -X github.com/raskrebs/sonar/internal/selfupdate.Version=v${finalAttrs.version}"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+  doInstallCheck = true;
+
+  meta = {
+    description = "CLI tool for inspecting and managing services listening on localhost ports";
+    homepage = "https://github.com/raskrebs/sonar";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ paepcke ];
+    mainProgram = "sonar";
+  };
+})


### PR DESCRIPTION
- CLI tool for inspecting and managing services listening on localhost ports 
- dependency free, static binary, first release v0.1.0 March 2018, current release v0.3.0 2 weeks ago, 940 gh stars 
- https://github.com/RasKrebs/sonar

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
