### PR TITLE
nixos/cloudflared: add per-tunnel protocol option

### DIFF
--- a/nixos/modules/services/networking/cloudflared.nix
+++ b/nixos/modules/services/networking/cloudflared.nix
@@ -240,6 +240,25 @@ in
                 example = "auto";
               };
 
+              protocol = lib.mkOption {
+                type = lib.types.enum [
+                  "auto"
+                  "http2"
+                  "quic"
+                ];
+                default = "auto";
+                description = ''
+                  Specifies the protocol used to establish a connection between `cloudflared` and the Cloudflare global network.
+
+                  The value `auto` lets `cloudflared` choose the protocol (currently QUIC, falling back to HTTP/2).
+                  Set to `http2` to work around QUIC/UDP connectivity issues, such as restrictive firewalls, broken UDP path MTU, or QUIC interop bugs.
+                  Set to `quic` to force QUIC.
+
+                  See [Tunnel run parameters](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/configure-tunnels/cloudflared-parameters/run-parameters/#protocol).
+                '';
+                example = "http2";
+              };
+
               default = lib.mkOption {
                 type = lib.types.str;
                 description = ''
@@ -397,6 +416,7 @@ in
         environment = {
           TUNNEL_ORIGIN_CERT = lib.mkIf (certFile != null) "%d/cert.pem";
           TUNNEL_EDGE_IP_VERSION = tunnel.edgeIPVersion;
+          TUNNEL_TRANSPORT_PROTOCOL = tunnel.protocol;
         };
       }
     ) config.services.cloudflared.tunnels;


### PR DESCRIPTION
cloudflared defaults to QUIC.
On networks with restrictive UDP handling, or in the face of QUIC interop bugs, this can be unreliable.
For example, see https://github.com/zhaofengli/attic/issues/281.
The only declarative workaround so far has been to wrap `cloudflared` in a shell script that injects `--protocol http2`.

Add a per-tunnel `protocol` option (enum of `auto`/`http2`/`quic`).
It sets `TUNNEL_TRANSPORT_PROTOCOL` on the systemd service, mirroring the existing `edgeIPVersion` option.

The default `auto` preserves current behaviour.
cloudflared treats `TUNNEL_TRANSPORT_PROTOCOL=auto` like omitting the flag, so existing configurations are unaffected.

cc @bbigras @anpin

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
