### PR TITLE
openwalletstandard: init at 1.3.2

### DIFF
--- a/pkgs/by-name/op/openwalletstandard/package.nix
+++ b/pkgs/by-name/op/openwalletstandard/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "openwalletstandard";
+  version = "1.3.2";
+
+  src = fetchFromGitHub {
+    owner = "open-wallet-standard";
+    repo = "core";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ARAiGgo/yjTIKy/kj/tN9xHBRpxGk7jeIiMk76gFx/I=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/ows";
+  buildAndTestSubdir = "crates/ows-cli";
+  cargoHash = "sha256-b1Mo27e88l0J34PvFP5Ev0DSS76vxT/hnBbdY7Djb1M=";
+  # Upstream enables the `fast-kdf` dev-only feature in tests, which fails under release-profile checks.
+  checkType = "debug";
+
+  passthru.updateScript = nix-update-script { };
+  meta = {
+    description = "CLI for the Open Wallet Standard";
+    homepage = "https://openwallet.sh";
+    license = lib.licenses.mit;
+    mainProgram = "ows";
+    maintainers = with lib.maintainers; [ _0xferrous ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
