### PR TITLE
notekit: init at 0-unstable-2026-01-28

### DIFF
--- a/pkgs/by-name/no/notekit/package.nix
+++ b/pkgs/by-name/no/notekit/package.nix
@@ -1,0 +1,49 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  wrapGAppsHook3,
+  lib,
+  cmake,
+  u-config,
+  gtkmm3,
+  gtksourceviewmm,
+  gtksourceview3,
+  jsoncpp,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "notekit";
+  version = "0-unstable-2026-01-28";
+
+  src = fetchFromGitHub {
+    owner = "blackhole89";
+    repo = "${finalAttrs.pname}";
+    rev = "f53fa3b999cdd7a5efe264301eaadfdb7e969553";
+    sha256 = "sha256-lXCwvDw7j7mPryqN7OI7jkneuBoNoLbNUP+Vm/q32RI=";
+  };
+
+  cmakeFlags = [
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+  ];
+
+  nativeBuildInputs = [
+    u-config
+    cmake
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    gtkmm3
+    gtksourceviewmm
+    jsoncpp
+    gtksourceview3
+  ];
+
+  meta = {
+    homepage = "https://github.com/blackhole89/${finalAttrs.pname}";
+    description = "Hierarchical markdown notetaking application with tablet support";
+    maintainers = [ lib.maintainers.philocalyst ];
+    license = lib.licenses.gpl3;
+    platforms = with lib.platforms; linux ++ darwin;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
