### PR TITLE
libpq: support dontDisableStatic

### DIFF
--- a/pkgs/servers/sql/postgresql/libpq.nix
+++ b/pkgs/servers/sql/postgresql/libpq.nix
@@ -163,7 +163,13 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   # PostgreSQL always builds both shared and static libs, so we delete those we don't want.
-  postInstall = if stdenv.hostPlatform.isStatic then "touch $out/empty" else "rm -rfv $dev/lib/*.a";
+  # Honour the `dontDisableStatic` convention (see `generic.nix`) so consumers can keep
+  # the static archives in `$dev/lib` alongside the shared libraries in `$out/lib`.
+  postInstall =
+    if stdenv.hostPlatform.isStatic then
+      "touch $out/empty"
+    else
+      lib.optionalString (!(finalAttrs.dontDisableStatic or false)) "rm -rfv $dev/lib/*.a";
 
   doCheck = false;
 


### PR DESCRIPTION
Bring libpq into line with `pkgs/servers/sql/postgresql/generic.nix`, which already lets consumers retain the static archives alongside the shared libraries by setting `dontDisableStatic = true`. libpq's `postInstall` previously deleted every `.a` from `$dev/lib` unconditionally on non-static builds; consumers that need both the shared library and a native-ELF static archive had no in-tree way to keep them.

The default behaviour is preserved: when `dontDisableStatic` is unset or `false`, the `.a` files are still removed, and the resulting `postInstall` string is identical to the previous one, so the derivation hash for existing consumers does not change. Verified directly with `nix-instantiate -A libpq` — the `.drv` path is byte-identical before and after the patch — so no reverse-dependency rebuild is triggered, and there's nothing for `nixpkgs-review` to build on the default code path.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage). (No reverse-dependency rebuilds are triggered — see above.)
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.
