### PR TITLE
nixos/starship: respect pre-set STARSHIP_CONFIG env variable

### DIFF
--- a/nixos/modules/programs/starship.nix
+++ b/nixos/modules/programs/starship.nix
@@ -116,7 +116,7 @@ in
         # config file.  starship appears to use a hardcoded config location
         # rather than one inside an XDG folder:
         # https://github.com/starship/starship/blob/686bda1706e5b409129e6694639477a0f8a3f01b/src/configure.rs#L651
-        if [[ ! -f "$HOME/.config/starship.toml" ]]; then
+        if [[ ! -f "$${STARSHIP_CONFIG:-$HOME/.config/starship.toml}" ]]; then
           export STARSHIP_CONFIG=${settingsFile}
         fi
         eval "$(${cfg.package}/bin/starship init bash --print-full-init)"
@@ -129,7 +129,8 @@ in
         # config file.  starship appears to use a hardcoded config location
         # rather than one inside an XDG folder:
         # https://github.com/starship/starship/blob/686bda1706e5b409129e6694639477a0f8a3f01b/src/configure.rs#L651
-        if not test -f "$HOME/.config/starship.toml";
+        set -q STARSHIP_CONFIG; or set STARSHIP_CONFIG "$HOME/.config/starship.toml"
+        if not test -f "$STARSHIP_CONFIG"
           set -x STARSHIP_CONFIG ${settingsFile}
         end
         ${lib.optionalString (!isNull cfg.transientPrompt.left) ''
@@ -153,7 +154,7 @@ in
         # config file.  starship appears to use a hardcoded config location
         # rather than one inside an XDG folder:
         # https://github.com/starship/starship/blob/686bda1706e5b409129e6694639477a0f8a3f01b/src/configure.rs#L651
-        if [[ ! -f "$HOME/.config/starship.toml" ]]; then
+        if [[ ! -f "$${STARSHIP_CONFIG:-$HOME/.config/starship.toml}" ]]; then
           export STARSHIP_CONFIG=${settingsFile}
         fi
         eval "$(${cfg.package}/bin/starship init zsh)"
@@ -167,8 +168,11 @@ in
         # config file.  starship appears to use a hardcoded config location
         # rather than one inside an XDG folder:
         # https://github.com/starship/starship/blob/686bda1706e5b409129e6694639477a0f8a3f01b/src/configure.rs#L651
-        if not `$HOME/.config/starship.toml`:
+        import os as _os
+        _sc = _os.environ.get('STARSHIP_CONFIG', _os.path.join(_os.environ['HOME'], '.config/starship.toml'))
+        if not _os.path.isfile(_sc):
           $STARSHIP_CONFIG = ('${settingsFile}')
+        del _os, _sc
         execx($(${cfg.package}/bin/starship init xonsh))
     '';
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Respect pre-set `STARSHIP_CONFIG` environment variable when deciding
whether to override it with the Nix-generated config file.

Previously, the module only checked for `$HOME/.config/starship.toml`.
If a user set `STARSHIP_CONFIG` to a custom path (e.g. via
`environment.interactiveShellInit`), the module would still override it
with the generated config, ignoring the user's preference.

Fix by using `${STARSHIP_CONFIG:-$HOME/.config/starship.toml}` in
bash/zsh, `set -q` in fish, and `os.environ.get()` in xonsh, so that
a pre-set `STARSHIP_CONFIG` pointing to an existing file is respected.

Resolve #512357

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
