### PR TITLE
maintainers: remove candeira

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4430,12 +4430,6 @@
     githubId = 289492;
     name = "Philip Horger";
   };
-  candeira = {
-    email = "javier@candeira.com";
-    github = "candeira";
-    githubId = 91694;
-    name = "Javier Candeira";
-  };
   caniko = {
     email = "gpg@rotas.mozmail.com";
     github = "caniko";

--- a/pkgs/by-name/xm/xmlcopyeditor/package.nix
+++ b/pkgs/by-name/xm/xmlcopyeditor/package.nix
@@ -62,10 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://xml-copy-editor.sourceforge.io/";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [
-      candeira
-      wegank
-    ];
+    maintainers = with lib.maintainers; [ wegank ];
     mainProgram = "xmlcopyeditor";
   };
 })


### PR DESCRIPTION
## Reasons

- Last commented in [April 2020](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Acandeira)
- Hasn't created any PRs / Issues since [April 2020](https://github.com/NixOS/nixpkgs/issues?q=author%3Acandeira)
- About 2 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Acandeira%20-commenter%3Acandeira%20-author%3Acandeira%20-reviewed-by%3Acandeira) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.