### PR TITLE
python3Packages.nvidia-cutlass: init at 4.2.0

### DIFF
--- a/pkgs/development/python-modules/nvidia-cutlass/default.nix
+++ b/pkgs/development/python-modules/nvidia-cutlass/default.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  cuda-bindings,
+  cuda-pathfinder,
+  networkx,
+  numpy,
+  pydot,
+  scipy,
+  treelib,
+
+  # tests
+  pytestCheckHook,
+  torch,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "nvidia-cutlass";
+  version = "4.2.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = "cutlass";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-XicHeV9ni9bSOWcUJM8HrCuz61mVK1EdZ9uxNvgWmvk=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  pythonRemoveDeps = [
+    # Replaced with the cuda-python sub-packages we actually need
+    "cuda-python"
+  ];
+  dependencies = [
+    cuda-bindings
+    cuda-pathfinder
+    networkx
+    numpy
+    pydot
+    scipy
+    treelib
+  ];
+
+  pythonImportsCheck = [
+    "cutlass_cppgen"
+    "cutlass_library"
+    "pycute"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    torch
+  ];
+
+  enabledTestPaths = [
+    "test"
+  ];
+
+  meta = {
+    description = "Python bindings for NVIDIA's CUTLASS library";
+    homepage = "https://github.com/NVIDIA/cutlass";
+    changelog = "https://github.com/NVIDIA/cutlass/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11437,6 +11437,8 @@ self: super: with self; {
 
   nvdlib = callPackage ../development/python-modules/nvdlib { };
 
+  nvidia-cutlass = callPackage ../development/python-modules/nvidia-cutlass { };
+
   nvidia-dlprof-pytorch-nvtx =
     callPackage ../development/python-modules/nvidia-dlprof-pytorch-nvtx
       { };


### PR DESCRIPTION
## Things done

Add [nvidia-cutlass](https://github.com/NVIDIA/cutlass/tree/main/python), CUTLASS Python interface.

- **python3Packages.nvidia-cutlass: init at 4.2.0**
- ~~**python3Packages.nvidia-cutlass-dsl: init at 4.5.0**~~

cc @NixOS/cuda-maintainers

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
