### PR TITLE
gits: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21949,6 +21949,13 @@
     githubId = 138074;
     name = "Pedro Pombeiro";
   };
+  pompydev = {
+    name = "pomp";
+    github = "pompydev";
+    githubId = 201753364;
+    email = "hello@pompy.dev";
+    keys = [ { fingerprint = "C11A 893F DB6F 2EFF 2312  57B0 9E9C 8C5C 4A36 1D83"; } ];
+  };
   pongo1231 = {
     email = "pongo12310@gmail.com";
     github = "pongo1231";

--- a/pkgs/by-name/gi/gits/package.nix
+++ b/pkgs/by-name/gi/gits/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "gits";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "pompydev";
+    repo = "gits";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+mYqjq0P4sI7Ol5IpftCgxM4dKacw8Ohg2mkBHAKsbY=";
+  };
+
+  cargoHash = "sha256-J9OrpVhPbIIhDxXmqwfFO4UcnVLZq5/xMrX5dRaJtkQ=";
+
+  meta = {
+    description = "git stats as TUI";
+    homepage = "https://github.com/pompydev/gits";
+    license = with lib.licenses; [ agpl3Plus ];
+    maintainers = with lib.maintainers; [ pompydev ];
+    mainProgram = "gits";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
init [gits](https://github.com/pompydev/gits), a TUI for git repo statistics at `0.1.0`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
