### PR TITLE
Fix `juce.projucerHook` and propagate common dependencies; init `plasma` at 1.2.1

### DIFF
--- a/pkgs/by-name/ju/juce/projucer-hook.sh
+++ b/pkgs/by-name/ju/juce/projucer-hook.sh
@@ -5,11 +5,11 @@ set -e
 projucerConfigurePhase() {
   runHook preConfigure
 
-  Projucer --set-global-search-path linux defaultJuceModulePath @src@/modules
+  Projucer --set-global-search-path linux defaultJuceModulePath @juce@/modules
   if [ -n "${jucerUserModules-}" ]; then
     Projucer --set-global-search-path linux defaultUserModulePath "$jucerUserModules"
   fi
-  Projucer --resave "${jucerFile:-$pname.jucer}"
+  Projucer --resave "${jucerFile:-$pname.jucer}" --fix-missing-dependencies
 
   runHook postConfigure
 }

--- a/pkgs/by-name/ju/juce/projucerHook.nix
+++ b/pkgs/by-name/ju/juce/projucerHook.nix
@@ -2,10 +2,46 @@
   makeSetupHook,
   lib,
   callPackage,
+  writableTmpDirAsHomeHook,
+  alsa-lib,
+  curl,
+  gtk3,
+  libGL,
+  libx11,
+  libxcursor,
+  libxext,
+  libxinerama,
+  libxrandr,
+  pkg-config,
+  webkitgtk_4_1,
 }:
+let
+  juce = callPackage ./package.nix { };
+in
 makeSetupHook {
   name = "projucer-hook";
-  propagatedBuildInputs = [ (callPackage ./package.nix { }) ];
+
+  propagatedBuildInputs = [
+    juce
+    writableTmpDirAsHomeHook
+    pkg-config
+  ];
+
+  depsTargetTargetPropagated = [
+    alsa-lib
+    curl
+    gtk3
+    libGL
+    libx11
+    libxcursor
+    libxext
+    libxinerama
+    libxrandr
+    webkitgtk_4_1
+  ];
+
+  substitutions.juce = juce.src;
+
   meta = {
     platforms = lib.platforms.linux;
     license = lib.licenses.mit;

--- a/pkgs/by-name/pl/plasma/package.nix
+++ b/pkgs/by-name/pl/plasma/package.nix
@@ -1,0 +1,32 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  juce,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "plasma";
+  version = "1.2.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Dimethoxy";
+    repo = "Plasma";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-XfHYGZRgZ2fuVIasp4CSnwmO/MW254b6fgFAQmVug2Q=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ juce.projucerHook ];
+
+  jucerFile = "Plasma.jucer";
+
+  meta = {
+    description = "Asymmetrical Distortion Audio Plugin";
+    homepage = "https://github.com/Dimethoxy/Plasma";
+    license = lib.licenses.agpl3Plus;
+    inherit (juce.projucerHook.meta) platforms;
+    maintainers = [ lib.maintainers.bandithedoge ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
