### PR TITLE
kopuz: init at 0.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27072,6 +27072,12 @@
     github = "tembleking";
     githubId = 2988780;
   };
+  temidaradev = {
+    name = "temidaradev";
+    email = "temidaradev@proton.me";
+    github = "temidaradev";
+    githubId = 118509044;
+  };
   tengkuizdihar = {
     name = "Tengku Izdihar";
     email = "tengkuizdihar@gmail.com";

--- a/pkgs/by-name/ko/kopuz/package.nix
+++ b/pkgs/by-name/ko/kopuz/package.nix
@@ -1,0 +1,136 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  pkg-config,
+  cmake,
+  openssl,
+  tailwindcss_4,
+  dioxus-cli,
+  yt-dlp,
+  fetchFromGitHub,
+  libopus,
+  # Linux only
+  wrapGAppsHook3,
+  webkitgtk_4_1,
+  gtk3,
+  libsoup_3,
+  glib-networking,
+  alsa-lib,
+  xdotool,
+  wayland,
+  dbus,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "kopuz";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "Kopuz-org";
+    repo = "kopuz";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+HT76hfgTEkEVV1wn2r97PshoRJ08r4fTrExmQDuymg=";
+  };
+
+  cargoHash = "sha256-lTGrwN2CGbmOgrjjbqrizNWPQoxWrEbDkcjhjMergoE=";
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    tailwindcss_4
+    dioxus-cli
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    libopus
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    webkitgtk_4_1
+    gtk3
+    libsoup_3
+    glib-networking
+    alsa-lib
+    openssl
+    xdotool
+    wayland
+    dbus
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    tailwindcss -i tailwind.css -o kopuz/assets/tailwind.css --minify
+
+    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+            mkdir -p "$TMPDIR/fake-bin"
+            cat > "$TMPDIR/fake-bin/codesign" << 'CODESIGN_EOF'
+      #!/bin/sh
+      exec true
+      CODESIGN_EOF
+            chmod +x "$TMPDIR/fake-bin/codesign"
+            export PATH="$TMPDIR/fake-bin:$PATH"
+    ''}
+
+    dx build --release --platform desktop -p kopuz --offline --frozen
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+
+    ${
+      if stdenv.hostPlatform.isLinux then
+        ''
+          cp -r target/dx/kopuz/release/linux/app/* $out/bin/
+
+          install -Dm644 data/com.temidaradev.kopuz.desktop \
+            $out/share/applications/com.temidaradev.kopuz.desktop
+          substituteInPlace $out/share/applications/com.temidaradev.kopuz.desktop \
+
+          install -Dm644 data/com.temidaradev.kopuz.metainfo.xml \
+            $out/share/metainfo/com.temidaradev.kopuz.metainfo.xml
+
+          install -Dm644 kopuz/assets/logo.png \
+            $out/share/icons/hicolor/256x256/apps/com.temidaradev.kopuz.png
+        ''
+      else
+        ''
+          # Dioxus outputs the bundle at macos/Kopuz.app (capitalised, no app/ subdir)
+          cp -r target/dx/kopuz/release/macos/Kopuz.app $out/bin/kopuz.app
+          # Symlink whatever binary dioxus placed in MacOS/ (name may differ in case)
+          macBin=$(find $out/bin/kopuz.app/Contents/MacOS -maxdepth 1 -type f | head -1)
+          ln -s "$macBin" $out/bin/kopuz
+        ''
+    }
+
+    runHook postInstall
+  '';
+
+  preFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    gappsWrapperArgs+=(
+      --chdir $out/bin
+      --prefix PATH : ${lib.makeBinPath [ yt-dlp ]}
+    )
+  '';
+
+  meta = {
+    description = "Fast, modern music player with Jellyfin and local library support";
+    homepage = "https://github.com/Kopuz-org/kopuz";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      temidaradev
+      NotAShelf
+    ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    mainProgram = "kopuz";
+  };
+})


### PR DESCRIPTION
New package: kopuz - a fast, modern desktop music player built with Rust and Dioxus.
Supports local music libraries and Jellyfin/Subsonic server streaming.
Homepage: https://github.com/Kopuz-org/kopuz

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
