### PR TITLE
nym-wg-go: init at 1.29.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22670,6 +22670,12 @@
     github = "DaRacci";
     githubId = 90304606;
   };
+  rachyandco = {
+    name = "rachyandco";
+    email = "alexis@nymtech.net";
+    github = "rachyandco";
+    githubId = 2358699;
+  };
   RadxaYuntian = {
     # This is the work account for @MakiseKurisu
     name = "ZHANG Yuntian";

--- a/pkgs/by-name/ny/nym-wg-go/package.nix
+++ b/pkgs/by-name/ny/nym-wg-go/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "nym-wg-go";
+  version = "1.29.3";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "nymtech";
+    repo = "nym-vpn-client";
+    tag = "nym-vpn-core-v${version}";
+    hash = "sha256-ZBcFC4ng/0NJvI6C/fbc7Oo2lOeiFFLpzrIUV1UNz+4=";
+  };
+
+  sourceRoot = "${src.name}/wireguard/libwg";
+
+  vendorHash = "sha256-Ql9GuKInJYnijINlbYTB1H4GVJcO9lkVnclQzzNtCqQ=";
+
+  buildPhase = ''
+    runHook preBuild
+    go build \
+      -ldflags="-buildid=" \
+      -trimpath \
+      -buildvcs=false \
+      -v \
+      -o libwg.a \
+      -buildmode c-archive \
+      .
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm644 libwg.a $out/lib/libwg.a
+    install -Dm644 libwg.h $out/include/libwg.h
+    runHook postInstall
+  '';
+
+  doCheck = false;
+
+  meta = {
+    description = "Go-based WireGuard userspace library for NymVPN clients";
+    longDescription = ''
+      libwg is a CGo wrapper around the AmneziaWG fork of wireguard-go,
+      built as a C static archive. It exposes a small C API consumed by
+      the Rust nym-wg-go crate, which in turn is used by nym-vpnd to
+      provide WireGuard userspace tunneling without a kernel module.
+    '';
+    homepage = "https://github.com/nymtech/nym-vpn-client";
+    changelog = "https://github.com/nymtech/nym-vpn-client/releases/tag/nym-vpn-core-v${version}";
+    license = with lib.licenses; [
+      gpl3Only
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [ rachyandco ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
Initial packaging of `nym-wg-go`, the Go-based WireGuard userspace
library (`libwg`) used by NymVPN clients. Built as a C static archive
that exposes ~13 C-exported functions consumed by the Rust `nym-wg-go`
FFI crate in the upstream `nym-vpn-core` workspace.

This package is a prerequisite for the forthcoming `nym-vpn` (daemon +
CLI) and `nym-vpn-app` (Tauri GUI) packages.

Source: https://github.com/nymtech/nym-vpn-client/tree/nym-vpn-core-v1.29.3/wireguard/libwg

Output layout (chosen to be Nix-idiomatic rather than mirroring upstream's
`build/lib/$TARGET/` layout):
- `$out/lib/libwg.a`
- `$out/include/libwg.h`

The future `nym-vpn` derivation will arrange these into the path expected
by upstream's `build.rs` via a `preBuild` hook setting `BUILD_TOP`.

This PR now also contains the `maintainers: add rachyandco` commit
(cherry-picked from the now-closed #519908 per @GraysonTinker's review).

Disclosure: I work for Nym Technologies; this packaging is offered as a
community contribution.