### PR TITLE
ntpd-rs: 1.7.2 -> 1.8.0

### DIFF
--- a/pkgs/by-name/nt/ntpd-rs/package.nix
+++ b/pkgs/by-name/nt/ntpd-rs/package.nix
@@ -13,16 +13,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ntpd-rs";
-  version = "1.7.2";
+  version = "1.8.0";
 
   src = fetchFromGitHub {
     owner = "pendulum-project";
     repo = "ntpd-rs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-xH9Z/aOfqY51GxbJeTidsEIbbKNaqNa/okIInvPKxp0=";
+    hash = "sha256-JeOgXIvn5kVy+KjCpjkR+7di1SYD3hi0dEoVpm5vxDg=";
   };
 
-  cargoHash = "sha256-9NeNBoq8OzSUilZVvYC1jL9Mf3pLKAsFBMWiSO/ky7I=";
+  cargoHash = "sha256-rQdLNYa9nyiA7xgi57aDjeSQpa4D7BDW32SVEduSm2U=";
 
   nativeBuildInputs = [
     pandoc
@@ -39,18 +39,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--skip=daemon::ntp_source::tests::test_deny_stops_poll"
     "--skip=daemon::ntp_source::tests::test_timeroundtrip"
     "--skip=daemon::server::tests::test_server_serves"
-    "--skip=nts::tests::test_key_exchange_roundtrip_no_cookies"
-    "--skip=nts::tests::test_keyexchange_fixed_key_no_permission"
-    "--skip=nts::tests::test_keyexchange_roundtrip_fixed_key"
-    "--skip=nts::tests::test_keyexchange_roundtrip_fixed_key_keep_alive"
-    "--skip=nts::tests::test_keyexchange_roundtrip_fixed_key_no_permit"
-    "--skip=nts::tests::test_keyexchange_roundtrip_no_proto_overlap"
-    "--skip=nts::tests::test_keyexchange_roundtrip_no_upgrade_possible"
-    "--skip=nts::tests::test_keyexchange_roundtrip_supports"
-    "--skip=nts::tests::test_keyexchange_roundtrip_upgrading"
-    "--skip=nts::tests::test_keyexchange_roundtrip_v4"
-    "--skip=nts::tests::test_keyexchange_roundtrip_v5"
-    "--skip=nts::tests::test_keyexchange_supports_no_permission"
+    "--skip=daemon::spawn::nts::tests::allow_srv_direct_name_resolution"
   ];
 
   postPatch = ''


### PR DESCRIPTION
Changelog: https://github.com/pendulum-project/ntpd-rs/blob/v1.8.0/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
