### PR TITLE
nixos/anki-sync-server: Use hashed passwords for user accounts

### DIFF
--- a/nixos/modules/services/misc/anki-sync-server.nix
+++ b/nixos/modules/services/misc/anki-sync-server.nix
@@ -122,6 +122,7 @@ in
         SYNC_BASE = cfg.baseDirectory;
         SYNC_HOST = specEscape cfg.address;
         SYNC_PORT = toString cfg.port;
+        PASSWORDS_HASHED = lib.mkIf (lib.versionAtLeast config.system.stateVersion "26.11") "1";
       };
 
       serviceConfig = {


### PR DESCRIPTION
Passwords for user accounts are stored in cleartext at the moment.
Probably because the anki-sync-server didn't support hashed passwords
since always. However, it got support for hashed passwords by now and
so there's no reason to store them in cleartext on the server side
anymore.

Thus, enable hashed passwords for NixOS versions starting from 26.11 by
default. For more information on this, please look at the official
documentation [1].

[1] https://docs.ankiweb.net/sync-server.html#hashed-passwords

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
