### PR TITLE
odin: makes symlinks for wgpu-native library where odin expects and updates license to zlib

### DIFF
--- a/pkgs/by-name/od/odin/package.nix
+++ b/pkgs/by-name/od/odin/package.nix
@@ -6,7 +6,7 @@
   which,
   nix-update-script,
   wgpu-native,
-  enableWgpu ? true, #currently only available for x86_64-linux
+  enableWgpu ? true, # currently only available for x86_64-linux
 }:
 
 let
@@ -56,9 +56,9 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs --build build_odin.sh
   ''
   + lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux" && enableWgpu) ''
-        ${lib.optionalString (!stdenv.hostPlatform.isStatic)
-          "substituteInPlace vendor/wgpu/wgpu.odin --replace-fail \"#config(WGPU_SHARED, false)\" \"#config(WGPU_SHARED, true)\""
-        }
+    ${lib.optionalString (!stdenv.hostPlatform.isStatic)
+      "substituteInPlace vendor/wgpu/wgpu.odin --replace-fail \"#config(WGPU_SHARED, false)\" \"#config(WGPU_SHARED, true)\""
+    }
   '';
 
   env.LLVM_CONFIG = lib.getExe' llvmPackages.llvm.dev "llvm-config";
@@ -114,7 +114,7 @@ stdenv.mkDerivation (finalAttrs: {
     downloadPage = "https://github.com/odin-lang/Odin";
     homepage = "https://odin-lang.org/";
     changelog = "https://github.com/odin-lang/Odin/releases/tag/${finalAttrs.version}";
-    license = lib.licenses.bsd3;
+    license = lib.licenses.zlib;
     mainProgram = "odin";
     maintainers = with lib.maintainers; [
       astavie

--- a/pkgs/by-name/od/odin/package.nix
+++ b/pkgs/by-name/od/odin/package.nix
@@ -5,11 +5,23 @@
   makeBinaryWrapper,
   which,
   nix-update-script,
+  wgpu-native,
+  enableWgpu ? true, #currently only available for x86_64-linux
 }:
 
 let
   llvmPackages = llvmPackages_18;
   inherit (llvmPackages) stdenv;
+  wgpu = wgpu-native.overrideAttrs (oldAttrs: rec {
+    version = "29.0.0.0";
+    src = fetchFromGitHub {
+      owner = "gfx-rs";
+      repo = "wgpu-native";
+      tag = "v${version}";
+      hash = "sha256-XOT6Wx5TfbFzwcSjoyqUwv7mbN0RShaMf99qADmCKxg=";
+      fetchSubmodules = true;
+    };
+  });
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "odin";
@@ -42,6 +54,11 @@ stdenv.mkDerivation (finalAttrs: {
     rm -r vendor/raylib/{linux,macos,macos-arm64,wasm,windows}
 
     patchShebangs --build build_odin.sh
+  ''
+  + lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux" && enableWgpu) ''
+        ${lib.optionalString (!stdenv.hostPlatform.isStatic)
+          "substituteInPlace vendor/wgpu/wgpu.odin --replace-fail \"#config(WGPU_SHARED, false)\" \"#config(WGPU_SHARED, true)\""
+        }
   '';
 
   env.LLVM_CONFIG = lib.getExe' llvmPackages.llvm.dev "llvm-config";
@@ -63,6 +80,11 @@ stdenv.mkDerivation (finalAttrs: {
 
     mkdir -p $out/share
     cp -r {base,core,vendor,shared} $out/share
+
+    ${lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux" && enableWgpu) ''
+      mkdir -p $out/share/vendor/wgpu/lib/wgpu-linux-x86_64-release/lib
+      ln -s ${wgpu}/lib/libwgpu_native.so $out/share/vendor/wgpu/lib/wgpu-linux-x86_64-release/lib/
+    ''}
 
     wrapProgram $out/bin/odin \
       --prefix PATH : ${


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Patched odin to use the wgpu version from nixpkgs (though, our wgpu is a little out of date. seems to work okay, though)

updated version of: https://github.com/NixOS/nixpkgs/pull/365445

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
