### PR TITLE
raycast: 1.104.10 -> 1.104.17, raycast-beta: init at 0.60.0.0

### DIFF
--- a/pkgs/by-name/ra/raycast-beta/package.nix
+++ b/pkgs/by-name/ra/raycast-beta/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  writeShellApplication,
+  cacert,
+  curl,
+  openssl,
+  undmg,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "raycast-beta";
+  version = "0.60.0.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src =
+    {
+      aarch64-darwin = fetchurl {
+        name = "Raycast_Beta.dmg";
+        url = "https://x-r2.raycast-releases.com/Raycast_Beta_${finalAttrs.version}_2fc04147cc_arm64.dmg";
+        hash = "sha256-PQX5l5UzlphKySIR5QRcJvJLe9NxQrTOPLy3itV0QHU=";
+      };
+    }
+    .${stdenvNoCC.system} or (throw "raycast-beta: ${stdenvNoCC.system} is unsupported.");
+
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  nativeBuildInputs = [ undmg ];
+
+  sourceRoot = "Raycast Beta.app";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications/Raycast Beta.app"
+    cp -R . "$out/Applications/Raycast Beta.app"
+    mkdir -p "$out/bin"
+    ln -s "$out/Applications/Raycast Beta.app/Contents/MacOS/Raycast Beta" "$out/bin/raycast-beta"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = lib.getExe (writeShellApplication {
+    name = "raycast-beta-update-script";
+    runtimeInputs = [
+      cacert
+      curl
+      openssl
+    ];
+    text = ''
+      url=$(curl --silent "https://www.raycast.com/new" | grep -o 'https://x-r2\.raycast-releases\.com/Raycast_Beta_[^"]*_arm64\.dmg' | head -n1)
+      version=$(echo "$url" | sed -E 's|.*/Raycast_Beta_([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)_[^/]+_arm64\.dmg|\1|')
+      hash="sha256-$(curl -sL "$url" | openssl dgst -sha256 -binary | openssl base64)"
+
+      sed -i -E \
+        -e 's|(version = )"[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+";|\1"'"$version"'";|' \
+        -e 's|url = "https://x-r2\.raycast-releases\.com/Raycast_Beta_[^"]*_arm64\.dmg";|url = "'"$url"'";|' \
+        -e 's|(hash = )"sha256-[A-Za-z0-9+/]+=";|\1"'"$hash"'";|' \
+        ./pkgs/by-name/ra/raycast-beta/package.nix
+    '';
+  });
+
+  meta = {
+    description = "Control your tools with a few keystrokes - beta release";
+    homepage = "https://raycast.app/";
+    license = lib.licenses.unfree;
+    mainProgram = "raycast-beta";
+    maintainers = with lib.maintainers; [ FlameFlag ];
+    platforms = [ "aarch64-darwin" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/ra/raycast/package.nix
+++ b/pkgs/by-name/ra/raycast/package.nix
@@ -12,19 +12,19 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "raycast";
-  version = "1.104.10";
+  version = "1.104.17";
 
   src =
     {
       aarch64-darwin = fetchurl {
         name = "Raycast.dmg";
         url = "https://releases.raycast.com/releases/${finalAttrs.version}/download?build=arm";
-        hash = "sha256-YXEynLEEZChlbk+y3yfO0qYHY95eC00kWf9tzmQk5Ho=";
+        hash = "sha256-muX6PPanjU+ElCQhIfo7Y7cChbTO8Q/gH12ULvBK43s=";
       };
       x86_64-darwin = fetchurl {
         name = "Raycast.dmg";
         url = "https://releases.raycast.com/releases/${finalAttrs.version}/download?build=x86_64";
-        hash = "sha256-xr2//lFv67QlL1At2OEjAvZMnYbhbGjFTFUN6un3zY4=";
+        hash = "sha256-E8VGFydX5GXE3graZUSzN0S2JGbBXM/LD+DLm9waAus=";
       };
     }
     .${stdenvNoCC.system} or (throw "raycast: ${stdenvNoCC.system} is unsupported.");


### PR DESCRIPTION
## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
