### PR TITLE
yaziPlugins: support finalAttrs pattern; yazi{Plugins}: add meta.changelog

### DIFF
--- a/pkgs/by-name/ya/yazi-unwrapped/package.nix
+++ b/pkgs/by-name/ya/yazi-unwrapped/package.nix
@@ -62,6 +62,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Blazing fast terminal file manager written in Rust, based on async I/O";
     homepage = "https://github.com/sxyazi/yazi";
+    changelog = "https://github.com/sxyazi/yazi/blob/${finalAttrs.passthru.srcs.code_src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       eljamm

--- a/pkgs/by-name/ya/yazi/package.nix
+++ b/pkgs/by-name/ya/yazi/package.nix
@@ -102,6 +102,7 @@ runCommand yazi-unwrapped.name
         license
         maintainers
         mainProgram
+        changelog
         ;
     };
 

--- a/pkgs/by-name/ya/yazi/plugins/compress/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/compress/default.nix
@@ -3,7 +3,7 @@
   fetchFromGitHub,
   mkYaziPlugin,
 }:
-mkYaziPlugin {
+mkYaziPlugin (finalAttrs: {
   pname = "compress.yazi";
   version = "0.6";
 
@@ -17,7 +17,8 @@ mkYaziPlugin {
   meta = {
     description = "Yazi plugin that compresses selected files to an archive";
     homepage = "https://github.com/KKV9/compress.yazi";
+    changelog = "https://github.com/KKV9/compress.yazi/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ eljamm ];
   };
-}
+})

--- a/pkgs/by-name/ya/yazi/plugins/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/default.nix
@@ -8,21 +8,23 @@ let
   root = ./.;
   updateScript = ./update.py;
 
-  mkYaziPlugin =
-    args@{
-      pname,
-      src,
-      meta ? { },
-      installPhase ? null,
-      ...
-    }:
-    let
-      # Extract the plugin name from pname (removing .yazi suffix if present)
-      pluginName = lib.removeSuffix ".yazi" pname;
-    in
-    stdenvNoCC.mkDerivation (
-      args
-      // {
+  mkYaziPlugin = lib.extendMkDerivation {
+    constructDrv = stdenvNoCC.mkDerivation;
+
+    extendDrvArgs =
+      finalAttrs:
+      {
+        pname,
+        src,
+        meta ? { },
+        installPhase ? null,
+        ...
+      }@args:
+      let
+        # Extract the plugin name from pname (removing .yazi suffix if present)
+        pluginName = lib.removeSuffix ".yazi" pname;
+      in
+      {
         installPhase =
           if installPhase != null then
             installPhase
@@ -66,8 +68,8 @@ let
             supportedFeatures = [ "commit" ];
           };
         };
-      }
-    );
+      };
+  };
 
   call = name: callPackage (root + "/${name}") { inherit mkYaziPlugin; };
 in

--- a/pkgs/by-name/ya/yazi/plugins/sshfs/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/sshfs/default.nix
@@ -3,7 +3,7 @@
   fetchFromGitHub,
   mkYaziPlugin,
 }:
-mkYaziPlugin {
+mkYaziPlugin (finalAttrs: {
   pname = "sshfs.yazi";
   version = "2.1.0";
 
@@ -17,7 +17,8 @@ mkYaziPlugin {
   meta = {
     description = "Minimal SSHFS integration for the Yazi terminal file‑manager";
     homepage = "https://github.com/uhs-robert/sshfs.yazi";
+    changelog = "https://github.com/uhs-robert/sshfs.yazi/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ ilosariph ];
   };
-}
+})

--- a/pkgs/by-name/ya/yazi/plugins/yatline/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/yatline/default.nix
@@ -3,7 +3,7 @@
   fetchFromGitHub,
   mkYaziPlugin,
 }:
-mkYaziPlugin {
+mkYaziPlugin (finalAttrs: {
   pname = "yatline.yazi";
   version = "0.5.0";
 
@@ -17,7 +17,8 @@ mkYaziPlugin {
   meta = {
     description = "Yazi plugin for customizing both header-line and status-line";
     homepage = "https://github.com/imsi32/yatline.yazi";
+    changelog = "https://github.com/imsi32/yatline.yazi/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ khaneliman ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Make `mkYaziPlugin` support `finalAttrs` pattern
Add meta.changelog to have easier trace to actual release links. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
