### PR TITLE
jitterentropy-rngd: fix systemd mlock

### DIFF
--- a/pkgs/by-name/ji/jitterentropy-rngd/package.nix
+++ b/pkgs/by-name/ji/jitterentropy-rngd/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -11,9 +12,17 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "smuellerDD";
     repo = "jitterentropy-rngd";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-iXpeN0PAPk8mcaNXwj6TlyK57NSFNOVs/XmEmUG1gIg=";
   };
+
+  patches = [
+    # Allow the systemd service to mlock the daemon's entropy buffer.
+    (fetchpatch {
+      url = "https://github.com/smuellerDD/jitterentropy-rngd/compare/v1.3.1...61ad2e7c83b95402536b90b52eabe20ce60cfbd7.patch";
+      hash = "sha256-Twg59vrqJGF0bH4pkIewbReCjabOFuqq+MtCnwjO9lw=";
+    })
+  ];
 
   enableParallelBuilding = true;
 
@@ -36,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Random number generator, which injects entropy to the kernel";
     homepage = "https://github.com/smuellerDD/jitterentropy-rngd";
-    changelog = "https://github.com/smuellerDD/jitterentropy-rngd/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/smuellerDD/jitterentropy-rngd/releases/tag/${finalAttrs.src.tag}";
     license = [
       lib.licenses.gpl2Only
       lib.licenses.bsd3


### PR DESCRIPTION
Latest update (https://github.com/NixOS/nixpkgs/pull/516780) introduced a bug in the upstream systemd service https://github.com/smuellerDD/jitterentropy-rngd/issues/33 that makes jitterentropy-rngd get killed with SIGSYS by systemd's seccomp filter

This in concecuense makes the module no longer work as expected `services.jitterentropy-rngd.enable`

Got patch from:
https://github.com/smuellerDD/jitterentropy-rngd/pull/34
https://github.com/smuellerDD/jitterentropy-rngd/compare/v1.3.1...61ad2e7c83b95402536b90b52eabe20ce60cfbd7

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
