### PR TITLE
freecad: fix crash on GNOME/Wayland when opening/saving files by addi…

### DIFF
--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -30,6 +30,8 @@
   nix-update-script,
   gmsh,
   which,
+  gtk3,
+  gsettings-desktop-schemas,
 }:
 let
   pythonDeps = with python3Packages; [
@@ -127,6 +129,7 @@ freecad-utils.makeCustomizable (
         "--set COIN_GL_NO_CURRENT_CONTEXT_CHECK 1"
         "--prefix PATH : ${binPath}"
         "--prefix PYTHONPATH : ${python3Packages.makePythonPath pythonDeps}"
+        "--prefix XDG_DATA_DIRS : ${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}"
       ];
 
     postFixup = ''


### PR DESCRIPTION
#### **Summary**

This PR fixes a critical issue where FreeCAD crashes or hangs on GNOME (specifically in Wayland sessions) whenever a file dialog is triggered (e.g., "Open", "Save", or "Save As"). 

#### **Root Cause**

The crash is caused by the absence of GSettings schemas in the application's environment. When FreeCAD (a Qt application) attempts to invoke the system's file portal or GTK-based dialogs, the underlying GLib/GTK libraries fail to find necessary configuration metadata (schemas), leading to a deadlock or segmentation fault. 

#### **Changes**

* Modified `qtWrapperArgs` in `pkgs/applications/science/geometry/freecad/package.nix`. 

* Prefixed `XDG_DATA_DIRS` with the paths to `gsettings-desktop-schemas` and `gtk3`. 

* Added `gsettings-desktop-schemas` and `gtk3` to the package dependencies to ensure schema availability. 

#### **Technical Details**

The following environment variable is now injected into the FreeCAD wrapper:

```bash
--prefix XDG_DATA_DIRS : "${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}"

```

#### **Verification**

* **Environment**: NixOS 26.05/Unstable, GNOME 49.4 (Wayland).
* **Result**: Successfully opened and saved files without any UI hangs or terminal errors. Font sizes and icon scales remain consistent with the default Qt behavior.