### PR TITLE
zfs_2_4: 2.4.1 -> 2.4.2; zfs_2_3: 2.3.6 -> 2.3.7; nixosTests.zfs: fix and test with systemd stage 1

### DIFF
--- a/nixos/tests/zfs.nix
+++ b/nixos/tests/zfs.nix
@@ -238,6 +238,18 @@ in
       systemdStage1 = false;
     }).zfsroot;
 
+  installerBootWithSystemdStage1 =
+    (import ./installer.nix {
+      inherit system;
+      systemdStage1 = true;
+    }).separateBootZfs;
+
+  installerWithSystemdStage1 =
+    (import ./installer.nix {
+      inherit system;
+      systemdStage1 = true;
+    }).zfsroot;
+
   expand-partitions = makeTest {
     name = "multi-disk-zfs";
     nodes = {

--- a/nixos/tests/zfs.nix
+++ b/nixos/tests/zfs.nix
@@ -226,8 +226,17 @@ in
     enableSystemdStage1 = true;
   };
 
-  installerBoot = (import ./installer.nix { inherit system; }).separateBootZfs;
-  installer = (import ./installer.nix { inherit system; }).zfsroot;
+  installerBoot =
+    (import ./installer.nix {
+      inherit system;
+      systemdStage1 = false;
+    }).separateBootZfs;
+
+  installer =
+    (import ./installer.nix {
+      inherit system;
+      systemdStage1 = false;
+    }).zfsroot;
 
   expand-partitions = makeTest {
     name = "multi-disk-zfs";

--- a/pkgs/os-specific/linux/zfs/2_3.nix
+++ b/pkgs/os-specific/linux/zfs/2_3.nix
@@ -13,10 +13,10 @@ callPackage ./generic.nix args {
   kernelModuleAttribute = "zfs_2_3";
 
   kernelMinSupportedMajorMinor = "4.18";
-  kernelMaxSupportedMajorMinor = "6.19";
+  kernelMaxSupportedMajorMinor = "7.0";
 
   # this package should point to the latest release.
-  version = "2.3.6";
+  version = "2.3.7";
 
   tests = {
     inherit (nixosTests.zfs) series_2_3;
@@ -30,5 +30,5 @@ callPackage ./generic.nix args {
     amarshall
   ];
 
-  hash = "sha256-5p9UbOQ0WY+XeAO+btDyJ04nRnOQuEuwszduEV7cbso=";
+  hash = "sha256-67Yo5bAJP3dXC94xybrC4xhwz7pGtrp0MUT9P6OInog=";
 }

--- a/pkgs/os-specific/linux/zfs/2_4.nix
+++ b/pkgs/os-specific/linux/zfs/2_4.nix
@@ -13,10 +13,10 @@ callPackage ./generic.nix args {
   kernelModuleAttribute = "zfs_2_4";
 
   kernelMinSupportedMajorMinor = "4.18";
-  kernelMaxSupportedMajorMinor = "6.19";
+  kernelMaxSupportedMajorMinor = "7.0";
 
   # this package should point to the latest release.
-  version = "2.4.1";
+  version = "2.4.2";
 
   tests = {
     inherit (nixosTests.zfs) series_2_4;
@@ -30,5 +30,5 @@ callPackage ./generic.nix args {
     amarshall
   ];
 
-  hash = "sha256-gapM2PNVOjhwGw6TAZF6QDxLza7oqOf1tpj7q0EN9Vg=";
+  hash = "sha256-OqsKHzyFjjyX8CoajDGydY4TbuQqMA37PIaEOL+vDug=";
 }

--- a/pkgs/os-specific/linux/zfs/generic.nix
+++ b/pkgs/os-specific/linux/zfs/generic.nix
@@ -102,13 +102,10 @@ let
 
       patches =
         extraPatches
-        ++
-          lib.optional
-            (kernel != null && lib.versionAtLeast version "2.4" && lib.versionOlder kernel.version "5.14")
-            (fetchpatch2 {
-              url = "https://github.com/openzfs/zfs/commit/58c8dc5f6926eb96903a3f38b141e8998ef9261b.patch?full_index=1";
-              hash = "sha256-eYkMhHsHBA9MKXnB/GuHpuv44g1SCGV5Or0InPBeNkU=";
-            });
+        ++ lib.optional (kernel != null && lib.versionOlder kernel.version "5.14") (fetchpatch2 {
+          url = "https://github.com/openzfs/zfs/commit/58c8dc5f6926eb96903a3f38b141e8998ef9261b.patch?full_index=1";
+          hash = "sha256-eYkMhHsHBA9MKXnB/GuHpuv44g1SCGV5Or0InPBeNkU=";
+        });
 
       postPatch =
         optionalString buildKernel ''

--- a/pkgs/os-specific/linux/zfs/generic.nix
+++ b/pkgs/os-specific/linux/zfs/generic.nix
@@ -4,6 +4,7 @@ let
       lib,
       stdenv,
       fetchFromGitHub,
+      fetchpatch2,
       autoreconfHook269,
       util-linux,
       nukeReferences,
@@ -99,7 +100,15 @@ let
         inherit rev hash;
       };
 
-      patches = extraPatches;
+      patches =
+        extraPatches
+        ++
+          lib.optional
+            (kernel != null && lib.versionAtLeast version "2.4" && lib.versionOlder kernel.version "5.14")
+            (fetchpatch2 {
+              url = "https://github.com/openzfs/zfs/commit/58c8dc5f6926eb96903a3f38b141e8998ef9261b.patch?full_index=1";
+              hash = "sha256-eYkMhHsHBA9MKXnB/GuHpuv44g1SCGV5Or0InPBeNkU=";
+            });
 
       postPatch =
         optionalString buildKernel ''

--- a/pkgs/os-specific/linux/zfs/unstable.nix
+++ b/pkgs/os-specific/linux/zfs/unstable.nix
@@ -10,20 +10,20 @@ callPackage ./generic.nix args {
   kernelModuleAttribute = "zfs_unstable";
 
   kernelMinSupportedMajorMinor = "4.18";
-  kernelMaxSupportedMajorMinor = "6.19";
+  kernelMaxSupportedMajorMinor = "7.0";
 
   # this package should point to a version / git revision compatible with the latest kernel release
   # IMPORTANT: Always use a tagged release candidate or commits from the
   # zfs-<version>-staging branch, because this is tested by the OpenZFS
   # maintainers.
-  version = "2.4.1";
+  version = "2.4.2";
   # rev = "";
 
   tests = {
     inherit (nixosTests.zfs) unstable;
   };
 
-  hash = "sha256-gapM2PNVOjhwGw6TAZF6QDxLza7oqOf1tpj7q0EN9Vg=";
+  hash = "sha256-OqsKHzyFjjyX8CoajDGydY4TbuQqMA37PIaEOL+vDug=";
 
   extraLongDescription = ''
     This is "unstable" ZFS, and will usually be a pre-release version of ZFS.


### PR DESCRIPTION
See individual commits and msgs for details.

## Things done

Ran `nix-build -A zfs_2_3.passthru.tests -A zfs_2_4.passthru.tests -A nixosTests.zfs --keep-going` plus nixpkgs-review (based on nixos-unstable, results below).

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `bb9becb05b258b9aec479f7d1aa8fc2e4fe459dd`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 7 packages marked as broken and skipped:</summary>
  <ul>
    <li>haskellPackages.batchd-libvirt</li>
    <li>haskellPackages.batchd-libvirt.doc</li>
    <li>haskellPackages.libvirt-hs</li>
    <li>haskellPackages.libvirt-hs.doc</li>
    <li>haskellPackages.libzfs</li>
    <li>haskellPackages.libzfs.doc</li>
    <li>htcondor</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 94 packages built:</summary>
  <ul>
    <li>appvm</li>
    <li>booster</li>
    <li>calamares</li>
    <li>calamares-nixos</li>
    <li>calamares-nixos.debug</li>
    <li>calamares.debug</li>
    <li>collectd</li>
    <li>diffoscope</li>
    <li>diffoscope.dist</li>
    <li>diffoscope.man</li>
    <li>easysnap</li>
    <li>facter</li>
    <li>fdroidserver</li>
    <li>fdroidserver.dist</li>
    <li>field-monitor</li>
    <li>gnome-boxes</li>
    <li>guestfs-tools</li>
    <li>kdePackages.kpmcore</li>
    <li>kdePackages.kpmcore.debug</li>
    <li>kdePackages.kpmcore.dev</li>
    <li>kdePackages.kpmcore.devtools</li>
    <li>kdePackages.partitionmanager</li>
    <li>kdePackages.partitionmanager.debug</li>
    <li>kdePackages.partitionmanager.dev</li>
    <li>kdePackages.partitionmanager.devtools</li>
    <li>libguestfs (python313Packages.guestfs)</li>
    <li>libguestfs-with-appliance</li>
    <li>libguestfs-with-appliance.guestfsd</li>
    <li>libguestfs.guestfsd (python313Packages.guestfs.guestfsd)</li>
    <li>librenms</li>
    <li>libvirt</li>
    <li>libvirt-dbus</li>
    <li>libvirt-dbus.man</li>
    <li>libvirt-glib</li>
    <li>libvirt-glib.dev</li>
    <li>libvirt-glib.devdoc</li>
    <li>libvmi</li>
    <li>libvmi.dev</li>
    <li>libvmi.lib</li>
    <li>linuxKernel.packages.linux_5_10.zfs_2_3</li>
    <li>linuxKernel.packages.linux_5_10.zfs_2_4 (linuxKernel.packages.linux_5_10.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_5_15.zfs_2_3</li>
    <li>linuxKernel.packages.linux_5_15.zfs_2_4 (linuxKernel.packages.linux_5_15.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_6_1.zfs_2_3</li>
    <li>linuxKernel.packages.linux_6_1.zfs_2_4 (linuxKernel.packages.linux_6_1.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_6_12.zfs_2_3</li>
    <li>linuxKernel.packages.linux_6_12.zfs_2_4 (linuxKernel.packages.linux_6_12.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_6_18.zfs_2_3</li>
    <li>linuxKernel.packages.linux_6_18.zfs_2_4 (linuxKernel.packages.linux_6_18.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_6_6.zfs_2_3</li>
    <li>linuxKernel.packages.linux_6_6.zfs_2_4 (linuxKernel.packages.linux_6_6.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_7_0.zfs_2_3</li>
    <li>linuxKernel.packages.linux_7_0.zfs_2_4 (linuxKernel.packages.linux_7_0.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_xanmod.zfs_2_3</li>
    <li>linuxKernel.packages.linux_xanmod.zfs_2_4 (linuxKernel.packages.linux_xanmod.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_xanmod_latest.zfs_2_3 (linuxKernel.packages.linux_xanmod_stable.zfs_2_3)</li>
    <li>linuxKernel.packages.linux_xanmod_latest.zfs_2_4 (linuxKernel.packages.linux_xanmod_latest.zfs_unstable, linuxKernel.packages.linux_xanmod_stable.zfs_2_4, linuxKernel.packages.linux_xanmod_stable.zfs_unstable)</li>
    <li>linuxKernel.packages.linux_zen.zfs_2_3</li>
    <li>linuxKernel.packages.linux_zen.zfs_2_4 (linuxKernel.packages.linux_zen.zfs_unstable)</li>
    <li>mgmt</li>
    <li>minikube</li>
    <li>nagiosPlugins.check_zfs</li>
    <li>ocamlPackages.ocaml_libvirt</li>
    <li>perl5Packages.SysVirt</li>
    <li>perl5Packages.SysVirt.devdoc</li>
    <li>podman-bootc</li>
    <li>prometheus-libvirt-exporter</li>
    <li>python313Packages.libvirt</li>
    <li>python313Packages.libvirt.dist</li>
    <li>python314Packages.guestfs</li>
    <li>python314Packages.guestfs.guestfsd</li>
    <li>python314Packages.libvirt</li>
    <li>python314Packages.libvirt.dist</li>
    <li>rubyPackages.ruby-libvirt</li>
    <li>rubyPackages_3_3.ruby-libvirt</li>
    <li>rubyPackages_4_0.ruby-libvirt</li>
    <li>sanoid</li>
    <li>tzpfms</li>
    <li>vagrant</li>
    <li>virt-manager</li>
    <li>virt-top</li>
    <li>virt-v2v</li>
    <li>virt-viewer</li>
    <li>virtnbdbackup</li>
    <li>virtnbdbackup.dist</li>
    <li>zfs (zfs_unstable)</li>
    <li>zfs.dev (zfs_unstable.dev)</li>
    <li>zfs.man (zfs_unstable.man)</li>
    <li>zfs_2_3</li>
    <li>zfs_2_3.dev</li>
    <li>zfs_2_3.man</li>
    <li>zfstools</li>
    <li>zpool-auto-expand-partitions</li>
    <li>zxfer</li>
  </ul>
</details>


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
