### PR TITLE
stdenv: linux: enable 3-stage internal bootstrap for final-stage GCC

### DIFF
--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -14,6 +14,7 @@
   langGo ? false,
   reproducibleBuild ? true,
   profiledCompiler ? false,
+  disableBootstrap ? !stdenv.hostPlatform.isDarwin && !profiledCompiler,
   langJit ? false,
   langRust ? false,
   cargo,
@@ -95,8 +96,6 @@ let
   #   "14.2.1.20250322" -> "14.2.1"
   #   "14.2.0" -> "14.2.0"
   baseVersion = lib.concatStringsSep "." (lib.take 3 (lib.splitVersion version));
-
-  disableBootstrap = !stdenv.hostPlatform.isDarwin && !profiledCompiler;
 
   inherit (stdenv) buildPlatform hostPlatform targetPlatform;
   targetConfig = if (!hostIsTarget) then targetPlatform.config else null;

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -587,6 +587,8 @@ in
               commonGccOverrides
               // {
                 inherit (prevStage) which;
+                # Self-emit libgcc/libstdc++; otherwise the final stdenv links xgcc-emitted ones.
+                disableBootstrap = false;
               }
             )).overrideAttrs
               (a: {


### PR DESCRIPTION
## Summary

Enables GCC's internal 3-stage bootstrap (\`--enable-bootstrap\`) for the GCC built in stage 3 of the Linux stdenv. As a result, the libgcc/libstdc++ shipped in the final stdenv are emitted by the final compiler itself rather than by xgcc.

This is structurally two commits:
1. \`gcc: expose disableBootstrap as overridable argument\` — pure refactor, promotes the existing \`let\`-binding to a function argument with the same default expression. No call-site behaviour change.
2. \`stdenv: linux: enable 3-stage bootstrap for final-stage GCC\` — sets \`disableBootstrap = false\` in stage 3's GCC override.

## Why

On master, every binary in the final stdenv links a libgcc emitted by **xgcc** — the throwaway compiler built early in the bootstrap by bootstrap-tools' GCC. With this change, libgcc/libstdc++ are emitted by the **final** GCC after it has compiled itself twice and verified the two outputs are byte-identical (GCC's \`stage2 === stage3\` reproducibility self-check).

- **Purity:** final stdenv stops carrying compilation products of a throwaway compiler.
- **Codegen:** the libgcc/libstdc++ in the closure are emitted by a self-compiled GCC instead of by a compiler that was itself emitted under reproducibility constraints by bootstrap-tools GCC. Modest but real improvement for everyone linking against libstdc++.
- **Reproducibility:** GCC's own \`stage2 === stage3\` byte-equality check now runs on every bootstrap. Catches a class of miscompilation bugs in xgcc that would otherwise silently ship.
- **Unlocks PGO:** \`profiledCompiler = true\` requires \`!disableBootstrap\`. On master the arg was a \`let\`-binding so even overriding it didn't take effect. After this PR, PGO becomes a flip-of-a-switch.

## Cost

- **Stage 3 GCC build time:**: GCC now builds three times sequentially. 
- **Memory pressure during stage 3 build:** ~2x peak.

## What does NOT change

- GCC version (still 15.2.0).
- glibc, binutils, kernel headers — they're built by xgcc on master and still by xgcc here (unchanged).
- Cross-compilation (\`pkgsCross.*\` doesn't use this stdenv chain).
- Darwin (excluded by the default expression: \`disableBootstrap ? !isDarwin && !profiledCompiler\`).
- Any package's configure flags or hardening settings.

## Test plan

- [x] \`nix-instantiate --eval --strict -A stdenv\` succeeds
- [x] gcc-unwrapped's \`configureFlags\` no longer contains \`--disable-bootstrap\`
- [ ] \`nix-build -A stdenv\` end-to-end
- [ ] \`nix-build pkgs/stdenv/linux/test-bootstrap-tools.nix\`
- [ ] Final stdenv binaries link a libgcc that is **not** in \`xgcc\`'s store path