### PR TITLE
home-assistant-custom-lovelace-modules.xiaomi-vacuum-map-card: init at 2.3.2

### DIFF
--- a/pkgs/servers/home-assistant/custom-lovelace-modules/xiaomi-vacuum-map-card/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/xiaomi-vacuum-map-card/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage rec {
+  pname = "lovelace-xiaomi-vacuum-map-card";
+  version = "2.3.2";
+
+  src = fetchFromGitHub {
+    owner = "PiotrMachowski";
+    repo = "lovelace-xiaomi-vacuum-map-card";
+    tag = "v${version}";
+    hash = "sha256-3329L+2Su2XvrKQIKa5btJz3CQWgS+c8qHD/9vxuEbM=";
+  };
+
+  npmDepsHash = "sha256-vLxmzqDSmB+6VKjiwG5WH9FUvn0NlVHo9TBmbx5UkG0=";
+
+  # rollup-plugin-typescript2 tries to require tslib/package.json, but the
+  # bundled tslib 2.1.0 uses the legacy "./": "./" exports subpath pattern that
+  # newer Node no longer honours. Rewrite it to the supported wildcard form.
+  preBuild = ''
+    substituteInPlace node_modules/rollup-plugin-typescript2/node_modules/tslib/package.json \
+      --replace-fail '"./": "./"' '"./*": "./*"'
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    cp dist/xiaomi-vacuum-map-card.js $out
+
+    runHook postInstall
+  '';
+
+  passthru.entrypoint = "xiaomi-vacuum-map-card.js";
+
+  meta = {
+    description = "Interactive map card for map-based vacuums in Home Assistant";
+    homepage = "https://github.com/PiotrMachowski/lovelace-xiaomi-vacuum-map-card";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
Adds the Lovelace card from https://github.com/PiotrMachowski/lovelace-xiaomi-vacuum-map-card.

One quirk: rollup-plugin-typescript2 0.30 brings an old tslib whose `exports` uses the legacy `"./": "./"` subpath. Newer Node won't honour that, so the build can't read `tslib/package.json` and dies. `preBuild` rewrites it to `"./*": "./*"`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
