### PR TITLE
mercurial: refactor recipe using `finalAttrs`

### DIFF
--- a/pkgs/by-name/me/mercurial/package.nix
+++ b/pkgs/by-name/me/mercurial/package.nix
@@ -38,206 +38,86 @@ let
     pip
     ;
 
-  self = python3Packages.buildPythonApplication rec {
-    pname = "mercurial${lib.optionalString fullBuild "-full"}";
-    version = "7.2.2";
+in
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "mercurial${lib.optionalString fullBuild "-full"}";
+  version = "7.2.2";
 
-    src = fetchurl {
-      url = "https://mercurial-scm.org/release/mercurial-${version}.tar.gz";
-      hash = "sha256-8uyOfu7wUAWRcG03RVXwzrEYgiBo51+jsyvgfdIYT2w=";
-    };
-
-    pyproject = false;
-
-    passthru = { inherit python; }; # pass it so that the same version can be used in hg2git
-
-    cargoDeps =
-      if rustSupport then
-        rustPlatform.fetchCargoVendor {
-          inherit src;
-          name = "mercurial-${version}";
-          hash = "sha256-OGsHK3Bh47V4n+7HYpVp/jymCz1QY45rkWlAW0Hob7g=";
-          sourceRoot = "mercurial-${version}/rust";
-        }
-      else
-        null;
-    cargoRoot = if rustSupport then "rust" else null;
-
-    # enable building with Python 3.14
-    # FIXME remove once PyO3 is updated in Cargo.lock
-    env.PYO3_USE_ABI3_FORWARD_COMPATIBILITY = 1;
-
-    propagatedBuildInputs =
-      lib.optional re2Support google-re2
-      ++ lib.optional gitSupport pygit2
-      ++ lib.optional highlightSupport pygments;
-    nativeBuildInputs = [
-      makeWrapper
-      gettext
-      installShellFiles
-      setuptools
-      setuptools-scm
-      pip
-    ]
-    ++ lib.optionals rustSupport [
-      rustPlatform.cargoSetupHook
-      cargo
-      rustc
-    ];
-    buildInputs = [ docutils ];
-
-    makeFlags = [ "PREFIX=$(out)" ] ++ lib.optional rustSupport "PURE=--rust";
-
-    postInstall =
-      (lib.optionalString guiSupport ''
-        mkdir -p $out/etc/mercurial
-        cp contrib/hgk $out/bin
-        cat >> $out/etc/mercurial/hgrc << EOF
-        [extensions]
-        hgk=$out/${python.sitePackages}/hgext/hgk.py
-        EOF
-        # setting HG so that hgk can be run itself as well (not only hg view)
-        WRAP_TK=" --set TK_LIBRARY ${tk}/lib/${tk.libPrefix}
-                  --set HG $out/bin/hg
-                  --prefix PATH : ${tk}/bin "
-      '')
-      + ''
-        for i in $(cd $out/bin && ls); do
-          wrapProgram $out/bin/$i \
-            $WRAP_TK
-        done
-
-        # copy hgweb.cgi to allow use in apache
-        mkdir -p $out/share/cgi-bin
-        cp -v hgweb.cgi contrib/hgweb.wsgi $out/share/cgi-bin
-        chmod u+x $out/share/cgi-bin/hgweb.cgi
-
-        installShellCompletion --cmd hg \
-          --bash contrib/bash_completion \
-          --zsh contrib/zsh_completion
-      '';
-
-    passthru.tests = {
-      mercurial-tests = makeTests { flags = "--with-hg=$MERCURIAL_BASE/bin/hg"; };
-    };
-
-    meta = {
-      description = "Fast, lightweight SCM system for very large distributed projects";
-      homepage = "https://www.mercurial-scm.org";
-      downloadPage = "https://www.mercurial-scm.org/release/";
-      changelog = "https://wiki.mercurial-scm.org/Release${lib.versions.majorMinor version}";
-      license = lib.licenses.gpl2Plus;
-      maintainers = with lib.maintainers; [
-        lukegb
-        euxane
-        techknowlogick
-      ];
-      platforms = lib.platforms.unix;
-      mainProgram = "hg";
-    };
+  src = fetchurl {
+    url = "https://mercurial-scm.org/release/mercurial-${finalAttrs.version}.tar.gz";
+    hash = "sha256-8uyOfu7wUAWRcG03RVXwzrEYgiBo51+jsyvgfdIYT2w=";
   };
 
-  makeTests =
-    {
-      mercurial ? self,
-      nameSuffix ? "",
-      flags ? "",
-    }:
-    runCommand "${mercurial.pname}${nameSuffix}-tests"
-      {
-        inherit (mercurial) src;
+  pyproject = false;
 
-        SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt"; # needed for git
-        MERCURIAL_BASE = mercurial;
-        nativeBuildInputs = [
-          python
-          unzip
-          which
-          sqlite
-          git
-          gnupg
-        ];
-
-        # https://bz.mercurial-scm.org/show_bug.cgi?id=6887
-        propagatedBuildInputs = [ setuptools ];
-
-        postPatch = ''
-          patchShebangs .
-
-          for f in **/*.{py,c,t}; do
-            # not only used in shebangs
-            substituteAllInPlace "$f" '/bin/sh' '${stdenv.shell}'
-          done
-
-          for f in **/*.t; do
-            substituteInPlace 2>/dev/null "$f" \
-              --replace '*/hg:' '*/*hg*:' \${
-                # paths emitted by our wrapped hg look like ..hg-wrapped-wrapped
-                ""
-              }
-              --replace '"$PYTHON" "$BINDIR"/hg' '"$BINDIR"/hg' ${
-                # 'hg' is a wrapper; don't run using python directly
-                ""
-              }
-          done
-        '';
-
-        # This runs Mercurial _a lot_ of times.
-        requiredSystemFeatures = [ "big-parallel" ];
-
-        # Don't run tests if not-Linux or if cross-compiling.
-        meta.broken = !stdenv.hostPlatform.isLinux || stdenv.buildPlatform != stdenv.hostPlatform;
+  cargoDeps =
+    if rustSupport then
+      rustPlatform.fetchCargoVendor {
+        inherit (finalAttrs) src;
+        name = "mercurial-${finalAttrs.version}";
+        hash = "sha256-OGsHK3Bh47V4n+7HYpVp/jymCz1QY45rkWlAW0Hob7g=";
+        sourceRoot = "mercurial-${finalAttrs.version}/rust";
       }
-      ''
-        addToSearchPathWithCustomDelimiter : PYTHONPATH "${mercurial}/${python.sitePackages}"
+    else
+      null;
+  cargoRoot = if rustSupport then "rust" else null;
 
-        unpackPhase
-        cd "$sourceRoot"
-        patchPhase
+  # enable building with Python 3.14
+  # FIXME remove once PyO3 is updated in Cargo.lock
+  env.PYO3_USE_ABI3_FORWARD_COMPATIBILITY = 1;
 
-        cat << EOF > tests/blacklists/nix
-        # tests enforcing "/usr/bin/env" shebangs, which are patched for nix
-        test-run-tests.t
-        test-check-shbang.t
+  propagatedBuildInputs =
+    lib.optional re2Support google-re2
+    ++ lib.optional gitSupport pygit2
+    ++ lib.optional highlightSupport pygments;
+  nativeBuildInputs = [
+    makeWrapper
+    gettext
+    installShellFiles
+    setuptools
+    setuptools-scm
+    pip
+  ]
+  ++ lib.optionals rustSupport [
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
+  buildInputs = [ docutils ];
 
-        # unstable experimental/unsupported features
-        # https://bz.mercurial-scm.org/show_bug.cgi?id=6633#c1
-        test-git-interop.t
+  makeFlags = [ "PREFIX=$(out)" ] ++ lib.optional rustSupport "PURE=--rust";
 
-        # doesn't like the extra setlocale warnings emitted by our bash wrappers
-        test-locale.t
+  postInstall =
+    (lib.optionalString guiSupport ''
+      mkdir -p $out/etc/mercurial
+      cp contrib/hgk $out/bin
+      cat >> $out/etc/mercurial/hgrc << EOF
+      [extensions]
+      hgk=$out/${python.sitePackages}/hgext/hgk.py
+      EOF
+      # setting HG so that hgk can be run itself as well (not only hg view)
+      WRAP_TK=" --set TK_LIBRARY ${tk}/lib/${tk.libPrefix}
+                --set HG $out/bin/hg
+                --prefix PATH : ${tk}/bin "
+    '')
+    + ''
+      for i in $(cd $out/bin && ls); do
+        wrapProgram $out/bin/$i \
+          $WRAP_TK
+      done
 
-        # Python 3.10-3.12 deprecation warning: asyncore
-        # https://bz.mercurial-scm.org/show_bug.cgi?id=6727
-        test-patchbomb-tls.t
+      # copy hgweb.cgi to allow use in apache
+      mkdir -p $out/share/cgi-bin
+      cp -v hgweb.cgi contrib/hgweb.wsgi $out/share/cgi-bin
+      chmod u+x $out/share/cgi-bin/hgweb.cgi
 
-        # Python 3.12 _lsprof module change, breaking profile test
-        # https://bz.mercurial-scm.org/show_bug.cgi?id=6846
-        test-profile.t
+      installShellCompletion --cmd hg \
+        --bash contrib/bash_completion \
+        --zsh contrib/zsh_completion
+    '';
 
-        # Python 3.12 deprecation warning: multi-threaded fork in worker.py
-        # https://bz.mercurial-scm.org/show_bug.cgi?id=6892
-        test-clone-stream.t
-        test-clonebundles.t
-        test-fix-topology.t
-        test-fix.t
-        test-persistent-nodemap.t
-        test-profile.t
-        test-simple-update.t
-
-        EOF
-
-        export HGTEST_REAL_HG="${mercurial}/bin/hg"
-        # include tests for native components
-        export HGMODULEPOLICY="rust+c"
-        # extended timeout necessary for tests to pass on the busy CI workers
-        export HGTESTFLAGS="--blacklist blacklists/nix --timeout 1800 -j$NIX_BUILD_CORES ${flags}"
-        make check
-        touch $out
-      '';
-in
-self.overridePythonAttrs (origAttrs: {
-  passthru = origAttrs.passthru // rec {
+  passthru = {
+    inherit python; # pass it so that the same version can be used in hg2git
     # withExtensions takes a function which takes the python packages set and
     # returns a list of extensions to install.
     #
@@ -245,10 +125,10 @@ self.overridePythonAttrs (origAttrs: {
     withExtensions =
       f:
       let
-        python = self.python;
+        python = finalAttrs.passthru.python;
         mercurialHighPrio =
           ps:
-          (ps.toPythonModule self).overrideAttrs (oldAttrs: {
+          (ps.toPythonModule finalAttrs.finalPackage).overrideAttrs (oldAttrs: {
             meta = oldAttrs.meta // {
               priority = 50;
             };
@@ -257,12 +137,12 @@ self.overridePythonAttrs (origAttrs: {
         env = python.withPackages (ps: plugins);
       in
       stdenv.mkDerivation {
-        pname = "${self.pname}-with-extensions";
+        pname = "${finalAttrs.pname}-with-extensions";
 
-        inherit (self) src version meta;
+        inherit (finalAttrs) src version meta;
 
-        buildInputs = self.buildInputs ++ self.propagatedBuildInputs;
-        nativeBuildInputs = self.nativeBuildInputs;
+        buildInputs = finalAttrs.buildInputs ++ finalAttrs.propagatedBuildInputs;
+        nativeBuildInputs = finalAttrs.nativeBuildInputs;
 
         dontUnpack = true;
         dontPatch = true;
@@ -281,7 +161,7 @@ self.overridePythonAttrs (origAttrs: {
             done
           done
 
-          ln -s ${self}/share $out/share
+          ln -s ${finalAttrs.finalPackage}/share $out/share
 
           runHook postInstall
         '';
@@ -294,9 +174,131 @@ self.overridePythonAttrs (origAttrs: {
           runHook postInstallCheck
         '';
       };
+    tests =
+      let
+        makeTests =
+          {
+            mercurial ? finalAttrs.finalPackage,
+            nameSuffix ? "",
+            flags ? "",
+          }:
+          runCommand "${mercurial.pname}${nameSuffix}-tests"
+            {
+              inherit (mercurial) src;
 
-    tests = origAttrs.passthru.tests // {
-      withExtensions = withExtensions (pm: [ pm.hg-evolve ]);
-    };
+              SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt"; # needed for git
+              MERCURIAL_BASE = mercurial;
+              nativeBuildInputs = [
+                python
+                unzip
+                which
+                sqlite
+                git
+                gnupg
+              ];
+
+              # https://bz.mercurial-scm.org/show_bug.cgi?id=6887
+              propagatedBuildInputs = [ setuptools ];
+
+              postPatch = ''
+                patchShebangs .
+
+                for f in **/*.{py,c,t}; do
+                  # not only used in shebangs
+                  substituteAllInPlace "$f" '/bin/sh' '${stdenv.shell}'
+                done
+
+                for f in **/*.t; do
+                  substituteInPlace 2>/dev/null "$f" \
+                  --replace '*/hg:' '*/*hg*:' \${
+                    # paths emitted by our wrapped hg look like ..hg-wrapped-wrapped
+                    ""
+                  }
+                  --replace '"$PYTHON" "$BINDIR"/hg' '"$BINDIR"/hg' ${
+                    # 'hg' is a wrapper; don't run using python directly
+                    ""
+                  }
+                done
+
+                # https://bz.mercurial-scm.org/show_bug.cgi?id=6887
+                # Adding setuptools to the python path is not enough for the distutils
+                # module to be found, so we patch usage directly:
+                substituteInPlace tests/hghave.py \
+                --replace-fail "distutils" "setuptools._distutils"
+              '';
+
+              # This runs Mercurial _a lot_ of times.
+              requiredSystemFeatures = [ "big-parallel" ];
+
+              # Don't run tests if not-Linux or if cross-compiling.
+              meta.broken = !stdenv.hostPlatform.isLinux || stdenv.buildPlatform != stdenv.hostPlatform;
+            }
+            ''
+              addToSearchPathWithCustomDelimiter : PYTHONPATH "${mercurial}/${python.sitePackages}"
+
+              unpackPhase
+              cd "$sourceRoot"
+              patchPhase
+
+              cat << EOF > tests/blacklists/nix
+              # tests enforcing "/usr/bin/env" shebangs, which are patched for nix
+              test-run-tests.t
+              test-check-shbang.t
+
+              # unstable experimental/unsupported features
+              # https://bz.mercurial-scm.org/show_bug.cgi?id=6633#c1
+              test-git-interop.t
+
+              # doesn't like the extra setlocale warnings emitted by our bash wrappers
+              test-locale.t
+
+              # Python 3.10-3.12 deprecation warning: asyncore
+              # https://bz.mercurial-scm.org/show_bug.cgi?id=6727
+              test-patchbomb-tls.t
+
+              # Python 3.12 _lsprof module change, breaking profile test
+              # https://bz.mercurial-scm.org/show_bug.cgi?id=6846
+              test-profile.t
+
+              # Python 3.12 deprecation warning: multi-threaded fork in worker.py
+              # https://bz.mercurial-scm.org/show_bug.cgi?id=6892
+              test-clone-stream.t
+              test-clonebundles.t
+              test-fix-topology.t
+              test-fix.t
+              test-persistent-nodemap.t
+              test-profile.t
+              test-simple-update.t
+
+              EOF
+
+              export HGTEST_REAL_HG="${mercurial}/bin/hg"
+              # include tests for native components
+              export HGMODULEPOLICY="rust+c"
+              # extended timeout necessary for tests to pass on the busy CI workers
+              export HGTESTFLAGS="--blacklist blacklists/nix --timeout 1800 -j$NIX_BUILD_CORES ${flags}"
+              make check
+              touch $out
+            '';
+      in
+      {
+        mercurial-tests = makeTests { flags = "--with-hg=$MERCURIAL_BASE/bin/hg"; };
+        withExtensions = finalAttrs.passthru.withExtensions (pm: [ pm.hg-evolve ]);
+      };
+  };
+
+  meta = {
+    description = "Fast, lightweight SCM system for very large distributed projects";
+    homepage = "https://www.mercurial-scm.org";
+    downloadPage = "https://www.mercurial-scm.org/release/";
+    changelog = "https://wiki.mercurial-scm.org/Release${lib.versions.majorMinor finalAttrs.version}";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [
+      lukegb
+      euxane
+      techknowlogick
+    ];
+    platforms = lib.platforms.unix;
+    mainProgram = "hg";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

1. Since Python builder supports fixed-point lambdas, let's use them instead of that overriding (was a no-rebuild change).
2. ~~Wrapping `hg` with Tk originally produced a double wrapping, this fixes it. Additionally, `$tk/bin/wish` is patched into `hgk`'s shebang.~~

~~TODO: fix failing passthru tests, but i'm not sure my PC is powerful enough for running them (or i'm too impatient).~~ moved to #519499

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
