### PR TITLE
mesa-demos: split out essential utilities as mesa-utils

### DIFF
--- a/nixos/modules/services/desktop-managers/budgie.nix
+++ b/nixos/modules/services/desktop-managers/budgie.nix
@@ -200,7 +200,7 @@ in
         gammastep
         grim
         killall
-        mesa-demos # eglinfo
+        mesa-utils # eglinfo
         slurp
         swaybg
         swayidle

--- a/nixos/tests/miracle-wm.nix
+++ b/nixos/tests/miracle-wm.nix
@@ -54,7 +54,7 @@
         };
 
         systemPackages = with pkgs; [
-          mesa-demos
+          mesa-utils
           wayland-utils
           foot
           alacritty

--- a/nixos/tests/miriway.nix
+++ b/nixos/tests/miriway.nix
@@ -49,7 +49,7 @@
         };
 
         systemPackages = with pkgs; [
-          mesa-demos
+          mesa-utils
           wayland-utils
           foot
           alacritty

--- a/nixos/tests/sway.nix
+++ b/nixos/tests/sway.nix
@@ -21,7 +21,7 @@
       environment = {
         # For glinfo and wayland-info:
         systemPackages = with pkgs; [
-          mesa-demos
+          mesa-utils
           wayland-utils
           alacritty
         ];

--- a/nixos/tests/swayfx.nix
+++ b/nixos/tests/swayfx.nix
@@ -19,7 +19,7 @@
     environment = {
       # For glinfo and wayland-info:
       systemPackages = with pkgs; [
-        mesa-demos
+        mesa-utils
         wayland-utils
         alacritty
       ];

--- a/nixos/tests/turbovnc-headless-server.nix
+++ b/nixos/tests/turbovnc-headless-server.nix
@@ -10,7 +10,7 @@
     {
 
       environment.systemPackages = with pkgs; [
-        mesa-demos
+        mesa-utils
         procps # for `pkill`, `pidof` in the test
         scrot # for screenshotting Xorg
         turbovnc

--- a/pkgs/applications/editors/android-studio/common.nix
+++ b/pkgs/applications/editors/android-studio/common.nix
@@ -38,7 +38,7 @@
   libx11,
   libxcb,
   libxkbcommon,
-  mesa-demos,
+  mesa-utils,
   libxcb-wm,
   libxcb-render-util,
   libxcb-keysyms,
@@ -121,7 +121,7 @@ let
 
             # For Android emulator
             file
-            mesa-demos
+            mesa-utils
             pciutils
             setxkbmap
 

--- a/pkgs/applications/video/kodi/unwrapped.nix
+++ b/pkgs/applications/video/kodi/unwrapped.nix
@@ -67,7 +67,7 @@
   bzip2,
   zip,
   unzip,
-  mesa-demos,
+  mesa-utils,
   libcec,
   libcec_platform,
   dcadec,
@@ -319,7 +319,7 @@ stdenv.mkDerivation (
       bzip2
       zip
       unzip
-      mesa-demos
+      mesa-utils
       libcec
       libcec_platform
       dcadec
@@ -478,7 +478,7 @@ stdenv.mkDerivation (
             lib.makeBinPath (
               [
                 python3Packages.python
-                mesa-demos
+                mesa-utils
               ]
               ++ lib.optional x11Support xdpyinfo
               ++ lib.optional sambaSupport samba

--- a/pkgs/by-name/co/corectrl/package.nix
+++ b/pkgs/by-name/co/corectrl/package.nix
@@ -7,7 +7,7 @@
   lib,
   libdrm,
   kdePackages,
-  mesa-demos,
+  mesa-utils,
   polkit,
   procps,
   pugixml,
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
     kdePackages.qtsvg
     kdePackages.qttools
     kdePackages.quazip
-    mesa-demos
+    mesa-utils
     polkit
     procps
     pugixml
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   runtimeInputs = [
     hwdata
-    mesa-demos
+    mesa-utils
     procps
     util-linux
     vulkan-tools

--- a/pkgs/by-name/gp/gpu-viewer/package.nix
+++ b/pkgs/by-name/gp/gpu-viewer/package.nix
@@ -20,7 +20,7 @@
   python3,
   clinfo,
   lsb-release,
-  mesa-demos,
+  mesa-utils,
   vdpauinfo,
 
   # passthru
@@ -69,7 +69,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
         lib.makeBinPath [
           clinfo
           lsb-release
-          mesa-demos
+          mesa-utils
           vdpauinfo
           vulkan-tools
         ]

--- a/pkgs/by-name/ha/hardinfo2/package.nix
+++ b/pkgs/by-name/ha/hardinfo2/package.nix
@@ -37,7 +37,7 @@
   dmidecode,
   gawk,
   iperf,
-  mesa-demos,
+  mesa-utils,
   sysbench,
   udisks,
   vulkan-tools,
@@ -121,7 +121,7 @@ stdenv.mkDerivation (finalAttrs: {
   runtimeDeps = [
     # system stats
     dmidecode
-    mesa-demos # glxinfo + vkgears for benchmark
+    mesa-utils # glxinfo + vkgears for benchmark
 
     # display info
     vulkan-tools # vulkaninfo

--- a/pkgs/by-name/in/inxi/package.nix
+++ b/pkgs/by-name/in/inxi/package.nix
@@ -25,7 +25,7 @@
   upower,
   pciutils,
   withRecommendedDisplayInformationPrograms ? withRecommends,
-  mesa-demos,
+  mesa-utils,
   xrandr,
   xprop,
   xdpyinfo,
@@ -50,7 +50,7 @@ let
     pciutils
   ];
   recommendedDisplayInformationPrograms = lib.optionals withRecommendedDisplayInformationPrograms [
-    mesa-demos
+    mesa-utils
     xdpyinfo
     xprop
     xrandr

--- a/pkgs/by-name/lu/lutris-unwrapped/package.nix
+++ b/pkgs/by-name/lu/lutris-unwrapped/package.nix
@@ -24,7 +24,7 @@
   xrandr,
   pciutils,
   psmisc,
-  mesa-demos,
+  mesa-utils,
   vulkan-tools,
   pulseaudio,
   p7zip,
@@ -47,7 +47,7 @@ let
     xrandr
     pciutils
     psmisc
-    mesa-demos
+    mesa-utils
     vulkan-tools
     pulseaudio
     p7zip

--- a/pkgs/by-name/ma/mangojuice/package.nix
+++ b/pkgs/by-name/ma/mangojuice/package.nix
@@ -17,7 +17,7 @@
   wrapGAppsHook4,
 
   mangohud,
-  mesa-demos,
+  mesa-utils,
   vulkan-tools,
   vkbasalt,
 
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
     let
       path = lib.makeBinPath [
         mangohud
-        mesa-demos # glxgears
+        mesa-utils # glxgears
         pciutils # lspci
         vulkan-tools # vkcube
       ];

--- a/pkgs/by-name/me/mesa-demos/package.nix
+++ b/pkgs/by-name/me/mesa-demos/package.nix
@@ -31,6 +31,11 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-MEaj0mp7BRr3690lel8jv+sWDK1u2VIynN/x6fHtSWs=";
   };
 
+  outputs = [
+    "out"
+    "utils"
+  ];
+
   depsBuildBuild = [
     pkg-config
   ];
@@ -64,6 +69,23 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonEnable "osmesa" false)
     (lib.mesonEnable "wayland" (lib.meta.availableOn stdenv.hostPlatform wayland))
   ];
+
+  # Split the essential utilities into a `utils` output (re-exposed top-level
+  # as `mesa-utils`). For backwards compatibility, symlink them back into
+  # `$out/bin/` so existing consumers of `mesa-demos` keep working unchanged.
+  postInstall = ''
+    for bin in \
+      eglinfo eglgears_wayland eglgears_x11 eglkms \
+      egltri_wayland egltri_x11 peglgears xeglgears xeglthreads \
+      es2_info es2gears_wayland es2gears_x11 es2tri \
+      glxinfo glxgears \
+      vkgears; do
+      if [ -e "$out/bin/$bin" ]; then
+        moveToOutput "bin/$bin" "$utils"
+        ln -s "$utils/bin/$bin" "$out/bin/$bin"
+      fi
+    done
+  '';
 
   meta = {
     inherit (mesa.meta) homepage platforms;

--- a/pkgs/by-name/me/mesa-utils/package.nix
+++ b/pkgs/by-name/me/mesa-utils/package.nix
@@ -1,0 +1,23 @@
+{
+  mesa-demos,
+  symlinkJoin,
+}:
+
+# Top-level package exposing the essential Mesa utility binaries (glxinfo,
+# glxgears, eglinfo, vkgears, etc.) from the `utils` output of mesa-demos.
+# Provided as a separate attribute so consumers that only need the utilities
+# can avoid the full mesa-demos closure.
+symlinkJoin {
+  pname = "mesa-utils";
+  inherit (mesa-demos) version;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  paths = [ mesa-demos.utils ];
+
+  meta = mesa-demos.meta // {
+    description = "Essential Mesa utilities (glxinfo, glxgears, eglinfo, vkgears, etc.)";
+    mainProgram = "glxinfo";
+  };
+}

--- a/pkgs/by-name/op/opengamepadui/package.nix
+++ b/pkgs/by-name/op/opengamepadui/package.nix
@@ -9,7 +9,7 @@
   lib,
   libGL,
   libpulseaudio,
-  mesa-demos,
+  mesa-utils,
   nix-update-script,
   pkg-config,
   rustPlatform,
@@ -76,7 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
       runtimeDependencies = [
         gamescope
         hwdata
-        mesa-demos
+        mesa-utils
         udev
         upower
       ];

--- a/pkgs/by-name/pl/playonlinux/package.nix
+++ b/pkgs/by-name/pl/playonlinux/package.nix
@@ -8,7 +8,7 @@
   gnupg,
   icoutils,
   imagemagick,
-  mesa-demos,
+  mesa-utils,
   netcat-gnu,
   p7zip,
   python3,
@@ -42,7 +42,7 @@ let
     gnupg
     icoutils
     imagemagick
-    mesa-demos
+    mesa-utils
     netcat-gnu
     p7zip
     unzip

--- a/pkgs/by-name/qu/quickemu/package.nix
+++ b/pkgs/by-name/qu/quickemu/package.nix
@@ -8,7 +8,7 @@
   coreutils,
   curl,
   gawk,
-  mesa-demos,
+  mesa-utils,
   gnugrep,
   gnused,
   jq,
@@ -51,7 +51,7 @@ let
     zsync
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
-    mesa-demos
+    mesa-utils
     usbutils
     xdg-user-dirs
   ];

--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -178,7 +178,7 @@ let
       pkgs.libxi
       pkgs.libxkbcommon
       pkgs.libxslt
-      pkgs.mesa-demos
+      pkgs.mesa-utils
       pkgs.nspr
       pkgs.nss
       pkgs.pango

--- a/pkgs/kde/plasma/kinfocenter/default.nix
+++ b/pkgs/kde/plasma/kinfocenter/default.nix
@@ -7,7 +7,7 @@
   libdisplay-info,
   libusb1,
   lm_sensors,
-  mesa-demos,
+  mesa-utils,
   mkKdeDerivation,
   pkg-config,
   pciutils,
@@ -26,8 +26,8 @@ let
     clinfo = lib.getExe clinfo;
     di_edid_decode = lib.getExe libdisplay-info;
     dmidecode = lib.getExe' dmidecode "dmidecode";
-    eglinfo = lib.getExe' mesa-demos "eglinfo";
-    glxinfo = lib.getExe' mesa-demos "glxinfo";
+    eglinfo = lib.getExe' mesa-utils "eglinfo";
+    glxinfo = lib.getExe' mesa-utils "glxinfo";
     ip = lib.getExe' iproute2 "ip";
     lsblk = lib.getExe' util-linux "lsblk";
     lspci = lib.getExe' pciutils "lspci";

--- a/pkgs/tools/system/hw-probe/default.nix
+++ b/pkgs/tools/system/hw-probe/default.nix
@@ -39,7 +39,7 @@
   hdparm,
   acpica-tools,
   drm_info,
-  mesa-demos,
+  mesa-utils,
   memtester,
   sysstat,
   cpuid,
@@ -97,7 +97,7 @@ stdenv.mkDerivation rec {
         hdparm
         acpica-tools
         drm_info
-        mesa-demos
+        mesa-utils
         memtester
         sysstat # (iostat)
         util-linuxMinimal # (rfkill)

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -913,7 +913,7 @@ mapAliases {
   glfw-wayland-minecraft = throw "'glfw-wayland-minecraft' has been renamed to/replaced by 'glfw3-minecraft'"; # Converted to throw 2025-10-27
   globalprotect-openconnect = throw "'globalprotect-openconnect' was removed because it was unmaintained in Nixpkgs and needed upgrading to the Tauri rewrite, as the old version depends on the removed Qt 5 WebEngine"; # Added 2026-04-26
   glom = throw "'glom' has been removed as it was archived upstream and depended on libsoup 2.4"; # Added 2026-06-07
-  glxinfo = throw "'glxinfo' has been renamed to/replaced by 'mesa-demos'"; # Converted to throw 2025-10-27
+  glxinfo = throw "'glxinfo' has been renamed to/replaced by 'mesa-utils'"; # Converted to throw 2025-10-27
   gmnisrv = throw "'gmnisrv' has been removed due to lack of maintenance upstream"; # Added 2025-06-07
   gmu = throw "'gmu' has been removed as it was broken and unmaintained in Nixpkgs"; # Added 2026-04-04
   gnat11 = throw "gnat11 has been removed from Nixpkgs, as it is unmaintained and obsolete"; # Added 2025-08-08

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5620,7 +5620,7 @@ with pkgs;
       intel-media-driver
       intel-vaapi-driver
       mesa
-      mesa-demos
+      mesa-utils
       libva-vdpau-driver
       libvdpau-va-gl
       vdpauinfo


### PR DESCRIPTION
Tracking #515268.

Introduces a top-level `mesa-utils` package exposing the essential Mesa utility binaries (`glxinfo`, `glxgears`, `eglinfo`, `vkgears`, and the `egl*`/`es2*`/`xegl*` family — 16 binaries) so consumers that only need a utility no longer have to depend on the full `mesa-demos` closure.

### Changes

- `mesa-demos` builds two outputs (`out`, `utils`) from a single source. In `postInstall`, each of the 16 util binaries is relocated from `$out/bin/` to `$utils/bin/` via `moveToOutput`, then symlinked back into `$out/bin/`. **`mesa-demos` therefore stays a drop-in replacement** for every existing consumer — backwards compatibility is preserved.
- In-tree consumers that explicitly want only the utilities (`kinfocenter`, `kodi`, `android-studio`, `corectrl`, `gpu-viewer`, `hardinfo2`, `inxi`, `lutris-unwrapped`, `mangojuice`, `opengamepadui`, `playonlinux`, `quickemu`, `zoom-us`, `hw-probe`, the `budgie` DM module, and several Wayland/X compositor NixOS tests) switch to `mesa-utils` for the smaller closure. The graphical installation ISO and `profiles/graphical` stay on `mesa-demos` — those images already include a broad toolset and the demos are useful there.
- `driversi686Linux` exposes `mesa-utils` so 32-bit `glxinfo` remains reachable.
- The `glxinfo` alias `throw` redirects to `mesa-utils`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at \`passthru.tests\`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran \`nixpkgs-review\` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in \`./result/bin/\`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Assisted-by: claude-code with Opus 4.7 xhigh