### PR TITLE
livepeer: 0.8.8 -> 0.8.10

### DIFF
--- a/pkgs/by-name/ff/ffmpeg-livepeer/package.nix
+++ b/pkgs/by-name/ff/ffmpeg-livepeer/package.nix
@@ -17,6 +17,12 @@
   (old: {
     pname = "ffmpeg-livepeer";
 
+    postPatch = (old.postPatch or "") + ''
+            substituteInPlace libavcodec/tableprint_vlc.h \
+              --replace-fail 'define av_mallocz(s) NULL' 'define av_mallocz(s) NULL
+      #define av_malloc(s) NULL'
+    '';
+
     meta = {
       inherit (old.meta)
         license

--- a/pkgs/by-name/li/livepeer/package.nix
+++ b/pkgs/by-name/li/livepeer/package.nix
@@ -10,16 +10,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "livepeer";
-  version = "0.8.8";
+  version = "0.8.10";
 
   proxyVendor = true;
-  vendorHash = "sha256-cEpRLnLR0ia5vvoJ8Fwk/0qgvsnYw7vSpyS9BJQ8UfY=";
+  vendorHash = "sha256-Cn7GHNrFjGgzKPjSVGnoRE9Q2gd3Ji/ZrdVGB9v+0A8=";
 
   src = fetchFromGitHub {
     owner = "livepeer";
     repo = "go-livepeer";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-DVgB/pE3nq6oHzLi+g/WUMQqrmXvJhPub7bmeLgyEDQ=";
+    hash = "sha256-jz8lgZItPDzAGKJrAFLiEUJ5nyTdw6kGneP6LtmWDYw=";
   };
 
   nativeBuildInputs = [
@@ -29,6 +29,10 @@ buildGoModule (finalAttrs: {
   buildInputs = [
     ffmpeg-livepeer
     gnutls
+  ];
+
+  CGO_LDFLAGS = [
+    "-lm"
   ];
 
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
Update to 0.8.10

Fix build for ffmpeg-livepeer (which is a dependency)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
