### PR TITLE
ankiAddons.more-overview-stats: init at 2.1-unstable-2025-02-17

### DIFF
--- a/pkgs/by-name/an/anki/addons/default.nix
+++ b/pkgs/by-name/an/anki/addons/default.nix
@@ -16,6 +16,8 @@
 
   local-audio-yomichan = callPackage ./local-audio-yomichan { };
 
+  more-overview-stats = callPackage ./more-overview-stats { };
+
   passfail2 = callPackage ./passfail2 { };
 
   puppy-reinforcement = callPackage ./puppy-reinforcement { };

--- a/pkgs/by-name/an/anki/addons/more-overview-stats/default.nix
+++ b/pkgs/by-name/an/anki/addons/more-overview-stats/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  anki-utils,
+  fetchFromGitHub,
+  unstableGitUpdater,
+}:
+anki-utils.buildAnkiAddon (finalAttrs: {
+  pname = "more-overview-stats";
+  version = "2.1-unstable-2025-02-17";
+  src = fetchFromGitHub {
+    owner = "patrick-mahnkopf";
+    repo = "Anki_More_Overview_Stats";
+    rev = "239dccd68e2cc9e845b78947f6426b47a05582ea";
+    hash = "sha256-I5FjE7h2CaHzUuPFSK8DA91CJB+ngBs8ZF1UJo9gdNM=";
+  };
+  passthru.updateScript = unstableGitUpdater { };
+  meta = {
+    description = "Extending Anki's default overview screen with more statistics";
+    homepage = "https://github.com/patrick-mahnkopf/Anki_More_Overview_Stats";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ ethancedwards8 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
