### PR TITLE
 nixos/bcachefs: add upstream Systemd units to initrd

### DIFF
--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -273,6 +273,10 @@ in
           "bcachefs" = "${cfg.package}/bin/bcachefs";
           "mount.bcachefs" = "${cfg.package}/bin/mount.bcachefs";
         };
+        boot.initrd.systemd.storePaths = [
+          # Used by the ExecStart= in bcachefs-wait-devices@.service.
+          "${cfg.package}/sbin/bcachefs"
+        ];
         boot.initrd.extraUtilsCommands = lib.mkIf (!config.boot.initrd.systemd.enable) ''
           copy_bin_and_libs ${cfg.package}/bin/bcachefs
           copy_bin_and_libs ${cfg.package}/bin/mount.bcachefs

--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -289,6 +289,7 @@ in
           commonFunctions + lib.concatStrings (lib.mapAttrsToList openCommand bootFs)
         );
 
+        boot.initrd.systemd.packages = [ cfg.package ];
         boot.initrd.systemd.services = lib.mapAttrs' (mkUnits "/sysroot") bootFs;
       })
 


### PR DESCRIPTION
Add the `bcachefs-wait-devices@.service` unit to the initrd so that users can use it in `fileSystems` to make Systemd wait for all the devices in the filesystem to be initialized before trying to mount the filesystem.

Example configuration:
```nix
{
  fileSystems."/mountpoint" =
    let
      uuid = "...";
    in
    {
      device = "UUID=${uuid}";
      fsType = "bcachefs";
      options = [ "x-systemd.wants=bcachefs-wait-devices@${uuid}.service" ];
    };
}
```

This can be a workaround for #451418. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
