### PR TITLE
zsign: 0.9.6 -> 1.0.4

### DIFF
--- a/pkgs/by-name/zs/zsign/package.nix
+++ b/pkgs/by-name/zs/zsign/package.nix
@@ -4,9 +4,7 @@
   stdenv,
   openssl,
   pkg-config,
-  minizip,
   nix-update-script,
-  zlib,
   versionCheckHook,
 }:
 let
@@ -14,33 +12,24 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "zsign";
-  version = "0.9.6";
+  version = "1.0.4";
 
   src = fetchFromGitHub {
     owner = "zhlynn";
     repo = "zsign";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-e4k3W+FkdydqPy3DuhH6MbC+IilLZfqOb7FAbIiv/kM=";
+    hash = "sha256-NuwV8s+rzsXBha/vqnemvUo6Etm70ZVYL/CZKBJ1szA=";
   };
-
-  postPatch = ''
-    substituteInPlace ../../src/common/archive.cpp \
-      --replace-fail "#include <zip.h>" "#include <minizip/zip.h>" \
-      --replace-fail "#include <unzip.h>" "#include <minizip/unzip.h>"
-  '';
 
   sourceRoot = "${finalAttrs.src.name}/build/${platformName}";
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [
-    openssl
-    minizip
-    zlib
-  ];
+  buildInputs = [ openssl ];
 
   makeFlags = [
     "BINDIR=bin/"
     "CXX=${stdenv.cc.targetPrefix}c++"
+    "VERSION=${finalAttrs.version}"
   ];
 
   installPhase = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

* Upgrade zsign
* Remove the patch and dependencies, zsign now vendors them

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
