### PR TITLE
linuxPackages.nvidiaPackages: separate utility extraction and tool namespace, nvidia-modprobe: move to nvidiaPackages

### DIFF
--- a/pkgs/by-name/li/libnvidia-container/package.nix
+++ b/pkgs/by-name/li/libnvidia-container/package.nix
@@ -13,16 +13,17 @@
   removeReferencesTo,
   replaceVars,
   applyPatches,
-  nvidia-modprobe,
+  linuxPackages,
   go,
 }:
 let
   modprobeVersion = "550.54.14";
   patchedModprobe = applyPatches {
-    src = nvidia-modprobe.src.override {
-      version = modprobeVersion;
-      hash = "sha256-iBRMkvOXacs/llTtvc/ZC5i/q9gc8lMuUHxMbu8A+Kg=";
-    };
+    src =
+      (linuxPackages.nvidiaPackages.stable.modprobe.override {
+        version = modprobeVersion;
+        hash = "sha256-iBRMkvOXacs/llTtvc/ZC5i/q9gc8lMuUHxMbu8A+Kg=";
+      }).src;
     patches = [
       (replaceVars ./modprobe.patch {
         inherit modprobeVersion;

--- a/pkgs/os-specific/linux/nvidia-x11/binaries.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/binaries.nix
@@ -1,0 +1,217 @@
+{
+  # Package dependencies
+  lib,
+  stdenv,
+  fetchurl,
+  which,
+  libarchive,
+  jq,
+  zstd,
+  pkgs,
+  pkgsi686Linux,
+  config,
+  # Whether to build only userspace libraries (without bin/modsrc/firmware outputs)
+  libsOnly,
+  # don't include the bundled 32-bit libraries on 64-bit platforms,
+  # even if it's in downloaded binary
+  disable32Bit ? stdenv.hostPlatform.system == "aarch64-linux",
+  # 32 bit libs only version of this package
+  lib32,
+  # Whether to extract the GSP firmware; datacenter drivers and open
+  # kernel module builds need it
+  firmware ? openSha256 != null || useFabricmanager,
+  # Whether the user accepts the NVIDIA Software License
+  acceptLicense ? config.nvidia.acceptLicense or false,
+  # Hash for open kernel modules; if non-null, allows building
+  # without accepting the proprietary license
+  openSha256,
+  # Driver version and sources
+  version,
+  url,
+  sha256_32bit,
+  sha256_64bit,
+  sha256_aarch64,
+  # Feature flags
+  useGLVND,
+  useProfiles,
+  # Whether this is a datacenter driver (affects pname)
+  useFabricmanager,
+  # Whether this driver supports ibt
+  ibtSupport,
+  # Build customization
+  prePatch,
+  postPatch,
+  patchFlags,
+  patches,
+  preInstall,
+  postInstall,
+  # Whether the build is marked broken
+  broken,
+  brokenOpen,
+  ...
+}:
+
+assert lib.versionOlder version "391" -> sha256_32bit != null;
+
+let
+  # Create a library path string for the given package set
+  libPathFor =
+    pkgs:
+    lib.makeLibraryPath (
+      with pkgs;
+      [
+        libdrm
+        libxext
+        libx11
+        libxv
+        libxrandr
+        libxcb
+        zlib
+        stdenv.cc.cc
+        wayland
+        libgbm
+        libGL
+        openssl
+        dbus # for nvidia-powerd
+      ]
+    );
+
+  # Throw an error about license acceptance
+  throwLicense = throw ''
+    Use of NVIDIA Software requires license acceptance of the license:
+
+      - License For Customer Use of NVIDIA Software [1]
+
+    You can express acceptance by setting acceptLicense to true your nixpkgs.config.
+    Example:
+
+      configuration.nix:
+        nixpkgs.config.allowUnfree = true;
+        nixpkgs.config.nvidia.acceptLicense = true;
+
+      config.nix:
+        allowUnfree = true;
+        nvidia.acceptLicense = true;
+
+    [1]: https://www.nvidia.com/content/DriverDownloads/licence.php?lang=us
+  '';
+
+  pkgSuffix = lib.optionalString (lib.versionOlder version "304") "-pkg0";
+  i686bundled = lib.versionAtLeast version "391" && !disable32Bit;
+
+  libPath = libPathFor pkgs;
+  libPath32 = lib.optionalString i686bundled (libPathFor pkgsi686Linux);
+
+  src =
+    if !acceptLicense && (openSha256 == null) then
+      throwLicense
+    else if stdenv.hostPlatform.system == "x86_64-linux" then
+      fetchurl {
+        urls =
+          if url != null then
+            [ url ]
+          else
+            [
+              "https://us.download.nvidia.com/XFree86/Linux-x86_64/${version}/NVIDIA-Linux-x86_64-${version}${pkgSuffix}.run"
+              "https://download.nvidia.com/XFree86/Linux-x86_64/${version}/NVIDIA-Linux-x86_64-${version}${pkgSuffix}.run"
+            ];
+        sha256 = sha256_64bit;
+      }
+    else if stdenv.hostPlatform.system == "i686-linux" then
+      fetchurl {
+        urls =
+          if url != null then
+            [ url ]
+          else
+            [
+              "https://us.download.nvidia.com/XFree86/Linux-x86/${version}/NVIDIA-Linux-x86-${version}${pkgSuffix}.run"
+              "https://download.nvidia.com/XFree86/Linux-x86/${version}/NVIDIA-Linux-x86-${version}${pkgSuffix}.run"
+            ];
+        sha256 = sha256_32bit;
+      }
+    else if stdenv.hostPlatform.system == "aarch64-linux" && sha256_aarch64 != null then
+      fetchurl {
+        urls =
+          if url != null then
+            [ url ]
+          else
+            [
+              "https://us.download.nvidia.com/XFree86/aarch64/${version}/NVIDIA-Linux-aarch64-${version}${pkgSuffix}.run"
+              "https://download.nvidia.com/XFree86/Linux-aarch64/${version}/NVIDIA-Linux-aarch64-${version}${pkgSuffix}.run"
+            ];
+        sha256 = sha256_aarch64;
+      }
+    else
+      throw "nvidia-x11 does not support platform ${stdenv.hostPlatform.system}";
+
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nvidia-${if useFabricmanager then "dc" else "x11"}";
+
+  builder = ./builder.sh;
+
+  inherit src;
+
+  patches = if libsOnly then null else patches;
+  inherit prePatch postPatch patchFlags;
+  inherit preInstall postInstall;
+  inherit version useGLVND useProfiles;
+  inherit (stdenv.hostPlatform) system;
+  inherit i686bundled;
+
+  outputs = [
+    "out"
+  ]
+  ++ lib.optional i686bundled "lib32"
+  ++ lib.optionals (!libsOnly) [
+    "bin"
+    "modsrc"
+  ]
+  ++ lib.optional (!libsOnly && firmware) "firmware";
+  outputDev = if libsOnly then null else "bin";
+
+  dontStrip = true;
+  dontPatchELF = true;
+
+  inherit libPath libPath32;
+
+  nativeBuildInputs = [
+    libarchive
+    jq
+  ]
+  # NVIDIA has changed the compression format of their driver to zstd since version 530.30.02
+  # https://forums.developer.nvidia.com/t/linux-solaris-and-freebsd-driver-530-30-02-beta/244406
+  ++ (if (lib.versionAtLeast version "530") then [ zstd ] else [ which ]);
+
+  passthru = {
+    compressFirmware = false;
+    ibtSupport = ibtSupport || (lib.versionAtLeast version "530");
+  }
+  // lib.optionalAttrs (!i686bundled) {
+    inherit lib32;
+  };
+
+  meta = {
+    homepage = "https://www.nvidia.com/object/unix.html";
+    description = "${
+      if useFabricmanager then "Data Center" else "X.org"
+    } driver and kernel module for NVIDIA cards";
+    license = lib.licenses.unfreeRedistributable;
+    platforms = [
+      "x86_64-linux"
+    ]
+    ++ lib.optionals (sha256_32bit != null) [ "i686-linux" ]
+    ++ lib.optionals (sha256_aarch64 != null) [ "aarch64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [
+      binaryNativeCode
+      binaryFirmware
+    ];
+    maintainers = with lib.maintainers; [
+      kiskae
+      edwtjo
+    ];
+    priority = 4; # resolves collision with xorg-server's "lib/xorg/modules/extensions/libglx.so"
+    broken = broken && brokenOpen;
+  };
+})

