### PR TITLE
obsidian: use the bundled Electron in Obsidian binary instead of from nixpkgs

### DIFF
--- a/pkgs/by-name/ob/obsidian/package.nix
+++ b/pkgs/by-name/ob/obsidian/package.nix
@@ -1,14 +1,13 @@
 {
   stdenv,
-  fetchurl,
   lib,
+  fetchurl,
   makeWrapper,
-  electron_39, # as in upstream bundle, see https://github.com/NixOS/nixpkgs/pull/510075
+  autoPatchelfHook,
   makeDesktopItem,
   imagemagick,
-  autoPatchelfHook,
   writeScript,
-  _7zz,
+  pkgs,
   commandLineArgs ? "",
 }:
 let
@@ -77,22 +76,67 @@ let
       makeWrapper
       imagemagick
     ];
+
+    buildInputs = with pkgs; [
+      stdenv.cc.cc.lib
+      alsa-lib
+      atk
+      at-spi2-atk
+      at-spi2-core
+      cups
+      dbus
+      gtk3
+      gsettings-desktop-schemas
+      libdrm
+      libglvnd
+      libsecret
+      libxkbcommon
+      mesa
+      nspr
+      nss
+      systemd
+      vulkan-loader
+      libx11
+      libxcomposite
+      libxdamage
+      libxfixes
+      libxrandr
+      libxcb
+    ];
+
     installPhase = ''
       runHook preInstall
-      mkdir -p $out/bin
-      makeWrapper ${electron_39}/bin/electron $out/bin/obsidian \
-        --add-flags $out/share/obsidian/app.asar \
+
+      mkdir -p $out/bin $out/share/obsidian
+      cp -a ./* $out/share/obsidian/
+
+      OBSIDIAN_BIN="$out/share/obsidian/obsidian"
+      chmod +x "$OBSIDIAN_BIN"
+
+      makeWrapper "$OBSIDIAN_BIN" $out/bin/obsidian \
+        --run 'if ${pkgs.procps}/bin/pgrep -f "gnome-keyring" >/dev/null 2>&1; then export _OBS_PASS="--password-store=gnome-libsecret"; elif ${pkgs.procps}/bin/pgrep -f "kwallet" >/dev/null 2>&1; then export _OBS_PASS="--password-store=kwallet6"; else export _OBS_PASS=""; fi' \
+        --add-flags "\$_OBS_PASS" \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-wayland-ime=true --wayland-text-input-version=3}}" \
-        --add-flags ${lib.escapeShellArg commandLineArgs}
-      install -m 755 -D obsidian-cli $out/bin/obsidian-cli
-      install -m 444 -D resources/app.asar $out/share/obsidian/app.asar
-      install -m 444 -D resources/obsidian.asar $out/share/obsidian/obsidian.asar
-      install -m 444 -D "${desktopItem}/share/applications/"* \
-        -t $out/share/applications/
+        --add-flags ${lib.escapeShellArg commandLineArgs} \
+        --set LD_LIBRARY_PATH "${
+          lib.makeLibraryPath [
+            pkgs.libglvnd
+            pkgs.mesa
+            pkgs.vulkan-loader
+            pkgs.libsecret
+          ]
+        }" \
+        --set GSETTINGS_SCHEMA_DIR "${pkgs.gsettings-desktop-schemas}/share/gsettings-schemas/${pkgs.gsettings-desktop-schemas.name}:${pkgs.gtk3}/share/gsettings-schemas/${pkgs.gtk3.name}" \
+        --prefix XDG_DATA_DIRS : "${pkgs.gtk3}/share:${pkgs.gsettings-desktop-schemas}/share"
+
+      install -m 755 -D "$out/share/obsidian/obsidian-cli" $out/bin/obsidian-cli
+      install -m 444 -D "${desktopItem}/share/applications/"* -t $out/share/applications/
+
       for size in 16 24 32 48 64 128 256 512; do
         mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
         magick -background none ${icon} -resize "$size"x"$size" $out/share/icons/hicolor/"$size"x"$size"/apps/obsidian.png
       done
+
       runHook postInstall
     '';
 
@@ -116,7 +160,6 @@ let
     sourceRoot = "${appname}.app";
     nativeBuildInputs = [
       makeWrapper
-      _7zz
     ];
     installPhase = ''
       runHook preInstall


### PR DESCRIPTION
Obsidian's Nix derivation fetches the compiled Obsidian tarball from Obsidian GitHub release. The fetched tarball already has Electron bundled.

Original derivation enforces Obsidian to use `electron_39` from Nixpkgs instead of the one comes with it. Obsidian team seems to have patched Electron itself in the updates between v1.11.4 and v1.12.7. Using `electron_39` in Nixpkgs invalidates the patch and causes certain bugs. A known one is https://forum.obsidian.md/t/keyboard-triggered-context-menu-does-not-show-spell-suggestions/114141

This commit removes `electron_39` and `_7zz` dependency, making Obsidian depend on the Electron that is complied with it.

This commit also attempts to improve Electron's secret store auto-detection. The original detection fails on non-KDE or non-Gnome environments. A wrapper script is added to detect the currently running secret service and set the secret store backend flag instead of relying on matching user's desktop environment. This issue has already been improved in Electron 42: electron/electron#49054. But since Obsidian uses Obsidian 39, this patch is still needed.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
