### PR TITLE
stdenv: linux: simplify bootstrap by inheriting per-stage packages

### DIFF
--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -344,6 +344,7 @@ in
           perl
           patchelf
           nukeReferences
+          libxcrypt
           ;
         ${localSystem.libc} = prevStage.${localSystem.libc};
         gmp = super.gmp.override { cxx = false; };
@@ -460,6 +461,7 @@ in
           which
           nukeReferences
           autoconf269
+          libxcrypt
           ;
 
         # Avoids infinite recursion, as this is in the build-time dependencies of libc.

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -343,6 +343,7 @@ in
           gnum4
           perl
           patchelf
+          nukeReferences
           ;
         ${localSystem.libc} = prevStage.${localSystem.libc};
         gmp = super.gmp.override { cxx = false; };
@@ -457,6 +458,7 @@ in
           bison
           texinfo
           which
+          nukeReferences
           ;
 
         # Avoids infinite recursion, as this is in the build-time dependencies of libc.
@@ -565,6 +567,7 @@ in
             libidn2
             libunistring
             libxcrypt
+            nukeReferences
             ;
           # We build a special copy of libgmp which doesn't use libstdc++, because
           # xgcc++'s libstdc++ references the bootstrap-files (which is what

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -283,11 +283,7 @@ in
     stageFun prevStage {
       name = "bootstrap-stage1";
 
-      # Rebuild binutils to use from stage2 onwards.
       overrides = self: super: {
-        binutils-unwrapped = super.binutils-unwrapped.override {
-          enableGold = false;
-        };
         inherit (prevStage)
           ccWrapperStdenv
           gcc-unwrapped

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -459,6 +459,7 @@ in
           texinfo
           which
           nukeReferences
+          autoconf269
           ;
 
         # Avoids infinite recursion, as this is in the build-time dependencies of libc.
@@ -568,6 +569,7 @@ in
             libunistring
             libxcrypt
             nukeReferences
+            autoconf269
             ;
           # We build a special copy of libgmp which doesn't use libstdc++, because
           # xgcc++'s libstdc++ references the bootstrap-files (which is what

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -458,9 +458,6 @@ in
           texinfo
           which
           ;
-        dejagnu = super.dejagnu.overrideAttrs (a: {
-          doCheck = false;
-        });
 
         # Avoids infinite recursion, as this is in the build-time dependencies of libc.
         libiconv = self.libcIconv prevStage.libc;

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -570,6 +570,7 @@ in
             libxcrypt
             nukeReferences
             autoconf269
+            python3Minimal
             ;
           # We build a special copy of libgmp which doesn't use libstdc++, because
           # xgcc++'s libstdc++ references the bootstrap-files (which is what
@@ -634,6 +635,7 @@ in
           linuxHeaders
           libidn2
           libunistring
+          python3Minimal
           ;
         ${localSystem.libc} = prevStage.${localSystem.libc};
         # Since this is the first fresh build of binutils since stage2, our own runtimeShell will be used.

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -181,7 +181,13 @@ let
         buildPlatform = localSystem;
         hostPlatform = localSystem;
         targetPlatform = localSystem;
-        inherit extraNativeBuildInputs;
+        # Every real (post-dummy) stage needs this hook so configure scripts
+        # can recognise architectures (LoongArch, RISC-V, etc.).
+        extraNativeBuildInputs =
+          extraNativeBuildInputs
+          ++ lib.optional (
+            prevStage ? updateAutotoolsGnuConfigScriptsHook
+          ) prevStage.updateAutotoolsGnuConfigScriptsHook;
         inherit (stage0) initialPath;
         preHook = ''
           # Don't patch #!/interpreter because it leads to retained
@@ -311,9 +317,6 @@ in
           };
         });
       };
-
-      # `gettext` comes with obsolete config.sub/config.guess that don't recognize LoongArch64.
-      extraNativeBuildInputs = [ prevStage.updateAutotoolsGnuConfigScriptsHook ];
     }
   )
 
@@ -427,9 +430,6 @@ in
               '';
             });
       };
-
-      # `gettext` comes with obsolete config.sub/config.guess that don't recognize LoongArch64.
-      extraNativeBuildInputs = [ prevStage.updateAutotoolsGnuConfigScriptsHook ];
     }
   )
 
@@ -531,10 +531,6 @@ in
         );
 
       };
-
-      # `gettext` comes with obsolete config.sub/config.guess that don't recognize LoongArch64.
-      # `libtool` comes with obsolete config.sub/config.guess that don't recognize Risc-V.
-      extraNativeBuildInputs = [ prevStage.updateAutotoolsGnuConfigScriptsHook ];
     }
   )
 
