### PR TITLE
acheron: init at 0-unstable-2026-08-28

### DIFF
--- a/pkgs/by-name/ac/acheron/package.nix
+++ b/pkgs/by-name/ac/acheron/package.nix
@@ -1,0 +1,100 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  alsa-lib,
+  cmake,
+  curl-impersonate,
+  ffmpeg-headless,
+  libdave,
+  libopus,
+  libpulseaudio,
+  libsodium,
+  makeWrapper,
+  nlohmann_json,
+  pcre2,
+  pkg-config,
+  qt6Packages,
+  rnnoise,
+  voiceSupport ? true,
+  videoSupport ? true,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "acheron";
+  version = "0-unstable-2026-08-28";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "ouwou";
+    repo = "acheron";
+    rev = "fb08e68bf98978fa34aca4bbf576f5476e69fc7c";
+    hash = "sha256-L4aAgw8F2E+Tysov7UjCt6X1NY6pZDOHUcj1CNSYntw=";
+    fetchSubmodules = true;
+    # Leave miniaudio and emoji-segmenter vendored because they are single file libraries
+    # so there is little to no benefit to fetching them ourselves.
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+    pkg-config
+    qt6Packages.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    curl-impersonate
+    nlohmann_json
+    pcre2
+    qt6Packages.qtbase
+    qt6Packages.qtimageformats
+    qt6Packages.qtkeychain
+    qt6Packages.qttools
+  ]
+  ++ lib.optionals voiceSupport [
+    libdave
+    libopus
+    libsodium
+    rnnoise
+  ]
+  ++ lib.optionals videoSupport [ ffmpeg-headless ];
+
+  cmakeFlags = [
+    "-DUSE_VCPKG=OFF"
+    "-DCURL_LIBRARY=${curl-impersonate}/lib/libcurl-impersonate.so"
+  ]
+  ++ lib.optional (!voiceSupport) "-DENABLE_VOICE=OFF"
+  ++ lib.optional (!videoSupport) "-DENABLE_FFMPEG=OFF";
+
+  postPatch = lib.optionalString voiceSupport ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "add_subdirectory(vendor/libdave/cpp EXCLUDE_FROM_ALL)" \
+        "pkg_check_modules(libdave REQUIRED IMPORTED_TARGET libdave)"
+    sed -i \
+      -e '/pkg_check_modules/!s|\<libdave\>|PkgConfig::libdave|' \
+      CMakeLists.txt
+  '';
+
+  # Required as acheron uses bundled miniaudio.h for audio
+  postFixup = ''
+    wrapProgram $out/bin/acheron \
+      --prefix LD_LIBRARY_PATH : "${
+        lib.makeLibraryPath [
+          alsa-lib
+          libpulseaudio
+        ]
+      }"
+  '';
+
+  meta = {
+    description = "Alternative Discord client with voice support made with C++ and Qt 6 Widgets";
+    mainProgram = "acheron";
+    homepage = "https://github.com/ouwou/acheron";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ choco98 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/li/libdave/package.nix
+++ b/pkgs/by-name/li/libdave/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  mlspp,
+  nlohmann_json,
+  openssl,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libdave";
+  version = "1.1.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "discord";
+    repo = "libdave";
+    tag = "v${finalAttrs.version}/cpp";
+    hash = "sha256-ALDmtAjSkjnLDcmtpvcwiN7dPvpOgOTNFolr/H3SqsE=";
+  };
+
+  strictDeps = true;
+
+  # src contains both the JavaScript and C++ library, so build the C++ library
+  sourceRoot = "source/cpp";
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    mlspp
+    openssl
+    nlohmann_json
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DPERSISTENT_KEYS=OFF"
+  ];
+
+  postInstall = ''
+    mkdir -p $out/lib/pkgconfig
+    cat > $out/lib/pkgconfig/libdave.pc <<EOF
+    prefix=$out
+    libdir=\''${prefix}/lib
+    includedir=\''${prefix}/include
+
+    Name: libdave
+    Description: Discord DAVE library
+    Version: ${finalAttrs.version}
+    Requires: openssl
+    Libs: -L\''${libdir} -ldave
+    Cflags: -I\''${includedir}
+    EOF
+  '';
+
+  meta = {
+    description = "Discord's End-to-End Audio Visual Encryption (DAVE) library";
+    homepage = "https://github.com/discord/libdave";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ choco98 ];
+    platforms = lib.platforms.linux;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+  };
+})

