### PR TITLE
chainctl: init at 0.2.260

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5337,6 +5337,11 @@
     githubId = 118829;
     name = "codec";
   };
+  CodeCorrupt = {
+    github = "CodeCorrupt";
+    githubId = 8364947;
+    name = "Tyler Hoyt";
+  };
   CodedNil = {
     github = "CodedNil";
     githubId = 5075747;

--- a/pkgs/by-name/ch/chainctl/package.nix
+++ b/pkgs/by-name/ch/chainctl/package.nix
@@ -1,0 +1,89 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  installShellFiles,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "chainctl";
+  version = "0.2.260";
+
+  # Upstream installer: https://edu.chainguard.dev/chainguard/chainctl-usage/how-to-install-chainctl/
+  src =
+    finalAttrs.passthru.sources.${stdenvNoCC.hostPlatform.system}
+      or (throw "chainctl: no binary available for ${stdenvNoCC.hostPlatform.system}");
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [
+    installShellFiles
+    writableTmpDirAsHomeHook
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm0755 "$src" "$out/bin/chainctl"
+
+    # chainctl inspects argv[0] and acts as a Docker credential helper when
+    # invoked as "docker-credential-cgr".
+    ln -s chainctl "$out/bin/docker-credential-cgr"
+
+    runHook postInstall
+  '';
+
+  postInstall = lib.optionalString (stdenvNoCC.buildPlatform.canExecute stdenvNoCC.hostPlatform) ''
+    installShellCompletion --cmd chainctl \
+      --bash <($out/bin/chainctl completion bash) \
+      --fish <($out/bin/chainctl completion fish) \
+      --zsh  <($out/bin/chainctl completion zsh)
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckKeepEnvironment = [ "HOME" ];
+  versionCheckProgramArg = "version";
+
+  passthru = {
+    sources =
+      let
+        base = "https://dl.enforce.dev/chainctl/${finalAttrs.version}";
+      in
+      {
+        x86_64-linux = fetchurl {
+          url = "${base}/chainctl_linux_x86_64";
+          hash = "sha256-fkKzm40mFEFkPI6fUi5vgziJ9N6BO34cEX28+Yf3tbQ=";
+        };
+        aarch64-linux = fetchurl {
+          url = "${base}/chainctl_linux_arm64";
+          hash = "sha256-X0ytQUKEGbVaalklXzYjIBd7cBEOtFyi6OSPZONPRGk=";
+        };
+        x86_64-darwin = fetchurl {
+          url = "${base}/chainctl_darwin_x86_64";
+          hash = "sha256-cqwAHw/DpC50hvQqSF+Y1l1iEmltNeWDfbMqmMpwS1g=";
+        };
+        aarch64-darwin = fetchurl {
+          url = "${base}/chainctl_darwin_arm64";
+          hash = "sha256-A1zWFvnqbQ/2F9deIttu4MHGRxLHuYHpWYo6LCeuxMU=";
+        };
+      };
+
+    updateScript = ./update.sh;
+  };
+
+  meta = {
+    description = "Command-line interface for the Chainguard platform";
+    homepage = "https://edu.chainguard.dev/chainguard/chainctl/";
+    downloadPage = "https://dl.enforce.dev/chainctl/";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ CodeCorrupt ];
+    mainProgram = "chainctl";
+    platforms = lib.attrNames finalAttrs.passthru.sources;
+  };
+})

--- a/pkgs/by-name/ch/chainctl/update.sh
+++ b/pkgs/by-name/ch/chainctl/update.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq common-updater-scripts
+# shellcheck shell=bash
+
+set -euo pipefail
+
+VERSION="$(curl -fsSL https://dl.enforce.dev/chainctl/latest/metadata.json | jq -r .version)"
+echo "chainctl: latest upstream version is $VERSION"
+
+# --ignore-same-version: after the first iteration the version is already
+# current; subsequent calls only need to refresh the per-platform hash.
+for platform in \
+  x86_64-linux \
+  aarch64-linux \
+  x86_64-darwin \
+  aarch64-darwin; do
+  echo "chainctl: updating $platform"
+  update-source-version chainctl "$VERSION" \
+    --source-key="sources.${platform}" \
+    --ignore-same-version
+done
+
+echo "chainctl: done"


### PR DESCRIPTION
Add a new package for [Chainguard](https://www.chainguard.dev/)'s CLI tool `chainctl`.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
