### PR TITLE
frei0r: 2.5.1 -> 3.1.3

### DIFF
--- a/pkgs/by-name/fr/frei0r/package.nix
+++ b/pkgs/by-name/fr/frei0r/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "frei0r-plugins";
-  version = "2.5.1";
+  version = "3.1.3";
 
   src = fetchFromGitHub {
     owner = "dyne";
     repo = "frei0r";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-3gUWvO5izOrJt+XwcNBNiLfu+iMqo4nuPbx++TYzao0=";
+    hash = "sha256-D00sxSTnv4oqxhKYKayJPs5uWYW4HosEp2StuCVmGFY=";
   };
 
   nativeBuildInputs = [
@@ -33,6 +33,10 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals cudaSupport [
     cudaPackages.cuda_cudart
     cudaPackages.cuda_nvcc
+  ];
+
+  cmakeFlags = [
+    "-DWITHOUT_GAVL=ON"
   ];
 
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''


### PR DESCRIPTION
Update frei0r to 3.1.3

add flag to build without gavl which is not yet in nixpkgs (see #518832)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
