### PR TITLE
buildEnv: use concatMap instead of mapping and filtering

### DIFF
--- a/pkgs/build-support/buildenv/default.nix
+++ b/pkgs/build-support/buildenv/default.nix
@@ -13,6 +13,7 @@ let
   builder = replaceVars ./builder.pl {
     inherit (builtins) storeDir;
   };
+  inherit (lib) concatMap;
 in
 
 # Backward compatibility for deprecated custom overrider <env-pkg>.override
@@ -127,22 +128,17 @@ lib.makeOverridable (
                 [ drv ]
             )
             # Add any extra outputs specified by the caller of `buildEnv`.
-            ++ lib.filter (p: p != null) (
-              map (outName: drv.${outName} or null) finalAttrs.extraOutputsToInstall
-            );
+            ++ concatMap (
+              outName: if drv ? ${outName} then [ drv.${outName} ] else [ ]
+            ) finalAttrs.extraOutputsToInstall;
           priority = drv.meta.priority or lib.meta.defaultPriority;
           # Silently use the original `paths` if `passthru.paths` is missing.
         }) finalAttrs.passthru.paths or paths;
 
         extraPathsFrom = lib.optionalString finalAttrs.includeClosures (
-          let
-            pathsForClosure = lib.pipe finalAttrs.chosenOutputs [
-              (map (p: p.paths))
-              lib.flatten
-              (lib.remove null)
-            ];
-          in
-          writeClosure pathsForClosure
+          # filter all null elements and concatenate the output paths together
+          # in the final closure
+          writeClosure (lib.concatMap (p: if p == null then [ ] else p.paths) finalAttrs.chosenOutputs)
         );
 
         preferLocalBuild = derivationArgs.preferLocalBuild or true;


### PR DESCRIPTION
Very small performance win.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
