### PR TITLE
python3Packages.jupyter-server: disable flaky test_execution_state

### DIFF
--- a/pkgs/development/python-modules/jupyter-server/default.nix
+++ b/pkgs/development/python-modules/jupyter-server/default.nix
@@ -105,14 +105,13 @@ buildPythonPackage rec {
     "test_authorized_requests"
     # Fails under load on Hydra; kernel stays in 'starting' state due to a zmq socket error
     "test_cull_connected"
+    "test_execution_state"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # attempts to use trashcan, build env doesn't allow this
     "test_delete"
     # Insufficient access privileges for operation
     "test_regression_is_hidden"
-    # Fails under load (which causes failure on Hydra)
-    "test_execution_state"
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     # Failed: DID NOT RAISE <class 'tornado.web.HTTPError'>


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/328681452

`test_execution_state` fails on Linux (and Darwin) under load, apparently to a zmq socket error. Was disabled on Darwin only, now disabled on all.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
