### PR TITLE
houdini: update link to download requireFile

### DIFF
--- a/pkgs/by-name/ho/houdini/runtime.nix
+++ b/pkgs/by-name/ho/houdini/runtime.nix
@@ -6,7 +6,7 @@ callPackage ./runtime-build.nix rec {
   src = requireFile {
     name = "houdini-${version}-linux_x86_64_gcc11.2.tar.gz";
     hash = "sha256-bZmoH1NKQhhMAhIl3pTL7irUZ7HrOhS8R7GApLD5514=";
-    url = "https://www.sidefx.com/download/daily-builds/?production=true";
+    url = "https://www.sidefx.com/download/daily-builds/?show_launcher=false&production=true&linux=true";
   };
   outputHash = "sha256-/7ctlMUoyJdPdBQV7rRO9pWcg9bXcnMJsB9TN/Jo8QQ=";
 }


### PR DESCRIPTION
Currently the page linked to only shouws the houdini_launcher. I might need to look into packaging that too, since that's the quick way to install lab extensions.

This would require a module since the scripts adds a user. I have a WIP one that sets up sesinetd as a service that I need to get back to...

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
