### PR TITLE
android-file-transfer: 4.5 -> 4.5-unstable-2026-04-17

### DIFF
--- a/pkgs/by-name/an/android-file-transfer/package.nix
+++ b/pkgs/by-name/an/android-file-transfer/package.nix
@@ -11,13 +11,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "android-file-transfer";
-  version = "4.5";
+  version = "4.5-unstable-2026-04-17";
 
   src = fetchFromGitHub {
     owner = "whoozle";
     repo = "android-file-transfer-linux";
-    tag = "v${finalAttrs.version}";
-    sha256 = "sha256-G+ErwZ/F8Cl8WLSzC+5LrEWWqNZL3xDMBvx/gjkgAXk=";
+    # tag = "v${finalAttrs.version}";
+    # Switch to unreleased version for recent fixes, especially to fix the build on Darwin
+    # https://github.com/whoozle/android-file-transfer-linux/pull/360
+    # TODO: Switch back when the next version releases
+    rev = "88926930db41238c7b4d7237fc5849b9586cc7b8";
+    sha256 = "sha256-rk1QXq8JiLRZu+dz9HvWkOj5JyaLMXzTybByl46obE8=";
   };
 
   patches = [ ./darwin-dont-vendor-dependencies.patch ];


### PR DESCRIPTION
Switch to unreleased version for recent fixes, especially to fix the build on Darwin

ZHF: #516381

Hydra aarch64-darwin build status https://hydra.nixos.org/job/nixpkgs/unstable/android-file-transfer.aarch64-darwin

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
