### PR TITLE
python3Packages.labgrid: add pytest to dependencies for cross-compilation

### DIFF
--- a/pkgs/development/python-modules/labgrid/default.nix
+++ b/pkgs/development/python-modules/labgrid/default.nix
@@ -14,6 +14,7 @@
   pexpect,
   psutil,
   pyserial,
+  pytest,
   pytestCheckHook,
   pytest-benchmark,
   pytest-dependency,
@@ -72,6 +73,7 @@ buildPythonPackage rec {
     pyudev
     pyusb
     pyyaml
+    pytest
     requests
     xmodem
   ];


### PR DESCRIPTION
Cross-compilation (e.g. x86_64 → aarch64) was failing because upstream declares pytest as a mandatory runtime dependency (labgrid is a pytest plugin via the pytest11 entry point), but nixpkgs only had it in nativeCheckInputs.

During native builds, nativeCheckInputs are included in nativeBuildInputs (via doInstallCheck), so pytest is available and the pythonRuntimeDepsCheckHook passes. However, during cross-compilation, doInstallCheck is set to false (canExecuteHostOnBuild = false), nativeCheckInputs are omitted, pytest is unavailable, and the hook fails with "pytest not installed".

Fix by adding pytest to dependencies, matching the upstream declaration in pyproject.toml.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
