### PR TITLE
devenv: 2.1.0 -> 2.1.1

### DIFF
--- a/pkgs/by-name/de/devenv/package.nix
+++ b/pkgs/by-name/de/devenv/package.nix
@@ -24,7 +24,7 @@
 }:
 
 let
-  version = "2.1.0";
+  version = "2.1.1";
   devenvNixVersion = "2.34";
   devenvNixRev = "42d4b7de21c15f28c568410f4383fa06a8458a40";
 
@@ -49,11 +49,11 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "cachix";
     repo = "devenv";
-    tag = "v2.1";
-    hash = "sha256-U7rb9FufadyCBLLsxVY6AJfy6TN24+uwaBBh8JVOP8s=";
+    tag = "v2.1.1";
+    hash = "sha256-j+Vh1tQx+JQc6psaykHUX8rFpnHHvJdwHo4bVUswTxg=";
   };
 
-  cargoHash = "sha256-aONHe6r+lvXC45y6QeJ/tnVSHAYhy2IGuGWCrz+KVWc=";
+  cargoHash = "sha256-rfZ4HAEDiEcNceZ0Pge7s7eOMBvqJkc4HB5vzRSCOWU=";
 
   env = {
     RUSTFLAGS = "--cfg tracing_unstable";


### PR DESCRIPTION
Release notes: https://github.com/cachix/devenv/releases/tag/v2.1.1