### PR TITLE
nixbox: init at 0.1.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22702,6 +22702,12 @@
     githubId = 314564;
     name = "Ryan Lahfa";
   };
+  rajveer = {
+    email = "therajveersingh@icloud.com";
+    github = "SINGH-RAJVEER";
+    githubId = 168363474;
+    name = "Rajveer Singh";
+  };
   rake5k = {
     email = "christian@harke.ch";
     github = "rake5k";

--- a/pkgs/by-name/ni/nixbox/package.nix
+++ b/pkgs/by-name/ni/nixbox/package.nix
@@ -1,0 +1,22 @@
+{ lib, rustPlatform, fetchCrate }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "nixbox";
+  version = "0.1.0";
+
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-+xOoEV4wUxLmeHZd7W32sVAMu6cCP4/NlSHAURkeCOM=";
+  };
+
+  cargoHash = "sha256-3YJ56WxmTSNSSe8KhX0SLhMt1MXyDa1XAgUsyHHbLtI=";
+
+  meta = with lib; {
+    description = "TUI package manager for NixOS that wires selections into your flake + home-manager config";
+    homepage = "https://github.com/SINGH-RAJVEER/nix-box";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ rajveer ];
+    mainProgram = "nixbox";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/by-name/ni/nixbox/package.nix
+++ b/pkgs/by-name/ni/nixbox/package.nix
@@ -11,6 +11,8 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-3YJ56WxmTSNSSe8KhX0SLhMt1MXyDa1XAgUsyHHbLtI=";
 
+  __structuredAttrs = true;
+
   meta = with lib; {
     description = "TUI package manager for NixOS that wires selections into your flake + home-manager config";
     homepage = "https://github.com/SINGH-RAJVEER/nix-box";

--- a/pkgs/by-name/ni/nixbox/package.nix
+++ b/pkgs/by-name/ni/nixbox/package.nix
@@ -1,15 +1,19 @@
-{ lib, rustPlatform, fetchCrate }:
+{
+  lib,
+  rustPlatform,
+  fetchCrate,
+}:
 
 rustPlatform.buildRustPackage rec {
   pname = "nixbox";
-  version = "0.1.0";
+  version = "0.1.8";
 
   src = fetchCrate {
     inherit pname version;
-    hash = "sha256-+xOoEV4wUxLmeHZd7W32sVAMu6cCP4/NlSHAURkeCOM=";
+    hash = "sha256-+BYx8GecYy6Kc4zLlqskrF/5ZH/YzIIpTEe7SAhWhqM=";
   };
 
-  cargoHash = "sha256-3YJ56WxmTSNSSe8KhX0SLhMt1MXyDa1XAgUsyHHbLtI=";
+  cargoHash = "sha256-n2+1fXZhOy6CwRKNuEcZiQvS6BE1CKSgITDl/IhyTGc=";
 
   __structuredAttrs = true;
 


### PR DESCRIPTION
Add [nixbox](https://github.com/SINGH-RAJVEER/nix-box), a TUI package manager for NixOS that wires package selections into your flake and home-manager config.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests
  - [ ] Package tests at `passthru.tests`
  - [ ] Tests in lib/tests or pkgs/test
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.