### PR TITLE
fuzzel: search for pixmaps in /run/current-system

### DIFF
--- a/pkgs/by-name/fu/fuzzel/package.nix
+++ b/pkgs/by-name/fu/fuzzel/package.nix
@@ -70,6 +70,12 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonOption "svg-backend" (if svgSupport then svgBackend else "none"))
   ];
 
+  postPatch = ''
+    substituteInPlace icon.c \
+      --replace-fail '"/usr/share/pixmaps", NULL' \
+                     '"/usr/share/pixmaps", "/run/current-system/sw/share/pixmaps", NULL'
+  '';
+
   meta = {
     changelog = "https://codeberg.org/dnkl/fuzzel/releases/tag/${finalAttrs.version}";
     description = "Wayland-native application launcher, similar to rofi’s drun mode";


### PR DESCRIPTION
Since version 1.12.0, fuzzel no longer looks for icons in the pixmaps sub-directory of each XDG data dir[^1][^2].

This commit appends /run/current-system/sw/share/pixmaps to the list of searched directories, so that NixOS' pixmaps icons can be displayed along with the ones from non-NixOS distros.

---

Demo:

```console
$ ls -l /run/current-system/sw/share/pixmaps/
[...] proton-vpn-logo.svg -> /nix/store/4hq5h8jcrq82r12fa7cz9jp2nhgy60bk-proton-vpn-4.15.3/share/pixmaps/proton-vpn-logo.svg
```
<img width="618" height="425" alt="fuzzel" src="https://github.com/user-attachments/assets/66211906-fe22-4807-83f4-1c856aada096" />

[^1]: https://codeberg.org/dnkl/fuzzel/commit/e071a61937234e27af20b06170d0c36a67d3203d
[^2]: https://codeberg.org/dnkl/fuzzel/commit/07d77fd0ffce39c81fd315b7db4ac79fb5ecf356

---

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
