### PR TITLE
nixos/suricata: add support for NFQUEUE packet capture mode

### DIFF
--- a/nixos/modules/services/networking/suricata/default.nix
+++ b/nixos/modules/services/networking/suricata/default.nix
@@ -152,12 +152,24 @@ in
 
     netfilterQueues = mkOption {
       type = types.listOf types.ints.u16;
-      default = [];
+      default = [ ];
       example = literalExpression ''
         [ 67 68 69 ];
       '';
       description = ''
         The netfilter queue numbers to listen on. They should be consecutive. Use in conjunction with `settings.nfq`.
+      '';
+    };
+
+    extraArgs = mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [
+        "-v"
+        "--simulate-ips"
+      ];
+      description = ''
+        Additional command-line arguments to pass to suricata.
       '';
     };
   };
@@ -194,7 +206,9 @@ in
     mkIf cfg.enable {
       assertions = [
         {
-          assertion = lib.xor ((builtins.length captureInterfaces) > 0) ((builtins.length netfilterQueuesSorted) > 0);
+          assertion = lib.xor ((builtins.length captureInterfaces) > 0) (
+            (builtins.length netfilterQueuesSorted) > 0
+          );
           message = "services.suricata.netfilterQueues is mutually exclusive with other capture modes (e.g. af-packet).";
         }
         {
@@ -209,7 +223,8 @@ in
           '';
         }
         {
-          assertion = if builtins.length captureInterfaces == 0 then listIsSequential netfilterQueuesSorted else true;
+          assertion =
+            if builtins.length captureInterfaces == 0 then listIsSequential netfilterQueuesSorted else true;
           message = "`services.suricata.netfilterQueues` must be consecutive (e.g. [ 5 6 7 8 ]).";
         }
       ];
@@ -289,12 +304,12 @@ in
               nfqueueOptions = lib.concatStringsSep " " (
                 map (s: "-q " + builtins.toString s) cfg.netfilterQueues
               );
+              extraOptions = lib.concatStringsSep " " cfg.extraArgs;
+              captureModeOptions = if cfg.settings.nfq != null then nfqueueOptions else interfaceOptions;
             in
             {
               ExecStartPre = "!${pkg}/bin/suricata -c ${cfg.configFile} -T";
-              ExecStart = "!${pkg}/bin/suricata -c ${cfg.configFile} ${
-                (if cfg.settings.nfq != null then nfqueueOptions else interfaceOptions)
-              }";
+              ExecStart = "!${pkg}/bin/suricata -c ${cfg.configFile} ${captureModeOptions} ${extraOptions}";
               Restart = "on-failure";
 
               User = cfg.settings.run-as.user;

--- a/nixos/modules/services/networking/suricata/default.nix
+++ b/nixos/modules/services/networking/suricata/default.nix
@@ -149,6 +149,17 @@ in
         List of rules that should be disabled.
       '';
     };
+
+    netfilterQueues = mkOption {
+      type = types.listOf types.ints.u16;
+      default = [];
+      example = literalExpression ''
+        [ 67 68 69 ];
+      '';
+      description = ''
+        The netfilter queue numbers to listen on. They should be consecutive. Use in conjunction with `settings.nfq`.
+      '';
+    };
   };
 
   config =
@@ -167,18 +178,39 @@ in
             ++ (optionals (cfg.settings.pcap != null) cfg.settings.pcap)
           )
         );
