### PR TITLE
tonearm: add auto-update script

### DIFF
--- a/pkgs/by-name/to/tonearm/package.nix
+++ b/pkgs/by-name/to/tonearm/package.nix
@@ -1,5 +1,5 @@
 {
-  buildGo126Module,
+  buildGoModule,
   cairo,
   copyDesktopItems,
   fetchFromGitea,
@@ -15,7 +15,8 @@
   libsecret,
   librsvg,
   makeDesktopItem,
-  makeWrapper,
+  makeBinaryWrapper,
+  nix-update-script,
   pango,
   pkg-config,
   symlinkJoin,
@@ -38,7 +39,8 @@ let
     ];
   };
 in
-buildGo126Module (finalAttrs: {
+buildGoModule (finalAttrs: {
+  __structuredAttrs = true;
   pname = "tonearm";
   version = "1.4.0";
   src = fetchFromGitea {
@@ -67,7 +69,7 @@ buildGo126Module (finalAttrs: {
   nativeBuildInputs = [
     pkg-config
     copyDesktopItems
-    makeWrapper
+    makeBinaryWrapper
     wrapGAppsHook4
   ];
 
@@ -107,6 +109,8 @@ buildGo126Module (finalAttrs: {
     glib-compile-schemas $out/share/glib-2.0/schemas
   '';
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "GTK client for TIDAL written in Golang";
     homepage = "https://codeberg.org/dergs/Tonearm";
@@ -116,5 +120,6 @@ buildGo126Module (finalAttrs: {
       nilathedragon
     ];
     mainProgram = "tonearm";
+    platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
Updated tonearm to 1.4.1 to follow upstream
- Changed version string to "1.4.1"
- Added `passthru.updateScript` to automate subsequent version bumps, allowing for faster integration
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
