### PR TITLE
python3Packages.cutlass: init at 0.4.0

### DIFF
--- a/pkgs/development/python-modules/cutlass/default.nix
+++ b/pkgs/development/python-modules/cutlass/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  numpy,
+  pandas,
+
+  # optional-dependencies
+  matplotlib,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "cutlass";
+  version = "0.4.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  # No tags on GitHub
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-+9Y7twguzeqGJP9813hAStzjLVlTeLD+JHrHndzA9AM=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    numpy
+    pandas
+  ];
+
+  optional-dependencies = {
+    plots = [
+      matplotlib
+    ];
+  };
+
+  pythonImportsCheck = [ "cutlass" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Rectified L1 logistic regression with CUTLASS critical range encoding";
+    homepage = "https://github.com/jworender/cutlass";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3456,6 +3456,8 @@ self: super: with self; {
 
   cutie = callPackage ../development/python-modules/cutie { };
 
+  cutlass = callPackage ../development/python-modules/cutlass { };
+
   cv2-enumerate-cameras = callPackage ../development/python-modules/cv2-enumerate-cameras { };
 
   cvelib = callPackage ../development/python-modules/cvelib { };


### PR DESCRIPTION
## Things done

Add [cutlass](https://github.com/jworender/cutlass), a Python implementation of rectified L1 logistic regression with CUTLASS critical range encoding.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
