### PR TITLE
rosec: init at 0.0.28

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18777,6 +18777,12 @@
     githubId = 1387206;
     name = "Mike Sperber";
   };
+  mikilio = {
+    email = "kilian.mio@mikilio.com";
+    github = "Mikilio";
+    githubId = 86004375;
+    name = "Kilian Mio";
+  };
   mikoim = {
     email = "ek@esh.ink";
     github = "mikoim";

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -88,6 +88,8 @@
 
 - [OO7](https://github.com/linux-credentials/oo7) is a desktop-agnostic Secret Service provider. Available as [services.oo7](#opt-services.oo7.enable)
 
+- [rosec](https://github.com/jmylchreest/rosec), a secrets daemon implementing the freedesktop.org Secret Service API with modular backend providers. It can automatically unlock the user's vault on login via PAM. Available as [services.rosec](#opt-services.rosec.enable).
+
 - [NordVPN](https://github.com/NordSecurity/nordvpn-linux), a NordVPN client for linux. Available as [services.nordvpn](options.html#opt-services.nordvpn.enable).
 
 - [RNSD](https://reticulum.network/), the Reticulum Network Stack Daemon. It provides a secure and efficient way to communicate over the Reticulum Network. Available as [services.rnsd](#opt-services.rnsd.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1574,6 +1574,7 @@
   ./services/security/physlock.nix
   ./services/security/pocket-id.nix
   ./services/security/reaction.nix
+  ./services/security/rosec.nix
   ./services/security/shibboleth-sp.nix
   ./services/security/sks.nix
   ./services/security/spire/agent.nix

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -686,6 +686,18 @@ let
           '';
         };
 
+        rosec = {
+          enable = lib.mkOption {
+            default = false;
+            type = lib.types.bool;
+            description = ''
+              If enabled, pam_rosec will attempt to automatically unlock the
+              user's rosec vault upon login. If the user login password does not
+              match their vault password, rosec will prompt separately after login.
+            '';
+          };
+        };
+
         enableUMask = lib.mkOption {
           default = config.security.pam.enableUMask;
           defaultText = lib.literalExpression "config.security.pam.enableUMask";
@@ -1209,6 +1221,7 @@ let
                       || cfg.kwallet.enable
                       || cfg.enableGnomeKeyring
                       || cfg.oo7.enable
+                      || cfg.rosec.enable
                       || config.services.intune.enable
                       || cfg.googleAuthenticator.enable
                       || cfg.gnupg.enable
@@ -1277,6 +1290,12 @@ let
                       enable = cfg.oo7.enable;
                       control = "optional";
                       modulePath = "${pkgs.oo7-pam}/lib/security/pam_oo7.so";
+                    }
+                    {
+                      name = "rosec";
+                      enable = cfg.rosec.enable;
+                      control = "optional";
+                      modulePath = "${pkgs.rosec}/lib/security/pam_rosec.so";
                     }
                     {
                       name = "intune";
@@ -1498,6 +1517,12 @@ let
                 enable = cfg.oo7.enable;
                 control = "optional";
                 modulePath = "${pkgs.oo7-pam}/lib/security/pam_oo7.so";
+              }
+              {
+                name = "rosec";
+                enable = cfg.rosec.enable;
+                control = "optional";
+                modulePath = "${pkgs.rosec}/lib/security/pam_rosec.so";
               }
             ];
 
@@ -1725,6 +1750,12 @@ let
                 settings = {
                   auto_start = true;
                 };
+              }
+              {
+                name = "rosec";
+                enable = cfg.rosec.enable;
+                control = "optional";
+                modulePath = "${pkgs.rosec}/lib/security/pam_rosec.so";
               }
               {
                 name = "gnupg";

--- a/nixos/modules/services/security/rosec.nix
+++ b/nixos/modules/services/security/rosec.nix
@@ -12,6 +12,22 @@ in
     enable = lib.mkEnableOption "rosec, a secrets daemon implementing the freedesktop.org Secret Service API";
 
     package = lib.mkPackageOption pkgs "rosec" { };
+
+    pam = {
+      enable = lib.mkEnableOption "PAM integration to automatically unlock the rosec vault on login";
+
+      services = lib.mkOption {
+        type = with lib.types; listOf str;
+        default = [ "login" ];
+        example = [
+          "login"
+          "greetd"
+        ];
+        description = ''
+          List of PAM services for which to enable rosec automatic unlock.
+        '';
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -22,6 +38,12 @@ in
     systemd.packages = [ cfg.package ];
 
     xdg.portal.extraPortals = [ cfg.package ];
+
+    security.pam.services = lib.mkIf cfg.pam.enable (
+      lib.genAttrs cfg.pam.services (_: {
+        rosec.enable = true;
+      })
+    );
   };
 
   meta.maintainers = with lib.maintainers; [ mikilio ];

--- a/nixos/modules/services/security/rosec.nix
+++ b/nixos/modules/services/security/rosec.nix
@@ -1,0 +1,28 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.rosec;
+in
+{
+  options.services.rosec = {
+    enable = lib.mkEnableOption "rosec, a secrets daemon implementing the freedesktop.org Secret Service API";
+
+    package = lib.mkPackageOption pkgs "rosec" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    services.dbus.packages = [ cfg.package ];
+
+    systemd.packages = [ cfg.package ];
+
+    xdg.portal.extraPortals = [ cfg.package ];
+  };
+
+  meta.maintainers = with lib.maintainers; [ mikilio ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1524,6 +1524,7 @@ in
   rnsd = runTest ./networking/rnsd.nix;
   robustirc-bridge = runTest ./robustirc-bridge.nix;
   romm = runTest ./romm.nix;
+  rosec = runTest ./rosec.nix;
   rosenpass = runTest ./rosenpass.nix;
   roundcube = runTest ./roundcube.nix;
   routinator = handleTest ./routinator.nix { };

--- a/nixos/tests/rosec.nix
+++ b/nixos/tests/rosec.nix
@@ -1,0 +1,101 @@
+{ pkgs, lib, ... }:
+let
+  rosec-config = pkgs.writeText "rosec-config.toml" ''
+    [[provider]]
+    id = "local"
+    kind = "local"
+    path = "/home/alice/.local/share/rosec/providers/local.vault"
+  '';
+in
+{
+  name = "rosec";
+  meta.maintainers = [ lib.maintainers.mikilio ];
+  # NOTE: PAM auto-unlock subtest requires interactive TTY login, which is
+  # architecture-dependent on QEMU (serial device and GPU differ between x86
+  # and aarch64). No existing test in nixpkgs handles this cross-platform.
+  # The D-Bus activation and PAM config subtests are platform-agnostic.
+  meta.broken = pkgs.stdenv.hostPlatform.isAarch64;
+
+  nodes.machine =
+    { nodes, ... }:
+    let
+      user = nodes.machine.users.users.alice;
+    in
+    {
+      imports = [ ./common/user-account.nix ];
+
+      services.rosec = {
+        enable = true;
+        pam.enable = true;
+      };
+
+      environment.systemPackages = [ pkgs.libsecret ];
+
+      environment.etc."rosec/test-askpass" = {
+        text = ''
+          #!/bin/sh
+          echo "${user.password}"
+        '';
+        mode = "0755";
+      };
+
+      environment.variables = {
+        SSH_ASKPASS = lib.mkForce "/etc/rosec/test-askpass";
+        SSH_ASKPASS_REQUIRE = lib.mkForce "force";
+        DBUS_SESSION_BUS_ADDRESS = "unix:path=/run/user/${toString user.uid}/bus";
+      };
+    };
+
+  testScript =
+    { nodes, ... }:
+    let
+      user = nodes.machine.users.users.alice;
+      config-path = "${rosec-config}";
+    in
+    ''
+      machine.wait_until_tty_matches("1", "login: ")
+      machine.send_chars("alice\n")
+      machine.wait_until_tty_matches("1", "login: alice")
+      machine.wait_until_succeeds("pgrep login")
+      machine.wait_until_tty_matches("1", "Password: ")
+      machine.send_chars("${user.password}\n")
+      machine.wait_until_succeeds("pgrep -u alice bash")
+
+      machine.succeed("su - alice -c 'mkdir -p ~/.config/rosec ~/.local/share/rosec/providers'")
+      machine.succeed("su - alice -c 'cp ${config-path} ~/.config/rosec/config.toml'")
+      machine.succeed("su - alice -c 'systemctl --user import-environment SSH_ASKPASS SSH_ASKPASS_REQUIRE'")
+
+      with subtest("D-Bus activation starts rosecd and registers portal"):
+          machine.succeed("su - alice -c 'secret-tool lookup application nonexistent-rosec-test >/dev/null 2>&1 || true'")
+          _, output = machine.systemctl("status rosecd --no-pager", "alice")
+          assert "Active: active (running)" in output
+          machine.succeed("su - alice -c 'busctl --user list | grep -q org.freedesktop.impl.portal.desktop.rosec'")
+
+      with subtest("PAM is configured with pam_rosec"):
+          login_pam = machine.succeed("cat /etc/pam.d/login")
+
+          import re
+          assert any(re.match(r"auth\s+.*pam_rosec", l) for l in login_pam.splitlines()), "pam_rosec missing from auth stack"
+          assert any(re.match(r"password\s+.*pam_rosec", l) for l in login_pam.splitlines()), "pam_rosec missing from password stack"
+          assert any(re.match(r"session\s+.*pam_rosec", l) for l in login_pam.splitlines()), "pam_rosec missing from session stack"
+
+      with subtest("PAM auto-unlocks the vault on login"):
+          machine.succeed("su - alice -c 'echo ${user.password} | secret-tool store --label=PamTest application rosec-pam-test'")
+          machine.succeed("su - alice -c 'rosec lock'")
+
+          machine.send_chars("exit\n")
+          machine.wait_until_fails("pgrep -u alice bash")
+          machine.wait_until_tty_matches("1", "login: ")
+          machine.send_chars("alice\n")
+          machine.wait_until_tty_matches("1", "login: alice")
+          machine.wait_until_succeeds("pgrep login")
+          machine.wait_until_tty_matches("1", "Password: ")
+          machine.send_chars("${user.password}\n")
+          machine.wait_until_succeeds("pgrep -u alice bash")
+
+          machine.wait_until_succeeds("su - alice -c 'systemctl --user is-active rosecd'", timeout=30)
+          machine.succeed("su - alice -c 'timeout 30 bash -c \"until secret-tool lookup application rosec-pam-test >/dev/null 2>&1; do sleep 1; done\"'")
+          result = machine.succeed("su - alice -c 'secret-tool lookup application rosec-pam-test'")
+          assert "${user.password}" in result
+    '';
+}

--- a/pkgs/by-name/ro/rosec-bitwarden-pm/package.nix
+++ b/pkgs/by-name/ro/rosec-bitwarden-pm/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  rustPlatform,
+  rosec,
+  lld,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: rec {
+  pname = "rosec-bitwarden-pm";
+
+  inherit (rosec) src version;
+
+  sourceRoot = "${src.name}/rosec-bitwarden-pm";
+
+  cargoHash = "sha256-hNeCZPclwz2WMKnHsECBL0TduqkWsYhadEfsw54lGBg=";
+
+  env.RUSTFLAGS = "-C linker=wasm-ld";
+  nativeBuildInputs = [ lld ];
+
+  passthru.updateScript = nix-update-script { };
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Bitwarden (Personal) provider for rosec";
+    homepage = "https://github.com/jmylchreest/rosec";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mikilio ];
+    platforms = lib.platforms.wasi;
+  };
+})

--- a/pkgs/by-name/ro/rosec-bitwarden-sm/package.nix
+++ b/pkgs/by-name/ro/rosec-bitwarden-sm/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  rustPlatform,
+  rosec,
+  lld,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: rec {
+  pname = "rosec-bitwarden-sm";
+
+  inherit (rosec) src version;
+
+  sourceRoot = "${src.name}/rosec-bitwarden-sm";
+
+  cargoHash = "sha256-E4xxxK+7LEyYh7QtLnN8bHYwb2I9DQ7t4Inxbu72Fq4=";
+
+  env.RUSTFLAGS = "-C linker=wasm-ld";
+  nativeBuildInputs = [ lld ];
+
+  passthru.updateScript = nix-update-script { };
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Bitwarden Secret Manager provider for rosec";
+    homepage = "https://github.com/jmylchreest/rosec";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mikilio ];
+    platforms = lib.platforms.wasi;
+  };
+})

