### PR TITLE
macaulay2: add darwin support

### DIFF
--- a/pkgs/by-name/ma/macaulay2/package.nix
+++ b/pkgs/by-name/ma/macaulay2/package.nix
@@ -23,6 +23,7 @@
   flint,
   frobby,
   gdbm,
+  getconf,
   gfortran,
   gfan,
   givaro,
@@ -53,10 +54,11 @@
   readline,
   singular,
   texinfo,
-  time,
+  runtimeShell,
   topcom,
   which,
   xz,
+  llvmPackages,
 
   downloadDocs ? true,
 }:
@@ -87,6 +89,7 @@ stdenv.mkDerivation (finalAttrs: {
     flint
     frobby
     gdbm
+    getconf
     givaro
     glpk
     gtest
@@ -111,6 +114,9 @@ stdenv.mkDerivation (finalAttrs: {
     readline
     singular
     xz
+  ]
+  ++ lib.optionals stdenv.cc.isClang [
+    llvmPackages.openmp
   ];
 
   nativeBuildInputs = [
@@ -119,6 +125,7 @@ stdenv.mkDerivation (finalAttrs: {
     emacs-nox
     flex
     gdbm
+    getconf
     gfortran
     makeWrapper
     pkg-config
@@ -147,6 +154,13 @@ stdenv.mkDerivation (finalAttrs: {
     sed -i 's/AC_SUBST(REL,.*uname -r.*)/AC_SUBST(REL,"")/' configure.ac
     substituteInPlace Macaulay2/packages/DeterminantalRepresentations.m2 \
       --replace-fail "eps = 1e-15" "eps = 1e-14"
+  ''
+  # ForeignFunctions.m2 uses `brew --prefix` to discover potential library paths,
+  # which fails when Homebrew is not installed.
+  # We patch it to return an empty path instead, which should be harmless
+  + ''
+    substituteInPlace Macaulay2/packages/ForeignFunctions.m2 \
+      --replace-fail 'get "!brew --prefix"' 'try get "!brew --prefix" else ""'
   '';
 
   preConfigure = ''
@@ -181,8 +195,17 @@ stdenv.mkDerivation (finalAttrs: {
     "MakeDocumentation=false"
   ];
 
+  env.LDFLAGS = lib.concatStringsSep " " (
+    lib.optionals stdenv.hostPlatform.isDarwin [
+      "-lblas"
+    ]
+  );
+
   postInstall = ''
-    wrapProgram "$out/bin/M2" \
+    substituteInPlace "$out/bin/M2" \
+      --replace-fail "/bin/sh" "${runtimeShell}"
+
+    wrapProgram "$out/bin/M2-binary" \
       --prefix PATH : ${
         lib.makeBinPath [
           _4ti2
@@ -198,7 +221,7 @@ stdenv.mkDerivation (finalAttrs: {
           topcom
         ]
       } \
-      --prefix LD_LIBRARY_PATH : ${
+      --prefix ${if stdenv.hostPlatform.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH"} : ${
         lib.makeLibraryPath [
           cddlib
           flint


### PR DESCRIPTION
As the title says (and probably also ZHF? https://hydra.nixos.org/job/nixpkgs/unstable/macaulay2.aarch64-darwin)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
