### PR TITLE
[Backport 25.11] macaulay2: init at 1.26.05

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5327,6 +5327,12 @@
     githubId = 32609395;
     name = "B YI";
   };
+  coolcuber = {
+    email = "rpgeorg@clemson.edu";
+    github = "coolcuber";
+    githubId = 35880825;
+    name = "Ross George";
+  };
   corbanr = {
     email = "corban@raunco.co";
     github = "CorbanR";

--- a/pkgs/by-name/_4/_4ti2/package.nix
+++ b/pkgs/by-name/_4/_4ti2/package.nix
@@ -5,6 +5,7 @@
   autoreconfHook,
   glpk,
   gmp,
+  which,
 }:
 
 stdenv.mkDerivation rec {
@@ -17,6 +18,12 @@ stdenv.mkDerivation rec {
     rev = "Release_${builtins.replaceStrings [ "." ] [ "_" ] version}";
     hash = "sha256-gbYG55LfVhjJJFJu0L8AWIAnFDViHIW2N1qtS8xOFAc=";
   };
+
+  postPatch = ''
+    substituteInPlace src/{groebner/script.template.in,zsolve/{graver,hilbert}.template} \
+      --replace-fail 'SCRIPT=$(realpath $(which "$0"))' \
+                     'SCRIPT=$(realpath $(${lib.getExe which} "$0"))'
+  '';
 
   nativeBuildInputs = [
     autoreconfHook

--- a/pkgs/by-name/co/cohomcalg/fix-compilers.patch
+++ b/pkgs/by-name/co/cohomcalg/fix-compilers.patch
@@ -1,0 +1,25 @@
+diff --git a/Makefile b/Makefile
+--- a/Makefile
++++ b/Makefile
+@@ -5,9 +5,10 @@
+ #########################################################################
+ 
+ # compilers & flags
+-CC        := g++
++CC        ?= gcc
++CXX       ?= g++
+ CFLAGS    := -O3
+-LD        := g++
++LD        := $(CXX)
+ # Note: (1) If you want to enforce 32-bit or 64-bit compilation, 
+ #           add "-m32" or "-m64" to both CFLAGS and LDFLAGS.
+ #       (2) If you want to enforce a static linking of all libraries 
+@@ -35,7 +36,7 @@ vpath %.cpp $(COHOMCALG_SRC_DIR)
+ # macros for .c/.cpp dirs
+ define make-goal-cpp
+ $1/%.o: %.cpp
+-	$(CC) $(INCLUDES) $(DEFS) $(CPPFLAGS) $(CXXFLAGS) -c $$< -o $$@
++	$(CXX) $(INCLUDES) $(DEFS) $(CPPFLAGS) $(CXXFLAGS) -c $$< -o $$@
+ endef
+ 
+ define make-goal-c

--- a/pkgs/by-name/co/cohomcalg/package.nix
+++ b/pkgs/by-name/co/cohomcalg/package.nix
@@ -1,0 +1,53 @@
+{
+  fetchFromGitHub,
+  fetchpatch,
+  lib,
+  stdenv,
+
+  versionCheckHook,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cohomcalg";
+  version = "0.32";
+
+  src = fetchFromGitHub {
+    owner = "BenjaminJurke";
+    repo = "cohomCalg";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9kKKfb8STiCjaHiWgYEQsERNTnOXlwN8axIBJHg43zk=";
+  };
+
+  __structuredAttrs = true;
+
+  strictDeps = true;
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/BenjaminJurke/cohomCalg/commit/7aa864b5655c91eb2afc79c419bbf2bf8a4f791b.diff";
+      hash = "sha256-JteQ3m2ELmMHaWCN9Sm954KKDn0ax8TywtbQ3dBWk80=";
+    })
+    ./fix-compilers.patch
+  ];
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -D bin/cohomcalg $out/bin/cohomcalg
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  doInstallCheck = true;
+
+  meta = {
+    mainProgram = "cohomcalg";
+    description = "Software package for computation of sheaf cohomologies for line bundles on toric varieties";
+    homepage = "https://github.com/BenjaminJurke/cohomCalg";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ coolcuber ];
+  };
+})

