### PR TITLE
[Backport release-25.11] forgejo: 15.0.1 -> 15.0.2, forgejo-lts: 11.0.13 -> 11.0.14

### DIFF
--- a/pkgs/by-name/fo/forgejo/lts.nix
+++ b/pkgs/by-name/fo/forgejo/lts.nix
@@ -1,8 +1,8 @@
 import ./generic.nix {
-  version = "11.0.13";
-  hash = "sha256-bXJ4ddUKTGKRWagL1G71sasMghr5FdiZPtHjrOTpxDY=";
-  npmDepsHash = "sha256-ZAcv/EnCx8dikjW9wgQBNln9WUQOkw0RCLVRoDPY8Gc=";
-  vendorHash = "sha256-0oh1zhMRz8B5TInAuuvYg63noxSAoupSQvQeerO3TFI=";
+  version = "11.0.14";
+  hash = "sha256-rFF+naEEvTj1UqcX8Y2UTHGcBdM8mGgZWJgcC69jdxQ=";
+  npmDepsHash = "sha256-B5ndsIk9Jntu7f7w6NrsBxfFSxhYFeq1NfXTtzckklw=";
+  vendorHash = "sha256-bdp3Qy/09qa/bwPUIDmdrJXma39zdgovIZqENo+AVyY=";
   lts = true;
   nixUpdateExtraArgs = [
     "--override-filename"

--- a/pkgs/by-name/fo/forgejo/package.nix
+++ b/pkgs/by-name/fo/forgejo/package.nix
@@ -1,8 +1,8 @@
 import ./generic.nix {
-  version = "15.0.1";
-  hash = "sha256-40hyQ6MPskyty/LsMVczuDpbu2q3Syoj3c00HUS+pVE=";
-  npmDepsHash = "sha256-xWbnSX11RkLjtJ62qG6rD+xQAOnUuI99r9uEHakkZPY=";
-  vendorHash = "sha256-JUBAcRYgflrvoAK0OvaU/Xr6/BakgaUtYwtvBF9vyk0=";
+  version = "15.0.2";
+  hash = "sha256-ba5jog6eXY4TTmBblhfVa2LSLPGE1/HPfslIb30b3kk=";
+  npmDepsHash = "sha256-70w39jbMWpuAsbzBC9oFHaUMwshtFDeTSEOXDgFNPmE=";
+  vendorHash = "sha256-I6bGvXBP2K3+Xx9E9DS/AyG6Ilqf/s8VjfBnCmLUHsk=";
   lts = false;
   nixUpdateExtraArgs = [
     "--override-filename"


### PR DESCRIPTION
Manual backport of #519405 because of a merge conflict caused by `lts = true;` on `master` and `lts = false;` on `release-25.11`.

https://codeberg.org/forgejo/forgejo/releases/tag/v15.0.2

And `forgejo-lts: 11.0.13 -> 11.0.14` because `forgejo-lts` follows `11.x` on `release-25.11` and `15.x` on `master`.

https://codeberg.org/forgejo/forgejo/releases/tag/v11.0.14

Previously: #514782

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
