### PR TITLE
sngrep: 1.8.2 -> 1.8.3

### DIFF
--- a/pkgs/by-name/sn/sngrep/fix-sng_strncpy-declaration.patch
+++ b/pkgs/by-name/sn/sngrep/fix-sng_strncpy-declaration.patch
@@ -1,0 +1,15 @@
+--- a/src/util.h
++++ b/src/util.h
+@@ -58,6 +58,12 @@
+ char *
+ sng_basename(const char *name);
+ 
++/**
++ * @brief Wrapper for strncpy
++ */
++char *
++sng_strncpy(char *dst, const char *src, size_t len);
++
+ /**
+  * @brief Compare two timeval structures
+  *

--- a/pkgs/by-name/sn/sngrep/package.nix
+++ b/pkgs/by-name/sn/sngrep/package.nix
@@ -4,31 +4,34 @@
   autoconf,
   automake,
   fetchFromGitHub,
+  libgcrypt,
   libpcap,
   ncurses,
   openssl,
   pcre,
+  pkg-config,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sngrep";
-  version = "1.8.2";
+  version = "1.8.3";
 
   src = fetchFromGitHub {
     owner = "irontec";
     repo = "sngrep";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-nvuT//FWJAa6DzmjBsBW9s2p1M+6Zs4cVmpK4dVemnE=";
+    hash = "sha256-4DLbQ3OOMvJw37n3jVuztG49HlPbWrfxByi6g6AvELQ=";
   };
 
   nativeBuildInputs = [
     autoconf
     automake
+    pkg-config
   ];
 
   buildInputs = [
+    libgcrypt
     libpcap
-    ncurses
     ncurses
     openssl
     pcre
@@ -40,6 +43,10 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-ipv6"
     "--enable-eep"
     "--with-openssl"
+  ];
+
+  patches = [
+    ./fix-sng_strncpy-declaration.patch
   ];
 
   preConfigure = ''


### PR DESCRIPTION
update to 1.8.3

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
