### PR TITLE
dico: use pcre2

### DIFF
--- a/pkgs/by-name/di/dico/package.nix
+++ b/pkgs/by-name/di/dico/package.nix
@@ -9,7 +9,7 @@
   gsasl,
   guile,
   python3,
-  pcre,
+  pcre2,
   libffi,
   groff,
   libxcrypt,
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     gsasl
     guile
     python3
-    pcre
+    pcre2
     libffi
     libxcrypt
   ];


### PR DESCRIPTION
- #356387 

PCRE only used in the pcre module. In `NEWS` file for version 2.12:

```
* pcre module now requires libpcre2

Support for obsolescent libpcre has been withdrawn.
```

Currently by not providing pcre2 the `pcre` module isn't actually built.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
