### PR TITLE
perseus: fix build with gcc15

### DIFF
--- a/pkgs/by-name/pe/perseus/fix-gcc15.patch
+++ b/pkgs/by-name/pe/perseus/fix-gcc15.patch
@@ -1,0 +1,57 @@
+diff --git a/Cells/Point.h b/Cells/Point.h
+index b03113c..472372e 100644
+--- a/Cells/Point.h
++++ b/Cells/Point.h
+@@ -91,7 +91,7 @@ public:
+ template <typename PS>
+ struct ptcomp
+ {
+-	bool operator ()(Point<PS>* p, Point<PS>* q)
++	bool operator ()(Point<PS>* p, Point<PS>* q) const
+ 	{
+ 		if (p == q) return false;
+ 		if (p == NULL && q != NULL) return true;
+@@ -106,7 +106,7 @@ struct ptcomp
+ template <typename PS>
+ struct ptcomplex
+ {
+-	bool operator ()(Point<PS>* p, Point<PS>* q)
++	bool operator ()(Point<PS>* p, Point<PS>* q) const
+ 	{
+ 		if (p == q) return false;
+ 		if (p == NULL && q != NULL) return true;
+diff --git a/Complexes/CToplex.h b/Complexes/CToplex.h
+index bdd026f..732701e 100644
+--- a/Complexes/CToplex.h
++++ b/Complexes/CToplex.h
+@@ -24,7 +24,7 @@
+ // vector lexico comparison for map-making
+ struct addcomp
+ {
+-	bool operator () (vector<num>* v1, vector<num>* v2)
++	bool operator () (vector<num>* v1, vector<num>* v2) const
+ 	{
+ 		//cout<<" here "; cin.get();
+ 		if (v1 == v2) return false;
+diff --git a/Global/Combinatorics.h b/Global/Combinatorics.h
+index d751a04..d8cf6b2 100644
+--- a/Global/Combinatorics.h
++++ b/Global/Combinatorics.h
+@@ -18,7 +18,7 @@
+ // order nums increasingly
+ struct incnum
+ {
+-	bool operator() (num n1, num n2)
++	bool operator() (num n1, num n2) const
+ 	{
+ 		return (n1 < n2);
+ 	}
+@@ -28,7 +28,7 @@ struct incnum
+ // order nums decreasingly
+ struct decnum
+ {
+-	bool operator() (num n1, num n2)
++	bool operator() (num n1, num n2) const
+ 	{
+ 		return (n1 > n2);
+ 	}

--- a/pkgs/by-name/pe/perseus/package.nix
+++ b/pkgs/by-name/pe/perseus/package.nix
@@ -18,6 +18,11 @@ stdenv.mkDerivation {
   };
 
   sourceRoot = ".";
+
+  patches = [
+    ./fix-gcc15.patch
+  ];
+
   env.NIX_CFLAGS_COMPILE = toString [ "-std=c++14" ];
   buildPhase = ''
     g++ Pers.cpp -O3 -fpermissive -o perseus


### PR DESCRIPTION
- #516381
- #475479 
- Fixes #497618
- https://hydra.nixos.org/build/326852015

Error messages are as scary as the most benign C++ template issues you can think of. The fixes are simple, as always.

I don't have the faintest idea on what this package does so I only verified the built binary starts up and outputs _something_ using the examples from the project's website.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
