### PR TITLE
emilua: fix fallback allocator on aarch64-linux

### DIFF
--- a/pkgs/development/interpreters/emilua/default.nix
+++ b/pkgs/development/interpreters/emilua/default.nix
@@ -73,6 +73,19 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonOption "version_suffix" "-nixpkgs1")
   ];
 
+  patches = [
+    # https://gitlab.com/emilua/emilua/-/commit/9f3964f22b2289c98b64a1af729712a862459aeb
+    # The above commit added a fallback allocator that just calls `realloc` from
+    # libc, which is fine on x86 because Linux userspace pointers are 47 bits on
+    # x86-64 and that aligns perfectly with LuaJIT's NaN-tagging representation:
+    # https://github.com/LuaJIT/LuaJIT/issues/49
+    # But on ARM64, Linux userspace pointers are 48 bits, so libc does not
+    # provide an allocator that can be safely used for LuaJIT. To fix that, we
+    # delete the libc-based allocator and instead use LuaJIT's own default
+    # allocator as the fallback, which is what Emilua did before the regression.
+    ./use-luajit-default-allocator.patch
+  ];
+
   postPatch = ''
     patchShebangs src/emilua_gperf.awk --interpreter '${lib.getExe gawk} -f'
   '';

--- a/pkgs/development/interpreters/emilua/use-luajit-default-allocator.patch
+++ b/pkgs/development/interpreters/emilua/use-luajit-default-allocator.patch
@@ -1,0 +1,65 @@
+diff --git a/src/allocator.cpp b/src/allocator.cpp
+index cb80c99..c41ed4e 100644
+--- a/src/allocator.cpp
++++ b/src/allocator.cpp
+@@ -9,25 +9,6 @@ namespace emilua {
+ 
+ namespace interprocess = boost::interprocess;
+ 
+-static inline
+-void* do_std_alloc(void* ptr, std::size_t osize, std::size_t nsize)
+-{
+-    if (nsize == 0) {
+-        // free_sized only appeared in C23
+-        free(ptr);
+-        return nullptr;
+-    } else {
+-        // even in C23, we don't have realloc_sized() to pass osize along
+-        auto ret = realloc(ptr, nsize);
+-        if (nsize <= osize) {
+-            // According to Programming in Lua 3rd edition § 32.1 ¶ 8, Lua is
+-            // unable to recover from allocation shrinking failures.
+-            assert(ret);
+-        }
+-        return ret;
+-    }
+-}
+-
+ general_purpose_allocator::general_purpose_allocator(
+     std::shared_ptr<void> block, std::size_t block_size)
+     : block{std::move(block)}
+@@ -50,17 +31,8 @@ lua_Alloc general_purpose_allocator::get_lua_allocator()
+             ptr, osize, nsize);
+     };
+ 
+-    static constexpr auto use_c_allocator = [](
+-        void* /*ud*/, void* ptr, std::size_t osize, std::size_t nsize
+-    ) -> void* {
+-        return do_std_alloc(ptr, osize, nsize);
+-    };
+-
+-    if (allocator) {
+-        return use_boost_allocator;
+-    } else {
+-        return use_c_allocator;
+-    }
++    assert(allocator);
++    return use_boost_allocator;
+ }
+ 
+ void general_purpose_allocator::allow_reserved_zone()
+diff --git a/src/core.cpp b/src/core.cpp
+index 8cb4365..fb63706 100644
+--- a/src/core.cpp
++++ b/src/core.cpp
+@@ -183,7 +183,9 @@ vm_context::vm_context(
+     , lua_errmem(false)
+     , exit_request(false)
+     , alloc{memory_resource, memory_resource_size}
+-    , L_(lua_newstate(alloc.get_lua_allocator(), &alloc))
++    , L_(memory_resource
++         ? lua_newstate(alloc.get_lua_allocator(), &alloc)
++         : luaL_newstate())
+     , current_fiber_(nullptr)
+ {
+     if (!L_)


### PR DESCRIPTION
[![](https://hydra-banner.harinn.dev/build/329274277)](https://hydra.nixos.org/build/329274277)

ZHF: #516381

This PR fixes the `emilua` package on `aarch64-linux`, after #500410 broke it due to [a regression](https://gitlab.com/emilua/emilua/-/commit/9f3964f22b2289c98b64a1af729712a862459aeb); quoting the comment I wrote in the code for this PR:

> The above commit added a fallback allocator that just calls `realloc` from libc, which is fine on x86 because [Linux userspace pointers are 47 bits on x86-64](https://docs.kernel.org/6.3/x86/x86_64/mm.html) and that aligns perfectly with LuaJIT's NaN-tagging representation: LuaJIT/LuaJIT#49
>
> But [on ARM64, Linux userspace pointers are 48 bits](https://docs.kernel.org/6.3/arm64/memory.html), so libc does not provide an allocator that can be safely used for LuaJIT. To fix that, we delete the libc-based allocator and instead use LuaJIT's own default allocator as the fallback, which is what Emilua did before the regression.

Seems like this patch should probably also be submitted upstream; does anyone know how to do that? I've used GitLab years ago but for some reason I can't figure out how to use the current UI.

Disclosure: GPT-5.5 (via Codex) diagnosed the root cause and suggested an initial patch, then explained the issue to me in enough detail that I understood it, at which point I proposed a different patch which is what this PR uses.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
