### PR TITLE
python3Packages.jupyterlab-execute-time:build from github source, fix build system

### DIFF
--- a/pkgs/development/python-modules/jupyterlab-execute-time/default.nix
+++ b/pkgs/development/python-modules/jupyterlab-execute-time/default.nix
@@ -1,8 +1,19 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+  hatch-jupyter-builder,
+
+  # build inputs
   jupyterlab,
+  nodejs,
+  writableTmpDirAsHomeHook,
+  yarn-berry_3,
+
+  # dependencies
   jupyter-packaging,
 }:
 
@@ -11,25 +22,43 @@ buildPythonPackage rec {
   version = "3.3.0";
   pyproject = true;
 
-  src = fetchPypi {
-    pname = "jupyterlab_execute_time";
-    inherit version;
-    hash = "sha256-kA/Rrrv9PZQ9NiXu+XPu1VW7J0XUmEBAJ4OVnIod/Do=";
+  src = fetchFromGitHub {
+    owner = "deshaw";
+    repo = "jupyterlab-execute-time";
+    rev = "v${version}";
+    hash = "sha256-1eNv6yTyorg64PXQm68eqp56Ig0eUbhPWluI/s4oijE=";
   };
 
-  # jupyterlab is required to build from source but we use the pre-build package
+  # Fix version requirements and replace jupyterlab's pinned yarn (jlpm) with yarn
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail '"jupyterlab~=4.0.0"' ""
+      --replace-fail "jupyterlab~=4.0.0" "jupyterlab"
+    substituteInPlace pyproject.toml package.json \
+      --replace-fail 'jlpm' 'yarn'
   '';
+
+  build-system = [
+    hatchling
+    hatch-jupyter-builder
+  ];
+
+  nativeBuildInputs = [
+    jupyterlab
+    nodejs
+    writableTmpDirAsHomeHook
+    yarn-berry_3
+    yarn-berry_3.yarnBerryConfigHook
+  ];
+
+  offlineCache = yarn-berry_3.fetchYarnBerryDeps {
+    yarnLock = "${src}/yarn.lock";
+    hash = "sha256-aCuw+4FqA0JPMr++AgE4WI+KmXda1IosaU2yk/vE7vw=";
+  };
 
   dependencies = [
     jupyterlab
     jupyter-packaging
   ];
-
-  # has no tests
-  doCheck = false;
 
   pythonImportsCheck = [ "jupyterlab_execute_time" ];
 


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/328896016

`python3Packages.jupyterlab-execute-time` fails to parse pyproject.toml after a `postPatch` substitution. Fixed the substitution.

That hid an issue with the build system changing to hatching (alongside other tools). Fixed and took the opportunity to build from github source instead of PyPi.

ZHF: #516381

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
