### PR TITLE
treewide: rename NAHO developer identity to Noah Biewesch and add email

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -22,6 +22,7 @@ Lin Jian <me@linj.tech> <75130626+jian-lin@users.noreply.github.com>
 Martin Weinelt <hexa@darmstadt.ccc.de> <mweinelt@users.noreply.github.com>
 Martin Häcker <spamfaenger@gmx.de> <spamfaenger@gmx.de>
 moni <lythe1107@gmail.com> <lythe1107@icloud.com>
+Noah Biewesch <dev@noahbiewesch.com> <90870942+trueNAHO@users.noreply.github.com>
 quantenzitrone <nix@dev.quantenzitrone.eu>
 quantenzitrone <nix@dev.quantenzitrone.eu> <74491719+Quantenzitrone@users.noreply.github.com>
 quantenzitrone <nix@dev.quantenzitrone.eu> <74491719+quantenzitrone@users.noreply.github.com>

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19047,7 +19047,7 @@
   naho = {
     github = "trueNAHO";
     githubId = 90870942;
-    name = "Noah Pierre Biewesch";
+    name = "Noah Biewesch";
     keys = [ { fingerprint = "5FC6 088A FB1A 609D 4532  F919 0C1C 177B 3B64 68E0"; } ];
   };
   nalbyuites = {

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19048,6 +19048,7 @@
     github = "trueNAHO";
     githubId = 90870942;
     name = "Noah Biewesch";
+    email = "nix@noahbiewesch.com";
     keys = [ { fingerprint = "5FC6 088A FB1A 609D 4532  F919 0C1C 177B 3B64 68E0"; } ];
   };
   nalbyuites = {

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19044,13 +19044,6 @@
     github = "nagymathev";
     githubId = 49335802;
   };
