### PR TITLE
stdenv/check-meta: verify that licenses aren't derivations

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -16,12 +16,10 @@ let
     filter
     findFirst
     getName
-    isDerivation
     length
     concatMap
     mutuallyExclusive
     optional
-    optionalString
     isAttrs
     isString
     warn
@@ -308,15 +306,17 @@ let
         union
         int
         attrs
-        attrsOf
         any
         listOf
         bool
         record
+        intersection
+        not
+        derivation
         ;
       platforms = listOf (union [
         str
-        (attrsOf any)
+        attrs
       ]); # see lib.meta.platformMatch
     in
     record {
@@ -338,7 +338,10 @@ let
         let
           # TODO disallow `str` licenses, use a module
           licenseType = union [
-            (attrsOf any)
+            (intersection [
+              attrs
+              (not derivation)
+            ])
             str
           ];
         in
@@ -347,9 +350,9 @@ let
           licenseType
         ];
       sourceProvenance = listOf attrs;
-      maintainers = listOf (attrsOf any); # TODO use the maintainer type from lib/tests/maintainer-module.nix
-      nonTeamMaintainers = listOf (attrsOf any); # TODO use the maintainer type from lib/tests/maintainer-module.nix
-      teams = listOf (attrsOf any); # TODO similar to maintainers, use a teams type
+      maintainers = listOf attrs; # TODO use the maintainer type from lib/tests/maintainer-module.nix
+      nonTeamMaintainers = listOf attrs; # TODO use the maintainer type from lib/tests/maintainer-module.nix
+      teams = listOf attrs; # TODO similar to maintainers, use a teams type
       priority = int;
       pkgConfigModules = listOf str;
       inherit platforms;

--- a/pkgs/stdenv/generic/meta-types.nix
+++ b/pkgs/stdenv/generic/meta-types.nix
@@ -10,6 +10,7 @@ let
     isInt
     isAttrs
     isList
+    isDerivation
     all
     any
     attrNames
@@ -103,6 +104,11 @@ lib.fix (self: {
           ) (attrNames attrs);
     };
 
+  derivation = {
+    name = "derivation";
+    verify = isDerivation;
+  };
+
   listOf =
     t:
     assert isTypeDef t;
@@ -139,6 +145,29 @@ lib.fix (self: {
     {
       name = "union<${concatStringsSep "," (map (t: t.name) types)}>";
       verify = v: any (func: func v) funcs;
+    };
+
+  intersection =
+    types:
+    assert all isTypeDef types;
+    let
+      # Store a list of functions so we don't have to pay the cost of attrset lookups at runtime.
+      funcs = map (t: t.verify) types;
+    in
+    {
+      name = "intersection<${concatStringsSep "," (map (t: t.name) types)}>";
+      verify = v: all (func: func v) funcs;
+    };
+
+  not =
+    t:
+    assert isTypeDef t;
+    let
+      inherit (t) verify;
+    in
+    {
+      name = "not<${t.name}>";
+      verify = v: !(verify v);
     };
 
   enum =


### PR DESCRIPTION
Among other things, `zlib` is a license, and it's difficult to debug the eval errors that occur when that derivation gets added to meta.licenses instead of the license.

See https://matrix.to/#/!EoslJfrUGMtQOAfnht:lassul.us/$NtdQVzc0lg-lhTdYTTQSIpXG_Pnuql5DfJljZzg9Law?via=nixos.org&via=matrix.org&via=catgirl.cloud and follow-ups.

Replaces:
```
       Last 25 log lines:
       >              | ^
       >            55|   version = "2";
       >
       >        … while evaluating attribute 'packages'
       >          at /nix/store/0x9x3wk1qbkz10ir1r8vfnssp9g5yq5x-source/pkgs/top-level/packages-info.nix:56:3:
       >            55|   version = "2";
       >            56|   packages = lib.listToAttrs (generateInfo [ ] (lib.recurseIntoAttrs pkgs));
       >              |   ^
       >            57| }
       >
       >        … while evaluating package set attribute path 'vgmtrans'
       >
       >        (stack trace truncated; use '--show-trace' to show the full, detailed trace)
       >
       >        error: stack overflow; max-call-depth exceeded
       >        at /nix/store/0x9x3wk1qbkz10ir1r8vfnssp9g5yq5x-source/lib/lists.nix:477:15:
       >           476|   */
       >           477|   remove = e: filter (x: x != e);
       >              |               ^
       >           478|
```

With:
```
       error: Refusing to evaluate package 'vgmtrans-1.3' in /home/m/nixpkgs/pkgs/by-name/vg/vgmtrans/package.nix:53 because it has an invalid meta attrset:
         - vgmtrans.meta.license: Invalid value; expected union<listOf<union<intersection<attrsOf<any>,not<isDerivation>>,string>>,union<intersection<attrsOf<any>,not<isDerivation>>,string>>, got
           [
             <derivation zlib-1.3.2>
             {
               deprecated = false;
               free = true;
               fullName = "libpng License";
               licenseType = "simple";
               redistributable = true;
               shortName = "libpng";
               spdxId = "Libpng";
               url = "https://spdx.org/licenses/Libpng.html";
             }
             {
               deprecated = false;
               free = true;
               fullName = "BSD 3-clause \"New\" or \"Revised\" License";
               licenseType = "simple";
               redistributable = true;
               shortName = "bsd3";
               spdxId = "BSD-3-Clause";
               url = "https://spdx.org/licenses/BSD-3-Clause.html";
             }
           ]
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
