### PR TITLE
pkgs/README: document deprecation-before-removal guidelines

### DIFF
--- a/pkgs/README.md
+++ b/pkgs/README.md
@@ -676,9 +676,50 @@ If you do need to create this sort of patch file, one way to do so is with git:
 
 ## Deprecating/removing packages
 
-There is currently no policy when to remove a package.
+Before removing a package, try to find a new maintainer or fix smaller issues first.
 
-Before removing a package, one should try to find a new maintainer or fix smaller issues first.
+If your package is widely used (by other packages, NixOS modules, or end-user configs), give people more warnings before you remove it.
+
+### Deprecation before removal
+
+Evaluation-time warnings are the only channel that reliably reaches every user.
+
+You should include removals/deprecations into the release notes.
+
+**When a replacement exists**, use `warnAlias` in `pkgs/top-level/aliases.nix` to use the replacement while emitting an eval-warning into the users terminal.
+Keep the alias for at least one full release cycle so that users on stable have time to migrate, then convert it to a `throw`.
+
+```nix
+{
+  # 26.05: warn and redirect
+  jbidwatcher = warnAlias "'jbidwatcher' has been renamed to 'jbidwatcher2'" jbidwatcher2; # Added 2026-05-01
+
+  # 26.11 (or later): convert to throw
+  jbidwatcher = throw "'jbidwatcher' has been removed. Use 'jbidwatcher2' instead."; # Converted to throw 2026-11-01
+}
+```
+
+**When no replacement exists**, consider adding a `lib.warn` to the package expression for one release before removing it, so users get a heads-up while their system still builds.
+
+**When immediate removal is necessary** (e.g., security vulnerability, package already fails to build), go directly to a `throw`.
+
+For bigger removals (an entire package set, a widely-used library, a language ecosystem), the **warning phase** matters even more.
+Post in the [Breaking changes thread on Discourse](https://discourse.nixos.org/t/breaking-changes-announcement-for-unstable/17574) *before* you merge the removal.
+
+### Writing good messages
+
+The `throw` message is the only thing users see when their evaluation breaks.
+We don't know how good everyone is at finding github PRs and issues. To show users we care about them.
+Tell them what happened and what to do about it:
+
+```nix
+# "[What happened]. [Optional migration instruction]"
+# ->
+throw
+  "'pkgs.foolers.foo' has been removed. Use 'foo' from the top-level package set instead (pkgs.foo)." # Added 2026-03-29
+```
+
+Always include a date comment (`# Added YYYY-MM-DD`) so that stale throws can be identified and pruned by `maintainers/scripts/remove-old-aliases.py`.
 
 ### Steps to remove a package from Nixpkgs
 
@@ -688,23 +729,22 @@ We use jbidwatcher as an example for a discontinued project here.
 1. Create a new branch for your change, e.g. `git checkout -b jbidwatcher`
 1. Remove the actual package including its directory, e.g. `git rm -rf pkgs/applications/misc/jbidwatcher`
 1. Remove the package from the list of all packages (`pkgs/top-level/all-packages.nix`).
-1. Add an alias for the package name in `pkgs/top-level/aliases.nix` (There is also `pkgs/applications/editors/vim/plugins/aliases.nix`.
+1. Add an alias in `pkgs/top-level/aliases.nix` (There is also `pkgs/applications/editors/vim/plugins/aliases.nix`.
    Package sets typically do not have aliases, so we can't add them there.)
 
-    For example in this case:
+    If the package has been moved or renamed, use `warnAlias` (see above).
+    If it has been removed entirely, use a `throw` with a good message:
 
     ```nix
     {
-      jbidwatcher = throw "jbidwatcher was discontinued in march 2021"; # added 2021-03-15
+      jbidwatcher = throw "'jbidwatcher' has been removed because the project was discontinued and the ebay login it depends on no longer works."; # Added 2021-03-15
     }
     ```
 
-    The throw message should explain in short why the package was removed for users that still have it installed.
-
-1. Test if the changes introduced any issues by running `nix-env -qaP -f . --show-trace`.
+2. Test if the changes introduced any issues by running `nix-env -qaP -f . --show-trace`.
    It should show the list of packages without errors.
-1. Commit the changes.
-   Explain again why the package was removed.
+3. Commit the changes.
+   Explain why the package was removed.
    If it was declared discontinued upstream, add a link to the source.
 
     ```ShellSession
@@ -722,8 +762,8 @@ We use jbidwatcher as an example for a discontinued project here.
     https://web.archive.org/web/20210315205723/http://www.jbidwatcher.com/
     ```
 
-1. Push changes to your GitHub fork with `git push`
-1. Create a pull request against Nixpkgs.
+4. Push changes to your GitHub fork with `git push`
+5. Create a pull request against Nixpkgs.
    Mention the package maintainer.
 
 This is what the pull request looks like in this case: [https://github.com/NixOS/nixpkgs/pull/116470](https://github.com/NixOS/nixpkgs/pull/116470)


### PR DESCRIPTION
The deprecation section currently says "There is currently no policy when to remove a package" and then jumps straight to the removal steps. Which demands for inserting a `throw`

Although I feel like we are actually already living a three stage lifecycle. As seen in: maintainers/scripts/remove-old-aliases.py
We usually insert warnings & aliases before removal (throw), but this guide does not mention any of that.

i noticed some issues when tracing commits how people apply this guide: (I will not include any references here, because i dont want to point fingers at anyone)

- Introducing a `throw`, will immediately brick evaluation of all downstream users. (We can do this better)
- The message often explains *why* it was removed, however does often not include a migration instruction, regardless if one exists.

I think this is a structural issue with this document and here is what i would like to add to improve this:

1. Ask for introducing evaluation `warning` via `warnAlias` before removal. This should by applied when it makes sense, based on blast-radius. Sometimes it is not worth doing and we should just add a `throw` directly. This is where the package maintainer needs to apply their own judgement.

2. Ask for actionable messages. The updated examples should foster actionable messages.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
