### PR TITLE
luastatus: remove unused pcre dependency

### DIFF
--- a/pkgs/by-name/lu/luastatus/package.nix
+++ b/pkgs/by-name/lu/luastatus/package.nix
@@ -16,7 +16,6 @@
   libxau,
   libxdmcp,
   pcre2,
-  pcre,
   util-linux,
   libselinux,
   libsepol,
@@ -61,7 +60,6 @@ stdenv.mkDerivation (finalAttrs: {
     glib
     udev
     pcre2
-    pcre
     util-linux
     lua5
     docutils


### PR DESCRIPTION
- #356387 

Doing `grep pcre` resulted in nothing in the codebase. With `lddtree` I can only see one binary `plugin-dbus.so` has an indirect dependency on pcre2:

```
lib/luastatus/plugins/plugin-dbus.so (interpreter => None)
    libgio-2.0.so.0 => /nix/store/0iksbi3kkh2af1jv5zzf7jx1f0rxh201-glib-2.86.3/lib/libgio-2.0.so.0
        libgmodule-2.0.so.0 => /nix/store/0iksbi3kkh2af1jv5zzf7jx1f0rxh201-glib-2.86.3/lib/libgmodule-2.0.so.0
        libz.so.1 => /nix/store/6v5hbaxvndmaf21rfyryxpn1xjkljrid-zlib-1.3.2/lib/libz.so.1
        libmount.so.1 => /nix/store/32ppr0svyq3mqwm228pks8ysf8rm0fqc-util-linux-minimal-2.41.3-lib/lib/libmount.so.1
            libblkid.so.1 => /nix/store/32ppr0svyq3mqwm228pks8ysf8rm0fqc-util-linux-minimal-2.41.3-lib/lib/libblkid.so.1
            ld-linux-x86-64.so.2 => /nix/store/pdwlyjkmc6icc0wb5gaw08m9ynqrg683-glibc-2.40-218/lib/ld-linux-x86-64.so.2
        libselinux.so.1 => /nix/store/07ryaqh422ngl2iznwqkj4128nlvk8zk-libselinux-3.8.1/lib/libselinux.so.1
            libpcre2-8.so.0 => /nix/store/9jzp4zpxzjaz9xhpmqlrgz06m166p8kh-pcre2-10.46/lib/libpcre2-8.so.0
            libdl.so.2 => /nix/store/pdwlyjkmc6icc0wb5gaw08m9ynqrg683-glibc-2.40-218/lib/libdl.so.2
    libgobject-2.0.so.0 => /nix/store/0iksbi3kkh2af1jv5zzf7jx1f0rxh201-glib-2.86.3/lib/libgobject-2.0.so.0
        libffi.so.8 => /nix/store/6rwsi7k52chjbpxr74khmzdr5hzlc4bb-libffi-3.5.2/lib/libffi.so.8
    libglib-2.0.so.0 => /nix/store/0iksbi3kkh2af1jv5zzf7jx1f0rxh201-glib-2.86.3/lib/libglib-2.0.so.0
    libc.so.6 => /nix/store/pdwlyjkmc6icc0wb5gaw08m9ynqrg683-glibc-2.40-218/lib/libc.so.6
```
It seems neither `pcre` nor `pcre2` is directly depended by this software.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
