### PR TITLE
jextract: fix build on Darwin

### DIFF
--- a/pkgs/by-name/je/jextract/copy_lib_clang.patch
+++ b/pkgs/by-name/je/jextract/copy_lib_clang.patch
@@ -1,13 +1,13 @@
 diff --git a/build.gradle b/build.gradle
-index 9ce544a..0c77609 100644
+index 9ce544a..9445e97 100644
 --- a/build.gradle
 +++ b/build.gradle
-@@ -79,7 +79,7 @@ task copyLibClang(type: Sync) {
-             "libclang.so.${clang_version}" : "*clang*"
+@@ -76,7 +76,7 @@ task copyLibClang(type: Sync) {
+     // make sure we only pick up the "real" shared library file from LLVM installation
+     // (e.g. exclude symlinks on Linux)
+     def clang_path_include = (Os.isFamily(Os.FAMILY_UNIX) && !Os.isFamily(Os.FAMILY_MAC)) ?
+-            "libclang.so.${clang_version}" : "*clang*"
++            "libclang.so*" : "*clang*"
  
      from("${libclang_dir}") {
--        include(clang_path_include)
-+        include("libclang.so*")
-         include("libLLVM.*")
-         exclude("clang.exe")
-         into("libs")
+         include(clang_path_include)


### PR DESCRIPTION
Apply the Linux patch to the initialization string for `clang_path_include` instead of replacing `clang_path_include` with the patched string. This allows the correct value for Darwin to be selected by the ternary expression.

It looks like the Darwin build has been broken since:  6fe1b5b11010b2b5c4f3e5a20f3c702be92c1490

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
