### PR TITLE
lib.strings: small performance cleanups

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -801,15 +801,15 @@ rec {
     :::
   */
   hasPrefix =
-    pref: str:
-    # Before 23.05, paths would be copied to the store before converting them
-    # to strings and comparing. This was surprising and confusing.
+    pref:
     if isPath pref then
+      # Before 23.05, paths would be copied to the store before converting them
+      # to strings and comparing. This was surprising and confusing.
       throw ''
         lib.strings.hasPrefix: The first argument (${toString pref}) is a path value, but only strings are supported.
             You might want to use `lib.path.hasPrefix` instead, which correctly supports paths.''
     else
-      substring 0 (stringLength pref) str == pref;
+      str: substring 0 (stringLength pref) str == pref;
 
   /**
     Determine whether a string has given suffix.
@@ -842,19 +842,20 @@ rec {
     :::
   */
   hasSuffix =
-    suffix: content:
-    let
-      lenContent = stringLength content;
-      lenSuffix = stringLength suffix;
-    in
-    # Before 23.05, paths would be copied to the store before converting them
-    # to strings and comparing. This was surprising and confusing.
+    suffix:
     if isPath suffix then
+      # Before 23.05, paths would be copied to the store before converting them
+      # to strings and comparing. This was surprising and confusing.
       throw ''
         lib.strings.hasSuffix: The first argument (${toString suffix}) is a path value, but only strings are supported.
         There is almost certainly a bug in the calling code, since this function always returns `false` in such a case.
         This function also copies the path to the Nix store, which may not be what you want.''
     else
+      content:
+      let
+        lenContent = stringLength content;
+        lenSuffix = stringLength suffix;
+      in
       lenContent >= lenSuffix && substring (lenContent - lenSuffix) lenContent content == suffix;
 
   /**
@@ -892,16 +893,16 @@ rec {
     :::
   */
   hasInfix =
-    infix: content:
-    # Before 23.05, paths would be copied to the store before converting them
-    # to strings and comparing. This was surprising and confusing.
+    infix:
     if isPath infix then
+      # Before 23.05, paths would be copied to the store before converting them
+      # to strings and comparing. This was surprising and confusing.
       throw ''
         lib.strings.hasInfix: The first argument (${toString infix}) is a path value, but only strings are supported.
             There is almost certainly a bug in the calling code, since this function always returns `false` in such a case.
             This function also copies the path to the Nix store, which may not be what you want.''
     else
-      builtins.match ".*${escapeRegex infix}.*" "${content}" != null;
+      content: builtins.match ".*${escapeRegex infix}.*" "${content}" != null;
 
   /**
     Convert a string `s` to a list of characters (i.e. singleton strings).
@@ -1852,15 +1853,16 @@ rec {
     :::
   */
   removePrefix =
-    prefix: str:
-    # Before 23.05, paths would be copied to the store before converting them
-    # to strings and comparing. This was surprising and confusing.
+    prefix:
     if isPath prefix then
+      # Before 23.05, paths would be copied to the store before converting them
+      # to strings and comparing. This was surprising and confusing.
       throw ''
         lib.strings.removePrefix: The first argument (${toString prefix}) is a path value, but only strings are supported.
             There is almost certainly a bug in the calling code, since this function never removes any prefix in such a case.
             This function also copies the path to the Nix store, which may not be what you want.''
     else
+      str:
       let
         preLen = stringLength prefix;
       in
@@ -1901,15 +1903,16 @@ rec {
     :::
   */
   removeSuffix =
-    suffix: str:
-    # Before 23.05, paths would be copied to the store before converting them
-    # to strings and comparing. This was surprising and confusing.
+    suffix:
     if isPath suffix then
+      # Before 23.05, paths would be copied to the store before converting them
+      # to strings and comparing. This was surprising and confusing.
       throw ''
         lib.strings.removeSuffix: The first argument (${toString suffix}) is a path value, but only strings are supported.
             There is almost certainly a bug in the calling code, since this function never removes any suffix in such a case.
             This function also copies the path to the Nix store, which may not be what you want.''
     else
+      str:
       let
         sufLen = stringLength suffix;
         sLen = stringLength str;

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -6,8 +6,6 @@ let
 
   inherit (builtins) length;
 
-  inherit (lib.trivial) warnIf;
-
   asciiTable = import ./ascii-table.nix;
 
 in
@@ -732,15 +730,12 @@ rec {
   */
   normalizePath =
     s:
-    warnIf (isPath s)
-      ''
+    if isPath s then
+      throw ''
         lib.strings.normalizePath: The argument (${toString s}) is a path value, but only strings are supported.
-            Path values are always normalised in Nix, so there's no need to call this function on them.
-            This function also copies the path to the Nix store and returns the store path, the same as "''${path}" will, which may not be what you want.
-            This behavior is deprecated and will throw an error in the future.''
-      (
-        builtins.foldl' (x: y: if y == "/" && hasSuffix "/" x then x else x + y) "" (stringToCharacters s)
-      );
+            Path values are always normalised in Nix, so there's no need to call this function on them.''
+    else
+      builtins.foldl' (x: y: if y == "/" && hasSuffix "/" x then x else x + y) "" (stringToCharacters s);
 
   /**
     Depending on the boolean `cond`, return either the given string
@@ -809,14 +804,12 @@ rec {
     pref: str:
     # Before 23.05, paths would be copied to the store before converting them
     # to strings and comparing. This was surprising and confusing.
-    warnIf (isPath pref)
-      ''
+    if isPath pref then
+      throw ''
         lib.strings.hasPrefix: The first argument (${toString pref}) is a path value, but only strings are supported.
-            There is almost certainly a bug in the calling code, since this function always returns `false` in such a case.
-            This function also copies the path to the Nix store, which may not be what you want.
-            This behavior is deprecated and will throw an error in the future.
             You might want to use `lib.path.hasPrefix` instead, which correctly supports paths.''
-      (substring 0 (stringLength pref) str == pref);
+    else
+      substring 0 (stringLength pref) str == pref;
 
   /**
     Determine whether a string has given suffix.
@@ -856,13 +849,13 @@ rec {
     in
     # Before 23.05, paths would be copied to the store before converting them
     # to strings and comparing. This was surprising and confusing.
-    warnIf (isPath suffix)
-      ''
+    if isPath suffix then
+      throw ''
         lib.strings.hasSuffix: The first argument (${toString suffix}) is a path value, but only strings are supported.
-            There is almost certainly a bug in the calling code, since this function always returns `false` in such a case.
-            This function also copies the path to the Nix store, which may not be what you want.
-            This behavior is deprecated and will throw an error in the future.''
-      (lenContent >= lenSuffix && substring (lenContent - lenSuffix) lenContent content == suffix);
+        There is almost certainly a bug in the calling code, since this function always returns `false` in such a case.
+        This function also copies the path to the Nix store, which may not be what you want.''
+    else
+      lenContent >= lenSuffix && substring (lenContent - lenSuffix) lenContent content == suffix;
 
   /**
     Determine whether a string contains the given infix
@@ -902,13 +895,13 @@ rec {
     infix: content:
     # Before 23.05, paths would be copied to the store before converting them
     # to strings and comparing. This was surprising and confusing.
-    warnIf (isPath infix)
-      ''
+    if isPath infix then
+      throw ''
         lib.strings.hasInfix: The first argument (${toString infix}) is a path value, but only strings are supported.
             There is almost certainly a bug in the calling code, since this function always returns `false` in such a case.
-            This function also copies the path to the Nix store, which may not be what you want.
-            This behavior is deprecated and will throw an error in the future.''
-      (builtins.match ".*${escapeRegex infix}.*" "${content}" != null);
+            This function also copies the path to the Nix store, which may not be what you want.''
+    else
+      builtins.match ".*${escapeRegex infix}.*" "${content}" != null;
 
   /**
     Convert a string `s` to a list of characters (i.e. singleton strings).
@@ -1862,22 +1855,20 @@ rec {
     prefix: str:
     # Before 23.05, paths would be copied to the store before converting them
     # to strings and comparing. This was surprising and confusing.
-    warnIf (isPath prefix)
-      ''
+    if isPath prefix then
+      throw ''
         lib.strings.removePrefix: The first argument (${toString prefix}) is a path value, but only strings are supported.
             There is almost certainly a bug in the calling code, since this function never removes any prefix in such a case.
-            This function also copies the path to the Nix store, which may not be what you want.
-            This behavior is deprecated and will throw an error in the future.''
-      (
-        let
-          preLen = stringLength prefix;
-        in
-        if substring 0 preLen str == prefix then
-          # -1 will take the string until the end
-          substring preLen (-1) str
-        else
-          str
-      );
+            This function also copies the path to the Nix store, which may not be what you want.''
+    else
+      let
+        preLen = stringLength prefix;
+      in
+      if substring 0 preLen str == prefix then
+        # -1 will take the string until the end
+        substring preLen (-1) str
+      else
+        str;
 
   /**
     Returns a string without the specified suffix, if the suffix matches.
@@ -1913,22 +1904,20 @@ rec {
     suffix: str:
     # Before 23.05, paths would be copied to the store before converting them
     # to strings and comparing. This was surprising and confusing.
-    warnIf (isPath suffix)
-      ''
+    if isPath suffix then
+      throw ''
         lib.strings.removeSuffix: The first argument (${toString suffix}) is a path value, but only strings are supported.
             There is almost certainly a bug in the calling code, since this function never removes any suffix in such a case.
-            This function also copies the path to the Nix store, which may not be what you want.
-            This behavior is deprecated and will throw an error in the future.''
-      (
-        let
-          sufLen = stringLength suffix;
-          sLen = stringLength str;
-        in
-        if sufLen <= sLen && suffix == substring (sLen - sufLen) sufLen str then
-          substring 0 (sLen - sufLen) str
-        else
-          str
-      );
+            This function also copies the path to the Nix store, which may not be what you want.''
+    else
+      let
+        sufLen = stringLength suffix;
+        sLen = stringLength str;
+      in
+      if sufLen <= sLen && suffix == substring (sLen - sufLen) sufLen str then
+        substring 0 (sLen - sufLen) str
+      else
+        str;
 
   /**
     Returns true if string `v1` denotes a version older than `v2`.

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -729,13 +729,18 @@ rec {
     :::
   */
   normalizePath =
+    let
+      startsWithSlash = hasSuffix "/";
+    in
     s:
     if isPath s then
       throw ''
         lib.strings.normalizePath: The argument (${toString s}) is a path value, but only strings are supported.
             Path values are always normalised in Nix, so there's no need to call this function on them.''
     else
-      builtins.foldl' (x: y: if y == "/" && hasSuffix "/" x then x else x + y) "" (stringToCharacters s);
+      builtins.foldl' (x: y: if y == "/" && startsWithSlash x then x else x + y) "" (
+        stringToCharacters s
+      );
 
   /**
     Depending on the boolean `cond`, return either the given string

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -1999,7 +1999,7 @@ rec {
 
     :::
   */
-  versionAtLeast = v1: v2: !versionOlder v1 v2;
+  versionAtLeast = v1: v2: compareVersions v2 v1 != 1;
 
   /**
     This function takes an argument `x` that's either a derivation or a

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -904,6 +904,9 @@ rec {
   */
   hasInfix =
     infix:
+    let
+      escapedInfix = escapeRegex infix;
+    in
     if isPath infix then
       # Before 23.05, paths would be copied to the store before converting them
       # to strings and comparing. This was surprising and confusing.
@@ -912,7 +915,7 @@ rec {
             There is almost certainly a bug in the calling code, since this function always returns `false` in such a case.
             This function also copies the path to the Nix store, which may not be what you want.''
     else
-      content: builtins.match ".*${escapeRegex infix}.*" "${content}" != null;
+      content: builtins.match ".*${escapedInfix}.*" "${content}" != null;
 
   /**
     Convert a string `s` to a list of characters (i.e. singleton strings).

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -16,6 +16,7 @@ rec {
 
   inherit (builtins)
     compareVersions
+    concatMap
     elem
     elemAt
     filter
@@ -564,7 +565,10 @@ rec {
     :::
   */
   makeSearchPath =
-    subDir: paths: concatStringsSep ":" (map (path: path + "/" + subDir) (filter (x: x != null) paths));
+    subDir: paths:
+    concatStringsSep ":" (
+      concatMap (path: if path != null then [ (path + "/" + subDir) ] else [ ]) paths
+    );
 
   /**
     Construct a Unix-style search path by appending the given

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -1594,7 +1594,7 @@ rec {
       (
         let
           firstChar = substring 0 1 str;
-          rest = substring 1 (stringLength str) str;
+          rest = substring 1 (-1) str; # -1 takes till the end of the string
         in
         addContextFrom str (toUpper firstChar + toLower rest)
       );

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -1804,31 +1804,27 @@ rec {
     predicate: keepSplit: str:
     let
       len = stringLength str;
+      withContext = addContextFrom str;
 
       # Helper function that processes the string character by character
       go =
         pos: currentPart: result:
         # Base case: reached end of string
         if pos == len then
-          result ++ [ currentPart ]
+          result ++ [ (withContext currentPart) ]
         else
           let
             currChar = substring pos 1 str;
             prevChar = if pos > 0 then substring (pos - 1) 1 str else "";
-            isSplit = predicate prevChar currChar;
           in
-          if isSplit then
+          if predicate prevChar currChar then
             # Split here - add current part to results and start a new one
-            let
-              newResult = result ++ [ currentPart ];
-              newCurrentPart = if keepSplit then currChar else "";
-            in
-            go (pos + 1) newCurrentPart newResult
+            go (pos + 1) (if keepSplit then currChar else "") (result ++ [ (withContext currentPart) ])
           else
             # Keep building current part
             go (pos + 1) (currentPart + currChar) result;
     in
-    if len == 0 then [ (addContextFrom str "") ] else map (addContextFrom str) (go 0 "" [ ]);
+    if len == 0 then [ (withContext "") ] else go 0 "" [ ];
 
   /**
     Returns a string without the specified prefix, if the prefix matches.

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -606,8 +606,14 @@ rec {
     :::
   */
   makeSearchPathOutput =
-    output: subDir: pkgs:
-    makeSearchPath subDir (map (lib.getOutput output) pkgs);
+    output:
+    let
+      getOutput' = lib.getOutput output;
+    in
+    subDir: pkgs:
+    concatStringsSep ":" (
+      concatMap (path: if path != null then [ (getOutput' path + "/" + subDir) ] else [ ]) pkgs
+    );
 
   /**
     Construct a library search path (such as RPATH) containing the

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -1313,8 +1313,11 @@ rec {
     :::
   */
   toShellVar =
-    name: value:
-    lib.throwIfNot (isValidPosixName name) "toShellVar: ${name} is not a valid shell variable name" (
+    name:
+    if (!isValidPosixName name) then
+      throw "toShellVar: ${name} is not a valid shell variable name"
+    else
+      value:
       if isAttrs value && !isStringLike value then
         "declare -A ${name}=(${
           concatStringsSep " " (lib.mapAttrsToList (n: v: "[${escapeShellArg n}]=${escapeShellArg v}") value)
@@ -1322,8 +1325,7 @@ rec {
       else if isList value then
         "declare -a ${name}=(${escapeShellArgs value})"
       else
-        "${name}=${escapeShellArg value}"
-    );
+        "${name}=${escapeShellArg value}";
 
   /**
     Translate an attribute set `vars` into corresponding shell variable declarations

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -1742,9 +1742,7 @@ rec {
   splitString =
     sep: s:
     let
-      splits = builtins.filter builtins.isString (
-        builtins.split (escapeRegex (toString sep)) (toString s)
-      );
+      splits = filter isString (split (escapeRegex (toString sep)) (toString s));
     in
     map (addContextFrom s) splits;
 

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -802,6 +802,9 @@ rec {
   */
   hasPrefix =
     pref:
+    let
+      lenPrefix = stringLength pref;
+    in
     if isPath pref then
       # Before 23.05, paths would be copied to the store before converting them
       # to strings and comparing. This was surprising and confusing.
@@ -809,7 +812,7 @@ rec {
         lib.strings.hasPrefix: The first argument (${toString pref}) is a path value, but only strings are supported.
             You might want to use `lib.path.hasPrefix` instead, which correctly supports paths.''
     else
-      str: substring 0 (stringLength pref) str == pref;
+      str: substring 0 lenPrefix str == pref;
 
   /**
     Determine whether a string has given suffix.
@@ -843,6 +846,9 @@ rec {
   */
   hasSuffix =
     suffix:
+    let
+      lenSuffix = stringLength suffix;
+    in
     if isPath suffix then
       # Before 23.05, paths would be copied to the store before converting them
       # to strings and comparing. This was surprising and confusing.
@@ -854,7 +860,6 @@ rec {
       content:
       let
         lenContent = stringLength content;
-        lenSuffix = stringLength suffix;
       in
       lenContent >= lenSuffix && substring (lenContent - lenSuffix) lenContent content == suffix;
 
@@ -1854,6 +1859,9 @@ rec {
   */
   removePrefix =
     prefix:
+    let
+      preLen = stringLength prefix;
+    in
     if isPath prefix then
       # Before 23.05, paths would be copied to the store before converting them
       # to strings and comparing. This was surprising and confusing.
@@ -1863,9 +1871,6 @@ rec {
             This function also copies the path to the Nix store, which may not be what you want.''
     else
       str:
-      let
-        preLen = stringLength prefix;
-      in
       if substring 0 preLen str == prefix then
         # -1 will take the string until the end
         substring preLen (-1) str
@@ -1904,6 +1909,9 @@ rec {
   */
   removeSuffix =
     suffix:
+    let
+      sufLen = stringLength suffix;
+    in
     if isPath suffix then
       # Before 23.05, paths would be copied to the store before converting them
       # to strings and comparing. This was surprising and confusing.
@@ -1914,7 +1922,6 @@ rec {
     else
       str:
       let
-        sufLen = stringLength suffix;
         sLen = stringLength str;
       in
       if sufLen <= sLen && suffix == substring (sLen - sufLen) sufLen str then

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -2162,8 +2162,9 @@ rec {
         "LIST"
       ];
     in
-    type: feature: value:
+    type:
     assert (elem (toUpper type) types);
+    feature: value:
     assert (isString feature);
     assert (isString value);
     "-D${feature}:${toUpper type}=${value}";
@@ -2232,7 +2233,7 @@ rec {
 
     :::
   */
-  cmakeFeature = feature: value: cmakeOptionType "string" feature value;
+  cmakeFeature = cmakeOptionType "string";
 
   /**
     Create a `"-D<feature>=<value>"` string that can be passed to typical Meson

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -1596,7 +1596,7 @@ rec {
           firstChar = substring 0 1 str;
           rest = substring 1 (-1) str; # -1 takes till the end of the string
         in
-        addContextFrom str (toUpper firstChar + toLower rest)
+        toUpper firstChar + toLower rest
       );
 
   /**
@@ -1653,7 +1653,7 @@ rec {
         first = if length parts > 0 then toLower (head parts) else "";
         rest = if length parts > 1 then map toSentenceCase (tail parts) else [ ];
       in
-      concatStrings (map (addContextFrom str) ([ first ] ++ rest))
+      concatStrings ([ first ] ++ rest)
     );
 
   /**

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -2199,7 +2199,6 @@ rec {
   */
   cmakeBool =
     condition: flag:
-    assert (lib.isString condition);
     assert (lib.isBool flag);
     cmakeOptionType "bool" condition (lib.toUpper (lib.boolToString flag));
 
@@ -2233,11 +2232,7 @@ rec {
 
     :::
   */
-  cmakeFeature =
-    feature: value:
-    assert (lib.isString feature);
-    assert (lib.isString value);
-    cmakeOptionType "string" feature value;
+  cmakeFeature = feature: value: cmakeOptionType "string" feature value;
 
   /**
     Create a `"-D<feature>=<value>"` string that can be passed to typical Meson
@@ -2307,7 +2302,6 @@ rec {
   */
   mesonBool =
     condition: flag:
-    assert (lib.isString condition);
     assert (lib.isBool flag);
     mesonOption condition (lib.boolToString flag);
 
@@ -2344,7 +2338,6 @@ rec {
   */
   mesonEnable =
     feature: flag:
-    assert (lib.isString feature);
     assert (lib.isBool flag);
     mesonOption feature (if flag then "enabled" else "disabled");
 

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -2200,7 +2200,7 @@ rec {
   cmakeBool =
     condition: flag:
     assert (lib.isBool flag);
-    cmakeOptionType "bool" condition (lib.toUpper (lib.boolToString flag));
+    cmakeOptionType "bool" condition (if flag then "TRUE" else "FALSE");
 
   /**
     Create a `"-D<feature>:STRING=<value>"` string that can be passed to typical

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -1740,11 +1740,11 @@ rec {
     :::
   */
   splitString =
-    sep: s:
+    sep:
     let
-      splits = filter isString (split (escapeRegex (toString sep)) (toString s));
+      escapedSep = escapeRegex (toString sep);
     in
-    map (addContextFrom s) splits;
+    s: map (addContextFrom s) (filter isString (split escapedSep (toString s)));
 
   /**
     Splits a string into substrings based on a predicate that examines adjacent characters.


### PR DESCRIPTION
Started with a `concatMap` savings in `makeBinPath`, and snowballed into a bunch of other small things.

We notably change all warnings for being passed a path to instead use `throw`. These have persisted for 3 years at this point, and throwing allows for performance optimizations without readability concerns. 

The improvements to `lib.hasSuffix` and its friends are very meaningful when partial application is performed. My test case using my [`listFilesRecursiveCond` function](https://github.com/NixOS/nixpkgs/pull/481379) is:
```sh
NIX_SHOW_STATS_PATH=before.json NIX_SHOW_STATS=1 nix eval --expr 'let lib = import ./lib; in builtins.length (lib.filesystem.listFilesRecursiveCond ./. (lib.hasSuffix ".nix"))' --impure
```
And this gives me a diff of:
```json
{
  "attrset": {
    "lookups": null,
    "merges": null,
    "mergeCopies": null
  },
  "list": {
    "concats": false
  },
  "parser": {
    "expressions": "-16.05%"
  },
  "memory": {
    "envs": "-32.19%",
    "list": "+0%",
    "sets": "-0.04%",
    "symbols": "-0.02%",
    "values": "-35.72%",
    "total": "-26.23%"
  },
  "speed": {
    "primops": "-25.27%",
    "functionCalls": "-47.81%",
    "thunksMade": "-35.72%",
    "thunksAvoided": "-15.81%"
  }
}
```
Finally, we avoid running a `filter` -> `map` -> `map` for all instances of `makeBinPath`, and instead perform a single `concatMap`. This does require `makeSearchPathOutput` to no longer call `makeSearchPath` directly, but I consider the performance diff for `pkgs.git` to be worth it:
```json
{
  "attrset": {
    "lookups": "-0.4%",
    "merges": null,
    "mergeCopies": null
  },
  "list": {
    "concats": null
  },
  "parser": {
    "expressions": "+0.01%"
  },
  "memory": {
    "envs": "-0.64%",
    "list": "-1.62%",
    "sets": null,
    "symbols": "+0%",
    "values": "-0.32%",
    "total": "-0.16%"
  },
  "speed": {
    "primops": "-0.55%",
    "functionCalls": "-1.01%",
    "thunksMade": "-0.31%",
    "thunksAvoided": "-0.08%"
  }
}
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
