### PR TITLE
python3Packages.pendulum: 3.1.0-unstable-2025-10-28 -> 3.2.0

### DIFF
--- a/pkgs/development/python-modules/pendulum/default.nix
+++ b/pkgs/development/python-modules/pendulum/default.nix
@@ -3,10 +3,8 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  isPyPy,
 
   # build-system
-  poetry-core,
   rustPlatform,
 
   # native dependencies
@@ -14,54 +12,49 @@
 
   # dependencies
   python-dateutil,
-  time-machine,
   tzdata,
 
   # tests
   pytestCheckHook,
-  pytz,
+  time-machine,
 }:
 
 buildPythonPackage rec {
   pname = "pendulum";
-  version = "3.1.0-unstable-2025-10-28";
+  version = "3.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "sdispater";
     repo = "pendulum";
-    rev = "2982f25feaad2e58ad1530d3b53cc30fc1c82bd6";
-    hash = "sha256-1ULvlWLZx3z5eGmWJfrN46x0ohJ+mAxipm6l6rykGPY=";
+    tag = version;
+    hash = "sha256-zpBymeYhCy+yu6RPhOuN5xOVk6928hd3+oRsfiBPPuY=";
   };
 
   cargoRoot = "rust";
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
     sourceRoot = "${src.name}/rust";
-    hash = "sha256-Ozg+TW/woJsqmbmyDsgdMua3Lmnn+KBvBhd9kVik3XY=";
+    hash = "sha256-tC65lxI561ygOhBFujWzGk32XiQH6QB42nqboWSfQrg=";
   };
 
   nativeBuildInputs = [
-    poetry-core
     rustPlatform.maturinBuildHook
     rustPlatform.cargoSetupHook
   ];
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ iconv ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     python-dateutil
     tzdata
-  ]
-  ++ lib.optionals (!isPyPy) [
-    time-machine
   ];
 
   pythonImportsCheck = [ "pendulum" ];
 
   nativeCheckInputs = [
     pytestCheckHook
-    pytz
+    time-machine
   ];
 
   disabledTestPaths = [
@@ -75,7 +68,7 @@ buildPythonPackage rec {
   meta = {
     description = "Python datetimes made easy";
     homepage = "https://github.com/sdispater/pendulum";
-    changelog = "https://github.com/sdispater/pendulum/blob/${src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/sdispater/pendulum/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = [ ];
   };

--- a/pkgs/development/python-modules/pendulum/default.nix
+++ b/pkgs/development/python-modules/pendulum/default.nix
@@ -19,7 +19,7 @@
   time-machine,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pendulum";
   version = "3.2.0";
   pyproject = true;
@@ -27,14 +27,14 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "sdispater";
     repo = "pendulum";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-zpBymeYhCy+yu6RPhOuN5xOVk6928hd3+oRsfiBPPuY=";
   };
 
   cargoRoot = "rust";
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit pname version src;
-    sourceRoot = "${src.name}/rust";
+    inherit (finalAttrs) pname version src;
+    sourceRoot = "${finalAttrs.src.name}/rust";
     hash = "sha256-tC65lxI561ygOhBFujWzGk32XiQH6QB42nqboWSfQrg=";
   };
 
@@ -68,8 +68,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python datetimes made easy";
     homepage = "https://github.com/sdispater/pendulum";
-    changelog = "https://github.com/sdispater/pendulum/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/sdispater/pendulum/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/sdispater/pendulum/compare/2982f25feaad2e58ad1530d3b53cc30fc1c82bd6...3.2.0

Changelog: https://github.com/sdispater/pendulum/blob/3.2.0/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
