### PR TITLE
gdm: use systemd-userdbd

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -2554,7 +2554,18 @@ in
         setuid = true;
         owner = "root";
         group = "root";
-        source = "${package}/bin/unix_chkpwd";
+        source =
+          if (config.system.nssModules.path != [ ]) then
+            pkgs.runCommand "unix_chkpwd-with-nssModules"
+              {
+                nativeBuildInputs = [ pkgs.makeBinaryWrapper ];
+              }
+              ''
+                makeWrapper ${package}/bin/unix_chkpwd $out \
+                  --prefix LD_LIBRARY_PATH : ${config.system.nssModules.path}
+              ''
+          else
+            "${package}/bin/unix_chkpwd";
       };
     };
 

--- a/nixos/modules/services/display-managers/gdm.nix
+++ b/nixos/modules/services/display-managers/gdm.nix
@@ -25,22 +25,6 @@ let
         exec "$@"
       '';
 
-  # Solves problems like:
-  # https://wiki.archlinux.org/index.php/Talk:Bluetooth_headset#GDMs_pulseaudio_instance_captures_bluetooth_headset
-  # Instead of blacklisting plugins, we use Fedora's PulseAudio configuration for GDM:
-  # https://src.fedoraproject.org/rpms/gdm/blob/master/f/default.pa-for-gdm
-  pulseConfig = pkgs.writeText "default.pa" ''
-    load-module module-device-restore
-    load-module module-card-restore
-    load-module module-udev-detect
-    load-module module-native-protocol-unix
-    load-module module-default-device-restore
-    load-module module-always-sink
-    load-module module-intended-roles
-    load-module module-suspend-on-idle
-    load-module module-position-event-sounds
-  '';
-
   defaultSessionName = config.services.displayManager.defaultSession;
 
   setSessionScript = pkgs.callPackage ../x11/display-managers/account-service-util.nix { };
@@ -188,33 +172,7 @@ in
 
     services.xserver.displayManager.lightdm.enable = false;
 
-    users.users = lib.mkMerge [
-      {
-        gdm = {
-          name = "gdm";
-          uid = config.ids.uids.gdm;
-          group = "gdm";
-          description = "GDM user";
-        };
-
-        gdm-greeter = {
-          isSystemUser = true;
-          uid = 60578;
-          group = "gdm";
-          home = "/run/gdm";
-        };
-      }
-
-      (lib.genAttrs' [ 1 2 3 4 ] (
-        i:
-        lib.nameValuePair "gdm-greeter-${toString i}" {
-          isSystemUser = true;
-          uid = 60578 + i;
-          group = "gdm";
-          home = "/run/gdm-${toString i}";
-        }
-      ))
-    ];
+    services.userdbd.enable = true;
 
     users.groups.gdm.gid = config.ids.gids.gdm;
 
@@ -248,24 +206,15 @@ in
           GDM_X_SESSION_WRAPPER = "${xSessionWrapper}";
         };
         execCmd = "exec ${gdm}/bin/gdm";
-        preStart = lib.optionalString (defaultSessionName != null) ''
-          # Set default session in session chooser to a specified values – basically ignore session history.
-          ${setSessionScript}/bin/set-session ${config.services.displayManager.sessionData.autologinSession}
-        '';
+        preStart =
+          # sleep to avoid a race condition where userdb allocation isn't available yet, and gdm fails to start
+          "sleep 1"
+          + lib.optionalString (defaultSessionName != null) ''
+            # Set default session in session chooser to a specified values – basically ignore session history.
+            ${setSessionScript}/bin/set-session ${config.services.displayManager.sessionData.autologinSession}
+          '';
       };
     };
-
-    systemd.tmpfiles.rules = [
-      "d /run/gdm/.config 0711 gdm gdm"
-    ]
-    ++ lib.optionals config.services.pulseaudio.enable [
-      "d /run/gdm/.config/pulse 0711 gdm gdm"
-      "L+ /run/gdm/.config/pulse/${pulseConfig.name} - - - - ${pulseConfig}"
-    ]
-    ++ lib.optionals config.services.gnome.gnome-initial-setup.enable [
-      # Create stamp file for gnome-initial-setup to prevent it starting in GDM.
-      "f /run/gdm/.config/gnome-initial-setup-done 0711 gdm gdm - yes"
-    ];
 
     # Otherwise GDM will not be able to start correctly and display Wayland sessions
     systemd.packages = [
@@ -286,6 +235,8 @@ in
     systemd.services.display-manager.wants = [
       # Because sd_login_monitor_new requires /run/systemd/machines
       "systemd-machined.service"
+      # to allocate dynamic gdm-greeter{-N} users
+      "systemd-userdbd.service"
       # setSessionScript wants AccountsService
       "accounts-daemon.service"
     ];
@@ -294,6 +245,7 @@ in
       "rc-local.service"
       "systemd-machined.service"
       "systemd-user-sessions.service"
+      "systemd-userdbd.service"
       "plymouth-quit.service"
       "plymouth-start.service"
     ];
@@ -398,6 +350,13 @@ in
               ];
             }
             {
+              name = "env";
+              control = "required";
+              modulePath = "${config.security.pam.package}/lib/security/pam_env.so";
+              settings.conffile = "/etc/pam/environment";
+              settings.readenv = 0;
+            }
+            {
               name = "permit";
               control = "optional";
               modulePath = "${config.security.pam.package}/lib/security/pam_permit.so";
@@ -444,13 +403,6 @@ in
                 "ingroup"
                 "gdm"
               ];
-            }
-            {
-              name = "env";
-              control = "required";
-              modulePath = "${config.security.pam.package}/lib/security/pam_env.so";
-              settings.conffile = "/etc/pam/environment";
-              settings.readenv = 0;
             }
             {
               name = "systemd";

--- a/pkgs/by-name/gd/gdm/package.nix
+++ b/pkgs/by-name/gd/gdm/package.nix
@@ -139,10 +139,6 @@ stdenv.mkDerivation (finalAttrs: {
     # installed (mostly just because .passthru.tests can make use of it).
     substituteInPlace meson.build \
       --replace-fail "dconf_prefix = dconf_dep.get_variable(pkgconfig: 'prefix')" "dconf_prefix = gdm_prefix"
-
-    # Disable userdb dynamic users for now
-    substituteInPlace meson.build \
-      --replace-fail 'have_userdb = libsystemd_dep' 'have_userdb = false #'
   '';
 
   doInstallCheck = true;


### PR DESCRIPTION
An alternative to #517777 by fixing #458058. Thanks to @nikamarisa for the hint with the pam wrapper (https://github.com/NixOS/nixpkgs/issues/458058#issuecomment-4412387075)

I should note that this shows the evaluation warning https://github.com/NixOS/nixpkgs/blob/1c5f5f0d0901903b240211b4ca9a72c55a29b2ac/nixos/modules/system/boot/systemd/userdbd.nix#L39 for `nixbld` users with a GNOME DE, I don't know if we should `silenceHighSystemUsers` for users.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. (`nixosTests.gnome`)
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
