### PR TITLE
cel-go: 0.28.0 -> 0.28.1, add update script

### DIFF
--- a/pkgs/by-name/ce/cel-go/package.nix
+++ b/pkgs/by-name/ce/cel-go/package.nix
@@ -6,13 +6,13 @@
 let
   cel-spec = buildGoModule (finalAttrs: {
     pname = "cel-spec";
-    version = "0.25.1";
+    version = "0.25.2";
 
     src = fetchFromGitHub {
       owner = "google";
       repo = "cel-spec";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-D9NHnQerquU2nDhDIheHmzV2FUwKi+MfTO+sehMXudg=";
+      hash = "sha256-aNyBGUlpTqILCiQHo7BxaZShI6q9xgtRegywd+jQSlo=";
     };
 
     vendorHash = "sha256-7Ngemih4jRO6VHSH2QxU/p1Q/E/ukUZ5wuUbZzRj6kA=";
@@ -26,18 +26,18 @@ let
 in
 buildGoModule (finalAttrs: {
   pname = "cel-go";
-  version = "0.28.0";
+  version = "0.28.1";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "cel-go";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-A+SiKpagf73u+dFclntoPTCNCG+7m4kutS6fpeZ+jDU=";
+    hash = "sha256-fiFkoYVKdSdYkSMQxmC1SvEEGsalBasCl9tzsGSYwmw=";
   };
 
   modRoot = "repl";
 
-  vendorHash = "sha256-obxFjr++fSKJx7TxTZ28YFhts2e/pW32BFVhOGnY7XY=";
+  vendorHash = "sha256-tMaDwKoE5tzbQD5b7EnpKqiT/CT9WDCKgoxQeyhIlXE=";
 
   subPackages = [
     "main"

--- a/pkgs/by-name/ce/cel-go/package.nix
+++ b/pkgs/by-name/ce/cel-go/package.nix
@@ -62,6 +62,11 @@ buildGoModule (finalAttrs: {
     mv $out/bin/{main,cel-go}
   '';
 
+  passthru = {
+    inherit cel-spec;
+    updateScript = ./update.sh;
+  };
+
   meta = {
     changelog = "https://github.com/google/cel-go/releases/tag/${finalAttrs.src.tag}";
     description = "Fast, portable, non-Turing complete expression evaluation with gradual typing";

--- a/pkgs/by-name/ce/cel-go/update.sh
+++ b/pkgs/by-name/ce/cel-go/update.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq nix bash nix-update
+
+set -eou pipefail
+
+PACKAGE_DIR=$(realpath $(dirname $0))
+
+latestTag=$(curl ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} -sL https://api.github.com/repos/google/cel-go/releases/latest | jq --raw-output .tag_name)
+latestVersion=$(echo "$latestTag" | sed 's/^v//')
+
+currentVersion=$(nix-instantiate --eval -E "with import ./. {}; cel-go.version or (lib.getVersion cel-go)" | tr -d '"')
+
+if [[ "$currentVersion" == "$latestVersion" ]]; then
+    echo "package is up-to-date: $currentVersion"
+    exit 0
+fi
+
+nix-update cel-go
+nix-update cel-go.cel-spec


### PR DESCRIPTION
changelog: https://github.com/google/cel-go/releases/tag/v0.28.1
diff: https://github.com/google/cel-go/compare/v0.28.0...v0.28.1

Supersedes #519554

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
