### PR TITLE
worker: 5.2.2 -> 5.4.0

### DIFF
--- a/pkgs/by-name/wo/worker/package.nix
+++ b/pkgs/by-name/wo/worker/package.nix
@@ -2,25 +2,59 @@
   lib,
   stdenv,
   fetchurl,
+  pkg-config,
+  avfs,
+  dbus,
+  file, # for libmagic
+  imlib2,
+  libice,
+  libsm,
   libx11,
+  libxft,
+  libxinerama,
+  lua,
+  openssl,
+  udisks2,
+  luaSupport ? true,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "worker";
-  version = "5.2.2";
+  version = "5.4.0";
 
   src = fetchurl {
     url = "http://www.boomerangsworld.de/cms/worker/downloads/worker-${finalAttrs.version}.tar.gz";
-    hash = "sha256-xJxdOb6eEr8suf3u/vouYCGzTFugJpLtoKyCMeuoJv4=";
+    hash = "sha256-tH/EFfj2bx0LwiyN7FQIjH8xR270A1opV7Zror0Zk7I=";
   };
 
-  buildInputs = [ libx11 ];
+  nativeBuildInputs = [
+    avfs
+    pkg-config
+  ];
+
+  buildInputs = [
+    avfs
+    dbus
+    file
+    imlib2
+    libice
+    libsm
+    libx11
+    libxft
+    libxinerama
+    openssl
+    udisks2
+  ]
+  ++ lib.optionals luaSupport [
+    lua
+  ];
 
   outputs = [
     "out"
     "man"
   ];
 
+  __structuredAttrs = true;
   strictDeps = true;
 
   meta = {


### PR DESCRIPTION
WIP
Supersedes #460348

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
