### PR TITLE
grimoire-deadlock: init at 1.28.1

### DIFF
--- a/pkgs/by-name/gr/grimoire-deadlock/package.nix
+++ b/pkgs/by-name/gr/grimoire-deadlock/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  appimageTools,
+  makeDesktopItem,
+  fetchurl,
+}:
+let
+  pname = "grimoire";
+  version = "1.28.1";
+  src = fetchurl {
+    url = "https://github.com/Slush97/grimoire/releases/download/v${version}/Grimoire-${version}.AppImage";
+    hash = "sha256-q+QnLo1aaZ3bWSbEjGC+yITh4IthgyUeAJ0tcurbWhk=";
+  };
+  desktopItem = makeDesktopItem {
+    name = "grimoire";
+    desktopName = "Grimoire";
+    comment = "Mod manager for Deadlock";
+    exec = "grimoire";
+    icon = "grimoire";
+    terminal = false;
+    keywords = [
+      "Deadlock"
+      "Mods"
+      "Modding"
+      "Mod Manager"
+      "Game"
+      "Valve"
+    ];
+    startupWMClass = "grimoire";
+  };
+  contents = appimageTools.extract { inherit src pname version; };
+in
+(appimageTools.wrapType2 {
+  inherit pname version src;
+
+  executableName = "grimoire";
+
+  extraInstallCommands = ''
+    mkdir -p $out/share
+    ln -s ${desktopItem}/share/applications $out/share/applications
+    ln -s ${contents}/usr/share/icons $out/share/icons
+  '';
+
+  meta = with lib; {
+    description = "Mod manager for Deadlock";
+    homepage = "https://github.com/Slush97/grimoire";
+    license = licenses.mit;
+    mainProgram = "grimoire";
+    maintainers = with maintainers; [ justdeeevin ];
+    platforms = platforms.linux;
+  };
+}).overrideAttrs
+  (old: {
+    __structuredAttrs = true;
+    strictDeps = true;
+  })


### PR DESCRIPTION
Adds the Grimoire mod manager for deadlock.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
