### PR TITLE
python3Packages.aiorpcx: fix tests on python 3.14

### DIFF
--- a/pkgs/development/python-modules/aiorpcx/default.nix
+++ b/pkgs/development/python-modules/aiorpcx/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  fetchpatch2,
   buildPythonPackage,
   setuptools,
   websockets,
@@ -19,6 +20,20 @@ buildPythonPackage rec {
     tag = version;
     hash = "sha256-mFg9mWrlnfXiQpgZ1rxvUy9TBfwy41XEKmsCf2nvxGo=";
   };
+
+  patches = [
+    # fix asyncio.get_event_loop() usage in tests for python 3.14
+    (fetchpatch2 {
+      url = "https://github.com/kyuupichan/aiorpcX/commit/b8ce32889c45c98b44c4e247ec0b0ae206e9ee91.patch?full_index=1";
+      hash = "sha256-EIxGR3M5dfX4ZyPFftVdPFcsg9WwYBG/h31edu6Te8o=";
+      includes = [ "tests/test_util.py" ];
+    })
+    # make test_misc async so it runs inside pytest-asyncio's loop on python 3.14
+    (fetchpatch2 {
+      url = "https://github.com/kyuupichan/aiorpcX/commit/25043621700672ee375d20b78804118acac43b1b.patch?full_index=1";
+      hash = "sha256-q4tqbcPQj6SU06Xn/4ns1NriLLx8zmUOGJo11ucA6Dk=";
+    })
+  ];
 
   build-system = [ setuptools ];
 

--- a/pkgs/development/python-modules/aiorpcx/default.nix
+++ b/pkgs/development/python-modules/aiorpcx/default.nix
@@ -52,6 +52,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "aiorpcx" ];
 
+  __darwinAllowLocalNetworking = true;
+
   meta = {
     description = "Transport, protocol and framing-independent async RPC client and server implementation";
     homepage = "https://github.com/kyuupichan/aiorpcX";


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327130845)](https://hydra.nixos.org/build/327130845)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