--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -68,6 +68,7 @@ rec {
     fetchOpenFromNvidia = true;
     settingsSha256 = "sha256-GYCcnxfKPrTCrsmd25sMyzfC5cqJQJx0c31haooyTYM=";
     persistencedSha256 = "sha256-VyKtF/HdHPQrHHK6opSO69M72LmnGZtauuchj9uuje8=";
+    modprobeSha256 = "sha256-zyz/gjRNXw/Uh/XQPrBLLbQRLsP/u4uxjoHvLVSn+2o=";
   };
 
   new_feature = generic {
@@ -78,6 +79,7 @@ rec {
     fetchOpenFromNvidia = true;
     settingsSha256 = "sha256-ZEMo8I8Zc2Tq6RVDNYpAH+f094dUaZiBqO+5f6lIjRI=";
     persistencedSha256 = "sha256-aXmD2VY1RLlgAnlHhOUMWzvMyhI6JTClcFLm4imF/mA=";
+    modprobeSha256 = "sha256-NJ6gVlnQn/HJnRpqvlmF9uYJlGX0+iGJ6/AHcooNa0M=";
   };
 
   beta = generic {
@@ -88,6 +90,7 @@ rec {
     fetchOpenFromNvidia = true;
     settingsSha256 = "sha256-Y45pryyM+6ZTJyRaRF3LMKaiIWxB5gF5gGEEcQVr9nA=";
     persistencedSha256 = "sha256-5FoeUaRRMBIPEWGy4Uo0Aho39KXmjzQsuAD9m/XkNpA=";
+    modprobeSha256 = "sha256-DDeSu6R1JsUux77LfsrAVBTwW6MPu6P1v8W4o2VCN2g=";
   };
 
   # Vulkan developer beta driver
@@ -96,11 +99,13 @@ rec {
     version = "595.44.09";
     persistencedVersion = "595.45.04";
     settingsVersion = "595.45.04";
+    modprobeVersion = "595.45.04";
     sha256_64bit = "sha256-LOcwE47hUG1aZX7JvLmTb/yC5qQgXYZ0TAavSn38Xug=";
     openSha256 = "sha256-+ZLnlNhMkLG7UNMRmc4yHojs4lsBSiFC/bGf2qk0W+o=";
     fetchOpenFromNvidia = true;
     settingsSha256 = "sha256-Y45pryyM+6ZTJyRaRF3LMKaiIWxB5gF5gGEEcQVr9nA=";
     persistencedSha256 = "sha256-5FoeUaRRMBIPEWGy4Uo0Aho39KXmjzQsuAD9m/XkNpA=";
+    modprobeSha256 = "sha256-DDeSu6R1JsUux77LfsrAVBTwW6MPu6P1v8W4o2VCN2g=";
     url = "https://developer.nvidia.com/downloads/vulkan-beta-${lib.concatStrings (lib.splitVersion version)}-linux";
   };
 
@@ -115,6 +120,7 @@ rec {
     fabricmanagerSha256 = "sha256-f/AQ8HrgoqBQyXNrXA/UaI4OMQ9QcjjYWIhr1/5uM74=";
     openSha256 = "sha256-uGQQkQf1oKkGhOXgJ3IzQX1NkB7cGFcnl0HWuqeN8d4=";
     fetchOpenFromNvidia = true;
+    modprobeSha256 = "sha256-Vtp5FDDmzbwtDe11O0w/S8Mptpp8Li21/gBfJzfE0/g=";
     useSettings = false;
     usePersistenced = true;
     useFabricmanager = true;
@@ -128,6 +134,7 @@ rec {
     fabricmanagerSha256 = "sha256-xZnTQYZy/uPrTLD6mACflGGWtaYB4luzh0AFxTstNIw=";
     openSha256 = "sha256-/wWZGvDN+Rmq2j6otbBjbrnbzGR9seMYmrATNnhKBnA=";
     fetchOpenFromNvidia = true;
+    modprobeSha256 = "sha256-2zdTEcAQDrmik2R2FDk6UL5oczkMTHQ9KcinD3jJCCI=";
     useSettings = false;
     usePersistenced = true;
     useFabricmanager = true;
@@ -141,6 +148,7 @@ rec {
     fabricmanagerSha256 = "sha256-jSTKzeRVTUcYma1Cb0ajSdXKCi6KzUXCp2OByPSWSR4=";
     openSha256 = "sha256-bwJQUj7eEM7XMji1bjS8T1Uw3qJtSE+fzZCtBKyHPH0=";
     fetchOpenFromNvidia = true;
+    modprobeSha256 = "sha256-Sk5ogsasf6DBz0j54dhlqZp7p8swnNnvITkdIudc69k=";
     useSettings = false;
     usePersistenced = true;
     useFabricmanager = true;
@@ -159,6 +167,7 @@ rec {
     fetchOpenFromNvidia = true;
     settingsSha256 = "sha256-KcrGHoR+ZMdsFyI4myU8/eVls2f8GkNSX/j2JnZndyM=";
     persistencedSha256 = "sha256-3Omj160wtWdKAZDzWt/m/cbUTQ9DMJ1rSxMrnIrKXiw=";
+    modprobeSha256 = "sha256-2zdTEcAQDrmik2R2FDk6UL5oczkMTHQ9KcinD3jJCCI=";
   };
 
   # Last one without the bug reported here:
@@ -171,6 +180,7 @@ rec {
     fetchOpenFromNvidia = true;
     settingsSha256 = "sha256-hN4IWAD/M+th7brbzdBtgOQ2P1QUVrrWITgVGiuCxWw=";
     persistencedSha256 = "sha256-q061VN6om3UzbpWD7+tJJVgU/e2YCJF4IgEv53qx9ZA=";
+    modprobeSha256 = "sha256-4GYNBKQthFpV3BnFQkUTkElcemssyV0oKGzDzHbSWW0=";
   };
 
   # Last one supporting Kepler architecture
@@ -189,6 +199,7 @@ rec {
       sha256_aarch64 = "sha256-e+QvE+S3Fv3JRqC9ZyxTSiCu8gJdZXSz10gF/EN6DY0=";
       settingsSha256 = "sha256-kftQ4JB0iSlE8r/Ze/+UMnwLzn0nfQtqYXBj+t6Aguk=";
       persistencedSha256 = "sha256-iYoSib9VEdwjOPBP1+Hx5wCIMhW8q8cCHu9PULWfnyQ=";
+      modprobeSha256 = "sha256-x2bMn0Hjb8axAdqhjODFvKR875DhP7R3OiwxI3FVy1M=";
 
       patches = map (patch: "${aurPatches}/${patch}") [
         "0001-Fix-conftest-to-ignore-implicit-function-declaration.patch"
@@ -218,6 +229,7 @@ rec {
     sha256_64bit = "sha256-W+u8puj+1da52BBw+541HxjtxTSVJVPL3HHo/QubMoo=";
     settingsSha256 = "sha256-uJZO4ak/w/yeTQ9QdXJSiaURDLkevlI81de0q4PpFpw=";
     persistencedSha256 = "sha256-NuqUQbVt80gYTXgIcu0crAORfsj9BCRooyH3Gp1y1ns=";
+    modprobeSha256 = "sha256-RxFTC1Nc8f6Gzlvllsa4QGwNurfOocvC4QC4gPYO3lY=";
 
     patches = map (patch: "${aurPatches}/${patch}") [
       "kernel-4.16+-memory-encryption.patch"
@@ -280,6 +292,7 @@ rec {
       sha256_64bit = "06xp6c0sa7v1b82gf0pq0i5p0vdhmm3v964v0ypw36y0nzqx8wf6";
       settingsSha256 = "0zm29jcf0mp1nykcravnzb5isypm8l8mg2gpsvwxipb7nk1ivy34";
       persistencedSha256 = "1ax4xn3nmxg1y6immq933cqzw6cj04x93saiasdc0kjlv0pvvnkn";
+      modprobeSha256 = "sha256-aEVCKYliPCk8SJybZ/wcgU8bppmx7tlAUuOaAQqJgeQ=";
       useGLVND = false;
 
       broken = kernel.kernelAtLeast "6.7";

--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -10,17 +10,7 @@
 }:
 
 let
-  generic =
-    args:
-    let
-      imported = import ./generic.nix args;
-    in
-    callPackage imported {
-      lib32 =
-        (pkgsi686Linux.callPackage imported {
-          libsOnly = true;
-        }).out;
-    };
+  generic = callPackage ./generic.nix;
 
   selectHighestVersion = a: b: if lib.versionOlder a.version b.version then b else a;
 
@@ -74,7 +64,8 @@ rec {
     version = "595.99.02";
     sha256_64bit = "sha256-6HR3lYv3YwcFSTJL1a1slI66btIQ5EAFs+/4SUD24ew=";
     sha256_aarch64 = "sha256-CCqHZTN2KNOZ4yZp2rDcuRJp9pHfRw47k4m4dWnS/2w=";
-    openSha256 = "sha256-T36x/jx8yQ8l3LFp1rZIrTfcSwbGy8YSAvXOUSptpb4=";
+    openSha256 = "sha256-EfNJwJNgjWCJnHDvvw0rviiDojJN22GnntlnjXMDvu0=";
+    fetchOpenFromNvidia = true;
     settingsSha256 = "sha256-GYCcnxfKPrTCrsmd25sMyzfC5cqJQJx0c31haooyTYM=";
     persistencedSha256 = "sha256-VyKtF/HdHPQrHHK6opSO69M72LmnGZtauuchj9uuje8=";
   };
@@ -83,7 +74,8 @@ rec {
     version = "610.57.04";
     sha256_64bit = "sha256-suk1xmuDuwDAyFe8jg7g/VLekoa0DJzB7sKafOfrEW0=";
     sha256_aarch64 = "sha256-QCefrMBCmpOwuOyXv1k5Gj0iB2CYlPgnG3JToUw/j54=";
-    openSha256 = "sha256-rQHOOOY4KL92Ww3KDwh+j4eGU7oNAH8LutZC5wmFnPo=";
+    openSha256 = "sha256-yHT6rLyF91JmEF/+owRo+1HTffil/CnOenBO0GDQTjA=";
+    fetchOpenFromNvidia = true;
     settingsSha256 = "sha256-ZEMo8I8Zc2Tq6RVDNYpAH+f094dUaZiBqO+5f6lIjRI=";
     persistencedSha256 = "sha256-aXmD2VY1RLlgAnlHhOUMWzvMyhI6JTClcFLm4imF/mA=";
   };
@@ -92,7 +84,8 @@ rec {
     version = "595.45.04";
     sha256_64bit = "sha256-zUllSSRsuio7dSkcbBTuxF+dN12d6jEPE0WgGvVOj14=";
     sha256_aarch64 = "sha256-jl6lQWsgF6ya22sAhYPpERJ9r+wjnWzbGnINDpUMzsk=";
-    openSha256 = "sha256-uqNfImwTKhK8gncUdP1TPp0D6Gog4MSeIJMZQiJWDoE=";
+    openSha256 = "sha256-zkNIsepBEgDwlw0GvSB0CoZk3Zozsv6peqprs62U3rU=";
+    fetchOpenFromNvidia = true;
     settingsSha256 = "sha256-Y45pryyM+6ZTJyRaRF3LMKaiIWxB5gF5gGEEcQVr9nA=";
     persistencedSha256 = "sha256-5FoeUaRRMBIPEWGy4Uo0Aho39KXmjzQsuAD9m/XkNpA=";
   };
@@ -104,7 +97,8 @@ rec {
     persistencedVersion = "595.45.04";
     settingsVersion = "595.45.04";
     sha256_64bit = "sha256-LOcwE47hUG1aZX7JvLmTb/yC5qQgXYZ0TAavSn38Xug=";
-    openSha256 = "sha256-QboSiRWRZWseFg7GN/a4vZVQGGBF1UJlC9MyAxUxyF4=";
+    openSha256 = "sha256-+ZLnlNhMkLG7UNMRmc4yHojs4lsBSiFC/bGf2qk0W+o=";
+    fetchOpenFromNvidia = true;
     settingsSha256 = "sha256-Y45pryyM+6ZTJyRaRF3LMKaiIWxB5gF5gGEEcQVr9nA=";
     persistencedSha256 = "sha256-5FoeUaRRMBIPEWGy4Uo0Aho39KXmjzQsuAD9m/XkNpA=";
     url = "https://developer.nvidia.com/downloads/vulkan-beta-${lib.concatStrings (lib.splitVersion version)}-linux";
@@ -119,7 +113,8 @@ rec {
     sha256_64bit = "sha256-ueL4BpN4FDHMh/TNKRCeEz3Oy1ClDWto1LO/LWlr1ok=";
     persistencedSha256 = "sha256-wsNeuw7IaY6Qc/i/AzT/4N82lPjkwfrhxidKWUtcwW8=";
     fabricmanagerSha256 = "sha256-f/AQ8HrgoqBQyXNrXA/UaI4OMQ9QcjjYWIhr1/5uM74=";
-    openSha256 = "sha256-hECHfguzwduEfPo5pCDjWE/MjtRDhINVr4b1awFdP44=";
+    openSha256 = "sha256-uGQQkQf1oKkGhOXgJ3IzQX1NkB7cGFcnl0HWuqeN8d4=";
+    fetchOpenFromNvidia = true;
     useSettings = false;
     usePersistenced = true;
     useFabricmanager = true;
@@ -131,7 +126,8 @@ rec {
     sha256_64bit = "sha256-WXWobuRb/8tib1GuM9EWmxCBhqLqR61lHnLxP6S21vk=";
     persistencedSha256 = "sha256-3Omj160wtWdKAZDzWt/m/cbUTQ9DMJ1rSxMrnIrKXiw=";
     fabricmanagerSha256 = "sha256-xZnTQYZy/uPrTLD6mACflGGWtaYB4luzh0AFxTstNIw=";
-    openSha256 = "sha256-7eXEROG2rQK9+Ag26nG4jFPrnKeveVUQ0ugIAshJZPQ=";
+    openSha256 = "sha256-/wWZGvDN+Rmq2j6otbBjbrnbzGR9seMYmrATNnhKBnA=";
+    fetchOpenFromNvidia = true;
     useSettings = false;
     usePersistenced = true;
     useFabricmanager = true;
@@ -143,7 +139,8 @@ rec {
     sha256_64bit = "sha256-AlaGfggsr5PXsl+nyOabMWBiqcbHLG4ij617I4xvoX0=";
     persistencedSha256 = "sha256-x4K0Gp89LdL5YJhAI0AydMRxl6fyBylEnj+nokoBrK8=";
     fabricmanagerSha256 = "sha256-jSTKzeRVTUcYma1Cb0ajSdXKCi6KzUXCp2OByPSWSR4=";
-    openSha256 = "sha256-aTV5J4zmEgRCOavo6wLwh5efOZUG+YtoeIT/tnrC1Hg=";
+    openSha256 = "sha256-bwJQUj7eEM7XMji1bjS8T1Uw3qJtSE+fzZCtBKyHPH0=";
+    fetchOpenFromNvidia = true;
     useSettings = false;
     usePersistenced = true;
     useFabricmanager = true;
@@ -158,7 +155,8 @@ rec {
     version = "580.178.04";
     sha256_64bit = "sha256-WXWobuRb/8tib1GuM9EWmxCBhqLqR61lHnLxP6S21vk=";
     sha256_aarch64 = "sha256-71nsXSSFDhLW91UOwffPhNtTqEzpxj6zulXvXtDE8Ek=";
-    openSha256 = "sha256-7eXEROG2rQK9+Ag26nG4jFPrnKeveVUQ0ugIAshJZPQ=";
+    openSha256 = "sha256-/wWZGvDN+Rmq2j6otbBjbrnbzGR9seMYmrATNnhKBnA=";
+    fetchOpenFromNvidia = true;
     settingsSha256 = "sha256-KcrGHoR+ZMdsFyI4myU8/eVls2f8GkNSX/j2JnZndyM=";
     persistencedSha256 = "sha256-3Omj160wtWdKAZDzWt/m/cbUTQ9DMJ1rSxMrnIrKXiw=";
   };
@@ -169,7 +167,8 @@ rec {
     version = "535.288.01";
     sha256_64bit = "sha256-8gwy/W7NH3BcbfJ5fAwIQlPs9/9I8sNH+Co5YZiC7OE=";
     sha256_aarch64 = "sha256-2d3RYzU+W4uS6mUvpCNCfoVcAJA/aerNwm7Xbg0YJBo=";
-    openSha256 = "sha256-kDM8jeHjcRCyhOs8AQk+ce3Qzf2cI5RGzzIraJrSmOE=";
+    openSha256 = "sha256-cepwckGQ7L+HV5B+1vROQfGQKzVeGM0/i6exSnuy2do=";
+    fetchOpenFromNvidia = true;
     settingsSha256 = "sha256-hN4IWAD/M+th7brbzdBtgOQ2P1QUVrrWITgVGiuCxWw=";
     persistencedSha256 = "sha256-q061VN6om3UzbpWD7+tJJVgU/e2YCJF4IgEv53qx9ZA=";
   };

--- a/pkgs/os-specific/linux/nvidia-x11/fabricmanager.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/fabricmanager.nix
@@ -1,5 +1,3 @@
-nvidia_x11: sha256:
-
 {
   stdenv,
   lib,
@@ -8,23 +6,25 @@ nvidia_x11: sha256:
   zlib,
   glibc,
   versionCheckHook,
+  version,
+  hash,
 }:
 
 let
   sys = lib.concatStringsSep "-" (lib.reverseList (lib.splitString "-" stdenv.system));
   bsys = builtins.replaceStrings [ "_" ] [ "-" ] sys;
-  fmver = nvidia_x11.fabricmanagerVersion;
   ldd = (lib.getBin glibc) + "/bin/ldd";
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "fabricmanager";
-  version = fmver;
+  inherit version;
+
   src = fetchurl {
     url =
       "https://developer.download.nvidia.com/compute/nvidia-driver/redist/fabricmanager/"
-      + "${sys}/${pname}-${sys}-${fmver}-archive.tar.xz";
-    inherit sha256;
+      + "${sys}/${finalAttrs.pname}-${sys}-${finalAttrs.version}-archive.tar.xz";
+    inherit hash;
   };
 
   installPhase = ''
@@ -78,8 +78,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.nvidia.com/object/unix.html";
     description = "Fabricmanager daemon for NVLink initialization and control";
     license = lib.licenses.unfreeRedistributable;
-    platforms = nvidia_x11.meta.platforms;
     mainProgram = "nv-fabricmanager";
     maintainers = with lib.maintainers; [ edwtjo ];
   };
-}
+})

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -1,16 +1,30 @@
 {
+  # Package dependencies
+  lib,
+  runCommandLocal,
+  patchutils,
+  callPackage,
+  pkgsi686Linux,
+  fetchzip,
+  fetchFromGitHub,
+  libsOnly ? false,
+  # Driver version and sources
   version,
   url ? null,
   sha256_32bit ? null,
   sha256_64bit,
   sha256_aarch64 ? null,
   openSha256 ? null,
+  # Passthru package hashes and versions
   settingsSha256 ? null,
-  settingsVersion ? null,
+  settingsVersion ? version,
   persistencedSha256 ? null,
-  persistencedVersion ? null,
+  persistencedVersion ? version,
   fabricmanagerSha256 ? null,
-  fabricmanagerVersion ? null,
+  fabricmanagerVersion ? version,
+  # Whether to fetch the open-source kernel module sources from NVIDIA
+  fetchOpenFromNvidia ? false,
+  # Feature flags
   useGLVND ? true,
   useProfiles ? true,
   preferGtk2 ? false,
@@ -19,7 +33,7 @@
   usePersistenced ? true,
   useFabricmanager ? false,
   ibtSupport ? false,
-
+  # Build customization
   prePatch ? null,
   postPatch ? null,
   patchFlags ? null,
@@ -29,45 +43,48 @@
   postInstall ? null,
   broken ? false,
   brokenOpen ? broken,
-}@args:
-
-{
-  lib,
-  stdenv,
-  runCommandLocal,
-  patchutils,
-  callPackage,
-  pkgs,
-  pkgsi686Linux,
-  fetchurl,
-  fetchzip,
-  which,
-  libarchive,
-  jq,
-  zstd,
-  # Whether to build only userspace libraries (without bin/modsrc/firmware
-  # outputs). Used to support 32-bit binaries on 64-bit Linux.
-  libsOnly ? false,
-  # don't include the bundled 32-bit libraries on 64-bit platforms,
-  # even if it’s in downloaded binary
-  disable32Bit ? stdenv.hostPlatform.system == "aarch64-linux",
-  # 32 bit libs only version of this package
-  lib32 ? null,
-  # Whether to extract the GSP firmware, datacenter drivers needs to extract the
-  # firmware
-  firmware ? openSha256 != null || useFabricmanager,
-  # Whether the user accepts the NVIDIA Software License
-  config,
-  acceptLicense ? config.nvidia.acceptLicense or false,
 }:
 
-assert lib.versionOlder version "391" -> sha256_32bit != null;
 assert useSettings -> settingsSha256 != null;
 assert usePersistenced -> persistencedSha256 != null;
 assert useFabricmanager -> fabricmanagerSha256 != null;
 assert useFabricmanager -> !useSettings;
 
 let
+  fetchFromGithubOrNvidia =
+    {
+      owner,
+      repo,
+      tag,
+      nvrepo ? repo,
+      nvext ? "bz2",
+      ...
+    }@fetchArgs:
+    let
+      fetchArgs' = removeAttrs fetchArgs [
+        "owner"
+        "repo"
+        "tag"
+        "nvrepo"
+        "nvext"
+      ];
+      baseUrl = "https://github.com/${owner}/${repo}";
+    in
+    fetchzip (
+      fetchArgs'
+      // {
+        urls = [
+          "${baseUrl}/archive/${tag}.tar.gz"
+          "https://download.nvidia.com/XFree86/${nvrepo}/${nvrepo}-${tag}.tar.${nvext}"
+        ];
+        # github and nvidia use different compression algorithms,
+        # use an invalid file extension to force detection.
+        extension = "tar.??";
+        # do not try to retry 4xx errors
+        curlOptsList = [ "--no-retry-all-errors" ];
+      }
+    );
+
   # Rewrites patches meant for the kernel/* folder structure to kernel-open/*
   rewritePatch =
     { from, to }:
@@ -91,169 +108,62 @@ let
           --clean "$patch" > "$out"
       '';
 
-  pkgSuffix = lib.optionalString (lib.versionOlder version "304") "-pkg0";
-  i686bundled = lib.versionAtLeast version "391" && !disable32Bit;
-
-  libPathFor =
-    pkgs:
-    lib.makeLibraryPath (
-      with pkgs;
-      [
-        libdrm
-        libxext
-        libx11
-        libxv
-        libxrandr
-        libxcb
-        zlib
-        stdenv.cc.cc
-        wayland
-        libgbm
-        libGL
-        openssl
-        dbus # for nvidia-powerd
-      ]
-    );
-
-  # maybe silly since we've ignored this previously and just unfree..
-  throwLicense = throw ''
-    Use of NVIDIA Software requires license acceptance of the license:
-
-      - License For Customer Use of NVIDIA Software [1]
-
-    You can express acceptance by setting acceptLicense to true your nixpkgs.config.
-    Example:
-
-      configuration.nix:
-        nixpkgs.config.allowUnfree = true;
-        nixpkgs.config.nvidia.acceptLicense = true;
-
-      config.nix:
-        allowUnfree = true;
-        nvidia.acceptLicense = true;
-
-    [1]: https://www.nvidia.com/content/DriverDownloads/licence.php?lang=us
-  '';
-in
-
-stdenv.mkDerivation (finalAttrs: {
-  pname = "nvidia-${if useFabricmanager then "dc" else "x11"}";
-
-  builder = ./builder.sh;
-
-  src =
-    if !acceptLicense && (openSha256 == null) then
-      throwLicense
-    else if stdenv.hostPlatform.system == "x86_64-linux" then
-      fetchurl {
-        urls =
-          if args ? url then
-            [ args.url ]
-          else
-            [
-              "https://us.download.nvidia.com/XFree86/Linux-x86_64/${version}/NVIDIA-Linux-x86_64-${version}${pkgSuffix}.run"
-              "https://download.nvidia.com/XFree86/Linux-x86_64/${version}/NVIDIA-Linux-x86_64-${version}${pkgSuffix}.run"
-            ];
-        sha256 = sha256_64bit;
-      }
-    else if stdenv.hostPlatform.system == "i686-linux" then
-      fetchurl {
-        urls =
-          if args ? url then
-            [ args.url ]
-          else
-            [
-              "https://us.download.nvidia.com/XFree86/Linux-x86/${version}/NVIDIA-Linux-x86-${version}${pkgSuffix}.run"
-              "https://download.nvidia.com/XFree86/Linux-x86/${version}/NVIDIA-Linux-x86-${version}${pkgSuffix}.run"
-            ];
-        sha256 = sha256_32bit;
-      }
-    else if stdenv.hostPlatform.system == "aarch64-linux" && sha256_aarch64 != null then
-      fetchurl {
-        urls =
-          if args ? url then
-            [ args.url ]
-          else
-            [
-              "https://us.download.nvidia.com/XFree86/aarch64/${version}/NVIDIA-Linux-aarch64-${version}${pkgSuffix}.run"
-              "https://download.nvidia.com/XFree86/Linux-aarch64/${version}/NVIDIA-Linux-aarch64-${version}${pkgSuffix}.run"
-            ];
-        sha256 = sha256_aarch64;
-      }
-    else
-      throw "nvidia-x11 does not support platform ${stdenv.hostPlatform.system}";
-
-  patches = if libsOnly then null else patches;
-  inherit prePatch postPatch patchFlags;
-  inherit preInstall postInstall;
-  inherit version useGLVND useProfiles;
-  inherit (stdenv.hostPlatform) system;
-  inherit i686bundled;
-
-  outputs = [
-    "out"
-  ]
-  ++ lib.optional i686bundled "lib32"
-  ++ lib.optionals (!libsOnly) [
-    "bin"
-    "modsrc"
-  ]
-  ++ lib.optional (!libsOnly && firmware) "firmware";
-  outputDev = if libsOnly then null else "bin";
-
-  dontStrip = true;
-  dontPatchELF = true;
-
-  libPath = libPathFor pkgs;
-  libPath32 = lib.optionalString i686bundled (libPathFor pkgsi686Linux);
-
-  nativeBuildInputs = [
-    libarchive
-    jq
-  ]
-  # NVIDIA has changed the compression format of their driver to zstd since version 530.30.02
-  # https://forums.developer.nvidia.com/t/linux-solaris-and-freebsd-driver-530-30-02-beta/244406
-  ++ (if (lib.versionAtLeast version "530") then [ zstd ] else [ which ]);
-
-  passthru =
+  # The main build: extracts libraries, binaries, kernel module sources
+  # and firmware from the NVIDIA driver installer.
+  nvidiaDriver =
     let
-      fetchFromGithubOrNvidia =
-        {
-          owner,
-          repo,
-          rev,
-          ...
-        }@args:
-        let
-          args' = removeAttrs args [
-            "owner"
-            "repo"
-            "rev"
-          ];
-          baseUrl = "https://github.com/${owner}/${repo}";
-        in
-        fetchzip (
-          args'
-          // {
-            urls = [
-              "${baseUrl}/archive/${rev}.tar.gz"
-              "https://download.nvidia.com/XFree86/${repo}/${repo}-${rev}.tar.bz2"
-            ];
-            # github and nvidia use different compression algorithms,
-            #  use an invalid file extension to force detection.
-            extension = "tar.??";
-          }
-        );
+      # Driver arguments shared between the main build and the i686 lib32 build.
+      driverArgs = {
+        inherit
+          version
+          url
+          sha256_32bit
+          sha256_64bit
+          sha256_aarch64
+          openSha256
+          useGLVND
+          useProfiles
+          useFabricmanager
+          ibtSupport
+          prePatch
+          postPatch
+          patchFlags
+          patches
+          preInstall
+          postInstall
+          broken
+          brokenOpen
+          ;
+      };
     in
-    {
+    callPackage ./binaries.nix (
+      driverArgs
+      // {
+        inherit libsOnly;
+        lib32 =
+          (pkgsi686Linux.callPackage ./binaries.nix (
+            driverArgs
+            // {
+              libsOnly = true;
+              lib32 = null;
+              firmware = false;
+            }
+          )).out;
+      }
+    );
+in
+nvidiaDriver.overrideAttrs (
+  finalAttrs: prevAttrs: {
+    passthru = lib.recursiveUpdate prevAttrs.passthru {
       mod =
         if !libsOnly then
           callPackage ./kernel-modules.nix {
             open = false;
             nvidia_x11 = finalAttrs.finalPackage;
-            # build files already patched when building the main package, so no need to patch them again
+            # build files already patched when building the main package,
+            # so no need to patch them again
             patches = [ ];
-            inherit broken;
+            inherit broken fetchFromGithubOrNvidia;
           }
         else
           { };
@@ -270,25 +180,39 @@ stdenv.mkDerivation (finalAttrs: {
             }) patches)
             ++ patchesOpen;
           broken = brokenOpen;
+          fetchFromGithubOrNvidia =
+            if fetchOpenFromNvidia then
+              fetchFromGithubOrNvidia
+            else
+              args:
+              fetchFromGitHub (
+                removeAttrs args [
+                  "nvrepo"
+                  "nvext"
+                  "postFetch"
+                ]
+              );
         }
       ) openSha256;
       settings =
         if useSettings then
-          (if settings32Bit then pkgsi686Linux.callPackage else callPackage)
-            (import ./settings.nix finalAttrs.finalPackage settingsSha256)
-            {
-              withGtk2 = preferGtk2;
-              withGtk3 = !preferGtk2;
-              fetchFromGitHub = fetchFromGithubOrNvidia;
-            }
+          (if settings32Bit then pkgsi686Linux.callPackage else callPackage) ./settings.nix {
+            nvidia_x11 = finalAttrs.finalPackage;
+            version = settingsVersion;
+            hash = settingsSha256;
+            withGtk2 = preferGtk2;
+            withGtk3 = !preferGtk2;
+            inherit fetchFromGithubOrNvidia;
+          }
         else
           { };
       persistenced =
         if usePersistenced then
           lib.mapNullable (
             hash:
-            callPackage (import ./persistenced.nix finalAttrs.finalPackage hash) {
-              fetchFromGitHub = fetchFromGithubOrNvidia;
+            callPackage ./persistenced.nix {
+              version = persistencedVersion;
+              inherit fetchFromGithubOrNvidia hash;
             }
           ) persistencedSha256
         else
@@ -296,42 +220,19 @@ stdenv.mkDerivation (finalAttrs: {
       fabricmanager =
         if useFabricmanager then
           lib.mapNullable (
-            hash: callPackage (import ./fabricmanager.nix finalAttrs.finalPackage hash) { }
+            hash:
+            callPackage ./fabricmanager.nix {
+              version = fabricmanagerVersion;
+              inherit hash;
+            }
           ) fabricmanagerSha256
         else
           { };
-      settingsVersion = if settingsVersion != null then settingsVersion else finalAttrs.version;
-      persistencedVersion =
-        if persistencedVersion != null then persistencedVersion else finalAttrs.version;
-      fabricmanagerVersion =
-        if fabricmanagerVersion != null then fabricmanagerVersion else finalAttrs.version;
-      compressFirmware = false;
-      ibtSupport = ibtSupport || (lib.versionAtLeast version "530");
-    }
-    // lib.optionalAttrs (!i686bundled) {
-      inherit lib32;
+      inherit
+        settingsVersion
+        persistencedVersion
+        fabricmanagerVersion
+        ;
     };
-
-  meta = {
-    homepage = "https://www.nvidia.com/object/unix.html";
-    description = "${
-      if useFabricmanager then "Data Center" else "X.org"
-    } driver and kernel module for NVIDIA cards";
-    license = lib.licenses.unfreeRedistributable;
-    platforms = [
-      "x86_64-linux"
-    ]
-    ++ lib.optionals (sha256_32bit != null) [ "i686-linux" ]
-    ++ lib.optionals (sha256_aarch64 != null) [ "aarch64-linux" ];
-    sourceProvenance = with lib.sourceTypes; [
-      binaryNativeCode
-      binaryFirmware
-    ];
-    maintainers = with lib.maintainers; [
-      kiskae
-      edwtjo
-    ];
-    priority = 4; # resolves collision with xorg-server's "lib/xorg/modules/extensions/libglx.so"
-    broken = broken && brokenOpen;
-  };
-})
+  }
+)

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -22,6 +22,8 @@
   persistencedVersion ? version,
   fabricmanagerSha256 ? null,
   fabricmanagerVersion ? version,
+  modprobeSha256 ? null,
+  modprobeVersion ? version,
   # Whether to fetch the open-source kernel module sources from NVIDIA
   fetchOpenFromNvidia ? false,
   # Feature flags
@@ -228,10 +230,19 @@ nvidiaDriver.overrideAttrs (
           ) fabricmanagerSha256
         else
           { };
+      modprobe = lib.mapNullable (
+        hash:
+        callPackage ./modprobe.nix {
+          inherit hash fetchFromGithubOrNvidia;
+          version = modprobeVersion;
+          nvidia_x11 = finalAttrs.finalPackage;
+        }
+      ) modprobeSha256;
       inherit
         settingsVersion
         persistencedVersion
         fabricmanagerVersion
+        modprobeVersion
         ;
     };
   }

