### PR TITLE
iggy: init 0.8.0, nixos/iggy: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -10,6 +10,9 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- A NixOS module for [Apache Iggy](https://iggy.apache.org), a high-performance
+  persistent message streaming platform, has been added as `services.iggy`.
+
 - [tranquil](https://tangled.org/tranquil.farm/tranquil-pds) is an ATProto PDS (personal data server) implementation in Rust. A featureful, spec conscious and community driven alternative to the Bluesky reference implementation PDS. Available as [services.tranquil-pds](#opt-services.tranquil-pds.enable).
 
 - [scx_loader](https://github.com/sched-ext/scx-loader), a system daemon and DBus-based loader for sched_ext schedulers. `scxctl` is the command-line client for interacting with the loader, allowing users to switch schedulers, modes, and arguments dynamically. Available as [services.scx-loader](#opt-services.scx-loader.enable)

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -889,6 +889,7 @@
   ./services/misc/heisenbridge.nix
   ./services/misc/homepage-dashboard.nix
   ./services/misc/hyprwhspr-rs.nix
+  ./services/misc/iggy.nix
   ./services/misc/ihaskell.nix
   ./services/misc/iio-niri.nix
   ./services/misc/input-remapper.nix

--- a/nixos/modules/services/misc/iggy.nix
+++ b/nixos/modules/services/misc/iggy.nix
@@ -1,0 +1,161 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.iggy;
+  format = pkgs.formats.toml { };
+  configFile = format.generate "iggy-server.toml" cfg.settings;
+in
+{
+  meta.maintainers = with lib.maintainers; [ jpds ];
+
+  options.services.iggy = {
+    enable = lib.mkEnableOption "Apache Iggy message streaming server";
+
+    package = lib.mkPackageOption pkgs "iggy" { };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to open firewall ports for iggy's enabled transports.
+        Opens the ports derived from {option}`settings.http.address`,
+        {option}`settings.tcp.address`, and {option}`settings.quic.address`.
+      '';
+    };
+
+    secretsFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/run/secrets/iggy.env";
+      description = ''
+        Path to a file containing secret environment variables for iggy-server,
+        as described in {manpage}`systemd.exec(5)`. Use this to supply sensitive
+        values such as `IGGY_ROOT_PASSWORD`, `IGGY_HTTP_JWT_ENCODING_SECRET`,
+        and `IGGY_HTTP_JWT_DECODING_SECRET` without storing them in the Nix store.
+
+        Any iggy configuration key can be set via an environment variable with
+        the `IGGY_` prefix (e.g. `IGGY_TCP_ADDRESS=0.0.0.0:8090`).
+      '';
+    };
+
+    settings = lib.mkOption {
+      default = { };
+      description = ''
+        iggy-server configuration. Refer to the
+        [iggy documentation](https://iggy.apache.org/docs/server/configuration)
+        for available options. Sensitive values should be passed via
+        {option}`secretsFile` rather than set here.
+      '';
+      type = lib.types.submodule {
+        freeformType = format.type;
+        options = {
+          system.path = lib.mkOption {
+            type = lib.types.str;
+            default = "/var/lib/iggy";
+            readOnly = true;
+            description = ''
+              Path to the root directory where iggy stores its data.
+              Fixed to the systemd `StateDirectory` and cannot be changed.
+            '';
+          };
+          http.enabled = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = "Whether to enable the HTTP API transport.";
+          };
+          http.address = lib.mkOption {
+            type = lib.types.str;
+            default = "127.0.0.1:3000";
+            description = "Address and port for the HTTP API server.";
+          };
+          tcp.enabled = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = "Whether to enable the TCP transport.";
+          };
+          tcp.address = lib.mkOption {
+            type = lib.types.str;
+            default = "127.0.0.1:8090";
+            description = "Address and port for the TCP server.";
+          };
+          quic.enabled = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = "Whether to enable the QUIC transport.";
+          };
+          quic.address = lib.mkOption {
+            type = lib.types.str;
+            default = "127.0.0.1:8080";
+            description = "Address and port for the QUIC server.";
+          };
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.iggy-server = {
+      description = "Apache Iggy message streaming server";
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+      environment.IGGY_CONFIG_PATH = configFile;
+      serviceConfig = {
+        DynamicUser = true;
+        ExecStart = lib.getExe' cfg.package "iggy-server";
+        StateDirectory = "iggy";
+        StateDirectoryMode = "0750";
+        Restart = "on-failure";
+
+        CapabilityBoundingSet = "";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+        ];
+        UMask = "0077";
+      }
+      // lib.optionalAttrs (cfg.secretsFile != null) {
+        EnvironmentFile = cfg.secretsFile;
+      };
+    };
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts =
+        lib.optional cfg.settings.http.enabled (
+          lib.toInt (lib.last (lib.splitString ":" cfg.settings.http.address))
+        )
+        ++ lib.optional cfg.settings.tcp.enabled (
+          lib.toInt (lib.last (lib.splitString ":" cfg.settings.tcp.address))
+        );
+      allowedUDPPorts = lib.optional cfg.settings.quic.enabled (
+        lib.toInt (lib.last (lib.splitString ":" cfg.settings.quic.address))
+      );
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -799,6 +799,7 @@ in
   ifm = runTest ./ifm.nix;
   ifstate = import ./ifstate { inherit runTest; };
   iftop = runTest ./iftop.nix;
+  iggy = runTest ./iggy.nix;
   image-contents = handleTest ./image-contents.nix { };
   immich = runTest ./web-apps/immich.nix;
   immich-kiosk = runTest ./web-apps/immich-kiosk.nix;

--- a/nixos/tests/iggy.nix
+++ b/nixos/tests/iggy.nix
@@ -1,0 +1,104 @@
+{
+  lib,
+  ...
+}:
+{
+  name = "iggy";
+
+  meta = {
+    maintainers = with lib.maintainers; [ jpds ];
+  };
+
+  nodes = {
+    server =
+      { pkgs, ... }:
+      {
+        services.iggy = {
+          enable = true;
+          settings = {
+            http.address = "[::]:3000";
+            tcp.address = "[::]:8090";
+          };
+          secretsFile = pkgs.writeText "iggy-test-secrets" ''
+            IGGY_ROOT_USERNAME=iggy
+            IGGY_ROOT_PASSWORD=secret
+            IGGY_HTTP_JWT_ENCODING_SECRET=nixos-test-jwt-secret
+            IGGY_HTTP_JWT_DECODING_SECRET=nixos-test-jwt-secret
+          '';
+        };
+
+        environment.systemPackages = [ pkgs.iggy ];
+
+        networking.firewall.allowedTCPPorts = [
+          3000 # HTTP API
+          8090 # TCP
+        ];
+      };
+
+    mcp =
+      { pkgs, ... }:
+      let
+        mcpConfigFile = pkgs.writeText "iggy-mcp.toml" ''
+          transport = "http"
+
+          [http]
+          address = "[::]:8082"
+          path = "/mcp"
+
+          [iggy]
+          address = "server:8090"
+          username = "iggy"
+          password = "secret"
+          consumer = "iggy-mcp"
+
+          [permissions]
+          create = true
+          read = true
+          update = true
+          delete = true
+
+          [telemetry]
+          enabled = false
+          service_name = "iggy-mcp"
+        '';
+      in
+      {
+        systemd.services.iggy-mcp = {
+          description = "Iggy MCP Server";
+          wantedBy = [ "multi-user.target" ];
+          after = [ "network-online.target" ];
+          wants = [ "network-online.target" ];
+          environment.IGGY_MCP_CONFIG_PATH = "${mcpConfigFile}";
+          serviceConfig = {
+            ExecStart = lib.getExe' pkgs.iggy "iggy-mcp";
+            Restart = "on-failure";
+          };
+        };
+      };
+  };
+
+  testScript = ''
+    server.start()
+    server.wait_for_unit("iggy-server.service")
+    server.wait_for_open_port(3000)
+    server.wait_for_open_port(8090)
+
+    with subtest("create stream"):
+        server.succeed("IGGY_USERNAME=iggy IGGY_PASSWORD=secret iggy stream create teststream")
+
+    with subtest("create topic"):
+        server.succeed("IGGY_USERNAME=iggy IGGY_PASSWORD=secret iggy topic create teststream testtopic 1 none")
+
+    with subtest("send message"):
+        server.succeed("IGGY_USERNAME=iggy IGGY_PASSWORD=secret iggy message send teststream testtopic 'hello iggy'")
+
+    with subtest("poll message"):
+        server.succeed("IGGY_USERNAME=iggy IGGY_PASSWORD=secret iggy message poll --offset 0 teststream testtopic 0 | grep 'hello iggy'")
+
+    with subtest("mcp server check"):
+        mcp.start()
+        mcp.wait_for_unit("iggy-mcp.service")
+        mcp.wait_for_open_port(8082)
+        mcp.succeed("curl -sf http://127.0.0.1:8082/health | grep -q 'healthy'")
+  '';
+}

--- a/pkgs/by-name/ig/iggy/package.nix
+++ b/pkgs/by-name/ig/iggy/package.nix
@@ -1,0 +1,100 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  buildNpmPackage,
+  hwloc,
+  importNpmLock,
+  installShellFiles,
+  pkg-config,
+  rustPlatform,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (
+  finalAttrs:
+  let
+    webUI = buildNpmPackage {
+      pname = "iggy-web-ui";
+      version = finalAttrs.version;
+
+      src = "${finalAttrs.src}/web";
+
+      npmDeps = importNpmLock { npmRoot = "${finalAttrs.src}/web"; };
+      npmConfigHook = importNpmLock.npmConfigHook;
+
+      buildPhase = ''
+        npm run build:static
+      '';
+
+      installPhase = ''
+        cp -r build/static $out
+      '';
+    };
+  in
+  {
+    pname = "iggy";
+    version = "0.8.0";
+    __structuredAttrs = true;
+
+    src = fetchFromGitHub {
+      owner = "apache";
+      repo = "iggy";
+      tag = "server-${finalAttrs.version}";
+      hash = "sha256-WeqS6XVnDiTJlSs+AdOmBrQIZh5reW9YWbzm0sk34o0=";
+    };
+
+    cargoHash = "sha256-xkZ6eOtIzPdPgVDxFyPmO2KKRTaJrFRf+CALfEClb+U=";
+
+    cargoBuildFlags = [
+      "--bin=iggy"
+      "--bin=iggy-mcp"
+      "--bin=iggy-server"
+    ];
+
+    # Tests require librusty v8.
+    doCheck = false;
+
+    nativeBuildInputs = [
+      installShellFiles
+      pkg-config
+    ];
+
+    buildInputs = [ hwloc ];
+
+    preBuild = ''
+      mkdir -p web/build
+      cp -rL --no-preserve=mode ${webUI} web/build/static
+    '';
+
+    postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      installShellCompletion --cmd iggy \
+        --bash <($out/bin/iggy --generate bash) \
+        --zsh <($out/bin/iggy --generate zsh) \
+        --fish <($out/bin/iggy --generate fish)
+    '';
+
+    doInstallCheck = true;
+    nativeInstallCheckInputs = [ versionCheckHook ];
+
+    passthru = {
+      updateScript = nix-update-script {
+        extraArgs = [
+          "--version-regex"
+          "^server-(.*)"
+        ];
+      };
+    };
+
+    meta = {
+      description = "High-performance, persistent message streaming platform";
+      homepage = "https://iggy.apache.org";
+      changelog = "https://github.com/apache/iggy/releases/tag/server-${finalAttrs.version}";
+      license = lib.licenses.asl20;
+      maintainers = with lib.maintainers; [ jpds ];
+      platforms = lib.platforms.linux;
+      mainProgram = "iggy-server";
+    };
+  }
+)

--- a/pkgs/by-name/ig/iggy/package.nix
+++ b/pkgs/by-name/ig/iggy/package.nix
@@ -6,6 +6,7 @@
   hwloc,
   importNpmLock,
   installShellFiles,
+  nixosTests,
   pkg-config,
   rustPlatform,
   versionCheckHook,
@@ -79,6 +80,7 @@ rustPlatform.buildRustPackage (
     nativeInstallCheckInputs = [ versionCheckHook ];
 
     passthru = {
+      tests = { inherit (nixosTests) iggy; };
       updateScript = nix-update-script {
         extraArgs = [
           "--version-regex"


### PR DESCRIPTION
Package and module for https://iggy.apache.org/ - a persistent message streaming platform.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [X] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
