### PR TITLE
sequoia-keystore-server: init at 0.2.0

### DIFF
--- a/pkgs/by-name/se/sequoia-keystore-server/package.nix
+++ b/pkgs/by-name/se/sequoia-keystore-server/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitLab,
+  nettle,
+  pkg-config,
+  capnproto,
+}:
+rustPlatform.buildRustPackage (final: {
+  pname = "sequoia-keystore-server";
+  version = "0.2.0";
+
+  src = fetchFromGitLab {
+    owner = "sequoia-pgp";
+    repo = "sequoia-keystore";
+    rev = "server/v${final.version}";
+    hash = "sha256-UqlrMh1dDnykr69kR+fikx+mk9WsF9Y8jsfazKCvXV4=";
+  };
+
+  cargoHash = "sha256-uTpJzYncRQBs/mXiJylqmNw0/j4ia1MM4hhZ20g9Muw=";
+
+  buildAndTestSubdir = "server";
+
+  buildInputs = [ nettle.dev ];
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+    capnproto
+  ];
+
+  postInstall = ''
+    install -Dt $out/lib/sequoia $out/bin/${final.meta.mainProgram}
+    rm -rf $out/bin
+  '';
+
+  __structuredAttrs = true;
+
+  meta = {
+    homepage = "https://gitlab.com/sequoia-pgp/sequoia-keystore";
+    license = lib.licenses.lgpl2Plus;
+    mainProgram = "sequoia-keystore";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