@@ -605,8 +601,6 @@ in
         };
       extraNativeBuildInputs = [
         prevStage.patchelf
-        # Many tarballs come with obsolete config.sub/config.guess that don't recognize aarch64.
-        prevStage.updateAutotoolsGnuConfigScriptsHook
       ];
     }
   )
@@ -671,8 +665,6 @@ in
       extraNativeBuildInputs = [
         prevStage.patchelf
         prevStage.xz
-        # Many tarballs come with obsolete config.sub/config.guess that don't recognize aarch64.
-        prevStage.updateAutotoolsGnuConfigScriptsHook
       ];
     }
   )


### PR DESCRIPTION
# Summary 

(Asstisted-by: Claude code with opus 4.7)

The Linux stdenv bootstrap (`pkgs/stdenv/linux/default.nix`) drives six chained stages — stage0 → stage1 → xgcc → stage2 → stage3 → stage4 → final stdenv. A handful of build-only tools were rebuilt at every stage even when the previous stage's output was already usable as a build input. This PR routes those packages through `inherit` instead of rebuilding them, and drops two stale overrides.

## Commits

All 7 commits touch only `pkgs/stdenv/linux/default.nix`:

| # | Commit | Effect |
|---|---|---|
| 1 | centralise `updateAutotoolsGnuConfigScriptsHook` in `stageFun` | Hook was being threaded through five per-stage `extraNativeBuildInputs` lists; wired once. |
| 2 | drop dead `enableGold = false` override from stage1 | Override predates binutils-gold being on by default in the bootstrap binutils. |
| 3 | drop dead `dejagnu.doCheck = false` override from stage2 | dejagnu isn't reachable from stage2's package set. |
| 4 | inherit `nukeReferences` through xgcc/stage2/stage3 | Build-only ref-scrubbing tool; outputs never reach final closure. |
| 5 | inherit `autoconf269` at stage2/stage3 | Build-only configure-regen tool. |
| 6 | inherit `python3Minimal` at stage3/stage4 | Build-only python interpreter; used by meson/glib helpers. |
| 7 | inherit `libxcrypt` at xgcc/stage2 | Build-only library; not transitively linked into final stdenv. |

Each commit is independently revertable and preserves the per-stage `isFromBootstrapFiles` / `isBuiltByNixpkgsCompiler` assertion ladder.

## Effect

Closure of the stdenv `.drv` on x86_64-linux: **918 → 908 derivations (-10)**.

| Package | staging | HEAD | Δ |
|---|---|---|---|
| `nuke-refs` | 4 | 1 | -3 |
| `autoconf-2.69` | 2 | 1 | -1 |
| `python3-minimal` | 2 | 1 | -1 |
| `libxcrypt` | 3 | 2 | -1 |
| **Direct subtotal** | | | **-6** |
| Transitive (deduplicated build-deps of the above) | | | -4 |

## Safety contract

The constraint that drove which inheritances are safe: a package can be inherited forward only if (a) its `out` doesn't appear in the final stdenv runtime closure (`disallowedRequisites` check), and (b) its functionality at later stages doesn't depend on full nixpkgs-glibc-linked iconv/locale support. All four inherited packages satisfy both.

Multi-stage rebuilds that look inheritable but **are not**, deliberately excluded:

- `gettext`, `texinfo` — built at stage 1 against bootstrap-stage-0 libc, which lacks full iconv (no gconv modules / no UTF-8 ↔ ISO-8859-1 conversion). Master rebuilds these at stage 3 specifically so `msgfmt` / `makeinfo` can convert charsets against full nixpkgs glibc. Inheriting them forward causes stage 3 GCC's libstdc++ `.po` compilation to fail.
- `bashNonInteractive`, `gnu-config`, `expand-response-params`, `updateAutotoolsGnuConfigScriptsHook` — present in the final stdenv runtime closure; the intermediate rebuilds at stage 2/3/4 exist to scrub bootstrap-tools references that survive via `dontPatchShebangs=1`.

## What changes vs what doesn't

**Eval-time inputs to each final-stdenv package are identical** to staging — same compiler version, same `configureFlags`, same `NIX_CFLAGS_COMPILE`, same hardening flags. Only intermediate-stage derivation hashes change.

**Cross-compilation**: `pkgsCross.*.buildPackages` shares the native Linux stdenv chain, so cross builds will see the same kind of input-hash drift as native. Target-side chains (cross GCC/glibc/binutils) are not directly modified.

Follow-up filed as a separate staging PR:

- #519967 — distinguish `stdenvNoCC`'s derivation name from `stdenv`'s

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested:
   - [x] nix-build -A hello
   - [x] nix-build -A pkgsCross.musl64.hello