### PR TITLE
vnstat: modernise package and add choco98 as maintainer

### DIFF
--- a/pkgs/by-name/vn/vnstat/package.nix
+++ b/pkgs/by-name/vn/vnstat/package.nix
@@ -13,25 +13,30 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "vnstat";
   version = "2.13";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "vergoh";
     repo = "vnstat";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-Xd3s4Wrtfwis0dxRijeWhfloHcXPUNAj0P91uWi1C3M=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Xd3s4Wrtfwis0dxRijeWhfloHcXPUNAj0P91uWi1C3M=";
   };
 
+  strictDeps = true;
+
   postPatch = ''
-    substituteInPlace src/cfg.c --replace /usr/local $out
+    substituteInPlace src/cfg.c --replace-fail /usr/local $out
   '';
 
   nativeBuildInputs = [ pkg-config ];
+
   buildInputs = [
     gd
     ncurses
     sqlite
   ];
 
-  nativeCheckInputs = [ check ];
+  checkInputs = [ check ];
 
   doCheck = true;
 
@@ -44,9 +49,11 @@ stdenv.mkDerivation (finalAttrs: {
       This means that vnStat won't actually be sniffing any traffic and also
       ensures light use of system resources.
     '';
+    mainProgram = "vnstat";
     homepage = "https://humdi.net/vnstat/";
     license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ choco98 ];
     platforms = lib.platforms.linux;
-    maintainers = [ ];
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
### Modernise vnstat

This PR modernises the `vnstat` package to be more in accordance with current standards. Changes include `__structuredAttrs`, `strictDeps` (and fixing the package to make it build with that) and setting `sourceProvenance`

I also decided to adopt the package as its one I use often.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
