### PR TITLE
ut2004: init at OldUnreal patch 3374-preview-23

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5720,6 +5720,11 @@
     githubId = 3077118;
     name = "David McFarland";
   };
+  corps-fini = {
+    github = "corps-fini";
+    githubId = 44802527;
+    name = "corps-fini";
+  };
   costrouc = {
     email = "chris.ostrouchov@gmail.com";
     github = "costrouc";

--- a/pkgs/by-name/ut/ut2004/data.nix
+++ b/pkgs/by-name/ut/ut2004/data.nix
@@ -1,0 +1,42 @@
+{
+  fetchurl,
+  lib,
+  libarchive,
+  stdenv,
+  unshield,
+  ut2004Packages,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  name = "ut2004-data";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    libarchive
+    unshield
+  ];
+
+  unpackPhase = ''
+    mkdir cabs
+    bsdtar -xvf "${ut2004Packages.image}/ut2004.iso" -C cabs --strip-components 1 'Disk?/*.cab' 'Disk?/*.hdr'
+    unshield -d data x cabs/data1.cab
+  '';
+
+  installPhase = ''
+    mv data $out
+  '';
+
+  meta = {
+    description = "Unreal Tournament 2004 CD content provided by OldUnreal";
+    homepage = "https://oldunreal.com/downloads/ut2004/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ corps-fini ];
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/ut/ut2004/game.nix
+++ b/pkgs/by-name/ut/ut2004/game.nix
@@ -15,13 +15,13 @@
 
 let
   gameData = ut2004Packages.data;
-  patch-version = "3374-preview-17";
+  patch-version = "3374-preview-23";
   patch =
     rec {
       aarch64-linux = x86_64-linux;
       x86_64-linux = fetchurl {
-        url = "https://github.com/OldUnreal/UT2004Patches/releases/download/${patch-version}/OldUnreal-UT2004Patch3374-Linux-6369f34c.tar.bz2";
-        hash = "sha256-/PGV58gVe/R3lzYLheXfMWS4Y4KXp/oIzfIAorGxQzo=";
+        url = "https://github.com/OldUnreal/UT2004Patches/releases/download/${patch-version}/OldUnreal-UT2004Patch3374-Linux-094b94dc.tar.bz2";
+        hash = "sha256-F56kPIgxv/FHAFhQzTc8DsK3Dc9vhBwhCcFSXvEa1NM=";
       };
     }
     .${stdenv.hostPlatform.system} or (throw "Unsupported platform: ${stdenv.hostPlatform.system}");

--- a/pkgs/by-name/ut/ut2004/game.nix
+++ b/pkgs/by-name/ut/ut2004/game.nix
@@ -1,0 +1,172 @@
+{
+  autoPatchelfHook,
+  copyDesktopItems,
+  fetchurl,
+  imagemagick,
+  lib,
+  libGL,
+  libarchive,
+  makeDesktopItem,
+  openal,
+  sdl3,
+  stdenv,
+  ut2004Packages,
+}:
+
+let
+  gameData = ut2004Packages.data;
+  patch-version = "3374-preview-17";
+  patch =
+    rec {
+      aarch64-linux = x86_64-linux;
+      x86_64-linux = fetchurl {
+        url = "https://github.com/OldUnreal/UT2004Patches/releases/download/${patch-version}/OldUnreal-UT2004Patch3374-Linux-6369f34c.tar.bz2";
+        hash = "sha256-/PGV58gVe/R3lzYLheXfMWS4Y4KXp/oIzfIAorGxQzo=";
+      };
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported platform: ${stdenv.hostPlatform.system}");
+  systemDir =
+    {
+      aarch64-linux = "SystemARM64";
+      x86_64-linux = "System";
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported platform: ${stdenv.hostPlatform.system}");
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ut2004";
+  version = patch-version;
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = patch;
+
+  buildInputs = [
+    gameData
+    libGL
+    openal
+    sdl3
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    copyDesktopItems
+    imagemagick
+    libarchive
+  ];
+
+  unpackPhase = ''
+    # Install files to their (relative) final location.
+    # https://github.com/OldUnreal/FullGameInstallers/blob/748525188b80f47138f19af6c8c6899230cb214e/Linux/install-ut2004.sh#L2087-L2155.
+    mkdir -p ut2004/System
+
+    for folder in Animations Benchmark ForceFeedback Help KarmaData Maps Music StaticMeshes Textures Web; do
+      cp --no-preserve=mode -vrs ${gameData}/"All_$folder" ut2004/"$folder"
+    done
+
+    cp --no-preserve=mode -vrs ${gameData}/English_Manual ut2004/Manual
+    cp --no-preserve=mode -vrs ${gameData}/English_Sounds_Speech_System_Help/Sounds ut2004
+    cp --no-preserve=mode -vrs ${gameData}/English_Sounds_Speech_System_Help/Speech ut2004
+
+    cp --no-preserve=mode -vrs ${gameData}/All_UT2004.EXE/* ut2004/System
+    cp --no-preserve=mode -vrs ${gameData}/English_Sounds_Speech_System_Help/Help/* ut2004/Help
+    cp --no-preserve=mode -vrs ${gameData}/English_Sounds_Speech_System_Help/System/* ut2004/System
+    cp --no-preserve=mode -vrs ${gameData}/US_License.int ut2004/System
+
+    # Patch.
+    bsdtar --unlink-first -xf "${patch}" -C ut2004
+
+    # Remove files superseded by the patch.
+    # https://github.com/OldUnreal/FullGameInstallers/blob/748525188b80f47138f19af6c8c6899230cb214e/Linux/install-ut2004.sh#L2169-L2194
+    rm -v -- ut2004/System/{StreamLineFX,XVoting}.u
+
+    # Remove windows files.
+    # https://github.com/OldUnreal/FullGameInstallers/blob/748525188b80f47138f19af6c8c6899230cb214e/Linux/install-ut2004.sh#L2087-L2155.
+    rm -v -- ut2004/System/*.bat
+    rm -v -- ut2004/System/*.dll
+    rm -v -- ut2004/System/*.exe
+
+    # Remove unused architectures.
+    if [ "${systemDir}" != System ]; then
+        rm -v -- ut2004/System/*.so
+        rm -v -- ut2004/System/{UT2004,ut2004-bin,ut2004-bin-amd64}
+        rm -v -- ut2004/System/{UCC,ucc-bin,ucc-bin-amd64}
+    fi
+    for dir in SystemARM64 SystemPPC64LE; do
+      if [ "${systemDir}" != "$dir" ]; then
+        rm -rfv -- ut2004/"$dir"
+      fi
+    done
+
+    # Use system dependencies.
+    rm -v -- ut2004/${systemDir}/libopenal.so.1
+    rm -v -- ut2004/${systemDir}/libopenal.so.1.*
+    rm -v -- ut2004/${systemDir}/libSDL3.so.0
+    rm -v -- ut2004/${systemDir}/libSDL3.so.0.*
+
+    # Make icons.
+    # identify Unreal.ico
+    # Unreal.ico[0] ICO 48x48 48x48+0+0 4-bit sRGB 0.000u 0:00.000
+    # Unreal.ico[1] ICO 32x32 32x32+0+0 4-bit sRGB 0.000u 0:00.000
+    # Unreal.ico[2] ICO 16x16 16x16+0+0 4-bit sRGB 0.000u 0:00.000
+    # Unreal.ico[3] ICO 48x48 48x48+0+0 8-bit sRGB 0.000u 0:00.000
+    # Unreal.ico[4] ICO 32x32 32x32+0+0 8-bit sRGB 0.000u 0:00.000
+    # Unreal.ico[5] ICO 16x16 16x16+0+0 8-bit sRGB 0.000u 0:00.000
+    # Unreal.ico[6] ICO 48x48 48x48+0+0 8-bit sRGB 0.000u 0:00.000
+    # Unreal.ico[7] ICO 32x32 32x32+0+0 8-bit sRGB 24070B 0.000u 0:00.000
+    icon_src=ut2004/Help/Unreal.ico
+    mkdir -p icons/hicolor/{16x16,32x32,48x48}
+    magick -background none "$icon_src[5]" icons/hicolor/16x16/ut2004.png
+    magick -background none "$icon_src[7]" icons/hicolor/32x32/ut2004.png
+    magick -background none "$icon_src[6]" icons/hicolor/48x48/ut2004.png
+  '';
+
+  installPhase = ''
+    # Install game data.
+    mkdir -p "$out"/opt
+    mv ut2004 "$out"/opt
+
+    # Install icons.
+    mkdir -p "$out"/share
+    mv icons "$out"/share
+
+    # Install binaries.
+    mkdir -p "$out"/bin
+    ln -s "$out"/opt/ut2004/${systemDir}/ut2004-bin "$out"/bin/ut2004
+    ln -s "$out"/opt/ut2004/${systemDir}/ucc-bin "$out"/bin/ut2004-ucc
+
+    runHook postInstall
+  '';
+
+  appendRunpaths = [
+    "${placeholder "out"}/opt/ut2004/System"
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "ut2004";
+      desktopName = "Unreal Tournament 2004";
+      comment = "Unreal Tournament 2004 with OldUnreal patch ${patch-version}";
+      exec = "ut2004";
+      icon = "ut2004";
+      categories = [ "Game" ];
+    })
+  ];
+
+  meta = {
+    description = ''
+      Unreal Tournament 2004 with OldUnreal patch ${patch-version}.
+      Pin ut2004Packages.image to avoid downloading the disc image when build tools are updated (for example libarchive) at the cost of extra disk space.
+      To save disk space, pin ut2004Packages.data instead of ut2004Packages.image to avoid downloading the disc image when the patch is updated.
+    '';
+    homepage = "https://oldunreal.com/downloads/ut2004/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ corps-fini ];
+    mainProgram = "ut2004";
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/ut/ut2004/image.nix
+++ b/pkgs/by-name/ut/ut2004/image.nix
@@ -1,0 +1,37 @@
+{
+  fetchurl,
+  lib,
+  stdenvNoCC,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  name = "ut2004-image";
+
+  src = fetchurl {
+    urls = [
+      "https://files.oldunreal.net/UT2004.ISO"
+      "https://files2.oldunreal.net/UT2004.ISO"
+      "https://files3.oldunreal.net/UT2004.ISO"
+    ];
+    hash = "sha256-Q+kYKuILy8D29FiP7mwbM2wmHxRlQDEYoZc7CbGiJUE=";
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    mkdir $out
+    cp $src $out/ut2004.iso
+  '';
+
+  meta = {
+    description = "Unreal Tournament 2004 CD image provided by OldUnreal";
+    homepage = "https://oldunreal.com/downloads/ut2004/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ corps-fini ];
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/ut/ut2004/package.nix
+++ b/pkgs/by-name/ut/ut2004/package.nix
@@ -1,0 +1,3 @@
+{ ut2004Packages }:
+
+ut2004Packages.game

--- a/pkgs/by-name/ut/ut2004/packages.nix
+++ b/pkgs/by-name/ut/ut2004/packages.nix
@@ -1,0 +1,10 @@
+{
+  lib,
+  newScope,
+}:
+
+lib.makeScope newScope (self: {
+  image = self.callPackage ./image.nix { };
+  data = self.callPackage ./data.nix { };
+  game = self.callPackage ./game.nix { };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10088,6 +10088,8 @@ with pkgs;
 
   ultrastar-manager = libsForQt5.callPackage ../tools/misc/ultrastar-manager { };
 
+  ut2004Packages = recurseIntoAttrs (callPackage ../by-name/ut/ut2004/packages.nix { });
+
   # To ensure vdrift's code is built on hydra
   vdrift-bin = vdrift.bin;
 


### PR DESCRIPTION
Add Unreal Tournament 2004 with the patch 3374-preview-23, now released by OldUnreal.  
Tested manually. The game launches and multiplayer was fun (kicked from a lot of servers still using the latest AntiTCC before OldUnreal took over the code base).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
