### PR TITLE
netcdf: enable szip with libaec

### DIFF
--- a/pkgs/by-name/ne/netcdf/package.nix
+++ b/pkgs/by-name/ne/netcdf/package.nix
@@ -7,8 +7,8 @@
   bzip2,
   libzip,
   zstd,
-  szipSupport ? false,
-  szip,
+  szipSupport ? hdf5.szipSupport,
+  libaec,
   libxml2,
   m4,
   curl, # for DAP
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     libzip
     zstd
   ]
-  ++ lib.optional szipSupport szip
+  ++ lib.optional szipSupport libaec
   ++ lib.optional mpiSupport mpi;
 
   strictDeps = true;

--- a/pkgs/by-name/ne/netcdf/package.nix
+++ b/pkgs/by-name/ne/netcdf/package.nix
@@ -101,5 +101,8 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.unidata.ucar.edu/software/netcdf/";
     changelog = "https://docs.unidata.ucar.edu/netcdf-c/${finalAttrs.version}/RELEASE_NOTES.html";
     license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
+      doronbehar
+    ];
   };
 })


### PR DESCRIPTION
hdf5 did that in merge 4fcc02b9c which casued failure:
https://hydra.nixos.org/build/328852032/nixlog/1/tail
so I assume we simply do the same with netcdf.


<!--

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
