### PR TITLE
vscode-extensions.jnoortheen.nix-ide: 0.5.5 -> 0.5.9

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -2570,8 +2570,8 @@ let
         mktplcRef = {
           publisher = "jnoortheen";
           name = "nix-ide";
-          version = "0.5.5";
-          hash = "sha256-epdEMPAkSo0IXsd+ozicI8bjPPquDKIzB3ONRUYWwn8=";
+          version = "0.5.9";
+          hash = "sha256-hPOcp6Yksgfu1+In21/gJ3MthV8JUV5WaRpYHvo5GGk=";
         };
         meta = {
           changelog = "https://marketplace.visualstudio.com/items/jnoortheen.nix-ide/changelog";


### PR DESCRIPTION
Bumps the [Nix IDE](https://github.com/nix-community/vscode-nix-ide) VS Code extension to the latest marketplace release (0.5.9).

Changelog: https://marketplace.visualstudio.com/items/jnoortheen.nix-ide/changelog

<!-- Maintainer note: the package's meta.maintainers list is empty. -->

### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested via the `nix-build -A vscode-extensions.jnoortheen.nix-ide` test on the current branch.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc