### PR TITLE
kdePackages.plasma-remotecontrollers: init at 0-unstable-2026-06-06

### DIFF
--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -84,6 +84,7 @@ let
         phonon = self.callPackage ./misc/phonon { };
         phonon-vlc = self.callPackage ./misc/phonon-vlc { };
         plasma-pass = self.callPackage ./misc/plasma-pass { };
+        plasma-remotecontrollers = self.callPackage ./misc/plasma-remotecontrollers { };
         plasma-wayland-protocols = self.callPackage ./misc/plasma-wayland-protocols { };
         polkit-qt-1 = self.callPackage ./misc/polkit-qt-1 { };
         pulseaudio-qt = self.callPackage ./misc/pulseaudio-qt { };

--- a/pkgs/kde/misc/plasma-remotecontrollers/default.nix
+++ b/pkgs/kde/misc/plasma-remotecontrollers/default.nix
@@ -1,0 +1,62 @@
+{
+  mkKdeDerivation,
+  lib,
+  fetchFromGitLab,
+  pkg-config,
+  libevdev,
+  libcec,
+  libcec_platform,
+  plasma-workspace,
+  sdl3,
+  xwiimote,
+}:
+
+mkKdeDerivation {
+  pname = "plasma-remotecontrollers";
+  version = "0-unstable-2026-06-06";
+
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "plasma-bigscreen";
+    repo = "plasma-remotecontrollers";
+    rev = "3ee2a2a1c23759db74890e644f341a1969d4fe4f";
+    hash = "sha256-DgixSiQe4GGC4TMvtAOfEK+IJQp74f6GUu8gHPrX8wM=";
+  };
+
+  extraNativeBuildInputs = [
+    pkg-config
+  ];
+
+  extraBuildInputs = [
+    libevdev
+    libcec
+    libcec_platform
+    sdl3
+    xwiimote
+  ];
+
+  postPatch = ''
+    # Plasma version numbers are required to match, but we are building an
+    # unreleased package against a stable Plasma release.
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'set(PROJECT_VERSION "6.4.50")' 'set(PROJECT_VERSION "${plasma-workspace.version}")'
+  '';
+
+  meta = {
+    # Waiting on https://invent.kde.org/plasma-bigscreen/plasma-remotecontrollers/-/merge_requests/71
+    # To simplify/autofill
+    license = with lib.licenses; [
+      bsd2
+      cc0
+      gpl2Only
+      gpl2Plus
+      gpl3Only
+      lgpl2Plus
+      lgpl21Only
+      lgpl3Only
+      gpl3Plus # LicenseRef-KDE-Accepted-GPL
+      lgpl3Plus # LicenseRef-KDE-Accepted-LGPL
+    ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
