### PR TITLE
foundry: 1.5.1 -> 1.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24325,6 +24325,12 @@
     githubId = 12882091;
     name = "Sam L. Yes";
   };
+  samooyo = {
+    email = "samidarnaud@gmail.com";
+    github = "samooyo";
+    githubId = 46531012;
+    name = "Sami Darnaud";
+  };
   samrose = {
     email = "samuel.rose@gmail.com";
     github = "samrose";

--- a/pkgs/by-name/fo/foundry/package.nix
+++ b/pkgs/by-name/fo/foundry/package.nix
@@ -12,16 +12,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "foundry";
-  version = "1.5.1";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "foundry-rs";
     repo = "foundry";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-dMYuv5noIn86WuUJkUixnoNGLgByacung/TBU+EYhUw=";
+    hash = "sha256-UCaBo4hMStmh79UiyYu7vEO7UtrvwJshe4PTMkqZV0w=";
   };
 
-  cargoHash = "sha256-+5RLCkAQR8UepdUIsq1FnQmjKMg7YNC1Sxu0CVpWcnc=";
+  cargoHash = "sha256-iAWUEVgOgn2Zw9fINxyH9Bynh+flzCY40YFGoVLgG8k=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/fo/foundry/package.nix
+++ b/pkgs/by-name/fo/foundry/package.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   libusb1,
   nix-update-script,
+  perl,
   pkg-config,
   rustPlatform,
   versionCheckHook,
@@ -13,6 +14,8 @@
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "foundry";
   version = "1.7.0";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "foundry-rs";
@@ -23,7 +26,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-iAWUEVgOgn2Zw9fINxyH9Bynh+flzCY40YFGoVLgG8k=";
 
+  strictDeps = true;
+
   nativeBuildInputs = [
+    # `sha3-asm`'s build script runs cryptogams perl scripts to generate
+    # Keccak assembly, so perl must be available at build time.
+    perl
     pkg-config
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.DarwinTools ];
@@ -43,6 +51,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   env = {
+    # The build script in `crates/common/build.rs` uses vergen to embed
+    # `git describe` / SHA output, but the GitHub source tarball has no `.git`
+    # directory. Pre-set the values so vergen reuses them instead of shelling
+    # out to git.
+    VERGEN_GIT_SHA = finalAttrs.src.rev;
+    VERGEN_GIT_DESCRIBE = "v${finalAttrs.version}";
+
     SVM_RELEASES_LIST_JSON =
       if stdenv.hostPlatform.isDarwin then
         # Confusingly, these are universal binaries, not amd64.
@@ -64,6 +79,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       beeb
       mitchmindtree
       msanft
+      samooyo
     ];
     platforms = lib.platforms.unix;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

  Bumps foundry from 1.5.1 to 1.7.0.

  Two build adjustments were needed for the new version:
  - Added perl to nativeBuildInputs — the new sha3-asm transitive dep invokes cryptogams perl scripts to generate Keccak assembly during its build.
  - Pre-set VERGEN_GIT_SHA / VERGEN_GIT_DESCRIBE via env: crates/common/build.rs now uses vergen to embed git info, but the GitHub source tarball has no .git directory, so vergen panics unless those values are supplied directly.

  Changelog: https://github.com/foundry-rs/foundry/blob/v1.7.0/CHANGELOG.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
