### PR TITLE
nix-secret-bridge: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18835,6 +18835,11 @@
     github = "musjj";
     githubId = 72612857;
   };
+  mutasem-mk4 = {
+    github = "Mutasem-mk4";
+    githubId = 140179052;
+    name = "Mutasem Kharma";
+  };
   mvisonneau = {
     name = "Maxime VISONNEAU";
     email = "maxime@visonneau.fr";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1119,6 +1119,7 @@ in
   nix-ld = runTest ./nix-ld.nix;
   nix-misc = handleTest ./nix/misc.nix { };
   nix-required-mounts = runTest ./nix-required-mounts;
+  nix-secret-bridge = handleTest ./nix-secret-bridge.nix { };
   nix-serve = runTest ./nix-serve.nix;
   nix-serve-ssh = runTest ./nix-serve-ssh.nix;
   nix-store-veritysetup = runTest ./nix-store-veritysetup.nix;

--- a/nixos/tests/nix-secret-bridge.nix
+++ b/nixos/tests/nix-secret-bridge.nix
@@ -1,0 +1,24 @@
+import ./make-test-python.nix (
+  { pkgs, ... }:
+
+  {
+    name = "nix-secret-bridge";
+
+    meta = {
+      maintainers = [ pkgs.lib.maintainers."mutasem-mk4" ];
+    };
+
+    nodes.machine =
+      { ... }:
+      {
+        environment.systemPackages = [
+          pkgs.nix-secret-bridge
+        ];
+      };
+
+    testScript = ''
+      machine.wait_for_unit("multi-user.target")
+      machine.succeed("nix-secret-bridge --help")
+    '';
+  }
+)

--- a/pkgs/by-name/ni/nix-secret-bridge/package.nix
+++ b/pkgs/by-name/ni/nix-secret-bridge/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  makeWrapper,
+  sops,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "nix-secret-bridge";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "Mutasem-mk4";
+    repo = "nix-secret-bridge";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5HuQfJWO9zUz9qYhaEtoTWZJIZWupXHy87osg7FMyqg=";
+  };
+
+  cargoHash = "sha256-F7/9++8i03Ku0/Kbfu/eP6q91IBO5oWJwU8ZEZc8GDU=";
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  postInstall = ''
+    wrapProgram "$out/bin/nix-secret-bridge" \
+      --prefix PATH : ${lib.makeBinPath [ sops ]}
+  '';
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Bootstrap secret bridge for NixOS disko LUKS keys";
+    longDescription = ''
+      nix-secret-bridge decrypts age or SOPS-encrypted bootstrap secrets in
+      the installer environment and exposes the plaintext only on tmpfs so
+      disko can consume LUKS keys before the target NixOS system has booted.
+    '';
+    homepage = "https://github.com/Mutasem-mk4/nix-secret-bridge";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers."mutasem-mk4" ];
+    mainProgram = "nix-secret-bridge";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description

Adds \
ix-secret-bridge\, a CLI tool for decrypting bootstrap secrets such as LUKS keys into tmpfs during installer-oriented workflows. It supports age and sops backends and is designed to be usable alongside disko-based installs.

The NixOS module is intentionally omitted from this nixpkgs PR because module-level disko integration should remain in the upstream flake until the integration surface is ready for nixpkgs review.

- Package added under \pkgs/by-name/ni/nix-secret-bridge/\
- Maintainer added: @Mutasem-mk4
- Basic NixOS VM smoke test added: \
ixos/tests/nix-secret-bridge.nix\
- Release notes updated

Validation performed:

- Nixpkgs PR CI is green.
- Targeted fork workflow built \
ix-build -A nix-secret-bridge\ successfully.
- Targeted fork workflow ran \
ix-build nixos/tests/nix-secret-bridge.nix\ successfully.