### PR TITLE
emacs/wrapper.nix: expose extra package binaries via PATH

### DIFF
--- a/pkgs/applications/editors/emacs/build-support/wrapper.nix
+++ b/pkgs/applications/editors/emacs/build-support/wrapper.nix
@@ -180,6 +180,13 @@ runCommand (lib.appendToName "with-packages" emacs).name
           ;; "$out/share/emacs/site-lisp" is added to load-path in wrapper.sh
           ;; "$out/share/emacs/native-lisp" is added to native-comp-eln-load-path in wrapper.sh
           (add-to-list 'exec-path "$out/bin")
+          ;; Also expose extra package binaries via PATH so that subprocesses
+          ;; which rebuild their environment from PATH (e.g. direnv/envrc) can
+          ;; still find them. See https://github.com/purcell/envrc/issues/9
+          (let ((deps-bin "$out/bin")
+                (current-path (or (getenv "PATH") "")))
+            (unless (member deps-bin (split-string current-path path-separator))
+              (setenv "PATH" (concat deps-bin path-separator current-path))))
           ${lib.optionalString withTreeSitter ''
             (add-to-list 'treesit-extra-load-path "$out/lib/")
           ''}


### PR DESCRIPTION
The `emacs.pkgs.withPackages` wrapper aggregates external binaries supplied through `extraEmacsPackages` (LSP servers, formatters, etc.) under `emacs-packages-deps/bin`,
and prepends that directory to `exec-path` via the generated `site-start.el`.
However the `PATH` environment variable of the Emacs process is left untouched,
so tools that rebuild `process-environment` from `PATH` cannot see those binaries.

direnv's envrc-mode (purcell/envrc) reconstructs `process-environment` for buffers under direnv-managed directories starting from the inherited `PATH`.
Because `emacs-packages-deps/bin` is never placed on `PATH`, 
packages like

- `bash-language-server`
- `pyright`
- `vscode-langservers-extracted`

etc.
installed through `extraEmacsPackages` become invisible to `executable-find` inside those buffers, 
even though they work elsewhere.

For comparison,
when entering a direnv-managed directory from the shell (`direnv exec . bash` or `cd`-with-direnv),
the parent `PATH` entries from the user environment (`/etc/profiles/per-user/$USER/bin`, `~/.nix-profile/bin` etc.)
are preserved as the global baseline,
so globally installed CLI tools stay reachable.
Emacs should behave the same way:
the binaries bundled by `extraEmacsPackages` are effectively "globally installed for this Emacs",
so they should remain reachable inside any direnv-managed buffer,
just as shell-level globals remain reachable inside `direnv exec`.

Tracked at purcell/envrc#9 since 2020;
no nixpkgs-side fix has landed yet.

This change adds one idempotent `setenv` next to the existing `exec-path` update.
It uses `path-separator` for OS portability,
and a `member` / `split-string` guard so the prefix is not duplicated on repeated loads.
No new wrapper placeholders,
`wrapper.sh` is unchanged.

Risk: minimal.
`PATH` only gains a prefix already present on `exec-path`;
ordering matches existing semantics.
`site-start.el` runs once per Emacs startup,
so the value will not grow unbounded.

## Things done

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [x] Package tests at `passthru.tests` (see wrapper-test.nix)
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.
