### PR TITLE
nixos/minidlna: harden systemd service

### DIFF
--- a/nixos/modules/services/networking/minidlna.nix
+++ b/nixos/modules/services/networking/minidlna.nix
@@ -10,6 +10,12 @@ let
   format = pkgs.formats.keyValue { listsAsDuplicateKeys = true; };
   cfgfile = format.generate "minidlna.conf" cfg.settings;
 
+  # Match a media_dir entry under /home, allowing an optional `A,`/`V,`/`P,`
+  # media-type prefix.
+  mediaDirsUnderHome = lib.any (
+    dir: builtins.match "([AVP],)?/home/.*" dir != null
+  ) cfg.settings.media_dir;
+
 in
 {
   options.services.minidlna.enable = lib.mkEnableOption "MiniDLNA, a simple DLNA server. Consider adding `openFirewall = true` into your config";
@@ -133,6 +139,49 @@ in
         RuntimeDirectory = "minidlna";
         PIDFile = "/run/minidlna/pid";
         ExecStart = "${lib.getExe cfg.package} -S -P /run/minidlna/pid -f ${cfgfile}";
+
+        # Hardening
+        AmbientCapabilities = [ "" ];
+        CapabilityBoundingSet = [ "" ];
+        DeviceAllow = [ "" ];
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        # Many users keep media under /home; auto-disable ProtectHome when
+        # any media_dir entry is under /home. Override explicitly to force.
+        ProtectHome = lib.mkDefault (!mediaDirsUnderHome);
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        # AF_NETLINK is required for getifaddrs() to enumerate interfaces
+        # for SSDP multicast (239.255.255.250:1900) advertisements.
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_NETLINK"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallErrorNumber = "EPERM";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+          "~@resources"
+        ];
+        UMask = "0077";
       };
     };
   };


### PR DESCRIPTION
Adds sandboxing to `minidlna.service`. Part of #377827.

Drops all capabilities (8200/tcp and 1900/udp are unprivileged), filters syscalls to `@system-service` minus `@privileged` and `@resources`, and applies the usual `Protect*`/`Private*`/`Restrict*` options.

Two caveats:

- `AF_NETLINK` stays in `RestrictAddressFamilies`. minidlna uses `getifaddrs()` to pick the interface for SSDP multicast, and dropping  it silently breaks discovery.
- `ProtectHome` is `lib.mkDefault true` so users with media under `/home` can override with `services.minidlna.serviceConfig.ProtectHome = false;`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
