### PR TITLE
openresty: fix lib.optional misuse in configureFlags

### DIFF
--- a/pkgs/servers/http/openresty/default.nix
+++ b/pkgs/servers/http/openresty/default.nix
@@ -49,7 +49,7 @@ callPackage ../nginx/generic.nix args rec {
     patchShebangs configure bundle/
   '';
 
-  configureFlags = lib.optional withPostgres [ "--with-http_postgres_module" ];
+  configureFlags = lib.optionals withPostgres [ "--with-http_postgres_module" ];
 
   postInstall = ''
     ln -s $out/luajit/bin/luajit-2.1.ROLLING $out/bin/luajit-openresty


### PR DESCRIPTION
This PR fixes a small issue in the `openresty` derivation: `lib.optional` is currently used instead of `lib.optionals`.

This small difference meant that `--with-http_postgres_module` was added to `configureFlags` as a list, resulting in the nested form:

```console
$ nix-instantiate --eval --strict -E '(import ./. {}).openresty.configureFlags'
[ ... [ "--with-http_postgres_module" ] ]
```

Now, with `lib.optionals`:

```console
$ nix-instantiate --eval --strict -E '(import ./. {}).openresty.configureFlags'
[ ... "--with-http_postgres_module" ]
```

This didn't result in a build-issue because both of these forms flatten and stringify to the same value when `configureFlags` is serialized, resulting in identical `./configure` invocations.

However, this makes it harder to add custom overrides to `configureFlags`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
