### PR TITLE
calibre: disable flaky test_recipe_browser_qt test

### DIFF
--- a/pkgs/by-name/ca/calibre/package.nix
+++ b/pkgs/by-name/ca/calibre/package.nix
@@ -248,6 +248,9 @@ stdenv.mkDerivation (finalAttrs: {
         # eglInitialize: Failed to get system egl display
         # Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
         "test_recipe_browser_webengine"
+        # Flaky test, occasionally errors with python exception:
+        # urllib.error.URLError: <urlopen error NetworkError.RemoteHostClosedError: Connection closed>
+        "test_recipe_browser_qt"
       ]
       ++ lib.optionals stdenv.hostPlatform.isAarch64 [
         # https://github.com/microsoft/onnxruntime/issues/10038


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Test has failed a few times, including on [hydra](https://hydra.nixos.org/build/327812063/nixlog/1) and in a `nixpkgs-review` session. Seems like it occasionally tries to access the internet, based on the thrown python exception:
```
======================================================================
ERROR: test_recipe_browser_qt (calibre.scraper.test_fetch_backend.TestFetchBackend.test_recipe_browser_qt)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/build/calibre-9.7.0/src/calibre/scraper/test_fetch_backend.py", line 94, in test_recipe_browser_qt
    self.do_recipe_browser_test(Browser)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/build/calibre-9.7.0/src/calibre/scraper/test_fetch_backend.py", line 157, in do_recipe_browser_test
    r = get('/redirect')
  File "/build/calibre-9.7.0/src/calibre/scraper/test_fetch_backend.py", line 116, in get
    raw = res.read()
  File "/build/calibre-9.7.0/src/calibre/scraper/qt.py", line 57, in read
    self._wait()
    ~~~~~~~~~~^^
  File "/build/calibre-9.7.0/src/calibre/scraper/qt.py", line 52, in _wait
    raise ex
urllib.error.URLError: <urlopen error NetworkError.RemoteHostClosedError: Connection closed>

----------------------------------------------------------------------
```
ZHF: #516381

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
