### PR TITLE
proton-vpn: move icon to spec-compliant location

### DIFF
--- a/pkgs/by-name/pr/proton-vpn/linux.nix
+++ b/pkgs/by-name/pr/proton-vpn/linux.nix
@@ -62,12 +62,12 @@ python3Packages.buildPythonApplication (finalAttrs: {
   '';
 
   postInstall = ''
-    mkdir -p $out/share/{applications,pixmaps}
+    mkdir -p $out/share/applications
 
     # Fix the desktop file to correctly identify the wrapped app and show the icon during runtime
     substitute ${finalAttrs.src}/rpmbuild/SOURCES/proton.vpn.app.gtk.desktop $out/share/applications/proton.vpn.app.gtk.desktop \
       --replace-fail "StartupWMClass=protonvpn-app" "StartupWMClass=.protonvpn-app-wrapped"
-    install -Dm 644 ${finalAttrs.src}/rpmbuild/SOURCES/proton-vpn-logo.svg $out/share/pixmaps
+    install -Dm444 ${finalAttrs.src}/rpmbuild/SOURCES/proton-vpn-logo.svg -t $out/share/icons/hicolor/scalable/apps
   '';
 
   preCheck = ''


### PR DESCRIPTION
Part of #428824

Ref. #519051

```console
$ tree /nix/store/2xa84azwr0r7lbl07ipvhrv013x5j8yv-proton-vpn-4.15.3/share
/nix/store/2xa84azwr0r7lbl07ipvhrv013x5j8yv-proton-vpn-4.15.3/share
├── applications
│   └── proton.vpn.app.gtk.desktop
└── icons
    └── hicolor
        └── scalable
            └── apps
                └── proton-vpn-logo.svg

6 directories, 2 files
```

```console
$ l /nix/store/2xa84azwr0r7lbl07ipvhrv013x5j8yv-proton-vpn-4.15.3/share/icons/hicolor/scalable/apps
total 4.0K
-r--r--r-- 1 root root 1.5K Jan  1  1970 proton-vpn-logo.svg
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test