### PR TITLE
appimageTools.wrapType2: fnOrAttrs argument support

### DIFF
--- a/doc/build-helpers/images/appimagetools.section.md
+++ b/doc/build-helpers/images/appimagetools.section.md
@@ -12,7 +12,7 @@ The `appimageTools` API is unstable and may be subject to backwards-incompatible
 
 Use `wrapType2` to wrap any AppImage.
 This will create a FHS environment with many packages [expected to exist](https://github.com/AppImage/pkg2appimage/blob/master/excludelist) for the AppImage to work.
-`wrapType2` expects a function or an attrset with the `src` attribute, and either a `name` attribute or `pname` and `version` attributes.
+`wrapType2` expects a function or an attrset with the `src` attribute (pointing to an AppImage file), and either a `name` attribute or `pname` and `version` attributes.
 
 It will eventually call into [`buildFHSEnv`](#sec-fhs-environments), and any extra attributes in the argument to `wrapType2` will be passed through to it.
 This means that you can pass the `extraInstallCommands` attribute, for example, and it will have the same effect as described in [`buildFHSEnv`](#sec-fhs-environments).
@@ -24,7 +24,7 @@ However, [those were unified early 2020](https://github.com/NixOS/nixpkgs/pull/8
 
 :::{.example #ex-wrapping-appimage-from-github}
 
-# Wrapping an AppImage from GitHub
+# Wrapping an AppImage from GitHub releases page
 
 ```nix
 { appimageTools, fetchurl }:

--- a/doc/build-helpers/images/appimagetools.section.md
+++ b/doc/build-helpers/images/appimagetools.section.md
@@ -12,7 +12,7 @@ The `appimageTools` API is unstable and may be subject to backwards-incompatible
 
 Use `wrapType2` to wrap any AppImage.
 This will create a FHS environment with many packages [expected to exist](https://github.com/AppImage/pkg2appimage/blob/master/excludelist) for the AppImage to work.
-`wrapType2` expects an argument with the `src` attribute, and either a `name` attribute or `pname` and `version` attributes.
+`wrapType2` expects a function or an attrset with the `src` attribute, and either a `name` attribute or `pname` and `version` attributes.
 
 It will eventually call into [`buildFHSEnv`](#sec-fhs-environments), and any extra attributes in the argument to `wrapType2` will be passed through to it.
 This means that you can pass the `extraInstallCommands` attribute, for example, and it will have the same effect as described in [`buildFHSEnv`](#sec-fhs-environments).

--- a/pkgs/build-support/appimage/default.nix
+++ b/pkgs/build-support/appimage/default.nix
@@ -80,11 +80,11 @@ rec {
     );
 
   wrapType2 =
-    args@{
-      src,
-      extraPkgs ? pkgs: [ ],
-      ...
-    }:
+    fnOrAttrs:
+    let
+      args = (lib.fix (lib.toFunction fnOrAttrs));
+      extraPkgs = args.extraPkgs or (pkgs: [ ]);
+    in
     wrapAppImage (
       args
       // {


### PR DESCRIPTION
Added support for passing a function (as well as an attrset) to `appImageTools.wrapType2`. Now either of the following derivation is supported:
```nix
{
  appimageTools,
  fetchurl,
}:
let
  version = "1.0.1";
in
appimageTools.wrapType2 {
  pname = "Dusk";
  inherit version;
  src = fetchurl {
    url = "https://github.com/TwilitRealm/dusklight/releases/download/v${version}/Dusk-v${version}-linux-x86_64.AppImage";
    hash = "sha256-kcRqd/XlBx/Kx6UsIYIaknzi6TAbuzckZ1sgQHcfUBc=";
  };
}
```
```nix
{
  appimageTools,
  fetchurl,
}:
appimageTools.wrapType2 (a: {
  pname = "Dusk";
  version = "1.0.1";
  src = fetchurl {
    url = "https://github.com/TwilitRealm/dusklight/releases/download/v${a.version}/Dusk-v${a.version}-linux-x86_64.AppImage";
    hash = "sha256-kcRqd/XlBx/Kx6UsIYIaknzi6TAbuzckZ1sgQHcfUBc=";
  };
})
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests]. `rg appimage nixos/tests` no result
  - [ ] [Package tests] at `passthru.tests`. `rg test pkgs/build-support/appimage/` no result 
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality. `rg appimage lib/tests/` showed no result
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