--- a/pkgs/by-name/fr/frobby/package.nix
+++ b/pkgs/by-name/fr/frobby/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-
+  fixDarwinDylibNames,
   gmp,
 }:
 stdenv.mkDerivation (finalAttrs: {
@@ -15,6 +15,10 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-LndLfORnypLqFgNMPEJ8jc2Fa2xWWgYS9rZ7gGFbwwo=";
   };
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+    fixDarwinDylibNames
+  ];
 
   buildInputs = [
     gmp

--- a/pkgs/by-name/fr/frobby/package.nix
+++ b/pkgs/by-name/fr/frobby/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  gmp,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "frobby";
+  version = "0.9.9";
+
+  src = fetchFromGitHub {
+    owner = "Macaulay2";
+    repo = "frobby";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-LndLfORnypLqFgNMPEJ8jc2Fa2xWWgYS9rZ7gGFbwwo=";
+  };
+
+  buildInputs = [
+    gmp
+  ];
+
+  __structuredAttrs = true;
+
+  strictDeps = true;
+
+  enableParallelBuilding = true;
+
+  makeFlags = [
+    "MODE=shared"
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  buildFlags = [
+    "all"
+    "library"
+  ];
+
+  preCheck = ''
+    patchShebangs --build ./test
+  '';
+
+  checkTarget = "test";
+
+  doCheck = true;
+
+  meta = {
+    mainProgram = "frobby";
+    description = "Software system and project for computations with monomial ideals";
+    longDescription = ''
+      Current functionality includes Euler characteristic, Hilbert series,
+      maximal standard monomials, combinatorial optimization on monomial
+      ideals, primary decomposition, irreducible decomposition, Alexander dual,
+      associated primes, minimization and intersection of monomial ideals as
+      well as the computation of Frobenius problems (using 4ti2) with very
+      large numbers. Frobby is also able to translate between formats that can
+      be used with several different computer systems, such as Macaulay2,
+      Monos, 4ti2, CoCoA4 and Singular. Thus Frobby can be used with any of
+      those systems.
+    '';
+    homepage = "https://github.com/Macaulay2/frobby";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ coolcuber ];
+  };
+})

