### PR TITLE
stdenv/problems: only run problem if it's not ignored

### DIFF
--- a/pkgs/stdenv/generic/problems.nix
+++ b/pkgs/stdenv/generic/problems.nix
@@ -478,27 +478,25 @@ rec {
       ) automaticProblems;
     in
     attrs:
-    let
-      pname = getName attrs;
-    in
     if
       # Fast path for when there's no problem that needs to be handled
       all (
-        problem: problem.condition attrs -> problem.handler pname == "ignore"
+        problem: problem.condition attrs -> problem.handler (getName attrs) == "ignore"
       ) automaticProblemsConfigCache
       && (
         # No manual problems
         !attrs ? meta.problems
         # Or all manual problems are ignored
-        || all (name: handlerForProblem (attrs.meta.problems.${name}.kind or name) name pname == "ignore") (
-          attrNames attrs.meta.problems
-        )
+        || all (
+          name: handlerForProblem (attrs.meta.problems.${name}.kind or name) name (getName attrs) == "ignore"
+        ) (attrNames attrs.meta.problems)
       )
     then
       null
     else
       # Slow path, only here we actually figure out which problems we need to handle
       let
+        pname = getName attrs;
         problems = attrs.meta.problems or { } // genAutomaticProblems config attrs;
         problemsToHandle = filter (v: v.handler != "ignore") (
           mapAttrsToList (name: problem: rec {

--- a/pkgs/stdenv/generic/problems.nix
+++ b/pkgs/stdenv/generic/problems.nix
@@ -121,14 +121,16 @@ rec {
           allowBroken = config.allowBroken || builtins.getEnv "NIXPKGS_ALLOW_BROKEN" == "1";
 
           allowBrokenPredicate =
-            if config ? allowBrokenPredicate then
-              lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2605)
-                "config.allowBrokenPredicate is deprecated, use config.problems.handlers.myPackage.broken = \"warn\" for individual packages instead."
-                config.allowBrokenPredicate
-            else
-              x: false;
+            lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2605)
+              "config.allowBrokenPredicate is deprecated, use config.problems.handlers.myPackage.broken = \"warn\" for individual packages instead."
+              config.allowBrokenPredicate;
         in
-        attrs: attrs.meta.broken or false && !allowBroken && !allowBrokenPredicate attrs;
+        if allowBroken then
+          attrs: false
+        else if config ? allowBrokenPredicate then
+          attrs: attrs.meta.broken or false && !allowBrokenPredicate attrs
+        else
+          attrs: attrs.meta.broken or false;
       value.message = "This package is broken.";
     }
   ];

--- a/pkgs/stdenv/generic/problems.nix
+++ b/pkgs/stdenv/generic/problems.nix
@@ -128,9 +128,9 @@ rec {
         if allowBroken then
           attrs: false
         else if config ? allowBrokenPredicate then
-          attrs: attrs.meta.broken or false && !allowBrokenPredicate attrs
+          attrs: attrs ? meta.broken && attrs.meta.broken && !allowBrokenPredicate attrs
         else
-          attrs: attrs.meta.broken or false;
+          attrs: attrs ? meta.broken && attrs.meta.broken;
       value.message = "This package is broken.";
     }
   ];

--- a/pkgs/stdenv/generic/problems.nix
+++ b/pkgs/stdenv/generic/problems.nix
@@ -437,20 +437,21 @@ rec {
           kind: name: pname:
           switch
         else
-          kind: name: pname:
+          kind:
           let
-            switch' = switch.kindSpecific.${kind} or switch.kindFallback;
+            kindSwitch = switch.kindSpecific.${kind} or switch.kindFallback;
           in
-          if isString switch' then
-            switch'
+          if isString kindSwitch then
+            name: pname: kindSwitch
           else
+            name:
             let
-              switch'' = switch'.nameSpecific.${name} or switch'.nameFallback;
+              nameSwitch = kindSwitch.nameSpecific.${name} or kindSwitch.nameFallback;
             in
-            if isString switch'' then
-              switch''
+            if isString nameSwitch then
+              pname: nameSwitch
             else
-              switch''.packageSpecific.${pname} or switch''.packageFallback;
+              pname: nameSwitch.packageSpecific.${pname} or nameSwitch.packageFallback;
     };
 
   genCheckProblems =

