### PR TITLE
gmt: use pcre2

### DIFF
--- a/pkgs/by-name/gm/gmt/package.nix
+++ b/pkgs/by-name/gm/gmt/package.nix
@@ -7,7 +7,7 @@
   apple-sdk,
   fftwSinglePrec,
   netcdf,
-  pcre,
+  pcre2,
   gdal,
   blas,
   lapack,
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     curl
     gdal
     netcdf
-    pcre
+    pcre2
     dcw-gmt
     gshhg-gmt
   ]
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "DCW_ROOT" "${dcw-gmt.out}/share/dcw-gmt")
     (lib.cmakeFeature "GDAL_ROOT" "${gdal.out}")
     (lib.cmakeFeature "NETCDF_ROOT" "${netcdf.out}")
-    (lib.cmakeFeature "PCRE_ROOT" "${pcre.out}")
+    (lib.cmakeFeature "PCRE2_ROOT" "${pcre2.out}")
     (lib.cmakeBool "GMT_INSTALL_TRADITIONAL_FOLDERNAMES" false)
     (lib.cmakeBool "GMT_ENABLE_OPENMP" true)
     (lib.cmakeBool "GMT_INSTALL_MODULE_LINKS" false)


### PR DESCRIPTION
- #356387 

Supports three [regex backends](https://github.com/GenericMappingTools/gmt/blob/6.6.0/src/gmt_regexp.c): PCRE, PCRE2, and POSIX ERE.
Switch to pcre2 here.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
