### PR TITLE
[25.11] pocketbase: 0.33.0 -> 0.37.5

### DIFF
--- a/pkgs/by-name/po/pocketbase/package.nix
+++ b/pkgs/by-name/po/pocketbase/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule rec {
   pname = "pocketbase";
-  version = "0.33.0";
+  version = "0.34.0";
 
   src = fetchFromGitHub {
     owner = "pocketbase";
     repo = "pocketbase";
     rev = "v${version}";
-    hash = "sha256-j7Df+pl1pzSUQAbglnrAB/kat4TMFdm2ch2ZNeJDi68=";
+    hash = "sha256-kMj/JXPBsu30K0P7rCnAqb8xBTmBctGvVucDVwgKjjY=";
   };
 
-  vendorHash = "sha256-KhHW79vON4Kkw7TbNObKQtftBAlQepyFMpUjrRhUQh8=";
+  vendorHash = "sha256-Ri9fgCMfWqc/TBteSm8gAUkjserhfg4ZZ8CpofQJOdI=";
 
   # This is the released subpackage from upstream repo
   subPackages = [ "examples/base" ];

--- a/pkgs/by-name/po/pocketbase/package.nix
+++ b/pkgs/by-name/po/pocketbase/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "pocketbase";
-  version = "0.36.4";
+  version = "0.36.5";
 
   src = fetchFromGitHub {
     owner = "pocketbase";
     repo = "pocketbase";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-C1O6RsQ2fCcnjWbe0DS1AQShrdxTUUyZPKosHdhtkvQ=";
+    hash = "sha256-HSn6xpso0kAc6dR2JsZ3RqQb5dTYhAjKlDkcLnMJq8Y=";
   };
 
-  vendorHash = "sha256-3SDzoSfF7f2OptRdyHgWdBbJoqhqlkNq0uQ3lCr3/BI=";
+  vendorHash = "sha256-p+leu8tYLwdTkV5FCyPUIjRmBHqFNZN02R+4lhhiznY=";
 
   # This is the released subpackage from upstream repo
   subPackages = [ "examples/base" ];

--- a/pkgs/by-name/po/pocketbase/package.nix
+++ b/pkgs/by-name/po/pocketbase/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule rec {
   pname = "pocketbase";
-  version = "0.36.1";
+  version = "0.36.2";
 
   src = fetchFromGitHub {
     owner = "pocketbase";
     repo = "pocketbase";
     rev = "v${version}";
-    hash = "sha256-mDQhsVvO6rj5zkbFOKdM/d0+BWa0Flfdx2kEGqjFeWg=";
+    hash = "sha256-+gayRZ9iwKSb4xW3LVvd6CFms0koHrv7DF1J5O8FvGY=";
   };
 
-  vendorHash = "sha256-8Y5nYDR2RKd2S41yelvz0EooPJkZGv+xp7JA4QQGDA8=";
+  vendorHash = "sha256-OZ2jAOdi/g7yVAPfXTPRxsjBtUi43i8B1k2ANet1SO8=";
 
   # This is the released subpackage from upstream repo
   subPackages = [ "examples/base" ];

--- a/pkgs/by-name/po/pocketbase/package.nix
+++ b/pkgs/by-name/po/pocketbase/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule rec {
   pname = "pocketbase";
-  version = "0.36.0";
+  version = "0.36.1";
 
   src = fetchFromGitHub {
     owner = "pocketbase";
     repo = "pocketbase";
     rev = "v${version}";
-    hash = "sha256-sl3OsGV6J1kxCW8ter71ACk7BkPZjImIKdcGJOtoEmg=";
+    hash = "sha256-mDQhsVvO6rj5zkbFOKdM/d0+BWa0Flfdx2kEGqjFeWg=";
   };
 
-  vendorHash = "sha256-2nLjbIqjxFNd/epJfi+3C9HHlKYipv9HbqNKgtgH6H8=";
+  vendorHash = "sha256-8Y5nYDR2RKd2S41yelvz0EooPJkZGv+xp7JA4QQGDA8=";
 
   # This is the released subpackage from upstream repo
   subPackages = [ "examples/base" ];

--- a/pkgs/by-name/po/pocketbase/package.nix
+++ b/pkgs/by-name/po/pocketbase/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule rec {
   pname = "pocketbase";
-  version = "0.35.0";
+  version = "0.36.0";
 
   src = fetchFromGitHub {
     owner = "pocketbase";
     repo = "pocketbase";
     rev = "v${version}";
-    hash = "sha256-rvEchQfJr4frFOmuKPRcV2dwl97u36tgayJvbm3X7ks=";
+    hash = "sha256-sl3OsGV6J1kxCW8ter71ACk7BkPZjImIKdcGJOtoEmg=";
   };
 
-  vendorHash = "sha256-dNkpHGMtnR0sL9+Fl+NOfyQLJ9AXxgsnV5X9ieAVcao=";
+  vendorHash = "sha256-2nLjbIqjxFNd/epJfi+3C9HHlKYipv9HbqNKgtgH6H8=";
 
   # This is the released subpackage from upstream repo
   subPackages = [ "examples/base" ];

--- a/pkgs/by-name/po/pocketbase/package.nix
+++ b/pkgs/by-name/po/pocketbase/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule rec {
   pname = "pocketbase";
-  version = "0.34.2";
+  version = "0.35.0";
 
   src = fetchFromGitHub {
     owner = "pocketbase";
     repo = "pocketbase";
     rev = "v${version}";
-    hash = "sha256-Ytvti0RBpbpFIaoqR6+YBYkFydcDKGbDGUapmy6TdHU=";
+    hash = "sha256-rvEchQfJr4frFOmuKPRcV2dwl97u36tgayJvbm3X7ks=";
   };
 
-  vendorHash = "sha256-Oo0zfS7WLrF6hpphuWMV6Of7k6ezcWp3MtfQgCiSuo8=";
+  vendorHash = "sha256-dNkpHGMtnR0sL9+Fl+NOfyQLJ9AXxgsnV5X9ieAVcao=";
 
   # This is the released subpackage from upstream repo
   subPackages = [ "examples/base" ];

--- a/pkgs/by-name/po/pocketbase/package.nix
+++ b/pkgs/by-name/po/pocketbase/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule rec {
   pname = "pocketbase";
-  version = "0.34.0";
+  version = "0.34.2";
 
   src = fetchFromGitHub {
     owner = "pocketbase";
     repo = "pocketbase";
     rev = "v${version}";
-    hash = "sha256-kMj/JXPBsu30K0P7rCnAqb8xBTmBctGvVucDVwgKjjY=";
+    hash = "sha256-Ytvti0RBpbpFIaoqR6+YBYkFydcDKGbDGUapmy6TdHU=";
   };
 
-  vendorHash = "sha256-Ri9fgCMfWqc/TBteSm8gAUkjserhfg4ZZ8CpofQJOdI=";
+  vendorHash = "sha256-Oo0zfS7WLrF6hpphuWMV6Of7k6ezcWp3MtfQgCiSuo8=";
 
   # This is the released subpackage from upstream repo
   subPackages = [ "examples/base" ];

--- a/pkgs/by-name/po/pocketbase/package.nix
+++ b/pkgs/by-name/po/pocketbase/package.nix
@@ -7,13 +7,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "pocketbase";
-  version = "0.36.5";
+  version = "0.36.6";
 
   src = fetchFromGitHub {
     owner = "pocketbase";
     repo = "pocketbase";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-HSn6xpso0kAc6dR2JsZ3RqQb5dTYhAjKlDkcLnMJq8Y=";
+    hash = "sha256-LK4W5ZRwjt+mVQjdCI3KSW4dkz1WCmFw7hhv+oLnVUo=";
   };
 
   vendorHash = "sha256-p+leu8tYLwdTkV5FCyPUIjRmBHqFNZN02R+4lhhiznY=";

--- a/pkgs/by-name/po/pocketbase/package.nix
+++ b/pkgs/by-name/po/pocketbase/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "pocketbase";
-  version = "0.36.6";
+  version = "0.36.7";
 
   src = fetchFromGitHub {
     owner = "pocketbase";
     repo = "pocketbase";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-LK4W5ZRwjt+mVQjdCI3KSW4dkz1WCmFw7hhv+oLnVUo=";
+    hash = "sha256-CI4OiFqYHr662EYa1mSGqAYyVDhoqXIOSPZQv5IVxk0=";
   };
 
-  vendorHash = "sha256-p+leu8tYLwdTkV5FCyPUIjRmBHqFNZN02R+4lhhiznY=";
+  vendorHash = "sha256-2zqDgHgZ8W1/iFkgmP5Frcd5YmPqr2PEC3aYTMrmdtE=";
 
   # This is the released subpackage from upstream repo
   subPackages = [ "examples/base" ];

--- a/pkgs/by-name/po/pocketbase/package.nix
+++ b/pkgs/by-name/po/pocketbase/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "pocketbase";
-  version = "0.37.3";
+  version = "0.37.4";
 
   src = fetchFromGitHub {
     owner = "pocketbase";
     repo = "pocketbase";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-n7oUsBMLKtFmz8iWu79vphBy7L9b7PMau8hOKKzi6Dc=";
+    hash = "sha256-d4JqA1iPPVA+wDS5Q3tJMUVnGvMFhK3JvuVLI7ZXvE0=";
   };
 
-  vendorHash = "sha256-7Y7cn8t3HTV4vsTRXuM8gG0UjqCnxivQyo/KM47Itro=";
+  vendorHash = "sha256-PB95KUhHzkTDJZPXI0dU7SsupTprVufxukQN2OSy7mQ=";
 
   # This is the released subpackage from upstream repo
   subPackages = [ "examples/base" ];

--- a/pkgs/by-name/po/pocketbase/package.nix
+++ b/pkgs/by-name/po/pocketbase/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "pocketbase";
-  version = "0.36.9";
+  version = "0.37.3";
 
   src = fetchFromGitHub {
     owner = "pocketbase";
     repo = "pocketbase";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-OClsHslrnQMzHib+C6HKDjlO5sM2j00k4/LuJjh4Uk8=";
+    hash = "sha256-n7oUsBMLKtFmz8iWu79vphBy7L9b7PMau8hOKKzi6Dc=";
   };
 
-  vendorHash = "sha256-5gbGLq6icXT8cVA1f1zjuV35scPozDjjhHMrgunD0hw=";
+  vendorHash = "sha256-7Y7cn8t3HTV4vsTRXuM8gG0UjqCnxivQyo/KM47Itro=";
 
   # This is the released subpackage from upstream repo
   subPackages = [ "examples/base" ];

--- a/pkgs/by-name/po/pocketbase/package.nix
+++ b/pkgs/by-name/po/pocketbase/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "pocketbase";
-  version = "0.36.7";
+  version = "0.36.8";
 
   src = fetchFromGitHub {
     owner = "pocketbase";
     repo = "pocketbase";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-CI4OiFqYHr662EYa1mSGqAYyVDhoqXIOSPZQv5IVxk0=";
+    hash = "sha256-47Z0piORkQphm/XSoTLEXrYsKJXcdOKIes9OLRxjFfY=";
   };
 
-  vendorHash = "sha256-2zqDgHgZ8W1/iFkgmP5Frcd5YmPqr2PEC3aYTMrmdtE=";
+  vendorHash = "sha256-p085Ru3csNpGDMeF5q+W23Mc30WwhF9zHv0U29aEp/w=";
 
   # This is the released subpackage from upstream repo
   subPackages = [ "examples/base" ];

--- a/pkgs/by-name/po/pocketbase/package.nix
+++ b/pkgs/by-name/po/pocketbase/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "pocketbase";
-  version = "0.36.8";
+  version = "0.36.9";
 
   src = fetchFromGitHub {
     owner = "pocketbase";
     repo = "pocketbase";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-47Z0piORkQphm/XSoTLEXrYsKJXcdOKIes9OLRxjFfY=";
+    hash = "sha256-OClsHslrnQMzHib+C6HKDjlO5sM2j00k4/LuJjh4Uk8=";
   };
 
-  vendorHash = "sha256-p085Ru3csNpGDMeF5q+W23Mc30WwhF9zHv0U29aEp/w=";
+  vendorHash = "sha256-5gbGLq6icXT8cVA1f1zjuV35scPozDjjhHMrgunD0hw=";
 
   # This is the released subpackage from upstream repo
   subPackages = [ "examples/base" ];

--- a/pkgs/by-name/po/pocketbase/package.nix
+++ b/pkgs/by-name/po/pocketbase/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "pocketbase";
-  version = "0.37.4";
+  version = "0.37.5";
 
   src = fetchFromGitHub {
     owner = "pocketbase";
     repo = "pocketbase";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-d4JqA1iPPVA+wDS5Q3tJMUVnGvMFhK3JvuVLI7ZXvE0=";
+    hash = "sha256-z5brZQEblcPkNNg6kNDw9C/3CwUCdMF/TPcOIFaPoKI=";
   };
 
-  vendorHash = "sha256-PB95KUhHzkTDJZPXI0dU7SsupTprVufxukQN2OSy7mQ=";
+  vendorHash = "sha256-8YtDQLeStdUb6HXX/KEifDHiX//9cH7XCBu2LtHrCQM=";
 
   # This is the released subpackage from upstream repo
   subPackages = [ "examples/base" ];

--- a/pkgs/by-name/po/pocketbase/package.nix
+++ b/pkgs/by-name/po/pocketbase/package.nix
@@ -5,18 +5,18 @@
   nix-update-script,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "pocketbase";
-  version = "0.36.2";
+  version = "0.36.4";
 
   src = fetchFromGitHub {
     owner = "pocketbase";
     repo = "pocketbase";
-    rev = "v${version}";
-    hash = "sha256-+gayRZ9iwKSb4xW3LVvd6CFms0koHrv7DF1J5O8FvGY=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-C1O6RsQ2fCcnjWbe0DS1AQShrdxTUUyZPKosHdhtkvQ=";
   };
 
-  vendorHash = "sha256-OZ2jAOdi/g7yVAPfXTPRxsjBtUi43i8B1k2ANet1SO8=";
+  vendorHash = "sha256-3SDzoSfF7f2OptRdyHgWdBbJoqhqlkNq0uQ3lCr3/BI=";
 
   # This is the released subpackage from upstream repo
   subPackages = [ "examples/base" ];
@@ -27,7 +27,7 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/pocketbase/pocketbase.Version=${version}"
+    "-X github.com/pocketbase/pocketbase.Version=${finalAttrs.version}"
   ];
 
   postInstall = ''
@@ -46,4 +46,4 @@ buildGoModule rec {
     ];
     mainProgram = "pocketbase";
   };
-}
+})


### PR DESCRIPTION
changelog: https://github.com/pocketbase/pocketbase/blob/v0.37.5/CHANGELOG.md
diff: https://github.com/pocketbase/pocketbase/compare/v0.33.0...v0.37.5

Backports #465176
Backports #469097
Backports #473200
Backports #480615
Backoprts #482808
Backports #487382
Backports #487704 (partially)
Backports #492382
Backports #494924
Backports #497778
Backports #503084
Backports #506149
Backports #508795
Backports #511316
Backports #513955
Backports #516972

Closes #519717

<details>

<summary>nixpkgs-review</summary>


## `nixpkgs-review` result

Generated using [`nixpkgs-review-gha`](https://github.com/Defelo/nixpkgs-review-gha)

Command: `nixpkgs-review pr 519881`
Commit: [`32d5eb2c16ba9d01b8bd6f6213fee8616556b892`](https://github.com/NixOS/nixpkgs/commit/32d5eb2c16ba9d01b8bd6f6213fee8616556b892) ([subsequent changes](https://github.com/NixOS/nixpkgs/compare/32d5eb2c16ba9d01b8bd6f6213fee8616556b892..pull/519881/head))
Merge: [`59adaf935082f26bd5fed4cb1d1860e2b91aebe5`](https://github.com/NixOS/nixpkgs/commit/59adaf935082f26bd5fed4cb1d1860e2b91aebe5)

Logs: https://github.com/Hythera/nixpkgs-review-gha/actions/runs/25819534577


---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>pocketbase</li>
  </ul>
</details>

---
### `aarch64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>pocketbase</li>
  </ul>
</details>

---
### `x86_64-darwin` (sandbox = relaxed)
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>pocketbase</li>
  </ul>
</details>

---
### `aarch64-darwin` (sandbox = relaxed)
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>pocketbase</li>
  </ul>
</details>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
