### PR TITLE
singular: fix aarch64-darwin build

### DIFF
--- a/pkgs/by-name/si/singular/package.nix
+++ b/pkgs/by-name/si/singular/package.nix
@@ -26,7 +26,8 @@
   latex2html,
   texinfo,
   texliveSmall,
-  enableDocs ? true,
+  # Error: while running example drawTropicalCurve from d2t_singular/tropical_lib.doc:610
+  enableDocs ? !(stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64),
 }:
 
 stdenv.mkDerivation rec {
@@ -53,6 +54,11 @@ stdenv.mkDerivation rec {
     "--enable-gfanlib"
     "--with-ntl=${ntl}"
     "--with-flint=${flint}"
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
+    # omalloc does not support pagesizes >= 16K
+    # https://github.com/Singular/Singular/blob/spielwiese/omalloc/configure.ac
+    "--disable-omalloc"
   ]
   ++ lib.optionals enableDocs [
     "--enable-doc-build"


### PR DESCRIPTION
ZHF: #516381

https://hydra.nixos.org/job/nixpkgs/unstable/singular.aarch64-darwin

NB: This PR does not fix `sage`, as `linbox` likely depends on #513589.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
