### PR TITLE
 pa-dlna: init at 1.2 

### DIFF
--- a/pkgs/by-name/pa/pa-dlna/package.nix
+++ b/pkgs/by-name/pa/pa-dlna/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  curl,
+  fetchFromGitLab,
+  flac,
+  ffmpeg-headless,
+  lame,
+  pulseaudio,
+  python3,
+}:
+
+python3.pkgs.buildPythonApplication (finalAttrs: {
+  pname = "pa-dlna";
+  version = "1.2";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    owner = "xdegaye";
+    repo = "pa-dlna";
+    tag = finalAttrs.version;
+    hash = "sha256-f0JGJwenKH/4LQv40AhmpYmzAzqkSUhdTBeB4VzqTaQ=";
+  };
+
+  postPatch = ''
+    substituteInPlace pa_dlna/encoders.py \
+      --replace-fail "shutil.which('ffmpeg')" "'${lib.getExe ffmpeg-headless}'" \
+      --replace-fail "shutil.which('flac')" "'${lib.getExe flac}'" \
+      --replace-fail "shutil.which('lame')" "'${lib.getExe lame}'"
+    substituteInPlace pa_dlna/pa_dlna.py \
+      --replace-fail "shutil.which('parec')" "'${lib.getExe' pulseaudio "parec"}'"
+    substituteInPlace systemd/pa-dlna.service \
+      --replace-fail "/usr/bin/pa-dlna" "$out/bin/pa-dlna"
+  '';
+
+  build-system = [ python3.pkgs.flit-core ];
+
+  dependencies = with python3.pkgs; [
+    libpulse
+    psutil
+    systemd-python
+  ];
+
+  postInstall = ''
+    install systemd/pa-dlna.service -Dt $out/share/systemd/user/
+  '';
+
+  nativeCheckInputs = [
+    curl
+    ffmpeg-headless
+    python3.pkgs.pytestCheckHook
+  ];
+
+  disabledTests = [
+    # path to parec is patched and which breaks the mocking
+    "test_no_parec"
+  ];
+
+  pythonImportsCheck = [ "pa_dlna" ];
+
+  meta = {
+    description = "UPnP control point forwarding PulseAudio streams to DLNA devices";
+    homepage = "https://gitlab.com/xdegaye/pa-dlna";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+    mainProgram = "pa-dlna";
+  };
+})

--- a/pkgs/development/python-modules/libpulse/default.nix
+++ b/pkgs/development/python-modules/libpulse/default.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitLab,
+  flit-core,
+  glibcLocales,
+  libpulseaudio,
+  pulseaudio,
+  pytestCheckHook,
+  stdenv,
+  writableTmpDirAsHomeHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "libpulse";
+  version = "0.7";
+  pyproject = true;
+
+  src = fetchFromGitLab {
+    owner = "xdegaye";
+    repo = "libpulse";
+    tag = finalAttrs.version;
+    hash = "sha256-JxWJaD/9WxvF/lajWWot10/urqGktr4JGGOJRNhbPjk=";
+  };
+
+  postPatch = ''
+    substituteInPlace libpulse/libpulse_ctypes.py \
+      --replace-fail "find_library('pulse')" "'${lib.getLib libpulseaudio}/lib/libpulse${stdenv.hostPlatform.extensions.sharedLibrary}'"
+  '';
+
+  build-system = [ flit-core ];
+
+  nativeCheckInputs = [
+    glibcLocales
+    pulseaudio
+    pytestCheckHook
+    writableTmpDirAsHomeHook
+  ];
+
+  # using pulseaudio as it is easier to setup than pipewire
+  preCheck = ''
+    mkdir -p $HOME/.config/pulse/
+    cp ${pulseaudio}/etc/pulse/* $HOME/.config/pulse/
+    pulseaudio --verbose --daemonize=yes
+  '';
+
+  disabledTests = [
+    # path to lib is patched and which breaks the mocking
+    "test_missing_lib"
+  ];
+
+  pythonImportsCheck = [ "libpulse" ];
+
+  meta = {
+    description = "Asyncio interface to the Pulseaudio and Pipewire pulse library";
+    homepage = "https://gitlab.com/xdegaye/libpulse";
+    license = lib.licenses.mit;
+    mainProgram = "pactl-py";
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8855,6 +8855,8 @@ self: super: with self; {
     pkgsLibpcap = pkgs.libpcap; # Needs the C library
   };
 
+  libpulse = callPackage ../development/python-modules/libpulse { };
+
   libpurecool = callPackage ../development/python-modules/libpurecool { };
 
   libpwquality = lib.pipe pkgs.libpwquality [


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
