### PR TITLE
nixos/jellyfin: fix hevc10bit decoding toggle being silently ignored

### DIFF
--- a/nixos/modules/services/misc/jellyfin.nix
+++ b/nixos/modules/services/misc/jellyfin.nix
@@ -33,7 +33,11 @@ let
     ;
   cfg = config.services.jellyfin;
   filteredDecodingCodecs = builtins.filter (
-    c: c != "hevcRExt10bit" && c != "hevcRExt12bit" && cfg.transcoding.hardwareDecodingCodecs.${c}
+    c:
+    c != "hevc10bit"
+    && c != "hevcRExt10bit"
+    && c != "hevcRExt12bit"
+    && cfg.transcoding.hardwareDecodingCodecs.${c}
   ) (builtins.attrNames cfg.transcoding.hardwareDecodingCodecs);
   encodingXmlText = ''
     <?xml version="1.0" encoding="utf-8"?>
@@ -58,6 +62,7 @@ let
       <AllowAv1Encoding>${boolToString cfg.transcoding.hardwareEncodingCodecs.av1}</AllowAv1Encoding>
       <EnableIntelLowPowerH264HwEncoder>${boolToString cfg.transcoding.enableIntelLowPowerEncoding}</EnableIntelLowPowerH264HwEncoder>
       <EnableIntelLowPowerHevcHwEncoder>${boolToString cfg.transcoding.enableIntelLowPowerEncoding}</EnableIntelLowPowerHevcHwEncoder>
+      <EnableDecodingColorDepth10Hevc>${boolToString cfg.transcoding.hardwareDecodingCodecs.hevc10bit}</EnableDecodingColorDepth10Hevc>
       <EnableDecodingColorDepth10HevcRext>${boolToString cfg.transcoding.hardwareDecodingCodecs.hevcRExt10bit}</EnableDecodingColorDepth10HevcRext>
       <EnableDecodingColorDepth12HevcRext>${boolToString cfg.transcoding.hardwareDecodingCodecs.hevcRExt12bit}</EnableDecodingColorDepth12HevcRext>
       <HardwareDecodingCodecs>

--- a/nixos/tests/jellyfin.nix
+++ b/nixos/tests/jellyfin.nix
@@ -33,6 +33,7 @@
           hardwareDecodingCodecs = {
             h264 = true;
             hevc = true;
+            hevc10bit = true;
             vp9 = true;
             hevcRExt10bit = true;
             hevcRExt12bit = true;
@@ -174,7 +175,8 @@
           assert config.get("EnableIntelLowPowerH264HwEncoder") == True, f"Intel low power H264: expected True, got '{config.get('EnableIntelLowPowerH264HwEncoder')}'"
           assert config.get("EnableIntelLowPowerHevcHwEncoder") == True, f"Intel low power HEVC: expected True, got '{config.get('EnableIntelLowPowerHevcHwEncoder')}'"
 
-          # HEVC RExt color depth verification
+          # HEVC color depth verification
+          assert config.get("EnableDecodingColorDepth10Hevc") == True, f"HEVC 10bit: expected True, got '{config.get('EnableDecodingColorDepth10Hevc')}'"
           assert config.get("EnableDecodingColorDepth10HevcRext") == True, f"HEVC RExt 10bit: expected True, got '{config.get('EnableDecodingColorDepth10HevcRext')}'"
           assert config.get("EnableDecodingColorDepth12HevcRext") == True, f"HEVC RExt 12bit: expected True, got '{config.get('EnableDecodingColorDepth12HevcRext')}'"
 


### PR DESCRIPTION
Fixes `services.jellyfin.transcoding.hardwareDecodingCodecs.hevc10bit` being silently ignored.

The option was being written as a `<string>hevc10bit</string>` entry inside `<HardwareDecodingCodecs>` in `encoding.xml`, but Jellyfin only treats that element as a list of ffmpeg codec names (h264, hevc, vp9, ...), so the entry was discarded. The actual gate for 10-bit HEVC hardware decoding is the dedicated `<EnableDecodingColorDepth10Hevc>` boolean, which this module never emitted - meaning the upstream default of `true` was always in effect regardless of how the NixOS option was set.

This change mirrors how `hevcRExt10bit` and `hevcRExt12bit` are already handled: exclude `hevc10bit` from the codec string list and emit it as its own XML element.

### Note for reviewers

- The `hevc10bit` option keeps its existing default of `false` which is different from Jellyfin's upstream default of `true`.

- The same shape of bug exists for `EnableDecodingColorDepth10Vp9`, but the corresponding `vp910bit` option doesn't exist on the module today, so adding it is a separate change.

Closes #517352

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage).
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.
