### PR TITLE
xla: pin rules_go SDK metadata

### DIFF
--- a/pkgs/by-name/xl/xla/grpc-pin-go-sdk.patch
+++ b/pkgs/by-name/xl/xla/grpc-pin-go-sdk.patch
@@ -1,0 +1,105 @@
+--- a/bazel/grpc_extra_deps.bzl
++++ b/bazel/grpc_extra_deps.bzl
+@@ -1,91 +1,100 @@
+ # Copyright 2021 The gRPC Authors
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ #     http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ """Loads the dependencies necessary for the external repositories defined in grpc_deps.bzl."""
+ 
+ load("@bazel_features//:deps.bzl", "bazel_features_deps")
+ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+ load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")
+ load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
+ load("@com_envoyproxy_protoc_gen_validate//:dependencies.bzl", "go_third_party")
+ load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+ load("@com_google_googletest//:googletest_deps.bzl", "googletest_deps")
+ load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+ load("@envoy_api//bazel:repositories.bzl", "api_dependencies")
+ load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
++load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_rules_dependencies")
+ load("@rules_java//java:rules_java_deps.bzl", "rules_java_dependencies")
+ load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
+ load("@rules_python//python:repositories.bzl", "py_repositories")
+ load("@rules_shell//shell:repositories.bzl", "rules_shell_dependencies", "rules_shell_toolchains")
+ 
+ def grpc_extra_deps(ignore_version_differences = False):
+     """Loads the extra dependencies.
+ 
+     These are necessary for using the external repositories defined in
+     grpc_deps.bzl. Projects that depend on gRPC as an external repository need
+     to call both grpc_deps and grpc_extra_deps, if they have not already loaded
+     the extra dependencies. For example, they can do the following in their
+     WORKSPACE
+     ```
+     load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps", "grpc_test_only_deps")
+     grpc_deps()
+ 
+     grpc_test_only_deps()
+ 
+     load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+ 
+     grpc_extra_deps()
+     ```
+ 
+     Args:
+       ignore_version_differences: Plumbed directly to the invocation of
+         apple_rules_dependencies.
+     """
+     rules_shell_dependencies()
+     rules_shell_toolchains()
+ 
+     rules_java_dependencies()
+ 
+     protobuf_deps()
+ 
+     rules_proto_dependencies()
+     bazel_features_deps()
+ 
+     api_dependencies()
+ 
+     go_rules_dependencies()
+-    go_register_toolchains(version = "1.22.5")
++    go_download_sdk(
++        name = "go_sdk",
++        sdks = {
++            "linux_amd64": [
++                "go1.22.5.linux-amd64.tar.gz",
++                "904b924d435eaea086515bc63235b192ea441bd8c9b198c507e85009e6e4c7f0",
++            ],
++        },
++        version = "1.22.5",
++    )
+     gazelle_dependencies()
+ 
+     # Pull-in the go 3rd party dependencies for protoc_gen_validate, which is
+     # needed for building C++ xDS protos
+     go_third_party()
+ 
+     apple_rules_dependencies(ignore_version_differences = ignore_version_differences)
+ 
+     apple_support_dependencies()
+ 
+     # Initialize Google APIs with only C++ and Python targets
+     switched_rules_by_language(
+         name = "com_google_googleapis_imports",
+         cc = True,
+         grpc = True,
+         python = True,
+     )
+ 
+     google_cloud_cpp_deps()
+ 
+     py_repositories()
+ 
+     googletest_deps()

--- a/pkgs/by-name/xl/xla/package.nix
+++ b/pkgs/by-name/xl/xla/package.nix
@@ -96,6 +96,19 @@ in
           '] + extra_patches,' \
           '"@xla//third_party/py:rules_python_nix_patchelf.patch",
           ] + extra_patches,'
+    ''
+    # Pin gRPC's rules_go SDK metadata. Without `sdks`, rules_go downloads the
+    # live Go release manifest into @go_sdk/versions.json, making the deps tar
+    # change whenever go.dev publishes a new release.
+    + ''
+      cp ${./grpc-pin-go-sdk.patch} third_party/grpc/grpc-pin-go-sdk.patch
+      substituteInPlace workspace2.bzl \
+        --replace-fail \
+          'patch_file = ["//third_party/grpc:grpc.patch"],' \
+          'patch_file = [
+            "//third_party/grpc:grpc.patch",
+            "//third_party/grpc:grpc-pin-go-sdk.patch",
+          ],'
     '';
 
   # Configure XLA for CPU-only build using the official configure.py script.
@@ -146,7 +159,7 @@ in
   fetchAttrs = {
     sha256 =
       {
-        x86_64-linux = "sha256-QTUqcP5t91Z4s+esxxFz2tGJAJplWXWZuYPqcC7ld+E=";
+        x86_64-linux = "sha256-9L+oVq/yHqUGLhzSpwqxfYSJ1bIVcnaZgFVB3sjokXs=";
       }
       .${stdenv.hostPlatform.system} or (throw "unsupported system: ${stdenv.hostPlatform.system}");
     preInstall =


### PR DESCRIPTION
## Description of changes

`xla.deps` included `external/go_sdk/versions.json`, which rules_go downloaded from the live Go release manifest while resolving gRPC's Go toolchain. That file changes whenever Go publishes a release, so the fixed-output deps tar hash could become stale without any nixpkgs or XLA source change.

Patch gRPC's `grpc_extra_deps.bzl` in the XLA source to call `go_download_sdk` with pinned SDK metadata for `go1.22.5.linux-amd64.tar.gz` instead of using `go_register_toolchains(version = "1.22.5")`, which performs the live manifest lookup.

The resulting deps tar no longer contains `external/go_sdk/versions.json`.

Fixes the hash instability issue identified in https://github.com/NixOS/nixpkgs/pull/517119#issuecomment-4415869175. cc @samestep @GaetanLepage 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- For non-Linux: skipped
- Tested, as applicable:
  - [x] `nix-build --option builders "" -A xla.deps`
  - [x] `nix-build --option builders "" --check -A xla.deps`
