### PR TITLE
sink-rotate: update src and accept upstream versioning

### DIFF
--- a/pkgs/by-name/si/sink-rotate/package.nix
+++ b/pkgs/by-name/si/sink-rotate/package.nix
@@ -5,22 +5,20 @@
   pipewire,
   wireplumber,
   makeWrapper,
+  nix-update-script,
 }:
-let
-  version = "2.3.0";
-in
 rustPlatform.buildRustPackage {
   pname = "sink-rotate";
-  inherit version;
+  version = "2.3.0-unstable-2026-05-14";
 
   src = fetchFromGitHub {
     owner = "mightyiam";
     repo = "sink-rotate";
-    rev = "v${version}";
-    hash = "sha256-gGmnji7KqmCxUaeXOGMnHMI6b8AJ6Np+xVjibqgGSKM=";
+    rev = "8bf24a2ebad7151fe5a7e8dd4577effccbd6fa2a";
+    hash = "sha256-ftSu04fWCgZ9Beu4pMAF8KKe3nfe0km1F6ExVWbmoxQ=";
   };
 
-  cargoHash = "sha256-7/EyDBWANoL5m9mx93LKMKD8hgcc3VgvrcLD6oTBXN8=";
+  cargoHash = "sha256-qiHrntm6p3j5784Pzh0NxeyQMasTQpgsfXq+DyDqies=";
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -29,6 +27,10 @@ rustPlatform.buildRustPackage {
       --prefix PATH : ${pipewire}/bin/pw-dump \
       --prefix PATH : ${wireplumber}/bin/wpctl
   '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
 
   meta = {
     description = "Command that rotates the default PipeWire audio sink";


### PR DESCRIPTION
Upstream (me) adopted a policy of "default branch is release".
This PR accepts that.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
