### PR TITLE
phpExtensions.relay Fix wrong dylib mapping in Darwin

### DIFF
--- a/pkgs/development/php-packages/relay/default.nix
+++ b/pkgs/development/php-packages/relay/default.nix
@@ -10,6 +10,7 @@
   lz4,
   autoPatchelfHook,
   writeShellScript,
+  runCommand,
   curl,
   common-updater-scripts,
 }:
@@ -89,20 +90,46 @@ stdenv.mkDerivation (finalAttrs: {
     if stdenv.hostPlatform.isDarwin then
       let
         args =
-          lib.strings.concatMapStrings
-            (v: " -change ${v.name}" + " ${lib.strings.makeLibraryPath [ v.value ]}/${baseNameOf v.name}")
+          lib.concatMapStrings
             (
-              with lib.attrsets;
-              [
-                (nameValuePair "/opt/homebrew/opt/hiredis/lib/libhiredis.1.1.0.dylib" hiredis)
-                (nameValuePair "/opt/homebrew/opt/hiredis/lib/libhiredis_ssl.dylib.1.1.0" hiredis)
-                (nameValuePair "/opt/homebrew/opt/concurrencykit/lib/libck.0.dylib" libck)
-                (nameValuePair "/opt/homebrew/opt/openssl@3/lib/libssl.3.dylib" openssl)
-                (nameValuePair "/opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib" openssl)
-                (nameValuePair "/opt/homebrew/opt/zstd/lib/libzstd.1.dylib" zstd)
-                (nameValuePair "/opt/homebrew/opt/lz4/lib/liblz4.1.dylib" lz4)
-              ]
-            );
+              v:
+              let
+                targetName = if v ? to then v.to else builtins.baseNameOf v.from;
+              in
+              " -change ${v.from} ${lib.strings.makeLibraryPath [ v.pkg ]}/${targetName}"
+            )
+            [
+              {
+                from = "/opt/homebrew/opt/concurrencykit/lib/libck.0.dylib";
+                pkg = libck;
+              }
+              {
+                from = "/opt/homebrew/opt/openssl@3/lib/libssl.3.dylib";
+                pkg = openssl;
+              }
+              {
+                from = "/opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib";
+                pkg = openssl;
+              }
+              {
+                from = "/opt/homebrew/opt/zstd/lib/libzstd.1.dylib";
+                pkg = zstd;
+              }
+              {
+                from = "/opt/homebrew/opt/lz4/lib/liblz4.1.dylib";
+                pkg = lz4;
+              }
+              {
+                from = "/opt/homebrew/opt/hiredis/lib/libhiredis.1.3.0.dylib";
+                pkg = hiredis;
+                to = "libhiredis.1.1.0.dylib";
+              }
+              {
+                from = "/opt/homebrew/opt/hiredis/lib/libhiredis_ssl.1.3.0.dylib";
+                pkg = hiredis;
+                to = "libhiredis_ssl.dylib.1.1.0";
+              }
+            ];
       in
       # fixDarwinDylibNames can't be used here because we need to completely remap .dylibs, not just add absolute paths
       ''
@@ -120,6 +147,13 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
+    tests.smokeTest = runCommand "php-relay-smoke-test" { } ''
+      ${lib.getExe php} \
+        -d extension=${finalAttrs.finalPackage}/lib/php/extensions/relay.so \
+        -r 'exit(extension_loaded("relay") ? 0 : 1);'
+      touch $out
+    '';
+
     updateScript = writeShellScript "update-${finalAttrs.pname}" ''
       set -o errexit
       export PATH="$PATH:${


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done


- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

This package was broken for some time. It was being built, but PHP was not able to import it. This fixes it.