### PR TITLE
numatop: adopt

### DIFF
--- a/pkgs/by-name/nu/numatop/package.nix
+++ b/pkgs/by-name/nu/numatop/package.nix
@@ -7,6 +7,7 @@
   numactl,
   ncurses,
   check,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -34,12 +35,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Tool for runtime memory locality characterization and analysis of processes and threads on a NUMA system";
     mainProgram = "numatop";
-    homepage = "https://01.org/numatop";
+    homepage = "https://www.intel.com/content/www/us/en/developer/topic-technology/open/numatop/overview.html";
     license = lib.licenses.bsd3;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ VZstless ];
     platforms = [
       "i686-linux"
       "x86_64-linux"


### PR DESCRIPTION
You know why I'm willing to adopt this one... ;-)
If anyone is running NixOS on Intel Xeon processor, please help me maintain this package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - (for official build system, this is x86 platform only)
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
