### PR TITLE
audit: 4.1.2-unstable-2025-09-06 -> 4.1.4

### DIFF
--- a/pkgs/by-name/au/audit/package.nix
+++ b/pkgs/by-name/au/audit/package.nix
@@ -30,13 +30,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "audit";
-  version = "4.1.2-unstable-2025-09-06"; # fixes to non-static builds right after 4.1.2 release
+  version = "4.1.4";
 
   src = fetchFromGitHub {
     owner = "linux-audit";
     repo = "audit-userspace";
-    rev = "cb13fe75ee2c36d5c525ed9de22aae10dbc8caf4";
-    hash = "sha256-NX0TWA+LtcZgbM9aQfokWv2rGNAAb3ksGqAH8URAkYM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-GdJ9nzlDAdOazOHH/YWuEoELrJh+G5ZJUKwIqAKAzpo=";
   };
 
   postPatch = ''
@@ -132,10 +132,6 @@ stdenv.mkDerivation (finalAttrs: {
   # Instead, we load audit rules in a dedicated module.
   postFixup = ''
     moveToOutput bin/augenrules $scripts
-    substituteInPlace $scripts/bin/augenrules \
-      --replace-fail "/sbin/auditctl -R" "$bin/bin/auditctl -R" \
-      --replace-fail "auditctl -s" "$bin/bin/auditctl -s" \
-      --replace-fail "/bin/ls" "ls"
     wrapProgram $scripts/bin/augenrules \
       --prefix PATH : ${
         lib.makeBinPath [


### PR DESCRIPTION
Upstream diff: https://github.com/linux-audit/audit-userspace/compare/cb13fe75ee2c36d5c525ed9de22aae10dbc8caf4...v4.1.4

Adds support for io_uring and syscalls of Linux 7.0 kernels.

Because previously the new syscalls were not properly audited, i believe this update deserves security tag.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