--- a/pkgs/by-name/ro/rosec-gnome-keyring/package.nix
+++ b/pkgs/by-name/ro/rosec-gnome-keyring/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  rustPlatform,
+  rosec,
+  lld,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: rec {
+  pname = "rosec-gnome-keyring";
+
+  inherit (rosec) src version;
+
+  sourceRoot = "${src.name}/rosec-gnome-keyring";
+
+  cargoHash = "sha256-gkbD1N4veXhETwc5uzL/eq7a6naGq6suqJOAp53suFI=";
+
+  env.RUSTFLAGS = "-C linker=wasm-ld";
+  nativeBuildInputs = [ lld ];
+
+  passthru.updateScript = nix-update-script { };
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "GNOME keyring provider for rosec";
+    homepage = "https://github.com/jmylchreest/rosec";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mikilio ];
+    platforms = lib.platforms.wasi;
+  };
+})

--- a/pkgs/by-name/ro/rosec/package.nix
+++ b/pkgs/by-name/ro/rosec/package.nix
@@ -1,0 +1,119 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  stdenv,
+  autoPatchelfHook,
+  symlinkJoin,
+  pam,
+  dbus,
+  wayland,
+  libxkbcommon,
+  nixosTests,
+  nix-update-script,
+  provider ? [ ],
+}:
+symlinkJoin (
+  finalAttrs:
+  let
+    inherit (finalAttrs) version;
+
+    src = fetchFromGitHub {
+      owner = "jmylchreest";
+      repo = "rosec";
+      tag = "v${version}";
+      hash = "sha256-qs6WjgiK2AFhGlbsl85fEmVaWr/aw5pOIaKw68rsLZ0=";
+    };
+
+    rosecPam = stdenv.mkDerivation {
+      pname = "pam_rosec";
+      inherit version src;
+      sourceRoot = "${src.name}/contrib/pam";
+
+      buildInputs = [ pam ];
+
+      makeFlags = [
+        "PREFIX=$(out)"
+        "ROSEC_PAM_UNLOCK_PATH=${rosecCore}/libexec/rosec/rosec-pam-unlock"
+      ];
+
+      installPhase = ''
+        runHook preInstall
+        install -Dm755 pam_rosec.so "$out/lib/security/pam_rosec.so"
+        runHook postInstall
+      '';
+    };
+
+    rosecCore = rustPlatform.buildRustPackage {
+      pname = "rosec-unwrapped";
+      inherit version src;
+
+      cargoHash = "sha256-kE3qpdQGvXtjlospxSeoyPIUNyioLq5Ao5y94yIsjMs=";
+
+      nativeBuildInputs = [
+        autoPatchelfHook
+        dbus
+      ];
+
+      runtimeDependencies = [
+        libxkbcommon
+        wayland
+      ];
+
+      buildInputs = [
+        stdenv.cc.cc.lib
+      ];
+
+      preCheck = ''
+        export $(dbus-launch --config-file=${dbus}/share/dbus-1/session.conf)
+      '';
+
+      postInstall = ''
+        mkdir -p $out/libexec/rosec
+        mkdir -p $out/lib/rosec/providers
+        mkdir -p $out/share/dbus-1/system.d
+        mkdir -p $out/share/systemd/user
+
+        mv $out/bin/rosec-pam-unlock $out/libexec/rosec/
+
+        # `rosec enable` writes the D-Bus, systemd user unit and xdg portal
+        # registrations to $XDG_CONFIG_HOME and $XDG_DATA_HOME, which are
+        # redirected into the output here.
+        XDG_CONFIG_HOME=$out/lib XDG_DATA_HOME=$out/share $out/bin/rosec enable
+      '';
+    };
+  in
+  {
+    pname = "rosec";
+    version = "0.0.28";
+
+    paths = [
+      rosecCore
+      rosecPam
+    ]
+    ++ provider;
+
+    __structuredAttrs = true;
+    strictDeps = true;
+
+    passthru = {
+      tests = { inherit (nixosTests) rosec; };
+      inherit rosecCore src version;
+      updateScript = nix-update-script {
+        extraArgs = [
+          "--subpackage"
+          "rosecCore"
+        ];
+      };
+    };
+
+    meta = {
+      description = "Secrets daemon implementing the freedesktop.org Secret Service API with modular backend providers";
+      homepage = "https://github.com/jmylchreest/rosec";
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [ mikilio ];
+      platforms = lib.platforms.linux;
+      mainProgram = "rosec";
+    };
+  }
+)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2800,6 +2800,14 @@ with pkgs;
 
   rmate = rubyPackages.rmate;
 
+  rosecFull = pkgs.rosec.override {
+    provider = with pkgsCross.wasi32; [
+      rosec-bitwarden-pm
+      rosec-bitwarden-sm
+      rosec-gnome-keyring
+    ];
+  };
+
   rpatool = with python3Packages; toPythonApplication rpatool;
 
   rpm = callPackage ../tools/package-management/rpm {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
