### PR TITLE
linuxPackages.r8127: init at 11.015.00

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29893,6 +29893,14 @@
     github = "wuyoli";
     githubId = 104238274;
   };
+  wwmoraes = {
+    email = "nixpkgs@artero.dev";
+    github = "wwmoraes";
+    githubId = 682095;
+    keys = [ { fingerprint = "32B4 330B 1B66 828E 4A96  9EEB EED9 9464 5D7C 9BDE"; } ];
+    matrix = "@wwmoraes:hachyderm.io";
+    name = "William Artero";
+  };
   wykurz = {
     email = "wykurz@gmail.com";
     github = "wykurz";

--- a/pkgs/os-specific/linux/r8127/default.nix
+++ b/pkgs/os-specific/linux/r8127/default.nix
@@ -1,0 +1,58 @@
+{
+  fetchFromGitHub,
+  kernel,
+  kernelModuleMakeFlags,
+  lib,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "r8127";
+  version = "11.015.00";
+
+  src = fetchFromGitHub {
+    owner = "openwrt";
+    repo = "rtl8127";
+    tag = finalAttrs.version;
+    hash = "sha256-U0i/IxB7EiiHGulwI4TdYeaOpHq8v4JBSTVZ0qMbcx0=";
+  };
+
+  hardeningDisable = [
+    "pic"
+  ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  prePatch = ''
+    substituteInPlace Makefile \
+      --replace-fail /lib/modules/ "${kernel.dev}/lib/modules/" \
+      --replace-fail '$(shell uname -r)' "${kernel.modDirVersion}" \
+      ;
+  '';
+
+  makeFlags = kernelModuleMakeFlags;
+
+  enableParallelBuilding = true;
+
+  buildFlags = [ "modules" ];
+
+  installPhase =
+    let
+      modDestDir = "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/net/ethernet/realtek/r8127";
+    in
+    ''
+      runHook preInstall
+
+      install -Dm0644 *.ko -t ${modDestDir}
+
+      runHook postInstall
+    '';
+
+  meta = {
+    description = "Realtek 8127 10G Ethernet driver";
+    homepage = "https://github.com/openwrt/rtl8127";
+    license = lib.licenses.gpl2Plus;
+    maintainers = [ lib.maintainers.wwmoraes ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -437,6 +437,8 @@ in
 
         r8125 = callPackage ../os-specific/linux/r8125 { };
 
+        r8127 = callPackage ../os-specific/linux/r8127 { };
+
         r8168 = callPackage ../os-specific/linux/r8168 { };
 
         rtl8188eus-aircrack = callPackage ../os-specific/linux/rtl8188eus-aircrack { };


### PR DESCRIPTION
Added a driver for the Realtek 8127 ethernet NIC. This is a new model (late 2025) of low-cost 10GbE adapters used by newer SBCs/mini-PCs. The driver isn't in the mainline linux kernel yet as of May 2026.

The package uses a [git repository provided by the OpenWRT community](https://github.com/openwrt/rtl8127), which is a convenience carbon-copy of the [drivers' source code provided by Realtek](https://www.realtek.com/Download/List?cate_id=584) in tarball format but hidden behind a captcha-of-sorts anti-bot protection.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - used `nix run nixpkgs#nixpkgs-review -- rev HEAD`
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
