### PR TITLE
nixos/nix-gc: prevent race conditions during garbage cleaning

### DIFF
--- a/nixos/modules/services/misc/nix-gc.nix
+++ b/nixos/modules/services/misc/nix-gc.nix
@@ -90,6 +90,8 @@ in
       startAt = lib.optionals cfg.automatic cfg.dates;
       # do not start and delay when switching
       restartIfChanged = false;
+      # run garbage collection through nix-daemon to prevent deletion race conditions
+      environment.NIX_REMOTE = "daemon";
     };
 
     systemd.timers.nix-gc = lib.mkIf cfg.automatic {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Lately I've been running into an annoying issue where some of my machines were ending up with missing derivation paths, breaking builds until the store was either manually repaired, or the machine was rotated out. I was able to somewhat track the precondition to garbage collection, which I noticed was running by itself (since nix saw itself was root); and possibly badly interacting with simultaneously running builds.

My current hypothesis for the corruption is below:

1. `nix store gc` and a build run at the same time.
2. build depends on path A, which currently has no referrers
3. gc marks A to be removed
4. build creates path B that depends on A
5. gc then removes A, with the store ending up as corrupted.

Offloading garbage collection to nix daemon should help the daemon mark things correctly (stopping builds), and avoid race conditions.

## Things done

Passed NIX_REMOTE=daemon to `nix-gc.service`, so that garbage collection is coordinated via nix-daemon, which should not result in race conditions.

An alternative approach would be to run garbage collection as a dedicated user.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
