### PR TITLE
discord: disable module updates with OpenASAR

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/darwin.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/darwin.nix
@@ -65,14 +65,12 @@ let
   stageModules = writeShellScript "discord-stage-modules" ''
     store_modules="$1"
     modules_dir="$HOME/Library/Application Support/${configDirName}/${version}/modules"
-    if [ ! -f "$modules_dir/installed.json" ]; then
-      mkdir -p "$modules_dir"
-      for m in ${lib.concatStringsSep " " (lib.attrNames moduleSrcs)}; do
-        ln -sfn "$store_modules/$m" "$modules_dir/$m"
-      done
-      echo '${builtins.toJSON (lib.mapAttrs (_: mod: { installedVersion = mod; }) moduleVersions)}' \
-        > "$modules_dir/installed.json"
-    fi
+    mkdir -p "$modules_dir"
+    for m in ${lib.concatStringsSep " " (lib.attrNames moduleSrcs)}; do
+      ln -sfn "$store_modules/$m" "$modules_dir/$m"
+    done
+    echo '${builtins.toJSON (lib.mapAttrs (_: mod: { installedVersion = mod; }) moduleVersions)}' \
+      > "$modules_dir/installed.json"
   '';
 
   disableBreakingUpdates =
@@ -80,6 +78,7 @@ let
       {
         pythonInterpreter = "${python3.interpreter}";
         configDirName = lib.toLower binaryName;
+        skipModuleUpdate = lib.boolToString withOpenASAR;
         meta.mainProgram = "disable-breaking-updates.py";
       }
       ''
@@ -141,7 +140,7 @@ stdenv.mkDerivation {
     mkdir -p $out/bin
     makeWrapper "$out/Applications/${desktopName}.app/Contents/MacOS/${binaryName}" "$out/bin/${binaryName}" \
       --run ${lib.getExe disableBreakingUpdates} \
-      --run "${stageModules} $out/Applications/${desktopName}.app/Contents/Resources/modules" \
+      --run "${stageModules} \"$out/Applications/${desktopName}.app/Contents/Resources/modules\"" \
       --add-flags ${lib.escapeShellArg commandLineArgs}
 
     runHook postInstall

--- a/pkgs/applications/networking/instant-messengers/discord/disable-breaking-updates.py
+++ b/pkgs/applications/networking/instant-messengers/discord/disable-breaking-updates.py
@@ -41,11 +41,16 @@ if os.path.exists(settings_path):
 else:
     settings = {}
 
-if settings.get("SKIP_HOST_UPDATE"):
-    print("[Nix] Disabling updates already done")
-else:
-    skip_host_update = {"SKIP_HOST_UPDATE": True}
-    settings.update(skip_host_update)
+required_settings = {"SKIP_HOST_UPDATE": True}
+if "@skipModuleUpdate@" == "true":
+    required_settings["SKIP_MODULE_UPDATE"] = True
+
+missing_settings = {
+    key: value for key, value in required_settings.items() if settings.get(key) != value
+}
+
+if missing_settings:
+    settings.update(missing_settings)
 
     os.makedirs(os.path.dirname(settings_path), exist_ok=True)
 
@@ -54,3 +59,5 @@ else:
 
     settings_path_temp.rename(settings_path)
     print("[Nix] Disabled updates")
+else:
+    print("[Nix] Disabling updates already done")

--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -167,6 +167,7 @@ let
       {
         pythonInterpreter = "${python3.interpreter}";
         configDirName = lib.toLower binaryName;
+        skipModuleUpdate = lib.boolToString withOpenASAR;
         meta.mainProgram = "disable-breaking-updates.py";
       }
       ''


### PR DESCRIPTION
Closes: https://github.com/NixOS/nixpkgs/issues/515106

When OpenASAR is enabled, Discord's module updater can try to fetch module versions as undefined and loop/fail during startup

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
