### PR TITLE
psrdada: init at 1.2.3

### DIFF
--- a/pkgs/by-name/ps/psrdada/package.nix
+++ b/pkgs/by-name/ps/psrdada/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  cmake,
+  hwloc,
+  rdma-core,
+  config,
+  cudaSupport ? config.cudaSupport,
+  cudaPackages,
+}:
+let
+  effectiveStdenv = if cudaSupport then cudaPackages.backendStdenv else stdenv;
+in
+effectiveStdenv.mkDerivation (finalAttrs: {
+  pname = "psrdada";
+  version = "1.2.3";
+
+  src = fetchgit {
+    url = "https://git.code.sf.net/p/psrdada/code";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-yK1Ma+pHsyPZ02m+VcYvZw56OKI879YLLYhjgfkJYCo=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ]
+  ++ lib.optionals cudaSupport [ cudaPackages.cuda_nvcc ];
+
+  buildInputs = [
+    hwloc
+    rdma-core
+  ]
+  ++ lib.optionals cudaSupport [ cudaPackages.cuda_cudart ];
+
+  # They hard-code arch in their CMakeLists for some reason
+  cmakeFlags = lib.optionals cudaSupport [
+    (lib.cmakeFeature "CMAKE_CUDA_ARCHITECTURES" cudaPackages.flags.cmakeCudaArchitecturesString)
+  ];
+
+  strictDeps = true;
+
+  __structuredAttrs = true;
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Distributed data acquisition library for pulsar astronomy";
+    homepage = "https://psrdada.sourceforge.net/";
+    changelog = "https://sourceforge.net/p/psrdada/code/ci/${finalAttrs.version}/tree/";
+    license = with lib.licenses; [
+      afl21
+      gpl3Only
+    ];
+    maintainers = with lib.maintainers; [ kiranshila ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/ps/psrdada/update.sh
+++ b/pkgs/by-name/ps/psrdada/update.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p common-updater-scripts git gnused gnugrep coreutils
+set -euo pipefail
+
+repo="https://git.code.sf.net/p/psrdada/code"
+
+# Get tags, strip refs/tags/ prefix, filter to numeric x.y.z, sort semver-aware, take latest
+latest=$(git ls-remote --tags --refs "$repo" \
+    | awk '{print $2}' \
+    | sed 's|refs/tags/||' \
+    | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+    | sort -V \
+    | tail -n1)
+
+if [[ -z "$latest" ]]; then
+    echo "No tags found" >&2
+    exit 1
+fi
+
+# UPDATE_NIX_ATTR_PATH is set by nixpkgs' update.nix runner
+update-source-version "${UPDATE_NIX_ATTR_PATH:-psrdada}" "$latest"


### PR DESCRIPTION
Adds the PSRDADA library and collection of executables.
This package is for "distributed data acquisition library for pulsar astronomy, used in the implementation of instrumentation for radio telescopes" and is one of the de facto standards in building pulsar/FRB pipelines.

License is listed as both AFL 2.1 and GPL-3.0 because the per-file headers declare AFL 2.1 while the COPYING file is GPL-3.0. This inconsistency exists upstream and has not been resolved.

CUDA support is optional and gated behind config.cudaSupport.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
