### PR TITLE
[Backport release-25.11] python3Packages.arxiv: 2.3.1 -> 3.0.0

### DIFF
--- a/pkgs/development/python-modules/arxiv/default.nix
+++ b/pkgs/development/python-modules/arxiv/default.nix
@@ -4,7 +4,8 @@
   fetchFromGitHub,
 
   # build-system
-  setuptools,
+  hatchling,
+  hatch-vcs,
 
   # dependencies
   feedparser,
@@ -16,17 +17,20 @@
 }:
 buildPythonPackage rec {
   pname = "arxiv";
-  version = "2.3.1";
+  version = "2.4.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "lukasschwab";
     repo = "arxiv.py";
     tag = version;
-    hash = "sha256-7TGepKZ6Y/WTgJK70oOGR2TlXRwK0YgzslXAnklRSCA=";
+    hash = "sha256-96m2UHNoilRhbMnzArUFbm0wZDQS6j97etgOJ7qZmEc=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [
+    hatchling
+    hatch-vcs
+  ];
 
   dependencies = [
     feedparser

--- a/pkgs/development/python-modules/arxiv/default.nix
+++ b/pkgs/development/python-modules/arxiv/default.nix
@@ -17,14 +17,14 @@
 }:
 buildPythonPackage rec {
   pname = "arxiv";
-  version = "2.4.0";
+  version = "2.4.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "lukasschwab";
     repo = "arxiv.py";
     tag = version;
-    hash = "sha256-96m2UHNoilRhbMnzArUFbm0wZDQS6j97etgOJ7qZmEc=";
+    hash = "sha256-3GQ0HBYwkKlZ5WNgbJI/gHNi800WlnZiAJB6aSVBvjo=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/arxiv/default.nix
+++ b/pkgs/development/python-modules/arxiv/default.nix
@@ -17,14 +17,14 @@
 }:
 buildPythonPackage rec {
   pname = "arxiv";
-  version = "2.4.1";
+  version = "3.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "lukasschwab";
     repo = "arxiv.py";
     tag = version;
-    hash = "sha256-3GQ0HBYwkKlZ5WNgbJI/gHNi800WlnZiAJB6aSVBvjo=";
+    hash = "sha256-o2Vqkr5Tlx7Iv1NEWDSU8X6hvlGUslIl4oHiRQNGdqI=";
   };
 
   build-system = [


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/509454.

(And the other intermediate bumps since release https://github.com/NixOS/nixpkgs/pull/482463 https://github.com/NixOS/nixpkgs/pull/498568)

Since the requests version update [got backported](https://github.com/NixOS/nixpkgs/commit/d1aa7217f1c9441805ed770f8d58016cf3f194a7), [arxiv is broken on release-25.11](https://hydra.nixos.org/job/nixpkgs/staging-next-25.11/python313Packages.arxiv.x86_64-linux), and in extension [papis](https://hydra.nixos.org/job/nixpkgs/staging-next-25.11/python313Packages.papis.x86_64-linux) which depends on it. This backport of #509454 (along w/ the intermediate version bumps) fixes this issue.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
