### PR TITLE
slack: move icon to spec-compliant location

### DIFF
--- a/pkgs/by-name/sl/slack/linux.nix
+++ b/pkgs/by-name/sl/slack/linux.nix
@@ -151,6 +151,10 @@ stdenv.mkDerivation rec {
       --suffix PATH : ${lib.makeBinPath [ xdg-utils ]} \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations,WebRTCPipeWireCapturer --enable-wayland-ime=true}}"
 
+    # Move the icon to a spec-compliant location
+    mkdir -p $out/share/icons/hicolor/512x512
+    mv $out/share/{pixmaps,icons/hicolor/512x512/apps}
+
     # Fix the desktop link
     substituteInPlace $out/share/applications/slack.desktop \
       --replace /usr/bin/ $out/bin/ \


### PR DESCRIPTION
Part of #428824

```console
$ tree /nix/store/4kpz6p2iq9sx5jprpg87dwkd3qcya6k6-slack-4.48.100/share/
/nix/store/4kpz6p2iq9sx5jprpg87dwkd3qcya6k6-slack-4.48.100/share/
├── applications
│   └── slack.desktop
├── doc
│   └── slack-desktop
│       └── OPEN_SOURCE_LICENSE_ATTRIBUTIONS
└── icons
    └── hicolor
        └── 512x512
            └── apps
                └── slack.png
```

```console
$ l /nix/store/4kpz6p2iq9sx5jprpg87dwkd3qcya6k6-slack-4.48.100/share/icons/hicolor/512x512/apps
total 40K
-r--r--r-- 1 root root 38K Jan  1  1970 slack.png
```

8 directories, 3 files

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test