--- a/pkgs/os-specific/linux/nvidia-x11/kernel-modules.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/kernel-modules.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchFromGitHub,
+  fetchFromGithubOrNvidia,
   kernel,
   kernelModuleMakeFlags,
   nvidia_x11,
@@ -19,11 +19,15 @@ stdenv.mkDerivation {
 
   src =
     if open then
-      fetchFromGitHub {
+      fetchFromGithubOrNvidia {
         owner = "NVIDIA";
         repo = "open-gpu-kernel-modules";
         tag = nvidia_x11.version;
+        nvrepo = "NVIDIA-kernel-module-source";
+        nvext = "xz";
         inherit hash;
+        # remove files which causes hash mismatches
+        postFetch = "rm -rf $out/.github $out/CHANGELOG.md";
       }
     else
       nvidia_x11.modsrc;

--- a/pkgs/os-specific/linux/nvidia-x11/modprobe.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/modprobe.nix
@@ -1,18 +1,21 @@
 {
   stdenv,
   lib,
-  fetchFromGitHub,
+  fetchFromGithubOrNvidia,
   gnum4,
+  nvidia_x11,
+  version,
+  hash,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "nvidia-modprobe";
-  version = "595.71.05";
+  inherit version;
 
-  src = fetchFromGitHub {
+  src = fetchFromGithubOrNvidia {
     owner = "NVIDIA";
     repo = "nvidia-modprobe";
-    rev = finalAttrs.version;
-    hash = "sha256-XVWvnUZkEqEh3UjPIU6DaZuYU9DvjfIMsWbLJ78jJWs=";
+    tag = finalAttrs.version;
+    inherit hash;
   };
 
   nativeBuildInputs = [ gnum4 ];
@@ -25,6 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Load the NVIDIA kernel module and create NVIDIA character device files";
     homepage = "https://github.com/NVIDIA/nvidia-modprobe";
     license = lib.licenses.gpl2;
-    platforms = lib.platforms.linux;
+    platforms = nvidia_x11.meta.platforms;
+    mainProgram = "nvidia-modprobe";
   };
 })

--- a/pkgs/os-specific/linux/nvidia-x11/persistenced.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/persistenced.nix
@@ -1,28 +1,28 @@
-nvidia_x11: sha256:
-
 {
   stdenv,
   lib,
-  fetchFromGitHub,
+  fetchFromGithubOrNvidia,
   buildPackages,
   m4,
   pkg-config,
   addDriverRunpath,
   libtirpc,
+  version,
+  hash,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "nvidia-persistenced";
-  version = nvidia_x11.persistencedVersion;
+  inherit version;
 
-  src = fetchFromGitHub {
+  src = fetchFromGithubOrNvidia {
     owner = "NVIDIA";
     repo = "nvidia-persistenced";
-    rev = nvidia_x11.persistencedVersion;
-    inherit sha256;
+    tag = finalAttrs.version;
+    inherit hash;
   };
 
-  env = lib.optionalAttrs (lib.versionOlder nvidia_x11.persistencedVersion "450.51") {
+  env = lib.optionalAttrs (lib.versionOlder finalAttrs.version "450.51") {
     NIX_CFLAGS_COMPILE = toString [ "-I${libtirpc.dev}/include/tirpc" ];
     NIX_LDFLAGS = toString [ "-ltirpc" ];
   };
@@ -61,8 +61,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/NVIDIA/nvidia-persistenced";
     description = "NVIDIA driver persistence daemon";
     license = lib.licenses.mit;
-    platforms = nvidia_x11.meta.platforms;
     maintainers = [ ];
     mainProgram = "nvidia-persistenced";
   };
-}
+})

