### PR TITLE
ob-xf: set strictDeps and __structuredAttrs

### DIFF
--- a/pkgs/by-name/ob/ob-xf/package.nix
+++ b/pkgs/by-name/ob/ob-xf/package.nix
@@ -42,6 +42,9 @@ stdenv.mkDerivation (finalAttrs: {
     EOF
   '';
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   nativeBuildInputs = [
     cmake
     pkg-config


### PR DESCRIPTION
- **ob-xf: set strictDeps and __structuredAttrs**
- **ob-xf: add missing optional dependencies**

fix https://github.com/NixOS/nixpkgs/actions/runs/25826931072/job/75882374953

While at it, I saw these in the build log:

```
ob-xf> --   Found fontconfig, version 2.17.1
ob-xf> Package expat was not found in the pkg-config search path.
ob-xf> Perhaps you should add the directory containing `expat.pc'
ob-xf> to the PKG_CONFIG_PATH environment variable
ob-xf> Package 'expat', required by 'fontconfig', not found
ob-xf> Package expat was not found in the pkg-config search path.
ob-xf> Perhaps you should add the directory containing `expat.pc'
ob-xf> to the PKG_CONFIG_PATH environment variable
ob-xf> Package 'expat', required by 'fontconfig', not found
ob-xf> Package expat was not found in the pkg-config search path.
ob-xf> Perhaps you should add the directory containing `expat.pc'
ob-xf> to the PKG_CONFIG_PATH environment variable
ob-xf> Package 'expat', required by 'fontconfig', not found
ob-xf> Package expat was not found in the pkg-config search path.
ob-xf> Perhaps you should add the directory containing `expat.pc'
ob-xf> to the PKG_CONFIG_PATH environment variable
ob-xf> Package 'expat', required by 'fontconfig', not found
```

```
ob-xf> -- Checking for module 'libcurl'
ob-xf> --   No package 'libcurl' found
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
