### PR TITLE
uemacs: 4.0-unstable-2018-07-19 -> 4.0-unstable-2021-30-03

### DIFF
--- a/pkgs/by-name/ue/uemacs/package.nix
+++ b/pkgs/by-name/ue/uemacs/package.nix
@@ -7,12 +7,12 @@
 
 gccStdenv.mkDerivation {
   pname = "uemacs";
-  version = "4.0-unstable-2018-07-19";
+  version = "4.0-unstable-2021-30-03";
 
   src = fetchgit {
     url = "https://git.kernel.org/pub/scm/editors/uemacs/uemacs.git";
-    rev = "1cdcf9df88144049750116e36fe20c8c39fa2517";
-    hash = "sha256-QSouqZiBmKBU6FqRRfWtTGRIl5sqJ8tVPYwdytt/43w=";
+    rev = "1c1b25ef723c952ca557cb5ff6d8db159ef1d4bc";
+    hash = "sha256-NN3FpeHycPyIhJuEcRm7IO4n+mvAAhxecqSCTuw2elA=";
   };
 
   buildInputs = [ ncurses ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Changelog: https://git.kernel.org/pub/scm/editors/uemacs/uemacs.git/commit/?id=1c1b25ef723c952ca557cb5ff6d8db159ef1d4bc 

## Things done
uemacs: 4.0-unstable-2018-07-19 -> 4.0-unstable-2021-30-03

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
