### PR TITLE
nixos/niri: don't restart niri.service on switch

### DIFF
--- a/nixos/modules/programs/wayland/niri.nix
+++ b/nixos/modules/programs/wayland/niri.nix
@@ -40,6 +40,17 @@ in
 
         systemd.packages = [ cfg.package ];
 
+        # Restarting the compositor kills the graphical session; same
+        # treatment as the display-manager modules.
+        systemd.user.services.niri = {
+          restartIfChanged = false;
+          # Defining the unit here generates a drop-in; without this it
+          # would carry the NixOS default Environment="PATH=coreutils:…",
+          # clobbering the PATH that niri-session imported into the user
+          # manager and breaking spawn actions that rely on it.
+          enableDefaultPath = false;
+        };
+
         xdg.portal = {
           enable = lib.mkDefault true;
 


### PR DESCRIPTION
Since #507588, switch-to-configuration restarts changed user units. The packaged `niri.service` bakes the niri store path into `ExecStart=`, so any rebuild of niri (including transitive dependency bumps) now causes s-t-c to restart the compositor mid-switch, killing the graphical session.

Mirror what the display-manager modules do and mark `niri.service` as `restartIfChanged = false`. `enableDefaultPath = false` keeps the generated drop-in from injecting the NixOS default `Environment="PATH=…"`, which would otherwise override the environment that `niri-session` imported into the user manager and break `spawn` actions that rely on it.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc @getchoo @sodiboo
