### PR TITLE
unity-test: fix clang build

### DIFF
--- a/pkgs/by-name/un/unity-test/package.nix
+++ b/pkgs/by-name/un/unity-test/package.nix
@@ -27,6 +27,7 @@ let
     "-Wno-unsafe-buffer-usage"
     "-Wno-reserved-identifier"
     "-Wno-extra-semi-stmt"
+    "-Wno-implicit-void-ptr-cast"
   ];
 in
 stdenv.mkDerivation (finalAttrs: {


### PR DESCRIPTION
`unity-test` has been failing on Darwin since 2025-10-07.

Newer Clang emits `-Wimplicit-void-ptr-cast` errors when Unity's own test suite is built with `-Weverything -Werror`. 

This adds `-Wno-implicit-void-ptr-cast` to `ignoredErrors`, gated on `stdenv.cc.isClang`.

Hit this trying to use `cava` on macOS (`cava` → `iniparser` → `unity-test`).
All three now build on `aarch64-darwin`.

Resolves #462587. Tracking ZHF: #516381.

nixpkgs-review-gha build: https://github.com/matteo-pacini/nixpkgs-review-gha/actions/runs/25848057047

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
