### PR TITLE
docs: split out modular services options to a separate section

### DIFF
--- a/doc/default.nix
+++ b/doc/default.nix
@@ -1,6 +1,16 @@
 {
   pkgs ? (import ../ci { }).docPkgs,
+  # The package set whose modular services are documented.
+  # `pkgs` provides the documentation tooling and comes from a pinned Nixpkgs,
+  # so it cannot be used here: the manual has to describe the services of the
+  # tree it is built from.
+  treePkgs ? import ../. { inherit (pkgs.stdenv.hostPlatform) system; },
   nixpkgs ? { },
 }:
 
-pkgs.callPackage ./doc-support/package.nix { inherit nixpkgs; }
+let
+  bundledModularServiceModules = pkgs.lib.mapAttrs (_: pkg: pkg.services) (
+    import ../pkgs/top-level/modular-services-bundled.nix treePkgs
+  );
+in
+pkgs.callPackage ./doc-support/package.nix { inherit nixpkgs bundledModularServiceModules; }

--- a/doc/doc-support/package.nix
+++ b/doc/doc-support/package.nix
@@ -11,11 +11,13 @@
   nixos-render-docs,
   nixos-render-docs-redirects,
   writeShellScriptBin,
+  writeText,
   nixpkgs ? { },
   markdown-code-runner,
   roboto,
   treefmt,
   nixosOptionsDoc,
+  bundledModularServiceModules ? { },
 }:
 stdenvNoCC.mkDerivation (
   finalAttrs:
@@ -52,6 +54,89 @@ stdenvNoCC.mkDerivation (
       inherit (lib.evalModules { modules = [ ../../modules/generic/meta-maintainers.nix ]; }) options;
       transformOptions = opt: hide-lib (mapURLs opt);
     };
+
+    portableServiceOptions = nixosOptionsDoc {
+      inherit
+        (lib.evalModules {
+          modules = [
+            (lib.modules.importApply ../../lib/services/service.nix {
+              pkgs = throw "nixpkgs-manual / portableServiceOptions: Do not reference pkgs in docs";
+            })
+          ];
+        })
+        options
+        ;
+      transformOptions = mapURLs;
+    };
+
+    bundledModularServiceNames = builtins.attrNames bundledModularServiceModules;
+
+    bundledModularServiceOptions = lib.mapAttrs (
+      pkgName: services:
+      lib.mapAttrs (
+        serviceName: serviceModule:
+        nixosOptionsDoc {
+          inherit
+            (lib.evalModules {
+              modules = [
+                (lib.modules.importApply ../../lib/services/service.nix {
+                  pkgs = throw "nixpkgs-manual / bundledModularServiceOptions: Do not reference pkgs in docs";
+                })
+                serviceModule
+              ];
+            })
+            options
+            ;
+          transformOptions =
+            opt:
+            let
+              strippedDecls = map toURL opt.declarations;
+              hasAppDeclaration = builtins.any (
+                d: builtins.isAttrs d && lib.hasPrefix "nixpkgs/pkgs/" d.name
+              ) strippedDecls;
+            in
+            opt
+            // {
+              declarations = strippedDecls;
+              visible = if !hasAppDeclaration then false else opt.visible or true;
+            };
+        }
+      ) services
+    ) bundledModularServiceModules;
+
+    bundledModularServicesMarkdown = lib.concatStringsSep "\n" (
+      lib.flatten (
+        map (
+          pkgName:
+          lib.mapAttrsToList (serviceName: doc: ''
+            ## `pkgs.${pkgName}.services.${serviceName}` {#modular-service-bundled-${pkgName}-${serviceName}}
+
+            ```{=include=} options
+            id-prefix: service-opt-${pkgName}-${serviceName}-
+            list-id: service-options-${pkgName}-${serviceName}
+            source: ${doc.optionsJSON}/share/doc/nixos/options.json
+            ```
+          '') bundledModularServiceOptions.${pkgName}
+        ) bundledModularServiceNames
+      )
+    );
+
+    mergedRedirects = writeText "redirects.json" (
+      builtins.toJSON (
+        lib.listToAttrs (
+          lib.flatten (
+            map (
+              pkgName:
+              lib.mapAttrsToList (serviceName: _: {
+                name = "modular-service-bundled-${pkgName}-${serviceName}";
+                value = [ "package-module-options.html#modular-service-bundled-${pkgName}-${serviceName}" ];
+              }) bundledModularServiceModules.${pkgName}
+            ) bundledModularServiceNames
+          )
+        )
+        // builtins.fromJSON (builtins.readFile ../redirects.json)
+      )
+    );
   in
   {
     version = lib.trivial.release;
@@ -72,7 +157,6 @@ stdenvNoCC.mkDerivation (
             ../anchor-use.js
             ../anchor.min.js
             ../manpage-urls.json
-            ../redirects.json
             ../nav.json
           ]
         );
