### PR TITLE
polkit_gnome: allow XDG autostart in non-GNOME environments

### DIFF
--- a/pkgs/by-name/po/polkit_gnome/polkit-gnome-authentication-agent-1.desktop
+++ b/pkgs/by-name/po/polkit_gnome/polkit-gnome-authentication-agent-1.desktop
@@ -84,5 +84,5 @@ Terminal=false
 Type=Application
 Categories=
 NoDisplay=true
-OnlyShowIn=GNOME;XFCE;Unity;
+#OnlyShowIn=GNOME;XFCE;Unity;
 AutostartCondition=GNOME3 unless-session gnome


### PR DESCRIPTION
Allows `polkit-gnome-authentication-agent-1` to be auto-started in desktop environments other than GNOME, like it was done for `gnome-keyring` in #436128.

[XDG Autostart](https://specifications.freedesktop.org/autostart-spec/autostart-spec-latest.html) (commonly implemented through `systemd-xdg-autostart-generator(8)`) currently skips the startup of this polkit agent outside of GNOME. I believe that this is _no longer a reasonable default_ for 2 reasons:

- GNOME has stopped relying on `polkit_gnome` years ago. It now ships with a built-in polkit agent, making this condition obsolete.
- `polkit_gnome` is useful outside of GNOME. Data shows that NixOS users (myself included) [run it alongside Wayland compositors](https://github.com/search?q=%2Fpolkit_gnome%2F+%2F\s(hyprland|niri|sway)%24%2F+lang%3Anix&type=code) such as Niri, Sway or Hyprland, and resort to various hacks to circumvent the current autostart restriction.

I purposely commented the line instead of deleting it to make it clear that the attribute was altered from the original file, and to remain consistent with the packaging of `gnome-keyring`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test