### PR TITLE
maintainers: remove davisrichard437

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6328,12 +6328,6 @@
     githubId = 4347318;
     email = "davinci42.cn@gmail.com";
   };
-  davisrichard437 = {
-    email = "davisrichard437@gmail.com";
-    github = "davisrichard437";
-    githubId = 85075437;
-    name = "Richard Davis";
-  };
   davorb = {
     email = "davor@davor.se";
     github = "davorb";

--- a/pkgs/by-name/fi/fiji/package.nix
+++ b/pkgs/by-name/fi/fiji/package.nix
@@ -96,6 +96,6 @@ stdenv.mkDerivation (finalAttrs: {
       bsd2
       publicDomain
     ];
-    maintainers = with lib.maintainers; [ davisrichard437 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/gs/gscreenshot/package.nix
+++ b/pkgs/by-name/gs/gscreenshot/package.nix
@@ -91,6 +91,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
     mainProgram = "gscreenshot";
-    maintainers = [ lib.maintainers.davisrichard437 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/development/python-modules/abjad/default.nix
+++ b/pkgs/development/python-modules/abjad/default.nix
@@ -63,6 +63,6 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     homepage = "https://abjad.github.io/";
     changelog = "https://abjad.github.io/appendices/changes.html";
-    maintainers = [ lib.maintainers.davisrichard437 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/uqbar/default.nix
+++ b/pkgs/development/python-modules/uqbar/default.nix
@@ -84,6 +84,6 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/supriya-project/uqbar";
     changelog = "https://github.com/supriya-project/uqbar/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ davisrichard437 ];
+    maintainers = [ ];
   };
 })


### PR DESCRIPTION
## Reasons

- Last commented in [December 2024](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Adavisrichard437)
- Hasn't created any PRs / Issues since [July 2024](https://github.com/NixOS/nixpkgs/issues?q=author%3Adavisrichard437)
- About 24 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Adavisrichard437%20-commenter%3Adavisrichard437%20-author%3Adavisrichard437%20-reviewed-by%3Adavisrichard437) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] fiji 
- [ ] gscreenshot
- [ ] pythonPackages.abjad
- [ ] pythonPackages.abjad