### PR TITLE
caido: 0.55.3 -> 0.56.0

### DIFF
--- a/pkgs/by-name/ca/caido-cli/package.nix
+++ b/pkgs/by-name/ca/caido-cli/package.nix
@@ -9,25 +9,25 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "caido-cli";
-  version = "0.55.3";
+  version = "0.56.0";
 
   src = fetchurl (
     {
       x86_64-linux = {
         url = "https://caido.download/releases/v${finalAttrs.version}/caido-cli-v${finalAttrs.version}-linux-x86_64.tar.gz";
-        hash = "sha256-ys5gMO0jGy5d8ncwQo9ES0gn7Ddckf3496CAyGgKEus=";
+        hash = "sha256-G8E/GtVYzTM5JIkNnQm3PxzfZya3hVJlzUxN3s4CEdM=";
       };
       aarch64-linux = {
         url = "https://caido.download/releases/v${finalAttrs.version}/caido-cli-v${finalAttrs.version}-linux-aarch64.tar.gz";
-        hash = "sha256-JvWktRnNyzu98NeSOFJ6nhF60uQfSL6ys5BmTkYuwCQ=";
+        hash = "sha256-X+jDesBDXOWSQBTPA1kCaGBRvoaDGCR0TkNWNqYtNok=";
       };
       x86_64-darwin = {
         url = "https://caido.download/releases/v${finalAttrs.version}/caido-cli-v${finalAttrs.version}-mac-x86_64.zip";
-        hash = "sha256-bnFGa8GMDTdCjk9xJL9rGvZ1H6MMzzXrlWXGRlE5XPg=";
+        hash = "sha256-6Rnybe9kH65C4PHg7j9Rwz2TMjH1XPGnI1mu0/g0up8=";
       };
       aarch64-darwin = {
         url = "https://caido.download/releases/v${finalAttrs.version}/caido-cli-v${finalAttrs.version}-mac-aarch64.zip";
-        hash = "sha256-UVBQKkGsYJ84cthFkCXrHI85t8LJPy4z5sP5TobVNeA=";
+        hash = "sha256-07huWaIC1wO7RxC2F8VhgqKvtXcrNxbWDKFhuZhv/E8=";
       };
     }
     .${stdenv.hostPlatform.system}

--- a/pkgs/by-name/ca/caido-desktop/package.nix
+++ b/pkgs/by-name/ca/caido-desktop/package.nix
@@ -9,24 +9,24 @@
 
 let
   pname = "caido-desktop";
-  version = "0.55.3";
+  version = "0.56.0";
 
   sources = {
     x86_64-linux = {
       url = "https://caido.download/releases/v${version}/caido-desktop-v${version}-linux-x86_64.AppImage";
-      hash = "sha256-pGRmFYE7uO5Ka94Kfjl9LR5PAwZ5dCxHqCqJKhtLPco=";
+      hash = "sha256-UA4MPEEnFiiR0ueYoE3H1Z5f7J56NYNahTbWyAImmfQ=";
     };
     aarch64-linux = {
       url = "https://caido.download/releases/v${version}/caido-desktop-v${version}-linux-aarch64.AppImage";
-      hash = "sha256-s99+HXf7Ada2wiPUZ/5M/p09JiadFn5GnKrzqo9yNPQ=";
+      hash = "sha256-HTegv6UlWe0gID5sGLlUTFc0z6giF7BCIwbCHb/rLjc=";
     };
     x86_64-darwin = {
       url = "https://caido.download/releases/v${version}/caido-desktop-v${version}-mac-x86_64.dmg";
-      hash = "sha256-V33bRaTwhxozBR/wV83bU89TZluenKpFc8GU0KaaO8w=";
+      hash = "sha256-ZnN8DK3OuzZ0rKE+1czFhn2rH8QHJvlgvjc9k3DrV/Q=";
     };
     aarch64-darwin = {
       url = "https://caido.download/releases/v${version}/caido-desktop-v${version}-mac-aarch64.dmg";
-      hash = "sha256-fEzPN84zoSvlIgUBYVmPta7SUmTDRQghoJMTZXW7eI4=";
+      hash = "sha256-XbcmecB4DKPp0WlqBBnc2TvorXEMsDSR5oW/VeUBcVs=";
     };
   };
 


### PR DESCRIPTION
this includes both caido-cli and caido-desktop as separate commits, but they're part of the same app in a different form.

would like a quick build/run test on darwin if possible, given the dual-parts. i'm sure it's right but precision is nice and i have no darwin hardware.

https://github.com/caido/caido/releases/tag/v0.56.0

> This adds many QoL improvements including:
>   - Match & Replace in Replay
>   - Connecting to remote instances via HTTPs
>   - Collection/session re-ordering in Replay
>
> This release also includes other bug fixes and improvements.
> View the full list of [changes](https://github.com/caido/caido/milestone/90?closed=1).

changelog: https://github.com/caido/caido/milestone/90?closed=1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