+      netfilterQueuesSorted = builtins.sort (a: b: a < b) cfg.netfilterQueues;
+      listIsSequential =
+        l:
+        if lists.length l < 2 then
+          true
+        else
+          let
+            first = lists.head l;
+            # using tail recursively is slow
+            second = lists.head (lists.tail l);
+          in
+          second == first + 1 && listIsSequential (lists.tail l);
     in
     mkIf cfg.enable {
       assertions = [
         {
-          assertion = (builtins.length captureInterfaces) > 0;
+          assertion = lib.xor ((builtins.length captureInterfaces) > 0) ((builtins.length netfilterQueuesSorted) > 0);
+          message = "services.suricata.netfilterQueues is mutually exclusive with other capture modes (e.g. af-packet).";
+        }
+        {
+          assertion = (builtins.length captureInterfaces) > 0 || (builtins.length netfilterQueuesSorted) > 0;
           message = ''
-            At least one capture interface must be configured:
+            At least one layer 2 capture interface must be configured, or `services.suricata.netfilterQueues` must be nonempty.
+            Layer 2 capture interfaces:
             - `services.suricata.settings.af-packet`
             - `services.suricata.settings.af-xdp`
             - `services.suricata.settings.dpdk.interfaces`
             - `services.suricata.settings.pcap`
           '';
+        }
+        {
+          assertion = if builtins.length captureInterfaces == 0 then listIsSequential netfilterQueuesSorted else true;
+          message = "`services.suricata.netfilterQueues` must be consecutive (e.g. [ 5 6 7 8 ]).";
         }
       ];
 
@@ -253,11 +285,16 @@ in
           after = [ "suricata-update.service" ];
           serviceConfig =
             let
-              interfaceOptions = strings.concatMapStrings (interface: " -i ${interface}") captureInterfaces;
+              interfaceOptions = strings.concatMapStrings (interface: "-i ${interface}") captureInterfaces;
+              nfqueueOptions = lib.concatStringsSep " " (
+                map (s: "-q " + builtins.toString s) cfg.netfilterQueues
+              );
             in
             {
               ExecStartPre = "!${pkg}/bin/suricata -c ${cfg.configFile} -T";
-              ExecStart = "!${pkg}/bin/suricata -c ${cfg.configFile}${interfaceOptions}";
+              ExecStart = "!${pkg}/bin/suricata -c ${cfg.configFile} ${
+                (if cfg.settings.nfq != null then nfqueueOptions else interfaceOptions)
+              }";
               Restart = "on-failure";
 
               User = cfg.settings.run-as.user;

--- a/nixos/modules/services/networking/suricata/default.nix
+++ b/nixos/modules/services/networking/suricata/default.nix
@@ -191,17 +191,7 @@ in
           )
         );
       netfilterQueuesSorted = builtins.sort (a: b: a < b) cfg.netfilterQueues;
-      listIsSequential =
-        l:
-        if lists.length l < 2 then
-          true
-        else
-          let
-            first = lists.head l;
-            # using tail recursively is slow
-            second = lists.head (lists.tail l);
-          in
-          second == first + 1 && listIsSequential (lists.tail l);
+      listIsConsecutive = l: l == lib.genList (lib.add (lib.head l)) (lib.length l);
     in
     mkIf cfg.enable {
       assertions = [
@@ -209,12 +199,11 @@ in
           assertion = lib.xor ((builtins.length captureInterfaces) > 0) (
             (builtins.length netfilterQueuesSorted) > 0
           );
-          message = "services.suricata.netfilterQueues is mutually exclusive with other capture modes (e.g. af-packet).";
-        }
-        {
-          assertion = (builtins.length captureInterfaces) > 0 || (builtins.length netfilterQueuesSorted) > 0;
           message = ''
-            At least one layer 2 capture interface must be configured, or `services.suricata.netfilterQueues` must be nonempty.
+            At least one layer 2 capture interface must be configured, or
+            `services.suricata.netfilterQueues` must be nonempty. Netfilter
+            capture mode is mutually exclusive with layer 2 capture modes.
+
             Layer 2 capture interfaces:
             - `services.suricata.settings.af-packet`
             - `services.suricata.settings.af-xdp`
@@ -223,8 +212,7 @@ in
           '';
         }
         {
-          assertion =
-            if builtins.length captureInterfaces == 0 then listIsSequential netfilterQueuesSorted else true;
+          assertion = builtins.length captureInterfaces == 0 -> listIsConsecutive netfilterQueuesSorted;
           message = "`services.suricata.netfilterQueues` must be consecutive (e.g. [ 5 6 7 8 ]).";
         }
       ];

