### PR TITLE
chkcrontab: migrate to pyproject

### DIFF
--- a/pkgs/by-name/ch/chkcrontab/package.nix
+++ b/pkgs/by-name/ch/chkcrontab/package.nix
@@ -9,12 +9,20 @@ with python3.pkgs;
 buildPythonApplication (finalAttrs: {
   pname = "chkcrontab";
   version = "1.7";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
     sha256 = "0gmxavjkjkvjysgf9cf5fcpk589gb75n1mn20iki82wifi1pk1jn";
   };
+
+  postPatch = ''
+    # cannot install the manpage as it is not present in the wheel
+    substituteInPlace setup.py \
+      --replace-fail "'doc/chkcrontab.1'" ""
+  '';
+
+  build-system = [ setuptools ];
 
   meta = {
     description = "Tool to detect crontab errors";

--- a/pkgs/by-name/ch/chkcrontab/package.nix
+++ b/pkgs/by-name/ch/chkcrontab/package.nix
@@ -1,12 +1,10 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchPypi,
 }:
 
-with python3.pkgs;
-
-buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "chkcrontab";
   version = "1.7";
   pyproject = true;
@@ -22,7 +20,7 @@ buildPythonApplication (finalAttrs: {
       --replace-fail "'doc/chkcrontab.1'" ""
   '';
 
-  build-system = [ setuptools ];
+  build-system = [ python3Packages.setuptools ];
 
   meta = {
     description = "Tool to detect crontab errors";


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/515974

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
