### PR TITLE
nixos/gpu-screen-recorder: add overlayUI option with UI package

### DIFF
--- a/nixos/modules/programs/gpu-screen-recorder.nix
+++ b/nixos/modules/programs/gpu-screen-recorder.nix
@@ -10,6 +10,11 @@ let
   package = cfg.package.override {
     inherit (config.security) wrapperDir;
   };
+
+  uiPackage = cfg.ui.package.override {
+    gpu-screen-recorder = package;
+    inherit (config.security) wrapperDir;
+  };
 in
 {
   options = {
@@ -24,19 +29,47 @@ in
           wrappers for promptless recording.
         '';
       };
+
+      ui = {
+        enable = lib.mkEnableOption "the GPU Screen Recorder overlay UI";
+        package = lib.mkPackageOption pkgs "gpu-screen-recorder-ui" { };
+        notifPackage = lib.mkPackageOption pkgs "gpu-screen-recorder-notification" { };
+      };
     };
   };
 
-  config = lib.mkIf cfg.enable {
-    environment.systemPackages = [ cfg.package ];
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        environment.systemPackages = [ cfg.package ];
 
-    security.wrappers."gsr-kms-server" = {
-      owner = "root";
-      group = "root";
-      capabilities = "cap_sys_admin+ep";
-      source = lib.getExe' package "gsr-kms-server";
-    };
-  };
+        security.wrappers."gsr-kms-server" = {
+          owner = "root";
+          group = "root";
+          capabilities = "cap_sys_admin+ep";
+          source = lib.getExe' package "gsr-kms-server";
+        };
+      }
 
-  meta.maintainers = with lib.maintainers; [ timschumi ];
+      (lib.mkIf cfg.ui.enable {
+        environment.systemPackages = [
+          cfg.ui.package
+          cfg.ui.notifPackage
+        ];
+
+        security.wrappers."gsr-global-hotkeys" = {
+          owner = "root";
+          group = "root";
+          capabilities = "cap_setuid+ep";
+          source = lib.getExe' uiPackage "gsr-global-hotkeys";
+        };
+      })
+    ]
+  );
+
+  meta.maintainers = with lib.maintainers; [
+    timschumi
+    AhmedAmr
+    keenanweaver
+  ];
 }

--- a/pkgs/by-name/gp/gpu-screen-recorder-notification/package.nix
+++ b/pkgs/by-name/gp/gpu-screen-recorder-notification/package.nix
@@ -1,0 +1,79 @@
+{
+  fetchgit,
+  gitUpdater,
+  gsettings-desktop-schemas,
+  lib,
+  libglvnd,
+  libx11,
+  libxext,
+  libxkbcommon,
+  libxrandr,
+  libxrender,
+  makeWrapper,
+  meson,
+  ninja,
+  pango,
+  pkg-config,
+  stdenv,
+  wayland-scanner,
+  wayland,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gpu-screen-recorder-notification";
+  version = "1.3.4";
+
+  src = fetchgit {
+    url = "https://repo.dec05eba.com/gpu-screen-recorder-notification";
+    tag = finalAttrs.version;
+    hash = "sha256-rGredPrTda6/3pG4+0k6fHr4fRSVCRvTC/+sRFytrWo=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    makeWrapper
+    wayland-scanner
+  ];
+
+  depsBuildBuild = [ pkg-config ];
+
+  buildInputs = [
+    libglvnd
+    pango
+    libx11
+    libxrandr
+    libxrender
+    libxkbcommon
+    libxext
+    wayland
+    gsettings-desktop-schemas
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  mesonBuildType = "release";
+
+  postInstall = ''
+    wrapProgram "$out/bin/gsr-notify" \
+      --prefix XDG_DATA_DIRS : "${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libglvnd ]}"
+  '';
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = {
+    description = "Notification in the style of ShadowPlay";
+    homepage = "https://git.dec05eba.com/gpu-screen-recorder-notification/about";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "gsr-notify";
+    maintainers = with lib.maintainers; [
+      AhmedAmr
+      keenanweaver
+    ];
+    platforms = lib.platforms.linux;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+  };
+})

