### PR TITLE
mysql84: 8.4.8 -> 8.4.9

### DIFF
--- a/pkgs/by-name/my/mysql84/package.nix
+++ b/pkgs/by-name/my/mysql84/package.nix
@@ -27,11 +27,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mysql";
-  version = "8.4.8";
+  version = "8.4.9";
 
   src = fetchurl {
     url = "https://dev.mysql.com/get/Downloads/MySQL-${lib.versions.majorMinor finalAttrs.version}/mysql-${finalAttrs.version}.tar.gz";
-    hash = "sha256-vp2Wzfh/J2lSos3ZYPEGuWCohg5GwRXtOcG18uA4eiA=";
+    hash = "sha256-5KqLOeQtH+B48zu9c2lfrCtU28e7E38L2+Y/e+GgLWs=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
https://dev.mysql.com/doc/relnotes/mysql/8.4/en/news-8-4-9.html

Fixes CVE-2026-34270
Fixes CVE-2026-34271
Fixes CVE-2026-34276
Fixes CVE-2026-34308
Fixes CVE-2026-22009
Fixes CVE-2026-22017
Fixes CVE-2026-34303
Fixes CVE-2025-14017
Fixes CVE-2026-34318
Fixes CVE-2026-34317
Fixes CVE-2025-14017
Fixes CVE-2026-34318
Fixes CVE-2026-34317
Fixes CVE-2026-34319
Fixes CVE-2026-22004
Fixes CVE-2026-34304
Fixes CVE-2026-35236
Fixes CVE-2026-35237
Fixes CVE-2026-35238
Fixes CVE-2026-35239
Fixes CVE-2026-21998
Fixes CVE-2026-22005
Fixes CVE-2026-22002
Fixes CVE-2026-35240
Fixes CVE-2026-22015
Fixes CVE-2026-22001

https://www.oracle.com/security-alerts/cpuapr2026.html#AppendixMSQL


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 519154`
Commit: `c0cef1c5dd6137791260d0eb8d7d55726939571c`

---
### `x86_64-linux`
<details>
  <summary>:x: 1 package failed to build:</summary>
  <ul>
    <li>vep</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 34 packages built:</summary>
  <ul>
    <li>exim</li>
    <li>libmysqlconnectorcpp</li>
    <li>longview</li>
    <li>mylvmbackup</li>
    <li>mysql-workbench</li>
    <li>mysql84</li>
    <li>mysql84.static</li>
    <li>opendmarc</li>
    <li>opendmarc.bin</li>
    <li>opendmarc.dev</li>
    <li>opendmarc.doc</li>
    <li>percona-toolkit</li>
    <li>percona-xtrabackup (percona-xtrabackup_8_4)</li>
    <li>perlPackages.DBDmysql (perl5Packages.DBDmysql)</li>
    <li>perlPackages.DBDmysql.devdoc (perl5Packages.DBDmysql.devdoc)</li>
    <li>perlPackages.MinionBackendmysql (perl5Packages.MinionBackendmysql)</li>
    <li>perlPackages.MinionBackendmysql.devdoc (perl5Packages.MinionBackendmysql.devdoc)</li>
    <li>perlPackages.Mojomysql (perl5Packages.Mojomysql)</li>
    <li>perlPackages.Mojomysql.devdoc (perl5Packages.Mojomysql.devdoc)</li>
    <li>perlPackages.PerconaToolkit (perl5Packages.PerconaToolkit)</li>
    <li>perlPackages.Testmysqld (perl5Packages.Testmysqld)</li>
    <li>perlPackages.Testmysqld.devdoc (perl5Packages.Testmysqld.devdoc)</li>
    <li>perlPackages.maatkit (perl5Packages.maatkit)</li>
    <li>python313Packages.mysql-connector</li>
    <li>python313Packages.mysql-connector.dist</li>
    <li>python314Packages.mysql-connector</li>
    <li>python314Packages.mysql-connector.dist</li>
    <li>sqitchMysql</li>
    <li>sqlit-tui</li>
    <li>sqlit-tui.dist</li>
    <li>sqlite3-to-mysql</li>
    <li>sqlite3-to-mysql.dist</li>
    <li>sympa</li>
    <li>zoneminder</li>
  </ul>
</details>

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
