### PR TITLE
lemurs: misc updates

### DIFF
--- a/pkgs/by-name/le/lemurs/package.nix
+++ b/pkgs/by-name/le/lemurs/package.nix
@@ -1,10 +1,8 @@
 {
   fetchFromGitHub,
   lib,
-  bash,
   linux-pam,
   rustPlatform,
-  systemdMinimal,
   versionCheckHook,
   nixosTests,
 }:
@@ -22,9 +20,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-XoGtIHYCGXNuwnpDTU7NbZAs6rCO+69CAG89VCv9aAc=";
 
   buildInputs = [
-    bash
     linux-pam
-    systemdMinimal
   ];
 
   postInstall = ''

--- a/pkgs/by-name/le/lemurs/package.nix
+++ b/pkgs/by-name/le/lemurs/package.nix
@@ -27,6 +27,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     systemdMinimal
   ];
 
+  postInstall = ''
+    install -Dm0755 extra/xsetup.sh "$out/etc/xsetup.sh"
+  '';
+
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- while i added the missing `xsetup.sh` script, i did not update the module to use it - i will leave it to the module maintainers to add `services.displayManagers.lemurs.settings.x11.xsetup_path = "${cfg.package}/etc/xsetup.sh";` to the module
- in #384051 both `bash` and `systemd` were added to `buildInputs` in an attempt to provide relevant executables on `PATH` for `lemurs` - that isn't how `buildInputs` works, and even if it were... this is configurable via `config.toml` so should be set there... so let's drop them as they aren't used

cc @JeremiahSecrist and/or @nullcubee for review please :bowing_man:

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
