### PR TITLE
ruby_4_0: 4.0.3 -> 4.0.4

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -181,6 +181,10 @@ let
             // lib.optionalAttrs docSupport {
               # Have `configure' avoid `/usr/bin/nroff' in non-chroot builds.
               NROFF = "${groff}/bin/nroff";
+            }
+            // lib.optionalAttrs (docSupport && ver.majMin == "4.0") {
+              # RDoc parses referenced source files with the locale encoding.
+              LANG = "C.UTF-8";
             };
 
           enableParallelBuilding = true;
@@ -411,8 +415,8 @@ in
   };
 
   ruby_4_0 = generic {
-    version = rubyVersion "4" "0" "3" "";
-    hash = "sha256-d5ZKzDcNXIN1uVAuW6bBPAPvkaueufUhyE+0K5yaaw8=";
+    version = rubyVersion "4" "0" "4" "";
+    hash = "sha256-819u36Pauz9yP50M8ZBsZRKud/TkEqseaMxukdIw+oA=";
     cargoHash = "sha256-z7NwWc4TaR042hNx0xgRkh/BQEpEJtE53cfrN0qNiE0=";
   };
 


### PR DESCRIPTION
Updates Ruby 4.0 to 4.0.4.

Release notes: https://github.com/ruby/ruby/releases/tag/v4.0.4

This also sets a UTF-8 locale while building Ruby documentation. RDoc may parse referenced source files using the locale encoding; Ruby 4.0.4 includes non-ASCII text in a referenced C source file, which fails under the default US-ASCII locale during documentation generation.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests
  - [ ] Package tests
  - [ ] lib/tests
- [ ] Ran `nixpkgs-review`
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits CONTRIBUTING.md and relevant READMEs.