### PR TITLE
stdenv: distinguish stdenvNoCC name from stdenv

### DIFF
--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -55,6 +55,7 @@ in
   # `stdenv` without a C compiler. Passing in this helps avoid infinite
   # recursions, and may eventually replace passing in the full stdenv.
   stdenvNoCC ? stdenv.override {
+    name = "${stdenv.name}-no-cc";
     cc = null;
     hasCC = false;
     # Darwin doesn’t need an SDK in `stdenvNoCC`.  Dropping it shrinks the closure


### PR DESCRIPTION
## Summary (Co-authored by claude-code)

The default `stdenvNoCC` is constructed via `stdenv.override { cc = null; hasCC = false; }` in `pkgs/top-level/stage.nix`. It inherited the parent stdenv's `name` attribute verbatim, so every bootstrap stage produced two derivations with identical names — one with a C compiler, one without.

This PR appends `-no-cc` to the overridden stdenv's name, so each stage's stdenv/stdenvNoCC pair is uniquely identifiable in store paths and graph traces.

## Why

When debugging the bootstrap, listing `nix-store -q --requisites $(nix-instantiate -A stdenv)` produced output like:

```
bootstrap-stage4-stdenv-linux.drv  (cc-bearing)
bootstrap-stage4-stdenv-linux.drv  (cc-less)   ← same name, different hash
```

Diagnosing which derivation in a closure-pollution report is the CC-bearing variant required inspecting the store-path hash by hand. With this change:

```
bootstrap-stage4-stdenv-linux.drv
bootstrap-stage4-stdenv-linux-no-cc.drv
```

## Backward compatibility

Searched all of `pkgs/` and `lib/` for `stdenv.name` and `stdenvNoCC.name` references. The only consumers compare against specific known names (`bootstrap-stage0-stdenv-darwin`, `stdenv-linux`); none assume stdenv and stdenvNoCC share a name. Safe.

## Cost

Mass rebuild. `stdenvNoCC`'s derivation hash changes, so every package built with `stdenvNoCC.mkDerivation` gets a new build input → rebuilt. The content of those derivations is unchanged; only their stdenv-input's name attribute differs. This is why the PR targets staging.

## Test plan

- [x] `pkgs.stdenv.name == "stdenv-linux"` (unchanged)
- [x] `pkgs.stdenvNoCC.name == "stdenv-linux-no-cc"` (was "stdenv-linux")
- [x] `nix-instantiate --eval --strict -A stdenv` succeeds
- [x] `nix-build -A stdenv` end-to-end