### PR TITLE
dagster: init at 1.13.4

### DIFF
--- a/pkgs/development/python-modules/dagster-graphql/default.nix
+++ b/pkgs/development/python-modules/dagster-graphql/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  dagster,
+  gql,
+  graphene,
+  requests-toolbelt,
+  starlette,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "dagster-graphql";
+  version = "1.13.4";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchPypi {
+    inherit (finalAttrs) version;
+    pname = "dagster_graphql";
+    hash = "sha256-740NWSw8hmIi977f8CEv1Ri9oF+BWzSu4r+CAJ6jJ20=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    dagster
+    gql
+    graphene
+    requests-toolbelt
+    starlette
+  ];
+
+  pythonImportsCheck = [ "dagster_graphql" ];
+
+  meta = {
+    description = "GraphQL API for Dagster";
+    homepage = "https://dagster.io";
+    changelog = "https://github.com/dagster-io/dagster/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ lucperkins ];
+  };
+})

--- a/pkgs/development/python-modules/dagster-pipes/default.nix
+++ b/pkgs/development/python-modules/dagster-pipes/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+
+  # build-system
+  hatchling,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "dagster-pipes";
+  version = "1.13.4";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchPypi {
+    inherit (finalAttrs) version;
+    pname = "dagster_pipes";
+    hash = "sha256-qbmWXh7/XcE91nl2KK441WFD7tYXTeS33g9bVN61lvo=";
+  };
+
+  build-system = [ hatchling ];
+
+  pythonImportsCheck = [ "dagster_pipes" ];
+
+  meta = {
+    description = "Lightweight library for orchestration-aware execution from Dagster, runnable in any Python subprocess";
+    homepage = "https://docs.dagster.io/concepts/dagster-pipes";
+    changelog = "https://github.com/dagster-io/dagster/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      lucperkins
+    ];
+  };
+})

--- a/pkgs/development/python-modules/dagster-shared/default.nix
+++ b/pkgs/development/python-modules/dagster-shared/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  platformdirs,
+  pydantic,
+  pyyaml,
+  tomlkit,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "dagster-shared";
+  version = "1.13.4";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchPypi {
+    inherit (finalAttrs) version;
+    pname = "dagster_shared";
+    hash = "sha256-QRastaeKrIUgJ+Q+utkURx6YME/q15kvBMO67Dn6DS0=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    platformdirs
+    pydantic
+    pyyaml
+    tomlkit
+  ];
+
+  pythonImportsCheck = [ "dagster_shared" ];
+
+  meta = {
+    description = "Shared utilities and types used across the Dagster ecosystem";
+    homepage = "https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-shared";
+    changelog = "https://github.com/dagster-io/dagster/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      lucperkins
+    ];
+  };
+})

--- a/pkgs/development/python-modules/dagster-webserver/default.nix
+++ b/pkgs/development/python-modules/dagster-webserver/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  dagster-graphql,
+  uvicorn,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "dagster-webserver";
+  version = "1.13.4";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchPypi {
+    inherit (finalAttrs) version;
+    pname = "dagster_webserver";
+    hash = "sha256-Kdpr8c6Ik9P1Ptor4O3+jrDm7FzEQTny33jwyz6CUzE=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    dagster-graphql
+    uvicorn
+  ];
+
+  pythonImportsCheck = [ "dagster_webserver" ];
+
+  meta = {
+    description = "Web UI and server for Dagster";
+    homepage = "https://dagster.io";
+    changelog = "https://github.com/dagster-io/dagster/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    mainProgram = "dagster-webserver";
+    maintainers = with lib.maintainers; [ lucperkins ];
+  };
+})

--- a/pkgs/development/python-modules/dagster/default.nix
+++ b/pkgs/development/python-modules/dagster/default.nix
@@ -1,0 +1,102 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  alembic,
+  antlr4-python3-runtime,
+  click,
+  coloredlogs,
+  dagster-pipes,
+  dagster-shared,
+  docstring-parser,
+  filelock,
+  grpcio,
+  grpcio-health-checking,
+  jinja2,
+  protobuf,
+  psutil,
+  python-dateutil,
+  python-dotenv,
+  pytz,
+  requests,
+  rich,
+  structlog,
+  tabulate,
+  tomli,
+  toposort,
+  tqdm,
+  tzdata,
+  universal-pathlib,
+  watchdog,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "dagster";
+  version = "1.13.4";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-chQjTEzyV6J24BtmLncLxpq1uu/ydVSHsvSU2fHAtTI=";
+  };
+
+  build-system = [ hatchling ];
+
+  pythonRelaxDeps = [
+    "coloredlogs" # coloredlogs<=14.0,>=6.1 not satisfied by version 15.0.1
+    "protobuf" # protobuf<7,>=4 not satisfied by version 7.34.1
+  ];
+
+  dependencies = [
+    alembic
+    antlr4-python3-runtime
+    click
+    coloredlogs
+    dagster-pipes
+    dagster-shared
+    docstring-parser
+    filelock
+    grpcio
+    grpcio-health-checking
+    jinja2
+    protobuf
+    psutil
+    python-dateutil
+    python-dotenv
+    pytz
+    requests
+    rich
+    structlog
+    tabulate
+    tomli
+    toposort
+    tqdm
+    tzdata
+    universal-pathlib
+    watchdog
+  ];
+
+  # Dagster's test suite requires a number of things that don't fit with Nix's sandboxing
+  # model, including a running Postgres instance and gRPC servers.
+  doCheck = false;
+
+  pythonImportsCheck = [ "dagster" ];
+
+  meta = {
+    description = "Orchestration platform for the development, production, and observation of data assets";
+    homepage = "https://dagster.io";
+    changelog = "https://github.com/dagster-io/dagster/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      lucperkins
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3555,6 +3555,16 @@ self: super: with self; {
 
   daff = callPackage ../development/python-modules/daff { };
 
+  dagster = callPackage ../development/python-modules/dagster { };
+
+  dagster-graphql = callPackage ../development/python-modules/dagster-graphql { };
+
+  dagster-pipes = callPackage ../development/python-modules/dagster-pipes { };
+
+  dagster-shared = callPackage ../development/python-modules/dagster-shared { };
+
+  dagster-webserver = callPackage ../development/python-modules/dagster-webserver { };
+
   dahlia = callPackage ../development/python-modules/dahlia { };
 
   daiquiri = callPackage ../development/python-modules/daiquiri { };


### PR DESCRIPTION
This PR introduces [Dagster](https://dagster.io/) into Nixpkgs. It includes the core Dagster package plus two required dependencies (`dagster-pipes` and `dagster-shared`) and two commonly used programs from the core repo (`dagster-graphql` and `dagster-webserver`).