### PR TITLE
litellm: 1.83.7 -> 1.83.14

### DIFF
--- a/pkgs/by-name/li/litellm/package.nix
+++ b/pkgs/by-name/li/litellm/package.nix
@@ -8,6 +8,7 @@ python3Packages.toPythonApplication (
     dependencies =
       (oldAttrs.dependencies or [ ])
       ++ litellm.optional-dependencies.proxy
-      ++ litellm.optional-dependencies.extra_proxy;
+      ++ litellm.optional-dependencies.extra_proxy
+      ++ litellm.optional-dependencies.proxy-runtime;
   })
 )

--- a/pkgs/development/python-modules/litellm/default.nix
+++ b/pkgs/development/python-modules/litellm/default.nix
@@ -1,10 +1,13 @@
 {
   lib,
+  a2a-sdk,
   aiohttp,
+  anthropic,
   apscheduler,
   azure-identity,
   azure-keyvault-secrets,
   azure-storage-blob,
+  azure-storage-file-datalake,
   backoff,
   boto3,
   buildPythonPackage,
@@ -16,33 +19,42 @@
   fetchFromGitHub,
   google-cloud-iam,
   google-cloud-kms,
+  google-genai,
+  grpcio,
   gunicorn,
   httpx,
   importlib-metadata,
   jinja2,
   jsonschema,
+  langfuse,
   mcp,
   openai,
+  opentelemetry-api,
+  opentelemetry-exporter-otlp,
+  opentelemetry-sdk,
   orjson,
-  poetry-core,
   polars,
   prisma,
+  prometheus-client,
   pydantic,
   pyjwt,
   pynacl,
-  python,
+  pypdf,
   python-dotenv,
   python-multipart,
   pyyaml,
   requests,
   resend,
+  restrictedpython,
   rich,
   rq,
+  sentry-sdk,
   soundfile,
   tiktoken,
   tokenizers,
-  uvloop,
+  uv-build,
   uvicorn,
+  uvloop,
   websockets,
   nixosTests,
   nix-update-script,
@@ -50,17 +62,22 @@
 
 buildPythonPackage rec {
   pname = "litellm";
-  version = "1.83.7";
+  version = "1.83.14";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "BerriAI";
     repo = "litellm";
     tag = "v${version}-stable";
-    hash = "sha256-oVQ0FHZmXDY7HU4AMEQ9xcl10mIbqja9/j2mdunTWI4=";
+    hash = "sha256-SZow0qof9DRlohWjT3J/NHtmhe96OLLcdHt55RQ7Zmw=";
   };
 
-  build-system = [ poetry-core ];
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build==0.10.7" "uv_build"
+  '';
+
+  build-system = [ uv-build ];
 
   dependencies = [
     aiohttp
@@ -98,6 +115,7 @@ buildPythonPackage rec {
       pynacl
       python-multipart
       pyyaml
+      restrictedpython
       rich
       rq
       soundfile
@@ -107,6 +125,7 @@ buildPythonPackage rec {
     ];
 
     extra_proxy = [
+      a2a-sdk
       azure-identity
       azure-keyvault-secrets
       google-cloud-iam
@@ -115,12 +134,29 @@ buildPythonPackage rec {
       # FIXME package redisvl
       resend
     ];
+
+    proxy-runtime = [
+      anthropic
+      # FIXME package azure-ai-contentsafety
+      azure-storage-file-datalake
+      # FIXME package ddtrace
+      # FIXME package detect-secrets
+      # FIXME package google-cloud-aiplatform
+      google-genai
+      grpcio
+      langfuse
+      # FIXME package mangum
+      opentelemetry-api
+      opentelemetry-exporter-otlp
+      opentelemetry-sdk
+      # FIXME package llm-sandbox
+      prometheus-client
+      pypdf
+      sentry-sdk
+    ];
   };
 
-  pythonImportsCheck = [
-    "litellm"
-    "litellm_enterprise"
-  ];
+  pythonImportsCheck = [ "litellm" ];
 
   pythonRelaxDeps = [
     "aiohttp"
@@ -133,13 +169,6 @@ buildPythonPackage rec {
 
   # access network
   doCheck = false;
-
-  postFixup = ''
-    # Symlink litellm_enterprise to make it discoverable
-    pushd $out/lib/python${python.pythonVersion}/site-packages
-    ln -s enterprise/litellm_enterprise litellm_enterprise
-    popd
-  '';
 
   passthru = {
     tests = { inherit (nixosTests) litellm; };


### PR DESCRIPTION
Bump LiteLLM to fix #508886. The [GitHub
advisory](https://github.com/advisories/GHSA-wxxx-gvqv-xp7p) states that the vulnerability has been patched in 1.83.10.

Between .7 and .14 LiteLLM switched their build-system to uv-build, which has some effects on the derivation; notably, uv-build is configured to put the `enterprise` dir into another uv "workspace", meaning it's no longer accessible for us in the postFixup for symlinking. This is just as well, because the enterprise directory is under a separate license and from what I can see, all imports for litellm_enterprise are guarded with a try/catch anyways.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
