### PR TITLE
nixos/tailscale-auth: fix hang on request body

### DIFF
--- a/nixos/modules/services/web-servers/nginx/tailscale-auth.nix
+++ b/nixos/modules/services/web-servers/nginx/tailscale-auth.nix
@@ -72,6 +72,10 @@ in
 
           proxy_pass http://unix:${cfgAuth.socketPath};
           proxy_pass_request_body off;
+          # Upstream does not unset Content-Length, but nginx documentation says to do this when discarding the request body,
+          # and failure to do this may cause requests with request bodies to hang.
+          # https://docs.nginx.com/nginx/admin-guide/security-controls/configuring-subrequest-authentication/#configuring-nginx-and-nginx-plus
+          proxy_set_header Content-Length "";
 
           # Upstream uses $http_host here, but we are using gixy to check nginx configurations
           # gixy wants us to use $host: https://github.com/yandex/gixy/blob/master/docs/en/plugins/hostspoofing.md


### PR DESCRIPTION
I don't know how this was working previously and why it became a problem only when I upgraded to unstable (f9c171bbc3b92e59118e2898dacaf7dd70ece3ac) from 25.11. The Nginx documentation says that when you are doing proxy authentication you should unset the Content-Length header, which makes sense because sending Content-Length without any content is a malformed HTTP request. The Tailscale documentation does not do this, and it doesn't look like the NixOS module has ever done it. I guess most likely something changed with the Tailscale authentication service and how it handles incoming requests.

On my system, without clearing Content-Length, all requests with bodies (eg logging in using a POST request) hang and eventually timeout. The Nginx logs report errors about upstream timeouts and auth failures in pairs:

```
May 13 23:19:03 macro nginx[3855]: 2026/05/13 23:19:03 [error] 3855#3855: *1309 upstream timed out (110: Connection timed out) while reading response header from upstream, client: [TAILNET_CLIENT_IP], server: [VHOST], request: "POST /user/login HTTP/2.0", subrequest: "/auth", upstream: "http://unix:/run/tailscale-nginx-auth/tailscale-nginx-auth.sock/auth", host: "[VHOST]", referrer: "https://[VHOST]/"
May 13 23:19:03 macro nginx[3855]: 2026/05/13 23:19:03 [error] 3855#3855: *1309 auth request unexpected status: 504 while sending to client, client: [TAILNET_CLIENT_IP], server: [VHOST], request: "POST /user/login HTTP/2.0", host: "[VHOST]", referrer: "https://[VHOST]/"
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
