### PR TITLE
dxmt: init at 0.80

### DIFF
--- a/pkgs/by-name/dx/dxmt/package.nix
+++ b/pkgs/by-name/dx/dxmt/package.nix
@@ -1,0 +1,132 @@
+{
+  lib,
+  stdenv,
+  pkgsCross,
+  fetchFromGitHub,
+  buildPackages,
+  cmake,
+  git,
+  python3,
+  meson,
+  ninja,
+  tinyxxd,
+  sqlite,
+  libz,
+  ncurses,
+  libxml2,
+  wine64,
+  darwin,
+  symlinkJoin,
+}:
+let
+  dxmt-llvm = stdenv.mkDerivation rec {
+    pname = "dxmt-llvm";
+    version = "15.0.7";
+
+    src = fetchFromGitHub {
+      owner = "llvm";
+      repo = "llvm-project";
+      tag = version;
+      hash = "sha256-wjuZQyXQ/jsmvy6y1aksCcEDXGBjuhpgngF3XQJ/T4s=";
+    };
+
+    nativeBuildInputs = [
+      cmake
+      git
+      ninja
+      python3
+    ];
+
+    cmakeFlags = [
+      "-DLLVM_ENABLE_ZSTD=OFF"
+      "-DLLVM_BUILD_TOOLS=Off"
+      "-S ../llvm"
+    ];
+  };
+  inherit (darwin) xcode;
+
+  dxmt = pkgsCross.mingwW64.stdenv.mkDerivation (finalAttrs: {
+    pname = "dxmt";
+    version = "0.80";
+
+    src = fetchFromGitHub {
+      owner = "3shain";
+      repo = "dxmt";
+      rev = "v${finalAttrs.version}";
+      hash = "sha256-HNSKqEYu8se8DyzwRbqfmHRRyBXyW6D5ddPaEdnkuL4=";
+      fetchSubmodules = true;
+    };
+
+    patches = [
+      ./winecrt0.patch
+    ];
+
+    postPatch = ''
+      substituteInPlace src/airconv/darwin/meson.build --replace-fail -lcurses -lncurses
+
+      sed -e "/find_program('xcrun')/d" \
+          -e "s,metalir_generator = generator(xcrun,metalir_generator = generator(find_program('${xcode}/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/metal')," \
+          -e "s,metallib_generator = generator(xcrun,metallib_generator = generator(find_program('${xcode}/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/metallib')," \
+          -e "s/'-sdk', 'macosx', 'metal\(lib\)\{0,1\}', //" \
+          -i meson.build
+    '';
+
+    nativeBuildInputs = [
+      meson
+      ninja
+      tinyxxd
+      buildPackages.stdenv.cc
+    ];
+
+    buildInputs = [
+      sqlite
+      libz
+      ncurses
+      libxml2
+    ];
+
+    mesonFlags = [
+      (lib.mesonOption "native_llvm_path" "${dxmt-llvm}")
+      (lib.mesonOption "wine_install_path" "${wine64}")
+    ];
+
+    preBuild = ''
+      export HOME=$TMPDIR
+    '';
+
+    __structuredAttrs = true;
+    strictDeps = true;
+
+    meta = {
+      description = "Metal-based translation layer for Direct3D 10/11";
+      homepage = "https://github.com/3shain/dxmt";
+      license = lib.licenses.mit;
+      maintainers = [ lib.maintainers.feyorsh ];
+      platforms = lib.platforms.windows;
+      hydraPlatforms = [ ];
+    };
+  });
+in
+symlinkJoin {
+  name = "dxmt-${dxmt.version}";
+
+  paths = [ dxmt ];
+
+  passthru = {
+    inherit dxmt;
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  meta = {
+    inherit (dxmt.meta)
+      description
+      homepage
+      maintainers
+      license
+      ;
+    platforms = [ "x86_64-darwin" ];
+    hydraPlatforms = [ ];
+  };
+}

--- a/pkgs/by-name/dx/dxmt/winecrt0.patch
+++ b/pkgs/by-name/dx/dxmt/winecrt0.patch
@@ -1,0 +1,33 @@
+diff --git c/src/winemetal/meson.build i/src/winemetal/meson.build
+index 858d4b3..d937e29 100644
+--- c/src/winemetal/meson.build
++++ i/src/winemetal/meson.build
+@@ -26,8 +26,19 @@ elif wine_install_path != ''
+   if not wine_install_path.startswith('/')
+     wine_install_path = join_paths(meson.project_source_root(), wine_install_path)
+   endif
+-  lib_winecrt0 = cc.find_library('winecrt0', dirs : [ join_paths(wine_install_path,'lib/wine', windows_builtin_install_dir) ])
+-  lib_ntdll = cc.find_library('ntdll', dirs : [ join_paths(wine_install_path, 'lib/wine', windows_builtin_install_dir)], static: true)
++  winecrt0_unix_archive = custom_target(
++    'winecrt0_fixup',
++    output : 'libwinecrt0_fixed.a',
++    command : [
++      'sh', '-c',
++      'ar p "$1" unix_lib.o > unix_lib.o && ar crs "$2" unix_lib.o',
++      'sh',
++      join_paths(wine_install_path, 'lib/wine', windows_builtin_install_dir, 'libwinecrt0.a'),
++      '@OUTPUT@',
++    ],
++  )
++  lib_winecrt0 = declare_dependency(sources : winecrt0_unix_archive)
++  lib_ntdll = cc.find_library('ntdll', dirs : [ join_paths(wine_install_path, 'lib/wine', windows_builtin_install_dir)])
+   lib_dbghelp = cc.find_library('dbghelp', dirs : [ join_paths(wine_install_path, 'lib/wine', windows_builtin_install_dir) ])
+   winebuild = join_paths(wine_install_path, 'bin/winebuild')
+ else
+@@ -59,4 +70,4 @@ custom_target('postprocess_lib',
+ 
+ if cpu_family == 'x86_64' or cpu_family == 'aarch64'
+   subdir('unix')
+-endif
+\ No newline at end of file
++endif


### PR DESCRIPTION
D3D10/11 support for macOS using Metal.
This is quite handy as vkd3d-proton does not support macOS, and furthermore DXMT is (anecdotally) faster than Apple's proprietary D3DMetal for D3D11 because it doesn't get translated to D3D12.

I am aware that `x86_64-darwin` support is being sunset, but this currently has plenty of utility for `aarch64-darwin` systems running Windows games under Wine+Rosetta2 (at least that's my use case).

### Notes
I do not think building MinGW with the Win32 thread model is necessary, I just cargo culted it from the DXVK derivation.

winecrt0.patch is meant to address what I believe are corrupted static archives from the Wine derivation:
```
$ ar t result-wine/lib/wine/x86_64-windows/libwinecrt0.a
/
arm64ec.o
crt_dllmain.o
crt_fltused.o
debug.o
delay_load.o
dll_canunload.o
dll_main.o
dll_register.o
dll_version.o
exception.o
exe16_entry.o
register.o
setjmp.o
stub.o
unix_lib.o

$ nm -A result-wine/lib/wine/x86_64-windows/libwinecrt0.a
nm: error: result-wine/lib/wine/x86_64-windows/libwinecrt0.a(/): The end of the file was unexpectedly encountered
```
I don't know if this is due to how Wine is packaged in nixpkgs or if this is an upstream bug (unlikely), but this prevents the linker from finding symbols that are in `libwinecrt0.a`.
I would prefer to address this in Wine instead of adding a hacky workaround here, but I lack and know-how to make the fix.


cc @reckenrode

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

<!-- Message of single commit: -->

dxmt: init at 0.80