### PR TITLE
(unstable) caligula: update from v0.4.11 -> v0.5.0-rc.1

### DIFF
--- a/pkgs/by-name/ca/caligula/package.nix
+++ b/pkgs/by-name/ca/caligula/package.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "caligula";
-  version = "0.4.11";
+  version = "0.5.0-rc.1";
 
   src = fetchFromGitHub {
     owner = "ifd3f";
     repo = "caligula";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-2KCP7Utb785yIn8w/Ls19UPS9ylg1PtLRki87+BD+xw=";
+    hash = "sha256-ZCnTn0s6bWczKlJZ2GtbkjJHpPiR98G3c5pjlpUvI38=";
   };
 
-  cargoHash = "sha256-C86wu2Pc9O7YM1TnnfotzzOQlnJXJe2zmsX04JyJsjA=";
+  cargoHash = "sha256-I3qMrU7iwOAR6xUE2uhi3ToeEoh3+UY93dxTFdgyH3k=";
 
   nativeBuildInputs = [
     rustPlatform.bindgenHook


### PR DESCRIPTION
[Release notes](https://github.com/ifd3f/caligula/releases/tag/v0.5.0-rc.1)

This release candidate constitutes a very large refactor of 3000 or so lines, improving reliability significantly. It's been thoroughly tested on my machine and in CI, and I am very confident that it works, but I'd like to validate it in the wild on nixpkgs unstable first.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

I also ran this build inside a test VM and wrote a USB successfully.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
