### PR TITLE
kdePackages.extra-cmake-modules: support all platforms

### DIFF
--- a/pkgs/kde/frameworks/extra-cmake-modules/default.nix
+++ b/pkgs/kde/frameworks/extra-cmake-modules/default.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   mkKdeDerivation,
   python3,
 }:
@@ -18,4 +19,7 @@ mkKdeDerivation {
   ];
 
   setupHook = ./ecm-hook.sh;
+
+  # Pure CMake macros, also used by non-KDE packages on all platforms.
+  meta.platforms = lib.platforms.all;
 }


### PR DESCRIPTION
ECM is a pure CMake macro collection. The KF5-era package had
platforms.all; restore it so non-KDE consumers like turbo-unwrapped
keep evaluating on Darwin.
