### PR TITLE
crimson, raleway, geist-font: use installFonts hook

### DIFF
--- a/pkgs/by-name/cr/crimson/package.nix
+++ b/pkgs/by-name/cr/crimson/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  installFonts,
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -15,13 +16,15 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-Wp9L77q93TRmrAr0P4iH9gm0tqFY0X/xSsuFcd19aAE=";
   };
 
-  installPhase = ''
-    runHook preInstall
+  outputs = [
+    "out"
+    "webfont"
+  ];
 
-    install -m444 -Dt $out/share/fonts/opentype "Desktop Fonts/OTF/"*.otf
-    install -m444 -Dt $out/share/doc/${pname}-${version}    README.md
+  nativeBuildInputs = [ installFonts ];
 
-    runHook postInstall
+  postInstall = ''
+    install -m444 -Dt $out/share/doc/${pname}-${version} README.md
   '';
 
   meta = {

--- a/pkgs/by-name/ge/geist-font/package.nix
+++ b/pkgs/by-name/ge/geist-font/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchzip,
+  installFonts,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -17,13 +18,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   sourceRoot = ".";
 
-  installPhase = ''
-    runHook preInstall
+  outputs = [
+    "out"
+    "webfont"
+  ];
 
-    install -D source/fonts/{Geist,GeistMono}/otf/*.otf -t $out/share/fonts/opentype
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   meta = {
     description = "Font family created by Vercel in collaboration with Basement Studio";

--- a/pkgs/by-name/ra/raleway/package.nix
+++ b/pkgs/by-name/ra/raleway/package.nix
@@ -2,6 +2,7 @@
   lib,
   fetchzip,
   stdenvNoCC,
+  installFonts,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -13,14 +14,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     hash = "sha256-itNHIMoRjiaqYAJoDNetkCquv47VAfel8MAzwsd//Ww=";
   };
 
-  installPhase = ''
-    runHook preInstall
+  outputs = [
+    "out"
+    "webfont"
+  ];
 
-    install -D -m444 -t $out/share/fonts/truetype $src/static/TTF/*.ttf
-    install -D -m444 -t $out/share/fonts/opentype $src/static/OTF/*.otf
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   meta = {
     description = "Raleway is an elegant sans-serif typeface family";


### PR DESCRIPTION
Part of #495640.

The `installFonts` hook (#484477) finds font files by extension recursively and installs them to the correct `$out/share/fonts/<format>` paths, removing per-package `install -D -m444` boilerplate. These three are clean cases: OTF/TTF only, no woff complications, so no `webfont` output is needed.

- **crimson**: hook finds OTFs under `Desktop Fonts/OTF/` recursively; `postInstall` kept to install the README doc
- **raleway**: TTF and OTF both handled by hook; entire `installPhase` dropped; converted `rec` to `finalAttrs`
- **geist-font**: OTFs found recursively under `sourceRoot = "."`; `installPhase` dropped

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test