### PR TITLE
wpcleaner: 2.0.5-unstable-2025-04-25 -> 2.0.5-unstable-2026-05-11

### DIFF
--- a/pkgs/by-name/wp/wpcleaner/package.nix
+++ b/pkgs/by-name/wp/wpcleaner/package.nix
@@ -24,12 +24,12 @@ let
 in
 stdenv.mkDerivation {
   pname = "wpcleaner";
-  version = "2.0.5-unstable-2025-04-25";
+  version = "2.0.5-unstable-2026-05-11";
   src = fetchFromGitHub {
     owner = "WPCleaner";
     repo = "wpcleaner";
-    rev = "7fd357cf26349658183517658139870dd45eaedc";
-    hash = "sha256-iaAP/5Z+ghvMAn4ke7lhRqKov/3jXr0LMwbPDZ052j0=";
+    rev = "5d94f34e8aeb1d8353ec1981083acbc50eca10ee";
+    hash = "sha256-sUtaDGxoNF3EBvnDSRmFeGhceqLZxboQzU3H7MYOxP4";
   };
 
   dontConfigure = true;


### PR DESCRIPTION
This update adds a lot of translation, fixes the login due to the introduction of BotPasswords in wikipedia, and improves analysis. See the list of commits in the official github repo.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
