### PR TITLE
llvmPackages_22.libc: fix by using hdrgen unconditionally

### DIFF
--- a/pkgs/development/compilers/llvm/common/libc/default.nix
+++ b/pkgs/development/compilers/llvm/common/libc/default.nix
@@ -31,6 +31,8 @@ let
       cp -r ${monorepoSrc}/third-party "$out"
     ''
   );
+
+  needHdrGen = isFullBuild || lib.versionAtLeast release_version "22";
 in
 stdenv.mkDerivation (finalAttrs: {
   inherit pname version patches;
@@ -44,13 +46,13 @@ stdenv.mkDerivation (finalAttrs: {
     python3
     ninja
   ]
-  ++ (lib.optional isFullBuild python3Packages.pyyaml);
+  ++ (lib.optional needHdrGen python3Packages.pyyaml);
 
   buildInputs = lib.optional (isFullBuild && stdenv.hostPlatform.isLinux) linuxHeaders;
 
   outputs = [ "out" ] ++ (lib.optional isFullBuild "dev");
 
-  postUnpack = lib.optionalString isFullBuild ''
+  postUnpack = lib.optionalString needHdrGen ''
     chmod +w $sourceRoot/../$pname/utils/hdrgen
     patchShebangs $sourceRoot/../$pname/utils/hdrgen/main.py
     chmod +x $sourceRoot/../$pname/utils/hdrgen/main.py


### PR DESCRIPTION
- #516381
- https://hydra.nixos.org/build/326828040

```
[218/1923] Generating header elf_proxy.h from /build/libc-src-22.1.2/runtimes/../libc/include/elf.yaml
FAILED: [code=1] libc/hdr/elf_proxy.h /build/libc-src-22.1.2/runtimes/build/libc/hdr/elf_proxy.h 
...
Traceback (most recent call last):
  File "/build/libc-src-22.1.2/libc/utils/hdrgen/main.py", line 11, in <module>
    from hdrgen.main import main
  File "/build/libc-src-22.1.2/libc/utils/hdrgen/hdrgen/main.py", line 17, in <module>
    from hdrgen.yaml_to_classes import load_yaml_file, fill_public_api
  File "/build/libc-src-22.1.2/libc/utils/hdrgen/hdrgen/yaml_to_classes.py", line 11, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
```

Never built on hydra since its inception.
Apparently `hdrgen` is [required unconditionally](https://github.com/llvm/llvm-project/blob/llvmorg-22.1.5/libc/hdr/CMakeLists.txt#L269) since version 22.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
