### PR TITLE
gavl: init at 2.0.1

### DIFF
--- a/pkgs/by-name/ga/gavl/package.nix
+++ b/pkgs/by-name/ga/gavl/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  autoreconfHook,
+  nettle,
+  gnutls,
+  libpng,
+  libdrm,
+  libva,
+  libGL,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gavl";
+  version = "2.0.1";
+
+  src = fetchFromGitHub {
+    owner = "bplaum";
+    repo = "gavl";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-nvgBsUiSF6+voMzo5XRWHig2Iq8DD2hVV5hWodGxgQo=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    autoreconfHook
+  ];
+
+  buildInputs = [
+    nettle
+    gnutls
+    libpng
+    libdrm
+    libva
+    libGL
+  ];
+
+  configureFlags = [
+    "--without-doxygen"
+    "--with-cpuflags=none"
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  makeFlags = [ "LDFLAGS=-lm" ];
+
+  meta = {
+    description = "Gmerlin Audio Video Library";
+    homepage = "https://github.com/bplaum/gavl";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ tbutter ];
+  };
+})


### PR DESCRIPTION
Init Gmerlin Audio Video Library at 2.0.1

gavl is an optional dependency of frei0r that is already in nixpkgs

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (tested with frei0r)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
