### PR TITLE
nym: 2024.14-crunch-patched -> 2026.9-venaco

### DIFF
--- a/pkgs/by-name/ny/nym/package.nix
+++ b/pkgs/by-name/ny/nym/package.nix
@@ -13,13 +13,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "nym";
-  version = "2024.14-crunch-patched";
+  version = "2026.9-venaco";
 
   src = fetchFromGitHub {
     owner = "nymtech";
     repo = "nym";
     tag = "nym-binaries-v${version}";
-    hash = "sha256-ze0N+Hg+jVFKaoreCrZUUA3cHGtUZFtxCh5RwTqOdsc=";
+    hash = "sha256-s3I4yfJfewJpMSqzHXmMFzvsfQAsVNZKzIroatpnfpA=";
   };
 
   swagger-ui = fetchurl {
@@ -27,11 +27,18 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-SBJE0IEgl7Efuu73n3HZQrFxYX+cn5UU5jrL4T5xzNw=";
   };
 
-  cargoHash = "sha256-51QdzV4eYnA+pC1b7TagSF1g+n67IvZw3euJyI3ZRtM=";
+  cargoHash = "sha256-ifdz+jZK9Hgezx4/Q9bDsOZOFynqE4GEFfIwXISuxp8=";
 
   env = {
     SWAGGER_UI_DOWNLOAD_URL = "file://${swagger-ui}";
     OPENSSL_NO_VENDOR = true;
+    VERGEN_BUILD_TIMESTAMP = "0";
+    VERGEN_BUILD_SEMVER = version;
+    VERGEN_GIT_COMMIT_TIMESTAMP = "0";
+    VERGEN_GIT_BRANCH = "master";
+    VERGEN_RUSTC_SEMVER = rustc.version;
+    VERGEN_RUSTC_CHANNEL = "stable";
+    VERGEN_CARGO_PROFILE = "release";
   };
 
   nativeBuildInputs = [
@@ -48,18 +55,12 @@ rustPlatform.buildRustPackage rec {
     rev-prefix = "nym-binaries-v";
   };
 
-  env = {
-    VERGEN_BUILD_TIMESTAMP = "0";
-    VERGEN_BUILD_SEMVER = version;
-    VERGEN_GIT_COMMIT_TIMESTAMP = "0";
-    VERGEN_GIT_BRANCH = "master";
-    VERGEN_RUSTC_SEMVER = rustc.version;
-    VERGEN_RUSTC_CHANNEL = "stable";
-    VERGEN_CARGO_PROFILE = "release";
-  };
-
   checkFlags = [
     "--skip=ping::http::tests::resolve_host_with_valid_hostname_returns_some"
+    "--skip=ecash::tests::credential_tests::blind_sign_correct"
+    "--skip=ecash::tests::credential_tests::already_issued"
+    "--skip=ecash::tests::issued_ticketbooks::issued_ticketbooks_for"
+    "--skip=ecash::tests::issued_ticketbooks::issued_ticketbooks_challenge_commitment"
   ];
 
   meta = {


### PR DESCRIPTION
Release notes: https://github.com/nymtech/nym/releases/tag/nym-binaries-v2026.9-venaco

Skip ecash tests that require a live nyxd validator connection. They panic in the Nix build sandbox where outbound network is unavailable:

  - ecash::tests::credential_tests::blind_sign_correct
  - ecash::tests::credential_tests::already_issued
  - ecash::tests::issued_ticketbooks::issued_ticketbooks_for
  - ecash::tests::issued_ticketbooks::issued_ticketbooks_challenge_commitment

Merge the two duplicate `env = { ... }` attribute sets into one. The second was previously shadowing `SWAGGER_UI_DOWNLOAD_URL` and `OPENSSL_NO_VENDOR` at evaluation.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
