### PR TITLE
perf: fix cross compilation

### DIFF
--- a/pkgs/by-name/pe/perf/package.nix
+++ b/pkgs/by-name/pe/perf/package.nix
@@ -27,6 +27,7 @@
   systemtap-unwrapped,
   numactl,
   zlib,
+  withBabeltrace ? stdenv.buildPlatform == stdenv.hostPlatform,
   babeltrace,
   withGtk ? false,
   gtk2,
@@ -77,6 +78,12 @@ stdenv.mkDerivation {
       --replace "/usr/share/d3-flame-graph/d3-flamegraph-base.html" \
       "${d3-flame-graph-templates}/share/d3-flame-graph/d3-flamegraph-base.html"
 
+    # Replace python-config calls with pkg-config calls.
+    substituteInPlace Makefile.config \
+      --replace-fail '$(shell $(PYTHON_CONFIG_SQ) --includes 2>/dev/null)' '$(shell ${stdenv.cc.targetPrefix}pkg-config --cflags python3-embed)' \
+      --replace-fail '$(shell $(PYTHON_CONFIG_SQ) $(PYTHON_CONFIG_LDFLAGS) 2>/dev/null)' '$(shell ${stdenv.cc.targetPrefix}pkg-config --libs python3-embed)' \
+      --replace-fail '$(subst $(PYTHON_NATIVE),$(shell $(CC) -dumpmachine),$(PYTHON_EMBED_LDOPTS))' '$(shell ${stdenv.cc.targetPrefix}pkg-config --libs python3-embed)'
+
     patchShebangs pmu-events/jevents.py
   '';
 
@@ -108,7 +115,11 @@ stdenv.mkDerivation {
     makeWrapper
     pkg-config
     python3
-  ];
+    elfutils
+    zlib
+    openssl
+  ]
+  ++ lib.optional withZstd zstd;
 
   buildInputs = [
     elfutils
@@ -119,11 +130,11 @@ stdenv.mkDerivation {
     zlib
     openssl
     numactl
-    babeltrace
     libopcodes
     libpfm
   ]
   ++ lib.optional (lib.meta.availableOn stdenv.hostPlatform systemtap-unwrapped) systemtap-unwrapped
+  ++ lib.optional withBabeltrace babeltrace
   ++ lib.optional withGtk gtk2
   ++ lib.optional withZstd zstd
   ++ lib.optional withLibcap libcap


### PR DESCRIPTION
perf's build system has some logic that tries to run python-config on the build machine and modify its output to be correct for the host, which doesn't work with Nix, so the binaries end up being linked against the build machine's libpython. Fix it by patching Makefile.config to use pkg-config instead.

libbpf creates a "bootstrap" library for the build machine that links against libelf, zlib and openssl, which requires these packages to be added to nativeBuildInputs. Somehow the build succeeds in the sandbox, but not under `nix develop`.

babeltrace depends on glib whose build is broken when cross compiling (at least when cross compiling for a different libc), so disable it when cross compiling.

With all of that, this succeeds on an aarch64 build machine:
```
nix build .#pkgsCross.aarch64-multiplatform-musl.perf
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
