### PR TITLE
python3Packages.pdf-oxide: cleanup

### DIFF
--- a/pkgs/development/python-modules/pdf-oxide/default.nix
+++ b/pkgs/development/python-modules/pdf-oxide/default.nix
@@ -1,7 +1,5 @@
 {
-  lib,
   pkgs,
-  fetchFromGitHub,
   buildPythonPackage,
 
   # build-system
@@ -22,6 +20,7 @@ buildPythonPackage (finalAttrs: {
     ;
 
   pyproject = true;
+  __structuredAttrs = true;
 
   nativeBuildInputs = with rustPlatform; [
     cargoSetupHook
@@ -43,9 +42,7 @@ buildPythonPackage (finalAttrs: {
     "test_issue_401_two_embedded_fonts_save_encrypted"
   ];
 
-  pythonImportsCheck = [
-    "pdf_oxide"
-  ];
+  pythonImportsCheck = [ "pdf_oxide" ];
 
   meta = pkgs.pdf-oxide.meta // {
     description = "Python bindings for the pdf_oxide library";


### PR DESCRIPTION
## Things done



- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
