### PR TITLE
rust.lib: restore required trailing \

### DIFF
--- a/pkgs/build-support/rust/lib/default.nix
+++ b/pkgs/build-support/rust/lib/default.nix
@@ -77,7 +77,7 @@
       + lib.optionalString (rustTargetPlatform != rustHostPlatform) ''
         "CC_${stdenv.targetPlatform.rust.cargoEnvVarTarget}=${ccForTarget}" \
         "CXX_${stdenv.targetPlatform.rust.cargoEnvVarTarget}=${cxxForTarget}" \
-        "CARGO_TARGET_${stdenv.targetPlatform.rust.cargoEnvVarTarget}_LINKER=${ccForTarget}"
+        "CARGO_TARGET_${stdenv.targetPlatform.rust.cargoEnvVarTarget}_LINKER=${ccForTarget}" \
       '';
     };
 }


### PR DESCRIPTION
Commit c4f5dfad0dfd was intended as a stylistic cleanup, but the trailing \ it removed from pkgs/build-support/rust/lib/default.nix was not stylistic: it is a shell line continuation that joins the cross-only env var block to the cargo command added by consumers. Without it, `CC_*`, `CXX_*`, and `CARGO_TARGET_*_LINKER` are silently not passed to cargo when rustTargetPlatform != rustHostPlatform.

This in turn can break cross compilation of Rust packages.

Fix it by adding back the trailing \

Fixes: #497857

(CC @l0b0 @imincik)

## Testing

I manged to pinpoint the issue to this commit by bisecting nixpkgs while building a Rust package on x86_64 that cross compile to aarch64. git bisect pointed me to c4f5dfad0dfd as first bad commit, which in fact breaks my package:

```
$ nix build /home/jibi/nix-config#nixosConfigurations.rpi.config.services.bisca.backend.package --override-input bisca/nixpkgs "git+file:///home/jibi/nixpkgs?rev=21ad3e929a5074dec3565eb53d29ed7ad715996e"
[..]
error: Cannot build '/nix/store/5650idafkyka68v5z0bqsylzflcqvrzg-bisca-backend-aarch64-unknown-linux-gnu-0.1.0.drv'.
       Reason: builder failed with exit code 101.
       Output paths:
         /nix/store/imm25v8db8858mw2rgnlc76bycln0spy-bisca-backend-aarch64-unknown-linux-gnu-0.1.0
       Last 25 log lines:
[..]
       >   cargo:warning=aarch64-unknown-linux-gnu-gcc: error: unrecognized command-line option '-m64'
       >
       >   --- stderr
       >
       >
       >   error occurred in cc-rs: command did not execute successfully (status code exit status: 1): LC_ALL="C" "aarch64-unknown-linux-gnu-gcc" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-m64" "-w" "-DSQLITE_CORE" "-DSQLITE_DEFAULT_FOREIGN_KEYS=1" "-DSQLITE_ENABLE_API_ARMOR" "-DSQLITE_ENABLE_COLUMN_METADATA" "-DSQLITE_ENABLE_DBSTAT_VTAB" "-DSQLITE_ENABLE_FTS3" "-DSQLITE_ENABLE_FTS3_PARENTHESIS" "-DSQLITE_ENABLE_FTS5" "-DSQLITE_ENABLE_JSON1" "-DSQLITE_ENABLE_LOAD_EXTENSION=1" "-DSQLITE_ENABLE_MEMORY_MANAGEMENT" "-DSQLITE_ENABLE_RTREE" "-DSQLITE_ENABLE_STAT2" "-DSQLITE_ENABLE_STAT4" "-DSQLITE_SOUNDEX" "-DSQLITE_THREADSAFE=1" "-DSQLITE_USE_URI" "-DHAVE_USLEEP=1" "-D_POSIX_THREAD_SAFE_FUNCTIONS" "-DHAVE_ISNAN" "-DHAVE_LOCALTIME_R" "-DSQLITE_ENABLE_UNLOCK_NOTIFY" "-o" "/build/backend/target/release/build/libsqlite3-sys-134436ce0303c69a/out/c877a2978823c39d-sqlite3.o" "-c" "sqlite3/sqlite3.c"
```

while with this change I'm able to build the package again:

```
$ nix build /home/jibi/nix-config#nixosConfigurations.rpi.config.services.bisca.backend.package --override-input bisca/nixpkgs "git+file:///home/jibi/nixpkgs?rev=42955023b2aa6d0ebfef5dbff0c9bc474e343a08"
[..]
$ ls result/bin
backend
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