--- a/pkgs/by-name/ma/macaulay2/package.nix
+++ b/pkgs/by-name/ma/macaulay2/package.nix
@@ -1,0 +1,272 @@
+{
+  fetchFromGitHub,
+  fetchurl,
+  lib,
+  makeWrapper,
+  runCommand,
+  stdenv,
+  writableTmpDirAsHomeHook,
+
+  _4ti2,
+  autoreconfHook,
+  bison,
+  blas,
+  boehmgc,
+  boost,
+  cddlib,
+  cohomcalg,
+  csdp,
+  eigen,
+  emacs-nox,
+  fflas-ffpack,
+  flex,
+  flint,
+  frobby,
+  gdbm,
+  gfortran,
+  gfan,
+  givaro,
+  glpk,
+  gtest,
+  icu,
+  jansson,
+  libffi,
+  libxml2,
+  libz,
+  lrs,
+  mathic,
+  mathicgb,
+  memtailor,
+  mpfi,
+  mpfr,
+  msolve,
+  mpsolve,
+  nauty,
+  normaliz,
+  ntl,
+  onetbb,
+  openssl,
+  R,
+  rWrapper,
+  pkg-config,
+  python3,
+  readline,
+  singular,
+  texinfo,
+  time,
+  topcom,
+  which,
+  xz,
+
+  downloadDocs ? true,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "macaulay2";
+  version = "1.26.05";
+
+  src = fetchFromGitHub {
+    owner = "Macaulay2";
+    repo = "M2";
+    tag = "release-${finalAttrs.version}";
+    hash = "sha256-UiPLownaFtuYFUlZhBl+Nl/sRZRhG9OUwepZtFTkTqc";
+    fetchSubmodules = true;
+  };
+
+  docs = fetchurl {
+    url = "https://macaulay2.com/Downloads/OtherSourceCode/Macaulay2-docs-${finalAttrs.version}.tar.gz";
+    hash = "sha256-rz9b7HvxfxI978yM9wE7XvLu7DO38i/amokXBU0RjSg=";
+  };
+
+  buildInputs = [
+    blas
+    boehmgc
+    boost
+    cddlib
+    eigen
+    fflas-ffpack
+    flint
+    frobby
+    gdbm
+    givaro
+    glpk
+    gtest
+    icu
+    jansson
+    libffi
+    libxml2
+    libz
+    mathic
+    mathicgb
+    memtailor
+    mpfi
+    mpfr
+    mpsolve
+    msolve
+    nauty
+    ntl
+    normaliz
+    onetbb
+    openssl
+    python3
+    readline
+    singular
+    xz
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    bison
+    emacs-nox
+    flex
+    gdbm
+    gfortran
+    makeWrapper
+    pkg-config
+    texinfo
+    which
+
+    # TODO the configure script looks for these in $PATH
+    _4ti2
+    cohomcalg
+    csdp
+    gfan
+    lrs
+    msolve
+    nauty
+    normaliz
+    topcom
+  ];
+
+  __structuredAttrs = true;
+
+  strictDeps = true;
+
+  sourceRoot = "${finalAttrs.src.name}/M2";
+
+  postPatch = ''
+    sed -i 's/AC_SUBST(REL,.*uname -r.*)/AC_SUBST(REL,"")/' configure.ac
+  '';
+
+  preConfigure = ''
+    cd BUILD/build
+  '';
+
+  configureScript = "../../configure";
+
+  configureFlags = [
+    "--disable-download"
+    "--enable-shared"
+    "--with-issue=nixos"
+    "--with-boost-libdir=${boost}/lib"
+    "--with-system-libs"
+    "CPPFLAGS=-I${lib.getDev cddlib}/include/cddlib"
+    "PYTHON_BIN=${python3.interpreter}"
+  ];
+
+  configurePlatforms = [
+    "build"
+    "host"
+  ];
+
+  enableParallelBuilding = true;
+
+  preBuild = lib.optionalString downloadDocs ''
+    ln -s ${finalAttrs.docs} ../tarfiles/${finalAttrs.docs.name}
+    make -C libraries all-in-Macaulay2-docs
+  '';
+
+  buildFlags = lib.optionals downloadDocs [
+    "MakeDocumentation=false"
+  ];
+
+  postInstall = ''
+    wrapProgram "$out/bin/M2" \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          _4ti2
+          cohomcalg
+          csdp
+          gfan
+          lrs
+          msolve
+          nauty
+          normaliz
+          openssl
+          R
+          topcom
+        ]
+      } \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          cddlib
+          flint
+          givaro
+          glpk
+          mpfi
+          mpfr
+          mpsolve
+          normaliz
+          ntl
+          singular
+        ]
+      } \
+      --prefix R_LIBS_SITE : ${lib.makeSearchPath "library" rWrapper.recommendedPackages}
+  '';
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/M2 --check 1
+    runHook postInstallCheck
+  '';
+
+  doInstallCheck = true;
+
+  passthru.tests = {
+    core =
+      runCommand "macaulay2-core-tests"
+        {
+          nativeBuildInputs = [
+            finalAttrs.finalPackage
+            writableTmpDirAsHomeHook
+          ];
+        }
+        ''
+          M2 --check 2 && touch $out
+        '';
+
+    all-packages =
+      runCommand "macaulay2-all-packages-test"
+        {
+          nativeBuildInputs = [
+            finalAttrs.finalPackage
+            writableTmpDirAsHomeHook
+          ];
+        }
+        ''
+          M2 --check 3 && touch $out
+        '';
+  };
+
+  meta = {
+    description = "System for computing in commutative algebra, algebraic geometry and related fields";
+    mainProgram = "M2";
+    longDescription = ''
+      Macaulay2 is a software system devoted to supporting research in
+      algebraic geometry and commutative algebra, whose creation has been
+      funded by the National Science Foundation since 1992.
+
+      Macaulay2 includes core algorithms for computing Gröbner bases and graded
+      or multi-graded free resolutions of modules over quotient rings of graded
+      or multi-graded polynomial rings with a monomial ordering. The core
+      algorithms are accessible through a versatile high level interpreted user
+      language with a powerful debugger supporting the creation of new classes
+      of mathematical objects and the installation of methods for computing
+      specifically with them. Macaulay2 can compute Betti numbers, Ext,
+      cohomology of coherent sheaves on projective varieties, primary
+      decomposition of ideals, integral closure of rings, and more.
+    '';
+    homepage = "https://macaulay2.com/";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ coolcuber ];
+  };
+})