--- a/pkgs/stdenv/generic/problems.nix
+++ b/pkgs/stdenv/generic/problems.nix
@@ -434,10 +434,10 @@ rec {
       inherit switch definedConstraints;
       handlerForProblem =
         if isString switch then
-          pname: name: kind:
+          kind: name: pname:
           switch
         else
-          pname: name: kind:
+          kind: name: pname:
           let
             switch' = switch.kindSpecific.${kind} or switch.kindFallback;
           in
@@ -466,12 +466,14 @@ rec {
       configuredProblems = definedConstraints.kinds ++ definedConstraints.names;
 
       # Filter out any problems that are always ignored in config.problems.
-      # Makes sure that automatic problems can cache with just config applied
+      # Makes sure to cache the condition by appliny config, and the handler
+      # by applying the problem's kind and name
       automaticProblemsConfigCache = concatMap (
         problem:
-        optionals (elem problem.kindName configuredProblems) [
-          (problem // { condition = problem.condition config; })
-        ]
+        optional (elem problem.kindName configuredProblems) {
+          condition = problem.condition config;
+          handler = handlerForProblem problem.kindName problem.kindName;
+        }
       ) automaticProblems;
     in
     attrs:
@@ -480,16 +482,14 @@ rec {
     in
     if
       # Fast path for when there's no problem that needs to be handled
-      # No automatic problems that needs handling
       all (
-        problem:
-        problem.condition attrs -> handlerForProblem pname problem.kindName problem.kindName == "ignore"
+        problem: problem.condition attrs -> problem.handler pname == "ignore"
       ) automaticProblemsConfigCache
       && (
         # No manual problems
         !attrs ? meta.problems
         # Or all manual problems are ignored
-        || all (name: handlerForProblem pname name (attrs.meta.problems.${name}.kind or name) == "ignore") (
+        || all (name: handlerForProblem (attrs.meta.problems.${name}.kind or name) name pname == "ignore") (
           attrNames attrs.meta.problems
         )
       )
@@ -504,7 +504,7 @@ rec {
             inherit name;
             # Kind falls back to the name
             kind = problem.kind or name;
-            handler = handlerForProblem pname name kind;
+            handler = handlerForProblem kind name pname;
             inherit problem;
           }) problems
         );

--- a/pkgs/stdenv/generic/problems.nix
+++ b/pkgs/stdenv/generic/problems.nix
@@ -475,7 +475,6 @@ rec {
     attrs:
     let
       pname = getName attrs;
-      manualProblems = attrs.meta.problems or { };
     in
     if
       # Fast path for when there's no problem that needs to be handled
@@ -486,10 +485,10 @@ rec {
       ) automaticProblemsConfigCache
       && (
         # No manual problems
-        manualProblems == { }
+        !attrs ? meta.problems
         # Or all manual problems are ignored
-        || all (name: handlerForProblem pname name (manualProblems.${name}.kind or name) == "ignore") (
-          attrNames manualProblems
+        || all (name: handlerForProblem pname name (attrs.meta.problems.${name}.kind or name) == "ignore") (
+          attrNames attrs.meta.problems
         )
       )
     then

--- a/pkgs/stdenv/generic/problems.nix
+++ b/pkgs/stdenv/generic/problems.nix
@@ -48,6 +48,8 @@ rec {
     groupBy
     subtractLists
     genAttrs
+    concatMap
+    unique
     ;
 
   handlers = rec {
@@ -330,7 +332,10 @@ rec {
         };
       };
 
-    Returns both the structure itself for inspection and a function that can query it with very few allocations/lookups
+      Returns:
+      - the structure itself for inspection
+      - a function that can query the structure with very few allocations/lookups
+      - a list of problem kinds/names/packages that require handling
 
     This allows collapsing arbitrarily many problem handlers/matchers into a predictable structure that can be queried in a predictable and fast way
   */
@@ -351,6 +356,20 @@ rec {
             }) forPackage
           ) config.problems.handlers
         );
+
+      # Lookup table for all the kinds/names/packages that actually need to be
+      # handled
+      definedConstraints = listToAttrs (
+        map (ident: {
+          name = "${ident}s"; # plural
+          value = unique (
+            concatMap (
+              constraint:
+              optionals (constraint.${ident} != null && constraint.handler != "ignore") [ (constraint.${ident}) ]
+            ) constraints
+          );
+        }) identOrder
+      );
 
       getHandler =
         list:
@@ -410,7 +429,7 @@ rec {
       switch = doLevel 0 constraints;
     in
     {
-      inherit switch;
+      inherit switch definedConstraints;
       handlerForProblem =
         if isString switch then
           pname: name: kind:
@@ -438,10 +457,19 @@ rec {
       # This is here so that it gets cached for a (checkProblems config) thunk
       inherit (genHandlerSwitch config)
         handlerForProblem
+        definedConstraints
         ;
+
+      # All the problem kinds that actually need to be checked
+      configuredProblems = definedConstraints.kinds ++ definedConstraints.names;
+
+      # Filter out any problems that are always ignored in config.problems.
       # Makes sure that automatic problems can cache with just config applied
-      automaticProblemsConfigCache = map (
-        problem: problem // { condition = problem.condition config; }
+      automaticProblemsConfigCache = concatMap (
+        problem:
+        optionals (elem problem.kindName configuredProblems) [
+          (problem // { condition = problem.condition config; })
+        ]
       ) automaticProblems;
     in
     attrs:

--- a/pkgs/test/problems/unit.nix
+++ b/pkgs/test/problems/unit.nix
@@ -10,7 +10,7 @@ let
   genHandlerTest =
     let
       slowReference =
-        config: package: name: kind:
+        config: kind: name: package:
         # Try to find an explicit handler
         (config.problems.handlers.${package} or { }).${name}
           # Fall back, iterating through the matchers
@@ -36,7 +36,7 @@ let
             map
               (
                 name:
-                map (kind: f package name kind) [
+                map (kind: f kind name package) [
                   "k1"
                   "k2"
                   "k3"

--- a/pkgs/test/problems/unit.nix
+++ b/pkgs/test/problems/unit.nix
@@ -2,6 +2,11 @@
 let
   p = import ../../stdenv/generic/problems.nix { inherit lib; };
 
+  genConstraintsTest = problems: expected: {
+    expr = (p.genHandlerSwitch { inherit problems; }).definedConstraints;
+    inherit expected;
+  };
+
   genHandlerTest =
     let
       slowReference =
@@ -150,4 +155,84 @@ lib.runTests {
     ];
     handlers = { };
   };
+
+  testDefinedConstraintsEmpty =
+    genConstraintsTest
+      {
+        matchers = [ ];
+        handlers = { };
+      }
+      {
+        kinds = [ ];
+        names = [ ];
+        packages = [ ];
+      };
+
+  testDefinedConstraintsMatchers =
+    genConstraintsTest
+      {
+        handlers = { };
+        matchers = [
+          {
+            package = null;
+            name = null;
+            kind = "k1";
+            handler = "warn";
+          }
+          {
+            package = null;
+            name = null;
+            kind = "k2";
+            handler = "error";
+          }
+          {
+            package = null;
+            name = null;
+            kind = "k3";
+            handler = "ignore";
+          }
+          {
+            package = "p1";
+            name = "n1";
+            kind = null;
+            handler = "error";
+          }
+          {
+            package = "p2";
+            name = "n1";
+            kind = null;
+            handler = "warn";
+          }
+        ];
+      }
+      {
+        kinds = [
+          "k1"
+          "k2"
+        ];
+        names = [ "n1" ];
+        packages = [
+          "p1"
+          "p2"
+        ];
+      };
+
+  testDefinedConstraintsHandlers =
+    genConstraintsTest
+      {
+        matchers = [ ];
+        handlers.p1.n1 = "warn";
+        handlers.p1.n2 = "error";
+        handlers.p2.n3 = "ignore";
+      }
+      {
+        kinds = [ ];
+        names = [
+          "n1"
+          "n2"
+        ];
+        packages = [
+          "p1"
+        ];
+      };
 }


### PR DESCRIPTION
The problems system was designed with an oversight - this bit of code:
```nix
  all (
    problem:
    problem.condition attrs -> handlerForProblem pname problem.kindName problem.kindName == "ignore"
  ) automaticProblemsConfigCache
```
calls `problem.condition` on every problem, before checking if the problem is ignored. This is specifically meaningful in a nixpkgs context, because `maintainerless` is _not_ on by default, but it is in `automaticProblems`. This makes every package check that it has nonempty maintainers when it doesn't have to. What's more, packages with empty maintainers have to call `handlerForProblem` unnecessarily, which allocates memory, calls some primops, and requires several function calls. 

I originally just tried swapping the order of the conditions - but this made things a lot worse, since it now ran `handlerForProblem` (with its own overhead) on non-broken packages. Instead, I filter the problems to only those that that are defined and non-ignored. This checks both `problems.matchers` and `problems.config`, while being a constant-time operation only done once.

In the future, I hope to make `handlerForProblem` less punishing. As it stands, the function performs a lot of unnecessary logic on every single derivation, when it has all of the data ahead of time, and could do much less.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
