### PR TITLE
vikunja-desktop: 2.2.2 -> 2.3.0

### DIFF
--- a/pkgs/by-name/vi/vikunja-desktop/package.nix
+++ b/pkgs/by-name/vi/vikunja-desktop/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   makeWrapper,
   makeDesktopItem,
+  darwin,
   pnpm_10_29_2,
   pnpmConfigHook,
   nodejs,
@@ -52,6 +53,9 @@ stdenv.mkDerivation (finalAttrs: {
     pnpm_10_29_2
     pnpmConfigHook
     vikunja.passthru.frontend
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    darwin.autoSignDarwinBinariesHook
   ];
 
   buildPhase = ''
@@ -60,7 +64,18 @@ stdenv.mkDerivation (finalAttrs: {
     sed -i "s/\$${version}/${version}/g" package.json
     sed -i "s/\"version\": \".*\"/\"version\": \"${version}\"/" package.json
     ln -s '${vikunja.passthru.frontend}' frontend
-    pnpm run pack -c.electronDist="${electron.dist}" -c.electronVersion="${electron.version}"
+
+    electronDist="${electron.dist}"
+    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+      electronDist="$(mktemp -d)"
+      cp -R "${electron.dist}/." "$electronDist"
+      chmod -R u+w "$electronDist"
+      export CSC_IDENTITY_AUTO_DISCOVERY=false
+    ''}
+    pnpm run pack \
+      -c.electronDist="$electronDist" \
+      -c.electronVersion="${electron.version}" \
+      ${lib.optionalString stdenv.hostPlatform.isDarwin "-c.mac.identity=null"}
 
     runHook postBuild
   '';
@@ -70,20 +85,30 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p "$out/share/lib/vikunja-desktop"
-    cp -r ./dist/*-unpacked/{locales,resources{,.pak}} "$out/share/lib/vikunja-desktop"
-    cp -r ./node_modules "$out/share/lib/vikunja-desktop/resources"
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      mkdir -p "$out/share/lib/vikunja-desktop"
+      cp -r ./dist/*-unpacked/{locales,resources{,.pak}} "$out/share/lib/vikunja-desktop"
+      cp -r ./node_modules "$out/share/lib/vikunja-desktop/resources"
 
-    install -Dm644 "build/icon.png" "$out/share/icons/hicolor/256x256/apps/vikunja-desktop.png"
+      install -Dm644 "build/icon.png" "$out/share/icons/hicolor/256x256/apps/vikunja-desktop.png"
 
-    # use makeShellWrapper (instead of the makeBinaryWrapper provided by wrapGAppsHook3) for proper shell variable expansion
-    # see https://github.com/NixOS/nixpkgs/issues/172583
-    makeShellWrapper "${lib.getExe electron}" "$out/bin/vikunja-desktop" \
-      --add-flags "$out/share/lib/vikunja-desktop/resources/app.asar" \
-      "''${gappsWrapperArgs[@]}" \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=UseOzonePlatform,WaylandWindowDecorations,WebRTCPipeWireCapturer}}" \
-      --set-default ELECTRON_IS_DEV 0 \
-      --inherit-argv0
+      # use makeShellWrapper (instead of the makeBinaryWrapper provided by wrapGAppsHook3) for proper shell variable expansion
+      # see https://github.com/NixOS/nixpkgs/issues/172583
+      makeShellWrapper "${lib.getExe electron}" "$out/bin/vikunja-desktop" \
+        --add-flags "$out/share/lib/vikunja-desktop/resources/app.asar" \
+        "''${gappsWrapperArgs[@]}" \
+        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=UseOzonePlatform,WaylandWindowDecorations,WebRTCPipeWireCapturer}}" \
+        --set-default ELECTRON_IS_DEV 0 \
+        --inherit-argv0
+    ''}
+
+    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+      mkdir -p "$out/Applications" "$out/bin"
+      mv ./dist/mac*/*.app "$out/Applications"
+      makeWrapper \
+        "$out/Applications/Vikunja Desktop.app/Contents/MacOS/Vikunja Desktop" \
+        "$out/bin/vikunja-desktop"
+    ''}
 
     runHook postInstall
   '';

--- a/pkgs/by-name/vi/vikunja-desktop/package.nix
+++ b/pkgs/by-name/vi/vikunja-desktop/package.nix
@@ -16,12 +16,12 @@
 
 let
   executableName = "vikunja-desktop";
-  version = "2.2.2";
+  version = "2.3.0";
   src = fetchFromGitHub {
     owner = "go-vikunja";
     repo = "vikunja";
     rev = "v${version}";
-    hash = "sha256-+Tqo9z+QXzcYNWZl+DoHaClkMokTa6a2S1FlazZBDyI=";
+    hash = "sha256-bdHiSFaN0vNQMhy6GPlpoFeYrk2CLvO7E30d8J/9GC0=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
       ;
     pnpm = pnpm_10_29_2;
     fetcherVersion = 3;
-    hash = "sha256-/dPjUxD01G1H3nRZfW8x046x33OaiChYuiLhZYOPrTo=";
+    hash = "sha256-phvNUUYh858CDt0O8GCWkgO402C0wiYtzEorOIV789M=";
   };
 
   env = {


### PR DESCRIPTION
## Changes
- Fix Darwin builds by copying Electron's ditributions to a writable directory before running `electron-builder`
- Disable `electron-builder`signing on Darwin and use `autoSignDarwinBinariesHook`. 
- Install the generated macOS `.app` bundle under `$out/Applications`.
- Add a Darwin launcher for `vikunja-desktop`.
- Upstream 2.3.0 also includes the new desktop OAuth/deep-link login flow.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
