### PR TITLE
seaweedfs: 4.19 -> 4.24

### DIFF
--- a/pkgs/by-name/se/seaweedfs/package.nix
+++ b/pkgs/by-name/se/seaweedfs/package.nix
@@ -5,13 +5,14 @@
   installShellFiles,
   lib,
   libredirect,
+  glibc,
   nix-update-script,
   stdenv,
   versionCheckHook,
 }:
 buildGoModule (finalAttrs: {
   pname = "seaweedfs";
-  version = "4.19";
+  version = "4.24";
 
   src = fetchFromGitHub {
     owner = "seaweedfs";
@@ -24,7 +25,7 @@ buildGoModule (finalAttrs: {
       find "$out" -name .git -print0 | xargs -0 rm -rf
       popd
     '';
-    hash = "sha256-xMfV3WE10iP8MqxYd5w8JRUL5O7vO6ATN1ZEHB8MRxg=";
+    hash = "sha256-PYVCoeO+EYZ87gNwd9r+wgkpoeLhKKmV8fOimKkqR6w";
   };
 
   postPatch = ''
@@ -32,7 +33,11 @@ buildGoModule (finalAttrs: {
     rm -rf unmaintained
   '';
 
-  vendorHash = "sha256-mGiA91y6ebbbdAu0+ZDylUDuZb8vcNaqeGv70/IFx9k=";
+  vendorHash = "sha256-lTCfs/4FrICgb+uESM3XZBdinQw9Z0GrHkCIwmKSRh8";
+
+  buildInputs = [
+    glibc.static
+  ];
 
   nativeBuildInputs = [
     installShellFiles
@@ -64,6 +69,7 @@ buildGoModule (finalAttrs: {
   };
 
   preBuild = ''
+    export NIX_CFLAGS_LINK="-L${glibc.static}/lib"
     ldflags+=" -X \"github.com/seaweedfs/seaweedfs/weed/util/version.COMMIT=$(<COMMIT)\""
   '';
 
@@ -71,9 +77,10 @@ buildGoModule (finalAttrs: {
     # Test all targets.
     unset subPackages
 
+    export NIX_CFLAGS_LINK="-L${glibc.static}/lib"
     # Remove tests that require specialized environment or additional setup
     # that's not possible to achieve inside a sandbox.
-    for i in test/{fuse_integration,kafka,s3,sftp,volume_server}; do
+    for i in test/{fuse_dlm,fuse_integration,fuse_p2p,kafka,nfs,s3,sftp,volume_server}; do
       find "$i" -name '*_test.go' -delete
     done
 


### PR DESCRIPTION
Update to 4.23

Disable/remove fuse and nfs tests that won't work in sandbox.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
