### PR TITLE
semcode: init at 0.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22881,6 +22881,12 @@
     githubId = 45141270;
     name = "Steve Mathew Joy";
   };
+  razelighter777 = {
+    email = "utilityemal77@gmail.com";
+    github = "razelighter777";
+    githubId = 25808399;
+    name = "Justin Suess";
+  };
   razvan = {
     email = "razvan.panda@gmail.com";
     github = "freeman42x";

--- a/pkgs/by-name/se/semcode/package.nix
+++ b/pkgs/by-name/se/semcode/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  openssl,
+  protobuf,
+  protobufc,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "semcode";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "facebookexperimental";
+    repo = "semcode";
+    tag = finalAttrs.version;
+    hash = "sha256-nkb4a+H11gzMGz0zBAH+G77zE+oDl9elTu+bfYmIz9k=";
+  };
+  nativeBuildInputs = [
+    pkg-config
+    protobuf
+  ];
+  checkFlags = [
+    # git test requires network connectivity
+    "--skip=git"
+  ];
+  buildInputs = [
+    openssl
+    protobufc
+  ];
+  __structuredAttrs = true;
+  cargoHash = "sha256-xOIaoOaHWYhV9z3IoIAfAaRd+AbVBuX8VKomfuFN2QM=";
+  meta = {
+    description = "Semantic code search tool for C/C++ codebases";
+    homepage = "https://github.com/facebookexperimental/semcode";
+    changelog = "https://github.com/facebookexperimental/semcode/releases/tag/${finalAttrs.version}";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [
+      razelighter777
+    ];
+    mainProgram = "semcode";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Semcode is a semantic code search tool for C/C++ codebases. It includes a command line search utility, database generating tool, and an MCP server allowing AI tools to quickly index and understand massive codebases. Semcode is actively maintained, and has important upstream users such as the [Sashiko AI patchset review tool](https://github.com/sashiko-dev/sashiko), used to automate review for patchsets in the Linux Kernel.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
