### PR TITLE
plezy: add opt-in workaround for aarch64-linux 16K page size bug

### DIFF
--- a/pkgs/by-name/pl/plezy/16k-font-workaround.patch
+++ b/pkgs/by-name/pl/plezy/16k-font-workaround.patch
@@ -1,0 +1,35 @@
+diff --git a/lib/theme/mono_theme.dart b/lib/theme/mono_theme.dart
+index b423b4c6..04834360 100644
+--- a/lib/theme/mono_theme.dart
++++ b/lib/theme/mono_theme.dart
+@@ -42,7 +42,7 @@ ThemeData monoTheme({required bool dark, bool oled = false}) {
+   );
+ 
+   final base = ThemeData(
+-    useMaterial3: true,
++    useMaterial3: true, fontFamily: 'NotoSans',
+     brightness: isDark ? Brightness.dark : Brightness.light,
+     colorScheme: ColorScheme(
+       brightness: isDark ? Brightness.dark : Brightness.light,
+@@ -85,7 +85,7 @@ ThemeData monoTheme({required bool dark, bool oled = false}) {
+       titleTextStyle: TextStyle(color: c.text, fontSize: 18, fontWeight: FontWeight.w700, letterSpacing: -0.2),
+     ),
+     textTheme: Typography.englishLike2021
+-        .apply(bodyColor: c.text, displayColor: c.text)
++        .apply(fontFamily: 'NotoSans', bodyColor: c.text, displayColor: c.text)
+         .copyWith(
+           displayLarge: const TextStyle(fontWeight: FontWeight.w700, letterSpacing: -0.5),
+           titleMedium: const TextStyle(fontWeight: FontWeight.w600),
+diff --git a/pubspec.yaml b/pubspec.yaml
+index 8de9f2e3..5b6f1f14 100644
+--- a/pubspec.yaml
++++ b/pubspec.yaml
+@@ -142,3 +142,8 @@ flutter:
+     - assets/shaders/anime4k/
+     - assets/player_icons/
+     - assets/rating_icons/
++
++  fonts:
++    - family: NotoSans
++      fonts:
++        - asset: assets/fonts/NotoSans.ttc

--- a/pkgs/by-name/pl/plezy/package.nix
+++ b/pkgs/by-name/pl/plezy/package.nix
@@ -21,6 +21,8 @@
   _7zz,
   makeBinaryWrapper,
   runCommand,
+  noto-fonts-cjk-sans ? null,
+  use16kPagesizeWorkaround ? false,
 }:
 
 let
@@ -73,7 +75,12 @@ let
     # Upstream uses a sentry-dart fork that fetches sentry-native as a zip instead of via
     # git clone. The PR was merged and reverted upstream (getsentry/sentry-dart#3630), so
     # we use upstream since theres no actual meaningful difference
-    patches = [ ./replace-sentry-fork.patch ];
+    patches = [
+      ./replace-sentry-fork.patch
+    ]
+    ++ lib.optionals use16kPagesizeWorkaround [
+      ./16k-font-workaround.patch
+    ];
 
     nativeBuildInputs = [
       pkg-config
@@ -102,6 +109,12 @@ let
       substituteInPlace linux/CMakeLists.txt \
         --replace-fail "URL https://github.com/simdutf/simdutf/releases/download/v6.4.2/singleheader.zip" \
                        "URL file://${simdutf}"
+    ''
+    + lib.optionalString use16kPagesizeWorkaround ''
+      # Opt-in workaround for invisible text on aarch64-linux systems with 16K page size kernels
+      # (e.g. Asahi Linux). Text was invisible; bundling the font as a Dart asset fixed it,
+      # likely related to libflutter_linux_gtk.so being compiled with 4K page alignment only.
+      install -Dm644 ${noto-fonts-cjk-sans}/share/fonts/opentype/noto-cjk/NotoSansCJK-VF.otf.ttc assets/fonts/NotoSans.ttc
     '';
 
     desktopItems = [


### PR DESCRIPTION
Closes #512891 
Adds an opt-in use16kPagesizeWorkaround flag for Asahi Linux users experiencing invisible text. When enabled, bundles NotoSans as a Dart asset instead of relying on system font loading, which fails silently on 16K page size kernels, likely due to libflutter_linux_gtk.so being compiled with 4K page alignment only. Standard users are unaffected.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test