--- a/nixos/modules/services/networking/suricata/settings.nix
+++ b/nixos/modules/services/networking/suricata/settings.nix
@@ -526,34 +526,47 @@ in
                 "route"
               ];
               default = "accept";
+              description = ''
+                The mode determines how packets are handled.
+                - `accept`: Suricata accepts or rejects the packet, and does not send it back through the kernel network stack.
+                - `repeat`: Suricata sends packets back through the kernel network stack after processing.
+                - `route`: Suricata sends packets to another netfilter queue.
+              '';
             };
             repeat-mark = mkOption {
-              type = types.either types.ints.u32 (types.coercedTo (types.str lib.fromHexString types.ints.u32));
+              type = types.ints.u32;
               default = 1;
+              description = "Firewall mark to apply to packets in repeat mode.";
             };
             repeat-mask = mkOption {
-              type = types.either types.ints.u32 (types.coercedTo (types.str lib.fromHexString types.ints.u32));
+              type = types.ints.u32;
               default = 1;
+              description = "Firewall mark mask to apply to packets in repeat mode.";
             };
             bypass-mark = mkOption {
-              type = types.either types.ints.u32 (types.coercedTo (types.str lib.fromHexString types.ints.u32));
+              type = types.ints.u32;
               default = 1;
+              description = "Firewall mark to apply to packets in bypass mode.";
             };
             bypass-mask = mkOption {
-              type = types.either types.ints.u32 (types.coercedTo (types.str lib.fromHexString types.ints.u32));
+              type = types.ints.u32;
               default = 1;
+              description = "Firewall mark mask to apply to packets in bypass mode";
             };
             route-queue = mkOption {
               type = types.ints.u16;
               default = 2;
+              description = "Netfilter queue to route packets to in route mode.";
             };
             batchcount = mkOption {
               type = types.int;
               default = 1;
+              description = "Process this many packets before sending a verdict (worker runmode only).";
             };
             fail-open = mkOption {
               type = types.bool;
               default = true;
+              description = "Whether to accept packets if Suricata is not able to keep pace.";
             };
           };
         });

--- a/nixos/modules/services/networking/suricata/settings.nix
+++ b/nixos/modules/services/networking/suricata/settings.nix
@@ -513,6 +513,56 @@ in
       '';
     };
 
