### PR TITLE
texmacs: 2.1.4 -> 2.1.5

### DIFF
--- a/pkgs/applications/editors/texmacs/default.nix
+++ b/pkgs/applications/editors/texmacs/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   callPackage,
   fetchurl,
+  gnutls,
   guile_1_8,
   xmodmap,
   which,
@@ -15,12 +16,8 @@
   python3 ? null,
   cmake,
   pkg-config,
-  wrapQtAppsHook,
   xdg-utils,
-  qtbase,
-  qtsvg,
-  qtmacextras,
-  fetchpatch,
+  qt6,
   ghostscriptX ? null,
   extraFonts ? false,
   chineseFonts ? false,
@@ -30,7 +27,7 @@
 
 let
   pname = "texmacs";
-  version = "2.1.4";
+  version = "2.1.5";
   common = callPackage ./common.nix {
     inherit
       extraFonts
@@ -46,47 +43,40 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.texmacs.org/Download/ftp/tmftp/source/TeXmacs-${version}-src.tar.gz";
-    hash = "sha256-h6aSLuDdrAtVzOnNVPqMEWX9WLDHtkCjPy9JXWnBgYY=";
+    hash = "sha256-s6EnvbqOeQELI5KRQVy+NDEzNSHiRHeoFLWG4bQCc2A=";
   };
 
   postPatch = common.postPatch + ''
     substituteInPlace configure \
-      --replace "-mfpmath=sse -msse2" ""
+      --replace-fail "-mfpmath=sse -msse2" ""
   '';
 
   nativeBuildInputs = [
     guile_1_8
     pkg-config
-    wrapQtAppsHook
+    qt6.wrapQtAppsHook
     xdg-utils
     cmake
   ];
 
   buildInputs = [
+    gnutls
     guile_1_8
-    qtbase
-    qtsvg
+    qt6.qtbase
+    qt6.qtsvg
+    qt6.qt5compat
     ghostscriptX
     freetype
     libjpeg
     sqlite
     git
     python3
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "TEXMACS_GUI" "Qt6")
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    qtmacextras
-  ];
-
-  patches = [
-    (fetchpatch {
-      name = "fix-compile-clang-19.5.patch";
-      url = "https://github.com/texmacs/texmacs/commit/e72783b023f22eaa0456d2e4cc76ae509d963672.patch";
-      hash = "sha256-oJCiXWTY89BdxwbgtFvfThid0WM83+TAUThSihfr0oA=";
-    })
-  ];
-
-  cmakeFlags = lib.optionals stdenv.hostPlatform.isDarwin [
-    (lib.cmakeFeature "TEXMACS_GUI" "Qt")
     (lib.cmakeFeature "CMAKE_INSTALL_PREFIX" "./TeXmacs.app/Contents/Resources")
   ];
 
@@ -111,6 +101,11 @@ stdenv.mkDerivation {
       git
       python3
     ])
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    "--set"
+    "TEXMACS_PATH"
+    "${placeholder "out"}/Applications/TeXmacs.app/Contents/Resources/share/TeXmacs"
   ];
 
   postFixup = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3256,7 +3256,7 @@ with pkgs;
     pythonPackages = python3Packages;
   };
 
-  texmacs = libsForQt5.callPackage ../applications/editors/texmacs {
+  texmacs = callPackage ../applications/editors/texmacs {
     extraFonts = true;
   };
 


### PR DESCRIPTION
https://www.texmacs.org/tmweb/about/changes.en.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
