### PR TITLE
python3Packages.pydantic: 2.12.5 -> 2.13.4

### DIFF
--- a/pkgs/development/python-modules/pydantic-core/default.nix
+++ b/pkgs/development/python-modules/pydantic-core/default.nix
@@ -2,9 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  cargo,
   rustPlatform,
-  rustc,
   typing-extensions,
   pytestCheckHook,
   hypothesis,
@@ -21,26 +19,31 @@
 let
   pydantic-core = buildPythonPackage rec {
     pname = "pydantic-core";
-    version = "2.41.5";
+    version = "2.46.4";
     pyproject = true;
 
     src = fetchFromGitHub {
       owner = "pydantic";
-      repo = "pydantic-core";
-      tag = "v${version}";
-      hash = "sha256-oIYHLSep8tWOXEaUybXG8Gv9WBoPGQ1Aj7QyqYksvMw=";
+      repo = "pydantic";
+      tag = "core-v${version}";
+      hash = "sha256-G4Xo6BF6tOn4g/qG3RNDP3/+lYnCOuw3AB1OrVOGcSA=";
     };
 
+    sourceRoot = "${src.name}/pydantic-core";
+
     cargoDeps = rustPlatform.fetchCargoVendor {
-      inherit pname version src;
-      hash = "sha256-Kvc0a34C6oGc9oS/iaPaazoVUWn5ABUgrmPa/YocV+Y=";
+      inherit
+        pname
+        version
+        src
+        sourceRoot
+        ;
+      hash = "sha256-5L317YTV7/Bc/YJLLzc745oJntiYkcZupdeUxiQwcOU=";
     };
 
     nativeBuildInputs = [
-      cargo
       rustPlatform.cargoSetupHook
       rustPlatform.maturinBuildHook
-      rustc
     ];
 
     dependencies = [ typing-extensions ];
@@ -64,9 +67,8 @@ let
     ];
 
     meta = {
-      changelog = "https://github.com/pydantic/pydantic-core/releases/tag/${src.tag}";
       description = "Core validation logic for pydantic written in rust";
-      homepage = "https://github.com/pydantic/pydantic-core";
+      homepage = "https://github.com/pydantic/pydantic/tree/main/pydantic-core";
       license = lib.licenses.mit;
       inherit (pydantic.meta) maintainers;
     };

--- a/pkgs/development/python-modules/pydantic/default.nix
+++ b/pkgs/development/python-modules/pydantic/default.nix
@@ -3,7 +3,6 @@
   python,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
 
   # build-system
   hatchling,
@@ -19,31 +18,26 @@
   cloudpickle,
   email-validator,
   dirty-equals,
+  hypothesis,
+  inline-snapshot,
   jsonschema,
   pytestCheckHook,
   pytest-mock,
   pytest-run-parallel,
+  pytest-timeout,
 }:
 
 buildPythonPackage rec {
   pname = "pydantic";
-  version = "2.12.5";
+  version = "2.13.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pydantic";
     repo = "pydantic";
     tag = "v${version}";
-    hash = "sha256-9TRLtVNBw2WHQnS0XFHg16Q7FdpTf3e2nb5qE5rlLUA=";
+    hash = "sha256-G4Xo6BF6tOn4g/qG3RNDP3/+lYnCOuw3AB1OrVOGcSA=";
   };
-
-  patches = lib.optionals (lib.versionAtLeast python.version "3.14.1") [
-    # Fix build with python 3.14.1
-    (fetchpatch {
-      url = "https://github.com/pydantic/pydantic/commit/53cb5f830207dd417d20e0e55aab2e6764f0d6fc.patch";
-      hash = "sha256-Y1Ob1Ei0rrw0ua+0F5L2iE2r2RdpI9DI2xuiu9pLr5Y=";
-    })
-  ];
 
   postPatch = ''
     sed -i "/--benchmark/d" pyproject.toml
@@ -68,15 +62,19 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     cloudpickle
     dirty-equals
+    hypothesis
+    (inline-snapshot.overridePythonAttrs { doCheck = false; })
     jsonschema
     pytest-mock
     pytest-run-parallel
+    pytest-timeout
     pytestCheckHook
   ]
   ++ lib.concatAttrValues optional-dependencies;
 
   disabledTestPaths = [
     "tests/benchmarks"
+    "tests/pydantic_core/benchmarks"
 
     # avoid cyclic dependency
     "tests/test_docs.py"


### PR DESCRIPTION
Diff: https://github.com/pydantic/pydantic/compare/v2.12.5...v2.13.4

Changelog: https://github.com/pydantic/pydantic/blob/v2.13.4/HISTORY.md

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
