### PR TITLE
python3Packages.xdis: 6.1.8 -> 6.3.0

### DIFF
--- a/pkgs/development/python-modules/uncompyle6/default.nix
+++ b/pkgs/development/python-modules/uncompyle6/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  fetchpatch,
   setuptools,
   spark-parser,
   xdis,
@@ -19,6 +20,14 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-eLdk1MhDsEVfs5223rQhpI1dPruEZTe6ZESv4QfE68E=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "support-xdis-6.3-api.patch";
+      url = "https://github.com/rocky/python-uncompyle6/commit/62372825c62044428c29a9ce86b5afa81e93c5ae.patch";
+      hash = "sha256-z11AKF5RC4gibUbH3hI2Rsbn8VDg49SnKfqV4TuVnjc=";
+    })
+  ];
 
   build-system = [ setuptools ];
 

--- a/pkgs/development/python-modules/xdis/default.nix
+++ b/pkgs/development/python-modules/xdis/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   click,
   fetchFromGitHub,
+  fetchpatch,
   pytestCheckHook,
   setuptools,
   six,
@@ -10,15 +11,30 @@
 
 buildPythonPackage rec {
   pname = "xdis";
-  version = "6.1.8";
+  version = "6.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "rocky";
     repo = "python-xdis";
     tag = version;
-    hash = "sha256-sAL2D7Rg/iyob2nawXX/b5F/uOGCMsb1q0ZnPLIfh6o=";
+    hash = "sha256-k1SawlgbItbWe8J2pAxYOku/4CHyzWH3UR1j3kBZy1Q=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "python-3.13.13.patch";
+      url = "https://github.com/rocky/python-xdis/commit/f2c46c8c89898157c2345c0a026a2d31f14e7ea9.patch";
+      includes = [ "xdis/magics.py" ];
+      hash = "sha256-+k3mbiAmM69Pl7k0Wogx+qpib5+p3Gn/pSpnDn5e6pE=";
+    })
+    (fetchpatch {
+      name = "python-3.14.4.patch";
+      url = "https://github.com/rocky/python-xdis/commit/36a1a2442c224e3bfca776f727a5e262968855a4.patch";
+      includes = [ "xdis/magics.py" ];
+      hash = "sha256-q+MX737Xn+iUObuV5IirnT71/0W6JH0TgtmS1cqR0x4=";
+    })
+  ];
 
   build-system = [
     setuptools


### PR DESCRIPTION
Changelog: https://github.com/rocky/python-xdis/releases/tag/6.3.0
Diff: https://github.com/rocky/python-xdis/compare/6.1.8...6.3.0

This fixes the build of `python313Packages.xdis`.

Hydra: https://hydra.nixos.org/build/326877709
ZHF: https://github.com/NixOS/nixpkgs/issues/516381

Closes https://github.com/NixOS/nixpkgs/pull/507468

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `python3{13,14}Packages.{xdis,uncompyle6}`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
