### PR TITLE
pgmoneta: 0.19.1 -> 0.21.0

### DIFF
--- a/pkgs/by-name/pg/pgmoneta/package.nix
+++ b/pkgs/by-name/pg/pgmoneta/package.nix
@@ -11,8 +11,11 @@
   libev,
   libgccjit,
   libssh,
+  libyaml,
   lz4,
+  ncurses,
   openssl,
+  pkg-config,
   systemd,
   zlib,
   zstd,
@@ -20,18 +23,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pgmoneta";
-  version = "0.19.1";
+  version = "0.21.0";
 
   src = fetchFromGitHub {
     owner = "pgmoneta";
     repo = "pgmoneta";
     rev = finalAttrs.version;
-    hash = "sha256-qsKjUFCuxKSc7klB/S2N3TG+jqnS4NW0RZC6e9JQXtA=";
+    hash = "sha256-55oXnyNLwhtT3s4qTEh24N08vf0zhNUDVoxrUiYkVZc=";
   };
 
   nativeBuildInputs = [
     cmake
     docutils # for rst2man
+    pkg-config
   ];
 
   buildInputs = [
@@ -42,7 +46,9 @@ stdenv.mkDerivation (finalAttrs: {
     libev
     libgccjit
     libssh
+    libyaml
     lz4
+    ncurses
     openssl
     systemd
     zlib


### PR DESCRIPTION
Update to 0.21.0

Add ncurses and libyaml dependencies.

Upstream changes:
https://github.com/pgmoneta/pgmoneta/releases/tag/0.20.0
https://github.com/pgmoneta/pgmoneta/releases/tag/0.21.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
