### PR TITLE
mercurial: refactor wrapping

### DIFF
--- a/pkgs/by-name/me/mercurial/package.nix
+++ b/pkgs/by-name/me/mercurial/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchurl,
   python3Packages,
-  makeWrapper,
   gettext,
   installShellFiles,
   re2Support ? true,
@@ -48,6 +47,7 @@ let
     };
 
     pyproject = false;
+    __structuredAttrs = true;
 
     passthru = { inherit python; }; # pass it so that the same version can be used in hg2git
 
@@ -72,7 +72,6 @@ let
       ++ lib.optional gitSupport pygit2
       ++ lib.optional highlightSupport pygments;
     nativeBuildInputs = [
-      makeWrapper
       gettext
       installShellFiles
       setuptools
@@ -84,7 +83,7 @@ let
       cargo
       rustc
     ];
-    buildInputs = [ docutils ];
+    buildInputs = [ docutils ] ++ lib.optionals guiSupport [ tk ];
 
     makeFlags = [ "PREFIX=$(out)" ] ++ lib.optional rustSupport "PURE=--rust";
 
@@ -97,16 +96,12 @@ let
         hgk=$out/${python.sitePackages}/hgext/hgk.py
         EOF
         # setting HG so that hgk can be run itself as well (not only hg view)
-        WRAP_TK=" --set TK_LIBRARY ${tk}/lib/${tk.libPrefix}
-                  --set HG $out/bin/hg
-                  --prefix PATH : ${tk}/bin "
+        WRAP_TK=( --set TK_LIBRARY ${tk}/lib/${tk.libPrefix}
+                  --set HG $out/bin/hg )
+        makeWrapperArgs+=(''${wrapTk[@]})
+        wrapProgram $out/bin/hgk ''${wrapTk[@]}
       '')
       + ''
-        for i in $(cd $out/bin && ls); do
-          wrapProgram $out/bin/$i \
-            $WRAP_TK
-        done
-
         # copy hgweb.cgi to allow use in apache
         mkdir -p $out/share/cgi-bin
         cp -v hgweb.cgi contrib/hgweb.wsgi $out/share/cgi-bin


### PR DESCRIPTION
~~TODO: fix failing passthru tests (except i pulled too new of a branch, where stdenv isn't built yet)~~ they do not fail when cherry-picked to master (which i'm able to build)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
