### PR TITLE
copacetic: 0.13.0 -> 0.14.0

### DIFF
--- a/pkgs/by-name/co/copacetic/package.nix
+++ b/pkgs/by-name/co/copacetic/package.nix
@@ -12,16 +12,21 @@
 
 buildGoModule (finalAttrs: {
   pname = "copacetic";
-  version = "0.13.0";
+  version = "0.14.0";
 
   src = fetchFromGitHub {
     owner = "project-copacetic";
     repo = "copacetic";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-FTldgBYOmJt3VIC3vwp415oPNRCAiR1cxEF8lJr5TSU=";
+    hash = "sha256-LuJn6DGINUMI7KVSCMMVBZyvNYWEk+DOQJqfciJ0n8E=";
   };
 
-  vendorHash = "sha256-nkVAHqe61AR0GBK5upsk650kl8UDp1ppFWhyi3erpr4=";
+  vendorHash = "sha256-RKqaIwGDZj91lfbEJHcnG8RhIrixtR0VtieCfZD/rns=";
+
+  excludedPackages = [
+    "integration/..."
+    "test/..."
+  ];
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
Update to 0.14.0

disable integration tests requiring docker (not available in sandbox)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
