### PR TITLE
cdparanoia-iii: fix build on darwin, add maintainer `olduser101`

### DIFF
--- a/pkgs/by-name/cd/cdparanoia-iii/package.nix
+++ b/pkgs/by-name/cd/cdparanoia-iii/package.nix
@@ -171,6 +171,9 @@ stdenv.mkDerivation (finalAttrs: {
       gpl2Plus
       lgpl21Plus
     ];
+    maintainers = with lib.maintainers; [
+      olduser101
+    ];
     platforms = lib.platforms.unix;
     mainProgram = "cdparanoia";
   };

--- a/pkgs/by-name/cd/cdparanoia-iii/package.nix
+++ b/pkgs/by-name/cd/cdparanoia-iii/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
       })
     ]
     ++ lib.optional stdenv.hostPlatform.isMusl ./utils.patch
-    ++ [
+    ++ lib.optional (!stdenv.hostPlatform.isDarwin) [
       (fetchpatch {
         url = "https://raw.githubusercontent.com/freebsd/freebsd-ports/42da4cdf2d9161fea8f7cdfc19aefda7707fadf4/audio/cdparanoia/files/patch-interface_low__interface.h";
         hash = "sha256-bXrcRFCbU7/7/N+J8VGKGSxIB1m8XwoAlc/KTnt9wN0=";


### PR DESCRIPTION
Some patches added for FreeBSD in #387243 conflict with existing patches for Darwin. 
The fix for this is simply enabling these patches on FreeBSD targets only.
Since these patches only need to be applied on FreeBSD, also remove Linux-specific replacement rules.

Also add myself as a maintainer for this package in future.

**Note:** I don't have a Darwin machine to test these changes on, while I am quite confident they should work based on file and build history, they may not. If anybody has a Darwin machine, please test this!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
