### PR TITLE
ddnet: remove unused pcre dependency

### DIFF
--- a/pkgs/by-name/dd/ddnet/package.nix
+++ b/pkgs/by-name/dd/ddnet/package.nix
@@ -15,7 +15,6 @@
   libogg,
   libx11,
   opusfile,
-  pcre,
   python3,
   SDL2,
   sqlite,
@@ -62,7 +61,6 @@ stdenv.mkDerivation rec {
   buildInputs = [
     curl
     libnotify
-    pcre
     python3
     sqlite
   ]


### PR DESCRIPTION
- #356387 

No mention of PCRE in the codebase. Only one binary `bin/DDNet` has indirect pcre2 dependency:

```
    libgio-2.0.so.0 => /nix/store/zcmsivndca5wmam9nwnbjrm0zkgykwfz-glib-2.86.3/lib/libgio-2.0.so.0
        libmount.so.1 => /nix/store/291rd5nk7hkhcpzbh7pxqiz75xikdll3-util-linux-minimal-2.42-lib/lib/libmount.so.1
            libblkid.so.1 => /nix/store/291rd5nk7hkhcpzbh7pxqiz75xikdll3-util-linux-minimal-2.42-lib/lib/libblkid.so.1
        libselinux.so.1 => /nix/store/kdlv714j07803x3ynn2w4a44xi84bh0c-libselinux-3.10/lib/libselinux.so.1
            libpcre2-8.so.0 => /nix/store/khhzkpj9169ydnyg7jjrjx7s5ygdkcas-pcre2-10.46/lib/libpcre2-8.so.0
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
