### PR TITLE
gitea-actions-runner: 0.4.0 -> 1.0.3

### DIFF
--- a/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
@@ -12,6 +12,7 @@ let
     attrValues
     concatStringsSep
     escapeShellArg
+    getExe
     hasInfix
     hasSuffix
     optionalAttrs
@@ -36,7 +37,7 @@ let
 
   # Check whether any runner instance label requires a container runtime
   # Empty label strings result in the upstream defined defaultLabels, which require docker
-  # https://gitea.com/gitea/act_runner/src/tag/v0.1.5/internal/app/cmd/register.go#L93-L98
+  # https://gitea.com/gitea/runner/src/tag/v0.1.5/internal/app/cmd/register.go#L93-L98
   hasDockerScheme =
     instance: instance.labels == [ ] || any (label: hasInfix ":docker:" label) instance.labels;
   wantsContainerRuntime = any hasDockerScheme (attrValues cfg.instances);
@@ -123,8 +124,8 @@ in
           };
           settings = mkOption {
             description = ''
-              Configuration for `act_runner daemon`.
-              See <https://gitea.com/gitea/act_runner/src/branch/main/internal/pkg/config/config.example.yaml> for an example configuration
+              Configuration for gitea-runner daemon.
+              See <https://gitea.com/gitea/runner/src/branch/main/internal/pkg/config/config.example.yaml> for an example configuration
             '';
 
             type = types.submodule {
@@ -252,7 +253,7 @@ in
                     rm -v "$INSTANCE_DIR/.runner" || true
 
                     # perform the registration
-                    ${cfg.package}/bin/act_runner register --no-interactive \
+                    ${getExe cfg.package} register --no-interactive \
                       --instance ${escapeShellArg instance.url} \
                       --token "$TOKEN" \
                       --name ${escapeShellArg instance.name} \
@@ -266,7 +267,7 @@ in
 
                 '')
               ];
-              ExecStart = "${cfg.package}/bin/act_runner daemon --config ${configFile}";
+              ExecStart = "${getExe cfg.package} daemon --config ${configFile}";
               SupplementaryGroups =
                 optionals wantsDocker [
                   "docker"

--- a/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
@@ -54,7 +54,7 @@ let
     || (instance.token != null && instance.tokenFile == null);
 in
 {
-  meta.maintainers = [ ];
+  meta.maintainers = pkgs.gitea-actions-runner.meta.maintainers;
 
   options.services.gitea-actions-runner = with types; {
     package = mkPackageOption pkgs "gitea-actions-runner" { };

--- a/pkgs/by-name/gi/gitea-actions-runner/package.nix
+++ b/pkgs/by-name/gi/gitea-actions-runner/package.nix
@@ -44,6 +44,9 @@ buildGoModule (finalAttrs: {
     homepage = "https://gitea.com/gitea/runner";
     license = lib.licenses.mit;
     mainProgram = "gitea-runner";
-    maintainers = with lib.maintainers; [ techknowlogick ];
+    maintainers = with lib.maintainers; [
+      superherointj
+      techknowlogick
+    ];
   };
 })

--- a/pkgs/by-name/gi/gitea-actions-runner/package.nix
+++ b/pkgs/by-name/gi/gitea-actions-runner/package.nix
@@ -8,23 +8,30 @@
 
 buildGoModule (finalAttrs: {
   pname = "gitea-actions-runner";
-  version = "0.4.0";
+  version = "1.0.3";
 
   src = fetchFromGitea {
     domain = "gitea.com";
     owner = "gitea";
-    repo = "act_runner";
+    repo = "runner";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-trKp5tIhvvb6VJ04iIpFD4Q/VK/V1urkbXEpGMwaEsE=";
+    hash = "sha256-p6NdkQiZiEeuQjJp3CKTayStZlyk3d1XGigSI5uuLp0=";
   };
 
-  vendorHash = "sha256-dUUe4BbBmRP9MImq/PYTGssv3M2Zn84oCxH5BKf9btg=";
+  vendorHash = "sha256-T1T5ZpGqGmipIkTWlYxlsLdAthW8bhcAvr0xyZ74+wQ=";
+
+  # Tests require network access (artifactcache tests try to determine outbound IP)
+  doCheck = false;
 
   ldflags = [
     "-s"
     "-w"
-    "-X gitea.com/gitea/act_runner/internal/pkg/ver.version=v${finalAttrs.version}"
+    "-X gitea.com/gitea/runner/internal/pkg/ver.version=v${finalAttrs.version}"
   ];
+
+  postInstall = ''
+    mv "$out/bin/runner" "$out/bin/gitea-runner"
+  '';
 
   passthru.tests.version = testers.testVersion {
     package = gitea-actions-runner;
@@ -32,11 +39,11 @@ buildGoModule (finalAttrs: {
   };
 
   meta = {
-    mainProgram = "act_runner";
-    maintainers = with lib.maintainers; [ techknowlogick ];
-    license = lib.licenses.mit;
-    changelog = "https://gitea.com/gitea/act_runner/releases/tag/v${finalAttrs.version}";
-    homepage = "https://gitea.com/gitea/act_runner";
+    changelog = "https://gitea.com/gitea/runner/releases/tag/v${finalAttrs.version}";
     description = "Runner for Gitea based on act";
+    homepage = "https://gitea.com/gitea/runner";
+    license = lib.licenses.mit;
+    mainProgram = "gitea-runner";
+    maintainers = with lib.maintainers; [ techknowlogick ];
   };
 })


### PR DESCRIPTION
`gitea-actions-runner: 0.4.0 -> 1.0.3`

This is a major upgrade — the upstream project was renamed from `act_runner` to `gitea-runner` in v1.0.0. The source repository moved from `gitea.com/gitea/act_runner` to `gitea.com/gitea/runner`.

Releases: 
- https://gitea.com/gitea/runner/releases/tag/v1.0.3
- https://gitea.com/gitea/runner/releases/tag/v1.0.2
- https://gitea.com/gitea/runner/releases/tag/v1.0.1
- https://gitea.com/gitea/runner/releases/tag/v1.0.0
- https://gitea.com/gitea/runner/releases/tag/v0.6.1
- https://gitea.com/gitea/runner/releases/tag/v0.6.0
- https://gitea.com/gitea/runner/releases/tag/v0.5.0
- https://gitea.com/gitea/runner/releases/tag/v0.4.1

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.