### PR TITLE
dovecot: 2.4.3 -> 2.4.4

### DIFF
--- a/pkgs/by-name/do/dovecot/package.nix
+++ b/pkgs/by-name/do/dovecot/package.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
-  version = "2.4.3";
-  hash = "sha256-NTtQMHK/IzAYHKb1lxClUUJkyJpeLo7mKRCAR1GaUTo=";
+  version = "2.4.4";
+  hash = "sha256-vy0R8TWQQ3BSOyTtWoa65CYgUfsJqkIU6QfnnzaqrI4=";
   patches = _: [
     # Fix loading extended modules.
     ./load-extended-modules.patch

--- a/pkgs/by-name/do/dovecot_pigeonhole/package.nix
+++ b/pkgs/by-name/do/dovecot_pigeonhole/package.nix
@@ -1,12 +1,12 @@
 import ./generic.nix {
-  version = "2.4.3";
+  version = "2.4.4";
   url =
     {
       version,
       dovecotMajorMinor,
     }:
     "https://pigeonhole.dovecot.org/releases/${dovecotMajorMinor}/dovecot-pigeonhole-${version}.tar.gz";
-  hash = "sha256-LQNhqYnBVICabluj8F07UOZR5frt6bd9JSyuHJDS6hc=";
+  hash = "sha256-KZjV0aSDGNJCmEaovaeUy4P8rQQFHBBk5E3vWL3MqNw=";
   patches = fetchpatch: [
     # https://github.com/NixOS/nixpkgs/pull/388463#issuecomment-3066016707
     (fetchpatch {


### PR DESCRIPTION
https://dovecot.org/mailman3/archives/list/dovecot-news@dovecot.org/thread/YW7GVOH3VVLNAYW2C4TEBTGJW52J7F6H/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
