### PR TITLE
librepcb: 2.0.0 -> 2.0.1

### DIFF
--- a/pkgs/by-name/li/librepcb/package.nix
+++ b/pkgs/by-name/li/librepcb/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "librepcb";
-  version = "2.0.0";
+  version = "2.0.1";
 
   src = fetchFromGitHub {
     owner = "librepcb";
     repo = "librepcb";
     rev = version;
-    hash = "sha256-8hMPrpqwGNYXUTJGL/CMSP+Sjv5F6ZTkJHqauuOxwTw=";
+    hash = "sha256-UliGKDJB/+Xud9/sf8vwboVDQuI/GWroAEWQsVr5tRw=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
I just updated the version and therefore also the hash.

I am not sure yet, if this package builds correctly. Suddenly, also the previous version (2.0.0) does not build on my local machine anymore.

Do you also get this error?
```
error: no matching package named `esp-backtrace` found
location searched: directory source `/nix/store/wz1jpmkiijg9xp1fxyvzykih4h68dsr8-cargo-deps-vendor` (which is replacing registry `crates-io`)
required by package `slint-cpp v1.15.0 (/build/source/libs/slint/api/cpp)`
make[2]: *** [libs/slint/CMakeFiles/_cargo-build_librepcbslint.dir/build.make:70: libs/slint/CMakeFiles/_cargo-build_librepcbslint] Error 101
make[1]: *** [CMakeFiles/Makefile2:821: libs/slint/CMakeFiles/_cargo-build_librepcbslint.dir/all] Error 2
```

## Things done

nix-build -A librepcb

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
