### PR TITLE
fetchPnpmDeps,pnpmConfigHook: drop pnpmWorkspace migration guards

### DIFF
--- a/pkgs/build-support/node/fetch-pnpm-deps/default.nix
+++ b/pkgs/build-support/node/fetch-pnpm-deps/default.nix
@@ -59,11 +59,6 @@ in
         else
           pnpm-fixup-state-db;
     in
-    # pnpmWorkspace was deprecated, so throw if it's used.
-    assert
-      !args ? pnpmWorkspace
-      || throw "fetchPnpmDeps: `pnpmWorkspace` is no longer supported, please migrate to `pnpmWorkspaces`.";
-
     assert
       fetcherVersion != null
       || throw "fetchPnpmDeps: `fetcherVersion` is not set, see https://nixos.org/manual/nixpkgs/stable/#javascript-pnpm-fetcherVersion.";

--- a/pkgs/build-support/node/fetch-pnpm-deps/pnpm-config-hook.sh
+++ b/pkgs/build-support/node/fetch-pnpm-deps/pnpm-config-hook.sh
@@ -74,11 +74,6 @@ pnpmConfigHook() {
     # See: https://pnpm.io/settings#packageimportmethod
     pnpm config set package-import-method clone-or-copy
 
-    if [[ -n "$pnpmWorkspace" ]]; then
-        echo "'pnpmWorkspace' is deprecated, please migrate to 'pnpmWorkspaces'."
-        exit 2
-    fi
-
     echo "Installing dependencies"
     if [[ -n "$pnpmWorkspaces" ]]; then
         local IFS=" "


### PR DESCRIPTION
The deprecated singular `pnpmWorkspace` attribute (superseded by `pnpmWorkspaces` in #350751) has no remaining in-tree users, so the assert and hook check pointing users to the new attribute are no longer needed.


```
❯ git grep --perl-regexp 'pnpmWorkspace\b'

❯ git grep --perl-regexp 'pnpmWorkspaces\b' | wc -l
69
```

This is a no-op: the singular attribute has no users (empty grep above), so the change only drops the now-dead deprecation guards. I tried `nixpkgs-review` but it ran out of disk space before finishing; since no derivations are affected, I left it at that.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
