### PR TITLE
python3Packages.nengo: 4.0.0 -> 4.1.0

### DIFF
--- a/pkgs/development/python-modules/nengo/default.nix
+++ b/pkgs/development/python-modules/nengo/default.nix
@@ -10,21 +10,21 @@
   scikit-learn,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "nengo";
-  version = "4.0.0";
+  version = "4.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "nengo";
     repo = "nengo";
-    tag = "v${version}";
-    sha256 = "sha256-b9mPjKdewIqIeRrddV1/M3bghSyox7Lz6VbfSLCHZjA=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-yZDnttXU5qMmQwFESkhQb06BXcqPEiPYl54azS5b284=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     numpy
   ]
   ++ lib.optionals scipySupport [ scipy ]
@@ -41,7 +41,7 @@ buildPythonPackage rec {
   meta = {
     description = "Python library for creating and simulating large-scale brain models";
     homepage = "https://nengo.ai/";
-    license = lib.licenses.unfreeRedistributable;
+    license = lib.licenses.gpl2Only;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
# python3Packages.nengo: 4.0.0 -> 4.1.0

## Description of changes

Bumps `python3Packages.nengo` from 4.0.0 to 4.1.0.

### Why

The 4.0.0 build was failing on Hydra with:

```
ERROR Missing dependencies:
 setuptools<64
```

Nengo 4.0.0's `pyproject.toml` contains:

```toml
[build-system]
requires = ["setuptools<64", "wheel"]
```

This conflicts with the modern setuptools (80.x) shipped in current nixpkgs. Upstream 4.1.0 drops this constraint and properly declares the build backend:

```toml
[build-system]
requires = ["setuptools", "wheel"]
build-backend = "setuptools.build_meta"
```

So the cleanest fix is a version bump rather than patching `pyproject.toml`.

### updateScript

Upstream tags 4.1.0 in git and publishes to PyPI but doesn't cut a corresponding GitHub Release, so `nix-update` defaulting to the Releases API doesn't discover it.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For new packages please note who the package maintainer is
- [x] Tested via `nixpkgs-review`
- [x] Tested basic functionality (import + minimal simulator run)

### nixpkgs-review

```
4 packages built:
python313Packages.nengo
python313Packages.nengo.dist
python314Packages.nengo
python314Packages.nengo.dist

2 packages failed to build:
nengo-gui
nengo-gui.dist
```

**`nengo-gui` failure is pre-existing and unrelated to this change.** Its `setup.py` does `import imp` on line 2, and the `imp` module was removed from Python in 3.12. The package is already gated off for modern Python and is not evaluated by Hydra — `hydra-check nengo-gui` reports:

> This job is not a member of the latest evaluation of its jobset. This means it was removed or had an evaluation error.

So this is `nixpkgs-review` not honoring the `disabled`/`broken` gate the way Hydra does, not a regression introduced here.

### Manual smoke test

```python
import nengo
import numpy as np

with nengo.Network() as net:
    stim = nengo.Node(lambda t: np.sin(t))
    ens = nengo.Ensemble(n_neurons=50, dimensions=1)
    nengo.Connection(stim, ens)
    p = nengo.Probe(ens, synapse=0.01)

with nengo.Simulator(net) as sim:
    sim.run(0.1)

print(sim.data[p].shape)  # -> (100, 1)
```

Imports cleanly, builds a network, runs the reference simulator, and probes work.

---
