### PR TITLE
ratty: init at 0.2.0

### DIFF
--- a/pkgs/by-name/ra/ratty/package.nix
+++ b/pkgs/by-name/ra/ratty/package.nix
@@ -1,0 +1,94 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  versionCheckHook,
+  alsa-lib,
+  fontconfig,
+  udev,
+  vulkan-loader,
+  wayland,
+  libxkbcommon,
+  libx11,
+  libxcursor,
+  libxi,
+  libxrandr,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ratty";
+  version = "0.2.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "orhun";
+    repo = "ratty";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-fDNlyTOhwI1nzNf2/Z9DWtTEdJCZEDogLu13ETbpJAw=";
+  };
+
+  cargoHash = "sha256-4oLBONIyC924UGTw0d9RzGvNBolWdLMzzC+mihcD3B0=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  # needed by bevy, see: https://github.com/bevyengine/bevy/blob/latest/docs/linux_dependencies.md
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    alsa-lib
+    fontconfig
+    udev
+    vulkan-loader
+    wayland
+    libxkbcommon
+    libx11
+    libxcursor
+    libxi
+    libxrandr
+  ];
+
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    NIX_LDFLAGS = toString [
+      "-framework AppKit"
+      "-framework CoreAudio"
+      "-framework CoreFoundation"
+      "-framework CoreGraphics"
+      "-framework Foundation"
+      "-framework IOKit"
+      "-framework Metal"
+      "-framework QuartzCore"
+    ];
+  };
+
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    patchelf $out/bin/ratty \
+      --add-rpath ${
+        lib.makeLibraryPath [
+          alsa-lib
+          udev
+          vulkan-loader
+          libxkbcommon
+          libx11
+          libxcursor
+          libxi
+          libxrandr
+        ]
+      }
+  '';
+
+  doInstallCheck = true;
+
+  versionCheckProgramArg = "--version";
+
+  meta = {
+    description = "GPU-rendered terminal emulator with inline 3D graphics";
+    homepage = "https://github.com/orhun/ratty";
+    changelog = "https://github.com/orhun/ratty/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ akosseres ];
+    mainProgram = "ratty";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR packages Ratty, a terminal emulator with inline 3D graphics.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

The project is written in Rust and uses the Bevy game engine for 3D rendering, so I packaged it how a normal Bevy project would be. Build and tested on x86_64-linux and aarch64-darwin, works well on both.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
