### PR TITLE
nixos/bazarr: add settings option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -38,6 +38,10 @@
 
 - Python 2 has been removed from the top-level package set, as it is long past end-of-life. The `python2`, `python27`, `python2Full`, `python27Full`, `python2Packages`, and `python27Packages` attributes, along with the legacy `python`, `pythonFull`, and `pythonPackages` aliases, now throw an error directing you to `python3`. The `isPy2` and `isPy27` package flags have been removed accordingly. The only remaining Python 2 interpreter is vendored inside the `resholve` package for its `oil` dependency and is not exposed for general use.
 
+- `services.bazarr` gained an RFC42-style [`services.bazarr.settings`](#opt-services.bazarr.settings) option backed by `DYNACONF_*` environment variables, with `_secret`-marker support for credentials via systemd's `LoadCredential=`.
+  `services.bazarr.listenPort` is now `services.bazarr.settings.general.port`; existing configurations continue working via `mkRenamedOptionModule`.
+  [`services.bazarr.settings.analytics.enabled`](#opt-services.bazarr.settings.analytics.enabled) defaults to `false` on NixOS to opt users out of upstream's enabled-by-default telemetry.
+
 - `security.polkit.enablePkexecWrapper` has been introduced, making the `pkexec` setuid wrapper opt-in.
 
 - `systemd.user.extraConfig` has been removed in favor of the structured [](#opt-systemd.user.settings.Manager) option. Use `systemd.user.settings.Manager` to set any `systemd-user.conf(5)` option directly. For example, replace `systemd.user.extraConfig = "DefaultTimeoutStartSec=60";` with `systemd.user.settings.Manager.DefaultTimeoutStartSec = 60;`.

--- a/nixos/modules/services/misc/bazarr.nix
+++ b/nixos/modules/services/misc/bazarr.nix
@@ -92,5 +92,8 @@ in
     };
   };
 
-  meta.maintainers = with lib.maintainers; [ connor-grady ];
+  meta.maintainers = with lib.maintainers; [
+    connor-grady
+    diogotcorreia
+  ];
 }

--- a/nixos/modules/services/misc/bazarr.nix
+++ b/nixos/modules/services/misc/bazarr.nix
@@ -91,4 +91,6 @@ in
       bazarr = { };
     };
   };
+
+  meta.maintainers = with lib.maintainers; [ connor-grady ];
 }

--- a/nixos/modules/services/misc/bazarr.nix
+++ b/nixos/modules/services/misc/bazarr.nix
@@ -6,8 +6,63 @@
 }:
 let
   cfg = config.services.bazarr;
+
+  secretType = lib.types.attrTag { _secret = lib.mkOption { type = lib.types.externalPath; }; };
+  settingsFormat = pkgs.formats.yaml { };
+  settingsType =
+    lib.types.oneOf [
+      secretType
+      (lib.types.attrsOf settingsType)
+      settingsFormat.type
+    ]
+    // {
+      description = ''${settingsFormat.type.description} or a `{ _secret = "<path>"; }` marker'';
+    };
+
+  settings = lib.mapAttrsToListRecursiveCond (
+    _: as: !secretType.check as
+  ) lib.nameValuePair cfg.settings;
+  secretSettings = lib.filter ({ value, ... }: secretType.check value) settings;
+  publicSettings = lib.filter ({ value, ... }: !secretType.check value) settings;
+
+  credId = lib.join ".";
+  toCredentials = map ({ name, value }: "${credId name}:${value._secret}");
+
+  envName = name: "DYNACONF_${lib.join "__" name}";
+  envValue =
+    name: value:
+    if lib.isBool value then
+      "@bool ${lib.boolToString value}"
+    else if lib.isFloat value then
+      "@float ${toString value}"
+    else if lib.isInt value then
+      "@int ${toString value}"
+    else if lib.isList value then
+      "@json ${lib.toJSON value}"
+    else if isNull value then
+      "@none"
+    else if lib.isString value then
+      "@str ${value}"
+    else
+      throw "services.bazarr.settings: unsupported value type ${lib.typeOf value} at ${lib.showAttrPath name}";
+  toEnvironment = lib.flip lib.pipe [
+    (map ({ name, value }: lib.nameValuePair (envName name) (envValue name value)))
+    lib.listToAttrs
+  ];
+
+  toScript = lib.flip lib.pipe [
+    (map ({ name, ... }: ''export ${envName name}="@str $(<$CREDENTIALS_DIRECTORY/${credId name})"''))
+    lib.concatLines
+  ];
 in
 {
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "services" "bazarr" "listenPort" ]
+      [ "services" "bazarr" "settings" "general" "port" ]
+    )
+  ];
+
   options = {
     services.bazarr = {
       enable = lib.mkEnableOption "bazarr, a subtitle manager for Sonarr and Radarr";
@@ -26,12 +81,6 @@ in
         description = "Open ports in the firewall for the bazarr web interface.";
       };
 
-      listenPort = lib.mkOption {
-        type = lib.types.port;
-        default = 6767;
-        description = "Port on which the bazarr web interface should listen";
-      };
-
       user = lib.mkOption {
         type = lib.types.str;
         default = "bazarr";
@@ -42,6 +91,53 @@ in
         type = lib.types.str;
         default = "bazarr";
         description = "Group under which bazarr runs.";
+      };
+
+      settings = lib.mkOption {
+        type = lib.types.submodule {
+          freeformType = settingsType;
+          options = {
+            analytics.enabled = lib.mkEnableOption "sending anonymous usage statistics to Bazarr's developers";
+
+            general = {
+              auto_update = lib.mkOption {
+                type = lib.types.bool;
+                default = false;
+                readOnly = true;
+                description = ''
+                  Bazarr's in-app updater is locked off on NixOS.
+                  The package is managed by Nix, so any self-update would fight the store.
+                  This option is emitted as `DYNACONF_general__auto_update=@bool false` so the in-memory settings agree,
+                  but the actual suppression is enforced unconditionally by the `--no-update` CLI flag,
+                  which also hides the entire Updates section from the web UI.
+                '';
+              };
+
+              port = lib.mkOption {
+                type = lib.types.port;
+                default = 6767;
+                description = "Port on which the Bazarr web interface listens.";
+              };
+            };
+          };
+        };
+        default = { };
+        description = ''
+          Bazarr configuration.
+          Settings are emitted as `DYNACONF_*` environment variables at startup,
+          overriding any value previously written by Bazarr's web UI to `config.yaml`.
+
+          Use `_secret` to load values from files via systemd's `LoadCredential=`.
+          Secret contents are exported into bazarr's environment at service start,
+          always as strings.
+        '';
+        example = {
+          general = {
+            instance_name = "NixOS Bazarr";
+            port = 12345;
+          };
+          auth.apikey._secret = "/run/secrets/bazarr-apikey";
+        };
       };
     };
   };