@@ -83,6 +167,8 @@ stdenvNoCC.mkDerivation (
       ln -s ${treefmt.functionsDoc.markdown} ./packages/treefmt-functions.section.md
       ln -s ${treefmt.optionsDoc.optionsJSON}/share/doc/nixos/options.json ./treefmt-options.json
       ln -s ${docs.generic.meta-maintainers.optionsJSON}/share/doc/nixos/options.json ./options-modules-generic-meta-maintainers.json
+      ln -s ${portableServiceOptions.optionsJSON}/share/doc/nixos/options.json ./modular-services-portable-options.json
+      ln -s ${mergedRedirects} ./redirects.json
     '';
 
     buildPhase = ''
@@ -95,6 +181,9 @@ stdenvNoCC.mkDerivation (
 
       substitute ./manual.md.in ./manual.md \
         --replace-fail '@MANUAL_VERSION@' '${lib.version}'
+
+      substituteInPlace ./modules/package-module-options.md \
+        --replace-fail '@BUNDLED_MODULAR_SERVICES@' ${lib.escapeShellArg bundledModularServicesMarkdown}
 
       mkdir -p out/media
 
@@ -154,6 +243,8 @@ stdenvNoCC.mkDerivation (
       optionsDoc = callPackage ./options-doc.nix { };
 
       pythonInterpreterTable = callPackage ./python-interpreter-table.nix { };
+
+      inherit bundledModularServiceOptions;
 
       shell =
         let

--- a/doc/manual.md.in
+++ b/doc/manual.md.in
@@ -22,6 +22,10 @@ interoperability.md
 languages-frameworks/index.md
 ```
 
+```{=include=} appendix html:into-file=//package-module-options.html
+modules/package-module-options.md
+```
+
 ```{=include=} appendix html:into-file=//release-notes.html
 release-notes/release-notes.md
 ```

--- a/doc/modules/index.md
+++ b/doc/modules/index.md
@@ -6,6 +6,7 @@ The following sections are organized by [module class].
 
 ```{=include=} chapters
 generic.chapter.md
+package-modules.chapter.md
 ```
 
 [Module System]: https://nixos.org/manual/nixpkgs/unstable/#module-system

--- a/doc/modules/modular-services.section.md
+++ b/doc/modules/modular-services.section.md
@@ -1,0 +1,163 @@
+
+# Modular Services {#modular-services}
+
+Status: in development. This functionality is new in release 25.11, and significant changes should be expected.
+We'd love to hear your feedback in in our [matrix channel](https://matrix.to/#/#modular-services:nixos.org)
+or at the [tracking issue](https://github.com/NixOS/nixpkgs/issues/428084).
+
+In NixOS, services were traditionally defined using sets of options *in* modules, not *as* modules. This made them non-modular, resulting in problems with composability, reuse, and portability.
+
+A configuration management framework is an application of `evalModules` with the `class` and `specialArgs` input attribute set to particular values.
+NixOS is such a configuration management framework, and so are [Home Manager](https://github.com/nix-community/home-manager),
+[`nimi`](https://github.com/weyl-ai/nimi) and [`finix`](https://github.com/finix-community/finix).
+
+The service management component of a configuration management framework is the set of module options that connects Nix expressions with the underlying service (or process) manager.
+For NixOS this is the module wrapping [`systemd`](https://systemd.io/), on `finix` this is the module wrapping [`finit`](https://github.com/finit-project/finit), and so on for additional service (or process) managers.
+
+A *modular service* is a [module] that defines values for a core set of options declared in the service management component of a configuration management framework, including which program to run.
+Since it's a module, it can be composed with other modules via `imports` to extend its functionality.
+
+NixOS provides two options into which such modules can be plugged:
+
+- `system.services.<name>`
+- an option for user services (TBD)
+
+Crucially, these options have the type [`attrsOf`] [`submodule`].
+The name of the service is the attribute name corresponding to `attrsOf`.
+<!-- ^ This is how composition is *always* provided, instead of a difficult thing (but this is reference docs, not a changelog) -->
+The `submodule` is pre-loaded with two modules:
+- a generic module that is intended to be portable
+- a module with systemd-specific options, whose values or defaults derive from the generic module's option values.
+
+So note that the default value of `system.services.<name>` is not a complete service. It requires that the user provide a value, and this is typically done by importing a module. For example:
+
+<!-- Not using typical example syntax, because reading this is *not* optional, and should it should not be folded closed. -->
+```nix
+{ pkgs, ... }:
+{
+  system.services.my-service-instance = {
+    imports = [ pkgs.some-application.services.some-service-module ];
+    foo.settings = {
+      # ...
+    };
+  };
+}
+```
+
+For NixOS-specific integration (systemd), see the [NixOS manual](https://nixos.org/manual/nixos/unstable/#modular-services-nixos).
+
+## Motivation {#modular-service-motivation}
+
+Traditionally a NixOS service is a set of options *in* a module: one module declares `services.foo.*`, there is exactly one instance of it, and its name is fixed by whoever wrote the module.
+Such a service cannot be instantiated twice, cannot be extended without patching the module that declares it, and cannot be used outside NixOS.
+
+A modular service is a module *as* a service, which makes it:
+
+- **instantiable** more than once, under a name you choose, by importing it at `system.services.<name>`;
+- **extensible**, by importing further modules alongside it rather than editing it;
+- **composable**, since a service can contain sub-services of its own -- see [](#modular-service-composition);
+- **portable** across configuration management frameworks that declare the same core options -- see [](#modular-service-portability).
+
+This is also the answer to "why not just ship a systemd unit file".
+A unit file describes one service, for one service manager, in a format with no notion of options, types, defaults, or merging; it cannot be parameterized, imported twice under different names, or extended without editing it.
+A modular service is a module that *produces* such a unit, and going through the module system is what buys the four properties above.
+systemd-specific escapes remain available through the `systemd` option tree, guarded as shown in [](#modular-service-portability).
+
+The portable option set is still small, as we try to find reusable abstractions.
+It describes how to start the service (`process.argv`), optionally how to reload it (`process.reloadSignal`, `process.reloadCommand`, and `configData` for files whose contents may change without a restart), and how the service signals readiness (`notificationProtocol`).
+Everything else -- ordering, dependencies, restart policy, isolation -- is left to the service manager, and on NixOS is reached through the `systemd` options.
+
+## Portability {#modular-service-portability}
+
+It is possible to write service modules that are portable.
+This is done by either avoiding the `systemd` option tree, or by defining process-manager-specific definitions in an optional way.
+
+A module that only defines portable options is portable, but requires some translation layer to be picked up by a service manager:
+
+```nix
+# Non-module dependencies (`importApply`)
+{ pkgs }:
+
+# Service module
+{ config, lib, ... }:
+let
+  cfg = config.foo;
+  format = pkgs.formats.toml { };
+in
+{
+  _class = "service";
+
+  options.foo = {
+    package = lib.mkPackageOption pkgs "foo" { };
+    settings = lib.mkOption {
+      type = format.type;
+      default = { };
+      description = "Configuration for `foo`, rendered to `foo.toml`.";
+    };
+  };
+
+  config.process.argv = [
+    (lib.getExe cfg.package)
+    "--config"
+    (format.generate "foo.toml" cfg.settings)
+  ];
+}
+```
+
+You can define process-manager-specific definitions in an optional way like:
+
+```nix
+{
+  config,
+  options,
+  lib,
+  ...
+}:
+{
+  _class = "service";
+  config = {
+    process.argv = [ (lib.getExe config.foo.program) ];
+  }
+  // lib.optionalAttrs (options ? systemd) {
+    # ... systemd-specific definitions ...
+  };
+}
+```
+
+This way, the module can be loaded into a configuration manager that does not use systemd, and the `systemd` definitions will be ignored.
+Similarly, other configuration managers can declare their own options for services to customize.
+
+## Composition and Ownership {#modular-service-composition}
+
+Compared to traditional services, modular services are inherently more composable, by virtue of being modules and receiving a user-provided name when imported.
+However, composition can not end there, because services need to be able to interact with each other.
+This can be achieved in two ways:
+1. Users can link services together by providing the necessary NixOS configuration.
+2. Services can be compositions of other services.
+
+These aren't mutually exclusive. In fact, it is a good practice when developing services to first write them as individual services, and then compose them into a higher-level composition. Each of these services is a valid modular service, including their composition.
+
+## Migration {#modular-service-migration}
+
+Many services could be migrated to the modular service system, but even when the modular service system is mature, it is not necessary to migrate all services.
+For instance, many system-wide services are a mandatory part of a desktop system, and it doesn't make sense to have multiple instances of them.
+Moving their logic into separate Nix files may still be beneficial for the efficient evaluation of configurations that don't use those services, but that is a rather minor benefit, unless modular services potentially become the standard way to define services.
+
+<!-- TODO example of a single-instance service -->
+
+## Writing and Reviewing a Modular Service {#modular-service-review}
+
+For more details, refer to the contributor documentation in [`nixos/README-modular-services.md`](https://github.com/NixOS/nixpkgs/blob/master/nixos/README-modular-services.md).
+
+## Modular Service Options {#modular-service-options}
+
+```{=include=} options
+id-prefix: service-opt-
+list-id: service-options
+source: ../modular-services-portable-options.json
+```
+
+[module]: #module-system
+<!-- TODO: more anchors -->
+[`attrsOf`]: https://nixos.org/manual/nixos/unstable/#sec-option-types-composed
+[`submodule`]: https://nixos.org/manual/nixos/unstable/#sec-option-types-submodule

--- a/doc/modules/package-module-options.md
+++ b/doc/modules/package-module-options.md
@@ -1,0 +1,20 @@
+# Bundled Package Modules {#package-module-bundled}
+
+Per-package modules shipped in nixpkgs.
+
+## Services {#package-module-bundled-services}
+
+The following modular services are shipped in nixpkgs. Each is consumed by importing the service module at `system.services.<name>`.
+For example, to use `pkgs.ghostunnel.services.default`:
+
+```nix
+{
+  system.services.ghostunnel = {
+    imports = [ pkgs.ghostunnel.services.default ];
+    # ghostunnel.package = ...;
+    # ...
+  };
+}
+```
+
+@BUNDLED_MODULAR_SERVICES@

--- a/doc/modules/package-modules.chapter.md
+++ b/doc/modules/package-modules.chapter.md
@@ -1,0 +1,13 @@
+# Package Modules {#package-modules}
+
+Nixpkgs ships modules under `pkgs.<pkg>.<category>`, available to any module-system consumer:
+NixOS, Home Manager, nix-darwin, or any custom `evalModules` context.
+Modules stored in packages this way are called package modules.
+
+Currently defined categories:
+
+- `services` ([modular services](#modular-services)): portable, composable service modules.
+
+```{=include=} sections
+modular-services.section.md
+```

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -239,6 +239,27 @@
   "modules-generic-meta-maintainers": [
     "index.html#modules-generic-meta-maintainers"
   ],
+  "modular-services": [
+    "index.html#modular-services"
+  ],
+  "modular-service-motivation": [
+    "index.html#modular-service-motivation"
+  ],
+  "modular-service-portability": [
+    "index.html#modular-service-portability"
+  ],
+  "modular-service-composition": [
+    "index.html#modular-service-composition"
+  ],
+  "modular-service-migration": [
+    "index.html#modular-service-migration"
+  ],
+  "modular-service-review": [
+    "index.html#modular-service-review"
+  ],
+  "modular-service-options": [
+    "index.html#modular-service-options"
+  ],
   "neovim": [
     "index.html#neovim"
   ],
@@ -405,6 +426,16 @@
   ],
   "pnpm-build-hook-honored-variables": [
     "index.html#pnpm-build-hook-honored-variables"
+  ],
+  "package-modules": [
+    "index.html#package-modules"
+  ],
+  "package-module-bundled": [
+    "package-module-options.html#package-module-bundled",
+    "modular-services-options.html#modular-service-bundled"
+  ],
+  "package-module-bundled-services": [
+    "package-module-options.html#package-module-bundled-services"
   ],
   "preface": [
     "index.html#preface",

--- a/nixos/README-modular-services.md
+++ b/nixos/README-modular-services.md
@@ -35,7 +35,7 @@ When reviewing a modular service, you should check the following. Details and ra
 - [ ] `_class = "service"`
 - [ ] Modular services provided through `passthru.services` must override the default of the package option using `finalAttrs.finalPackage`
 - [ ] Is the modular services infrastructure sufficient for this service? If one or more features are not covered, comment in https://github.com/NixOS/nixpkgs/issues/428084
-- [ ] Has been added to `nixos/modules/misc/documentation/modular-services.nix`
+- [ ] Has been added to `pkgs/top-level/modular-services-bundled.nix`
 ```
 
 ## Details

--- a/nixos/doc/manual/default.nix
+++ b/nixos/doc/manual/default.nix
@@ -20,10 +20,14 @@ let
     removePrefix
     flip
     foldr
+    flatten
+    mapAttrsToList
     types
     mkOption
     escapeShellArg
     concatMapStringsSep
+    concatStringsSep
+    listToAttrs
     sourceFilesBySuffices
     modules
     ;
@@ -122,34 +126,9 @@ let
       -i ./development/writing-nixos-tests.section.md
     substituteInPlace ./development/modular-services.md \
       --replace-fail \
-        '@PORTABLE_SERVICE_OPTIONS@' \
-        ${portableServiceOptions.optionsJSON}/${common.outputPath}/options.json
-    substituteInPlace ./development/modular-services.md \
-      --replace-fail \
         '@SYSTEMD_SERVICE_OPTIONS@' \
         ${systemdServiceOptions.optionsJSON}/${common.outputPath}/options.json
   '';
-
-  portableServiceOptions = buildPackages.nixosOptionsDoc {
-    inherit
-      (evalModules {
-        modules = [
-          (modules.importApply ../../../lib/services/service.nix {
-            pkgs = throw "nixos docs / portableServiceOptions: Do not reference pkgs in docs";
-          })
-        ];
-      })
-      options
-      ;
-    inherit revision warningsAreErrors;
-    transformOptions =
-      opt:
-      opt
-      // {
-        # Clean up declaration sites to not refer to the NixOS source tree.
-        declarations = map stripAnyPrefixes opt.declarations;
-      };
-  };
 
   systemdServiceOptions = buildPackages.nixosOptionsDoc {
     inherit (evalModules { modules = [ ../../modules/system/service/systemd/service.nix ]; }) options;
@@ -163,6 +142,68 @@ let
         declarations = map stripAnyPrefixes opt.declarations;
       };
   };