--- a/pkgs/by-name/li/libdave/package.nix
+++ b/pkgs/by-name/li/libdave/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  mlspp,
+  nlohmann_json,
+  openssl,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libdave";
+  version = "1.2.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "discord";
+    repo = "libdave";
+    tag = "v${finalAttrs.version}/cpp";
+    hash = "sha256-TuTYVK1jZ/2ZmdMNI9gGg+czWaJJlIwYUGnHZcxqksk=";
+  };
+
+  strictDeps = true;
+
+  # src contains both the JavaScript and C++ library, so build the C++ library
+  sourceRoot = "source/cpp";
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    mlspp
+    openssl
+    nlohmann_json
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DPERSISTENT_KEYS=OFF"
+  ];
+
+  postInstall = ''
+    mkdir -p $out/lib/pkgconfig
+    cat > $out/lib/pkgconfig/libdave.pc <<EOF
+    prefix=$out
+    libdir=\''${prefix}/lib
+    includedir=\''${prefix}/include
+    Name: libdave
+    Description: Discord DAVE library
+    Version: ${finalAttrs.version}
+    Requires: openssl
+    Libs: -L\''${libdir} -ldave
+    Cflags: -I\''${includedir}
+    EOF
+  '';
+
+  meta = {
+    description = "Discord's End-to-End Audio Visual Encryption (DAVE) library";
+    homepage = "https://github.com/discord/libdave";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ choco98 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/ml/mlspp/package.nix
+++ b/pkgs/by-name/ml/mlspp/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  nlohmann_json,
+  openssl,
+}:
+
+stdenv.mkDerivation {
+  pname = "mlspp";
+  version = "0.1.0-unstable-2026-04-13";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "cisco";
+    repo = "mlspp";
+    rev = "92aaa4134fa45ec39957a7c81a342401fba7feb2";
+    hash = "sha256-HElw0fvL7ClDSXBDYRw1qcPw73oWvbMfi7skQokyftY=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    nlohmann_json
+    openssl
+  ];
+
+  cmakeFlags = [
+    "-DMLS_CXX_NAMESPACE=mlspp"
+    "-DBUILD_TESTS=OFF"
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "-Werror" ""
+  '';
+
+  meta = {
+    description = "Messaging Layer Security (MLS) protocol implementation";
+    homepage = "https://github.com/cisco/mlspp";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ choco98 ];
+    platforms = lib.platforms.linux;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+  };
+}

--- a/pkgs/by-name/ml/mlspp/package.nix
+++ b/pkgs/by-name/ml/mlspp/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  nlohmann_json,
+  openssl,
+}:
+
+stdenv.mkDerivation {
+  pname = "mlspp";
+  version = "0.1.0-unstable-2026-04-13";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "cisco";
+    repo = "mlspp";
+    rev = "92aaa4134fa45ec39957a7c81a342401fba7feb2";
+    hash = "sha256-HElw0fvL7ClDSXBDYRw1qcPw73oWvbMfi7skQokyftY=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    nlohmann_json
+    openssl
+  ];
+
+  cmakeFlags = [
+    "-DMLS_CXX_NAMESPACE=mlspp"
+    "-DBUILD_TESTS=OFF"
+
+    # Fix build as all warnings are treated as errors
+    "-DCMAKE_CXX_FLAGS=-Wno-error=maybe-uninitialized"
+  ];
+
+  meta = {
+    description = "Messaging Layer Security (MLS) protocol implementation";
+    homepage = "https://github.com/cisco/mlspp";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ choco98 ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
This PR adds acheron, an alternative discord client using Qt6, to nixpkgs, along with 2 of the libraries that it depends on, libdave and mlspp. I also made myself maintainer of all of these as I'd be happy to keep them updated!

- https://github.com/ouwou/acheron
- https://github.com/cisco/mlspp
- https://github.com/discord/libdave

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
