### PR TITLE
pbkdf2-password-hash: init at 0-unstable-2024-03-21

### DIFF
--- a/pkgs/by-name/pb/pbkdf2-password-hash/package.nix
+++ b/pkgs/by-name/pb/pbkdf2-password-hash/package.nix
@@ -1,0 +1,31 @@
+{
+  fetchgit,
+  lib,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "pbkdf2-password-hash";
+  version = "0-unstable-2024-03-21";
+
+  src = fetchgit {
+    url = "https://git.sr.ht/~laalsaas/pbkdf2-password-hash";
+    rev = "9dfc0fd353bda7a6ccffbf681efc9a26dcc29a90";
+    hash = "sha256-eBRArvcGU+63VT8Fx6iIi5RP9F55860CwF4Q3YwT8WU=";
+  };
+
+  cargoHash = "sha256-n3VxmR+bjFN/mEJ/SuDYQJWcndR7QFmcVJdZhSHDdmQ=";
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Prompts for a password and prints the pbkdf2 hash";
+    homepage = "https://git.sr.ht/~laalsaas/pbkdf2-password-hash";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      felixsinger
+    ];
+    platforms = lib.platforms.linux;
+    mainProgram = "pbkdf2-hash-password";
+  };
+}


### PR DESCRIPTION
Needed for #519214. Couldn't find any other tool that prints the required hash format, so I've packaged what the Anki project referenced in their documentation https://docs.ankiweb.net/sync-server.html#hashed-passwords.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
