### PR TITLE
win2xcur: 0.2.0 -> 0.2.1

### DIFF
--- a/pkgs/by-name/wi/win2xcur/package.nix
+++ b/pkgs/by-name/wi/win2xcur/package.nix
@@ -6,14 +6,14 @@
 
 python3Packages.buildPythonPackage (finalAttrs: {
   pname = "win2xcur";
-  version = "0.2.0";
+  version = "0.2.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "quantum5";
     repo = "win2xcur";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-uG9yrH1BvdGyFosGBXLNB7lr0w7r89MWhW4gCVS+s1w=";
+    hash = "sha256-zr3zLbjbQAY7McoF89W2Dqgj49mpHDZZBS9zzhqTAm8=";
   };
 
   build-system = with python3Packages; [ setuptools ];
@@ -24,8 +24,11 @@ python3Packages.buildPythonPackage (finalAttrs: {
   ];
 
   pythonImportsCheck = [
+    "win2xcur.main.inspectcur"
     "win2xcur.main.win2xcur"
+    "win2xcur.main.win2xcurtheme"
     "win2xcur.main.x2wincur"
+    "win2xcur.main.x2wincurtheme"
   ];
 
   meta = {


### PR DESCRIPTION
Updated and added the new executables introduced in 0.2.0 to `pythonImportsCheck`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