@@ -57,32 +153,38 @@ in
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
 
+      environment = toEnvironment publicSettings;
+      script = ''
+        ${toScript secretSettings}
+        exec ${lib.getExe cfg.package} ${
+          lib.cli.toCommandLineShellGNU { } {
+            config = cfg.dataDir;
+            no-update = true;
+          }
+        }
+      '';
+
       serviceConfig = {
         Type = "simple";
         User = cfg.user;
         Group = cfg.group;
         SyslogIdentifier = "bazarr";
-        ExecStart = pkgs.writeShellScript "start-bazarr" ''
-          ${cfg.package}/bin/bazarr \
-            --config '${cfg.dataDir}' \
-            --port ${toString cfg.listenPort} \
-            --no-update True
-        '';
         Restart = "on-failure";
         KillSignal = "SIGINT";
         SuccessExitStatus = "0 156";
+        LoadCredential = toCredentials secretSettings;
       };
       unitConfig.RequiresMountsFor = [ cfg.dataDir ];
     };
 
     networking.firewall = lib.mkIf cfg.openFirewall {
-      allowedTCPPorts = [ cfg.listenPort ];
+      allowedTCPPorts = [ cfg.settings.general.port ];
     };
 
     users.users = lib.mkIf (cfg.user == "bazarr") {
       bazarr = {
+        inherit (cfg) group;
         isSystemUser = true;
-        group = cfg.group;
         home = cfg.dataDir;
       };
     };

--- a/nixos/tests/bazarr.nix
+++ b/nixos/tests/bazarr.nix
@@ -1,7 +1,27 @@
 { lib, ... }:
 
 let
-  port = 42069;
+  apikey = "0123456789abcdef0123456789abcdef";
+  radarrApikey = "fedcba9876543210fedcba9876543210";
+  port = 12345;
+
+  expected = {
+    analytics.enabled = false;
+    auth = {
+      inherit apikey;
+      type = null;
+    };
+    general = {
+      inherit port;
+      instance_name = "from-settings";
+    };
+    plex.migration_timestamp = 1700000000.5;
+    radarr.apikey = radarrApikey;
+    subsync.checker.blacklisted_providers = [
+      "fake-provider-a"
+      "fake-provider-b"
+    ];
+  };
 in
 {
   name = "bazarr";
@@ -11,18 +31,68 @@ in
     diogotcorreia
   ];
 