+
+  bundledModularServiceNames = config.documentation.nixos.bundledModularServiceNames;
+
+  # Per-service options docs used for the manpage merge.
+  # The HTML rendering lives in the nixpkgs manual; this is kept only for `configuration.nix(5)`.
+  bundledModularServiceOptions = pkgs.lib.genAttrs bundledModularServiceNames (
+    pkgName:
+    pkgs.lib.mapAttrs (
+      serviceName: serviceModule:
+      buildPackages.nixosOptionsDoc {
+        inherit
+          (evalModules {
+            modules = [
+              (modules.importApply ../../../lib/services/service.nix {
+                pkgs = throw "nixos docs / bundledModularServiceOptions: Do not reference pkgs in docs";
+              })
+              serviceModule
+            ];
+          })
+          options
+          ;
+        inherit revision warningsAreErrors;
+        transformOptions =
+          opt:
+          let
+            strippedDecls = map stripAnyPrefixes opt.declarations;
+            hasAppDeclaration = builtins.any (d: builtins.isString d && hasPrefix "pkgs/" d) strippedDecls;
+          in
+          opt
+          // {
+            declarations = strippedDecls;
+            visible = if !hasAppDeclaration then false else opt.visible or true;
+          };
+      }
+    ) pkgs.${pkgName}.services
+  );
+
+  # Manpage options: main NixOS options merged with per-service bundled options.
+  # Uses the same filtered per-service JSON as the nixpkgs manual appendix.
+  manpageOptionsJSON =
+    pkgs.runCommand "manpage-options.json"
+      {
+        nativeBuildInputs = [ pkgs.jq ];
+      }
+      ''
+        mkdir -p $out/${common.outputPath}
+        jq -s 'add' \
+          ${optionsDoc.optionsJSON}/${common.outputPath}/options.json \
+          ${
+            concatStringsSep " \\\n      " (
+              flatten (
+                map (
+                  pkgName:
+                  mapAttrsToList (
+                    serviceName: doc: "${doc.optionsJSON}/${common.outputPath}/options.json"
+                  ) bundledModularServiceOptions.${pkgName}
+                ) bundledModularServiceNames
+              )
+            )
+          } \
+          > $out/${common.outputPath}/options.json
+      '';
 
 in
 rec {
@@ -289,7 +330,7 @@ rec {
         mkdir -p $out/share/man/man5
         nixos-render-docs -j $NIX_BUILD_CORES options manpage \
           --revision ${escapeShellArg revision} \
-          ${optionsJSON}/${common.outputPath}/options.json \
+          ${manpageOptionsJSON}/${common.outputPath}/options.json \
           $out/share/man/man5/configuration.nix.5
         compressManPages $out
       '';

--- a/nixos/doc/manual/development/modular-services.md
+++ b/nixos/doc/manual/development/modular-services.md
@@ -1,35 +1,25 @@
 
-# Modular Services {#modular-services}
+# Modular Services {#modular-services-nixos}
 
-Status: in development. This functionality is new in NixOS 25.11, and significant changes should be expected. We'd love to hear your feedback in <https://github.com/NixOS/nixpkgs/pull/372170>
+Status: in development. This functionality is new in release 25.11, and significant changes should be expected.
+We'd love to hear your feedback in in our [matrix channel](https://matrix.to/#/#modular-services:nixos.org)
+or at the [tracking issue](https://github.com/NixOS/nixpkgs/issues/428084).
 
-Traditionally, NixOS services were defined using sets of options *in* modules, not *as* modules. This made them non-modular, resulting in problems with composability, reuse, and portability.
+Modular services are a framework for defining portable, composable NixOS services as modules.
+For the main documentation on these, see the [nixpkgs manual](https://nixos.org/manual/nixpkgs/unstable/#modular-services).
 
 A configuration management framework is an application of `evalModules` with the `class` and `specialArgs` input attribute set to particular values.
 NixOS is such a configuration management framework, and so are [Home Manager](https://github.com/nix-community/home-manager) and [`nix-darwin`](https://github.com/nix-darwin/nix-darwin).
 
-The service management component of a configuration management framework is the set of module options that connects Nix expressions with the underlying service (or process) manager.
-For NixOS this is the module wrapping [`systemd`](https://systemd.io/), on `nix-darwin` this is the module wrapping [`launchd`](https://en.wikipedia.org/wiki/Launchd).
+On NixOS, modular services are wired into `systemd` via `system.services.<name>`.
+That option has type [`attrsOf`] [`submodule`], where the `submodule` is pre-loaded with:
+- a generic portable module
+- a module with systemd-specific options whose values or defaults derive from the generic module.
 
-A *modular service* is a [module] that defines values for a core set of options declared in the service management component of a configuration management framework, including which program to run.
-Since it's a module, it can be composed with other modules via `imports` to extend its functionality.
+For example:
 
-NixOS provides two options into which such modules can be plugged:
-
-- `system.services.<name>`
-- an option for user services (TBD)
-
-Crucially, these options have the type [`attrsOf`] [`submodule`].
-The name of the service is the attribute name corresponding to `attrsOf`.
-<!-- ^ This is how composition is *always* provided, instead of a difficult thing (but this is reference docs, not a changelog) -->
-The `submodule` is pre-loaded with two modules:
-- a generic module that is intended to be portable
-- a module with systemd-specific options, whose values or defaults derive from the generic module's option values.
-
-So note that the default value of `system.services.<name>` is not a complete service. It requires that the user provide a value, and this is typically done by importing a module. For example:
-
-<!-- Not using typical example syntax, because reading this is *not* optional, and should it should not be folded closed. -->
 ```nix
+{ pkgs, ... }:
 {
   system.services.my-service-instance = {
     imports = [ pkgs.some-application.services.some-service-module ];
@@ -40,62 +30,7 @@ So note that the default value of `system.services.<name>` is not a complete ser
 }
 ```
 
-## Portability {#modular-service-portability}
-
-It is possible to write service modules that are portable. This is done by either avoiding the `systemd` option tree, or by defining process-manager-specific definitions in an optional way:
-
-```nix
-{
-  config,
-  options,
-  lib,
-  ...
-}:
-{
-  _class = "service";
-  config = {
-    process.argv = [ (lib.getExe config.foo.program) ];
-  }
-  // lib.optionalAttrs (options ? systemd) {
-    # ... systemd-specific definitions ...
-  };
-}
-```
-
-This way, the module can be loaded into a configuration manager that does not use systemd, and the `systemd` definitions will be ignored.
-Similarly, other configuration managers can declare their own options for services to customize.
-
-## Composition and Ownership {#modular-service-composition}
-
-Compared to traditional services, modular services are inherently more composable, by virtue of being modules and receiving a user-provided name when imported.
-However, composition can not end there, because services need to be able to interact with each other.
-This can be achieved in two ways:
-1. Users can link services together by providing the necessary NixOS configuration.
-2. Services can be compositions of other services.
-
-These aren't mutually exclusive. In fact, it is a good practice when developing services to first write them as individual services, and then compose them into a higher-level composition. Each of these services is a valid modular service, including their composition.
-
-## Migration {#modular-service-migration}
-
-Many services could be migrated to the modular service system, but even when the modular service system is mature, it is not necessary to migrate all services.
-For instance, many system-wide services are a mandatory part of a desktop system, and it doesn't make sense to have multiple instances of them.
-Moving their logic into separate Nix files may still be beneficial for the efficient evaluation of configurations that don't use those services, but that is a rather minor benefit, unless modular services potentially become the standard way to define services.
-
-<!-- TODO example of a single-instance service -->
-
-## Writing and Reviewing a Modular Service {#modular-service-review}
-
-A typical service module consists of the following:
-
-For more details, refer to the contributor documentation in [`nixos/README-modular-services.md`](https://github.com/NixOS/nixpkgs/blob/master/nixos/README-modular-services.md).
-
-## Portable Service Options {#modular-service-options-portable}
-
-```{=include=} options
-id-prefix: service-opt-
-list-id: service-options
-source: @PORTABLE_SERVICE_OPTIONS@
-```
+For a list of modular services bundled in nixpkgs, see the [nixpkgs manual appendix](https://nixos.org/manual/nixpkgs/unstable/package-module-options.html).
 
 ## Systemd-specific Service Options {#modular-service-options-systemd}
 
@@ -104,8 +39,5 @@ id-prefix: systemd-service-opt-
 list-id: systemd-service-options
 source: @SYSTEMD_SERVICE_OPTIONS@
 ```
-
-[module]: https://nixos.org/manual/nixpkgs/stable/index.html#module-system
-<!-- TODO: more anchors -->
 [`attrsOf`]: #sec-option-types-composed
 [`submodule`]: #sec-option-types-submodule

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -322,26 +322,17 @@
   "book-nixos-manual": [
     "index.html#book-nixos-manual"
   ],
-  "modular-service-composition": [
-    "index.html#modular-service-composition"
-  ],
-  "modular-service-migration": [
-    "index.html#modular-service-migration"
-  ],
-  "modular-service-options-portable": [
-    "index.html#modular-service-options-portable"
-  ],
   "modular-service-options-systemd": [
     "index.html#modular-service-options-systemd"
   ],
-  "modular-service-portability": [
-    "index.html#modular-service-portability"
-  ],
-  "modular-service-review": [
-    "index.html#modular-service-review"
-  ],
-  "modular-services": [
-    "index.html#modular-services"
+  "modular-services-nixos": [
+    "index.html#modular-services-nixos",
+    "index.html#modular-services",
+    "index.html#modular-service-portability",
+    "index.html#modular-service-composition",
+    "index.html#modular-service-migration",
+    "index.html#modular-service-review",
+    "index.html#modular-service-options"
   ],
   "module-services-amule": [
     "index.html#module-services-amule"

--- a/nixos/modules/misc/documentation/modular-services.nix
+++ b/nixos/modules/misc/documentation/modular-services.nix
@@ -2,37 +2,16 @@
   Renders documentation for modular services.
   For inclusion into documentation.nixos.extraModules.
 */
-{ lib, pkgs, ... }:
-let
-  /**
-    Causes a modular service's docs to be rendered.
-    This is an intermediate solution until we have "native" service docs in some nicer form.
-  */
-  fakeSubmodule =
-    module:
-    lib.mkOption {
-      type = lib.types.submoduleWith {
-        modules = [ module ];
-      };
-      description = "This is a [modular service](https://nixos.org/manual/nixos/unstable/#modular-services), which can be imported into a NixOS configuration using the [`system.services`](https://search.nixos.org/options?channel=unstable&show=system.services&query=modular+service) option.";
-    };
-
-  modularServicesModule = {
-    options = {
-      "<imports = [ pkgs.autopush-rs.services.autoconnect ]>" =
-        fakeSubmodule pkgs.autopush-rs.services.autoconnect;
-      "<imports = [ pkgs.autopush-rs.services.autoendpoint ]>" =
-        fakeSubmodule pkgs.autopush-rs.services.autoendpoint;
-      "<imports = [ pkgs.ghostunnel.services.default ]>" = fakeSubmodule pkgs.ghostunnel.services.default;
-      "<imports = [ pkgs.ktls-utils.services.default ]>" = fakeSubmodule pkgs.ktls-utils.services.default;
-      "<imports = [ pkgs.php.services.default ]>" = fakeSubmodule pkgs.php.services.default;
-      "<imports = [ pkgs.snid.services.default ]>" = fakeSubmodule pkgs.snid.services.default;
-      "<imports = [ pkgs.trailbase.services.default ]>" = fakeSubmodule pkgs.trailbase.services.default;
-    };
-  };
-in
+{ lib, ... }:
 {
-  documentation.nixos.extraModules = [
-    modularServicesModule
-  ];
+  options.documentation.nixos.bundledModularServiceNames = lib.mkOption {
+    type = lib.types.listOf lib.types.str;
+    internal = true;
+    default = builtins.attrNames (
+      import ../../../../pkgs/top-level/modular-services-bundled.nix (
+        throw "documentation.nixos.bundledModularServiceNames: pkgs must not be evaluated"
+      )
+    );
+    description = "Names of bundled modular services to include in NixOS documentation.";
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10589,7 +10589,13 @@ with pkgs;
     else
       haskell.lib.compose.justStaticExecutables haskellPackages.nix-serve-ng;
 
-  nixpkgs-manual = callPackage ../../doc/doc-support/package.nix { };
+  nixpkgs-manual =
+    let
+      bundledModularServiceModules = lib.mapAttrs (_: pkg: pkg.services) (
+        import ./modular-services-bundled.nix pkgs
+      );
+    in
+    callPackage ../../doc/doc-support/package.nix { inherit bundledModularServiceModules; };
 
   nixos-artwork = recurseIntoAttrs (callPackage ../data/misc/nixos-artwork { });
 

--- a/pkgs/top-level/modular-services-bundled.nix
+++ b/pkgs/top-level/modular-services-bundled.nix
@@ -1,0 +1,12 @@
+pkgs:
+# A list of all packages that define service modules, used for documentation rendering.
+# Pairs *attribute path* to package that defines it.
+# E.g. "pythonPackages.foo" = pkgs.pythonPackages.foo;
+{
+  "autopush-rs" = pkgs.autopush-rs;
+  "ghostunnel" = pkgs.ghostunnel;
+  "ktls-utils" = pkgs.ktls-utils;
+  "php" = pkgs.php;
+  "snid" = pkgs.snid;
+  "trailbase" = pkgs.trailbase;
+}


### PR DESCRIPTION
Moves documentation on modular services that are not specific to NixOS to the nixpkgs manual, including a new option page `package-module-options.html`.
This further allowed simplifying `modular-services.nix` for the purpose of adding new services for inclusion in the manual.
Additionally fixes an error on `man configuration.nix`.

Closes #432550.

Disclaimer: I used a coding agent in the creation of this patch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux - (`nix-build nixos/release.nix -A manual.x86_64-linux`, `man configuration.nix)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
