### PR TITLE
ersatztv: 26.3.0 -> 26.5.1, update repo to "legacy"

### DIFF
--- a/pkgs/by-name/er/ersatztv/nuget-deps.json
+++ b/pkgs/by-name/er/ersatztv/nuget-deps.json
@@ -1,13 +1,13 @@
 [
   {
     "pname": "Acornima",
-    "version": "1.2.0",
-    "hash": "sha256-eDApwoJgsWOmCTGPn+o2xpfZEXupAw1+41nCBtAzTas="
+    "version": "1.4.0",
+    "hash": "sha256-7SCe3Bgcyzlv6nXQfTOy3UZLc7ilZ3YXxgl6mcTF82s="
   },
   {
     "pname": "AdvancedStringBuilder",
-    "version": "0.1.1",
-    "hash": "sha256-pLixGUct2lQnSeckSHVnIEoGfsvz3gkA914QSHdaheE="
+    "version": "0.2.0",
+    "hash": "sha256-66bPgNGU/wLpGs9mydkBBlTEJRpvfHDwWEysUsufZJY="
   },
   {
     "pname": "AngleSharp",
@@ -46,8 +46,8 @@
   },
   {
     "pname": "BlazorSortable",
-    "version": "5.2.1",
-    "hash": "sha256-T+0zzQOq81NJUtER+9Ag5DQvn1v3+rbA5AOu/zqWFVg="
+    "version": "6.0.1",
+    "hash": "sha256-VrK9dW5ULwfTOwxKvZU+OiXLuFEldmOx2kju5OBxSu0="
   },
   {
     "pname": "Blurhash.Core",
@@ -60,34 +60,24 @@
     "hash": "sha256-I22mdiA6Ltr0D2pyryUyS0z5YboBr5UY9LZFcer3FPs="
   },
   {
-    "pname": "Bugsnag",
-    "version": "4.1.0",
-    "hash": "sha256-o30fm7J9tZouVRf0oZNR2hTukc2V8HpdRK30Uu5dZcc="
-  },
-  {
-    "pname": "Bugsnag.AspNet.Core",
-    "version": "4.1.0",
-    "hash": "sha256-L/aMCcmE7xLEtap5/H56VwCsDI4N/m8jgoj6SkxM7x8="
-  },
-  {
     "pname": "Chronic.Core",
     "version": "0.4.0",
     "hash": "sha256-5XUJ1kmVfeFjV4o9zBaHtHPQ03GoUBDPnQANQU+DZ6w="
   },
   {
     "pname": "CliWrap",
-    "version": "3.10.0",
-    "hash": "sha256-XMGTr0gkZxSOC72hrCjpIChpN0c0A19X3TqOAdBtgb4="
+    "version": "3.10.1",
+    "hash": "sha256-uH4SXiMkUIPw5RRyKtDTTCSkkr3BhBAPrxnC4O4ES4c="
   },
   {
     "pname": "Dapper",
-    "version": "2.1.66",
-    "hash": "sha256-e5n/wnAFGPDSe30oQQ0fanXrvFZYYa+qCDSTHtfQmPw="
+    "version": "2.1.72",
+    "hash": "sha256-9CKyz72/Vp5/GIoxJzl7RAXTj4MvKTgFi/7fGyhRqf4="
   },
   {
     "pname": "Destructurama.Attributed",
-    "version": "5.2.0",
-    "hash": "sha256-0WBuqkLizviaHA5xrbSbs8Z90MLy+fal+NPe4LyLP2k="
+    "version": "5.3.0",
+    "hash": "sha256-1hj6Y0MSgjNRCSP90fFoaC3md58pOO9VsZzTpXRWFy0="
   },
   {
     "pname": "EFCore.BulkExtensions",
@@ -126,13 +116,18 @@
   },
   {
     "pname": "Elastic.Clients.Elasticsearch",
-    "version": "9.3.0",
-    "hash": "sha256-h2ExrklcO6tVFV2ecxnGXA4uY9D1tiQ3sqmmN7wrRoM="
+    "version": "9.3.6",
+    "hash": "sha256-vRFjnDERVzH3uk9i2j0M8ygs9qzq9fL8jWxhnUX0ins="
+  },
+  {
+    "pname": "Elastic.Esql",
+    "version": "0.11.0",
+    "hash": "sha256-o4OYz2vJq5jOjuOzs6YVIwO5nIQYV5pDyVYwFzU2oDM="
   },
   {
     "pname": "Elastic.Transport",
-    "version": "0.10.3",
-    "hash": "sha256-9AcJAN3uP3wywsm52caPg6Qgt4iZS0nhjIl2bb0hlx8="
+    "version": "0.17.0",
+    "hash": "sha256-XRz9obr31ShKHAmNM9vkh9UZ7+u8GfGFvtX/wOduINw="
   },
   {
     "pname": "ExtendedNumerics.BigDecimal",
@@ -191,8 +186,8 @@
   },
   {
     "pname": "Heron.MudCalendar",
-    "version": "3.4.0",
-    "hash": "sha256-QVrlIlO35o2LElr+Ac3F6UZHlI9fosIjheucWBF+QZU="
+    "version": "4.0.0",
+    "hash": "sha256-B0XLRt7/V3pHxOwNNwDpua/R53wS8hN6TrA+iHw03Nk="
   },
   {
     "pname": "HtmlSanitizer",
@@ -206,8 +201,8 @@
   },
   {
     "pname": "Humanizer.Core",
-    "version": "3.0.1",
-    "hash": "sha256-Wxqf1FRXtsQulLFtbfsfYu4oZmrCuOZAikMcY2i6Dww="
+    "version": "3.0.10",
+    "hash": "sha256-mflSENjDof1Av9M9RLGEQcl4V4keVfH3qIxy/uxJ6FE="
   },
   {
     "pname": "J2N",
@@ -216,23 +211,23 @@
   },
   {
     "pname": "Jint",
-    "version": "4.5.0",
-    "hash": "sha256-1+cTMz+HMVl+AVYRdpd77wblEF+aVRL+tTMoI46H52c="
+    "version": "4.8.0",
+    "hash": "sha256-+K8NGiJ1SChiyMrjn4dJOiBdnWXP6UOfXSsNsJ5//tI="
   },
   {
     "pname": "Json.More.Net",
-    "version": "3.0.0",
-    "hash": "sha256-zlJb9Wi9ErFqN8FYphzog9paPxI3DBVnoTL0c12Bfks="
+    "version": "3.0.1",
+    "hash": "sha256-U4Ers0TkbNsrC8TBJsuQcm9IHirf2BRCOf+9uaOhQSs="
   },
   {
     "pname": "JsonPointer.Net",
-    "version": "7.0.0",
-    "hash": "sha256-/1GemlLhmYnz/HDQTpEEaGxaofoFkFUMNNPInKhAvM4="
+    "version": "7.0.1",
+    "hash": "sha256-KCU4NBKrNAJysKlew0IHN5TD+Euo83wfG9Pi1koAWEk="
   },
   {
     "pname": "JsonSchema.Net",
-    "version": "9.0.0",
-    "hash": "sha256-N5bp2OswdoQI5fe/ZaKmk7LwL9woJ5cV4D43IUeFJ3E="
+    "version": "9.2.0",
+    "hash": "sha256-vz2JWvZ7HM87NXgGc+MS2Nff2q4u+w1gns8GK41LOmw="
   },
   {
     "pname": "LanguageExt.Core",
@@ -280,11 +275,6 @@
     "hash": "sha256-hHL4liVC3k8+PZVIE8N8SdT8UQkEj55IocsY5QEX52s="
   },
   {
-    "pname": "Markdig",
-    "version": "0.44.0",
-    "hash": "sha256-EVuUTv5l68t7bP2vJ2njypxuRzH52AztXyBF9LUJrrI="
-  },
-  {
     "pname": "MedallionTopologicalSort",
     "version": "1.0.0",
     "hash": "sha256-pWRZ4ZEDmljvUsfm0lFRoniDmAGnap2SlbgviuBSChE="
@@ -316,33 +306,33 @@
   },
   {
     "pname": "Microsoft.AspNetCore.Authentication.JwtBearer",
-    "version": "10.0.2",
-    "hash": "sha256-3M89gVZd6YdEKk+/VnNJoWgAkqPkFj8PC32ai3vwm+E="
+    "version": "10.0.7",
+    "hash": "sha256-Y1DM6+4ji/xoAxv9NLsJOj7YUkQA5ItrlTR3NL2XcrE="
   },
   {
     "pname": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
-    "version": "10.0.2",
-    "hash": "sha256-Lkp2a7n4MSsk33irb5ByVQ/zFZS5WcoG6Q+rwV8B27Y="
+    "version": "10.0.7",
+    "hash": "sha256-hr1QgB9miQO2rXj5heibTX/fa3Tj/Nci8G/pDcrq11c="
   },
   {
     "pname": "Microsoft.AspNetCore.JsonPatch",
-    "version": "10.0.2",
-    "hash": "sha256-b1IIM+6HOht8cQsi82KM2epHJ/CvRn16UK57tyWRiU0="
+    "version": "10.0.7",
+    "hash": "sha256-sbF5N0U+OXZKRUXXPppPrvJXevmUGnvDl6LqPtpEsBY="
   },
   {
     "pname": "Microsoft.AspNetCore.Mvc.NewtonsoftJson",
-    "version": "10.0.2",
-    "hash": "sha256-KSRRa8gmn84qphEFNaLl0PwVmG/gQpgzMHc4FIct8E0="
+    "version": "10.0.7",
+    "hash": "sha256-nVAGFNglXbdJtuk099NVyC+qN/lgL3T0UdZ0GtJ1d1M="
   },
   {
     "pname": "Microsoft.AspNetCore.OpenApi",
-    "version": "10.0.2",
-    "hash": "sha256-FU57fPXL4NUDRqi+rLresi4yKttv1KcAnLuEdPCyTos="
+    "version": "10.0.7",
+    "hash": "sha256-WlAW49otxYzgrmuqHewUoBsjDcAZwhNz5WVbCT4EiIA="
   },
   {
     "pname": "Microsoft.AspNetCore.SpaServices.Extensions",
-    "version": "10.0.2",
-    "hash": "sha256-ZY0Aj8amA9XLD/SWu7+kc/2ROq8lwHa5cK7k0ec4j9k="
+    "version": "10.0.7",
+    "hash": "sha256-xDbi4sbKmyrNYw+L1EIQx3RrVrezxPWICuz250dsEjA="
   },
   {
     "pname": "Microsoft.Bcl.AsyncInterfaces",
@@ -421,8 +411,8 @@
   },
   {
     "pname": "Microsoft.Data.Sqlite.Core",
-    "version": "9.0.12",
-    "hash": "sha256-rV9MvBeKDh3DBf9IqHTzCogLKHsAJ0TEfcfSboCI/o0="
+    "version": "9.0.15",
+    "hash": "sha256-4KjfN468fFj8sapfSv4FzYpuhTie89UJ5jg18Nm06zc="
   },
   {
     "pname": "Microsoft.Data.Sqlite.Core",
@@ -436,23 +426,23 @@
   },
   {
     "pname": "Microsoft.EntityFrameworkCore",
-    "version": "9.0.12",
-    "hash": "sha256-TCGyEqqYfJ5nXiAi0xVZe8Bwx8TZ0xefLE7h87b40+Y="
+    "version": "9.0.15",
+    "hash": "sha256-Ou8paIss4D6SL2T4mUB3URVD9gkpK6YQ+mmvTuwmxzg="
   },
   {
     "pname": "Microsoft.EntityFrameworkCore.Abstractions",
-    "version": "9.0.12",
-    "hash": "sha256-52OUOGyGUXiwdjWHm7bXbdTmJ1hyphBrrXfFQebptOU="
+    "version": "9.0.15",
+    "hash": "sha256-JISfrDTChiNqsXiwIh9hMOjLTUJcdkakFPjUqC3IXb4="
   },
   {
     "pname": "Microsoft.EntityFrameworkCore.Analyzers",
-    "version": "9.0.12",
-    "hash": "sha256-RNwUiYCSp/DxNEw+cNO51jFbN1H6jRtTs4XQAcc629E="
+    "version": "9.0.15",
+    "hash": "sha256-8/WBMCzYsfpJXLzH70Z1Yz4RUjHWf6vWBBMVb3VwEjM="
   },
   {
     "pname": "Microsoft.EntityFrameworkCore.Design",
-    "version": "9.0.12",
-    "hash": "sha256-ulEXCCNkXc3tLSHKqd6tXhj5txfuRL1MTxZNS1tQHnc="
+    "version": "9.0.15",
+    "hash": "sha256-4SPaldOH+RASmKSfLGViFf9gzZ3OsAvpBrm5TReqcn4="
   },
   {
     "pname": "Microsoft.EntityFrameworkCore.Relational",
@@ -466,8 +456,8 @@
   },
   {
     "pname": "Microsoft.EntityFrameworkCore.Relational",
-    "version": "9.0.12",
-    "hash": "sha256-PNNKkfu7qB1oZDTI3QvT9TUk5EyR1YRriEznha4Q6+M="
+    "version": "9.0.15",
+    "hash": "sha256-Z/HgAgCHY2nWaOOWh5AYDTn1CpEZyNQJDOFv1GNlvp4="
   },
   {
     "pname": "Microsoft.EntityFrameworkCore.Relational",
@@ -476,13 +466,13 @@
   },
   {
     "pname": "Microsoft.EntityFrameworkCore.Sqlite",
-    "version": "9.0.12",
-    "hash": "sha256-CMrv+8yvKwUj3dHBkdARBfRAbk+lpngXaLeRKsT3Nck="
+    "version": "9.0.15",
+    "hash": "sha256-Ydym7NoDB8wADqoG5k5fTT81Dlcqe5yyfSCfknQxz1M="
   },
   {
     "pname": "Microsoft.EntityFrameworkCore.Sqlite.Core",
-    "version": "9.0.12",
-    "hash": "sha256-XyBi4Sf3r9xzgbWWhSaxXMq9L9l7jhl0Uouql/yLnAQ="
+    "version": "9.0.15",
+    "hash": "sha256-j8y6Iy2M+56wWXdLBo6ZDWk6UlA128kdrsAh9VBDnRg="
   },
   {
     "pname": "Microsoft.EntityFrameworkCore.Sqlite.Core",
@@ -506,28 +496,28 @@
   },
   {
     "pname": "Microsoft.Extensions.ApiDescription.Server",
-    "version": "10.0.2",
-    "hash": "sha256-3xz0RLS2+2wI6MI58VLRC5/gnEI+WpTAvPA56AZlE4E="
+    "version": "10.0.7",
+    "hash": "sha256-tqh27mFfF2GzXLCSSeX0uEQ9yXVuhlOZDHo3rJVLwKw="
   },
   {
     "pname": "Microsoft.Extensions.Caching.Abstractions",
-    "version": "10.0.2",
-    "hash": "sha256-nKmQuZTt1g5/8gBajo7wdCV64kdCucdiQR8JTt7ZZb0="
+    "version": "10.0.7",
+    "hash": "sha256-u3pHlFaDPeY2v89jNYLiHUQ2aGMKpe5wpXZUt8hkgdE="
   },
   {
     "pname": "Microsoft.Extensions.Caching.Abstractions",
-    "version": "9.0.12",
-    "hash": "sha256-5InZVZkpQztuUmMWSFtzanp9zPKfN1gb8Id0kNuaops="
+    "version": "9.0.15",
+    "hash": "sha256-x10lmXDYMA3mUS71ujHYKvDJSToDGVp5ajvxV0QaHuE="
   },
   {
     "pname": "Microsoft.Extensions.Caching.Memory",
-    "version": "10.0.2",
-    "hash": "sha256-sRUF7DM0s1yzZnfjM/hF9A/IysE6Er23gZ6jST+RWh0="
+    "version": "10.0.7",
+    "hash": "sha256-8qXL1F5gE9OZUEp/9pNVT33hjRMVAPt4eovT1NesKoQ="
   },
   {
     "pname": "Microsoft.Extensions.Caching.Memory",
-    "version": "9.0.12",
-    "hash": "sha256-jRs6ObQ4MmhCt0JoCSqlMLLjmPPu1uKnUGUncTjfFvg="
+    "version": "9.0.15",
+    "hash": "sha256-nlXdfEfziMtU3cEyadBlwU2ev3d+KtKSt9Sskgejteg="
   },
   {
     "pname": "Microsoft.Extensions.Caching.Memory",
@@ -541,13 +531,13 @@
   },
   {
     "pname": "Microsoft.Extensions.Configuration",
-    "version": "10.0.1",
-    "hash": "sha256-7xdHie4uHwoGZz5yUT4vWg2EWvkLvsSzItWCoqm4dTM="
+    "version": "10.0.2",
+    "hash": "sha256-dBJAKDyp/sm+ZSMQfH0+4OH8Jnv1s20aHlWS6HNnH+c="
   },
   {
     "pname": "Microsoft.Extensions.Configuration",
-    "version": "10.0.2",
-    "hash": "sha256-dBJAKDyp/sm+ZSMQfH0+4OH8Jnv1s20aHlWS6HNnH+c="
+    "version": "10.0.7",
+    "hash": "sha256-2RqDs7+dXtGY78E5jSd1qyKu+dMQkbzv+oMY09SEJm0="
   },
   {
     "pname": "Microsoft.Extensions.Configuration.Abstractions",
@@ -556,13 +546,13 @@
   },
   {
     "pname": "Microsoft.Extensions.Configuration.Abstractions",
-    "version": "10.0.1",
-    "hash": "sha256-s4PDp+vtzdxKIxnOT3+dDRoTDopyl8kqmmw4KDnkOtQ="
+    "version": "10.0.2",
+    "hash": "sha256-P+0kaDGO+xB9KxF9eWHDJ4hzi05sUGM/uMNEX5NdBTE="
   },
   {
     "pname": "Microsoft.Extensions.Configuration.Abstractions",
-    "version": "10.0.2",
-    "hash": "sha256-P+0kaDGO+xB9KxF9eWHDJ4hzi05sUGM/uMNEX5NdBTE="
+    "version": "10.0.7",
+    "hash": "sha256-MnUJzZYnl089xuVi6kpt9kymBIvYun9U+Itd12dM5Co="
   },
   {
     "pname": "Microsoft.Extensions.Configuration.Abstractions",
@@ -571,8 +561,8 @@
   },
   {
     "pname": "Microsoft.Extensions.Configuration.Abstractions",
-    "version": "9.0.12",
-    "hash": "sha256-FYIGDiv0aVApHCpoVQs4o9sWeFZhXb3XfK/zWXYlH1g="
+    "version": "9.0.15",
+    "hash": "sha256-oiFKtv9fTTQrlk4C/fMY0Jp0ZcxlbvN2WEsMVfPw9J8="
   },
   {
     "pname": "Microsoft.Extensions.Configuration.Abstractions",
@@ -586,13 +576,13 @@
   },
   {
     "pname": "Microsoft.Extensions.Configuration.Binder",
-    "version": "10.0.1",
-    "hash": "sha256-fiqTHE6EfaUXICaVrWzQEU/K6GjQNac6yRNErig6wRk="
+    "version": "10.0.2",
+    "hash": "sha256-resI9gIxHh2cc+258/i+TjW8xxzKf4ZBTLIcWAMEYz0="
   },
   {
     "pname": "Microsoft.Extensions.Configuration.Binder",
-    "version": "10.0.2",
-    "hash": "sha256-resI9gIxHh2cc+258/i+TjW8xxzKf4ZBTLIcWAMEYz0="
+    "version": "10.0.7",
+    "hash": "sha256-lU4G801+Cy3ua+S2slY5UVHOPXdF0I7r3lYX38mQSPw="
   },
   {
     "pname": "Microsoft.Extensions.DependencyInjection",
@@ -601,23 +591,23 @@
   },
   {
     "pname": "Microsoft.Extensions.DependencyInjection",
-    "version": "10.0.2",
-    "hash": "sha256-/9UWQRAI2eoocnJWWf1ktnAx/1Gt65c16fc0Xqr9+CQ="
+    "version": "10.0.7",
+    "hash": "sha256-dICogdaqa5mHqyvFA0lTomFa39Dqm4nn7Pit6qi6eQY="
   },
   {
     "pname": "Microsoft.Extensions.DependencyInjection",
-    "version": "9.0.12",
-    "hash": "sha256-pNKpg5UELjrn4Tm9s0aJigCX7qJ/JeqboU7TY3k+jUo="
-  },
-  {
-    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
-    "version": "10.0.1",
-    "hash": "sha256-zNUpau51ds7iQTaSUTFtyTHIUoinYc129W50CnufMdQ="
+    "version": "9.0.15",
+    "hash": "sha256-9GklcF6RO6QPZTSLzCe/Vy7mPLJIq4lbHhQ9xg+Nvlo="
   },
   {
     "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
     "version": "10.0.2",
     "hash": "sha256-UF9T13V5SQxJy2msfLmyovLmitZrjJayf8gHH+uK2eg="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "10.0.7",
+    "hash": "sha256-uQmTQarMn0fuZV03MyCb78Ex+96cuqFHNO5SyFOPkJk="
   },
   {
     "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
@@ -631,8 +621,8 @@
   },
   {
     "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
-    "version": "9.0.12",
-    "hash": "sha256-EZt7Vjl0dll6GZOVCTfC2cYxAG5IWtJHeOGlDJ7rHTg="
+    "version": "9.0.15",
+    "hash": "sha256-hszOr6dqOMuiuWPlIbBvqtay42oZfeWtwqX92rvM2MI="
   },
   {
     "pname": "Microsoft.Extensions.DependencyModel",
@@ -641,8 +631,8 @@
   },
   {
     "pname": "Microsoft.Extensions.DependencyModel",
-    "version": "9.0.12",
-    "hash": "sha256-CMh5AhCkjIzS0BP+GKael2eIoDSpyXsipWo/M7pcT8g="
+    "version": "9.0.15",
+    "hash": "sha256-g8Fe7eV3NX5av6rRA9nlvuf8Pc+0ht7eiVQ8YLG+T2o="
   },
   {
     "pname": "Microsoft.Extensions.DependencyModel",
@@ -650,14 +640,9 @@
     "hash": "sha256-0ygY8JLOIKuYFwwdVCtDl8/8fV5IC9JgivfzXsjXXsI="
   },
   {
-    "pname": "Microsoft.Extensions.DiagnosticAdapter",
-    "version": "3.1.32",
-    "hash": "sha256-moN7Vt47IZ0ZHRMjW+Y1Vbn/7ekvkj9GSm4yjIeAGnI="
-  },
-  {
     "pname": "Microsoft.Extensions.Diagnostics",
-    "version": "10.0.2",
-    "hash": "sha256-Zb/qJA0cZYiPQO7I3AegZCcNT0aJlKTycUP11Mqbm6o="
+    "version": "10.0.7",
+    "hash": "sha256-Sd0ZsXgO7w/35vOKN1B0CZdcIcMJnf/Z/8POSikTyRk="
   },
   {
     "pname": "Microsoft.Extensions.Diagnostics.Abstractions",
@@ -666,8 +651,8 @@
   },
   {
     "pname": "Microsoft.Extensions.Diagnostics.Abstractions",
-    "version": "10.0.2",
-    "hash": "sha256-Aob6wq51LdquE7SkkxtCzcuHBKWrJcb3Ebi/dU3aqA4="
+    "version": "10.0.7",
+    "hash": "sha256-ocntk68Qa3ccHGEnzmZuKdBWdQEnp4PgwJk63bSRjDA="
   },
   {
     "pname": "Microsoft.Extensions.FileProviders.Abstractions",
@@ -676,8 +661,8 @@
   },
   {
     "pname": "Microsoft.Extensions.FileProviders.Abstractions",
-    "version": "10.0.2",
-    "hash": "sha256-tibCkkT9WliU2E/i0ufx7/Va6H6QZX4hR/1oUp8ecgQ="
+    "version": "10.0.7",
+    "hash": "sha256-ibxSdxibq1UKOo4Mz+zthbZd0UUFipnJNb0hPwvEXCA="
   },
   {
     "pname": "Microsoft.Extensions.Hosting.Abstractions",
@@ -686,13 +671,13 @@
   },
   {
     "pname": "Microsoft.Extensions.Hosting.Abstractions",
-    "version": "10.0.2",
-    "hash": "sha256-mkeKUXepn4bfEdZFXdURmNEFdGiHQdpcxnm6joG+pUA="
+    "version": "10.0.7",
+    "hash": "sha256-S1WAgBHPi7H71uQUGyl2aG/IITgYfVNznyXsFrRe/kE="
   },
   {
     "pname": "Microsoft.Extensions.Http",
-    "version": "10.0.2",
-    "hash": "sha256-0q9E0HO4YIqUs9ceZpY+nMKtdqdtncTbOjyEOlYdWHs="
+    "version": "10.0.7",
+    "hash": "sha256-cbTDyODUPitTBOn88A5R5/QGPzOTCT7qeyP2gG6WOS0="
   },
   {
     "pname": "Microsoft.Extensions.Logging",
@@ -701,18 +686,18 @@
   },
   {
     "pname": "Microsoft.Extensions.Logging",
-    "version": "10.0.1",
-    "hash": "sha256-zuLP3SIpCToMOlIPOEv3Kq8y/minecd8k8GSkxFo13E="
-  },
-  {
-    "pname": "Microsoft.Extensions.Logging",
     "version": "10.0.2",
     "hash": "sha256-9+gfQwK32JMYscW1YvyCWEzc9mRZOjCACoD9U1vVaJI="
   },
   {
     "pname": "Microsoft.Extensions.Logging",
-    "version": "9.0.12",
-    "hash": "sha256-9QhfuxEeAiRoP6rYPs2TZY3N/BAd3AgHGwc1wEIcy6o="
+    "version": "10.0.7",
+    "hash": "sha256-AUOet0nWZHB132XCPuyUp5xTFNnWjHhoOtzooFcXHk4="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging",
+    "version": "9.0.15",
+    "hash": "sha256-V4ylLCMDJnQzmbR+20+NUlXXw6a3SpGn5VIZ1eCrjuU="
   },
   {
     "pname": "Microsoft.Extensions.Logging",
@@ -726,13 +711,13 @@
   },
   {
     "pname": "Microsoft.Extensions.Logging.Abstractions",
-    "version": "10.0.1",
-    "hash": "sha256-NRk0feNE1fgi/hyO0AVDbSGJQRT+9yte6Lpm4Hz/2Bs="
+    "version": "10.0.2",
+    "hash": "sha256-ndKGzq8+2J/hvaIULwBui0L/jDyMQTAY24j+ohX5VX8="
   },
   {
     "pname": "Microsoft.Extensions.Logging.Abstractions",
-    "version": "10.0.2",
-    "hash": "sha256-ndKGzq8+2J/hvaIULwBui0L/jDyMQTAY24j+ohX5VX8="
+    "version": "10.0.7",
+    "hash": "sha256-/ITLUXgcs5tRDdeileNlmNB92V25CRd1FGBocChJj0g="
   },
   {
     "pname": "Microsoft.Extensions.Logging.Abstractions",
@@ -746,23 +731,23 @@
   },
   {
     "pname": "Microsoft.Extensions.Logging.Abstractions",
-    "version": "9.0.12",
-    "hash": "sha256-pl+0ezSkx+GND5pH2gtvhdMiCPodD1YvNP7wl4gDQt4="
+    "version": "9.0.15",
+    "hash": "sha256-n8lNcXF+LGLOfYGn6eQ8iFO6eV+XyP2PjVknG73sQbM="
   },
   {
     "pname": "Microsoft.Extensions.Logging.Configuration",
-    "version": "10.0.1",
-    "hash": "sha256-/7ywcFsEmmQzWEcIvxoGAYHF0oDSXV/LTDAiW/MNQtg="
+    "version": "10.0.2",
+    "hash": "sha256-eSfmagvrcdRVmTXEdzfvWEDNBewB/YClOGSDq4gThk0="
   },
   {
     "pname": "Microsoft.Extensions.Logging.Console",
-    "version": "10.0.1",
-    "hash": "sha256-m/E02c5NSCYyH4THNKxpnsi3Kp8gqOi2aPrfXx7sQ9s="
+    "version": "10.0.2",
+    "hash": "sha256-mfaypUwMZxEIKBfnmzhnCScC/uPpZBRYN+/2SNcxcu4="
   },
   {
     "pname": "Microsoft.Extensions.Logging.TraceSource",
-    "version": "10.0.1",
-    "hash": "sha256-NS7P5jo7dtiH7DmyyipTIfaRf4ZwEJLU2UVG+4hlFSE="
+    "version": "10.0.2",
+    "hash": "sha256-iD2epXLjKr41et5vJJTzLTxm+GzVxbAUMrwRm9jmH1c="
   },
   {
     "pname": "Microsoft.Extensions.Options",
@@ -771,28 +756,28 @@
   },
   {
     "pname": "Microsoft.Extensions.Options",
-    "version": "10.0.1",
-    "hash": "sha256-vBiSS1vqAC7eDrpJNT4H3A9qLikCSAepnNRbry0mKnk="
-  },
-  {
-    "pname": "Microsoft.Extensions.Options",
     "version": "10.0.2",
     "hash": "sha256-12AfUEDdta/pmZUyEyqSUfOk0YoA7JOfGmIYnZQ//qk="
   },
   {
     "pname": "Microsoft.Extensions.Options",
-    "version": "9.0.12",
-    "hash": "sha256-WuEpn1zvPWdS+TTu30s1Z3KMUt+4GpdwRpzqrhtfd60="
+    "version": "10.0.7",
+    "hash": "sha256-XtyfdZ26kjnuCF/YHbdGdsIeR/nxSW7yyQZ04sOa9RU="
   },
   {
-    "pname": "Microsoft.Extensions.Options.ConfigurationExtensions",
-    "version": "10.0.1",
-    "hash": "sha256-1CNSVXZ3RAH4vzbYDqcQHl9c/YBhuSfrFUXCLIx5/rY="
+    "pname": "Microsoft.Extensions.Options",
+    "version": "9.0.15",
+    "hash": "sha256-p1ilUJEqSUSAx3mlTmMm6Jh3A9QvjL+L5D34wugbWIc="
   },
   {
     "pname": "Microsoft.Extensions.Options.ConfigurationExtensions",
     "version": "10.0.2",
     "hash": "sha256-WJahsWyT5wYdLPEJufHKpb3l/dl7D2iw2SnMK0Jr53U="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options.ConfigurationExtensions",
+    "version": "10.0.7",
+    "hash": "sha256-6UBnB1ouWwRkVEGt5xLfXZvpYsCQQJijKvBlBCJOmmM="
   },
   {
     "pname": "Microsoft.Extensions.Primitives",
@@ -801,8 +786,8 @@
   },
   {
     "pname": "Microsoft.Extensions.Primitives",
-    "version": "10.0.2",
-    "hash": "sha256-8Ccrjjv9cFVf9RyCc7GS/Byt8+DXdSNea0UX3A5BEdA="
+    "version": "10.0.7",
+    "hash": "sha256-cQBhL1IkRl1lxaZImAZBVS39CfWkB+J6+hJVEVBE35I="
   },
   {
     "pname": "Microsoft.Extensions.Primitives",
@@ -811,8 +796,8 @@
   },
   {
     "pname": "Microsoft.Extensions.Primitives",
-    "version": "9.0.12",
-    "hash": "sha256-aJBpI8kad6jm0Pno4WQWJZnbM2E3zayjfa8gvoMXI7I="
+    "version": "9.0.15",
+    "hash": "sha256-t5zLMH4Vkmuufk53RX0K/sHo7Yy16TuUd8fUd6de0N8="
   },
   {
     "pname": "Microsoft.Identity.Client",
@@ -921,8 +906,8 @@
   },
   {
     "pname": "MudBlazor",
-    "version": "8.15.0",
-    "hash": "sha256-I6kJEvND0i3I/amZBhDF8LjYeGGWuMwoSLiev6BS3UM="
+    "version": "9.4.0",
+    "hash": "sha256-PsWZYhD35e+W0iBvRN0rv6PspDr615MNBrYGHNIfcNY="
   },
   {
     "pname": "MySqlConnector",
@@ -936,13 +921,13 @@
   },
   {
     "pname": "NCalc.Core",
-    "version": "5.11.0",
-    "hash": "sha256-THgAix81mZxztHNMf5JlTPUGbcs1ZuRS3EVM7eFHseg="
+    "version": "5.12.0",
+    "hash": "sha256-TxeBjIq33bNgHGWgJRjdKmhnxr3lscEFmL59bBNG0UU="
   },
   {
     "pname": "NCalcSync",
-    "version": "5.11.0",
-    "hash": "sha256-Kui0K2WuLS0filTnpdcA3/H/XqqDOjtKms97WqbulEw="
+    "version": "5.12.0",
+    "hash": "sha256-Hraol6T5U8B8Z1DrincdjJZREjkt9ZbBPAH7wtZN4a4="
   },
   {
     "pname": "NETStandard.Library",
@@ -1016,8 +1001,8 @@
   },
   {
     "pname": "Parlot",
-    "version": "1.5.6",
-    "hash": "sha256-Ffbs7IpgN0aOKScBe64PGySnzWxapVSuM73fQmt+2nU="
+    "version": "1.5.7",
+    "hash": "sha256-mvAu74ty4uRP3f+Yy4R/HuhJKApOx/6ASl8nJ1mzvqM="
   },
   {
     "pname": "Pomelo.EntityFrameworkCore.MySql",
@@ -1026,23 +1011,23 @@
   },
   {
     "pname": "Refit",
-    "version": "9.0.2",
-    "hash": "sha256-FTq+jJLV9ow3hTrzTBEYwuAibxY6m0XgExNeIGoAAK4="
+    "version": "10.1.6",
+    "hash": "sha256-KC0PVsbqx5RHZxItYgJaBeUQBlPLQbTx643BzEhXIc0="
   },
   {
     "pname": "Refit.HttpClientFactory",
-    "version": "9.0.2",
-    "hash": "sha256-qxUm0NlJqoOPFRTu7ArdcSR696t5zCB+BniJv1+Xdkc="
+    "version": "10.1.6",
+    "hash": "sha256-/fkHB7cFXIRVUDnznQVJBgpwLS8KdhtiASF78xp4C8Q="
   },
   {
     "pname": "Refit.Newtonsoft.Json",
-    "version": "9.0.2",
-    "hash": "sha256-cxZtCv7gecMVIVzDrgjMBg81dEAq6DT9ccR10SKuFV4="
+    "version": "10.1.6",
+    "hash": "sha256-SJq065kLgo9cJn5sg64hK+7dMxezJbdQJdlp4U1M/1M="
   },
   {
     "pname": "Refit.Xml",
-    "version": "9.0.2",
-    "hash": "sha256-FNP7WAnsjncwdSvj4j7mxP2I+O3TNiYzlaTYVBlMWEo="
+    "version": "10.1.6",
+    "hash": "sha256-VgPvKHxAB+X5hkD+eapzDcgB8Z+0ZIeX/D14vGRhrCU="
   },
   {
     "pname": "RichTextKit.Stbear",
@@ -1051,13 +1036,13 @@
   },
   {
     "pname": "Scalar.AspNetCore",
-    "version": "2.12.32",
-    "hash": "sha256-0EZAD43NpMpX3P8quuctTLSGBxwjxxbyfQodo0e+nII="
+    "version": "2.14.10",
+    "hash": "sha256-NojV2iMXKFbZTypeqLhgNdebb9hGLsFyDjkHrjSOryM="
   },
   {
     "pname": "Scriban.Signed",
-    "version": "6.5.2",
-    "hash": "sha256-rnhmugQoX+lI0sO+V3KIAsQ9kWs0ow7EpEriQLCYAQw="
+    "version": "7.1.0",
+    "hash": "sha256-bUADaUvCUz4uOx/zpiG5IaQKHlWRLiUmCg+90CTuJgI="
   },
   {
     "pname": "Serilog",
@@ -1068,6 +1053,11 @@
     "pname": "Serilog",
     "version": "4.3.0",
     "hash": "sha256-jyIy4BjsyFXge3aO4GRFAdnX4/rz1MHfBkBDIpCDsTw="
+  },
+  {
+    "pname": "Serilog",
+    "version": "4.3.1",
+    "hash": "sha256-TY+GaQYnyDfOGl0gi67xDyUMOuV/mjz8BU66/UsmStI="
   },
   {
     "pname": "Serilog.AspNetCore",
@@ -1131,8 +1121,8 @@
   },
   {
     "pname": "SkiaSharp",
-    "version": "3.119.1",
-    "hash": "sha256-TIVr52NpQ9cab5eJCcH/OYHjNOTKhwCqpClK2c8S4TM="
+    "version": "3.119.2",
+    "hash": "sha256-A9F397K5FfLeOsNZacKmUh4IU/WMK60B4Z6TEtS/oqo="
   },
   {
     "pname": "SkiaSharp.HarfBuzz",
@@ -1146,18 +1136,18 @@
   },
   {
     "pname": "SkiaSharp.NativeAssets.Linux.NoDependencies",
-    "version": "3.119.1",
-    "hash": "sha256-SprThyApThbDoeTn/JaaS7TKdm9SkMoVO8V8HuCyppI="
+    "version": "3.119.2",
+    "hash": "sha256-79BCLZAYjfHP1DZKgB+hsyyBlhnyZQPi+Swvs0RYnng="
   },
   {
     "pname": "SkiaSharp.NativeAssets.macOS",
-    "version": "3.119.1",
-    "hash": "sha256-0QJGcO91MWLSeQpE4ZNn/KUVoHRcrPeDbKklxCVB00o="
+    "version": "3.119.2",
+    "hash": "sha256-KEeGqSiyAiMbzLgH/0JkwUz/pWcL49gYB1T1YLkMPaI="
   },
   {
     "pname": "SkiaSharp.NativeAssets.Win32",
-    "version": "3.119.1",
-    "hash": "sha256-ySPkn8SrShOqhihC33EJ4HJt9desDISC4gAI4FQBi2U="
+    "version": "3.119.2",
+    "hash": "sha256-CI6dg+MlxX8t+vbnkxtd5QE3xalMKkA8LUSudxg7TNU="
   },
   {
     "pname": "SQLitePCLRaw.bundle_e_sqlite3",
@@ -1196,8 +1186,8 @@
   },
   {
     "pname": "System.CommandLine",
-    "version": "2.0.2",
-    "hash": "sha256-PK3wKHjY8FHkPV75Z4ouxKU67WcuVSiMFjAkBs+iSAo="
+    "version": "2.0.7",
+    "hash": "sha256-CGm46Hk7eZFvIySEynE+A0Hs5EXDs2FNKKhk/rU77jM="
   },
   {
     "pname": "System.Composition",
@@ -1311,18 +1301,18 @@
   },
   {
     "pname": "Testably.Abstractions",
-    "version": "10.0.0",
-    "hash": "sha256-2rixQaYGhCM+NjmkxgOBNjJMFcNHr+3TPP+vsRUMj4w="
+    "version": "10.2.0",
+    "hash": "sha256-5qGJPTlon9GBIpXa8vmZOjjPGMTnbXIDzORY10FEl1w="
   },
   {
     "pname": "Testably.Abstractions.FileSystem.Interface",
-    "version": "10.0.0-pre.1",
-    "hash": "sha256-UO/Ly7Qd7AqYOIP52pS1YYoaQgOzzZ5745naHMqULZs="
+    "version": "10.2.0",
+    "hash": "sha256-4gUlDhO39+eBA/5xbraFpMztu4fcr0SzB+N4amLemQ4="
   },
   {
     "pname": "Testably.Abstractions.Interface",
-    "version": "10.0.0-pre.1",
-    "hash": "sha256-Te2+jj1jSleYGEJHlrmj9GYTht62mY14E5WCKDHx4pQ="
+    "version": "10.2.0",
+    "hash": "sha256-dNazu3BDDWJp/4O7+Rx2MTPDGypQa8p7LJ3fTAWaP7M="
   },
   {
     "pname": "TimeSpanParserUtil",
@@ -1341,8 +1331,8 @@
   },
   {
     "pname": "WebMarkupMin.Core",
-    "version": "2.20.1",
-    "hash": "sha256-6ze4MOSfIKdvMJsroQRtESB8KG5XogO3xk4qOSkHpXQ="
+    "version": "2.21.0",
+    "hash": "sha256-k51tTFcdL9Bwsg3gA51ZswGxDtdBFb22BAj9wbyZu1E="
   },
   {
     "pname": "Winista.MimeDetect",
@@ -1351,7 +1341,7 @@
   },
   {
     "pname": "YamlDotNet",
-    "version": "16.3.0",
-    "hash": "sha256-4Gi8wSQ8Rsi/3+LyegJr//A83nxn2fN8LN1wvSSp39Q="
+    "version": "17.1.0",
+    "hash": "sha256-Zdlw62rVud2U94BQKqrp5OFQiDcQ9rRrKeaVnNxREjY="
   }
 ]

