### PR TITLE
maintainers: remove sweber

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26624,12 +26624,6 @@
     githubId = 120188;
     name = "Scott W. Dunlop";
   };
-  sweber = {
-    email = "sweber2342+nixpkgs@gmail.com";
-    github = "sweber83";
-    githubId = 19905904;
-    name = "Simon Weber";
-  };
   sweenu = {
     name = "sweenu";
     email = "contact@sweenu.xyz";

--- a/nixos/modules/services/home-automation/zigbee2mqtt.nix
+++ b/nixos/modules/services/home-automation/zigbee2mqtt.nix
@@ -12,10 +12,7 @@ let
 
 in
 {
-  meta.maintainers = with lib.maintainers; [
-    sweber
-    hexa
-  ];
+  meta.maintainers = with lib.maintainers; [ hexa ];
 
   imports = [
     (lib.mkRemovedOptionModule [

--- a/pkgs/by-name/pk/pkgdiff/package.nix
+++ b/pkgs/by-name/pk/pkgdiff/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Tool for visualizing changes in Linux software packages";
     homepage = "https://lvc.github.io/pkgdiff/";
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [ sweber ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
     mainProgram = "pkgdiff";
   };

--- a/pkgs/by-name/zi/zigbee2mqtt/package.nix
+++ b/pkgs/by-name/zi/zigbee2mqtt/package.nix
@@ -65,10 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
       It bridges events and allows you to control your Zigbee devices via MQTT.
       In this way you can integrate your Zigbee devices with whatever smart home infrastructure you are using.
     '';
-    maintainers = with lib.maintainers; [
-      sweber
-      hexa
-    ];
+    maintainers = with lib.maintainers; [ hexa ];
     mainProgram = "zigbee2mqtt";
   };
 })


### PR DESCRIPTION
## Reasons

- Last commented in [March 2023](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Asweber83)
- Hasn't created any PRs / Issues since [November 2022](https://github.com/NixOS/nixpkgs/issues?q=author%3Asweber83)
- About 74 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Asweber83%20-commenter%3Asweber83%20-author%3Asweber83%20-reviewed-by%3Asweber83) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] pkgdiff