### PR TITLE
home-assistant-custom-components.garmin_connect: 0.2.38 -> 3.0.5

### DIFF
--- a/pkgs/development/python-modules/ha-garmin/default.nix
+++ b/pkgs/development/python-modules/ha-garmin/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  curl-cffi,
+  pydantic,
+  pytest-asyncio,
+  pytestCheckHook,
+  requests,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "ha-garmin";
+  version = "0.1.19";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "cyberjunky";
+    repo = "ha-garmin";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-vzr32vuAVafdx64Fmv257gS2a+ZbfwZNwwuF5NPQbS0=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    curl-cffi
+    pydantic
+    requests
+  ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Upstream test relies on a field not present in the test fixture
+    "test_fetch_core_data_sleep_fields"
+  ];
+
+  pythonImportsCheck = [ "ha_garmin" ];
+
+  meta = {
+    description = "Python client for Garmin Connect API, designed for Home Assistant integration";
+    homepage = "https://github.com/cyberjunky/ha-garmin";
+    changelog = "https://github.com/cyberjunky/ha-garmin/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/custom-components/garmin_connect/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/garmin_connect/package.nix
@@ -2,25 +2,23 @@
   lib,
   buildHomeAssistantComponent,
   fetchFromGitHub,
-  garminconnect,
-  tzlocal,
+  ha-garmin,
 }:
 
 buildHomeAssistantComponent rec {
   owner = "cyberjunky";
   domain = "garmin_connect";
-  version = "0.2.38";
+  version = "3.0.5";
 
   src = fetchFromGitHub {
     owner = "cyberjunky";
     repo = "home-assistant-garmin_connect";
     tag = version;
-    hash = "sha256-Df/ecgePR10LIeaGy0kmIWqiP9G7j+KscL/YA3VsARE=";
+    hash = "sha256-omHgfkrje5xR9gLnQpAz33+LtXm5eGJ8nERYBX4F2sY=";
   };
 
   dependencies = [
-    garminconnect
-    tzlocal
+    ha-garmin
   ];
 
   meta = {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6897,6 +6897,8 @@ self: super: with self; {
 
   ha-ffmpeg = callPackage ../development/python-modules/ha-ffmpeg { };
 
+  ha-garmin = callPackage ../development/python-modules/ha-garmin { };
+
   ha-iotawattpy = callPackage ../development/python-modules/ha-iotawattpy { };
 
   ha-mqtt-discoverable = callPackage ../development/python-modules/ha-mqtt-discoverable { };


### PR DESCRIPTION
Upstream rewrote the integration to use a new client library, `ha-garmin`, instead of `garminconnect` + `tzlocal`. This PR adds `python3Packages.ha-garmin` (0.1.19) and switches the component over.

`garminconnect` is kept since it's still used by `garmin-grafana`.

Changelog: https://github.com/cyberjunky/home-assistant-garmin_connect/releases/tag/3.0.5

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
