### PR TITLE
priviblur, npf-renderer: init

### DIFF
--- a/pkgs/by-name/np/npf-renderer/package.nix
+++ b/pkgs/by-name/np/npf-renderer/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  python3Packages,
+  fetchPypi,
+}:
+
+python3Packages.buildPythonPackage (finalAttrs: {
+  pname = "npf-renderer";
+  version = "0.13.0";
+  format = "pyproject";
+
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    pname = "npf_renderer";
+    inherit (finalAttrs) version;
+    hash = "sha256-u75HfEeNAlhCTwgJb3De1FPXKriNCn9UwkeIqBDBwgQ=";
+  };
+
+  nativeBuildInputs = [
+    python3Packages.setuptools
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    dominate
+    intervaltree
+    orjson
+  ];
+
+  pythonImportsCheck = [ "npf_renderer" ];
+
+  meta = {
+    description = "Renderer for Tumblr Neue Post Format";
+    longDescription = ''
+      Python library and renderer for Tumblr's Neue Post Format (NPF),
+      used to transform complex post structures into clean HTML.
+    '';
+    homepage = "https://github.com/syeopite/npf-renderer";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ philocalyst ];
+  };
+})

--- a/pkgs/by-name/pr/priviblur/package.nix
+++ b/pkgs/by-name/pr/priviblur/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  npf-renderer,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "priviblur";
+  version = "0-unstable-2025-08-27";
+
+  src = fetchFromGitHub {
+    owner = "syeopite";
+    repo = finalAttrs.pname;
+    rev = "251a8e67c64d792b3c8c141860ccaa227ce62e4d";
+    hash = "sha256-bN5jY2pEe+C5sZKz4reH0FWB21mZDMvte0GKOc7v/2c=";
+  };
+
+  # Doesn't follow any of the obvious python packaging methods
+  format = "other";
+
+  __structuredAttrs = true;
+
+  propagatedBuildInputs = with python3Packages; [
+    aiofiles
+    aiohttp
+    aiosignal
+    attrs
+    babel
+    dominate
+    frozenlist
+    html5tagger
+    httptools
+    idna
+    intervaltree
+    jinja2
+    markupsafe
+    multidict
+    orjson
+    pyyaml
+    redis
+    sanic
+    sanic-ext
+    pydantic
+    sanic-routing
+    sortedcontainers
+    tracerite
+    typing-extensions
+    ujson
+    uvloop
+    websockets
+    yarl
+    npf-renderer
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/${finalAttrs.pname} $out/bin
+    cp -r src locales assets $out/share/${finalAttrs.pname}/
+    touch $out/share/${finalAttrs.pname}/src/__init__.py
+
+    makeWrapper ${python3Packages.python.interpreter} $out/bin/${finalAttrs.pname} \
+      --set PYTHONPATH "$PYTHONPATH:$out/share/${finalAttrs.pname}" \
+      --add-flags "-m" \
+      --add-flags "src.server"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Privacy-focused alternative frontend to Tumblr";
+    longDescription = ''
+      Alternative web frontend for Tumblr that focuses on privacy and modern design,
+      providing a lightweight and tracker-free experience.
+    '';
+    homepage = "https://github.com/syeopite/priviblur";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ philocalyst ];
+    mainProgram = "priviblur";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
