### PR TITLE
py-spy: 0.4.0 -> 0.4.2

### DIFF
--- a/pkgs/by-name/py/py-spy/package.nix
+++ b/pkgs/by-name/py/py-spy/package.nix
@@ -5,36 +5,42 @@
   libunwind,
   python3,
   rustPlatform,
+  xz,
 }:
 
+let
+  # https://github.com/benfred/py-spy/blob/v0.4.2/build.rs#L6-L8
+  supportsUnwind =
+    stdenv.hostPlatform.isWindows && stdenv.hostPlatform.isx86_64
+    || stdenv.hostPlatform.isLinux && (stdenv.hostPlatform.isAarch || stdenv.hostPlatform.isx86_64);
+in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "py-spy";
-  version = "0.4.0";
+  version = "0.4.2";
 
   src = fetchFromGitHub {
     owner = "benfred";
     repo = "py-spy";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-T96F8xgB9HRwuvDLXi6+lfi8za/iNn1NAbG4AIpE0V0=";
+    hash = "sha256-5T6R2Neslw8rNYWJbXncLH78kH1o42fR6kidhip6/Bg=";
   };
 
-  cargoHash = "sha256-velwX7lcNQvwg3VAUTbgsOPLlA5fAcPiPvczrBBsMvs=";
+  cargoHash = "sha256-ZhtQjX15pZe3CM898LBj/79kXa6ESgPOSFkNghq0Ywo=";
 
-  buildFeatures = lib.optional stdenv.hostPlatform.isLinux "unwind";
+  buildFeatures = lib.optional supportsUnwind "unwind";
+
+  # https://github.com/benfred/remoteprocess/blob/v0.5.2/build.rs
+  buildInputs = lib.optionals (supportsUnwind && stdenv.hostPlatform.isLinux) [
+    libunwind
+    (lib.getLib xz)
+  ];
 
   nativeBuildInputs = [
     rustPlatform.bindgenHook
   ];
 
   nativeCheckInputs = [
-    python3
-  ];
-
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isLinux "-L${libunwind}/lib";
-
-  checkFlags = [
-    # assertion `left == right` failed
-    "--skip=test_negative_linenumber_increment"
+    (python3.withPackages (ps: [ ps.numpy ]))
   ];
 
   meta = {
@@ -44,8 +50,5 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/benfred/py-spy/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = [ ];
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
-    # https://github.com/benfred/py-spy/pull/330
-    broken = stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux;
   };
 })


### PR DESCRIPTION
Changelogs:
* https://github.com/benfred/py-spy/releases/tag/v0.4.1
* https://github.com/benfred/py-spy/releases/tag/v0.4.2

Both versions have unbricked some of the platforms: v0.4.1 fixed unwind on ARM (32-bit version), and v0.4.2 added unwind support on Aarch64.

While we are there, unbrick for the rest of the platforms, and also add unwind support for Windows, as it is supported by the upstream (checked with cross-compilation).

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