--- a/pkgs/by-name/ma/mathic/package.nix
+++ b/pkgs/by-name/ma/mathic/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+
+  autoreconfHook,
+  gtest,
+  memtailor,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mathic";
+  version = "1.3";
+
+  src = fetchFromGitHub {
+    owner = "Macaulay2";
+    repo = "mathic";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6xkNnn/8XugeBi91+9iTWHj8l5M6SH8tjsC8N2sLEnA=";
+  };
+
+  buildInputs = [
+    memtailor
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  checkInputs = [
+    gtest
+  ];
+
+  configureFlags = [
+    (lib.withFeature finalAttrs.doCheck "gtest")
+  ];
+
+  __structuredAttrs = true;
+
+  strictDeps = true;
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  meta = {
+    description = "C++ library of fast data structures designed for use in Groebner basis computation";
+    longDescription = ''
+      Mathic is a C++ library of fast data structures designed for use in
+      Groebner basis computation. This includes data structures for ordering
+      S-pairs, performing divisor queries and ordering polynomial terms during
+      polynomial reduction.  With Mathic you get to use highly optimized code
+      with little effort so that you can focus more of your time on whatever
+      part of your Groebner basis implementation that you are interested in.
+      The data structures use templates to allow you to use them with whatever
+      representation of monomials/terms and coefficients that your code uses.
+      In fact the only places where Mathic defines its own monomials/terms is
+      in the test code and example code. Currently only dense representations
+      of terms/monomials are suitable since Mathic will frequently ask "what is
+      the exponent of variable number x in this term/monomial?".
+    '';
+    homepage = "https://github.com/Macaulay2/mathic";
+    license = lib.licenses.lgpl2Plus;
+    maintainers = with lib.maintainers; [ coolcuber ];
+  };
+})

--- a/pkgs/by-name/ma/mathicgb/package.nix
+++ b/pkgs/by-name/ma/mathicgb/package.nix
@@ -1,0 +1,62 @@
+{
+  fetchFromGitHub,
+  lib,
+  stdenv,
+
+  autoreconfHook,
+  gtest,
+  mathic,
+  memtailor,
+  onetbb,
+  pkg-config,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mathicgb";
+  version = "1.3";
+
+  src = fetchFromGitHub {
+    owner = "Macaulay2";
+    repo = "mathicgb";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-zcHaYzznvbBkfeFXNxIxy9qlyD0esOvwUIOuEli4rwc=";
+  };
+
+  buildInputs = [
+    mathic
+    memtailor
+    onetbb
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config # clears up bad behavior of autoconf
+  ];
+
+  checkInputs = [
+    gtest
+  ];
+
+  __structuredAttrs = true;
+
+  strictDeps = true;
+
+  configureFlags = [
+    (lib.withFeature finalAttrs.doCheck "gtest")
+  ];
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  meta = {
+    mainProgram = "mgb";
+    description = "Program for computing Groebner basis and signature Grobner bases";
+    longDescription = ''
+      Mathicgb is a program for computing Groebner basis and signature Grobner
+      bases. Mathicgb is based on the fast data structures from mathic.
+    '';
+    homepage = "https://github.com/Macaulay2/mathicgb";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ coolcuber ];
+  };
+})

