### PR TITLE
jay: 1.12.0 -> 1.13.0

### DIFF
--- a/pkgs/by-name/ja/jay/package.nix
+++ b/pkgs/by-name/ja/jay/package.nix
@@ -50,6 +50,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
     vulkan-loader
   ];
 
+  checkFlags = [
+    # these 5 tests fail in the lix sandbox because they rely on io_uring
+    "--skip=cpu_worker::tests::cancel"
+    "--skip=cpu_worker::tests::complete"
+    "--skip=eventfd_cache::tests::test"
+    "--skip=io_uring::ops::read_write_no_cancel::tests::cancel_in_kernel"
+    "--skip=io_uring::ops::read_write_no_cancel::tests::cancel_in_userspace"
+  ];
+
   postInstall = ''
     install -D etc/jay.portal $out/share/xdg-desktop-portal/portals/jay.portal
     install -D etc/jay-portals.conf $out/share/xdg-desktop-portal/jay-portals.conf

--- a/pkgs/by-name/ja/jay/package.nix
+++ b/pkgs/by-name/ja/jay/package.nix
@@ -19,16 +19,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "jay";
-  version = "1.12.0";
+  version = "1.13.0";
 
   src = fetchFromGitHub {
     owner = "mahkoh";
     repo = "jay";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-JOt3xEONGDmLovk72hX0d3De01zTd51d2/J4HziBE9I=";
+    sha256 = "sha256-tC2V1BgUGsUMpZsKXjFSS8Mp28LrNI/QNu761zpgAkc=";
   };
 
-  cargoHash = "sha256-wK9v3YwP067etFAu6Ca9Sts+QrD4uL48chbL6tZKFkk=";
+  cargoHash = "sha256-96vCkZR/8dgZH0hJPeKzP7jQZ41W7XTi9yMnxFaIhoY=";
 
   nativeBuildInputs = [
     autoPatchelfHook

--- a/pkgs/by-name/ja/jay/package.nix
+++ b/pkgs/by-name/ja/jay/package.nix
@@ -81,7 +81,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/mahkoh/jay";
     license = lib.licenses.gpl3;
     platforms = lib.platforms.linux;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ uku3lig ];
     mainProgram = "jay";
   };
 })


### PR DESCRIPTION
Release notes: https://github.com/mahkoh/jay/releases/tag/v1.13.0

Additionally fixes a build failure on Lix and adds myself as maintainer.

~Targets staging-next because of hard dependency on Rust 1.95.0.~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
