### PR TITLE
python3Packages.compas: init at 2.15.1

### DIFF
--- a/pkgs/development/python-modules/compas/default.nix
+++ b/pkgs/development/python-modules/compas/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+
+  jsonschema,
+  networkx,
+  numpy,
+  scipy,
+  watchdog,
+
+  pytestCheckHook,
+  pytest-mock,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "compas";
+  version = "2.15.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "compas-dev";
+    repo = "compas";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-HnHD/CZNdRU5v2hTPctBBfVUJ5cEWOw1+4YwtkVAkFw=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-mock
+  ];
+
+  disabledTests = [
+    "test_xml_from_url"
+    "test_open_file_url_image"
+    "test_open_file_url_text"
+  ];
+
+  dependencies = [
+    jsonschema
+    networkx
+    numpy
+    scipy
+    watchdog
+  ];
+
+  meta = {
+    description = "Computational framework for research and collaboration in Architecture, Engineering, Fabrication and Construction.";
+    homepage = "https://github.com/compas-dev/compas";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tetov ];
+  };
+})

--- a/pkgs/development/python-modules/compas/default.nix
+++ b/pkgs/development/python-modules/compas/default.nix
@@ -10,6 +10,7 @@
   scipy,
   watchdog,
 
+  stdenv,
   pytestCheckHook,
   pytest-mock,
 }:
@@ -34,9 +35,13 @@ buildPythonPackage (finalAttrs: {
   ];
 
   disabledTests = [
-    "test_xml_from_url"
     "test_open_file_url_image"
     "test_open_file_url_text"
+    "test_xml_from_url"
+  ]
+  ++ lib.optionals (!stdenv.isDarwin) [
+    "test_basic_rpc_call"
+    "test_switch_package"
   ];
 
   dependencies = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3128,6 +3128,8 @@ self: super: with self; {
 
   commonregex = callPackage ../development/python-modules/commonregex { };
 
+  compas = callPackage ../development/python-modules/compas { };
+
   compit-inext-api = callPackage ../development/python-modules/compit-inext-api { };
 
   compliance-trestle = callPackage ../development/python-modules/compliance-trestle { };


### PR DESCRIPTION
[compas](https://compas.dev/) is "The computational framework for research and collaboration in Architecture, Engineering, Fabrication, and Construction". The core deals with geometry and data (for importing different CAD formats). It has CAD integrations, the core package includes integrations for Blender and Rhino (available on OS X and Windows).

It's MIT licensed and backed by the COMPAS association, an independent public benefit organisation established 2023 in Zürich. It was mainly developed at ETH Zürich.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
