### PR TITLE
crossmacro: align package and module with upstream

### DIFF
--- a/nixos/modules/services/desktops/crossmacro.nix
+++ b/nixos/modules/services/desktops/crossmacro.nix
@@ -64,9 +64,9 @@ in
       // {
         crossmacro = {
           isSystemUser = true;
-          group = "input";
+          group = "crossmacro";
           extraGroups = [
-            "crossmacro"
+            "input"
             "uinput"
           ];
           description = "CrossMacro Input Daemon User";
@@ -93,12 +93,12 @@ in
       serviceConfig = {
         Type = "notify";
         User = "crossmacro";
-        Group = "input";
+        Group = "crossmacro";
         ExecStart = lib.getExe cfg.daemonPackage;
         Restart = "always";
         RestartSec = 5;
         RuntimeDirectory = "crossmacro";
-        RuntimeDirectoryMode = "0755";
+        RuntimeDirectoryMode = "0750";
         CapabilityBoundingSet = [
           "CAP_SYS_ADMIN"
           "CAP_SETUID"

--- a/pkgs/by-name/cr/crossmacro/package.nix
+++ b/pkgs/by-name/cr/crossmacro/package.nix
@@ -3,6 +3,7 @@
   buildDotnetModule,
   dotnetCorePackages,
   fetchFromGitHub,
+  installShellFiles,
   nix-update-script,
   fontconfig,
   freetype,
@@ -14,8 +15,6 @@
   libxcursor,
   libxext,
   libxrandr,
-  libxrender,
-  libxfixes,
   libxtst,
   libglvnd,
   mesa,
@@ -66,8 +65,6 @@ buildDotnetModule rec {
     libxcursor
     libxext
     libxrandr
-    libxrender
-    libxfixes
     libxtst
     glib
     libglvnd
@@ -76,7 +73,11 @@ buildDotnetModule rec {
     libxkbcommon
   ];
 
+  nativeBuildInputs = [ installShellFiles ];
+
   postInstall = ''
+    installManPage docs/man/crossmacro.1
+
     install -Dm644 scripts/assets/CrossMacro.desktop $out/share/applications/crossmacro.desktop
 
     for size in 16 32 48 64 128 256 512; do
@@ -97,7 +98,7 @@ buildDotnetModule rec {
     description = "Cross-platform mouse and keyboard macro recorder and player";
     homepage = "https://github.com/alper-han/CrossMacro";
     changelog = "https://github.com/alper-han/CrossMacro/releases/tag/v${version}";
-    license = lib.licenses.gpl3Plus;
+    license = lib.licenses.gpl3Only;
     platforms = lib.platforms.linux;
     mainProgram = "crossmacro";
     maintainers = with lib.maintainers; [ alper-han ];


### PR DESCRIPTION
Align the CrossMacro package and NixOS module with upstream 1.1.0 expectations.

This installs the upstream `crossmacro(1)` man page, corrects the package license metadata to GPL-3.0-only, drops `libxrender` and `libxfixes` from the UI runtime dependencies, and updates the NixOS daemon service identity to match upstream.

The daemon now uses `crossmacro` as its primary group while keeping device access through the supplementary `input` and `uinput` groups. The runtime directory mode is also tightened from `0755` to `0750`

Follow-up to #519000 and #519002

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
