### PR TITLE
depthcharge-tools: init at 0.6.4

### DIFF
--- a/pkgs/by-name/de/depthcharge-tools/package.nix
+++ b/pkgs/by-name/de/depthcharge-tools/package.nix
@@ -1,0 +1,68 @@
+{
+  bzip2,
+  dtc,
+  fetchFromGitLab,
+  gzip,
+  lib,
+  lz4,
+  lzop,
+  makeWrapper,
+  nix-update-script,
+  python3Packages,
+  ubootTools,
+  vboot-utils,
+  xz,
+  zstd,
+}:
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "depthcharge-tools";
+  version = "0.6.4";
+  src = fetchFromGitLab {
+    domain = "gitlab.postmarketos.org";
+    owner = "postmarketOS";
+    repo = "depthcharge-tools";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-McnBtc0UpatKO4XBnMOHf2L8xxcrsRM/5DCbmAmfA1o=";
+  };
+
+  pyproject = true;
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    importlib-resources
+    importlib-metadata
+    packaging
+  ];
+
+  makeWrapperArgs = [
+    "--suffix"
+    "PATH"
+    ":"
+    "${lib.makeBinPath [
+      bzip2
+      dtc
+      gzip
+      lz4
+      lzop
+      ubootTools
+      vboot-utils
+      xz
+      zstd
+    ]}"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Tools to manage the Chrome OS bootloader";
+    homepage = "https://gitlab.postmarketos.org/postmarketOS/depthcharge-tools";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.ninelore ];
+    mainProgram = "depthchargectl";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
A set of tools for interacting with depthcharge, the (stock) bootloader of ChromeOS devices

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
