### PR TITLE
multi-scrobbler: init at 0.15.0

### DIFF
--- a/pkgs/by-name/mu/multi-scrobbler/package.nix
+++ b/pkgs/by-name/mu/multi-scrobbler/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  makeWrapper,
+  nodejs,
+  nix-update-script,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "multi-scrobbler";
+  version = "0.15.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "FoxxMD";
+    repo = "multi-scrobbler";
+    tag = finalAttrs.version;
+    hash = "sha256-vhda31xPLxGmnaU/3AnsrcafPvSE1IIbuRmj6xlttjc=";
+  };
+
+  npmDepsFetcherVersion = 2;
+  npmDepsHash = "sha256-dxNHz/r+ai8R9X+yVo5YaBWHPcvQKQUXa499HafAB00=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # A storybook devDependency refuses to install outside of pnpm, and native
+  # modules aren't needed regardless.
+  npmRebuildFlags = [ "--ignore-scripts" ];
+
+  # npm's --ignore-scripts skips patch-package too.
+  preBuild = ''
+    node_modules/.bin/patch-package
+  '';
+
+  npmBuildScript = "build:frontend";
+
+  postInstall = ''
+    npmPkgDir="$out/lib/node_modules/${finalAttrs.pname}"
+
+    # dist/ is gitignored; npm pack omits.
+    cp -r dist "$npmPkgDir/dist"
+
+    # node refuses type-stripping for any file under a "node_modules"
+    pkgDir="$out/libexec/${finalAttrs.pname}"
+    mkdir -p "$out/libexec"
+    mv "$npmPkgDir" "$pkgDir"
+    rmdir "$out/lib/node_modules" "$out/lib"
+
+    mkdir -p "$out/bin"
+
+    # node 24 runs TypeScript directly (built-in type stripping), no tsx needed.
+    makeWrapper "${lib.getExe nodejs}" "$out/bin/${finalAttrs.pname}" \
+      --add-flags "$pkgDir/src/backend/index.ts" \
+      --set NODE_ENV production \
+      --chdir "$pkgDir"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Scrobble music from many sources to many clients";
+    longDescription = ''
+      multi-scrobbler monitors music listening activity from many Sources
+      (Spotify, Jellyfin, Plex, Subsonic, Kodi, YouTube Music, Last.fm,
+      ListenBrainz, and more) and scrobbles to many Clients (Last.fm,
+      ListenBrainz, Maloja, Rocksky, teal.fm, and more).  A web interface
+      on port 9078 (PORT env var) provides status, logs, and OAuth flows.
+    '';
+    homepage = "https://github.com/FoxxMD/multi-scrobbler";
+    changelog = "https://github.com/FoxxMD/multi-scrobbler/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ philocalyst ];
+    mainProgram = "multi-scrobbler";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Really excited for this, which avoid all of the oddly hard-to-use-directly listenbrainz and librefm integrations, and allows clients to just like work with one endpoint.
- Want to get into transmitting and tracking my music and a lot of people do too! This allows them to be independent with it.
- Note that it's kind of flabbergasting how old the packaging and deps are in this package, so I might open a PR for them later to bring things up to date and get rid of some of the hacks here. Think 0.14 might fix this so will bump and check then (a week from now)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