--- a/pkgs/os-specific/linux/nvidia-x11/settings.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/settings.nix
@@ -1,9 +1,7 @@
-nvidia_x11: sha256:
-
 {
   stdenv,
   lib,
-  fetchFromGitHub,
+  fetchFromGithubOrNvidia,
   fetchpatch,
   pkg-config,
   m4,
@@ -21,16 +19,19 @@ nvidia_x11: sha256:
   libglvnd,
   wrapGAppsHook3,
   addDriverRunpath,
+  nvidia_x11,
+  version,
+  hash,
   withGtk2 ? false,
   withGtk3 ? true,
 }:
 
 let
-  src = fetchFromGitHub {
+  src = fetchFromGithubOrNvidia {
     owner = "NVIDIA";
     repo = "nvidia-settings";
-    rev = nvidia_x11.settingsVersion;
-    inherit sha256;
+    tag = version;
+    inherit hash;
   };
 
   meta = {
@@ -40,8 +41,7 @@ let
 
   libXNVCtrl = stdenv.mkDerivation {
     pname = "libXNVCtrl";
-    version = nvidia_x11.settingsVersion;
-    inherit src;
+    inherit version src;
 
     buildInputs = [
       libxrandr
@@ -61,7 +61,7 @@ let
     patches = [
       # Patch the Makefile to also produce a shared library.
       (
-        if lib.versionOlder nvidia_x11.settingsVersion "400" then
+        if lib.versionOlder version "400" then
           ./libxnvctrl-build-shared-3xx.patch
         else
           ./libxnvctrl-build-shared.patch
@@ -97,22 +97,16 @@ in
 
 stdenv.mkDerivation {
   pname = "nvidia-settings";
-  version = nvidia_x11.settingsVersion;
-
-  inherit src;
+  inherit version src;
 
   patches =
-    lib.optional (lib.versionOlder nvidia_x11.settingsVersion "440") (fetchpatch {
+    lib.optional (lib.versionOlder version "440") (fetchpatch {
       # fixes "multiple definition of `VDPAUDeviceFunctions'" linking errors
       url = "https://github.com/NVIDIA/nvidia-settings/commit/a7c1f5fce6303a643fadff7d85d59934bd0cf6b6.patch";
       hash = "sha256-ZwF3dRTYt/hO8ELg9weoz1U/XcU93qiJL2d1aq1Jlak=";
     })
     ++
-      lib.optional
-        (
-          (lib.versionAtLeast nvidia_x11.settingsVersion "515.43.04")
-          && (lib.versionOlder nvidia_x11.settingsVersion "545.29")
-        )
+      lib.optional ((lib.versionAtLeast version "515.43.04") && (lib.versionOlder version "545.29"))
         (fetchpatch {
           # fix wayland support for compositors that use wl_output version 4
           url = "https://github.com/NVIDIA/nvidia-settings/pull/99/commits/2e0575197e2b3247deafd2a48f45afc038939a06.patch";
@@ -152,7 +146,7 @@ stdenv.mkDerivation {
     dbus
     vulkan-headers
   ]
-  ++ lib.optionals (withGtk2 || lib.versionOlder nvidia_x11.settingsVersion "525.53") [ gtk2 ]
+  ++ lib.optionals (withGtk2 || lib.versionOlder version "525.53") [ gtk2 ]
   ++ lib.optionals withGtk3 [
     gtk3
     librsvg


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
## Task list
- [x] Split the utility extraction and tool namespace without altering the semantics
  - [x] Split with the help of LLM
  - [ ] Verify that the semantics have not been altered (help needed)
- [x] Move `nvidia-modprobe` to the `nvidiaPackages` namespace
- (Following changes will be presented in a new PR)
- [ ] Create a scope instead of using passthru to expose tools
  - [ ] Switch to scope
  - [ ] Provide a set of user-space tools that are not binded on a specific Linux kernel version
  - [ ] Modify the corresponding module

Although this PR relies heavily on LLM assistance, I believe these changes can be easily verified by ensuring the semantics remain unchanged.
I think the upcoming breaking changes should be included in a new PR.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
