### PR TITLE
buildGoModule: supported structuredAttrs with subPackages

### DIFF
--- a/pkgs/build-support/go/module.nix
+++ b/pkgs/build-support/go/module.nix
@@ -320,10 +320,15 @@ lib.extendMkDerivation {
               }
 
               getGoDirs() {
-                local type;
-                type="$1"
-                if [ -n "$subPackages" ]; then
-                  echo "$subPackages" | sed "s,\(^\| \),\1./,g"
+                local -r type="$1"
+
+                # Support strucuredAttrs, they are not space seperated
+                local -a subPackagesArray
+                concatTo subPackagesArray subPackages
+
+                # Outputs each element prefixed with './' if the array is not empty
+                if [[ ''${#subPackagesArray[@]} -gt 0 ]]; then
+                  echo "''${subPackagesArray[*]/#/./}"
                 else
                   find . -type f -name \*$type.go -exec dirname {} \; | grep -v "/vendor/" | sort --unique | grep -v "$exclude"
                 fi

--- a/pkgs/by-name/ne/neo-cowsay/package.nix
+++ b/pkgs/by-name/ne/neo-cowsay/package.nix
@@ -15,6 +15,7 @@ buildGoModule (finalAttrs: {
     hash = "sha256-DmIjqBTIzwkQ8aJ6xCgIwjDtczlTH5AKbPKFUGx3qQ8=";
   };
 
+  __structuredAttrs = true;
   vendorHash = "sha256-gBURmodXkod4fukw6LWEY+MBxPcf4vn/f6K78UR77n0=";
 
   modRoot = "./cmd";


### PR DESCRIPTION
## Things done

Fixes #519801
Part of #205690

1. concat `subPackages` to bash array `subPackagesArray` using the stdenv built-in `concatTo` which handles structured and non-strucutred attrs
2. Check if the array has any elements
3. If there are, output a string of the elements concat with spaces and prefixed with `./`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
