### PR TITLE
cudaPackages.libcusolvermp: fix build

### DIFF
--- a/pkgs/development/cuda-modules/packages/libcusolvermp.nix
+++ b/pkgs/development/cuda-modules/packages/libcusolvermp.nix
@@ -24,6 +24,11 @@ buildRedist {
     nccl
   ];
 
+  autoPatchelfIgnoreMissingDeps = [
+    # Needs to be dynamically loaded as it depends on the hardware
+    "libcuda.so.1"
+  ];
+
   meta = {
     description = "High-performance, distributed-memory, GPU-accelerated library that provides tools for solving dense linear systems and eigenvalue problems";
     longDescription = ''


### PR DESCRIPTION
## Things done

Follow up of https://github.com/NixOS/nixpkgs/pull/519690 which broke `cudaPackages.libcublasmp`.

```
searching for dependencies of /nix/store/5zzxirwkppb11vl6g9hgdl75b4z1c9ri-cuda12.9-libcusolvermp-0.8.0.3126-lib/lib/libcusolverMp.so.0.8.0.0
    libnccl.so.2 -> found: /nix/store/16riv18n1nia4dflcij5z7vlh661zr25-cuda12.9-nccl-2.28.7-1/lib
    libcublas.so.12 -> found: /nix/store/v80yfygm1jysr42byj1vpadkaddgxgzz-cuda12.9-libcublas-12.9.1.4-lib/lib
    libcusolver.so.11 -> found: /nix/store/wrdzns4lf17g40czhn0crj85ps2mj49z-cuda12.9-libcusolver-11.7.5.82-lib/lib
    libcuda.so.1 -> not found!
    libcublasLt.so.12 -> found: /nix/store/v80yfygm1jysr42byj1vpadkaddgxgzz-cuda12.9-libcublas-12.9.1.4-lib/lib
    libcusparse.so.12 -> found: /nix/store/jc88x5mzhpsbv1bf3mjqvzvf29icq69s-cuda12.9-libcusparse-12.5.10.65-lib/lib
    libnvJitLink.so.12 -> found: /nix/store/pvbf2yyzwh59cl80bjcllcs481ddhnxi-cuda12.9-libnvjitlink-12.9.86-lib/lib
    libcudart.so.12 -> found: /nix/store/98hg0wzq5xpk2wax4ihiykk8mc9slnja-cuda12.9-cuda_cudart-12.9.79/lib
    libstdc++.so.6 -> found: /nix/store/si4q3zks5mn5jhzzyri9hhd3cv789vlm-gcc-15.2.0-lib/lib
    libgcc_s.so.1 -> found: /nix/store/wrxyd3k2f4bmh52pr5rpdjxxsm5r2qxm-gcc-15.2.0-libgcc/lib
setting RPATH to: /nix/store/16riv18n1nia4dflcij5z7vlh661zr25-cuda12.9-nccl-2.28.7-1/lib:/nix/store/v80yfygm1jysr42byj1vpadkaddgxgzz-cuda12.9-libcublas-12.9.1.4-lib/lib:/nix/store/wrdzns4lf17g40czhn0crj85ps2mj49z-cuda12.9-libcusolver-11.7.5.82-lib/lib:/nix/store/jc88x5mzhpsbv1bf3mjqvzvf29icq69s-cuda12.9-libcusparse-12.5.10.65-lib/lib:/nix/store/pvbf2yyzwh59cl80bjcllcs481ddhnxi-cuda12.9-libnvjitlink-12.9.86-lib/lib:/nix/store/98hg0wzq5xpk2wax4ihiykk8mc9slnja-cuda12.9-cuda_cudart-12.9.79/lib:/nix/store/si4q3zks5mn5jhzzyri9hhd3cv789vlm-gcc-15.2.0-lib/lib:/nix/store/wrxyd3k2f4bmh52pr5rpdjxxsm5r2qxm-gcc-15.2.0-libgcc/lib:$ORIGIN
auto-patchelf: 1 dependencies could not be satisfied
error: auto-patchelf could not satisfy dependency libcuda.so.1 wanted by /nix/store/5zzxirwkppb11vl6g9hgdl75b4z1c9ri-cuda12.9-libcusolvermp-0.8.0.3126-lib/lib/libcusolverMp.so.0.8.0.0
auto-patchelf failed to find all the required dependencies.
Add the missing dependencies to --libs or use `--ignore-missing="foo.so.1 bar.so etc.so"`.
~
```

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
