### PR TITLE
pyradio: 0.9.3.11.30 -> 0.9.3.11.31

### DIFF
--- a/pkgs/by-name/py/pyradio/package.nix
+++ b/pkgs/by-name/py/pyradio/package.nix
@@ -54,7 +54,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   '';
 
   meta = {
-    homepage = "http://www.coderholic.com/pyradio/";
+    homepage = "https://github.com/coderholic/pyradio";
     description = "Curses based internet radio player";
     mainProgram = "pyradio";
     changelog = "https://github.com/coderholic/pyradio/releases/tag/${finalAttrs.src.tag}";

--- a/pkgs/by-name/py/pyradio/package.nix
+++ b/pkgs/by-name/py/pyradio/package.nix
@@ -7,14 +7,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "pyradio";
-  version = "0.9.3.11.30";
+  version = "0.9.3.11.31";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "coderholic";
     repo = "pyradio";
     tag = finalAttrs.version;
-    hash = "sha256-b4Euo9rD/A7PjROOaigx2ITel1uA7fa6S6bNi76FeUw=";
+    hash = "sha256-DZ/HffM53uBYpucIq9UEIIzkIeF/WxXCnC1tB++LD9c=";
   };
 
   nativeBuildInputs = [
@@ -28,6 +28,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     netifaces
     psutil
     python-dateutil
+    rapidfuzz
     requests
     rich
   ];


### PR DESCRIPTION
### pyradio: 0.9.3.11.30 -> 0.9.3.11.31
Release: https://github.com/coderholic/pyradio/releases/tag/0.9.3.11.31
Diff: https://github.com/coderholic/pyradio/compare/0.9.3.11.30...0.9.3.11.31

#### Homepage Update
The prior homepage was last indexed by the Internet Archive on the 6th of December 2024 and it is no longer reachable.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
