### PR TITLE
grokmirror: init at 2.0.12

### DIFF
--- a/pkgs/by-name/gr/grokmirror/package.nix
+++ b/pkgs/by-name/gr/grokmirror/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  stdenv,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonPackage (finalAttrs: {
+  pname = "grokmirror";
+  version = "2.0.12";
+  format = "setuptools";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "mricon";
+    repo = "grokmirror";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-4UwVcE5IYUmAkgbLTFg5Rw5yZUZWkok3iw7LO8pplV4=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    packaging
+    requests
+  ];
+
+  meta = {
+    homepage = "https://github.com/mricon/grokmirror";
+    description = "Framework to smartly mirror git repositories";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ maxmosk ];
+  };
+})


### PR DESCRIPTION
Framework to smartly mirror git repositories.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
