### PR TITLE
boost: fix python autoconfig + set strictDeps, boost191: init at 1.91.0

### DIFF
--- a/pkgs/by-name/bo/boost-build/package.nix
+++ b/pkgs/by-name/bo/boost-build/package.nix
@@ -35,7 +35,9 @@ stdenv.mkDerivation {
   patches =
     useBoost.boostBuildPatches or [ ]
     ++ lib.optional (
-      useBoost ? version && lib.versionAtLeast useBoost.version "1.81"
+      useBoost ? version
+      && lib.versionAtLeast useBoost.version "1.81"
+      && lib.versionOlder useBoost.version "1.88"
     ) ./fix-clang-target.patch;
 
   postPatch =

--- a/pkgs/development/libraries/boost/1.91.nix
+++ b/pkgs/development/libraries/boost/1.91.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  callPackage,
+  fetchurl,
+  ...
+}@args:
+
+callPackage ./generic.nix (
+  args
+  // rec {
+    version = "1.91.0";
+
+    src =
+      let
+        underVersion = lib.replaceString "." "_" version;
+      in
+      fetchurl {
+        urls = [
+          "https://archives.boost.io/release/${version}/source/boost_${underVersion}.tar.bz2"
+          # "mirror://sourceforge/boost/boost_${underVersion}.tar.bz2" 1.91.0.beta1 is available, but not 1.91.0
+        ];
+        # SHA256 from https://www.boost.org/releases/1.91.0/
+        sha256 = "de5e6b0e4913395c6bdfa90537febd9028ea4c0735d2cdb0cd9b45d5f51264f5";
+      };
+  }
+)

--- a/pkgs/development/libraries/boost/default.nix
+++ b/pkgs/development/libraries/boost/default.nix
@@ -31,4 +31,5 @@ in
   boost188 = makeBoost ./1.88.nix;
   boost189 = makeBoost ./1.89.nix;
   boost190 = makeBoost ./1.90.nix;
+  boost191 = makeBoost ./1.91.nix;
 }

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -74,6 +74,7 @@ let
 
   needUserConfig =
     stdenv.hostPlatform != stdenv.buildPlatform
+    || enablePython
     || useMpi
     || (stdenv.hostPlatform.isDarwin && enableShared);
 

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -423,5 +423,7 @@ stdenv.mkDerivation {
   ];
   setOutputFlags = false;
 
+  strictDeps = true;
+
   __structuredAttrs = true;
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6023,6 +6023,7 @@ with pkgs;
     boost188
     boost189
     boost190
+    boost191
     ;
 
   boost = boost189;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
