### PR TITLE
[25.11] pocket-id: fix CVE-2026-43983, 1.15.0 -> 1.16.0

### DIFF
--- a/pkgs/by-name/po/pocket-id/CVE-2026-43983.patch
+++ b/pkgs/by-name/po/pocket-id/CVE-2026-43983.patch
@@ -1,0 +1,57 @@
+diff --git a/backend/internal/service/oidc_service.go b/backend/internal/service/oidc_service.go
+index ef765b277..6c09cb8c5 100644
+--- a/backend/internal/service/oidc_service.go
++++ b/backend/internal/service/oidc_service.go
+@@ -534,6 +534,36 @@ func (s *OidcService) createTokenFromRefreshToken(ctx context.Context, input dto
+ 		return CreatedTokens{}, &common.OidcInvalidRefreshTokenError{}
+ 	}
+ 
++	if storedRefreshToken.User.Disabled {
++		return CreatedTokens{}, &common.OidcInvalidRefreshTokenError{}
++	}
++
++	var authorizedClient model.UserAuthorizedOidcClient
++	err = tx.
++		WithContext(ctx).
++		Where("user_id = ? AND client_id = ?", storedRefreshToken.UserID, input.ClientID).
++		First(&authorizedClient).
++		Error
++	if errors.Is(err, gorm.ErrRecordNotFound) {
++		err = tx.WithContext(ctx).Delete(&storedRefreshToken).Error
++		if err != nil {
++			return CreatedTokens{}, err
++		}
++
++		err = tx.Commit().Error
++		if err != nil {
++			return CreatedTokens{}, err
++		}
++
++		return CreatedTokens{}, &common.OidcInvalidRefreshTokenError{}
++	} else if err != nil {
++		return CreatedTokens{}, err
++	}
++
++	if !s.IsUserGroupAllowedToAuthorize(storedRefreshToken.User, *client) {
++		return CreatedTokens{}, &common.OidcAccessDeniedError{}
++	}
++
+ 	// Generate a new access token
+ 	authenticationMethods := storedRefreshToken.AuthenticationMethod
+ 	accessToken, err := s.jwtService.GenerateOAuthAccessToken(storedRefreshToken.User, input.ClientID, authenticationMethods)
+@@ -1500,6 +1537,15 @@ func (s *OidcService) RevokeAuthorizedClient(ctx context.Context, userID string,
+ 		return err
+ 	}
+ 
++	err = tx.
++		WithContext(ctx).
++		Where("user_id = ? AND client_id = ?", userID, clientID).
++		Delete(&model.OidcRefreshToken{}).
++		Error
++	if err != nil {
++		return err
++	}
++
+ 	err = tx.Commit().Error
+ 	if err != nil {
+ 		return err

--- a/pkgs/by-name/po/pocket-id/package.nix
+++ b/pkgs/by-name/po/pocket-id/package.nix
@@ -28,6 +28,11 @@ buildGo125Module (finalAttrs: {
       url = "https://github.com/pocket-id/pocket-id/commit/34890235ba8c2d856e3a121fdf59fe9d627e8596.patch?full_index=1";
       hash = "sha256-Th1/J9M7kxcXyuNa0CZIIX1CuIS31Dx12+O4bzSxS0E=";
     })
+    # based on https://github.com/pocket-id/pocket-id/commit/978ac87deffec58beaccd15aead975e91b94c8a5.patch, modifications:
+    # - remove added tests due to merge conflicts
+    # - remove group restriction check as it's a v2 feature: https://github.com/pocket-id/pocket-id/pull/1164
+    # - adapt to IsUserGroupAllowedToAuthorize function signature changes
+    ./CVE-2026-43983.patch
   ];
 
   patchFlags = [ "-p2" ];

--- a/pkgs/by-name/po/pocket-id/package.nix
+++ b/pkgs/by-name/po/pocket-id/package.nix
@@ -13,13 +13,13 @@
 }:
 buildGo125Module (finalAttrs: {
   pname = "pocket-id";
-  version = "1.15.0";
+  version = "1.16.0";
 
   src = fetchFromGitHub {
     owner = "pocket-id";
     repo = "pocket-id";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-mnmBwQ79sScTPM4Gh9g0x/QTmqm1TgxaOkww+bvs1b4=";
+    hash = "sha256-2tGd/gl0Pm5b5GfkTsChvZoWov4dwljwqDcitX5NKCY=";
   };
 
   patches = [
@@ -34,7 +34,7 @@ buildGo125Module (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/backend";
 
-  vendorHash = "sha256-CmhPURPNwcpmD9shLrQPVKFGBirEMjq0Z4lmgMCpxS8=";
+  vendorHash = "sha256-ttbiuYRWbn8KRZtg499R4NF/E9+B+fOylxZcMwNg69M=";
 
   env.CGO_ENABLED = 0;
   ldflags = [
@@ -50,6 +50,11 @@ buildGo125Module (finalAttrs: {
     mv $out/bin/cmd $out/bin/pocket-id
   '';
 
+  checkFlags = [
+    # requires networking
+    "-skip=TestOidcService_downloadAndSaveLogoFromURL"
+  ];
+
   frontend = stdenvNoCC.mkDerivation {
     pname = "pocket-id-frontend";
     inherit (finalAttrs) version src;
@@ -62,8 +67,8 @@ buildGo125Module (finalAttrs: {
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname version src;
       pnpm = pnpm_10;
-      fetcherVersion = 1;
-      hash = "sha256-/e1zBHdy3exqbMvlv0Jth7vpJd7DDnWXGfMV+Cdr56I=";
+      fetcherVersion = 3;
+      hash = "sha256-Ybief+B7M1ATqHf9GlBlPFjII+ybCN4ATU94p0GKtI4=";
     };
 
     env.BUILD_OUTPUT_PATH = "dist";

--- a/pkgs/by-name/po/pocket-id/package.nix
+++ b/pkgs/by-name/po/pocket-id/package.nix
@@ -60,6 +60,8 @@ buildGo125Module (finalAttrs: {
     "-skip=TestOidcService_downloadAndSaveLogoFromURL"
   ];
 
+  doCheck = !stdenvNoCC.hostPlatform.isDarwin;
+
   frontend = stdenvNoCC.mkDerivation {
     pname = "pocket-id-frontend";
     inherit (finalAttrs) version src;


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/519706.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
