### PR TITLE
various: stabilize fetchpatch2 hashes in my recent ZHF fixes

### DIFF
--- a/pkgs/by-name/ca/canaille/package.nix
+++ b/pkgs/by-name/ca/canaille/package.nix
@@ -26,13 +26,13 @@ python.pkgs.buildPythonApplication rec {
   patches = [
     # Backport authlib 1.7 compatibility.
     (fetchpatch2 {
-      url = "https://gitlab.com/yaal/canaille/-/commit/b356baa82109a7fdf61a8258572d199ffd3c9604.patch";
-      hash = "sha256-f5zJBtm9mJpWra5x4vr07eL9xe381lLFp3lfehc4Ypk=";
+      url = "https://gitlab.com/yaal/canaille/-/commit/b356baa82109a7fdf61a8258572d199ffd3c9604.diff";
+      hash = "sha256-/U6S3h6qIl763ZsGpOm6CVk4NaY3A7mq3PkT193aLEs=";
     })
     # Update OIDC tests for authlib 1.7 behavior.
     (fetchpatch2 {
-      url = "https://gitlab.com/yaal/canaille/-/commit/c1b6d103ebf374cd6a21d9af8376c910c2d0d5d9.patch";
-      hash = "sha256-N9kxiKU6iwXq6cw6itZQHairSOgyDgwAVByj0NnxMqY=";
+      url = "https://gitlab.com/yaal/canaille/-/commit/c1b6d103ebf374cd6a21d9af8376c910c2d0d5d9.diff";
+      hash = "sha256-MjwkUb54ikt1+xUXBTOIBi9E+DmPdwYhw0W0c0prF/Q=";
       includes = [ "tests/oidc/*" ];
     })
   ];

--- a/pkgs/development/python-modules/highdicom/default.nix
+++ b/pkgs/development/python-modules/highdicom/default.nix
@@ -30,8 +30,8 @@ buildPythonPackage rec {
   patches = [
     # Fix time-of-day-dependent failure in series_time validation.
     (fetchpatch2 {
-      url = "https://github.com/ImagingDataCommons/highdicom/commit/e9e3f2514a74b0d4be736cff222c934ef66d67ff.patch";
-      hash = "sha256-48dJAimxXYG0FQouquY5TLXi+3HarS8yx9HoLXiFymM=";
+      url = "https://github.com/ImagingDataCommons/highdicom/commit/e9e3f2514a74b0d4be736cff222c934ef66d67ff.patch?full_index=1";
+      hash = "sha256-1h9xmcezxuvHw54t4kLahDB62d0XHzEyrmHmPf6NW7M=";
     })
   ];
 


### PR DESCRIPTION
Recently I've submitted many ZHF fix patches, and some of the merged items involve fetchpatch2 without a stable hash (hashes that could change in the future, only affecting fetchpatch2, as fetchpatch has a bug that gives us stable hashes). So this PR was opened to correct ALL the mistakes and is an attempt to prevent future hash drift.

Functionality-wise, all fixes should still function the same. I'll then proceed to update my open PRs.

My affected PRs:
 - #518413
 - #519038
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
