### PR TITLE
vhd2vl: 0-unstable-2022-12-26 -> 0-unstable-2026-02-16

### DIFF
--- a/pkgs/by-name/vh/vhd2vl/package.nix
+++ b/pkgs/by-name/vh/vhd2vl/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation {
   pname = "vhd2vl";
-  version = "0-unstable-2022-12-26";
+  version = "0-unstable-2026-02-16";
 
   src = fetchFromGitHub {
     owner = "ldoolitt";
     repo = "vhd2vl";
-    rev = "869d442987dff6b9730bc90563ede89c1abfd28f";
-    sha256 = "sha256-Hz2XkT5m4ri5wVR2ciL9Gx73zr+RdW5snjWnUg300c8=";
+    rev = "a6ed1b45ce88bf978f18e8f6fc419e853a6676b4";
+    sha256 = "sha256-lFPGstQd7u5crEJz6bFbbMTmNoZgRFuHb3HVCDnzDYk=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
