### PR TITLE
runoff: init at 3.1.0-unstable-2026-05-01

### DIFF
--- a/pkgs/by-name/ru/runoff/package.nix
+++ b/pkgs/by-name/ru/runoff/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonApplication (finalAttrs: {
+  pname = "runoff";
+  version = "3.1.0-unstable-2026-05-01";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Real-Fruit-Snacks";
+    repo = "Runoff";
+    rev = "fa566364f641fa0656654de2984919df0ddfc536";
+    hash = "sha256-E5mMI5f9FS4zqiQrMQ5A8OHjhV6vCmH2ZNgjpMr9Z18=";
+  };
+
+  __structuredAttrs = true;
+
+  build-system = with python3.pkgs; [ setuptools ];
+
+  dependencies = with python3.pkgs; [
+    click
+    neo4j
+    pyyaml
+    requests
+    rich
+  ];
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytest-cov-stub
+    pytest-mock
+    pytestCheckHook
+    types-pyyaml
+    types-requests
+  ];
+
+  pythonImportsCheck = [ "runoff" ];
+
+  disabledTests = [
+    # rich.errors.MissingStyle: Failed to get style 'warn'...
+    "test_with_results"
+  ];
+
+  meta = {
+    description = "Active Directory security audit tool";
+    homepage = "https://github.com/Real-Fruit-Snacks/Runoff";
+    changelog = "https://github.com/Real-Fruit-Snacks/Runoff/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "runoff";
+  };
+})


### PR DESCRIPTION
Active Directory security audit tool

https://github.com/Real-Fruit-Snacks/Runoff

Related to https://github.com/NixOS/nixpkgs/issues/81418 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
