### PR TITLE
mesa: fix timeout on Darwin

### DIFF
--- a/pkgs/development/libraries/mesa/darwin.nix
+++ b/pkgs/development/libraries/mesa/darwin.nix
@@ -59,6 +59,17 @@ stdenv.mkDerivation {
     ./opencl.patch
   ];
 
+  postPatch = ''
+    # Darwin only installs `swrast_dri.so`. It is symlinked to `libdril_dri.dylib`, but the script never terminates
+    # checking for `swrast_dri.dylib`, which isn’t what will be created.
+    substituteInPlace bin/install_megadrivers.py \
+      --replace-fail "            while ext != '.' + args.libname_suffix" "            while ext != '.so'"
+
+    # Use `st_mtimespec` on Darwin instead of `st_mtim`.
+    substituteInPlace src/gallium/drivers/llvmpipe/lp_context.c \
+      --replace-fail 'st_mtim.' 'st_mtimespec.'
+  '';
+
   outputs = [
     "out"
     "dev"

--- a/pkgs/development/libraries/mesa/darwin.nix
+++ b/pkgs/development/libraries/mesa/darwin.nix
@@ -64,10 +64,6 @@ stdenv.mkDerivation {
     # checking for `swrast_dri.dylib`, which isn’t what will be created.
     substituteInPlace bin/install_megadrivers.py \
       --replace-fail "            while ext != '.' + args.libname_suffix" "            while ext != '.so'"
-
-    # Use `st_mtimespec` on Darwin instead of `st_mtim`.
-    substituteInPlace src/gallium/drivers/llvmpipe/lp_context.c \
-      --replace-fail 'st_mtim.' 'st_mtimespec.'
   '';
 
   outputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
