### PR TITLE
nixos/installer: correct comment in tools.nix

### DIFF
--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -76,7 +76,7 @@ let
     {
       inputs = {
         # This is pointing to an unstable release.
-        # If you prefer a stable release instead, you can this to the latest number shown here: https://nixos.org/download
+        # If you prefer a stable release instead, you can change the word unstable to the latest number shown here: https://nixos.org/download
         # i.e. nixos-24.11
         # Use `nix flake update` to update the flake to the latest revision of the chosen release channel.
         nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";


### PR DESCRIPTION
Fixed incomplete sentence in comment in the `flake.nix` file that gets generated by `nixos-generate-config --flake`.

Please, note that i'm not entirely sure if the resulting line length is ok. Though `nix fmt` didn't complain and i see another long (even longer) single-line comment in that file: https://github.com/NixOS/nixpkgs/blob/7d5c7ecf3d03cf18fc7b052fdb65093562076c7a/nixos/modules/installer/tools/tools.nix#L206