### PR TITLE
skypilot: fix for incompat. w/ defaults handling in click >= 8.2; wrap websocket_proxy.py with wrapPythonProgramsIn

### DIFF
--- a/pkgs/by-name/sk/skypilot/0001-Fix-docker-flag-default-for-Click-8.2-compatibility.patch
+++ b/pkgs/by-name/sk/skypilot/0001-Fix-docker-flag-default-for-Click-8.2-compatibility.patch
@@ -1,0 +1,31 @@
+From 6a2202baf3edff90aea6b66996a8e11e4e7c133e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ak=E1=B9=A3aya=20=C5=9Ar=C4=ABniv=C4=81san?=
+ <akssri@vakra.xyz>
+Date: Wed, 13 May 2026 13:31:19 +0530
+Subject: [PATCH] Fix --docker flag default for Click >= 8.2 compatibility
+
+Click 8.2 changed flag_value option handling: default=False is no longer
+normalised to None before the 'is None' guard. Change to default=None so
+sky launch works with Click >= 8.2 (e.g. nixpkgs).
+
+Upstream constrains click<8.2; this makes the code robust to newer versions.
+---
+ sky/client/cli/command.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sky/client/cli/command.py b/sky/client/cli/command.py
+index 6ee1102d0..15a5057d6 100644
+--- a/sky/client/cli/command.py
++++ b/sky/client/cli/command.py
+@@ -1072,7 +1072,7 @@ def _handle_infra_cloud_region_zone_options(infra: Optional[str],
+ @click.option('--docker',
+               'backend_name',
+               flag_value=backends.LocalDockerBackend.NAME,
+-              default=False,
++              default=None,
+               hidden=True,
+               help=('(Deprecated) Local docker support is deprecated. '
+                     'To run locally, create a local Kubernetes cluster with '
+-- 
+2.53.0
+

--- a/pkgs/by-name/sk/skypilot/0002-Fix-websocket-proxy-call-script-directly-as-executable.patch
+++ b/pkgs/by-name/sk/skypilot/0002-Fix-websocket-proxy-call-script-directly-as-executable.patch
@@ -1,0 +1,37 @@
+diff --git a/sky/client/cli/command.py b/sky/client/cli/command.py
+index 15a5057d6..5417cad9f 100644
+--- a/sky/client/cli/command.py
++++ b/sky/client/cli/command.py
+@@ -203,7 +203,6 @@ def _get_cluster_records_and_set_ssh_config(
+             escaped_key_path = shlex.quote(
+                 (cluster_utils.SSHConfigHelper.generate_local_key_file(
+                     handle.cluster_name, credentials)))
+-            escaped_executable_path = shlex.quote(sys.executable)
+             escaped_websocket_proxy_path = shlex.quote(
+                 f'{directory_utils.get_sky_dir()}/templates/websocket_proxy.py')
+             # Instead of directly use websocket_proxy.py, we add an
+@@ -220,8 +219,7 @@ def _get_cluster_records_and_set_ssh_config(
+                 # TODO(zhwu): write the template to a temp file, don't use
+                 # the one in skypilot repo, to avoid changing the file when
+                 # updating skypilot.
+-                f'\"{escaped_executable_path} '
+-                f'{escaped_websocket_proxy_path} '
++                f'\"{escaped_websocket_proxy_path} '
+                 f'{server_common.get_server_url()} '
+                 f'{handle.cluster_name} '
+                 f'kubernetes-pod-ssh-proxy\"')
+@@ -229,13 +227,11 @@ def _get_cluster_records_and_set_ssh_config(
+         elif isinstance(handle.launched_resources.cloud, clouds.Slurm):
+             # Replace the proxy command to proxy through the SkyPilot API
+             # server with websocket.
+-            escaped_executable_path = shlex.quote(sys.executable)
+             escaped_websocket_proxy_path = shlex.quote(
+                 f'{directory_utils.get_sky_dir()}/templates/websocket_proxy.py')
+             # %w is a placeholder for the node index, substituted per-node
+             # in cluster_utils.SSHConfigHelper.add_cluster().
+-            proxy_command = (f'{escaped_executable_path} '
+-                             f'{escaped_websocket_proxy_path} '
++            proxy_command = (f'{escaped_websocket_proxy_path} '
+                              f'{server_common.get_server_url()} '
+                              f'{handle.cluster_name} '
+                              f'slurm-job-ssh-proxy %w')

--- a/pkgs/by-name/sk/skypilot/package.nix
+++ b/pkgs/by-name/sk/skypilot/package.nix
@@ -35,6 +35,10 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pyproject = true;
   pythonRelaxDeps = true;
 
+  patches = [
+    ./0001-Fix-docker-flag-default-for-Click-8.2-compatibility.patch
+  ];
+
   nativeBuildInputs = [
     writableTmpDirAsHomeHook
   ];

--- a/pkgs/by-name/sk/skypilot/package.nix
+++ b/pkgs/by-name/sk/skypilot/package.nix
@@ -37,6 +37,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   patches = [
     ./0001-Fix-docker-flag-default-for-Click-8.2-compatibility.patch
+    ./0002-Fix-websocket-proxy-call-script-directly-as-executable.patch
   ];
 
   nativeBuildInputs = [
@@ -219,6 +220,11 @@ python3Packages.buildPythonApplication (finalAttrs: {
   postInstall = ''
     mkdir -p $out/${python3Packages.python.sitePackages}/sky/dashboard/out
     cp -r ${dashboard}/* $out/${python3Packages.python.sitePackages}/sky/dashboard/out/
+  '';
+
+  postFixup = ''
+    chmod +x $out/${python3Packages.python.sitePackages}/sky/templates/websocket_proxy.py
+    wrapPythonProgramsIn "$out/${python3Packages.python.sitePackages}/sky/templates" "$out ''${pythonPath[*]}"
   '';
 
   # Excluding the tests as it fails with error:


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
### Problem
- ```sky launch``` raises "ValueError: False backend is not supported." when run. 
This error stems from a "click" argument "--docker" (aliased as 'backend_name'), that uses 'default=False'.
The error comes from a change in default-handling upstream in Click.  Skypilot's python package wants Click < 8.2, but nixpkgs ships with 8.3.1.
In Click < 8.2, 'default=False' was handled as defaulting to None, but Click 8.2 changed this behaviour and defaults instead to the value given (ergo 'False').
This default value get caught in a downstream condition handler that raises this error.

- sky/templates/websocket_proxy.py is used by sky to ssh into k8 pods. The library generates ssh-configs on launch. The ProxyCommand field in these generated ssh-configs, uses the python interpreter of the parent script (sky) from sys.executable to call websocket_proxy.py.
This fails during ssh-calls since the interpreter doesn't have the necessary env variables (PYTHONPATH/PATH) that are created by the nix-wrapper.

### Fix

- Patch sky/client/cli/command.py to set default=None instead of default=False on the --docker option. This is correct for all Click versions and makes the existing guard work as intended.
- wraps  with ```websocket_proxy.py``` wrapPythonProgramsIn and patches CLI ```command.py``` to change the call in the generated ssh-config to directly call it.

### Testing

Reproduced by installing click==8.3.1 into a venv with skypilot and running sky launch. Confirmed fixed after applying the patch. Confirmed working with click==8.1.8 (the
venv default) before and after the patch.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
