### PR TITLE
fritzing: fix ngspice path on darwin

### DIFF
--- a/pkgs/by-name/fr/fritzing/package.nix
+++ b/pkgs/by-name/fr/fritzing/package.nix
@@ -87,7 +87,9 @@ stdenv.mkDerivation {
       --replace-fail "6.5.10" "${qt6.qtbase.version}"
 
     substituteInPlace src/simulation/ngspice_simulator.cpp \
-      --replace-fail 'path + "/" + libName' '"${libngspice}/lib/libngspice.so"'
+      --replace-fail 'path + "/" + libName' '"${
+        libngspice + "/lib/libngspice" + stdenv.hostPlatform.extensions.sharedLibrary
+      }"'
 
     mkdir parts
     cp -a ${parts}/* parts/


### PR DESCRIPTION
Adjusts the change made by #378397 to use `dylib` file extension (rather than `so`) when building on darwin. Otherwise the same error as in #371554 occurs.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
