### PR TITLE
sm64coopdx: Fix coopnet

### DIFF
--- a/pkgs/by-name/co/coopnet/Makefile
+++ b/pkgs/by-name/co/coopnet/Makefile
@@ -1,0 +1,41 @@
+ifndef LIB_EXT
+	$(error LIB_EXT must be set)
+endif
+
+CXXFLAGS += -Wall -Werror -Wno-unused-function -std=c++11 -DJUICE_STATIC -Icommon
+
+CXXFLAGS += $(shell pkg-config --cflags juice)
+LDFLAGS += $(shell pkg-config --libs juice)
+
+COMMON_SRC := $(wildcard common/*.cpp)
+COMMON_OBJ := $(patsubst common/%.cpp, bin/o/common/%.o, $(COMMON_SRC))
+
+CLIENT_SRC = $(wildcard client/*.cpp) $(COMMON_SRC)
+CLIENT_OBJ = $(patsubst %.cpp, bin/o/%.o, $(CLIENT_SRC))
+
+SERVER_SRC = $(wildcard server/*.cpp) $(wildcard server/extra/*.cpp) $(COMMON_SRC)
+SERVER_OBJ = $(patsubst %.cpp, bin/o/%.o, $(SERVER_SRC))
+
+default: build
+.PHONY: default
+
+bin/o/%.o: %.cpp
+	mkdir -p $(@D)
+	c++ $(CXXFLAGS) -c $< -o $@
+
+LINK_COMMAND = c++ $(CXXFLAGS) $(LDFLAGS) $(LDFLAGS) -o $@ $+
+
+bin/client: $(CLIENT_OBJ)
+	mkdir -p $(@D)
+	$(LINK_COMMAND)
+
+bin/server: $(SERVER_OBJ)
+	mkdir -p $(@D)
+	$(LINK_COMMAND)
+
+bin/lib/libcoopnet$(LIB_EXT): $(COMMON_OBJ)
+	mkdir -p $(@D)
+	$(LINK_COMMAND) -shared
+
+build: bin/client bin/server bin/lib/libcoopnet$(LIB_EXT)
+.PHONY: build

--- a/pkgs/by-name/co/coopnet/coopnet.pc
+++ b/pkgs/by-name/co/coopnet/coopnet.pc
@@ -1,0 +1,8 @@
+libdir=@out@/lib
+includedir=@dev@/include
+
+Name: @pname@
+Description: @description@
+Version: @version@
+Cflags: -I${includedir}/coopnet
+Libs: -L${libdir} -lcoopnet

--- a/pkgs/by-name/co/coopnet/hash-override.patch
+++ b/pkgs/by-name/co/coopnet/hash-override.patch
@@ -1,0 +1,24 @@
+diff --git i/common/client.cpp w/common/client.cpp
+index 6f375b4..22fa23f 100644
+--- i/common/client.cpp
++++ w/common/client.cpp
+@@ -73,10 +73,18 @@ bool Client::Begin(std::string aHost, uint32_t aPort, std::string aName, uint64_
+ 
+     mConnection->Begin(nullptr);
+ 
++    std::size_t hash;
++    const char* hashOverride = std::getenv("COOPNET_OVERRIDE_HASH");
++    if (!hashOverride) {
++      hash = hashFile();
++    } else {
++      hash = static_cast<size_t>(std::stoull(hashOverride));
++    }
++
+     MPacketInfo({
+         .destId = aDestId,
+         .infoBits = SocketGetInfoBits(mConnection->mSocket),
+-        .hash = hashFile(),
++        .hash = hash,
+     }, { aName }).Send(*mConnection);
+ 
+     return true;

--- a/pkgs/by-name/co/coopnet/package.nix
+++ b/pkgs/by-name/co/coopnet/package.nix
@@ -1,0 +1,89 @@
+{
+  lib,
+
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  libjuice,
+
+  withLogging ? false,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "coopnet";
+  version = "0-unstable-2025-11-12";
+
+  strictDeps = true;
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "coop-deluxe";
+    repo = "coopnet";
+    rev = "9d9b3dd4e87dba2fa3ca542ae32b73f43df32b0e";
+    hash = "sha256-dWG4BZbnRyr4VDgR2pqpss6quELDN6RCwxlyBVOZxEs=";
+  };
+
+  patches = [
+    # this is needed to allow nix-built packages to connect to the coopnet server
+    ./hash-override.patch
+  ];
+
+  postPatch = ''
+    # remove vendored libjuice
+    rm -rf lib
+
+    # upstream makefile supports a fixed number of platforms, and does not play well with cross comp and such
+    rm Makefile
+    ln -s ${builtins.path { path = ./Makefile; }} Makefile
+  '';
+
+  env.NIX_CFLAGS_COMPILE = toString (
+    [ ]
+    ++ lib.optional withLogging "-DLOGGING"
+    ++ lib.optional stdenv.hostPlatform.isDarwin "-DOSX_BUILD=1"
+  );
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ libjuice ];
+
+  makeFlags = [
+    "LIB_EXT=${stdenv.hostPlatform.extensions.library}"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mkdir -p $out/lib
+    mkdir -p $dev/include/coopnet
+    install -T bin/client $out/bin/coopnet-client
+    install -T bin/server $out/bin/coopnet-server
+    install bin/lib/* -t $out/lib
+    install common/libcoopnet.h -t $dev/include/coopnet
+
+    mkdir -p $dev/lib/pkgconfig
+    substitute ${builtins.path { path = ./coopnet.pc; }} $dev/lib/pkgconfig/coopnet.pc \
+      --subst-var out \
+      --subst-var dev \
+      --subst-var pname \
+      --subst-var version \
+      --subst-var-by description ${lib.escapeShellArg finalAttrs.meta.description}
+
+    runHook postInstall
+  '';
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Library for multiplayer sm64coopdx games";
+    homepage = "https://github.com/coop-deluxe/coopnet";
+    license = lib.licenses.agpl3Only;
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+    maintainers = [ lib.maintainers.shelvacu ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/li/libjuice/juice.pc
+++ b/pkgs/by-name/li/libjuice/juice.pc
@@ -1,0 +1,8 @@
+libdir=@out@/lib
+includedir=@dev@/include
+
+Name: @pname@
+Description: @description@
+Version: @version@
+Cflags: -I${includedir}/juice
+Libs: -L${libdir} -ljuice

--- a/pkgs/by-name/li/libjuice/package.nix
+++ b/pkgs/by-name/li/libjuice/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+
+  cmake,
+  fetchFromGitHub,
+  stdenv,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libjuice";
+  version = "1.7.1";
+
+  strictDeps = true;
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "paullouisageneau";
+    repo = "libjuice";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dFZ4IpcNpPJwfamJHAvc0pwAZu2DT/af4VraXx/fdRc=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  postInstall = ''
+    mkdir -p $dev/lib/pkgconfig
+    substitute ${builtins.path { path = ./juice.pc; }} $dev/lib/pkgconfig/juice.pc \
+      --subst-var out \
+      --subst-var dev \
+      --subst-var pname \
+      --subst-var version \
+      --subst-var-by description ${lib.escapeShellArg finalAttrs.meta.description}
+  '';
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Library for opening bidirectional UDP streams with NAT traversal";
+    homepage = "https://github.com/paullouisageneau/libjuice";
+    downloadPage = "https://github.com/paullouisageneau/libjuice/releases";
+    changelog = "https://github.com/paullouisageneau/libjuice/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mpl20;
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+    maintainers = [ lib.maintainers.shelvacu ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/sm/sm64coopdx/package.nix
+++ b/pkgs/by-name/sm/sm64coopdx/package.nix
@@ -6,6 +6,7 @@
   copyDesktopItems,
   makeDesktopItem,
   imagemagick,
+  pkg-config,
 
   curl,
   hexdump,
@@ -14,6 +15,7 @@
   stdenv,
   zlib,
   libGL,
+  coopnet ? null,
 
   sm64baserom,
   enableCoopNet ? true,
@@ -49,12 +51,21 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-BIdKKIp6q9Vp2DByXzT9CJzOszFhjriiWBEqFwUT28M=";
   };
 
-  patches = [ ./no-update-check.patch ];
+  postPatch = ''
+    # make sure coopnet is properly unvendored
+    rm -r lib/coopnet
+  '';
+
+  patches = [
+    ./no-update-check.patch
+    ./unvendor-coopnet.patch
+  ];
 
   nativeBuildInputs = [
     makeWrapper
     copyDesktopItems
     imagemagick
+    pkg-config
   ];
 
   buildInputs = [
@@ -65,7 +76,8 @@ stdenv.mkDerivation (finalAttrs: {
     SDL2
     zlib
     libGL
-  ];
+  ]
+  ++ lib.optional enableCoopNet coopnet;
 
   icon = "${finalAttrs.src}/res/icon.ico";
   desktopItems = [
@@ -116,10 +128,15 @@ stdenv.mkDerivation (finalAttrs: {
       magick icon-0.png -resize "$size"x"$size" $out/share/icons/hicolor/"$size"x"$size"/apps/${finalAttrs.pname}.png
     done
 
-    # coopdx always tries to load resources from the binary's directory, with no obvious way to change. Thus this small wrapper script to always run from the /share directory that has all the resources
     mkdir -p $out/bin
-    makeWrapper $share/sm64coopdx $out/bin/sm64coopdx \
+    declare -a makeWrapperArgs=(
+      makeWrapper "$share/sm64coopdx" "$out/bin/sm64coopdx"
+      # coopdx always tries to load resources from the binary's directory, with no obvious way to change. So always run from the /share directory that has all the resources
       --chdir $share
+      # coopnet will not work without it
+      --set-default COOPNET_OVERRIDE_HASH 4878409451714253510
+    )
+    "''${makeWrapperArgs[@]}"
 
     runHook postInstall
   '';
@@ -145,7 +162,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/coop-deluxe/sm64coopdx/releases/tag/${finalAttrs.version}";
     sourceProvenance = with lib.sourceTypes; [
       fromSource
-      # The lua engine, discord sdk, and coopnet library are vendored pre-built. See https://github.com/coop-deluxe/sm64coopdx/tree/v1.0.3/lib
+      # The lua engine and discord sdk are vendored pre-built. See https://github.com/coop-deluxe/sm64coopdx/tree/v1.0.3/lib
       binaryNativeCode
     ];
   };

--- a/pkgs/by-name/sm/sm64coopdx/unvendor-coopnet.patch
+++ b/pkgs/by-name/sm/sm64coopdx/unvendor-coopnet.patch
@@ -1,0 +1,42 @@
+diff --git i/Makefile w/Makefile
+index 66b02100f..5e07f484e 100644
+--- i/Makefile
++++ w/Makefile
+@@ -968,33 +968,10 @@ endif
+ # CoopNet
+ COOPNET_LIBS :=
+ ifeq ($(COOPNET),1)
+-  ifeq ($(WINDOWS_BUILD),1)
+-    ifeq ($(TARGET_BITS), 32)
+-      LDFLAGS += -Llib/coopnet/win32 -l:libcoopnet.a -l:libjuice.a -lbcrypt -liphlpapi
+-    else
+-      LDFLAGS += -Llib/coopnet/win64 -l:libcoopnet.a -l:libjuice.a -lbcrypt -liphlpapi
+-    endif
+-  else ifeq ($(OSX_BUILD),1)
+-    ifeq ($(shell uname -m),arm64)
+-      LDFLAGS += -Wl,-rpath,@loader_path -L./lib/coopnet/mac_arm/ -l coopnet
+-      COOPNET_LIBS += ./lib/coopnet/mac_arm/libcoopnet.dylib
+-      COOPNET_LIBS += ./lib/coopnet/mac_arm/libjuice.1.6.2.dylib
+-    else
+-      LDFLAGS += -Wl,-rpath,@loader_path -L./lib/coopnet/mac_intel/ -l coopnet
+-      COOPNET_LIBS += ./lib/coopnet/mac_intel/libcoopnet.dylib
+-      COOPNET_LIBS += ./lib/coopnet/mac_intel/libjuice.1.6.2.dylib
+-    endif
+-  else ifeq ($(TARGET_RPI),1)
+-    ifneq (,$(findstring aarch64,$(machine)))
+-      LDFLAGS += -Llib/coopnet/linux -l:libcoopnet-arm64.a -l:libjuice-arm64.a
+-    else
+-      LDFLAGS += -Llib/coopnet/linux -l:libcoopnet-arm.a -l:libjuice-arm.a
+-    endif
+-  else ifeq ($(TARGET_RK3588),1)
+-    LDFLAGS += -Llib/coopnet/linux -l:libcoopnet-arm64.a -l:libjuice.a
+-  else
+-    LDFLAGS += -Llib/coopnet/linux -l:libcoopnet.a -l:libjuice.a
+-  endif
++  LDFLAGS += $(shell pkg-config --libs coopnet)
++  COOPNET_CFLAGS := $(shell pkg-config --cflags coopnet)
++  CC_CHECK_CFLAGS += $(COOPNET_CFLAGS)
++  CFLAGS += $(COOPNET_CFLAGS)
+ endif
+ 
+ # Network/Discord (ugh, needs cleanup)


### PR DESCRIPTION
Resolves https://github.com/NixOS/nixpkgs/issues/515678

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `9b04b6c4d432258155ee14431619fd328e1fbedd`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 5 packages built:</summary>
  <ul>
    <li>coopnet</li>
    <li>coopnet.dev</li>
    <li>libjuice</li>
    <li>libjuice.dev</li>
    <li>sm64coopdx</li>
  </ul>
</details>


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
