### PR TITLE
claude-code: fix voice mode native module load on Linux

### DIFF
--- a/pkgs/by-name/cl/claude-code/package.nix
+++ b/pkgs/by-name/cl/claude-code/package.nix
@@ -9,6 +9,7 @@
   installShellFiles,
   makeBinaryWrapper,
   autoPatchelfHook,
+  alsa-lib,
   procps,
   ripgrep,
   bubblewrap,
@@ -56,7 +57,9 @@ stdenv.mkDerivation (finalAttrs: {
       --set-default FORCE_AUTOUPDATE_PLUGINS 1 \
       --set DISABLE_INSTALLATION_CHECKS 1 \
       --set USE_BUILTIN_RIPGREP 0 \
-      --prefix PATH : ${
+      ${lib.optionalString stdenv.hostPlatform.isLinux ''
+        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ alsa-lib ]} \
+      ''}--prefix PATH : ${
         lib.makeBinPath (
           [
             # claude-code uses [node-tree-kill](https://github.com/pkrumins/node-tree-kill) which requires procps's pgrep(darwin) or ps(linux)


### PR DESCRIPTION
The bun-compiled `claude` binary embeds `audio-capture.node` (Rust, built on top of cpal 0.15.3 and alsa-rs 0.9.1) inside bun's virtual filesystem. At runtime that module dlopens `libasound.so.2`. Because the embedded module is not visible to `autoPatchelfHook` during the build, no rpath is patched in and the dlopen fails on Linux, so `/voice` falls back through the documented chain (`arecord` -> `rec`) and ultimately prints the "install SoX" message even when neither tool would have been needed in the first place.

Exposing `alsa-lib` via `LD_LIBRARY_PATH` in the wrapper resolves the dlopen and lets the native module load directly.

### Alternative considered

#518968 takes a different approach by adding `sox` to `PATH` as a fallback. That works around the symptom but leaves the native module disabled and pulls SoX into the closure unconditionally (including on Darwin, where the native module already loads against the system framework). The fix here addresses the root cause and only adds the runtime library on Linux.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