--- a/pkgs/by-name/me/memtailor/package.nix
+++ b/pkgs/by-name/me/memtailor/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+
+  autoreconfHook,
+  gtest,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "memtailor";
+  version = "1.3";
+
+  src = fetchFromGitHub {
+    owner = "Macaulay2";
+    repo = "memtailor";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-x6z/BzU78od21l72ZAnX37UHHdyMHfJ6cjwJwNYOIcY=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  checkInputs = [
+    gtest
+  ];
+
+  __structuredAttrs = true;
+
+  strictDeps = true;
+
+  configureFlags = [
+    (lib.withFeature finalAttrs.doCheck "gtest")
+  ];
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  meta = {
+    description = "C++ library of special purpose memory allocators";
+    longDescription = ''
+      Memtailor is a C++ library of special purpose memory allocators. It
+      currently offers an arena allocator and a memory pool.
+
+      The main motivation to use a memtailor allocator is better and more
+      predictable performance than you get with new/delete. Sometimes a
+      memtailor allocator can also be more convenient due to the ability to
+      free many allocations at one time.
+    '';
+    homepage = "https://github.com/Macaulay2/memtailor";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ coolcuber ];
+  };
+})

--- a/pkgs/by-name/to/topcom/package.nix
+++ b/pkgs/by-name/to/topcom/package.nix
@@ -1,0 +1,83 @@
+{
+  fetchpatch,
+  fetchzip,
+  lib,
+  stdenv,
+
+  autoreconfHook,
+  cddlib,
+  gmpxx,
+
+  programPrefix ? "topcom-",
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "topcom";
+  version = "1.1.2";
+
+  versionUrl = builtins.replaceStrings [ "." ] [ "_" ] finalAttrs.version;
+
+  src = fetchzip {
+    url = "https://www.wm.uni-bayreuth.de/de/team/rambau_joerg/TOPCOM-Downloads/TOPCOM-${finalAttrs.versionUrl}.tgz";
+    hash = "sha256-r6dA2rQzxMu0Xxq5yl9rBZ5MJTRnmWVLav/F/QpkZ1A=";
+  };
+
+  buildInputs = [
+    cddlib
+    gmpxx
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  __structuredAttrs = true;
+
+  strictDeps = true;
+
+  patches = [
+    (fetchpatch {
+      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/topcom/-/raw/67c9a20c8e1597898f3950b486b4287641823363/system-libs.patch";
+      hash = "sha256-F+1ZtluGL3i+LKWp0poQnx2ZlV5TSp6WSK5yl2FmOP4";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace lib-src/Makefile.am lib-src-reg/Makefile.am src/Makefile.am src-reg/Makefile.am \
+      --replace-fail '$(includedir)/cddlib' '${lib.getDev cddlib}/include/cddlib'
+  '';
+
+  configureFlags = [
+    "--program-prefix=${programPrefix}"
+  ];
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+    for prog in $(find "$out/bin" -type f); do
+      echo "Checking $prog"
+      grep -q '^usage: ' <(echo "" | "$prog" 2>&1) && continue
+      "$prog" --help &>/dev/null && continue
+      echo "$prog doesn't seem to be working" >&2
+      exit 1
+    done
+    runHook postInstallCheck
+  '';
+
+  doInstallCheck = true;
+
+  meta = {
+    description = "Package for computing Triangulations Of Point Configurations and Oriented Matroid";
+    longDescription = ''
+      TOPCOM is a package for computing Triangulations Of Point Configurations
+      and Oriented Matroids. It was very much inspired by the maple program
+      PUNTOS, which was written by Jesus de Loera. TOPCOM is entirely written
+      in C++, so there is a significant speed up compared to PUNTOS.
+    '';
+    homepage = "https://www.wm.uni-bayreuth.de/de/team/rambau_joerg/TOPCOM/index.html";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ coolcuber ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This a backport of Macaulay2 and associated packages as merged in #514876 and #519868.  I know that release-26.05 is coming soon, but I'd really like to get this package up and ready to be used as soon as is reasonable.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
