### PR TITLE
openwhispr: init at 1.8.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3429,6 +3429,12 @@
     githubId = 32903896;
     keys = [ { fingerprint = "CB5C 7B3C 3E6F 2A59 A583  A90A 8A60 0376 7BE9 5976"; } ];
   };
+  benediktweyer = {
+    name = "Benedikt Weyer";
+    email = "bw.development@pm.me";
+    github = "benedikt-weyer";
+    githubId = 105204092;
+  };
   bengsparks = {
     email = "benjamin.sparks@protonmail.com";
     github = "bengsparks";

--- a/pkgs/by-name/op/openwhispr/package.nix
+++ b/pkgs/by-name/op/openwhispr/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+  runCommand,
+}:
+
+let
+  pname = "openwhispr";
+  version = "1.8.1";
+
+  src = fetchurl {
+    url = "https://github.com/OpenWhispr/openwhispr/releases/download/v${version}/OpenWhispr-${version}-linux-x86_64.AppImage";
+    hash = "sha256-9QPEEb20XrbhNNYl45z/TmC2d0/+CzzfkKi0EOzR9uY=";
+  };
+
+  appimageContents = appimageTools.extract {
+    inherit pname version src;
+  };
+
+  # Start Electron from the extracted app dir so utilityProcess worker imports
+  # resolve against the packaged resources instead of the caller's cwd.
+  patchedAppimageContents = runCommand "${pname}-${version}-patched-appdir" { } ''
+        cp -r ${appimageContents} $out
+        chmod -R u+w $out
+
+        # Removing linux-fast-paste to use the ydtool fallback because of the primary method beeing defect on at least GNOME Wayland
+        rm -f $out/resources/bin/linux-fast-paste
+
+        substituteInPlace $out/open-whispr \
+          --replace-fail 'exec -a "$0" "$HERE/open-whispr-app" "''${FLAGS[@]}" "$@"' \
+                         'cd "$HERE"
+    exec -a "$0" "$HERE/open-whispr-app" "''${FLAGS[@]}" "$@"'
+  '';
+in
+(appimageTools.wrapAppImage {
+  inherit pname version;
+  src = patchedAppimageContents;
+
+  extraPkgs =
+    pkgs: with pkgs; [
+      unzip
+    ];
+
+  extraInstallCommands = ''
+    install -Dm444 ${appimageContents}/open-whispr.desktop -t $out/share/applications
+    install -Dm444 ${appimageContents}/usr/share/icons/hicolor/256x256/apps/open-whispr.png \
+      -t $out/share/icons/hicolor/256x256/apps
+
+    substituteInPlace $out/share/applications/open-whispr.desktop \
+      --replace-fail 'Exec=AppRun --no-sandbox %U' 'Exec=${pname} %U'
+  '';
+
+  meta = {
+    description = "Privacy-first desktop voice dictation, meeting transcription, and notes app";
+    longDescription = ''
+      OpenWhispr is a cross-platform desktop application for voice dictation,
+      meeting transcription, notes, and AI-assisted actions.
+    '';
+    homepage = "https://github.com/OpenWhispr/openwhispr";
+    changelog = "https://github.com/OpenWhispr/openwhispr/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "openwhispr";
+    maintainers = with lib.maintainers; [ benediktweyer ];
+    platforms = [ "x86_64-linux" ];
+  };
+}).overrideAttrs
+  {
+    strictDeps = true;
+    __structuredAttrs = true;
+  }


### PR DESCRIPTION
https://github.com/OpenWhispr/openwhispr
https://openwhispr.com/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
