### PR TITLE
pg_textsearch: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_textsearch.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_textsearch.nix
@@ -8,36 +8,13 @@
 
 postgresqlBuildExtension (finalAttrs: {
   pname = "pg_textsearch";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "timescale";
     repo = "pg_textsearch";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-zZctWEJVItzJBke46J4CgvOAGDLmOZbCeUThkrnaPug";
-  };
-
-  passthru.tests.extension = postgresqlTestExtension {
-    inherit (finalAttrs) finalPackage;
-    postgresqlExtraSettings = ''
-      shared_preload_libraries='pg_textsearch'
-    '';
-    sql = ''
-      CREATE EXTENSION IF NOT EXISTS pg_textsearch;
-      CREATE TABLE documents (content text);
-      INSERT INTO documents VALUES
-        ('NixOS provides declarative configuration and reproducible system builds with the Nix package manager'),
-        ('Nix was originally developed by Eelco Dolstra'),
-        ('PostgreSQL is a powerful, open source object-relational database system');
-      CREATE INDEX documents_content_bm25_idx ON documents USING bm25(content) WITH (text_config='english');
-    '';
-    asserts = [
-      {
-        query = "SELECT count(*) FROM documents ORDER BY content <@> 'nix' LIMIT 10";
-        expected = "2";
-        description = "BM25 index can be queried successfully.";
-      }
-    ];
+    hash = "sha256-aFuaz/gd72rdMdQKI12ENF+CrKPaiqxysHUYidkLsHc=";
   };
 
   meta = {


### PR DESCRIPTION
https://github.com/timescale/pg_textsearch/releases/tag/v1.2.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
