### PR TITLE
python3Packages.aiomultiprocess: fix tests on python 3.14

### DIFF
--- a/pkgs/development/python-modules/aiomultiprocess/default.nix
+++ b/pkgs/development/python-modules/aiomultiprocess/default.nix
@@ -18,6 +18,11 @@ buildPythonPackage rec {
     hash = "sha256-LWrAr3i2CgOMZFxWi9B3kiou0UtaHdDbpkr6f9pReRA=";
   };
 
+  patches = [
+    # https://github.com/omnilib/aiomultiprocess/issues/220
+    ./python314-compat.patch
+  ];
+
   build-system = [ flit-core ];
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/aiomultiprocess/python314-compat.patch
+++ b/pkgs/development/python-modules/aiomultiprocess/python314-compat.patch
@@ -1,0 +1,21 @@
+diff --git a/aiomultiprocess/tests/base.py b/aiomultiprocess/tests/base.py
+--- a/aiomultiprocess/tests/base.py
++++ b/aiomultiprocess/tests/base.py
+@@ -56,7 +56,7 @@ async def terminate(process):
+ def async_test(fn):
+     @wraps(fn)
+     def wrapper(*args, **kwargs):
+-        loop = asyncio.get_event_loop()
++        loop = asyncio.new_event_loop()
+         return loop.run_until_complete(fn(*args, **kwargs))
+
+     return wrapper
+@@ -66,7 +66,7 @@ def perf_test(fn):
+     @wraps(fn)
+     @skipUnless(RUN_PERF_TESTS, "Performance test")
+     def wrapper(*args, **kwargs):
+-        loop = asyncio.get_event_loop()
++        loop = asyncio.new_event_loop()
+         return loop.run_until_complete(fn(*args, **kwargs))
+
+     return wrapper


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327130748)](https://hydra.nixos.org/build/327130748)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
