### PR TITLE
vscode-utils.buildVscodeExtension: fix cross-compilation

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/oliver-ni.scheme-fmt/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/oliver-ni.scheme-fmt/default.nix
@@ -1,9 +1,8 @@
 {
   lib,
   vscode-utils,
-  jq,
+  buildPackages,
   python3,
-  moreutils,
 }:
 
 vscode-utils.buildVscodeMarketplaceExtension {
@@ -16,7 +15,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
 
   postInstall = ''
     cd "$out/$installPrefix"
-    ${lib.getExe jq} '.contributes.configuration.properties."scheme-fmt.pythonPath".default = "${lib.getExe python3}"' package.json | ${lib.getExe' moreutils "sponge"} package.json
+    ${lib.getExe buildPackages.jq} '.contributes.configuration.properties."scheme-fmt.pythonPath".default = "${lib.getExe python3}"' package.json | ${lib.getExe' buildPackages.moreutils "sponge"} package.json
   '';
 
   meta = {

--- a/pkgs/applications/editors/vscode/extensions/vscode-utils.nix
+++ b/pkgs/applications/editors/vscode/extensions/vscode-utils.nix
@@ -5,6 +5,7 @@
   writeShellScriptBin,
   fetchurl,
   vscode,
+  buildPackages,
   unzip,
   makeSetupHook,
   writeScript,
@@ -15,7 +16,7 @@ let
   unpackVsixSetupHook = makeSetupHook {
     name = "unpack-vsix-setup-hook";
     substitutions = {
-      unzip = "${unzip}/bin/unzip";
+      unzip = "${buildPackages.unzip}/bin/unzip";
     };
   } ./unpack-vsix-setup-hook.sh;
   buildVscodeExtension = lib.extendMkDerivation {


### PR DESCRIPTION
Discovered in #514753:

```
Running phase: unpackPhase
unpacking source archive /nix/store/148w0vr6yz7z3byly0dgdg3pjdxfv1vs-oliver-ni-scheme-fmt.vsix
/nix/store/hr1i2bvp34gfvw2am3cgqb51bmk0q4rg-unpack-vsix-setup-hook/nix-support/setup-hook: line 10: /nix/store/qvlgkpszrqa3bybdgjzmp3alyg35k5cw-unzip-aarch64-unknown-linux-gnu-6.0/bin/unzip: cannot execute binary file: Exec format error
do not know how to unpack source archive /nix/store/148w0vr6yz7z3byly0dgdg3pjdxfv1vs-oliver-ni-scheme-fmt.vsix
```

Tested with `pkgsCross.aarch64-multiplatform.vscode-extensions.oliver-ni.scheme-fmt`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
