### PR TITLE
 nixos/pihole-ftl: fix systemd.enableStrictShellChecks, fix block list setup, fix /api/padd?full=true endpoint returning an error

### DIFF
--- a/nixos/modules/services/networking/pihole-ftl-setup-script.nix
+++ b/nixos/modules/services/networking/pihole-ftl-setup-script.nix
@@ -19,6 +19,7 @@ let
 in
 ''
   # Can't use -u (unset) because api.sh uses API_URL before it is set
+  set +u
   set -eo pipefail
   pihole="${lib.getExe pihole}"
   jq="${lib.getExe pkgs.jq}"
@@ -29,22 +30,24 @@ in
   if [ ! -f '${cfg.settings.files.gravity}' ]; then
     $pihole -g
     # Send SIGRTMIN to FTL, which makes it reload the database, opening the newly created one
-    ${lib.getExe' pkgs.procps "kill"} -s SIGRTMIN $(systemctl show --property MainPID --value ${config.systemd.services.pihole-ftl.name})
+    ${lib.getExe' pkgs.procps "kill"} -s SIGRTMIN "$(systemctl show --property MainPID --value ${config.systemd.services.pihole-ftl.name})"
   fi
 
+  # shellcheck disable=SC1091
   source ${pihole}/share/pihole/advanced/Scripts/api.sh
+  # shellcheck disable=SC1091
   source ${pihole}/share/pihole/advanced/Scripts/utils.sh
 
   any_failed=0
 
   addList() {
-    local payload="$1"
+    local payload="$1" result type error
 
     echo "Adding list: $payload"
-    local type=$($jq -r '.type' <<< "$payload")
-    local result=$(PostFTLData "lists?type=$type" "$payload")
+    type=$($jq -r '.type' <<< "$payload")
+    result=$(PostFTLData "lists?type=$type" "$payload")
 
-    local error="$($jq '.error' <<< "$result")"
+    error="$($jq '.error' <<< "$result")"
     if [[ "$error" != "null" ]]; then
         echo "Error: $error"
         any_failed=1
@@ -62,7 +65,7 @@ in
     echo "Added list ID $id: $result"
   }
 
-  for i in 1 2 3; do
+  for _ in 1 2 3; do
     (TestAPIAvailability) && break
     echo "Retrying API shortly..."
     ${lib.getExe' pkgs.coreutils "sleep"} .5s

--- a/nixos/modules/services/networking/pihole-ftl.nix
+++ b/nixos/modules/services/networking/pihole-ftl.nix
@@ -491,11 +491,18 @@ in
 
     users.groups.${cfg.group} = { };
 
-    environment.etc."pihole/pihole.toml" = {
-      source = settingsFile;
-      user = cfg.user;
-      group = cfg.group;
-      mode = "400";
+    environment.etc = {
+      "pihole/pihole.toml" = {
+        source = settingsFile;
+        user = cfg.user;
+        group = cfg.group;
+        mode = "400";
+      };
+
+      "pihole/versions".text = ''
+        CORE_VERSION=${cfg.piholePackage.src.src.tag}
+        FTL_VERSION=${cfg.package.src.tag}
+      '';
     };
 
     environment.systemPackages = [ cfg.pihole ];

--- a/nixos/modules/services/web-apps/pihole-web.nix
+++ b/nixos/modules/services/web-apps/pihole-web.nix
@@ -89,6 +89,8 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    environment.etc."pihole/versions".text = "WEB_VERSION=${cfg.package.src.tag}";
+
     services.pihole-ftl.settings.webserver = {
       domain = cfg.hostName;
       port = cfg.ports;


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
