### PR TITLE
quota-tracker: init at 0.1.35

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27611,6 +27611,11 @@
     githubId = 42005990;
     name = "Ali Mohammadzadeh";
   };
+  Thomas97460 = {
+    github = "Thomas97460";
+    githubId = 114427689;
+    name = "Thomas Collet";
+  };
   thomasdesr = {
     email = "git@hive.pw";
     github = "thomasdesr";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -941,6 +941,7 @@
   ./services/misc/portunus.nix
   ./services/misc/pufferpanel.nix
   ./services/misc/pykms.nix
+  ./services/misc/quota-tracker.nix
   ./services/misc/radicle.nix
   ./services/misc/realmd.nix
   ./services/misc/rebuilderd.nix

--- a/nixos/modules/services/misc/quota-tracker.nix
+++ b/nixos/modules/services/misc/quota-tracker.nix
@@ -1,0 +1,73 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.quota-tracker;
+in
+{
+  options.services.quota-tracker = {
+    enable = lib.mkEnableOption "quota-tracker daemon";
+
+    package = lib.mkPackageOption pkgs "quota-tracker" { };
+
+    host = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      description = "Host to bind the quota-tracker daemon to.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 8787;
+      description = "Port to bind the quota-tracker daemon to.";
+    };
+
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [
+        "--log-level"
+        "DEBUG"
+      ];
+      description = "Extra arguments to pass to the quota-tracker daemon.";
+    };
+
+    environment = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      example = {
+        QUOTA_TRACKER_LOG_LEVEL = "DEBUG";
+      };
+      description = "Environment variables for the quota-tracker service.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.user.services.quota-tracker = {
+      description = "Quota Tracker Daemon";
+      wantedBy = [ "default.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        ExecStart = lib.escapeShellArgs (
+          [
+            (lib.getExe cfg.package)
+            "daemon"
+            "--host"
+            cfg.host
+            "--port"
+            (toString cfg.port)
+          ]
+          ++ cfg.extraArgs
+        );
+        Restart = "on-failure";
+      };
+
+      inherit (cfg) environment;
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1410,6 +1410,7 @@ in
   qui = runTest ./qui.nix;
   quicktun = runTest ./quicktun.nix;
   quickwit = runTest ./quickwit.nix;
+  quota-tracker = runTest ./quota-tracker.nix;
   rabbitmq = runTest ./rabbitmq.nix;
   radarr = runTest ./radarr.nix;
   radicale = runTest ./radicale.nix;

--- a/nixos/tests/quota-tracker.nix
+++ b/nixos/tests/quota-tracker.nix
@@ -1,0 +1,36 @@
+{ pkgs, ... }:
+
+{
+  name = "quota-tracker";
+  meta = {
+    maintainers = [ pkgs.lib.maintainers.Thomas97460 ];
+  };
+
+  nodes.machine = {
+    imports = [ ./common/user-account.nix ];
+    services.quota-tracker = {
+      enable = true;
+      host = "127.0.0.1";
+      port = 9898;
+    };
+  };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+
+    # The service is a user service, so we need to start the user manager
+    machine.execute("loginctl enable-linger alice")
+    machine.systemctl("start user@1000")
+
+    # Wait for the user service to start
+    machine.wait_for_unit("quota-tracker.service", "alice")
+
+    # Check if the binary is available and works
+    machine.succeed("sudo -u alice ${pkgs.quota-tracker}/bin/quota-tracker --help")
+
+    # Check if the daemon is listening on its configured port 9898
+    machine.wait_for_open_port(9898)
+    machine.succeed("curl -f http://127.0.0.1:9898/api/version")
+  '';
+}

--- a/pkgs/by-name/qu/quota-tracker/package.nix
+++ b/pkgs/by-name/qu/quota-tracker/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "quota-tracker";
+  version = "0.1.35";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Thomas97460";
+    repo = "quota-tracker";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-OMd9IPp68RpNixzgs51RHGYdryzp+cmrnavdkkHNOpc=";
+  };
+
+  __structuredAttrs = true;
+
+  strictDeps = true;
+
+  build-system = with python3Packages; [
+    setuptools
+    wheel
+  ];
+
+  dependencies = with python3Packages; [
+    fastapi
+    httpx
+    uvicorn
+    pydantic
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+    pytest-cov
+  ];
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  postPatch = ''
+    rm -rf quota_tracker/frontend_dist
+    mkdir -p quota_tracker/frontend_dist
+    cp -r ${finalAttrs.passthru.frontend}/dist/* quota_tracker/frontend_dist/
+  '';
+
+  pythonImportsCheck = [ "quota_tracker" ];
+
+  passthru.frontend = buildNpmPackage {
+    pname = "${finalAttrs.pname}-frontend";
+    inherit (finalAttrs) version src;
+    sourceRoot = "${finalAttrs.src.name}/frontend";
+    npmDepsHash = "sha256-CzfezurcDIJJxCDNb/+5+2r+tutqZ1pIEBSNRw1c/Qg=";
+    npmBuildScript = "build";
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out
+      cp -r dist $out/dist
+      runHook postInstall
+    '';
+  };
+
+  meta = {
+    description = "Track token usage and quotas for Claude, Copilot, Codex, and Gemini";
+    homepage = "https://github.com/Thomas97460/quota-tracker";
+    license = lib.licenses.mit;
+    mainProgram = "quota-tracker";
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ Thomas97460 ];
+  };
+})


### PR DESCRIPTION
## Summary

Add `quota-tracker` at `0.1.35`.

`quota-tracker` is a local CLI/API daemon for tracking token usage and quota information for Claude, Copilot, Codex, and Gemini.

Homepage: https://github.com/Thomas97460/quota-tracker

This PR adds:
- the `quota-tracker` package under `pkgs/by-name/qu/quota-tracker`
- a NixOS module exposing `services.quota-tracker`
- a NixOS VM test for the service
- a new maintainer entry

The package builds the React/Vite frontend with `buildNpmPackage`, bundles the generated frontend assets into the Python package, and installs the `quota-tracker` executable.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
    - `nix-build -A nixosTests.quota-tracker`
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - `nix-build -A quota-tracker`
  - `./result/bin/quota-tracker --version`
  - `./result/bin/quota-tracker --help`
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test