### PR TITLE
lockfile-progs: 0.1.19 -> 0.2.0

### DIFF
--- a/pkgs/by-name/lo/lockfile-progs/package.nix
+++ b/pkgs/by-name/lo/lockfile-progs/package.nix
@@ -7,19 +7,27 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lockfile-progs";
-  version = "0.1.19";
+  version = "0.2.0";
 
   src = fetchurl {
-    url = "mirror://debian/pool/main/l/lockfile-progs/lockfile-progs_${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-LFcEsByPR0+CkheA5Fkqknsr9qbXYWNUpsXXzVZkhX4=";
+    url = "mirror://debian/pool/main/l/lockfile-progs/lockfile-progs_${finalAttrs.version}.tar.xz";
+    sha256 = "sha256-KYj7WotAflLiqmKCzkVJf0Zckh1ZETjBAPSJghWETJA=";
   };
 
   buildInputs = [ liblockfile ];
 
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isGNU (toString [
-    # Needed with GCC 12
-    "-Wno-error=format-overflow"
-  ]);
+  preBuild = ''
+    patchShebangs .
+  '';
+
+  env.NIX_CFLAGS_COMPILE =
+    lib.optionalString stdenv.cc.isGNU (toString [
+      # Needed with GCC 12
+      "-Wno-error=format-overflow"
+    ])
+    + lib.optionalString stdenv.hostPlatform.isDarwin (toString [
+      "-Wno-error=c23-extensions"
+    ]);
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
Update to 0.2.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
