### PR TITLE
mpsolve: modernize

### DIFF
--- a/pkgs/by-name/mp/mpsolve/package.nix
+++ b/pkgs/by-name/mp/mpsolve/package.nix
@@ -17,6 +17,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "mpsolve";
   version = "3.2.2";
 
+  outputs = [
+    "out"
+    "dev"
+    "man"
+  ];
+
   src = fetchFromGitHub {
     owner = "robol";
     repo = "MPSolve";
@@ -32,6 +38,8 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
+  strictDeps = true;
+
   nativeBuildInputs = [
     autoreconfHook
     bison
@@ -45,6 +53,8 @@ stdenv.mkDerivation (finalAttrs: {
     gtk3
     libsForQt5.qtbase
   ];
+
+  enableParallelBuilding = true;
 
   passthru.updateScript = gitUpdater { };
 

--- a/pkgs/by-name/mp/mpsolve/package.nix
+++ b/pkgs/by-name/mp/mpsolve/package.nix
@@ -12,6 +12,8 @@
   gtk3,
   pkg-config,
   libsForQt5,
+
+  withGUI ? true,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -46,13 +48,22 @@ stdenv.mkDerivation (finalAttrs: {
     bison
     flex
     pkg-config
+  ]
+  ++ lib.optionals withGUI [
     libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [
     gmp
+  ]
+  ++ lib.optionals withGUI [
     gtk3
     libsForQt5.qtbase
+  ];
+
+  configureFlags = [
+    (lib.enableFeature withGUI "graphical-debugger")
+    (lib.enableFeature withGUI "ui")
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/mp/mpsolve/package.nix
+++ b/pkgs/by-name/mp/mpsolve/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   autoreconfHook,
   bison,
   flex,
@@ -22,6 +23,14 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "de7ebfc7afc4834a0c9f92a04be7abdf5943d446";
     hash = "sha256-BGXvNxWUbto0yMIpEIxZ9wOYv9w0ev4OgVcniNYIKoU=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "include-cmath-in-c++-before-defining-isnan-macro.patch";
+      url = "https://github.com/robol/MPSolve/commit/260432c9d1002261f60159d0520af7862d4471ed.patch";
+      hash = "sha256-ODWpp966S1SsSN8hf7yuYgJR44GgbLwSxui280WWGmM=";
+    })
+  ];
 
   nativeBuildInputs = [
     autoreconfHook
@@ -45,6 +54,5 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ kilianar ];
     mainProgram = "mpsolve";
-    platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/mp/mpsolve/package.nix
+++ b/pkgs/by-name/mp/mpsolve/package.nix
@@ -5,6 +5,7 @@
   fetchpatch,
   autoreconfHook,
   bison,
+  check,
   flex,
   gitUpdater,
   gmp,
@@ -55,6 +56,12 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   enableParallelBuilding = true;
+
+  doCheck = true;
+
+  checkInputs = [ check ];
+
+  checkTarget = "check";
 
   passthru.updateScript = gitUpdater { };
 


### PR DESCRIPTION
- Made `mpsolve` build on Darwin (required pulling in https://github.com/robol/MPSolve/commit/260432c9d1002261f60159d0520af7862d4471ed)
- Added a flag to disable the GUI components
- Turned on the `checkPhase`
- Split outputs and other misc. tweaks

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