+    # set defaults according to upstream suricata.yaml.in
+    "nfq" = mkOption {
+      type =
+        with types;
+        nullOr (submodule {
+          options = {
+            mode = mkOption {
+              type = types.enum [
+                "accept"
+                "repeat"
+                "route"
+              ];
+              default = "accept";
+            };
+            repeat-mark = mkOption {
+              type = types.either types.ints.u32 (types.coercedTo (types.str lib.fromHexString types.ints.u32));
+              default = 1;
+            };
+            repeat-mask = mkOption {
+              type = types.either types.ints.u32 (types.coercedTo (types.str lib.fromHexString types.ints.u32));
+              default = 1;
+            };
+            bypass-mark = mkOption {
+              type = types.either types.ints.u32 (types.coercedTo (types.str lib.fromHexString types.ints.u32));
+              default = 1;
+            };
+            bypass-mask = mkOption {
+              type = types.either types.ints.u32 (types.coercedTo (types.str lib.fromHexString types.ints.u32));
+              default = 1;
+            };
+            route-queue = mkOption {
+              type = types.ints.u16;
+              default = 2;
+            };
+            batchcount = mkOption {
+              type = types.int;
+              default = 1;
+            };
+            fail-open = mkOption {
+              type = types.bool;
+              default = true;
+            };
+          };
+        });
+      default = null;
+      description = ''
+        NFQUEUE settings, see [upstream docs](https://docs.suricata.io/en/latest/configuration/suricata-yaml.html#nfq) and [upstream defaults](https://github.com/OISF/suricata/blob/main/suricata.yaml.in). Incompatible with the layer 2 packet capture modes (af-packet, af-xdp, dpdk). Requires a queue rule in the firewall.
+      '';
+    };
+
     "pcap" = mkOption {
       type =
         with types;

--- a/nixos/modules/services/networking/suricata/settings.nix
+++ b/nixos/modules/services/networking/suricata/settings.nix
@@ -150,7 +150,7 @@ in
             };
 
             port-groups = mkOption {
-              type = with types; nullOr (attrsOf str);
+              type = types.nullOr (types.attrsOf types.str);
               default = {
                 HTTP_PORTS = "80";
                 SHELLCODE_PORTS = "!80";
@@ -178,9 +178,8 @@ in
     };
 
     stats = mkOption {
-      type =
-        with types;
-        nullOr (submodule {
+      type = types.nullOr (
+        types.submodule {
           options = {
             enable = mkEnableOption "suricata global stats";
 
@@ -218,7 +217,8 @@ in
               '';
             };
           };
-        });
+        }
+      );
       default = null; # do not add to config unless specified
       description = ''
         Engine statistics such as packet counters, memory use counters and others can be logged in several ways. A separate text log 'stats.log' and an EVE record type 'stats' are enabled by default.
@@ -226,7 +226,7 @@ in
     };
 
     plugins = mkOption {
-      type = with types; nullOr (listOf path);
+      type = types.nullOr (types.listOf types.path);
       default = null;
       description = ''
         Plugins -- Experimental -- specify the filename for each plugin shared object.
@@ -234,18 +234,18 @@ in
     };
 
     outputs = mkOption {
-      type =
-        with types;
-        nullOr (
-          listOf (
-            attrsOf (submodule {
+      type = types.nullOr (
+        types.listOf (
+          types.attrsOf (
+            types.submodule {
               freeformType = yaml.type;
               options = {
                 enabled = mkEnableOption "<NAME>";
               };
-            })
+            }
           )
-        );
+        )
+      );
       default = null;
       example = literalExpression ''
         [
@@ -422,10 +422,9 @@ in
     };
 
     "af-packet" = mkOption {
-      type =
-        with types;
-        nullOr (
-          listOf (submodule {
+      type = types.nullOr (
+        types.listOf (
+          types.submodule {
             freeformType = yaml.type;
             options = {
               interface = mkOption {
@@ -436,8 +435,9 @@ in
                 '';
               };
             };
-          })
-        );
+          }
+        )
+      );
       default = null;
       description = ''
         Linux high speed capture support.
@@ -445,10 +445,9 @@ in
     };
 
     "af-xdp" = mkOption {
-      type =
-        with types;
-        nullOr (
-          listOf (submodule {
+      type = types.nullOr (
+        types.listOf (
+          types.submodule {
             freeformType = yaml.type;
             options = {
               interface = mkOption {
@@ -459,8 +458,9 @@ in
                 '';
               };
             };
-          })
-        );
+          }
+        )
+      );
       default = null;
       description = ''
         Linux high speed af-xdp capture support, see
@@ -469,22 +469,20 @@ in
     };
 
     "dpdk" = mkOption {
-      type =
-        with types;
-        nullOr (submodule {
+      type = types.nullOr (
+        types.submodule {
           options = {
             eal-params.proc-type = mkOption {
-              type = with types; nullOr str;
+              type = types.nullOr types.str;
               default = null;
               description = ''
                 dpdk eal-params.proc-type, see [data plane development kit docs](https://doc.dpdk.org/guides/linux_gsg/linux_eal_parameters.html#multiprocessing-related-options).
               '';
             };
             interfaces = mkOption {
-              type =
-                with types;
-                nullOr (
-                  listOf (submodule {
+              type = types.nullOr (
+                types.listOf (
+                  types.submodule {
                     freeformType = yaml.type;
                     options = {
                       interface = mkOption {
@@ -495,15 +493,17 @@ in
                         '';
                       };
                     };
-                  })
-                );
+                  }
+                )
+              );
               default = null;
               description = ''
                 See upstream docs: [docs/capture-hardware/dpdk](https://docs.suricata.io/en/suricata-7.0.7/capture-hardware/dpdk.html) and [docs/configuration/suricata-yaml.html#data-plane-development-kit-dpdk](https://docs.suricata.io/en/suricata-7.0.7/configuration/suricata-yaml.html#data-plane-development-kit-dpdk).
               '';
             };
           };
-        });
+        }
+      );
       default = null;
       description = ''
         Data Plane Development Kit is a framework for fast packet processing in data plane applications running on a wide variety of CPU architectures. DPDK's Environment Abstraction Layer (EAL) provides a generic interface to low-level resources. It is a unique way how DPDK libraries access NICs. EAL creates an API for an application to access NIC resources from the userspace level. In DPDK, packets are not retrieved via interrupt handling. Instead, the application polls the NIC for newly received packets.
@@ -515,9 +515,8 @@ in
 
     # set defaults according to upstream suricata.yaml.in
     "nfq" = mkOption {
-      type =
-        with types;
-        nullOr (submodule {
+      type = types.nullOr (
+        types.submodule {
           options = {
             mode = mkOption {
               type = types.enum [
@@ -569,7 +568,8 @@ in
               description = "Whether to accept packets if Suricata is not able to keep pace.";
             };
           };
-        });
+        }
+      );
       default = null;
       description = ''
         NFQUEUE settings, see [upstream docs](https://docs.suricata.io/en/latest/configuration/suricata-yaml.html#nfq) and [upstream defaults](https://github.com/OISF/suricata/blob/main/suricata.yaml.in). Incompatible with the layer 2 packet capture modes (af-packet, af-xdp, dpdk). Requires a queue rule in the firewall.
@@ -577,10 +577,9 @@ in
     };
 
     "pcap" = mkOption {
-      type =
-        with types;
-        nullOr (
-          listOf (submodule {
+      type = types.nullOr (
+        types.listOf (
+          types.submodule {
             freeformType = yaml.type;
             options = {
               interface = mkOption {
@@ -591,8 +590,9 @@ in
                 '';
               };
             };
-          })
-        );
+          }
+        )
+      );
       default = null;
       description = ''
         Cross platform libpcap capture support.
@@ -617,9 +617,8 @@ in
     };
 
     "app-layer" = mkOption {
-      type =
-        with types;
-        nullOr (submodule {
+      type = types.nullOr (
+        types.submodule {
           options = {
             "error-policy" = mkOption {
               type = types.enum [
@@ -639,10 +638,9 @@ in
               '';
             };
             protocols = mkOption {
-              type =
-                with types;
-                nullOr (
-                  attrsOf (submodule {
+              type = types.nullOr (
+                types.attrsOf (
+                  types.submodule {
                     freeformType = yaml.type;
                     options = {
                       enabled = mkOption {
@@ -659,15 +657,17 @@ in
                         '';
                       };
                     };
-                  })
-                );
+                  }
+                )
+              );
               default = null;
               description = ''
                 app-layer protocols, see [upstream docs](https://docs.suricata.io/en/latest/rules/app-layer.html).
               '';
             };
           };
-        });
+        }
+      );
       default = null; # do not add to config unless specified
       description = ''
         app-layer configuration, see [upstream docs](https://docs.suricata.io/en/latest/rules/app-layer.html).
@@ -703,9 +703,8 @@ in
     };
 
     "unix-command" = mkOption {
-      type =
-        with types;
-        nullOr (submodule {
+      type = types.nullOr (
+        types.submodule {
           options = {
             enabled = mkOption {
               type = types.either types.bool (types.enum [ "auto" ]);
@@ -722,7 +721,8 @@ in
               '';
             };
           };
-        });
+        }
+      );
       default = { };
       description = ''
         Unix command socket that can be used to pass commands to Suricata.
@@ -791,7 +791,7 @@ in
     };
 
     includes = mkOption {
-      type = with types; nullOr (listOf path);
+      type = types.nullOr (types.listOf types.path);
       default = null;
       description = ''
         Files to include in the suricata configuration. See

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1556,7 +1556,7 @@ in
   sudo = runTest ./sudo.nix;
   sudo-rs = runTest ./sudo-rs.nix;
   sunshine = runTest ./sunshine.nix;
-  suricata = runTest ./suricata.nix;
+  suricata = import ./suricata { inherit runTest; };
   suwayomi-server = import ./suwayomi-server.nix {
     inherit runTest;
     inherit (pkgs) lib;

--- a/nixos/tests/suricata/af-packet.nix
+++ b/nixos/tests/suricata/af-packet.nix
@@ -1,0 +1,32 @@
+{ lib, pkgs, ... }:
+{
+  name = "afPacket";
+  meta.maintainers = with lib.maintainers; [ felbinger ];
+
+  imports = [ ./common.nix ];
+
+  nodes = {
+    ids = {
+      services.suricata = {
+        settings.af-packet = [ { interface = "eth1"; } ];
+      };
+    };
+  };
+
+  testScript = ''
+    start_all()
+
+    # check that configuration has been applied correctly with suricatasc
+    with subtest("suricata configuration test"):
+        ids.wait_for_unit("suricata.service")
+        assert '1' in ids.succeed("suricatasc -c 'iface-list' | ${pkgs.jq}/bin/jq .message.count")
+
+    # test detection of events based on a static ruleset (output of id command)
+    with subtest("suricata rule test"):
+        helper.wait_for_unit("nginx.service")
+        ids.wait_for_unit("suricata.service")
+
+        ids.succeed("curl http://192.168.1.1/id/")
+        assert "id check returned root [**] [Classification: Potentially Bad Traffic]" in ids.succeed("tail -n 1 /var/log/suricata/fast.log"), "Suricata didn't detect the output of id comment"
+  '';
+}

--- a/nixos/tests/suricata/af-packet.nix
+++ b/nixos/tests/suricata/af-packet.nix
@@ -19,7 +19,7 @@
     # check that configuration has been applied correctly with suricatasc
     with subtest("suricata configuration test"):
         ids.wait_for_unit("suricata.service")
-        assert '1' in ids.succeed("suricatasc -c 'iface-list' | ${pkgs.jq}/bin/jq .message.count")
+        assert '1' in ids.wait_until_succeeds("suricatasc -c 'iface-list' | ${pkgs.jq}/bin/jq .message.count", timeout=5)
 
     # test detection of events based on a static ruleset (output of id command)
     with subtest("suricata rule test"):

--- a/nixos/tests/suricata/common.nix
+++ b/nixos/tests/suricata/common.nix
@@ -1,7 +1,7 @@
 { lib, pkgs, ... }:
 {
-  name = "suricata";
-  meta.maintainers = with lib.maintainers; [ felbinger ];
+  # shared configuration module for suricata tests. it not a NixOS test by itself.
+  meta.maintainers= with lib.maintainers; [ felbinger ];
 
   nodes = {
     ids = {
@@ -27,7 +27,6 @@
           vars.address-groups.HOME_NET = "192.168.1.0/24";
           unix-command.enabled = true;
           outputs = [ { fast.enabled = true; } ];
-          af-packet = [ { interface = "eth1"; } ];
           classification-file = "${pkgs.suricata}/etc/suricata/classification.config";
         };
       };
@@ -38,7 +37,7 @@
       ];
     };
     helper = {
-      imports = [ ../modules/profiles/minimal.nix ];
+      imports = [ ../../modules/profiles/minimal.nix ];
 
       networking.interfaces.eth1 = {
         useDHCP = false;
@@ -59,21 +58,4 @@
       networking.firewall.allowedTCPPorts = [ 80 ];
     };
   };
-
-  testScript = ''
-    start_all()
-
-    # check that configuration has been applied correctly with suricatasc
-    with subtest("suricata configuration test"):
-        ids.wait_for_unit("suricata.service")
-        assert '1' in ids.succeed("suricatasc -c 'iface-list' | ${pkgs.jq}/bin/jq .message.count")
-
-    # test detection of events based on a static ruleset (output of id command)
-    with subtest("suricata rule test"):
-        helper.wait_for_unit("nginx.service")
-        ids.wait_for_unit("suricata.service")
-
-        ids.succeed("curl http://192.168.1.1/id/")
-        assert "id check returned root [**] [Classification: Potentially Bad Traffic]" in ids.succeed("tail -n 1 /var/log/suricata/fast.log"), "Suricata didn't detect the output of id comment"
-  '';
 }

--- a/nixos/tests/suricata/common.nix
+++ b/nixos/tests/suricata/common.nix
@@ -1,7 +1,7 @@
 { lib, pkgs, ... }:
 {
   # shared configuration module for suricata tests. it not a NixOS test by itself.
-  meta.maintainers= with lib.maintainers; [ felbinger ];
+  meta.maintainers = with lib.maintainers; [ felbinger ];
 
   nodes = {
     ids = {

--- a/nixos/tests/suricata/default.nix
+++ b/nixos/tests/suricata/default.nix
@@ -1,0 +1,5 @@
+{ runTest, ... }:
+{
+  afPacket = runTest ./af-packet.nix;
+  nfqueue = runTest ./nfqueue.nix;
+}

--- a/nixos/tests/suricata/nfqueue.nix
+++ b/nixos/tests/suricata/nfqueue.nix
@@ -1,0 +1,52 @@
+{ lib, pkgs, ... }:
+{
+  name = "nfqueue";
+  meta.maintainers = with lib.maintainers; [ felbinger ];
+
+  imports = [ ./common.nix ];
+
+  nodes = {
+    ids = {
+      # need to put an early queue statement for suricata, so use a custom firewall.
+      networking.nftables.enable = true;
+      networking.nftables.tables.nixos-fw.enable = false;
+      networking.nftables.ruleset = ''
+        table inet default {
+          chain input {
+            type filter hook input priority filter;
+            queue flags fanout to 100 - 103
+          }
+          chain output {
+            type filter hook output priority filter;
+            queue flags fanout to 100 - 103
+          }
+        }
+      '';
+      services.suricata = {
+        enable = true;
+        netfilterQueues = [ 100 101 102 103 ];
+        settings.nfq = {
+          mode = "accept";
+          fail-open = true;
+        };
+      };
+    };
+  };
+
+  testScript = ''
+    start_all()
+
+    # check that configuration has been applied correctly with suricatasc
+    with subtest("suricata configuration test"):
+        ids.wait_for_unit("suricata.service")
+        assert '4' in ids.wait_until_succeeds("suricatasc -c 'iface-list' | ${pkgs.jq}/bin/jq .message.count", timeout=5)
+
+    # test detection of events based on a static ruleset (output of id command)
+    with subtest("suricata rule test"):
+        helper.wait_for_unit("nginx.service")
+        ids.wait_for_unit("suricata.service")
+
+        ids.succeed("curl http://192.168.1.1/id/")
+        assert "id check returned root [**] [Classification: Potentially Bad Traffic]" in ids.succeed("tail -n 1 /var/log/suricata/fast.log"), "Suricata didn't detect the output of id comment"
+  '';
+}

--- a/nixos/tests/suricata/nfqueue.nix
+++ b/nixos/tests/suricata/nfqueue.nix
@@ -24,7 +24,12 @@
       '';
       services.suricata = {
         enable = true;
-        netfilterQueues = [ 100 101 102 103 ];
+        netfilterQueues = [
+          100
+          101
+          102
+          103
+        ];
         settings.nfq = {
           mode = "accept";
           fail-open = true;


### PR DESCRIPTION
Added NFQUEUE-related options to Suricata module with accompanying NixOS test. Suricata supports several packet capture modes, many of which are configurable through this module. However, there are no options for NFQUEUE mode. NFQUEUE mode allows iptables/nftables to forward packets to Suricata.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
