### PR TITLE
icm: init at 0.10.49

### DIFF
--- a/pkgs/by-name/ic/icm/package.nix
+++ b/pkgs/by-name/ic/icm/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  nix-update-script,
+  onnxruntime,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "icm";
+  version = "0.10.49";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "rtk-ai";
+    repo = "icm";
+    tag = "icm-v${finalAttrs.version}";
+    hash = "sha256-GB2SH/Y2l4AkxoFqJfWcsGmWK4uOayCs1FSxBuXShwc=";
+  };
+
+  cargoHash = "sha256-U0mHWzRI6BDVC4LRpwWz/QbCeT0fEPxKoY5+1DrI048=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    onnxruntime
+  ];
+
+  # Build the HTTP dashboard
+  buildFeatures = [ "web" ];
+
+  env = {
+    # Use system OpenSSL instead of vendoring it
+    OPENSSL_NO_VENDOR = "1";
+    # Point ort (ONNX Runtime bindings) at the system library
+    ORT_STRATEGY = "system";
+    ORT_LIB_LOCATION = "${lib.getLib onnxruntime}/lib";
+  };
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^icm-(.*)"
+    ];
+  };
+
+  meta = {
+    description = "Permanent memory system for AI agents with MCP integration";
+    homepage = "https://github.com/rtk-ai/icm";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jpds ];
+    mainProgram = "icm";
+    platforms = lib.platforms.unix;
+    broken = stdenv.hostPlatform.isDarwin;
+  };
+})


### PR DESCRIPTION
https://github.com/rtk-ai/icm

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
