### PR TITLE
clippy-copy: init at 1.6.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16390,6 +16390,12 @@
     githubId = 8094643;
     keys = [ { fingerprint = "BAA9 7711 58CA D457 B4AE  8B06 8188 423D 2FA2 0A65"; } ];
   };
+  m4r1vs = {
+    email = "marius.niveri@gmail.com";
+    name = "Marius Niveri";
+    github = "m4r1vs";
+    githubId = 26097311;
+  };
   m7medvision = {
     name = "Mohammed";
     github = "m7medVision";

--- a/pkgs/by-name/cl/clippy-copy/package.nix
+++ b/pkgs/by-name/cl/clippy-copy/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "clippy-copy";
+  version = "1.6.9";
+
+  src = fetchFromGitHub {
+    owner = "neilberkman";
+    repo = "clippy";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8OdT+R4dvJCLhelIAsAgVoWGGwmWueTsiJFpCm1uQEc=";
+  };
+
+  vendorHash = "sha256-7do+KgoiIocS+mq2hsgv3NOd+TjMl2I9ew2Emx3/Bbg=";
+
+  ldflags = [
+    "-s"
+    "-X=github.com/neilberkman/clippy/cmd/internal/common.Version=${finalAttrs.version}"
+    "-X=github.com/neilberkman/clippy/cmd/internal/common.Commit=${finalAttrs.src.tag}"
+    "-X=github.com/neilberkman/clippy/cmd/internal/common.Date=1970-01-01T00:00:00Z"
+  ];
+
+  # Tests require access to the system clipboard (unavailable in sandbox)
+  doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Clipboard tool supporting both text and binary files";
+    homepage = "https://github.com/neilberkman/clippy";
+    changelog = "https://github.com/neilberkman/clippy/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ m4r1vs ];
+    mainProgram = "clippy";
+    platforms = lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
Based on #456824 

[Clippy](https://github.com/neilberkman/clippy) allows easily copy/pasting files and text on macos (more extensive than native pbcopy). I use it mainly to copy files from yazi into the browser, gimp, etc.

I've used clippy for a long time through nix-darwin and finally came around packaging it. The references PR does the same but the author seems a little busy so I'm suggesting this.

`doCheck = false` is set because clipboard related tests fail in the sandbox during build. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.