### PR TITLE
python3Packages.prowlpy: 1.1.5 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/prowlpy/default.nix
+++ b/pkgs/development/python-modules/prowlpy/default.nix
@@ -1,42 +1,42 @@
 {
   buildPythonPackage,
-  click,
+  cacert,
   fetchFromGitHub,
-  httpx,
   lib,
   loguru,
+  pyreqwest,
   pytest-asyncio,
   pytest-cov-stub,
   pytestCheckHook,
   respx,
   setuptools,
+  typer,
   xmltodict,
 }:
 
 buildPythonPackage rec {
   pname = "prowlpy";
-  version = "1.1.5";
+  version = "2.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "OMEGARAZER";
     repo = "prowlpy";
     tag = "v${version}";
-    hash = "sha256-psXq858y5wsDU5GqGOzVFmYBSZvfuYXzOTZ20mx8PMw=";
+    hash = "sha256-S+hhZndOb5O9okrrnXGt7D0N4VRIThbMN1LYVPGzFy8=";
   };
 
   build-system = [ setuptools ];
 
   dependencies = [
-    httpx
+    pyreqwest
     xmltodict
-  ]
-  ++ httpx.optional-dependencies.http2;
+  ];
 
   optional-dependencies = {
     cli = [
-      click
       loguru
+      typer
     ];
   };
 
@@ -49,6 +49,12 @@ buildPythonPackage rec {
     respx
   ]
   ++ lib.concatAttrValues optional-dependencies;
+
+  preCheck = ''
+    # Without this pyreqwest fails with
+    #     unexpected error: No CA certificates were loaded from the system
+    export SSL_CERT_FILE="${cacert}/etc/ssl/certs/ca-bundle.crt"
+  '';
 
   # tests fail without this
   pytestFlags = [ "-v" ];

--- a/pkgs/development/python-modules/pyreqwest/default.nix
+++ b/pkgs/development/python-modules/pyreqwest/default.nix
@@ -1,0 +1,78 @@
+{
+  buildPythonPackage,
+  cacert,
+  dirty-equals,
+  docker,
+  fetchFromGitHub,
+  granian,
+  httpx,
+  lib,
+  pydantic,
+  pytest-asyncio,
+  pytestCheckHook,
+  requests-toolbelt,
+  rustPlatform,
+  starlette,
+  syrupy,
+  trustme,
+  yarl,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pyreqwest";
+  version = "0.12.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "MarkusSintonen";
+    repo = "pyreqwest";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-o33/KkPBl4ActDV0R8KqWll6F47HPO3amHFI00rHryE=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-+flEikEImbiu/x+pJQz3rynYKmfjaS9N0/A1HSzH0jU=";
+  };
+
+  build-system = [
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+  ];
+
+  pythonImportsCheck = [ "pyreqwest" ];
+
+  nativeCheckInputs = [
+    dirty-equals
+    docker
+    granian
+    httpx
+    pydantic
+    pytest-asyncio
+    pytestCheckHook
+    requests-toolbelt
+    starlette
+    syrupy
+    trustme
+    yarl
+  ];
+
+  preCheck = ''
+    # Without this tests fails with
+    #     unexpected error: No CA certificates were loaded from the system
+    export SSL_CERT_FILE="${cacert}/etc/ssl/certs/ca-bundle.crt"
+  '';
+
+  disabledTestPaths = [
+    # requires a running Docker daemon
+    "tests/test_examples.py"
+  ];
+
+  meta = {
+    changelog = "https://github.com/MarkusSintonen/pyreqwest/releases/tag/${finalAttrs.src.tag}";
+    description = "Fast Python HTTP client based on Rust reqwest";
+    homepage = "https://github.com/MarkusSintonen/pyreqwest";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.dotlambda ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14948,6 +14948,8 @@ self: super: with self; {
 
   pyrepetierng = callPackage ../development/python-modules/pyrepetierng { };
 
+  pyreqwest = callPackage ../development/python-modules/pyreqwest { };
+
   pyrevolve = callPackage ../development/python-modules/pyrevolve { };
 
   pyrfc3339 = callPackage ../development/python-modules/pyrfc3339 { };


### PR DESCRIPTION
Most of pyreqwest's tests fail with

> unexpected error: No CA certificates were loaded from the system

I tried setting `$SSL_CERT_FILE` but that didn't help. Help would be appreciated!

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
