### PR TITLE
zotero: Use release channel

### DIFF
--- a/pkgs/by-name/zo/zotero/avoid-git.patch
+++ b/pkgs/by-name/zo/zotero/avoid-git.patch
@@ -1,16 +1,3 @@
-diff --git a/app/scripts/dir_build b/app/scripts/dir_build
-index 493288ad47..ccabb3722b 100755
---- a/app/scripts/dir_build
-+++ b/app/scripts/dir_build
-@@ -86,7 +86,7 @@ fi
- 
- CHANNEL="source"
- 
--hash=$(git -C "$ROOT_DIR" rev-parse --short HEAD)
-+hash="0000000000000000000000000000000000000000"
- 
- build_dir=$(mktemp -d)
- cleanup() { rm -rf "$build_dir"; }
 diff --git a/js-build/note-editor.js b/js-build/note-editor.js
 index 1435730342..6eebb10c50 100644
 --- a/js-build/note-editor.js

--- a/pkgs/by-name/zo/zotero/fix-x86_64-darwin.patch
+++ b/pkgs/by-name/zo/zotero/fix-x86_64-darwin.patch
@@ -1,0 +1,13 @@
+diff --git a/app/mac/set-channel-prefs-channel b/app/mac/set-channel-prefs-channel
+index 2431837584..ab85d7e5c0 100755
+--- a/app/mac/set-channel-prefs-channel
++++ b/app/mac/set-channel-prefs-channel
+@@ -19,7 +19,7 @@ binary=$1
+ from_channel=$2
+ to_channel=$3
+ # `strings` has a 4-character minimum by default, but we need 3 for 'dev'
+-strings_cmd="strings -n 3"
++strings_cmd="strings -n 3 -arch all"
+
+ if [ ${#to_channel} -gt 7 ]; then
+        echo "Channel length cannot exceed 7 characters -- aborting" >&2

--- a/pkgs/by-name/zo/zotero/package.nix
+++ b/pkgs/by-name/zo/zotero/package.nix
@@ -193,6 +193,7 @@ buildNpmPackage (finalAttrs: {
     ./js-build-fixes.patch
     ./avoid-xulrunner-fetch.patch
     ./build-fixes.patch
+    ./fix-x86_64-darwin.patch
   ];
 
   postPatch = ''

--- a/pkgs/by-name/zo/zotero/package.nix
+++ b/pkgs/by-name/zo/zotero/package.nix
@@ -223,30 +223,48 @@ buildNpmPackage (finalAttrs: {
     done
   '';
 
-  buildPhase = ''
-    runHook preBuild
+  buildPhase =
+    let
+      zoteroArch =
+        platform:
+        if platform.isAarch64 then
+          "arm64"
+        else if platform.isx86_64 then
+          "x64"
+        else if platform.isx86_32 then
+          "i686"
+        else
+          platform.parsed.cpu.name;
+    in
+    ''
+      runHook preBuild
 
-    npm run build
+      npm run build
 
-    # Place firefox files at the right place.
-    # The correct firefox version can be found in zotero/app/config.sh at `GECKO_VERSION_LINUX`.
-    mkdir -p app/xulrunner/
-  ''
-  + lib.optionalString stdenv.targetPlatform.isDarwin ''
-    cp -r "${firefox-esr-140-unwrapped}/Applications/Firefox ESR.app" app/xulrunner/Firefox.app
-  ''
-  + lib.optionalString (!stdenv.targetPlatform.isDarwin) ''
-    cp -r "${firefox-esr-140-unwrapped}/lib/firefox" "app/xulrunner/firefox-${stdenv.targetPlatform.parsed.kernel.name}-${
-      lib.replaceString "aarch64" "arm64" stdenv.targetPlatform.parsed.cpu.name
-    }"
-  ''
-  + ''
-    chmod -R u+w app/xulrunner/
+      # Place firefox files at the right place.
+      # The correct firefox version can be found in zotero/app/config.sh at `GECKO_VERSION_LINUX`.
+      mkdir -p app/xulrunner/
+    ''
+    + lib.optionalString stdenv.targetPlatform.isDarwin ''
+      cp -r "${firefox-esr-140-unwrapped}/Applications/Firefox ESR.app" app/xulrunner/Firefox.app
+    ''
+    + lib.optionalString (!stdenv.targetPlatform.isDarwin) ''
+      cp -r "${firefox-esr-140-unwrapped}/lib/firefox" "app/xulrunner/firefox-${stdenv.targetPlatform.parsed.kernel.name}-${
+        lib.replaceString "aarch64" "arm64" stdenv.targetPlatform.parsed.cpu.name
+      }"
+    ''
+    + ''
+      chmod -R u+w app/xulrunner/
 
-    ./app/scripts/dir_build
+      build_dir=$(mktemp -d)
+      ./app/scripts/prepare_build -s ./build -o "$build_dir" -c release
+      ./app/build.sh -d "$build_dir" -c release -s \
+        ${
+          if stdenv.targetPlatform.isDarwin then "-p m" else "-p l -a ${zoteroArch stdenv.targetPlatform}"
+        }
 
-    runHook postBuild
-  '';
+      runHook postBuild
+    '';
 
   inherit doCheck;
   # Build with test support if `doCheck` is enabled.


### PR DESCRIPTION
Our zotero build had the version string 9.0.2.SOURCE.000000000, while upstream releases of course only have 9.0.2. This leaks in HTTP headers and JavaScript functions, which is used e.g. by Better BibTeX. This add-on actually partially fails due to the unexpected version string.

This commit switches to the release channel. This also would enable updates, which fail/hang because the firefox updater is not included in our firefox builds.

Instead of patching app/scripts/dir_build, I opt to call app/scripts/prepare_build and app/build.sh directly. This also brings us closer to cross-compile support (as we now select the build system and architecture from targetHost).

Resolves https://github.com/NixOS/nixpkgs/issues/519332.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
