### PR TITLE
python3Packages.httpie: disable tests broken on Python 3.14

### DIFF
--- a/pkgs/development/python-modules/httpie/default.nix
+++ b/pkgs/development/python-modules/httpie/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   charset-normalizer,
   defusedxml,
@@ -112,6 +113,13 @@ buildPythonPackage rec {
   ++ lib.optionals (pythonAtLeast "3.14") [
     # https://github.com/httpie/cli/issues/1641
     "test_lazy_choices_help"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # requires network: hit pie.dev (sandbox blocks external)
+    "remote_httpbin"
+    "chunked"
+    "test_saved_session_cookies_on_different_domain"
+    "test_saved_session_cookie_pool"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/httpie/default.nix
+++ b/pkgs/development/python-modules/httpie/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   charset-normalizer,
   defusedxml,
@@ -14,6 +13,7 @@
   pytest-lazy-fixture,
   pytest-mock,
   pytestCheckHook,
+  pythonAtLeast,
   requests-toolbelt,
   requests,
   responses,
@@ -98,6 +98,8 @@ buildPythonPackage rec {
     "test_naked_invocation"
     # Test is flaky
     "test_stdin_read_warning"
+    # flaky: daemon status check exceeds attempt limit
+    "test_daemon_runner"
     # httpbin compatibility issues
     "test_binary_suppresses_when_terminal"
     "test_binary_suppresses_when_not_terminal_but_pretty"
@@ -107,9 +109,9 @@ buildPythonPackage rec {
     "test_terminal_output_response_charset_detection"
     "test_terminal_output_request_charset_detection"
   ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    # Test is flaky
-    "test_daemon_runner"
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # https://github.com/httpie/cli/issues/1641
+    "test_lazy_choices_help"
   ];
 
   meta = {


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327142412)](https://hydra.nixos.org/build/327142412)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test