### PR TITLE
[25.11] litellm: mark CVE-2026-40217 as known vulnerability

### DIFF
--- a/pkgs/development/python-modules/litellm/default.nix
+++ b/pkgs/development/python-modules/litellm/default.nix
@@ -140,6 +140,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/BerriAI/litellm";
     changelog = "https://github.com/BerriAI/litellm/releases/tag/${src.tag}";
     license = lib.licenses.mit;
+    knownVulnerabilities = [
+      "CVE-2026-40217: arbitrary code execution via bytecode rewriting at /guardrails/test_custom_code in the LiteLLM proxy process."
+    ];
     maintainers = with lib.maintainers; [ happysalada ];
   };
 }


### PR DESCRIPTION
## Description

This marks `litellm` in the 25.11 release branch as having a known vulnerability due to CVE-2026-40217.

The Nixpkgs security tracker issue #508886 lists `litellm 1.75.5@nixos-25.11`, `python312Packages.litellm 1.75.5@nixos-25.11`, and `python313Packages.litellm 1.75.5@nixos-25.11` as affected.

The issue describes arbitrary code execution via bytecode rewriting at `/guardrails/test_custom_code`. Since LiteLLM is commonly used as an LLM proxy/gateway and may hold provider credentials, marking this as a known vulnerability seems appropriate so users do not keep evaluating/rebuilding it silently.

Related issue:
- #508886

I am intentionally targeting `release-25.11` first because this affects the current stable channel.

## Things done

- [x] Added `meta.knownVulnerabilities` for CVE-2026-40217
- [x] Verified `nix-instantiate -A python312Packages.litellm` fails as insecure
- [x] Verified `nix-instantiate -A python313Packages.litellm` fails as insecure
- [x] Verified `nix-instantiate -A litellm` fails as insecure