### PR TITLE
peergos: include runtime web assets

### DIFF
--- a/pkgs/by-name/pe/peergos/package.nix
+++ b/pkgs/by-name/pe/peergos/package.nix
@@ -72,13 +72,19 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    install -Dvm644 server/Peergos.jar $out/share/java/peergos.jar
-    install -Dvm644 ${tweetnacl}/lib/libtweetnacl.so $out/native-lib/libtweetnacl.so
+    install -dm755 $out/share/peergos
 
-    # --chdir as peergos expects to find `libtweetnacl.so` in `native-lib/`
+    install -Dvm644 server/Peergos.jar \
+      $out/share/peergos/peergos.jar
+
+    install -Dvm644 ${tweetnacl}/lib/libtweetnacl.so \
+      $out/native-lib/libtweetnacl.so
+
+    cp -R server/webroot $out/share/peergos/webroot
+
     makeWrapper ${lib.getExe jre} $out/bin/peergos \
-      --chdir $out \
-      --add-flags "-Djava.library.path=native-lib -jar $out/share/java/peergos.jar"
+      --add-flags "-Djava.library.path=$out/native-lib" \
+      --add-flags "-jar $out/share/peergos/peergos.jar"
 
     runHook postInstall
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
