### PR TITLE
auto-patchelf: catch OSError for compressed ELF parsing failures

### DIFF
--- a/pkgs/by-name/au/auto-patchelf/source/auto-patchelf.py
+++ b/pkgs/by-name/au/auto-patchelf/source/auto-patchelf.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import errno
 import os
 import pprint
 import subprocess
@@ -195,6 +196,12 @@ def populate_cache(initial: list[Path], recursive: bool =False) -> None:
             except ELFError:
                 # Not an ELF file in the right format
                 pass
+            except OSError as e:
+                if e.errno == errno.EINVAL:
+                    # pyelftools can raise EINVAL for certain compressed sections.
+                    pass
+                else:
+                    raise
 
 
 def find_dependency(soname: str, soarch: str, soabi: str) -> Optional[Path]:
@@ -343,6 +350,10 @@ def auto_patchelf_file(logger: Logger, path: Path, runtime_deps: list[Path], app
 
     except ELFError:
         return []
+    except OSError as e:
+        if e.errno == errno.EINVAL:
+            return []
+        raise
 
     # these platforms are packaged in nixpkgs with ld.so in a separate derivation
     # than libc.so and friends. keep_libc is mandatory.


### PR DESCRIPTION
Fixes #519275

pyelftools raises `OSError: [Errno 22] Invalid argument` instead of `ELFError`
when parsing compressed ELF sections (`SHF_COMPRESSED`), for example in
`vscode` >= 1.118.

`auto-patchelf` currently catches `ELFError` but not `OSError` in the relevant
ELF parsing paths. This causes builds to abort instead of skipping files that
cannot be parsed as usable ELF inputs.

Extend the exception handling in `populate_cache` and `auto_patchelf_file` to
also catch `OSError`, consistent with the existing intent of ignoring
non-parseable ELF inputs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
