### PR TITLE
rrc-tui: Init at 0.1.0-unstable-2026-01-17

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26222,6 +26222,12 @@
     githubId = 55607356;
     name = "Stephan Heßelmann";
   };
+  stellarskylark = {
+    email = "stellarskylark@posteo.net";
+    github = "stellarskylark";
+    githubId = 2815515;
+    name = "Skylar Hill";
+  };
   stelcodes = {
     email = "stel@stel.codes";
     github = "stelcodes";

--- a/pkgs/by-name/rr/rrc-tui/package.nix
+++ b/pkgs/by-name/rr/rrc-tui/package.nix
@@ -1,0 +1,42 @@
+{ lib,
+  fetchFromGitHub,
+  python3Packages,
+}:
+
+with python3Packages;
+buildPythonApplication rec {
+  pname = "rrc-tui";
+  version = "0.1.0-unstable-2026-01-17";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "kc1awv";
+    repo = "rrc-tui";
+    rev = "c3edb67479133e23fe5d72d1de56c734be0d120f";
+    hash = "sha256-qVL/XqxUdabaQZGOKpTfETmTUC7tcTdXWht//bcecHI=";
+  };
+
+  dependencies = [
+    rns
+    textual
+    cbor2
+  ];
+
+  buildInputs = [
+    setuptools
+  ];
+
+  outputs = [ "out" ];
+
+  meta = {
+    homepage = "https://github.com/kc1awv/rrc-tui";
+    description = "A Text User Interface (TUI) client for RRC (Reticulum Relay Chat)";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      stellarskylark
+    ];
+    platforms = lib.platforms.linux;
+    mainProgram = "rrc-tui";
+  };
+
+}


### PR DESCRIPTION
Adds `rrc-tui`, a terminal client for the Reticulum Relay Chat protocol.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
