### PR TITLE
kanidm_1_9: 1.9.3 -> 1.9.4; kanidm_1_10: 1.10.1 -> 1.10.2

### DIFF
--- a/pkgs/servers/kanidm/1_10.nix
+++ b/pkgs/servers/kanidm/1_10.nix
@@ -1,5 +1,5 @@
 import ./generic.nix {
-  version = "1.10.1";
-  hash = "sha256-nIuxaYuVVNzQpnFRisyLkWFz7GWaJOUrj8mRRcGs2KI=";
-  cargoHash = "sha256-zti+7dlaU9k2EQfLQmdCL7Am9Xib1YKdUFVrLx15cCc=";
+  version = "1.10.2";
+  hash = "sha256-VkFsJPP3oGy307d7E0h9wanZC2EsXziy5XC10/6aoTI=";
+  cargoHash = "sha256-ureHJ5I8emHsltpe8PuzWUSQjokbXZQ7Kh0e2eTz0LE=";
 }

--- a/pkgs/servers/kanidm/1_9.nix
+++ b/pkgs/servers/kanidm/1_9.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
-  version = "1.9.3";
-  hash = "sha256-YI2nShQhsCd1vn7S4VeCELfcU0HsmZrFs60kllJJFAo=";
-  cargoHash = "sha256-b6kBDA/CDJHbybfvbRRZ++q9H+SVRu0BmgkwzN2i/YU=";
+  version = "1.9.4";
+  hash = "sha256-sz4jbnaRU+mUCBwxODMGkKnk9DMAmD6cyPyCbYp6aOQ=";
+  cargoHash = "sha256-1U262qRtYzRTQZLNF027LlCASCvbxmuBvZJpDPnI/vU=";
   eolDate = "2026-05-31";
 }


### PR DESCRIPTION
Release Notes:
- https://github.com/kanidm/kanidm/releases/tag/v1.9.4
- https://github.com/kanidm/kanidm/releases/tag/v1.10.2

Advisory: https://github.com/kanidm/kanidm/security/advisories/GHSA-xxwr-vvr3-2g9f

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
    - [x] /nix/store/1mwaqxlqhjcw9jbb9w3a1qmayjg7qg6f-kanidm-1.9.4
    - [x] /nix/store/dr7dhgckbsjdqif7faqp3av7by84k4fi-kanidm-1.10.2
    - [x] /nix/store/l3pv7439dzfbhyjqaiag6dynymq2pw3m-kanidm-with-secret-provisioning-1.10.2
    - [x] /nix/store/j489mn1r5xxzwnrfvi8ygmsf80kcx4xs-kanidm-with-secret-provisioning-1.9.4
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
