### PR TITLE
pulse-visualizer: 1.2.2 -> 1.3.9

### DIFF
--- a/pkgs/by-name/pu/pulse-visualizer/package.nix
+++ b/pkgs/by-name/pu/pulse-visualizer/package.nix
@@ -6,12 +6,14 @@
   ninja,
   pkg-config,
   sdl3,
+  sdl3-image,
   libpulseaudio,
   pipewire,
   fftwFloat,
   freetype,
   glew,
   libGL,
+  curl,
   yaml-cpp,
   libebur128,
   clang,
@@ -19,13 +21,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pulse-visualizer";
-  version = "1.2.2";
+  version = "1.3.9";
 
   src = fetchFromGitHub {
     owner = "Audio-Solutions";
     repo = "pulse-visualizer";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-OnZDNNDmN+OgsfzyPOtlpy8alt62WA6BNhNPJTtrHsU=";
+    hash = "sha256-IzJXFbsbpRszJEpU98exK4EKGU8kHH51BZzokJwzPzU=";
   };
 
   nativeBuildInputs = [
@@ -37,12 +39,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     sdl3
+    sdl3-image
     libpulseaudio
     pipewire
     fftwFloat
     freetype
     glew
     libGL
+    curl
     yaml-cpp
     libebur128
   ];


### PR DESCRIPTION
## Things done

In principal there's lot's of room for improvement to the expression, but it'll make sense to do it after upstream PR is accepted:

- https://github.com/Audio-Solutions/pulse-visualizer/pull/55

I should also note, that I experience https://github.com/Audio-Solutions/pulse-visualizer/issues/30 even with this version...

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test