### PR TITLE
xsecurelock: make authproto_{pamtester,htacceess} optional

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -13,6 +13,9 @@
 - `databricks-cli` has been updated from `0.290.2` to `1.x.x`, the first major release. OAuth tokens for interactive logins (`auth_type = databricks-cli`) are now stored in the OS-native secure store by default (Secret Service on Linux) instead of `~/.databricks/token-cache.json`; cached tokens from older versions are not migrated, so run `databricks auth login` once per profile after upgrading. To keep the previous file-backed storage, set `DATABRICKS_AUTH_STORAGE=plaintext` or add `auth_storage = plaintext` under `[__settings__]` in `~/.databrickscfg`. Additionally, the `vector_search_endpoints` DABs resource renamed `min_qps` to `target_qps` (and the `vector-search-endpoints` command renamed `--min-qps` to `--target-qps`). See the [upstream changelog](https://github.com/databricks/cli/blob/main/CHANGELOG.md) for details.
 
 - `hurl` has been updated to `8.x.x` which has some breaking changes. See [upstream changelog](https://github.com/Orange-OpenSource/hurl/releases/tag/8.0.0) for details.
+
+- `xsecurelock` no longer supports authentication via htaccess files (`~/.xsecurelock.pw`) or via the `pamtester` program by default. Only the recommended PAM module is supported unless rebuilt with `withHtaccess` or `withPamtester`.
+
 - `python3Packages.django-health-check` has been updated to major version 4. See its [migration guide](https://codingjoe.dev/django-health-check/migrate-to-v4/) and [changelog](https://github.com/codingjoe/django-health-check/releases/tag/4.0.0) for breaking changes.
 
 - `libgdata` has been removed, as it was archived upstream and relied on the insecure libsoup 2.4.

--- a/pkgs/by-name/xs/xsecurelock/package.nix
+++ b/pkgs/by-name/xs/xsecurelock/package.nix
@@ -12,16 +12,18 @@
   libxext,
   libxscrnsaver,
   pam,
-  apacheHttpd,
-  pamtester,
   coreutils,
   makeWrapper,
 
   # boolean flags
   withXscreensaver ? true,
-  xscreensaver ? null,
+  xscreensaver,
   withDocs ? false,
-  pandoc ? null,
+  pandoc,
+  withHtaccess ? false,
+  apacheHttpd,
+  withPamtester ? false,
+  pamtester,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -40,9 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     makeWrapper
   ]
-  ++ lib.optionals withDocs [
-    pandoc
-  ];
+  ++ lib.optional withDocs pandoc;
 
   buildInputs = [
     libx11
@@ -53,9 +53,9 @@ stdenv.mkDerivation (finalAttrs: {
     libxext
     libxscrnsaver
     pam
-    apacheHttpd
-    pamtester
-  ];
+  ]
+  ++ lib.optional withHtaccess apacheHttpd
+  ++ lib.optional withPamtester pamtester;
 
   configureFlags = [
     "--with-pam-service-name=login"


### PR DESCRIPTION
Importantly, this removes the apache-httpd dependency from xsecurelock (by default).

From the README:

>   `authproto_pamtester`: Authenticates via PAM using pamtester. Shouldn't be required unless you can't compile `authproto_pam`. Only supports simple password based conversations.

And:

>  `authproto_htpasswd`: Authenticates via a htpasswd style file stored in `~/.xsecurelock.pw`. To generate this file, run: `( umask 077; htpasswd -cB ~/.xsecurelock.pw "$USER" )` Use this only if you for some reason can't use PAM!

Given that this package is built against PAM (`authproto_pam`), there's no good reason to include these two modules by default.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test