### PR TITLE
duo-desktop: init on version 4.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19341,6 +19341,12 @@
     githubId = 69087176;
     name = "n0pl4c3";
   };
+  n0rad = {
+    email = "agithub@lmr.fr";
+    github = "n0rad";
+    githubId = 541709;
+    name = "Arnaud Lemaire";
+  };
   n3oney = {
     name = "Michał Minarowski";
     email = "nixpkgs@neoney.dev";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1518,6 +1518,7 @@
   ./services/security/clamav.nix
   ./services/security/crowdsec-firewall-bouncer.nix
   ./services/security/crowdsec.nix
+  ./services/security/duo-desktop.nix
   ./services/security/e-imzo.nix
   ./services/security/endlessh-go.nix
   ./services/security/endlessh.nix

--- a/nixos/modules/services/security/duo-desktop.nix
+++ b/nixos/modules/services/security/duo-desktop.nix
@@ -1,0 +1,73 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.duo-desktop;
+  installDir = "${cfg.package}/opt/duo/duo-desktop";
+  keysDir = "/etc/opt/duo/duo-desktop/https";
+  certPath = "${keysDir}/duo-desktop.crt";
+  keyPath = "${keysDir}/duo-desktop.key";
+  pfxPath = "${keysDir}/duo-desktop.pfx";
+
+  # Certificate generation script
+  # Regenerate if the cert is missing or expires within 30 days (2592000 seconds)
+  certGenerationScript = ''
+    if [ ! -f "${certPath}" ] || ! openssl x509 -checkend 2592000 -noout -in "${certPath}" 2>/dev/null; then
+      mkdir -p "${keysDir}"
+      chmod 700 "${keysDir}"
+      openssl req \
+        -newkey rsa:2048 -keyout "${keyPath}" \
+        -x509 \
+        -days 1095 \
+        -nodes \
+        -config "${installDir}/localhost.cfg" \
+        -out "${certPath}" 2>/dev/null
+      openssl pkcs12 \
+        -inkey "${keyPath}" -in "${certPath}" \
+        -export -out "${pfxPath}" \
+        -passout pass:
+      rm -f "${keyPath}"
+      chmod 600 "${pfxPath}"
+      chmod 644 "${certPath}"
+    fi
+  '';
+in
+{
+  options.services.duo-desktop = {
+    enable = lib.mkEnableOption "Duo Desktop";
+    package = lib.mkPackageOption pkgs "duo-desktop" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    # Include the systemd units from the package
+    systemd.packages = [ cfg.package ];
+
+    # Generate certificate during system activation to ensure it exists for the trust bundle
+    system.activationScripts.duo-desktop-cert-generate = {
+      deps = [ "specialfs" ];
+      text = ''
+        ${certGenerationScript}
+      '';
+    };
+
+    # Add the generated cert to the NixOS system trust bundle.
+    security.pki.certificateFiles = [ certPath ];
+
+    # Enable the duo-desktop daemon
+    systemd.services.duo-desktop = {
+      serviceConfig = {
+        # Override the ExecStart to point to the wrapper
+        ExecStart = [
+          ""
+          "${cfg.package}/bin/duo-desktop"
+        ];
+      };
+      wantedBy = [ "multi-user.target" ];
+    };
+  };
+}

--- a/pkgs/by-name/du/duo-desktop/package.nix
+++ b/pkgs/by-name/du/duo-desktop/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  pkgs,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  makeWrapper,
+}:
+# From https://aur.archlinux.org/cgit/aur.git/tree/?h=duo-desktop
+stdenv.mkDerivation rec {
+  pname = "duo-desktop";
+  # Version number is available at https://duo.com/docs/duo-desktop-notes#duo-desktop-for-linux
+  version = "4.5.0";
+
+  # Only latest package is available
+  src =
+    let
+      srcs = {
+        x86_64-linux = fetchurl {
+          url = "https://desktop.pkg.duosecurity.com/${pname}-latest.x86_64.rpm";
+          sha256 = "sha256-tT4H70ssW/igOXd/6hXnKDGPdU/Ft4sDuVpCzLw7kHw=";
+        };
+        aarch64-linux = fetchurl {
+          url = "https://desktop.pkg.duosecurity.com/${pname}-latest.aarch64.rpm";
+          sha256 = "sha256-GfsNxmo3zHUBzTkZzNjcsVMWB+YTr4KgFMRBWryGD3o=";
+        };
+      };
+    in
+    srcs.${stdenv.hostPlatform.system} or (throw "Unsupported platform: ${stdenv.hostPlatform.system}");
+
+  strictDeps = true;
+  nativeBuildInputs = with pkgs; [
+    rpm
+    cpio
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  unpackPhase = ''
+    rpm2cpio $src | cpio -idmv
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -dpr --no-preserve=ownership opt $out
+
+    # systemd unit is at the wrong location
+    cp -dpr --no-preserve=ownership usr/lib $out
+    # package's /url/lib contain a build result folder (.build-id) with symlinks to the binary.
+    # After moving the lib folder, the symlinks is broken, so we have to remove it.
+    rm -rf $out/lib/.build-id
+
+    makeWrapper $out/opt/duo/duo-desktop/duo-desktop $out/bin/duo-desktop \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath (
+          with pkgs;
+          [
+            openssl
+            icu
+            dpkg
+          ]
+        )
+      } \
+      --prefix PATH : $out/bin:${
+        lib.makeBinPath (
+          with pkgs;
+          [
+            iptables
+            dmidecode
+            which
+            util-linux
+            cryptsetup
+          ]
+        )
+      }
+  '';
+
+  __structuredAttrs = true;
+
+  meta = with lib; {
+    description = "Duo Desktop gives Duo customers more control over which computers can access corporate applications based on the trust (with Trusted Endpoints) and security posture of the device (with Device Health).";
+    homepage = "https://duo.com/docs/duo-desktop";
+    license = licenses.unfree;
+    sourceProvenance = [ sourceTypes.binaryNativeCode ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    maintainers = with maintainers; [ n0rad ];
+  };
+}


### PR DESCRIPTION
Add [duo desktop](https://duo.com/docs/checksums#duo-desktop) package and module

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [X] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
