### PR TITLE
plover: provide `wrapPloverExes` and `withPlugins`

### DIFF
--- a/pkgs/by-name/pl/plover/package.nix
+++ b/pkgs/by-name/pl/plover/package.nix
@@ -1,11 +1,40 @@
 {
   lib,
   config,
+  # For wrapper
+  callPackage,
   python3Packages,
   # For aliases
   plover_4,
 }:
-python3Packages.toPythonApplication python3Packages.plover
+
+(python3Packages.toPythonApplication python3Packages.plover).overrideAttrs (
+  finalAttrs: previousAttrs: {
+    passthru = previousAttrs.passthru or { } // {
+      /**
+        Shorthand of
+        ```nix
+        python3.plover.wrapPloverExes python3.withPlugins (ps: [ ps.plover ] ++ selectPackages ps)
+        ```
+        ::: {.note}
+        The result package is unrelated to the main package,
+        and is not affected by overriding applying to the main package.
+        Its `<pkg>.override` interface consists of only the `python3` argument,
+        whose `packageOverrides` can be overridden.
+        :::
+      */
+      withPlugins = callPackage ./with-plugins.nix { };
+      tests = {
+        plover-with-lapwing = finalAttrs.passthru.withPlugins (
+          ps: with ps; [
+            plover-lapwing-aio
+          ]
+        );
+      }
+      // previousAttrs.passthru.tests or { };
+    };
+  }
+)
 # Aliases to now-dropped plover.stable and plover.dev
 # Added 2026-04-22
 # TODO(@ShamrockLee): remove after Nixpkgs 25.11 EOL

--- a/pkgs/by-name/pl/plover/with-plugins.nix
+++ b/pkgs/by-name/pl/plover/with-plugins.nix
@@ -1,0 +1,4 @@
+{ python3 }:
+
+selectPackages:
+python3.pkgs.plover.wrapPloverExes (python3.withPackages (ps: [ ps.plover ] ++ selectPackages ps))

--- a/pkgs/development/python-modules/plover/4.nix
+++ b/pkgs/development/python-modules/plover/4.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   buildPythonPackage,
+  callPackage,
   fetchFromGitHub,
   versionCheckHook,
   appdirs,
@@ -86,6 +87,12 @@ buildPythonPackage (finalAttrs: {
   dontWrapQtApps = true;
 
   pythonImportsCheck = [ "plover" ];
+
+  passthru = {
+    wrapPloverExes = callPackage ./wrap-plover-exes.nix {
+      plover = finalAttrs.finalPackage;
+    };
+  };
 
   meta = {
     description = "OpenSteno Plover stenography software";

--- a/pkgs/development/python-modules/plover/5.nix
+++ b/pkgs/development/python-modules/plover/5.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildPackages,
   buildPythonPackage,
+  callPackage,
   fetchFromGitHub,
   versionCheckHook,
   appdirs,
@@ -152,6 +153,38 @@ buildPythonPackage (finalAttrs: {
   dontWrapQtApps = true;
 
   pythonImportsCheck = [ "plover" ];
+
+  passthru = {
+    /**
+      Take a `python3.withPackage`-constructed derivation containing Plover
+      and return a new derivation containing only the plover executables,
+      avoiding collisions while installing Plover with plugins.
+
+      Use as
+      ```nix
+      { python3 }:
+      let
+        python3Overridden = python3.override {
+          packageOverrides =
+            final: previous:
+            {
+              plover = final.plover_5;
+              plover-lapwing-aio = previous.plover-lapwing-aio.overrideAttrs { };
+            };
+        };
+      in
+      python3Overridden.pkgs.plover.wrapPloverExes (
+        python3Overridden.withPackages (ps: with ps; [
+          plover
+          plover-lapwing-aio
+        ])
+      )
+      ```
+    */
+    wrapPloverExes = callPackage ./wrap-plover-exes.nix {
+      plover = finalAttrs.finalPackage;
+    };
+  };
 
   meta = {
     description = "OpenSteno Plover stenography software";

--- a/pkgs/development/python-modules/plover/wrap-plover-exes.nix
+++ b/pkgs/development/python-modules/plover/wrap-plover-exes.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenvNoCC,
+  makeWrapper,
+  versionCheckHook,
+  plover,
+}:
+pythonEnv:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  inherit pythonEnv;
+  pname = "plover-wrapper-with-plugins";
+  inherit (plover) version;
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "''${!outputBin}/bin"
+    for _pathFromPlover in ${lib.getBin plover}/bin/*; do
+      _nameFromPlover=$(basename "$_pathFromPlover")
+      makeWrapper "$pythonEnv/bin/$_nameFromPlover" "''${!outputBin}/bin/$_nameFromPlover"
+    done
+    runHook postInstall
+  '';
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  meta = removeAttrs plover.meta [
+    "attrs"
+    "position"
+    "references"
+    "validity"
+  ];
+})


### PR DESCRIPTION
This PR provides a build helper `python3Packages.plover.wrapPloverExes` which exposes only Plover executables from a Python environment package containing Plover and plugins.
This allows clean installation of Plover with plugins while preserving the flexibility of `python3`'s `packageOverrides` package set extensibility.

```nix
{ python3 }:
let
  python3Overridden = python3.override {
    packageOverrides =
      final: previous:
      {
        plover = final.plover_5;
        plover-lapwing-aio = previous.plover-lapwing-aio.overrideAttrs { };
      };
  };
in
python3Overridden.pkgs.plover.wrapPloverExes (
  python3Overridden.withPackages (ps: with ps; [
    plover
    plover-lapwing-aio
  ])
)
```

This PR also provides `plover.withPlugins` for users who don't need custom overriding:

```nix
plover.withPlugins (ps: with ps; [ plover-lapwing-aio ])
```

> [!NOTE]
> The `plover.withPlugins` is independent to the main `plover` package and depends only on `python3` injected via a separate `callPackage` call.
> Overriding applied to the main package won't get propagated to the `withPlugins`-constructed package.
> In case downstream users need custom overriding, override the `python3` argument of `<plover-with-plugins>.override`.

Closes #89341 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
