### PR TITLE
zix: 0.6.2 -> 0.8.0

### DIFF
--- a/pkgs/by-name/zi/zix/package.nix
+++ b/pkgs/by-name/zi/zix/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "zix";
-  version = "0.6.2";
+  version = "0.8.0";
 
   src = fetchFromGitLab {
     owner = "drobilla";
     repo = "zix";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-1fdW014QKvTYHaEmDsivUVPzF/vZgnW3Srk6edp6G1o=";
+    hash = "sha256-742N2U/3viVzmyfCHFezpDCuzLzquCgoDlrdOtcxkUI=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Update zix to 0.8.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (not binaries but depndent binaries in jalv)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
