### PR TITLE
resholve: fix finalAttrs compatibility

### DIFF
--- a/pkgs/by-name/aa/aaxtomp3/package.nix
+++ b/pkgs/by-name/aa/aaxtomp3/package.nix
@@ -17,14 +17,14 @@
   resholve,
 }:
 
-resholve.mkDerivation rec {
+resholve.mkDerivation (finalAttrs: {
   pname = "aaxtomp3";
   version = "1.3";
 
   src = fetchFromGitHub {
     owner = "krumpetpirate";
     repo = "aaxtomp3";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-7a9ZVvobWH/gPxa3cFiPL+vlu8h1Dxtcq0trm3HzlQg=";
   };
 
@@ -76,4 +76,4 @@ resholve.mkDerivation rec {
     license = lib.licenses.wtfpl;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/ar/arch-install-scripts/package.nix
+++ b/pkgs/by-name/ar/arch-install-scripts/package.nix
@@ -22,7 +22,7 @@
   chrootSetprivPath ? "/usr/bin/setpriv",
 }:
 
-resholve.mkDerivation rec {
+resholve.mkDerivation (finalAttrs: {
   pname = "arch-install-scripts";
   version = "31";
 
@@ -30,7 +30,7 @@ resholve.mkDerivation rec {
     domain = "gitlab.archlinux.org";
     owner = "archlinux";
     repo = "arch-install-scripts";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Oh1nC/gPJDDy8cXiZPbEfpwOuO+RFRcxVCZuTtB2MV8=";
   };
 
@@ -121,4 +121,4 @@ resholve.mkDerivation rec {
     maintainers = with lib.maintainers; [ samlukeyes123 ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/ba/bats/package.nix
+++ b/pkgs/by-name/ba/bats/package.nix
@@ -27,14 +27,14 @@
   packcc,
 }:
 
-resholve.mkDerivation rec {
+resholve.mkDerivation (finalAttrs: {
   pname = "bats";
   version = "1.12.0";
 
   src = fetchFromGitHub {
     owner = "bats-core";
     repo = "bats-core";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-5VCkOzyaUOBW+HVVHDkH9oCWDI/MJW6yrLTQG60Ralk=";
   };
 
@@ -153,7 +153,7 @@ resholve.mkDerivation rec {
           --suffix BATS_LIB_PATH : "$out/share/bats"
       '';
 
-      inherit meta;
+      meta = removeAttrs finalAttrs.meta [ "position" ];
     };
 
   passthru.tests = {
@@ -281,4 +281,4 @@ resholve.mkDerivation rec {
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/dg/dgoss/package.nix
+++ b/pkgs/by-name/dg/dgoss/package.nix
@@ -8,7 +8,7 @@
   which,
 }:
 
-resholve.mkDerivation rec {
+resholve.mkDerivation (finalAttrs: {
   pname = "dgoss";
   version = goss.version;
   src = goss.src;
@@ -37,8 +37,8 @@ resholve.mkDerivation rec {
   };
 
   meta = {
-    homepage = "https://github.com/goss-org/goss/blob/v${version}/extras/dgoss/README.md";
-    changelog = "https://github.com/goss-org/goss/releases/tag/v${version}";
+    homepage = "https://github.com/goss-org/goss/blob/v${finalAttrs.version}/extras/dgoss/README.md";
+    changelog = "https://github.com/goss-org/goss/releases/tag/v${finalAttrs.version}";
     description = "Convenience wrapper around goss that aims to bring the simplicity of goss to docker containers";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux;
@@ -48,4 +48,4 @@ resholve.mkDerivation rec {
     ];
     mainProgram = "dgoss";
   };
-}
+})

--- a/pkgs/by-name/gi/git-ftp/package.nix
+++ b/pkgs/by-name/gi/git-ftp/package.nix
@@ -17,13 +17,13 @@
   man,
 }:
 
-resholve.mkDerivation rec {
+resholve.mkDerivation (finalAttrs: {
   pname = "git-ftp";
   version = "1.6.0";
   src = fetchFromGitHub {
     owner = "git-ftp";
     repo = "git-ftp";
-    rev = version;
+    rev = finalAttrs.version;
     sha256 = "1hxkqf7jbrx24q18yxpnd3dxzh4xk6asymwkylp1x7zg6mcci87d";
   };
 
@@ -101,4 +101,4 @@ resholve.mkDerivation rec {
     platforms = lib.platforms.unix;
     mainProgram = "git-ftp";
   };
-}
+})

--- a/pkgs/by-name/ni/nix-direnv/package.nix
+++ b/pkgs/by-name/ni/nix-direnv/package.nix
@@ -7,16 +7,14 @@
   writeText,
 }:
 
-# resholve does not yet support `finalAttrs` call pattern hence `rec`
-# https://github.com/abathur/resholve/issues/107
-resholve.mkDerivation rec {
+resholve.mkDerivation (finalAttrs: {
   pname = "nix-direnv";
   version = "3.1.1";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "nix-direnv";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-AsWnRH7LAb78iFfE+ZdYyCR5AVuPloT8ZnghDXW6arY=";
   };
 
@@ -77,4 +75,4 @@ resholve.mkDerivation rec {
       bbenne10
     ];
   };
-}
+})

--- a/pkgs/by-name/pi/pihole/package.nix
+++ b/pkgs/by-name/pi/pihole/package.nix
@@ -30,14 +30,14 @@
   stateDir ? "/etc/pihole",
 }:
 
-(resholve.mkDerivation rec {
+(resholve.mkDerivation (finalAttrs: {
   pname = "pihole";
   version = "6.4";
 
   src = fetchFromGitHub {
     owner = "pi-hole";
     repo = "pi-hole";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-aBQO+wAqeuXc9ekByVFlOZQ9SBCGsozGdoS8r1qhGuk=";
   };
 
@@ -234,7 +234,7 @@
   meta = {
     description = "Black hole for Internet advertisements";
     homepage = "https://pi-hole.net";
-    changelog = "https://github.com/pi-hole/pi-hole/releases/tag/v${version}";
+    changelog = "https://github.com/pi-hole/pi-hole/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.eupl12;
     maintainers = with lib.maintainers; [ averyvigolo ];
     platforms = lib.platforms.linux;
@@ -244,7 +244,7 @@
   passthru.tests = nixosTests.pihole-ftl;
 
   passthru = { inherit stateDir; };
-}).overrideAttrs
+})).overrideAttrs
   (old: {
     # Resholve can't fix the hardcoded absolute paths, so substitute them before resholving
     preFixup = ''

--- a/pkgs/by-name/sh/shunit2/package.nix
+++ b/pkgs/by-name/sh/shunit2/package.nix
@@ -10,14 +10,14 @@
   ncurses,
 }:
 
-resholve.mkDerivation rec {
+resholve.mkDerivation (finalAttrs: {
   pname = "shunit2";
   version = "2.1.8";
 
   src = fetchFromGitHub {
     owner = "kward";
     repo = "shunit2";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-IZHkgkVqzeh+eEKCDJ87sqNhSA+DU6kBCNDdQaUEeiM=";
   };
 
@@ -102,4 +102,4 @@ resholve.mkDerivation rec {
     platforms = lib.platforms.unix;
     mainProgram = "shunit2";
   };
-}
+})

--- a/pkgs/by-name/un/unix-privesc-check/package.nix
+++ b/pkgs/by-name/un/unix-privesc-check/package.nix
@@ -19,14 +19,12 @@
   which,
 }:
 
-# resholve does not yet support `finalAttrs` call pattern hence `rec`
-# https://github.com/abathur/resholve/issues/107
-resholve.mkDerivation rec {
+resholve.mkDerivation (finalAttrs: {
   pname = "unix-privesc-check";
   version = "1.4";
 
   src = fetchurl {
-    url = "https://pentestmonkey.net/tools/unix-privesc-check/unix-privesc-check-${version}.tar.gz";
+    url = "https://pentestmonkey.net/tools/unix-privesc-check/unix-privesc-check-${finalAttrs.version}.tar.gz";
     hash = "sha256-4fhef2n6ut0jdWo9dqDj2GSyHih2O2DOLmGBKQ0cGWk=";
   };
 
@@ -85,4 +83,4 @@ resholve.mkDerivation rec {
     platforms = lib.platforms.unix;
     license = lib.licenses.gpl2Plus;
   };
-}
+})

--- a/pkgs/by-name/wg/wgnord/package.nix
+++ b/pkgs/by-name/wg/wgnord/package.nix
@@ -12,14 +12,14 @@
   wireguard-tools,
 }:
 
-resholve.mkDerivation rec {
+resholve.mkDerivation (finalAttrs: {
   pname = "wgnord";
   version = "0.2.1";
 
   src = fetchFromGitHub {
     owner = "phirecc";
     repo = "wgnord";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-26cfYXtZVQ7kIRxY6oNGCqIjdw/hjwXhVKimVgolLgk=";
   };
 
@@ -64,4 +64,4 @@ resholve.mkDerivation rec {
     mainProgram = "wgnord";
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/ya/yadm/package.nix
+++ b/pkgs/by-name/ya/yadm/package.nix
@@ -28,7 +28,7 @@
   yadm,
 }:
 
-resholve.mkDerivation rec {
+resholve.mkDerivation (finalAttrs: {
   pname = "yadm";
   version = "3.5.0";
 
@@ -37,7 +37,7 @@ resholve.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "yadm-dev";
     repo = "yadm";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-hDo6zs70apNhKmuvR+eD51FzuTLj3SL/wHQXqLMD9QE=";
   };
 
@@ -118,7 +118,7 @@ resholve.mkDerivation rec {
   };
 
   passthru.tests = {
-    minimal = runCommand "${pname}-test" { } ''
+    minimal = runCommand "${finalAttrs.pname}-test" { } ''
       export HOME=$out
       ${yadm}/bin/yadm init
     '';
@@ -133,10 +133,10 @@ resholve.mkDerivation rec {
       * Provides a way to use alternate files on a specific OS or host.
       * Supplies a method of encrypting confidential data so it can safely be stored in your repository.
     '';
-    changelog = "https://github.com/yadm-dev/yadm/blob/${version}/CHANGES";
+    changelog = "https://github.com/yadm-dev/yadm/blob/${finalAttrs.version}/CHANGES";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ abathur ];
     platforms = lib.platforms.unix;
     mainProgram = "yadm";
   };
-}
+})

--- a/pkgs/by-name/zx/zxfer/package.nix
+++ b/pkgs/by-name/zx/zxfer/package.nix
@@ -14,14 +14,14 @@
   zfs,
 }:
 
-resholve.mkDerivation rec {
+resholve.mkDerivation (finalAttrs: {
   pname = "zxfer";
   version = "1.1.7";
 
   src = fetchFromGitHub {
     owner = "allanjude";
     repo = "zxfer";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-11SQJcD3GqPYBIgaycyKkc62/diVKPuuj2Or97j+NZY=";
   };
 
@@ -80,9 +80,9 @@ resholve.mkDerivation rec {
   meta = {
     description = "Popular script for managing ZFS snapshot replication";
     homepage = "https://github.com/allanjude/zxfer";
-    changelog = "https://github.com/allanjude/zxfer/releases/tag/v${version}";
+    changelog = "https://github.com/allanjude/zxfer/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.bsd2;
     maintainers = [ ];
     mainProgram = "zxfer";
   };
-}
+})

--- a/pkgs/development/misc/resholve/README.md
+++ b/pkgs/development/misc/resholve/README.md
@@ -129,7 +129,7 @@ trivial, so I'll also link to some real-world examples:
 
 ## Basic `resholve.phraseSolution` example
 
-This function has a similar API to `writeScript` and `writeScriptBin`, except it does require a `scripts` attr. It is intended to make resholve a little easier to mix into more types of builds. This example is a little
+This function has a similar API to `writeScript` and `writeScriptBin`, except it does require a `scripts` attr. It is intended to make resholve a little easier to mix into more types of build. This example is a little
 trivial for now. If you have a real usage that you find helpful, please PR it.
 
 ```nix

--- a/pkgs/development/misc/resholve/resholve-utils.nix
+++ b/pkgs/development/misc/resholve/resholve-utils.nix
@@ -219,50 +219,54 @@ rec {
         )}
       '';
     };
-  mkDerivation =
-    {
-      pname,
-      src,
-      version,
-      passthru ? { },
-      solutions,
-      postResholve ? "",
-      ...
-    }@attrs:
-    let
-      inherit stdenv;
+  /*
+    This uses nested derivations so we can:
+    - let project build however it needs in inner "unresholved" drv
+    - pass this drv through binlore to collect info on exec behavior
+      in any scripts and binaries in its output
+    - resholve with lore unresholved source and lore as inputs
 
-      /*
-        Knock out our special solutions arg, but otherwise
-        just build what the caller is giving us. We'll
-        actually resholve it separately below (after we
-        generate binlore for it).
-      */
-      unresholved = (
-        stdenv.mkDerivation (
-          (removeAttrs attrs [ "solutions" ])
-          // {
-            inherit version src;
-            pname = "${pname}-unresholved";
-          }
-        )
-      );
-    in
-    /*
-      resholve in a separate derivation; some concerns:
-      - we aren't keeping many of the user's args, so they
-        can't readily set LOGLEVEL and such...
-      - not sure how this affects multiple outputs
-    */
-    lib.extendDerivation true passthru (
+    some concerns:
+    - resholve drv isn't keeping many of the caller's args,
+      (to avoid re-triggering phases and such in outer build)
+      so they can't readily set LOGLEVEL and such...
+    - not sure how this affects multiple outputs
+  */
+  mkDerivation = lib.extendMkDerivation {
+    constructDrv = stdenv.mkDerivation;
+    excludeDrvArgNames = [
+      "postResholve"
+      "solutions"
+    ];
+    extendDrvArgs =
+      finalAttrs:
+      {
+        pname,
+        src,
+        version,
+        passthru ? { },
+        solutions,
+        postResholve ? "",
+        ...
+      }@args:
+      {
+        pname = "${pname}-unresholved";
+        passthru = passthru // {
+          # needed to resholve in outer drv
+          inherit postResholve solutions;
+        };
+      };
+    transformDrv =
+      unresholved:
       stdenv.mkDerivation {
         src = unresholved;
-        inherit version pname;
+        pname = lib.removeSuffix "-unresholved" unresholved.pname;
+        inherit (unresholved) version;
         buildInputs = [ resholve ];
         disallowedReferences = [ resholve ];
 
-        # retain a reference to the base
         passthru = unresholved.passthru // {
+          # retain a reference to the base
           unresholved = unresholved;
           # fallback attr for update bot to query our src
           originalSrc = unresholved.src;
@@ -279,12 +283,12 @@ rec {
         # enable below for verbose debug info if needed
         # supports default python.logging levels
         # LOGLEVEL="INFO";
-        preFixup = phraseSolutions solutions unresholved;
+        preFixup = phraseSolutions unresholved.solutions unresholved;
 
-        postFixup = postResholve;
+        postFixup = unresholved.postResholve;
 
         # don't break the metadata...
         meta = unresholved.meta;
-      }
-    );
+      };
+  };
 }

--- a/pkgs/development/misc/resholve/test.nix
+++ b/pkgs/development/misc/resholve/test.nix
@@ -82,7 +82,7 @@ let
   ];
 in
 rec {
-  module1 = resholve.mkDerivation {
+  module1 = resholve.mkDerivation(finalAttrs: {
     pname = "testmod1";
     version = "unreleased";
 
@@ -111,8 +111,9 @@ rec {
       };
     };
 
-    is_it_okay_with_arbitrary_envs = "shonuff";
-  };
+    # finalAttrs proof-of-life
+    passthru.version = finalAttrs.version;
+  });
   module2 = resholve.mkDerivation {
     pname = "testmod2";
     version = "unreleased";
@@ -335,7 +336,9 @@ rec {
   inherit msmtp;
   inherit nix-direnv;
   inherit pdf2odt;
-  inherit pdfmm;
+  # TODO: re-enable when safe; disabled may 9 2026 due
+  # to build failure down in pdfmm > zenity > appstream
+  # inherit pdfmm;
   inherit shunit2;
   inherit xdg-utils;
   inherit yadm;

--- a/pkgs/development/misc/resholve/test.nix
+++ b/pkgs/development/misc/resholve/test.nix
@@ -82,7 +82,7 @@ let
   ];
 in
 rec {
-  module1 = resholve.mkDerivation(finalAttrs: {
+  module1 = resholve.mkDerivation (finalAttrs: {
     pname = "testmod1";
     version = "unreleased";
 


### PR DESCRIPTION
Continuing #518513 here after I goofed a fixup/rebase.

---
Fix ongoing papercuts from lack of finalAttrs compatibility in resholve.mkDerivation. See also https://github.com/abathur/resholve/issues/107

Also converts the subset of packages using both resholve.mkDerivation and rec, since I imagine someone would've converted these in one of the various/treewide PRs over the past few years if _not_ for the lack of support in resholve.

(I don't have many spoons atm and am not inclined to field many additional style/norms/practices improvements for the second commit here. If it generates more than a few non-fix requests or I get the sense that it's holding this up, I'll likely drop it and leave that work for later/others.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