-  nodes.machine =
-    { pkgs, ... }:
-    {
+  nodes = {
+    configured = {
+      environment.etc = {
+        "bazarr-apikey".text = apikey;
+        "bazarr-radarr-apikey".text = radarrApikey;
+      };
       services.bazarr = {
         enable = true;
-        listenPort = port;
+        settings = lib.recursiveUpdate expected {
+          auth.apikey._secret = "/etc/bazarr-apikey";
+          radarr.apikey._secret = "/etc/bazarr-radarr-apikey";
+        };
       };
     };
 
+    defaults.services.bazarr.enable = true;
+  };
+
   testScript = ''
-    machine.wait_for_unit("bazarr.service")
-    machine.wait_for_open_port(${toString port})
-    machine.succeed("curl --fail http://localhost:${toString port}/")
+    import json
+
+    expected = json.loads('${builtins.toJSON expected}')
+
+    def assert_subset(expected, actual, path=()):
+      assert (expected_is_dict := isinstance(expected, dict)) == isinstance(actual, dict), (
+        f"{path}: type mismatch (expected {type(expected).__name__}, got {type(actual).__name__})"
+      )
+      if expected_is_dict:
+        for k, v in expected.items():
+          assert_subset(v, actual[k], path + (k,))
+      else:
+        assert expected == actual, f"{path}: expected {expected!r}, got {actual!r}"
+
+    def assert_declared():
+      response = configured.succeed(
+        "curl --fail -H 'X-API-KEY: ${apikey}' http://localhost:${toString port}/api/system/settings"
+      )
+      actual = json.loads(response)
+      assert_subset(expected, actual)
+
+    start_all()
+
+    with subtest("declarative settings reach bazarr at correct paths"):
+      configured.wait_for_unit("bazarr.service")
+      configured.wait_for_open_port(${toString port})
+      configured.wait_until_succeeds("curl --fail http://localhost:${toString port}/api/system/ping")
+      assert_declared()
+
+    with subtest("declarative settings override conflicting values in on-disk config.yaml"):
+      configured.succeed("systemctl stop bazarr.service")
+      configured.succeed(
+        "sed -i -E 's|^( *instance_name: *)from-settings$|\\1from-disk|' /var/lib/bazarr/config/config.yaml"
+      )
+      configured.succeed("grep -qE '^ *instance_name: *from-disk$' /var/lib/bazarr/config/config.yaml")
+      configured.succeed("systemctl start bazarr.service")
+      configured.wait_for_open_port(${toString port})
+      configured.wait_until_succeeds("curl --fail http://localhost:${toString port}/api/system/ping")
+      assert_declared()
+
+    with subtest("bazarr starts cleanly with no user-set settings"):
+      defaults.wait_for_unit("bazarr.service")
+      defaults.wait_for_open_port(6767)
+      defaults.wait_until_succeeds("curl --fail http://localhost:6767/api/system/ping")
   '';
 }

--- a/nixos/tests/bazarr.nix
+++ b/nixos/tests/bazarr.nix
@@ -6,7 +6,10 @@ in
 {
   name = "bazarr";
 
-  meta.maintainers = with lib.maintainers; [ connor-grady ];
+  meta.maintainers = with lib.maintainers; [
+    connor-grady
+    diogotcorreia
+  ];
 
   nodes.machine =
     { pkgs, ... }:

--- a/nixos/tests/bazarr.nix
+++ b/nixos/tests/bazarr.nix
@@ -6,6 +6,8 @@ in
 {
   name = "bazarr";
 
+  meta.maintainers = with lib.maintainers; [ connor-grady ];
+
   nodes.machine =
     { pkgs, ... }:
     {

--- a/pkgs/by-name/ba/bazarr/package.nix
+++ b/pkgs/by-name/ba/bazarr/package.nix
@@ -68,7 +68,10 @@ stdenv.mkDerivation rec {
     homepage = "https://www.bazarr.media/";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ diogotcorreia ];
+    maintainers = with lib.maintainers; [
+      connor-grady
+      diogotcorreia
+    ];
     mainProgram = "bazarr";
     platforms = lib.platforms.all;
   };


### PR DESCRIPTION
Supersedes #507378 [at @rhoriguchi's request](https://github.com/NixOS/nixpkgs/pull/507378#issuecomment-4432953846), implementing the env-var approach we discussed there.

Adds a declarative `services.bazarr.settings` option that flows through to Bazarr as `DYNACONF_*` environment variables at startup. Bazarr uses Dynaconf internally, so this leverages its native env-var overlay (env values take precedence over the on-disk `config.yaml` at load time) instead of introducing a second merge mechanism on top.

Secret values use the `_secret` marker (e.g. `auth.apikey._secret = "/run/secrets/bazarr-apikey";`) to load contents from a file via systemd's `LoadCredential=`. `pkgs.replace-secret` substitutes the value at startup; secret contents never reach the Nix store. Marker shape is validated at module-eval time via `lib.types.attrTag` + `lib.types.externalPath`.

`services.bazarr.listenPort` is moved to `services.bazarr.settings.general.port` via `mkRenamedOptionModule`; existing configurations continue working. This also incidentally fixes a pre-existing bug where the NixOS-configured port wasn't reflected in Bazarr's UI: the old module passed the port via the `--port` CLI flag, which overrode the actual bind port but left `settings.general.port` (the value the UI reads) at the stale on-disk value. The new path writes through `settings.general.port` directly via the `DYNACONF_*` env var, so the UI and the actual listener now agree.

Two declared defaults differ from upstream: `general.auto_update` is locked off (`readOnly = true`; Nix manages the package), and `analytics.enabled` defaults to `false` (privacy). Documented in the 26.11 release notes.

Tested via a two-machine NixOS test exercising every value type the emitter handles (bool, int, float, string, list, null, `_secret`), plus values at different depths, plus an override-conflict subtest that mutates `config.yaml` between stop and start to verify env vars actually win on restart.

Note: the test VM logs ERROR lines for bazarr's update/announcement checks against Github/jsdelivr. Expected, since the VM has no external network and these checks fail gracefully.

cc @diogotcorreia.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test