### PR TITLE
bitcoin-knots: 29.3.knots20260210 -> 29.3.knots20260508

### DIFF
--- a/pkgs/applications/blockchains/bitcoin-knots/default.nix
+++ b/pkgs/applications/blockchains/bitcoin-knots/default.nix
@@ -38,12 +38,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = if withGui then "bitcoin-knots" else "bitcoind-knots";
-  version = "29.3.knots20260210";
+  version = "29.3.knots20260508";
 
   src = fetchurl {
     url = "https://bitcoinknots.org/files/29.x/${finalAttrs.version}/bitcoin-${finalAttrs.version}.tar.gz";
     # hash retrieved from signed SHA256SUMS
-    hash = "sha256-CO87KbC6W+eMGyBipuwIxHndNqH4PS4PqbKk7JRdToo=";
+    hash = "sha256-jjrr2sqzL29rZdkMmKGIlSVToSpXfgtY0TUlv9Wd1jA=";
   };
 
   nativeBuildInputs = [
@@ -88,18 +88,18 @@ stdenv.mkDerivation (finalAttrs: {
       publicKeys = fetchFromGitHub {
         owner = "bitcoinknots";
         repo = "guix.sigs";
-        rev = "e34c3262de92940f4dc35e67abed84499c670af2";
-        sha256 = "sha256-Zrhe7xK/7YnIfyXlMd/jpO6Ab1dNVK0S1vwdhhH3Xuc=";
+        rev = "15113e2fe61b31354a6bcc3fddd17f759ce20c4a";
+        sha256 = "sha256-snbs2j88k9CBdv8+s3GaFoIXyJRVWlKoxiKA8R6ek9Y=";
       };
 
       checksums = fetchurl {
         url = "https://bitcoinknots.org/files/${majorVersion}.x/${finalAttrs.version}/SHA256SUMS";
-        hash = "sha256-fLqGSe8/s4Ikd991rW/z8CH7UMMjvOjTHqRBwEgSD/w=";
+        hash = "sha256-vFfeObwXowk143DSv9WZ++u+KA0fuHexFU1NizrCiV4=";
       };
 
       signatures = fetchurl {
         url = "https://bitcoinknots.org/files/${majorVersion}.x/${finalAttrs.version}/SHA256SUMS.asc";
-        hash = "sha256-Z6TTVKxr30OO37ve+4MrZHolo46prUVCB25kK1jLlGk=";
+        hash = "sha256-8pVhrITphjs7rnJZrmxAU92GVgkjVPlkA54ne9iwiIs=";
       };
 
       verifyBuilderKeys =
@@ -151,6 +151,7 @@ stdenv.mkDerivation (finalAttrs: {
     # building with db48 (for legacy wallet support) is broken on Darwin
     (lib.cmakeBool "WITH_BDB" (withWallet && !stdenv.hostPlatform.isDarwin))
     (lib.cmakeBool "WITH_USDT" enableTracing)
+    (lib.cmakeFeature "RDTS_CONSENT" "RUNTIME_WARN")
   ]
   ++ lib.optionals (!finalAttrs.doCheck) [
     (lib.cmakeBool "BUILD_TESTS" false)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
