### PR TITLE
spandsp3: fix test failure on musl

### DIFF
--- a/pkgs/development/libraries/spandsp/3.nix
+++ b/pkgs/development/libraries/spandsp/3.nix
@@ -12,6 +12,11 @@
     rev = "6ec23e5a7e411a22d59e5678d12c4d2942c4a4b6"; # upstream does not seem to believe in tags
     sha256 = "03w0s99y3zibi5fnvn8lk92dggfgrr0mz5255745jfbz28b2d5y7";
   };
+
+  patches = [
+    # https://github.com/freeswitch/spandsp/pull/120
+    ./Fix-buffer-overrun-in-t85-tests.patch
+  ];
 }).overrideAttrs
   (
     finalAttrs: previousAttrs: {

--- a/pkgs/development/libraries/spandsp/Fix-buffer-overrun-in-t85-tests.patch
+++ b/pkgs/development/libraries/spandsp/Fix-buffer-overrun-in-t85-tests.patch
@@ -1,0 +1,29 @@
+From bc1c899fa1b6746d430f7b3d7ee288506d50441a Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Mon, 11 May 2026 08:51:29 +0200
+Subject: [PATCH] Fix buffer overrun in t85 tests
+
+The variable length tests involve reading an extra row from
+test_image, which would previously read past the end of test_image.
+
+Identified with fortify-headers.
+---
+ tests/t85_tests.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/t85_tests.c b/tests/t85_tests.c
+index 436dfca..671ee6c 100644
+--- a/tests/t85_tests.c
++++ b/tests/t85_tests.c
+@@ -55,7 +55,7 @@ in ITU specifications T.85.
+ #include "spandsp.h"
+ 
+ #define TESTBUF_SIZE        400000
+-#define TEST_IMAGE_SIZE     (1951*1960/8)
++#define TEST_IMAGE_SIZE     (1952*1960/8)
+ 
+ uint8_t testbuf[TESTBUF_SIZE];
+ uint8_t test_image[TEST_IMAGE_SIZE];
+-- 
+2.53.0
+


### PR DESCRIPTION
(Due to a buffer overrun affecting all platforms.)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
