### PR TITLE
pnpm: 11.1.0 -> 11.1.1

### DIFF
--- a/pkgs/development/tools/pnpm/default.nix
+++ b/pkgs/development/tools/pnpm/default.nix
@@ -26,8 +26,8 @@ let
       hash = "sha256-jnDdxmSbGLw9iVzzqQjAKR6kw4A5rYcixH4Bja8enPw=";
     };
     "11" = {
-      version = "11.1.0";
-      hash = "sha256-VzyCrTVuiwl+bKxIG3OB+d7tM6MYr38xGYSFjr4fl+8=";
+      version = "11.1.1";
+      hash = "sha256-BbKC0GMyKVxzbwsgyL3xhTJb8bymgske2BFUo8aFHMA=";
     };
   };
 

--- a/pkgs/test/pnpm/pnpm_11/default.nix
+++ b/pkgs/test/pnpm/pnpm_11/default.nix
@@ -44,8 +44,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     install -Dm644 -t $out/lib/pnpm-11-test dist/index.js
 
-    makeWrapper ${lib.getExe nodejs} $out/bin/pnpm11test \
-      --add-flags "$out/lib/pnpm11test"
+    makeWrapper ${lib.getExe nodejs} $out/bin/pnpm-11-test \
+      --add-flags "$out/lib/pnpm-11-test"
 
     runHook postInstall
   '';
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     license = lib.licenses.mit;
-    mainProgram = "pnpm11test";
+    mainProgram = "pnpm-11-test";
     inherit (pnpm.meta) maintainers;
   };
 })


### PR DESCRIPTION
https://github.com/pnpm/pnpm/releases/tag/v11.1.1

Signed-off-by: Sefa Eyeoglu <contact@scrumplex.net>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
