### PR TITLE
geoclue2: 2.7.2 -> 2.8.1

### DIFF
--- a/nixos/tests/geoclue2.nix
+++ b/nixos/tests/geoclue2.nix
@@ -31,6 +31,6 @@
       assert ("Latitude:    12.345000°" in whereAmI), f"Incorrect latitude in:\n{whereAmI}"
       assert ("Longitude:   -67.890000°" in whereAmI), f"Incorrect longitude in:\n{whereAmI}"
       assert ("Altitude:    123.450000 meters" in whereAmI), f"Incorrect altitude in:\n{whereAmI}"
-      assert ("Accuracy:    1000.000000 meters" in whereAmI), f"Incorrect accuracy in:\n{whereAmI}"
+      assert ("Accuracy:    1000 meters" in whereAmI), f"Incorrect accuracy in:\n{whereAmI}"
     '';
 }

--- a/pkgs/by-name/ge/geoclue2/fix-sysusers_dir.patch
+++ b/pkgs/by-name/ge/geoclue2/fix-sysusers_dir.patch
@@ -1,0 +1,13 @@
+diff --git a/data/meson.build b/data/meson.build
+index 2591e6a..dc1bd8d 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -69,7 +69,7 @@ if get_option('enable-backend')
+         if systemd.found()
+             sysusers_dir = systemd.get_variable(pkgconfig: 'sysusersdir')
+         else
+-            sysusers_dir = '/usr/lib/sysusers.d'
++            sysusers_dir = join_paths(get_option('prefix'), 'usr/lib/sysusers.d')
+         endif
+         configure_file(output: 'geoclue-sysusers.conf',
+                        input: 'geoclue-sysusers.conf.in',

--- a/pkgs/by-name/ge/geoclue2/package.nix
+++ b/pkgs/by-name/ge/geoclue2/package.nix
@@ -29,7 +29,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "geoclue";
-  version = "2.7.2";
+  version = "2.8.1";
 
   outputs = [
     "out"
@@ -42,11 +42,12 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "geoclue";
     repo = "geoclue";
     tag = finalAttrs.version;
-    hash = "sha256-LwL1WtCdHb/NwPr3/OLISwaAwplhJwiZT9vUdX29Bbs=";
+    hash = "sha256-CyZhUMAa2vMUi61sL+gGBZFxGo0lu7Cm68fTjcbblTg=";
   };
 
   patches = [
     ./add-option-for-installation-sysconfdir.patch
+    ./fix-sysusers_dir.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
