### PR TITLE
python3Packages.dedupe-pylbfgs: fix tests

### DIFF
--- a/pkgs/development/python-modules/dedupe-pylbfgs/default.nix
+++ b/pkgs/development/python-modules/dedupe-pylbfgs/default.nix
@@ -26,6 +26,10 @@ buildPythonPackage rec {
     hash = "sha256-H416dgZQxyqsnhmlK5keW8cJWY6gea4mebVuP0IEVOU=";
   };
 
+  patches = [
+    ./tests-numpy-2.4.patch # https://github.com/dedupeio/pylbfgs/pull/52
+  ];
+
   build-system = [
     cython
     numpy

--- a/pkgs/development/python-modules/dedupe-pylbfgs/tests-numpy-2.4.patch
+++ b/pkgs/development/python-modules/dedupe-pylbfgs/tests-numpy-2.4.patch
@@ -1,0 +1,25 @@
+diff --git a/tests/test_lbfgs.py b/tests/test_lbfgs.py
+index 1af91ef..65e2da9 100644
+--- a/tests/test_lbfgs.py
++++ b/tests/test_lbfgs.py
+@@ -28,16 +28,16 @@ class TestOWLQN:
+ 
+     def test_owl_line_search_default(self):
+         def f(x, g, *args):
+-            g[0] = 2 * x
+-            return x ** 2
++            g[0] = 2 * x[0]
++            return x[0] ** 2
+ 
+         with pytest.warns(UserWarning, match="OWL-QN"):
+             xmin = fmin_lbfgs(f, 100., orthantwise_c=1)
+     
+     def test_owl_line_search_warning_explicit(self):
+         def f(x, g, *args):
+-            g[0] = 2 * x
+-            return x ** 2
++            g[0] = 2 * x[0]
++            return x[0] ** 2
+ 
+         with pytest.warns(UserWarning, match="OWL-QN"):
+             xmin = fmin_lbfgs(f, 100., orthantwise_c=1, line_search='default')


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This package got broken by #488406 bumping NumPy from 2.3 to 2.4; see dedupeio/pylbfgs#52.

Disclosure: this patch was written by GPT-5.5 via Codex.

ZHF: #516381

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
