### PR TITLE
nixos/i3lock: drop special treatment of u2f support

### DIFF
--- a/nixos/modules/programs/i3lock.nix
+++ b/nixos/modules/programs/i3lock.nix
@@ -19,21 +19,6 @@ in
       enable = lib.mkEnableOption "i3lock";
       package = lib.mkPackageOption pkgs "i3lock" {
         example = "i3lock-color";
-        extraDescription = ''
-          ::: {.note}
-          The i3lock package must include a i3lock file or link in its out directory in order for the u2fSupport option to work correctly.
-          :::
-        '';
-      };
-      u2fSupport = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        example = true;
-        description = ''
-          Whether to enable U2F support in the i3lock program.
-          U2F enables authentication using a hardware device, such as a security key.
-          When U2F support is enabled, the i3lock program will set the setuid bit on the i3lock binary and enable the pam u2f service,
-        '';
       };
     };
   };
@@ -43,15 +28,6 @@ in
   config = lib.mkIf cfg.enable {
 
     environment.systemPackages = [ cfg.package ];
-
-    security.wrappers.i3lock = lib.mkIf cfg.u2fSupport {
-      setuid = true;
-      owner = "root";
-      group = "root";
-      source = "${cfg.package.out}/bin/i3lock";
-    };
-
-    security.pam.services.i3lock.u2f.enable = cfg.u2fSupport;
 
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
