### PR TITLE
burstui: init at 3.1.0-unstable-2026-05-11

### DIFF
--- a/pkgs/by-name/bu/burstui/package.nix
+++ b/pkgs/by-name/bu/burstui/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  makeWrapper,
+  pkgs,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "burstui";
+  version = "3.1.0-unstable-2026-05-11";
+
+  src = fetchFromGitHub {
+    owner = "trifoliolate-antihypertensivedrug145";
+    repo = "burstui";
+    rev = "fa9a6e0c3d50736c56cb8ac785ae0320cfcacdd8";
+    hash = "sha256-mSWEngpnV1zycqxsW7DW1gVPBQM8EUf/dip/sqV63ps=";
+  };
+
+  __structuredAttrs = true;
+
+  vendorHash = "sha256-35IockAC27Va3+y2QwbyHeyKezgAG2F7mqTdNpo51lA=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  ldflags = [
+    "-s"
+    "-X=main.version=${finalAttrs.version}"
+    "-X=main.commit=${finalAttrs.src.rev}"
+    "-X=main.commitDate=1970-01-01T00:00:00Z"
+  ];
+
+  postFixup = ''
+    wrapProgram $out/bin/burstui \
+      --prefix PATH : ${lib.makeBinPath [ pkgs.gobuster ]} \
+  '';
+
+  meta = {
+    description = "TUI for Gobuster";
+    homepage = "https://github.com/trifoliolate-antihypertensivedrug145/burstui";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "burstui";
+  };
+})


### PR DESCRIPTION
TUI for Gobuster

https://github.com/trifoliolate-antihypertensivedrug145/burstui

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
