### PR TITLE
zapp: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15668,6 +15668,12 @@
     githubId = 725613;
     name = "Linus Arver";
   };
+  linusdikomey = {
+    email = "l.dikomey03@gmail.com";
+    github = "LinusDikomey";
+    githubId = 24570464;
+    name = "Linus Dikomey";
+  };
   linuxissuper = {
     email = "m+nix@linuxistcool.de";
     matrix = "@m:linuxistcool.de";

--- a/pkgs/by-name/za/zapp/package.nix
+++ b/pkgs/by-name/za/zapp/package.nix
@@ -1,0 +1,28 @@
+{
+  rustPlatform,
+  lib,
+  fetchFromGitHub,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "zapp";
+  version = "1.0.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "zsa";
+    repo = "zapp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0gf1famCPfsShYyankk9/Y/aA8/XbCbOJVmdNl416jk=";
+  };
+
+  cargoHash = "sha256-0jmYOfuAfmq8vJvWww6WHjt1J5nRbDDFNFi/vN5ANk8=";
+
+  meta = {
+    description = "A cross-platform CLI tool for flashing ZSA keyboards";
+    homepage = "https://github.com/zsa/zapp";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ linusdikomey ];
+    mainProgram = "zapp";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- This is a CLI tool for flashing firmware to ZSA keyboards. See [Github page](https://github.com/zsa/zapp) and the [introduction blogpost](https://blog.zsa.io/introducing-zapp/)
- Since keymapp is already packaged and this is a simpler open-source CLI tool with the same main use case of flashing firmware, I think it would be useful to package it
- I'm not sure if the `unfree` license is correct here since it's MIT with a Commons Clause Restriction
- This is my first contribution to nixpkgs, feel free to point out any mistakes

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
