### PR TITLE
nixos/nvidia-container-toolkit: add rprivate to default mountOptions

### DIFF
--- a/nixos/modules/services/hardware/nvidia-container-toolkit/default.nix
+++ b/nixos/modules/services/hardware/nvidia-container-toolkit/default.nix
@@ -31,6 +31,10 @@
               "nosuid"
               "nodev"
               "bind"
+              # Match nvidia-ctk's own generated mounts (NVIDIA/nvidia-container-toolkit#980):
+              # without rprivate, a user-supplied directory mount inherits the host's
+              # shared peer group, and per-file rbinds under it propagate back to the host.
+              "rprivate"
             ];
             type = lib.types.listOf lib.types.str;
             description = "Mount options.";


### PR DESCRIPTION
Mounts injected via `hardware.nvidia-container-toolkit.mounts` default to `bind` without `rprivate`, while every mount that `nvidia-ctk cdi generate` itself emits carries `rprivate` (added in [NVIDIA/nvidia-container-toolkit#980](https://github.com/NVIDIA/nvidia-container-toolkit/pull/980) for exactly this reason). On a host where `/` is in a `shared` peer group — the systemd default — a user-supplied directory mount inherits that group, and any per-file `rbind` under it (including nvidia-ctk's auto-discovered library mounts when the user entry is the driver lib directory) propagates to the host on the bind syscall. The per-file mount's own `rprivate` is a second `mount(MS_PRIVATE)` call that only privatizes the container's copy after the host already received one. With a `mountPropagation: Bidirectional` hostPath of `/` elsewhere in the pod, each GPU-container restart compounds the host's mount table until `runc create` returns `ENOSPC` at `fs.mount-max`.

This adds `rprivate` to the default so module-injected mounts match nvidia-ctk's own. Users who need shared propagation can still override `mountOptions` per entry.

Fixes #519565.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

Observed the failure mode on a live aarch64-linux Kubernetes node: with the current default, the CDI spec on the node shows the user-supplied directory mount with `ro,nosuid,nodev,bind` and every nvidia-ctk-generated entry with `rbind,rprivate`; repeated GPU-container restarts grow host `/proc/1/mountinfo` at the nvidia `.so` paths in 30·(2ⁿ−1) steps. The fix follows nvidia-container-toolkit#980's pattern.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
