### PR TITLE
terax: init at 0.6.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29128,6 +29128,12 @@
     githubId = 90166078;
     keys = [ { fingerprint = "A5B9 B2C5 8C04 DCB6 A157  566A 9CDF DE55 0783 E7BB"; } ];
   };
+  vomba = {
+    email = "harzallahhani@gmail.com";
+    github = "vomba";
+    githubId = 26633077;
+    name = "Hani Harzallah";
+  };
   vonfry = {
     email = "nixos@vonfry.name";
     github = "Vonfry";

--- a/pkgs/by-name/te/terax/package.nix
+++ b/pkgs/by-name/te/terax/package.nix
@@ -1,0 +1,97 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  cargo-tauri,
+  wrapGAppsHook4,
+  pnpm_9,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  nodejs,
+  pkg-config,
+  nix-update-script,
+
+  glib-networking,
+  webkitgtk_4_1,
+  openssl,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "terax";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "crynta";
+    repo = "terax-ai";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-Sjwh5XoTK19EcYjkVmOc4rMJdWNJKdQFXGZjLH3MW5A=";
+  };
+
+  cargoHash = "sha256-4yY9JvH7+E9ilMSK88MvfB1mVH90C0WddSIpKfwq5A0=";
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = "src-tauri";
+
+  pnpmDeps = fetchPnpmDeps {
+    fetcherVersion = 3;
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm_9;
+    hash = "sha256-LydUQvlS1zYpnhwX3B2EfZjPHfpA5l9Lh9pqMfQeTvQ=";
+  };
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    pnpmConfigHook
+    pnpm_9
+    nodejs
+    pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    openssl
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    glib-networking
+    webkitgtk_4_1
+  ];
+
+  # Disable updater artifacts in the nix build since we don't have the signing key.
+  # Write the config to src-tauri/ so it's accessible after pushd into buildAndTestSubdir.
+  tauriConf = builtins.toJSON { bundle.createUpdaterArtifacts = false; };
+  preBuild = ''
+    tauriConfPath="$PWD/src-tauri/tauriConf.json"
+    printf "%s" "$tauriConf" > "$tauriConfPath"
+    tauriBuildFlags+=(
+      "--config"
+      "tauriConf.json"
+    )
+  '';
+
+  passthru = {
+    inherit (finalAttrs) pnpmDeps;
+    updateScript = nix-update-script { };
+  };
+
+  env.NIX_CFLAGS_COMPILE = "-std=gnu17";
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "AI-native terminal emulator with multi-tab, file explorer, code editor, web preview, voice input, and AI agents";
+    longDescription = ''
+      Terax is an open-source terminal emulator that integrates AI capabilities
+      directly into the terminal experience. It features multiple tabs,
+      a file explorer, built-in code editor, web preview, voice input, and
+      first-class AI agent support through multiple providers.
+    '';
+    homepage = "https://github.com/crynta/terax-ai";
+    changelog = "https://github.com/crynta/terax-ai/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ vomba ];
+    mainProgram = "terax";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
## Description

Add the [Terax](https://github.com/crynta/terax-ai) package — an open-source AI-native terminal emulator built with Tauri 2, Rust, and pnpm.

### Package details

- **Name:** terax
- **Version:** 0.6.1
- **License:** Apache 2.0
- **Platforms:** linux, darwin
- **By-name path:** pkgs/by-name/te/terax/package.nix

### Build

Built using the standard Tauri 2 nixpkgs pattern:
- `cargo-tauri.hook` for the Tauri build pipeline
- `pnpm_9` + `fetchPnpmDeps` + `pnpmConfigHook` for frontend dependencies
- `wrapGAppsHook4` for Linux desktop integration

The package builds successfully on `x86_64-linux".

### Checklist

- [x] Package builds on `x86_64-linux` (tested)
- [x] `pkgs/by-name` convention followed
- [x] Maintainer entry added
- [x] `meta.mainProgram` set to `terax`
- [x] `passthru.updateScript` configured