### PR TITLE
yaziPlugins: update on 2026-05-13

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/clipboard/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/clipboard/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "clipboard.yazi";
-  version = "0-unstable-2026-04-24";
+  version = "0-unstable-2026-05-10";
 
   src = fetchFromGitHub {
     owner = "XYenon";
     repo = "clipboard.yazi";
-    rev = "d6fc53152a20aebad8dc6e2550940f7efe226838";
-    hash = "sha256-6jlMzVPgkbQRwVbfUCEtXVWLxBKdPymQeHVoh5z9mO8=";
+    rev = "68b506d9a9c2c5dde01a078a589520f551d05fe5";
+    hash = "sha256-jNBwkcFb9i5Z6BSMfkTOyrK7HZohAT/yB3cxcCOG54w=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/lazygit/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/lazygit/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "lazygit.yazi";
-  version = "0-unstable-2026-03-12";
+  version = "0-unstable-2026-05-02";
 
   src = fetchFromGitHub {
     owner = "Lil-Dank";
     repo = "lazygit.yazi";
-    rev = "8c4086c813c5856ab9571ae9142ed7d40ed3211e";
-    hash = "sha256-YpRWnR5fEXzHY9yBFNKy1NvTzHa8B1UhS2Qrfe9+Tpg=";
+    rev = "e73fd74c2af3300368b33da1cfbab6a8649a41a8";
+    hash = "sha256-KPvjXjYE0W4Q2xZiVfMwZbtalHt0FbgLtEK4sUWbYOI=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/split-tabs/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/split-tabs/default.nix
@@ -6,13 +6,13 @@
 
 mkYaziPlugin {
   pname = "split-tabs.yazi";
-  version = "0-unstable-2026-04-13";
+  version = "0-unstable-2026-05-13";
 
   src = fetchFromGitHub {
     owner = "terrakok";
     repo = "split-tabs.yazi";
-    rev = "6c0931840d764bffa0c38677b6a84e69928e283f";
-    hash = "sha256-FqeXVVFk4+aXn8d+LLs8idRBkLLzRPeVol6vMCh6mQ4=";
+    rev = "ca95efc94a3a62e6e58c741f60801c1a0ddba1a6";
+    hash = "sha256-ic09opWZcoJ874bU2HN+5Y9mbnZEnvds+abqRQYuiYE=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/sshfs/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/sshfs/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "sshfs.yazi";
-  version = "2.0.0-unstable-2026-04-15";
+  version = "0-unstable-2026-05-11";
 
   src = fetchFromGitHub {
     owner = "uhs-robert";
     repo = "sshfs.yazi";
-    rev = "7ba17a8c8498fca9f0a9c437704e74b56d96ed96";
-    hash = "sha256-TS3/xl8jbbCoF1LzPYvmG9BRqvlzPg4EZRErlL7S2/M=";
+    rev = "a8b8903c0da5a4febe91713108a9b0c8a2749475";
+    hash = "sha256-RYZ0wFkYfR/TfYntRipNPvpSl4gvtmNukLBQONRk1jU=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/sudo/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/sudo/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "sudo.yazi";
-  version = "0-unstable-2025-11-05";
+  version = "0-unstable-2026-05-07";
 
   src = fetchFromGitHub {
     owner = "TD-Sky";
     repo = "sudo.yazi";
-    rev = "86205aa8044f10b02471be1087f3381bbadc967e";
-    hash = "sha256-mpQLij+Sg88RarCC+0u7JfZ2EqcX4gB7jvy8bfBt90w=";
+    rev = "afd61cedbcd13c549c552766755645069561d28c";
+    hash = "sha256-5wa4fdYo7wOXOzdrigWMtADZIL/7alG8Jw7r8iWz9yA=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/toggle-pane/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/toggle-pane/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "toggle-pane.yazi";
-  version = "25.5.31-unstable-2025-06-18";
+  version = "26.1.22-unstable-2026-05-07";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "86d28e4fb4f25f36cc501b8cb0badb37a6b14263";
-    hash = "sha256-m/gJTDm0cVkIdcQ1ZJliPqBhNKoCW1FciLkuq7D1mxo=";
+    rev = "4ffa48f33465c22cce48c5d506295a3eb27c1979";
+    hash = "sha256-wr5QL493A175dRjYSyYpMMJax1RKWaZ3jAdFdL3XXTw=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/yafg/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/yafg/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "yafg.yazi";
-  version = "0-unstable-2026-01-10";
+  version = "0-unstable-2026-05-06";
 
   src = fetchFromGitHub {
     owner = "XYenon";
     repo = "yafg.yazi";
-    rev = "dd03b133d6cd1ff92368360558da193517169f9e";
-    hash = "sha256-xTZ+6KRr85A4QpPWAE9QN1AnUVnCw/tvRvsWOmmayao=";
+    rev = "e6ba85125bfa4e3a60ef28b70949299712103b2a";
+    hash = "sha256-IKQscTTirtfbsXKzCmaokPDrQZqXa4MSY2+6DbEQluU=";
   };
 
   meta = {


### PR DESCRIPTION
- clipboard: 0-unstable-2026-04-24 → 0-unstable-2026-05-10
  Compare: https://github.com/XYenon/clipboard.yazi/compare/d6fc53152a20aebad8dc6e2550940f7efe226838...68b506d9a9c2c5dde01a078a589520f551d05fe5
- lazygit: 0-unstable-2026-03-12 → 0-unstable-2026-05-02
  Compare: https://github.com/Lil-Dank/lazygit.yazi/compare/8c4086c813c5856ab9571ae9142ed7d40ed3211e...e73fd74c2af3300368b33da1cfbab6a8649a41a8
- split-tabs: 0-unstable-2026-04-13 → 0-unstable-2026-05-13
  Compare: https://github.com/terrakok/split-tabs.yazi/compare/6c0931840d764bffa0c38677b6a84e69928e283f...ca95efc94a3a62e6e58c741f60801c1a0ddba1a6
- sshfs: 2.0.0-unstable-2026-04-15 → 0-unstable-2026-05-11
  Compare: https://github.com/uhs-robert/sshfs.yazi/compare/7ba17a8c8498fca9f0a9c437704e74b56d96ed96...a8b8903c0da5a4febe91713108a9b0c8a2749475
- sudo: 0-unstable-2025-11-05 → 0-unstable-2026-05-07
  Compare: https://github.com/TD-Sky/sudo.yazi/compare/86205aa8044f10b02471be1087f3381bbadc967e...afd61cedbcd13c549c552766755645069561d28c
- toggle-pane: 25.5.31-unstable-2025-06-18 → 26.1.22-unstable-2026-05-07
  Compare: https://github.com/yazi-rs/plugins/compare/86d28e4fb4f25f36cc501b8cb0badb37a6b14263...4ffa48f33465c22cce48c5d506295a3eb27c1979
- yafg: 0-unstable-2026-01-10 → 0-unstable-2026-05-06
  Compare: https://github.com/XYenon/yafg.yazi/compare/dd03b133d6cd1ff92368360558da193517169f9e...e6ba85125bfa4e3a60ef28b70949299712103b2a


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
