### PR TITLE
clickhouse: 26.2.5.45 → 26.4.2.10, clickhouse-lts: 25.8.20.4 → 26.3.10.62

### DIFF
--- a/pkgs/by-name/cl/clickhouse/generic.nix
+++ b/pkgs/by-name/cl/clickhouse/generic.nix
@@ -8,7 +8,6 @@
 {
   lib,
   stdenv,
-  llvmPackages_19,
   llvmPackages_21,
   fetchFromGitHub,
   fetchpatch,
@@ -32,7 +31,7 @@
   versionCheckHook,
 }:
 let
-  llvmPackages = if lib.versionAtLeast version "26" then llvmPackages_21 else llvmPackages_19;
+  llvmPackages = llvmPackages_21;
   llvmStdenv = llvmPackages.stdenv;
 in
 llvmStdenv.mkDerivation (finalAttrs: {
@@ -128,26 +127,6 @@ llvmStdenv.mkDerivation (finalAttrs: {
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
 
   dontCargoSetupPostUnpack = true;
-
-  patches =
-    lib.optional (lib.versions.majorMinor version == "25.8") (fetchpatch {
-      # Disable building WASM lexer
-      url = "https://github.com/ClickHouse/ClickHouse/commit/67a42b78cdf1c793e78c1adbcc34162f67044032.patch";
-      hash = "sha256-7VF+JSztqTWD+aunCS3UVNxlRdwHc2W5fNqzDyeo3Fc=";
-    })
-    ++
-
-      lib.optional (lib.versions.majorMinor version == "25.8" && stdenv.hostPlatform.isDarwin)
-        (fetchpatch {
-          # Do not intercept memalign on darwin
-          url = "https://github.com/ClickHouse/ClickHouse/commit/0cfd2dbe981727fb650f3b9935f5e7e7e843180f.patch";
-          hash = "sha256-1iNYZbugX2g2dxNR1ZiUthzPnhLUR8g118aG23yhgUo=";
-        })
-    ++ lib.optional (!lib.versionAtLeast version "25.11" && stdenv.hostPlatform.isDarwin) (fetchpatch {
-      # Remove flaky macOS SDK version detection
-      url = "https://github.com/ClickHouse/ClickHouse/commit/11e172a37bd0507d595d27007170090127273b33.patch";
-      hash = "sha256-oI7MrjMgJpIPTsci2IqEOs05dUGEMnjI/WqGp2N+rps=";
-    });
 
   postPatch = ''
     patchShebangs src/ utils/

--- a/pkgs/by-name/cl/clickhouse/generic.nix
+++ b/pkgs/by-name/cl/clickhouse/generic.nix
@@ -23,6 +23,7 @@
   findutils,
   libiconv,
   removeReferencesTo,
+  zstd,
   rustSupport ? true,
   rustc,
   cargo,
@@ -44,8 +45,9 @@ llvmStdenv.mkDerivation (finalAttrs: {
     repo = "ClickHouse";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    name = "clickhouse-${tag}.tar.gz";
+    name = "clickhouse-${tag}.tar.zst";
     inherit hash;
+    nativeBuildInputs = [ zstd ];
     postFetch = ''
       # Delete files that make the source too big
       rm -rf $out/contrib/arrow/docs/
@@ -80,7 +82,7 @@ llvmStdenv.mkDerivation (finalAttrs: {
       # Compress to not exceed the 2GB output limit
       echo "Creating deterministic source tarball..."
 
-      tar -I 'gzip -n' \
+      tar -I 'zstd --no-progress' \
         --sort=name \
         --mtime=1970-01-01 \
         --owner=0 --group=0 \
@@ -103,6 +105,7 @@ llvmStdenv.mkDerivation (finalAttrs: {
     perl
     llvmPackages.lld
     removeReferencesTo
+    zstd
   ]
   ++ lib.optionals stdenv.hostPlatform.isx86_64 [
     nasm

--- a/pkgs/by-name/cl/clickhouse/generic.nix
+++ b/pkgs/by-name/cl/clickhouse/generic.nix
@@ -104,6 +104,10 @@ llvmStdenv.mkDerivation (finalAttrs: {
     python3
     perl
     llvmPackages.lld
+    # Provides llvm-ar/llvm-objcopy.
+    # Required by cmake/strip_rust_symbols.sh to match the LLVM toolchain
+    # Otherwise it corrupts .eh_frame in the Rust staticlibs
+    llvmPackages.bintools
     removeReferencesTo
     zstd
   ]
@@ -112,7 +116,6 @@ llvmStdenv.mkDerivation (finalAttrs: {
     yasm
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    llvmPackages.bintools
     findutils
     darwin.bootstrap_cmds
   ]

--- a/pkgs/by-name/cl/clickhouse/lts.nix
+++ b/pkgs/by-name/cl/clickhouse/lts.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
-  version = "25.8.20.4-lts";
-  rev = "2e1cd6354ae8898072e5dbf97aa6e5945761e3d7";
-  hash = "sha256-Xd9hLb4sXnSQby8NuKnD0b8R6iGb+M4u0L0yYASNvzw=";
+  version = "26.3.10.62-lts";
+  rev = "e1c11930c28196f954a93287e43c1aa112c8c607";
+  hash = "sha256-2vU3PRJISFqrh1KWRKub95QA0cawWGP+wzrn2Kwo5Bc=";
   lts = true;
 }

--- a/pkgs/by-name/cl/clickhouse/package.nix
+++ b/pkgs/by-name/cl/clickhouse/package.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
-  version = "26.2.5.45-stable";
-  rev = "9ca62f3f68fd635f4b56171568d75588b13b6258";
-  hash = "sha256-qzY3nFbLvKVJaIfXgNliAvAmO8dzEWNKf4o8HfZYyZA=";
+  version = "26.4.2.10-stable";
+  rev = "184f682d431389803dd383668f52729cf26e23db";
+  hash = "sha256-UCRwnrIY/j0gdjFnNmR5U7VZeBRqA96mIt6AEKRJQ5Q=";
   lts = false;
 }


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
