### PR TITLE
mlflow{,-server}: fix server startup and missing UI

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10136,6 +10136,12 @@
     githubId = 6893840;
     name = "Yacine Hmito";
   };
+  gquetel = {
+    email = "gregor.quetel@telecom-paris.fr";
+    github = "gquetel";
+    githubId = 48437427;
+    name = "Grégor Quetel";
+  };
   gracicot = {
     email = "dev@gracicot.com";
     matrix = "@gracicot-59e8f173d73408ce4f7ac803:gitter.im";

--- a/pkgs/by-name/ml/mlflow-server/package.nix
+++ b/pkgs/by-name/ml/mlflow-server/package.nix
@@ -1,37 +1,10 @@
-{ python3Packages, writers }:
+{ python3Packages }:
 
-let
-  py = python3Packages;
-
-  gunicornScript = writers.writePython3 "gunicornMlflow" { } ''
-    import re
-    import sys
-    from gunicorn.app.wsgiapp import run
-    if __name__ == '__main__':
-        sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', ''', sys.argv[0])
-        sys.exit(run())
-  '';
-in
-py.toPythonApplication (
-  py.mlflow.overridePythonAttrs (old: {
-
-    propagatedBuildInputs = old.dependencies ++ [
-      py.boto3
-      py.mysqlclient
+python3Packages.toPythonApplication (
+  python3Packages.mlflow.overridePythonAttrs (old: {
+    propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [
+      python3Packages.boto3
+      python3Packages.mysqlclient
     ];
-
-    postPatch = (old.postPatch or "") + ''
-      cat mlflow/utils/process.py
-
-      substituteInPlace mlflow/utils/process.py --replace-fail \
-        "process = subprocess.Popen(" \
-        "cmd[0]='${gunicornScript}'; process = subprocess.Popen("
-    '';
-
-    postInstall = ''
-      gpath=$out/bin/gunicornMlflow
-      cp ${gunicornScript} $gpath
-      chmod 555 $gpath
-    '';
   })
 )

--- a/pkgs/development/python-modules/mlflow-skinny/default.nix
+++ b/pkgs/development/python-modules/mlflow-skinny/default.nix
@@ -1,5 +1,7 @@
 {
+  lib,
   buildPythonPackage,
+  fetchFromGitHub,
   mlflow,
 
   # build-system
@@ -30,9 +32,16 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "mlflow-skinny";
-  inherit (mlflow) version src;
+  inherit (mlflow) version;
   pyproject = true;
   __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "mlflow";
+    repo = "mlflow";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-OxhM+KCem0sb9cwtyzrUD/MGfoiiCfgU47qipYRDaFk=";
+  };
 
   sourceRoot = "${finalAttrs.src.name}/libs/skinny";
 
@@ -69,5 +78,6 @@ buildPythonPackage (finalAttrs: {
   meta = mlflow.meta // {
     description = "Lightweight version of MLflow that is designed to minimize package size";
     homepage = "https://github.com/mlflow/mlflow/tree/master/libs/skinny";
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
   };
 })

--- a/pkgs/development/python-modules/mlflow-tracing/default.nix
+++ b/pkgs/development/python-modules/mlflow-tracing/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildPythonPackage,
+  fetchFromGitHub,
   mlflow,
 
   # build-system
@@ -15,9 +16,6 @@
   packaging,
   protobuf,
   pydantic,
-
-  # tests
-  pytestCheckHook,
 }:
 buildPythonPackage (finalAttrs: {
   pname = "mlflow-tracing";
@@ -25,13 +23,16 @@ buildPythonPackage (finalAttrs: {
   pyproject = true;
   __structuredAttrs = true;
 
-  inherit (mlflow) src;
+  src = fetchFromGitHub {
+    owner = "mlflow";
+    repo = "mlflow";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-OxhM+KCem0sb9cwtyzrUD/MGfoiiCfgU47qipYRDaFk=";
+  };
 
   sourceRoot = "${finalAttrs.src.name}/libs/tracing";
 
-  build-system = [
-    setuptools
-  ];
+  build-system = [ setuptools ];
 
   dependencies = [
     cachetools
@@ -53,6 +54,9 @@ buildPythonPackage (finalAttrs: {
     description = "Open-Source SDK for observability and monitoring GenAI applications";
     homepage = "https://github.com/mlflow/mlflow/tree/master/libs/tracing";
     inherit (mlflow.meta) license;
-    maintainers = with lib.maintainers; [ GaetanLepage ];
+    maintainers = with lib.maintainers; [
+      GaetanLepage
+      gquetel
+    ];
   };
 })

--- a/pkgs/development/python-modules/mlflow/default.nix
+++ b/pkgs/development/python-modules/mlflow/default.nix
@@ -1,10 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
-
-  # build-system
-  setuptools,
+  fetchPypi,
 
   # dependencies
   aiohttp,
@@ -31,26 +28,32 @@
 buildPythonPackage (finalAttrs: {
   pname = "mlflow";
   version = "3.12.0";
-  pyproject = true;
+  format = "wheel";
   __structuredAttrs = true;
 
-  src = fetchFromGitHub {
-    owner = "mlflow";
-    repo = "mlflow";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-OxhM+KCem0sb9cwtyzrUD/MGfoiiCfgU47qipYRDaFk=";
+  # We build from the PyPI wheel rather than fetchFromGitHub, because the mlflow-server
+  # JS UI is absent from GitHub but provided in the wheel.
+  src = fetchPypi {
+    pname = "mlflow";
+    inherit (finalAttrs) version;
+    format = "wheel";
+    dist = "py3";
+    python = "py3";
+    hash = "sha256-4cKO1MSFV8xSx2bxfxylgmdT3fJB1D8w+ZxF9+prPOA=";
   };
 
-  # ppyproject.release.toml is the one shipped in the Pypi package, so we use it too.
-  postPatch = ''
-    mv pyproject.release.toml pyproject.toml
+  # Nix-wrapped python populates sys.path via NIX_PYTHONPATH/site hooks,
+  # but PYTHONPATH stays unset in os.environ. mlflow spawns the server
+  # in a subprocess with a curated env, so without this patch the child
+  # interpreter cannot import uvicorn / mlflow itself.
+  postInstall = ''
+    patch -p1 -d "$out/lib/python"*/site-packages < ${./subprocess-pythonpath.patch}
   '';
-
-  build-system = [ setuptools ];
 
   pythonRelaxDeps = [
     "cryptography"
   ];
+
   dependencies = [
     aiohttp
     alembic
@@ -85,8 +88,12 @@ buildPythonPackage (finalAttrs: {
     description = "Open source platform for the machine learning lifecycle";
     mainProgram = "mlflow";
     homepage = "https://github.com/mlflow/mlflow";
-    changelog = "https://github.com/mlflow/mlflow/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/mlflow/mlflow/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.asl20;
+    # Build from wheel which contains pure Python and pre-built JS bundle.
+    sourceProvenance = with lib.sourceTypes; [
+      binaryBytecode
+    ];
     maintainers = with lib.maintainers; [
       GaetanLepage
     ];

--- a/pkgs/development/python-modules/mlflow/default.nix
+++ b/pkgs/development/python-modules/mlflow/default.nix
@@ -96,6 +96,7 @@ buildPythonPackage (finalAttrs: {
     ];
     maintainers = with lib.maintainers; [
       GaetanLepage
+      gquetel
     ];
   };
 })

--- a/pkgs/development/python-modules/mlflow/subprocess-pythonpath.patch
+++ b/pkgs/development/python-modules/mlflow/subprocess-pythonpath.patch
@@ -1,0 +1,14 @@
+--- a/mlflow/server/__init__.py
++++ b/mlflow/server/__init__.py
+@@ -471,6 +471,11 @@
+             else tempfile.mkdtemp()
+         )
++    # In Nix-packaged environments sys.path is populated by wrappers but
++    # PYTHONPATH is never set in os.environ, so subprocesses (uvicorn,
++    # gunicorn) cannot find packages. Propagate it when not already set.
++    if "PYTHONPATH" not in os.environ:
++        env_map.setdefault("PYTHONPATH", os.pathsep.join(p for p in sys.path if p))
+
+     server_proc = _exec_cmd(
+         full_command,
+         extra_env=env_map,


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Motivation
[mlflow/mlflow#17038](https://github.com/mlflow/mlflow/pull/17038) switched the default tracking-server backend from gunicorn to uvicorn. Combined with the GitHub source tree no longer shipping the pre-built JS UI bundle, `mlflow server` is currently unusable in two distinct ways:

```
$ nix-shell -p mlflow-server --run "mlflow server" 
Backend store URI not provided. Using sqlite:///mlflow.db
Registry store URI not provided. Using backend store URI.
2026/05/12 12:49:12 INFO mlflow.store.db.utils: Creating initial MLflow database tables...
2026/05/12 12:49:12 INFO mlflow.store.db.utils: Updating database tables
[MLflow] Security middleware enabled with default settings (localhost-only). To allow connections from other hosts, use --host 0.0.0.0 and configure --allowed-hosts and --cors-allowed-origins.
usage: 3zjgc3ghgbzwad1z3wp4k1fpkai1p7xc-gunicornMlflow [OPTIONS] [APP_MODULE]
3zjgc3ghgbzwad1z3wp4k1fpkai1p7xc-gunicornMlflow: error: argument -m/--umask: invalid auto_int value: 'uvicorn'
```

Independently, `python3Packages.mlflow` builds and serves correctly, but the JS UI bundle is missing so the landing page fails:

Server:
```
$ nix-shell -p python3Packages.mlflow --run "mlflow server"
Backend store URI not provided. Using sqlite:///mlflow.db
Registry store URI not provided. Using backend store URI.
[MLflow] Security middleware enabled with default settings (localhost-only). To allow connections from other hosts, use --host 0.0.0.0 and configure --allowed-hosts and --cors-allowed-origins.
2026/05/12 12:56:55 INFO:     Uvicorn running on http://127.0.0.1:5000 (Press CTRL+C to quit)
2026/05/12 12:56:55 INFO:     Started parent process [204719]
2026/05/12 12:56:57 INFO:     Started server process [204723]
2026/05/12 12:56:57 INFO:     Waiting for application startup.
2026/05/12 12:56:57 INFO:     Application startup complete.
2026/05/12 12:56:57 INFO:     127.0.0.1:51968 - "GET / HTTP/1.1" 200 OK
2026/05/12 12:56:58 INFO:     Started server process [204724]
2026/05/12 12:56:58 INFO:     Waiting for application startup.
2026/05/12 12:56:58 INFO:     Application startup complete.
2026/05/12 12:56:58 INFO:     Started server process [204725]
2026/05/12 12:56:58 INFO:     Waiting for application startup.
2026/05/12 12:56:58 INFO:     Application startup complete.
2026/05/12 12:56:58 INFO:     Started server process [204722]
2026/05/12 12:56:58 INFO:     Waiting for application startup.
2026/05/12 12:56:58 INFO:     Application startup complete.
2026/05/12 12:57:01 INFO mlflow.server.jobs.utils: Registered online_scoring_scheduler periodic task (runs every 1 minute)
```

Client:
```
$ curl -fsS http://127.0.0.1:5000 

Unable to display MLflow UI - landing page (index.html) not found.

You are very likely running the MLflow server using a source installation of the Python MLflow
package.

If you are a developer making MLflow source code changes and intentionally running a source
installation of MLflow, you can view the UI by running the Javascript dev server:
https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.md#running-the-javascript-dev-server

Otherwise, uninstall MLflow via 'pip uninstall mlflow', reinstall an official MLflow release
from PyPI via 'pip install mlflow', and rerun the MLflow server.
```

## Changes

- `mlflow-server`:  drop the gunicornMlflow shim and its cmd[0] rewrite. The shim aimed at solving a subprocess-imports problem but only for gunicorn. Once mlflow's default switched to uvicorn the substitution intercepted an argv it could not handle. We instead patch it at the library level instead (in python3Packages.mlflow):
- `python3Packages.mlflow`: add `subprocess-pythonpath.patch`. Spawned process now find their modules by populating `PYTHONPATH` before their invocation. 
- `python3Packages.mlflow`: build from the PyPI wheel rather than `fetchFromGitHub`, since only the wheel ships the compiled JS UI.

## Tests 

### mlflow-server
Server: 
```
$ nix-build -A mlflow-server
/nix/store/6kxzw4hy8sgm8h0l47d31ac87zhlmpkc-python3.13-mlflow-3.11.1
$ ./result/bin/mlflow server
Backend store URI not provided. Using sqlite:///mlflow.db
Registry store URI not provided. Using backend store URI.
[MLflow] Security middleware enabled with default settings (localhost-only). To allow connections from other hosts, use --host 0.0.0.0 and configure --allowed-hosts and --cors-allowed-origins.
2026/05/12 13:19:29 INFO:     Uvicorn running on http://127.0.0.1:5000 (Press CTRL+C to quit)
2026/05/12 13:19:29 INFO:     Started parent process [215336]
2026/05/12 13:19:31 INFO:     Started server process [215339]
2026/05/12 13:19:31 INFO:     Waiting for application startup.
2026/05/12 13:19:31 INFO:     Application startup complete.
2026/05/12 13:19:32 INFO:     Started server process [215342]
2026/05/12 13:19:32 INFO:     Waiting for application startup.
2026/05/12 13:19:32 INFO:     Application startup complete.
2026/05/12 13:19:32 INFO:     Started server process [215341]
2026/05/12 13:19:32 INFO:     Waiting for application startup.
2026/05/12 13:19:32 INFO:     Application startup complete.
2026/05/12 13:19:32 INFO:     Started server process [215340]
2026/05/12 13:19:32 INFO:     Waiting for application startup.
2026/05/12 13:19:32 INFO:     Application startup complete.
2026/05/12 13:19:32 INFO mlflow.server.jobs.utils: Registered online_scoring_scheduler periodic task (runs every 1 minute)
2026/05/12 13:19:34 INFO:     127.0.0.1:42060 - "GET / HTTP/1.1" 200 OK
```

Client: 
```
$ curl -fsS http://127.0.0.1:5000
<!doctype html><html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no"/><link rel="shortcut icon" href="./static-files/favicon.ico"/><meta name="theme-color" content="#000000"/><link rel="manifest" href="./static-files/manifest.json" crossorigin="use-credentials"/><title>MLflow</title><script defer="defer" src="static-files/static/js/main.9479d285.js"></script><link href="static-files/static/css/main.d4520ea4.css" rel="stylesheet"></head><body><noscript>You need to enable JavaScript to run this app.</noscript><div id="root" class="mlflow-ui-container"></div><div id="modal" class="mlflow-ui-container"></div></body></html>
```

### python3Packages.mlflow

Server: 
```
$ nix-build -A python3Packages.mlflow
/nix/store/nh15kax0bbsz3jyx45rvxv240z3z07bz-python3.13-mlflow-3.11.1
$./result/bin/mlflow server
Backend store URI not provided. Using sqlite:///mlflow.db
Registry store URI not provided. Using backend store URI.
[MLflow] Security middleware enabled with default settings (localhost-only). To allow connections from other hosts, use --host 0.0.0.0 and configure --allowed-hosts and --cors-allowed-origins.
2026/05/12 13:27:05 INFO:     Uvicorn running on http://127.0.0.1:5000 (Press CTRL+C to quit)
2026/05/12 13:27:05 INFO:     Started parent process [217361]
2026/05/12 13:27:07 INFO:     Started server process [217364]
2026/05/12 13:27:07 INFO:     Waiting for application startup.
2026/05/12 13:27:07 INFO:     Application startup complete.
2026/05/12 13:27:08 INFO:     Started server process [217367]
2026/05/12 13:27:08 INFO:     Waiting for application startup.
2026/05/12 13:27:08 INFO:     Application startup complete.
2026/05/12 13:27:08 INFO:     Started server process [217366]
2026/05/12 13:27:08 INFO:     Waiting for application startup.
2026/05/12 13:27:08 INFO:     Application startup complete.
2026/05/12 13:27:08 INFO:     Started server process [217365]
2026/05/12 13:27:08 INFO:     Waiting for application startup.
2026/05/12 13:27:08 INFO:     Application startup complete.
2026/05/12 13:27:10 INFO mlflow.server.jobs.utils: Registered online_scoring_scheduler periodic task (runs every 1 minute)
2026/05/12 13:27:11 INFO:     127.0.0.1:40446 - "GET / HTTP/1.1" 200 OK
```

Client: 
```
$ curl -fsS http://127.0.0.1:5000
<!doctype html><html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no"/><link rel="shortcut icon" href="./static-files/favicon.ico"/><meta name="theme-color" content="#000000"/><link rel="manifest" href="./static-files/manifest.json" crossorigin="use-credentials"/><title>MLflow</title><script defer="defer" src="static-files/static/js/main.9479d285.js"></script><link href="static-files/static/css/main.d4520ea4.css" rel="stylesheet"></head><body><noscript>You need to enable JavaScript to run this app.</noscript><div id="root" class="mlflow-ui-container"></div><div id="modal" class="mlflow-ui-container"></div></body></html>
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
