### PR TITLE
pcloud: 2.0.4 -> 2.1.0

### DIFF
--- a/pkgs/by-name/pc/pcloud/package.nix
+++ b/pkgs/by-name/pc/pcloud/package.nix
@@ -22,6 +22,7 @@
   fetchzip,
   lib,
   stdenv,
+  bashInteractive,
 
   # Runtime dependencies;
   # A few additional ones (e.g. Node) are already shipped together with the
@@ -31,7 +32,7 @@
   fuse,
   gsettings-desktop-schemas,
   gtk3,
-  libdbusmenu-gtk2,
+  libdbusmenu-gtk3,
   libgbm,
   libxdamage,
   nss,
@@ -40,13 +41,13 @@
 
 let
   pname = "pcloud";
-  version = "2.0.4";
-  code = "XZNttt5ZD5h5yXmbVPHHIIr4nEUwduLH837X";
+  version = "2.1.0";
+  code = "XZC8VU5ZEmdCknyJULblvtv3890nA80TSUiX";
 
   # Archive link's codes: https://www.pcloud.com/release-notes/linux.html
   src = fetchzip {
     url = "https://api.pcloud.com/getpubzip?code=${code}&filename=pcloud-${version}.zip";
-    hash = "sha256-VINx6xM8/unPC9xopV2ml64wqU0FdhZdGTnxLUpCiyY=";
+    hash = "sha256-vdQn1jIc44dGxUgK2xJMbVNObdF3hh8NvZi/YKpf+is=";
   };
 
 in
@@ -72,11 +73,12 @@ stdenv.mkDerivation {
     dbus-glib
     fuse
     gtk3
-    libdbusmenu-gtk2
+    libdbusmenu-gtk3
     libgbm
     libxdamage
     nss
     udev
+    bashInteractive
   ];
 
   installPhase = ''
@@ -128,6 +130,7 @@ stdenv.mkDerivation {
     description = "Secure and simple to use cloud storage for your files; pCloud Drive, Electron Edition";
     homepage = "https://www.pcloud.com/";
     changelog = "https://www.pcloud.com/release-notes/linux.html";
+    downloadPage = "https://www.pcloud.com/release-notes/linux.html";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
     maintainers = with lib.maintainers; [ patryk27 ];


### PR DESCRIPTION
Done:

- use libdbusmenu-gtk3  instead of libdbusmenu-gtk2
- added meta.downloadPage

Upstream changelog:

- 2.1.0 (12/05/2026) This update expands sharing — accept or decline pending folder invitations, and share multiple files at once.
  The app is now built on Electron 39 (Chromium 142), with improved Wayland support and better desktop integration.
  It also brings stability and reliability improvements across the app, including a more reliable updater and fixes for sync, file transfers, mounted Drive, Crypto folder, and peer-to-peer connections.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
