### PR TITLE
opencart-mcp: init at 0.4.1

### DIFF
--- a/pkgs/by-name/op/opencart-mcp/package.nix
+++ b/pkgs/by-name/op/opencart-mcp/package.nix
@@ -1,0 +1,35 @@
+{
+  fetchFromGitHub,
+  lib,
+  python3Packages,
+  ...
+}:
+
+python3Packages.buildPythonPackage rec {
+  pname = "opencart-mcp";
+  version = "0.4.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "chrisbray85";
+    repo = "opencart-mcp";
+    tag = "v${version}";
+    sha256 = "sha256-6ur+jla1w8a9T5Y64tld77c6PWK/s21mVkmNkFDCWnw=";
+  };
+
+  format = "pyproject";
+  nativeBuildInputs = [ python3Packages.setuptools ];
+
+  propagatedBuildInputs = with python3Packages; [
+    fastmcp
+    paramiko
+    python-dotenv
+  ];
+
+  meta = {
+    description = "MCP server for OpenCart.";
+    homepage = "https://github.com/chrisbray85/opencart-mcp";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.icedborn ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

MCP server for OpenCart — query products, orders, settings, and Journal3 theme via Claude Code or any MCP client

https://github.com/chrisbray85/opencart-mcp

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
