### PR TITLE
[release-25.11] python3Packages.granian: 2.5.6 -> 2.7.4

### DIFF
--- a/pkgs/development/python-modules/granian/default.nix
+++ b/pkgs/development/python-modules/granian/default.nix
@@ -20,14 +20,14 @@
 
 buildPythonPackage rec {
   pname = "granian";
-  version = "2.6.0";
+  version = "2.6.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "emmett-framework";
     repo = "granian";
     tag = "v${version}";
-    hash = "sha256-Jj75ycr9Y0aCTP5YGzd6um/7emWKqqegUDB7HpTfTcM=";
+    hash = "sha256-vsCDz749bmqFDzQeupYiNZlfIqwEmG2zIxdeCe4OHm4=";
   };
 
   # Granian forces a custom allocator for all the things it runs,
@@ -35,17 +35,12 @@ buildPythonPackage rec {
   # and allow the final application to make the allocator decision
   # via LD_PRELOAD or similar.
   patches = [
-    (fetchurl {
-      # Refresh expired TLS certificates for tests
-      url = "https://github.com/emmett-framework/granian/commit/189f1bed2effb4a8a9cba07b2c5004e599a6a890.patch";
-      hash = "sha256-7FgVR7/lAh2P5ptGx6jlFzWuk24RY7wieN+aLaAEY+c=";
-    })
     ./no-alloc.patch
   ];
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-Q7BWwvkK5rRuhVobxW4qXLo6tnusOaQYN8mBoNVoulw=";
+    hash = "sha256-iQdcpCqXG1alVTbzCW3o4x0127zxyJCqtKyso9oVWS8=";
   };
 
   nativeBuildInputs = with rustPlatform; [

--- a/pkgs/development/python-modules/granian/default.nix
+++ b/pkgs/development/python-modules/granian/default.nix
@@ -11,6 +11,7 @@
   versionCheckHook,
   pytestCheckHook,
   pytest-asyncio,
+  python-dotenv,
   websockets,
   httpx,
   sniffio,
@@ -19,14 +20,14 @@
 
 buildPythonPackage rec {
   pname = "granian";
-  version = "2.7.2";
+  version = "2.7.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "emmett-framework";
     repo = "granian";
     tag = "v${version}";
-    hash = "sha256-6CtmoY3BHO2t+ZjMzZPKUufOkaal0K+MTYhC1eiVXWQ=";
+    hash = "sha256-KId5e1ITRCkLNmvY5q/ZT18INzS8Uh9HFCzfKEablOY=";
   };
 
   # Granian forces a custom allocator for all the things it runs,
@@ -34,12 +35,12 @@ buildPythonPackage rec {
   # and allow the final application to make the allocator decision
   # via LD_PRELOAD or similar.
   patches = [
-    ./no-alloc.patch
+    ./no-alloc.patch # with --unified=1 context
   ];
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-7KeidUDMH79b8qgAR5bvY8tAmW5OHmVtLIdb9LlP9w0=";
+    hash = "sha256-rR65e05uWmag+21n1YA1TILYU6ArajW2+QVOfGn4zGo=";
   };
 
   nativeBuildInputs = with rustPlatform; [
@@ -52,6 +53,7 @@ buildPythonPackage rec {
   ];
 
   optional-dependencies = {
+    dotenv = [ python-dotenv ];
     pname = [ setproctitle ];
     reload = [ watchfiles ];
     # rloop = [ rloop ]; # not packaged

--- a/pkgs/development/python-modules/granian/default.nix
+++ b/pkgs/development/python-modules/granian/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  fetchurl,
   fetchFromGitHub,
   rustPlatform,
   cacert,
@@ -20,14 +19,14 @@
 
 buildPythonPackage rec {
   pname = "granian";
-  version = "2.6.1";
+  version = "2.7.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "emmett-framework";
     repo = "granian";
     tag = "v${version}";
-    hash = "sha256-vsCDz749bmqFDzQeupYiNZlfIqwEmG2zIxdeCe4OHm4=";
+    hash = "sha256-6CtmoY3BHO2t+ZjMzZPKUufOkaal0K+MTYhC1eiVXWQ=";
   };
 
   # Granian forces a custom allocator for all the things it runs,
@@ -40,7 +39,7 @@ buildPythonPackage rec {
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-iQdcpCqXG1alVTbzCW3o4x0127zxyJCqtKyso9oVWS8=";
+    hash = "sha256-7KeidUDMH79b8qgAR5bvY8tAmW5OHmVtLIdb9LlP9w0=";
   };
 
   nativeBuildInputs = with rustPlatform; [

--- a/pkgs/development/python-modules/granian/default.nix
+++ b/pkgs/development/python-modules/granian/default.nix
@@ -91,6 +91,14 @@ buildPythonPackage rec {
     "test_rsgi_ws_scope"
   ];
 
+  # This is a measure of last resort. Granian tests fully lock up
+  # on shutdown in >90% of cases, which makes the whole thing
+  # impossible to build without restarting it double digits
+  # numbers of times. The issue has not been fully identified,
+  # and upstream claims it does not exist.
+  # FIXME: root cause and fix this.
+  doCheck = false;
+
   pythonImportsCheck = [ "granian" ];
 
   versionCheckProgramArg = "--version";

--- a/pkgs/development/python-modules/granian/default.nix
+++ b/pkgs/development/python-modules/granian/default.nix
@@ -20,14 +20,14 @@
 
 buildPythonPackage rec {
   pname = "granian";
-  version = "2.5.6";
+  version = "2.6.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "emmett-framework";
     repo = "granian";
     tag = "v${version}";
-    hash = "sha256-XSDBSl7QWqIN5u48z4H5yPHR+ltRmmmrP0JSmvcCcsA=";
+    hash = "sha256-Jj75ycr9Y0aCTP5YGzd6um/7emWKqqegUDB7HpTfTcM=";
   };
 
   # Granian forces a custom allocator for all the things it runs,
@@ -45,7 +45,7 @@ buildPythonPackage rec {
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-zQAHJcBWNx5IT/t2wtm7UeOfVNnvfowcp137TePnwiM=";
+    hash = "sha256-Q7BWwvkK5rRuhVobxW4qXLo6tnusOaQYN8mBoNVoulw=";
   };
 
   nativeBuildInputs = with rustPlatform; [
@@ -84,6 +84,12 @@ buildPythonPackage rec {
   __darwinAllowLocalNetworking = true;
 
   enabledTestPaths = [ "tests/" ];
+
+  disabledTests = [
+    # SSLCertVerificationError: certificate verify failed: certificate has expired
+    "test_asgi_ws_scope"
+    "test_rsgi_ws_scope"
+  ];
 
   pythonImportsCheck = [ "granian" ];
 

--- a/pkgs/development/python-modules/granian/no-alloc.patch
+++ b/pkgs/development/python-modules/granian/no-alloc.patch
@@ -1,26 +1,26 @@
 diff --git a/Cargo.toml b/Cargo.toml
-index cbf1cdb..e819e14 100644
+index c7d1647..d5710bd 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -41,7 +41,6 @@ hyper = { version = "=1.6", features = ["http1", "http2", "server"] }
+@@ -41,7 +41,6 @@ hyper = { version = "=1.8", features = ["http1", "http2", "server"] }
  hyper-util = { version = "=0.1", features = ["server-auto", "tokio"] }
  itertools = "0.14"
  log = "0.4"
--mimalloc = { version = "0.1.43", default-features = false, features = ["local_dynamic_tls"], optional = true }
+-mimalloc = { version = "0.1.43", default-features = false, features = ["local_dynamic_tls", "v3"], optional = true }
  mime_guess = "=2.0"
  pem = "=3.0"
  percent-encoding = "=2.3"
-@@ -52,7 +51,6 @@ pyo3-log = "=0.12"
+@@ -52,7 +51,6 @@ pyo3-log = { version = "=0.13", git = "https://github.com/gi0baro/pyo3-log.git",
  rustls-pemfile = "2.2"
  socket2 = { version = "=0.6", features = ["all"] }
- sysinfo = "=0.36"
+ sysinfo = "=0.37"
 -tikv-jemallocator = { version = "0.6.0", default-features = false, features = ["disable_initial_exec_tls"], optional = true }
- tls-listener = { version = "=0.11", features = ["rustls-ring"] }
+ tls-listener = { version = "=0.11", git = "https://github.com/gi0baro/tls-listener.git", branch = "0.11.x", features = ["rustls-ring", "rustls-tls12"] }
  tokio = { version = "1.45", features = ["full"] }
  tokio-stream = "0.1"
 @@ -62,10 +60,6 @@ tokio-util = { version = "0.7", features = ["codec", "rt"] }
  [build-dependencies]
- pyo3-build-config = "=0.25"
+ pyo3-build-config = "=0.27"
  
 -[features]
 -jemalloc = ["dep:tikv-jemallocator"]

--- a/pkgs/development/python-modules/granian/no-alloc.patch
+++ b/pkgs/development/python-modules/granian/no-alloc.patch
@@ -1,39 +1,27 @@
 diff --git a/Cargo.toml b/Cargo.toml
-index c7d1647..d5710bd 100644
+index e1b6a3d..8fe77cf 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -41,7 +41,6 @@ hyper = { version = "=1.8", features = ["http1", "http2", "server"] }
- hyper-util = { version = "=0.1", features = ["server-auto", "tokio"] }
- itertools = "0.14"
+@@ -46,3 +46,2 @@ itertools = "0.14"
  log = "0.4"
--mimalloc = { version = "0.1.43", default-features = false, features = ["local_dynamic_tls", "v3"], optional = true }
+-mimalloc = { version = "0.1.49", default-features = false, features = ["local_dynamic_tls"], optional = true }
  mime_guess = "=2.0"
- pem = "=3.0"
- percent-encoding = "=2.3"
-@@ -52,7 +51,6 @@ pyo3-log = { version = "=0.13", git = "https://github.com/gi0baro/pyo3-log.git",
- rustls-pemfile = "2.2"
- socket2 = { version = "=0.6", features = ["all"] }
- sysinfo = "=0.37"
+@@ -58,3 +57,2 @@ socket2 = { version = "=0.6", features = ["all"] }
+ sysinfo = "=0.38"
 -tikv-jemallocator = { version = "0.6.0", default-features = false, features = ["disable_initial_exec_tls"], optional = true }
  tls-listener = { version = "=0.11", git = "https://github.com/gi0baro/tls-listener.git", branch = "0.11.x", features = ["rustls-ring", "rustls-tls12"] }
- tokio = { version = "1.45", features = ["full"] }
- tokio-stream = "0.1"
-@@ -62,10 +60,6 @@ tokio-util = { version = "0.7", features = ["codec", "rt"] }
- [build-dependencies]
- pyo3-build-config = "=0.27"
+@@ -68,6 +66,2 @@ pyo3-build-config = "=0.27"
  
 -[features]
 -jemalloc = ["dep:tikv-jemallocator"]
 -mimalloc = ["dep:mimalloc"]
 -
  [profile.release]
- codegen-units = 1
- debug = false
 diff --git a/src/lib.rs b/src/lib.rs
-index a17a7e5..8ea1a4d 100644
+index f3a8218..805b725 100644
 --- a/src/lib.rs
 +++ b/src/lib.rs
-@@ -1,11 +1,3 @@
+@@ -1,9 +1 @@
 -#[cfg(all(feature = "jemalloc", not(feature = "mimalloc")))]
 -#[global_allocator]
 -static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
@@ -43,5 +31,3 @@ index a17a7e5..8ea1a4d 100644
 -static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 -
  use pyo3::prelude::*;
- use std::sync::OnceLock;
- 


### PR DESCRIPTION
- **python3Packages.granian: 2.5.6 -> 2.6.0**
- **python313Packages.granian: skip tests**
- **python3Packages.granian: 2.6.0 -> 2.6.1**
- **python3Packages.granian: 2.6.1 -> 2.7.2**
- **python3Packages.granian: 2.7.2 -> 2.7.4**

made with

```shell
git cherry-pick -x 03e8aabf24b7 # python3Packages.granian: 2.5.6 -> 2.6.0
git cherry-pick -x 2b0caf2b96aa # python313Packages.granian: skip tests
git cherry-pick -x 12fa7705bec1 # python3Packages.granian: 2.6.0 -> 2.6.1
git cherry-pick -x 9c14f16f36fa # python3Packages.granian: 2.6.1 -> 2.7.2
git cherry-pick -x e888dc4c3bd7 # python3Packages.granian: 2.7.2 -> 2.7.4
```

* closes https://github.com/NixOS/nixpkgs/issues/519715
* closes https://github.com/NixOS/nixpkgs/issues/519707

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