-  naho = {
-    github = "trueNAHO";
-    githubId = 90870942;
-    name = "Noah Biewesch";
-    email = "nix@noahbiewesch.com";
-    keys = [ { fingerprint = "5FC6 088A FB1A 609D 4532  F919 0C1C 177B 3B64 68E0"; } ];
-  };
   nalbyuites = {
     email = "ashijit007@gmail.com";
     github = "nalbyuites";
@@ -19864,6 +19857,13 @@
     name = "Noah765";
     github = "Noah765";
     githubId = 99338019;
+  };
+  noahbiewesch = {
+    github = "trueNAHO";
+    githubId = 90870942;
+    name = "Noah Biewesch";
+    email = "nix@noahbiewesch.com";
+    keys = [ { fingerprint = "5FC6 088A FB1A 609D 4532  F919 0C1C 177B 3B64 68E0"; } ];
   };
   noahfraiture = {
     name = "Noahcode";

--- a/pkgs/by-name/an/antora-lunr-extension/package.nix
+++ b/pkgs/by-name/an/antora-lunr-extension/package.nix
@@ -57,7 +57,7 @@ buildNpmPackage rec {
       key](https://docs.antora.org/antora/3.1/extend/enable-extension).
     '';
 
-    maintainers = [ lib.maintainers.naho ];
+    maintainers = [ lib.maintainers.noahbiewesch ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/an/antora-ui-default/package.nix
+++ b/pkgs/by-name/an/antora-ui-default/package.nix
@@ -15,8 +15,8 @@ stdenvNoCC.mkDerivation {
   pname = "antora-ui-default";
   version = "0-unstable-2024-12-26";
 
-  # The UI bundle is fetched from lib.maintainers.naho's antora-ui-default fork
-  # for the following reasons:
+  # The UI bundle is fetched from lib.maintainers.noahbiewesch's
+  # antora-ui-default fork for the following reasons:
   #
   # > The UI bundle is currently unpackaged [1] [2], and only accessible by
   # > fetching the latest GitLab artifact or building from source. Neither
@@ -71,7 +71,7 @@ stdenvNoCC.mkDerivation {
       references.
     '';
 
-    maintainers = [ lib.maintainers.naho ];
+    maintainers = [ lib.maintainers.noahbiewesch ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/an/antora/package.nix
+++ b/pkgs/by-name/an/antora/package.nix
@@ -46,7 +46,7 @@ buildNpmPackage rec {
 
     maintainers = with lib.maintainers; [
       ehllie
-      naho
+      noahbiewesch
     ];
 
     platforms = lib.platforms.all;

--- a/pkgs/by-name/an/antora/test/default.nix
+++ b/pkgs/by-name/an/antora/test/default.nix
@@ -60,7 +60,7 @@ stdenvNoCC.mkDerivation {
   meta = {
     description = "Reproducible Antora test framework";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.naho ];
+    maintainers = [ lib.maintainers.noahbiewesch ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/mp/mpv/scripts/twitch-chat.nix
+++ b/pkgs/by-name/mp/mpv/scripts/twitch-chat.nix
@@ -30,6 +30,6 @@ buildLua {
     description = "Show Twitch chat messages as subtitles when watching Twitch VOD with mpv";
     homepage = "https://github.com/CrendKing/mpv-twitch-chat";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.naho ];
+    maintainers = [ lib.maintainers.noahbiewesch ];
   };
 }


### PR DESCRIPTION
```
commit 62c088642e96e9d7df69036b6ece3e52eed2cd6c
Author: Noah Biewesch
Date:   2026-05-12 22:38:03 +0200

    maintainers: canonicalize naho's name to Noah Biewesch

 maintainers/maintainer-list.nix | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

commit b14a0b6fe8d86013b1c57bd1b62ceaee7dab202c
Author: Noah Biewesch
Date:   2026-05-12 22:46:04 +0200

    maintainers: add naho's email address

 maintainers/maintainer-list.nix | 1 +
 1 file changed, 1 insertion(+)

commit f5bd4a2a331e68c7bf3af44e20f86be1197c4f48
Author: Noah Biewesch
Date:   2026-05-12 22:31:42 +0200

    mailmap: map NAHO developer identity to Noah Biewesch

 .mailmap | 1 +
 1 file changed, 1 insertion(+)

commit c3ecc39c7c4114b423fff5a6f67b7d6af82d96bd
Author: Noah Biewesch
Date:   2026-05-12 22:50:55 +0200

    maintainers: rename naho to noahbiewesch

 maintainers/maintainer-list.nix                   | 14 +++++++-------
 pkgs/by-name/an/antora-lunr-extension/package.nix |  2 +-
 pkgs/by-name/an/antora-ui-default/package.nix     |  6 +++---
 pkgs/by-name/an/antora/package.nix                |  2 +-
 pkgs/by-name/an/antora/test/default.nix           |  2 +-
 pkgs/by-name/mp/mpv/scripts/twitch-chat.nix       |  2 +-
 6 files changed, 14 insertions(+), 14 deletions(-)
```

This PR is part of a coordinated effort to canonicalize my developer identity:

- https://github.com/NixOS/nixpkgs/pull/519557
- https://github.com/nix-community/home-manager/pull/9308
- https://github.com/nix-community/nixvim/pull/4287
- https://github.com/nix-community/stylix/pull/2309

---

Although this is out of the scope of this PR, I would like to point out that it would be valuable to support deprecation phases when making breaking changes inside `lib.maintainers`, which happens surprisingly often, as implied by:

```
git log --oneline maintainers/maintainer-list.nix | grep rename
```
For example, `[PATCH 4/4] maintainers: rename naho to noahbiewesch` causes downstream breaking changes when accessing `lib.maintainers.naho`. [AFAIK](https://github.com/nix-community/stylix/pull/1676), `builtins.warn` cannot be used to prevent incompatibilities with other Nix runtimes, and `lib.warn` is inaccessible in this scope as it probably requires changing callers of `/maintainers/maintainer-list.nix`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
