### PR TITLE
jabcode-{reader,writer}: migrate overrides to by-name

### DIFF
--- a/pkgs/by-name/ja/jabcode-reader/package.nix
+++ b/pkgs/by-name/ja/jabcode-reader/package.nix
@@ -1,0 +1,11 @@
+{
+  jabcode,
+  ...
+}@args:
+
+jabcode.override (
+  {
+    subproject = "reader";
+  }
+  // removeAttrs args [ "jabcode" ]
+)

--- a/pkgs/by-name/ja/jabcode-writer/package.nix
+++ b/pkgs/by-name/ja/jabcode-writer/package.nix
@@ -1,0 +1,11 @@
+{
+  jabcode,
+  ...
+}@args:
+
+jabcode.override (
+  {
+    subproject = "writer";
+  }
+  // removeAttrs args [ "jabcode" ]
+)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9530,10 +9530,6 @@ with pkgs;
     callPackages ../applications/graphics/inkscape/extensions.nix { }
   );
 
-  jabcode-writer = jabcode.override {
-    subproject = "writer";
-  };
-
   jabcode-reader = jabcode.override {
     subproject = "reader";
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9530,10 +9530,6 @@ with pkgs;
     callPackages ../applications/graphics/inkscape/extensions.nix { }
   );
 
-  jabcode-reader = jabcode.override {
-    subproject = "reader";
-  };
-
   jackmix_jack1 = jackmix.override { jack = jack1; };
 
   inherit (callPackage ../applications/networking/cluster/k3s { })


### PR DESCRIPTION
This pull request refactors how the `jabcode-reader` and `jabcode-writer` packages are defined in the codebase. Instead of overriding `jabcode` directly in `all-packages.nix`, each now has its own dedicated `package.nix` file that handles the override. This change improves maintainability and modularity.

**Refactoring and modularization of package definitions:**

* Moved the override logic for `jabcode-reader` and `jabcode-writer` from `all-packages.nix` into their respective `package.nix` files, making the codebase more modular and easier to maintain.

* Removed the direct overrides for `jabcode-reader` and `jabcode-writer` from `pkgs/top-level/all-packages.nix`, delegating their configuration to the new modular files.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