--- a/pkgs/by-name/gp/gpu-screen-recorder-ui/package.nix
+++ b/pkgs/by-name/gp/gpu-screen-recorder-ui/package.nix
@@ -1,0 +1,120 @@
+{
+  dbus,
+  desktop-file-utils,
+  fetchgit,
+  gitUpdater,
+  gpu-screen-recorder,
+  gpu-screen-recorder-notification,
+  gsettings-desktop-schemas,
+  lib,
+  libcap,
+  libdrm,
+  libglvnd,
+  libpulseaudio,
+  libx11,
+  libxcomposite,
+  libxcursor,
+  libxext,
+  libxfixes,
+  libxi,
+  libxkbcommon,
+  libxrandr,
+  libxrender,
+  linuxHeaders,
+  makeWrapper,
+  meson,
+  ninja,
+  pango,
+  pkg-config,
+  stdenv,
+  wayland-scanner,
+  wayland,
+  wrapperDir ? "/run/wrappers/bin",
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gpu-screen-recorder-ui";
+  version = "1.13.5";
+
+  src = fetchgit {
+    url = "https://repo.dec05eba.com/gpu-screen-recorder-ui";
+    tag = finalAttrs.version;
+    hash = "sha256-ObIN8qD+34nXZv6v6vLK3f6bezVSXqOd0xPGci52awU=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    makeWrapper
+    desktop-file-utils
+    wayland-scanner
+  ];
+
+  depsBuildBuild = [ pkg-config ];
+
+  buildInputs = [
+    libx11
+    libxrandr
+    libxrender
+    libxkbcommon
+    libxcomposite
+    libxfixes
+    libxext
+    libxi
+    libxcursor
+    libglvnd
+    libpulseaudio
+    libdrm
+    dbus
+    linuxHeaders
+    wayland
+    pango
+    libcap
+    gsettings-desktop-schemas
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  mesonBuildType = "release";
+
+  mesonFlags = [
+    # must be handled in the nixos module as extra file permissions are stripped in the nix store
+    (lib.mesonBool "capabilities" false)
+  ];
+
+  postInstall =
+    let
+      gpu-screen-recorder-wrapped = gpu-screen-recorder.override {
+        inherit wrapperDir;
+      };
+    in
+    ''
+      wrapProgram "$out/bin/gsr-ui" \
+        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libglvnd ]}" \
+        --prefix XDG_DATA_DIRS : "${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}" \
+        --prefix PATH : "${wrapperDir}" \
+        --suffix PATH : "${
+          lib.makeBinPath [
+            gpu-screen-recorder-wrapped
+            gpu-screen-recorder-notification
+          ]
+        }"
+    '';
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = {
+    description = "Fullscreen overlay UI for GPU Screen Recorder in the style of ShadowPlay";
+    homepage = "https://git.dec05eba.com/gpu-screen-recorder-ui/about";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "gsr-ui";
+    maintainers = with lib.maintainers; [
+      AhmedAmr
+      keenanweaver
+    ];
+    platforms = lib.platforms.linux;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds [gpu-screen-recorder-ui](https://git.dec05eba.com/gpu-screen-recorder-ui/about) and [gpu-screen-recorder-notification](https://git.dec05eba.com/gpu-screen-recorder-notification/about) packages

and Integrated it with gpu-screen-recorder module in `programs.gpu-screen-recorder` with options `ui`
example config:
```nix
programs.gpu-screen-recorder = {
      enable = true;

      ui = {
        # package = pkgs.gpu-screen-recorder-ui; specify custom package if needed
        # notifPackage = pkgs.gpu-screen-recorder-notification; specify custom package if needed
        enable = true;
      };
    };
```
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
