### PR TITLE
[staging-next] pkgs-lib/formats: fix tests

### DIFF
--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -978,9 +978,9 @@ optionalAttrs allowAliases aliases
               __structuredAttrs = true;
             }
             ''
-              importsPath="$TMPDIR/imports"
+              export importsPath="$TMPDIR/imports"
               printf "%s" "$imports" > "$importsPath"
-              valuePath="$TMPDIR/value"
+              export valuePath="$TMPDIR/value"
               printf "%s" "$value" > "$valuePath"
               cat "$valuePath"
               python3 "$pythonGen" > $out
@@ -1027,7 +1027,7 @@ optionalAttrs allowAliases aliases
                 __structuredAttrs = true;
               }
               ''
-                valuePath="$TMPDIR/value"
+                export valuePath="$TMPDIR/value"
                 printf "%s" "$value" > "$valuePath"
                 python3 "$pythonGen" > $out
                 xmllint $out > /dev/null


### PR DESCRIPTION
Fixes the build for `tests.pkgs-lib.formats`.

Hydra build is still pending (https://hydra.nixos.org/build/328920557), but confirmed by https://github.com/NixOS/nixpkgs/pull/498928#issuecomment-4415291511 and by running `nix-build /nix/store/rsbwkrjdn9l998q4k5ddicbnpspah4jg-nixpkgs-pkgs-lib-format-tests.drv` (the drv path on Hydra). The derivation can be obtained by running `nix eval github:NixOS/nixpkgs/staging-next\#legacyPackages.x86_64-linux.tests.pkgs-lib.formats.drvPath`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
