### PR TITLE
kernel updates for 2026-05-14

### DIFF
--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -25,8 +25,8 @@
         "lts": true
     },
     "6.12": {
-        "version": "6.12.87",
-        "hash": "sha256:0c4qidff0qs2x0mvba83cw3ksaz2af3xwabvc839xvsc9djaf4nc",
+        "version": "6.12.88",
+        "hash": "sha256:1s2x66j46gxw17j8hh5iws0l00aivmphp3mn8vgwbn8sj44gacjb",
         "lts": true
     },
     "6.18": {

--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -30,8 +30,8 @@
         "lts": true
     },
     "6.18": {
-        "version": "6.18.29",
-        "hash": "sha256:0g584ak8p9nqxysn8d1qzxbp1asfd39hqy9np35gri9v3xdsfgn3",
+        "version": "6.18.30",
+        "hash": "sha256:1m5kvzky4g2jc8b09np8can0lasg1lwjfgdj41s3ymxgqdp8icx8",
         "lts": true
     },
     "7.0": {

--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -35,8 +35,8 @@
         "lts": true
     },
     "7.0": {
-        "version": "7.0.6",
-        "hash": "sha256:08vm18wx6399phzgr3wz94yga3ab4fyca79445ygvbspm904996b",
+        "version": "7.0.7",
+        "hash": "sha256:1x2xnb7gpj0inxdc317zi71i0d98b7wq64s0yzk2vzxalf3gxqf8",
         "lts": false
     }
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelogs:
- https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.12.88
- https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.18.30
- https://cdn.kernel.org/pub/linux/kernel/v7.x/ChangeLog-7.0.7

Should be (partially) backported as they contain the "rxrpc: Also unshare DATA/RESPONSE packets when paged frags are present" commit as part of the "Dirty Frag" LPE mitigation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