--- a/pkgs/by-name/er/ersatztv/package.nix
+++ b/pkgs/by-name/er/ersatztv/package.nix
@@ -9,13 +9,13 @@
 
 buildDotnetModule rec {
   pname = "ersatztv";
-  version = "26.3.0";
+  version = "26.5.1";
 
   src = fetchFromGitHub {
     owner = "ErsatzTV";
-    repo = "ErsatzTV";
+    repo = "legacy";
     rev = "v${version}";
-    sha256 = "sha256-yFGMkTI+IQs3WTOQzxhqj3ownENsIzLqrDr3nWurzfA=";
+    sha256 = "sha256-2w+4xppj3E8H6WXea/iuNfloUmBsFQKDBpTnUn3RWvE=";
   };
   postPatch = ''
     # Remove config of development tools that don't end up in

--- a/pkgs/by-name/er/ersatztv/update.sh
+++ b/pkgs/by-name/er/ersatztv/update.sh
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-latestVersion="$(curl -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "https://api.github.com/repos/ersatztv/ersatztv/releases?per_page=1" | jq -r ".[0].tag_name" | sed 's/^v//')"
+latestVersion="$(curl -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "https://api.github.com/repos/ersatztv/legacy/releases?per_page=1" | jq -r ".[0].tag_name" | sed 's/^v//')"
 currentVersion=$(nix-instantiate --eval -E "with import ./. {}; ersatztv.version or (lib.getVersion ersatztv)" | tr -d '"')
 
 if [[ "$currentVersion" == "$latestVersion" ]]; then


### PR DESCRIPTION
[ErzatzTV Changelog](https://github.com/ErsatzTV/legacy/releases)

Repository name has been updated to "ErsatzTV/legacy" as the author winds down the project

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
