### PR TITLE
zlcompressor: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/by-name/zl/zlcompressor/package.nix
+++ b/pkgs/by-name/zl/zlcompressor/package.nix
@@ -8,6 +8,7 @@
   darwin,
   ninja,
   pkg-config,
+  python3,
   writableTmpDirAsHomeHook,
 
   # buildInputs
@@ -29,13 +30,13 @@
 
 clangStdenv.mkDerivation (finalAttrs: {
   pname = "zlcompressor";
-  version = "0.4.0";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "ZL-Audio";
     repo = "ZLCompressor";
     tag = finalAttrs.version;
-    hash = "sha256-u+2cfCNjMUXo+7/qBUU4BdDQcUyeQfd9kvARi3AAK48=";
+    hash = "sha256-vSGadtUm6AEWEaNr3gCybEtc7NY3s3SQi8UVXoRsKCA=";
     fetchSubmodules = true;
   };
 
@@ -43,6 +44,7 @@ clangStdenv.mkDerivation (finalAttrs: {
     cmake
     ninja
     pkg-config
+    python3
     writableTmpDirAsHomeHook
   ]
   ++ lib.optionals clangStdenv.hostPlatform.isDarwin [ darwin.sigtool ];
@@ -93,6 +95,20 @@ clangStdenv.mkDerivation (finalAttrs: {
       if clangStdenv.hostPlatform.isAarch64 then "neon64" else "sse2;avx;avx2"
     ))
     (lib.cmakeBool "ZL_JUCE_COPY_PLUGIN" false)
+    # Highway is vendored as a submodule and built in single-target static
+    # dispatch mode (HWY_COMPILE_ONLY_STATIC), so exactly one SIMD target must
+    # be picked at build time. Accepted values: SSE2 / SSE4 / AVX2 / NEON.
+    #
+    # We pick SSE2 on x86_64 because that's the only SIMD extension guaranteed
+    # by nixpkgs' baseline x86_64-linux platform.
+    # Users who know their CPU supports more can opt in per-package:
+    #
+    #   zlcompressor.overrideAttrs (old: {
+    #     cmakeFlags = (old.cmakeFlags or []) ++ [ "-DZL_HWY_STATIC_TARGET=AVX2" ];
+    #   })
+    (lib.cmakeFeature "ZL_HWY_STATIC_TARGET" (
+      if clangStdenv.hostPlatform.isAarch64 then "NEON" else "SSE2"
+    ))
     # set the version for in the settings screen.
     (lib.cmakeFeature "FOOBAR_VERSION" "${finalAttrs.version}")
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
