### PR TITLE
jalv: 1.6.8 -> 1.10.0

### DIFF
--- a/pkgs/by-name/ja/jalv/package.nix
+++ b/pkgs/by-name/ja/jalv/package.nix
@@ -21,13 +21,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "jalv";
-  version = "1.6.8";
+  version = "1.10.0";
 
   src = fetchFromGitHub {
     owner = "drobilla";
     repo = "jalv";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-MAQoc+WcuoG6Psa44VRaZ2TWB2LBpvf6EmqbUZPUf38=";
+    hash = "sha256-lH4fqjXT6a5NZZiCUuBViDp8ht3CUFPsii5vWIQJezc";
   };
 
   nativeBuildInputs = [
@@ -54,9 +54,10 @@ stdenv.mkDerivation (finalAttrs: {
   mesonFlags = [
     (lib.mesonEnable "portaudio" (!useJack))
     (lib.mesonEnable "jack" useJack)
-    (lib.mesonEnable "gtk2" false)
     (lib.mesonEnable "gtk3" (!useQt))
     (lib.mesonEnable "qt5" useQt)
+    (lib.mesonEnable "qt6" false)
+    (lib.mesonEnable "man_html" false)
   ];
 
   meta = {


### PR DESCRIPTION
Updating to 1.10.0

adapting dependencies

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
