### PR TITLE
roundcube: 1.6.15 -> 1.7.0

### DIFF
--- a/nixos/modules/services/mail/roundcube.nix
+++ b/nixos/modules/services/mail/roundcube.nix
@@ -184,7 +184,7 @@ in
         ${cfg.hostName} = {
           forceSSL = lib.mkDefault true;
           enableACME = lib.mkDefault true;
-          root = cfg.package;
+          root = cfg.package + "/public_html";
           locations."/" = {
             index = "index.php";
             priority = 1100;
@@ -193,19 +193,6 @@ in
               client_max_body_size ${toString cfg.maxAttachmentSize};
             '';
           };
-          locations."~ ^/(SQL|bin|config|logs|temp|vendor)/" = {
-            priority = 3110;
-            extraConfig = ''
-              return 404;
-            '';
-          };
-          locations."~ ^/(CHANGELOG.md|INSTALL|LICENSE|README.md|SECURITY.md|UPGRADING|composer.json|composer.lock)" =
-            {
-              priority = 3120;
-              extraConfig = ''
-                return 404;
-              '';
-            };
           locations."~* \\.php(/|$)" = {
             priority = 3130;
             extraConfig = ''

--- a/nixos/modules/services/mail/roundcube.nix
+++ b/nixos/modules/services/mail/roundcube.nix
@@ -9,7 +9,7 @@ let
   fpm = config.services.phpfpm.pools.roundcube;
   localDB = cfg.database.host == "localhost";
   user = cfg.database.username;
-  phpWithPspell = pkgs.php83.withExtensions ({ enabled, all }: [ all.pspell ] ++ enabled);
+  phpWithPspell = pkgs.php84.withExtensions ({ enabled, all }: [ all.pspell ] ++ enabled);
 
   env = {
     ASPELL_CONF = "dict-dir ${pkgs.aspellWithDicts (_: cfg.dicts)}/lib/aspell";

--- a/nixos/tests/roundcube.nix
+++ b/nixos/tests/roundcube.nix
@@ -33,6 +33,6 @@
     roundcube.wait_for_unit("postgresql.target")
     roundcube.wait_for_unit("phpfpm-roundcube.service")
     roundcube.wait_for_unit("nginx.service")
-    roundcube.succeed("curl -sSfL http://roundcube/ | grep 'Keep me logged in'")
+    t.assertIn("Keep me logged in", roundcube.succeed("curl -sSfL http://roundcube/"))
   '';
 }

--- a/pkgs/servers/roundcube/0001-Don-t-resolve-symlinks-when-trying-to-find-INSTALL_P.patch
+++ b/pkgs/servers/roundcube/0001-Don-t-resolve-symlinks-when-trying-to-find-INSTALL_P.patch
@@ -1,27 +1,57 @@
-From c1832eabb99cec47f1714f696275285e1e28da34 Mon Sep 17 00:00:00 2001
+From c6b017ce9e85e7a27f65429ba41d3642bd6dc393 Mon Sep 17 00:00:00 2001
 From: Maximilian Bosch <maximilian@mbosch.me>
 Date: Tue, 2 Apr 2019 16:20:50 +0200
 Subject: [PATCH] Don't resolve symlinks when trying to find INSTALL_PATH
 
 Nix specific patch. This behavior breaks roundcube setups where plugins
 are in a store path with symlinks to the actual source.
+
+Also, __DIR__ resolves the symlink from `buildEnv`, so we do
+$_SERVER['SCRIPT_FILENAME'] instead.
 ---
- bin/update.sh | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ bin/update.sh          | 2 +-
+ public_html/index.php  | 1 +
+ public_html/static.php | 2 +-
+ 3 files changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/bin/update.sh b/bin/update.sh
-index 08e3bb5..b2ad498 100755
+index 4d8e829cc..3810aa2b9 100755
 --- a/bin/update.sh
 +++ b/bin/update.sh
 @@ -19,7 +19,7 @@
   +-----------------------------------------------------------------------+
  */
  
--define('INSTALL_PATH', realpath(__DIR__ . '/..') . '/' );
+-define('INSTALL_PATH', realpath(__DIR__ . '/..') . '/');
 +define('INSTALL_PATH', dirname(dirname($argv[0])).'/');
  
  require_once INSTALL_PATH . 'program/include/clisetup.php';
  
+diff --git a/public_html/index.php b/public_html/index.php
+index f8a0c4973..5fd1c57ec 100644
+--- a/public_html/index.php
++++ b/public_html/index.php
+@@ -36,6 +36,7 @@
+  +-------------------------------------------------------------------------+
+ */
+ 
++define('INSTALL_PATH', dirname($_SERVER['SCRIPT_FILENAME']) . '/../');
+ // include environment
+ require_once __DIR__ . '/../program/include/iniset.php';
+ 
+diff --git a/public_html/static.php b/public_html/static.php
+index f954ef365..a2cc3c24c 100644
+--- a/public_html/static.php
++++ b/public_html/static.php
+@@ -54,7 +54,7 @@ const ALLOWED_PATHS = [
+     'skins/',
+ ];
+ 
+-define('INSTALL_PATH', realpath(__DIR__ . '/..') . '/');
++define('INSTALL_PATH', dirname($_SERVER['SCRIPT_FILENAME']) . '/../');
+ 
+ $path = validateStaticFile($_SERVER['PATH_INFO']);
+ 
 -- 
-2.19.2
+2.51.2
 

--- a/pkgs/servers/roundcube/default.nix
+++ b/pkgs/servers/roundcube/default.nix
@@ -6,15 +6,16 @@
   roundcube,
   roundcubePlugins,
   nixosTests,
+  runCommand,
 }:
 
 stdenv.mkDerivation rec {
   pname = "roundcube";
-  version = "1.6.15";
+  version = "1.7.0";
 
   src = fetchurl {
     url = "https://github.com/roundcube/roundcubemail/releases/download/${version}/roundcubemail-${version}-complete.tar.gz";
-    sha256 = "sha256-SMnyEsd0YBMkkfZwq69EC3ZcgnYmg0mmkJE3ZNJq++8=";
+    sha256 = "sha256-o0w2baK3okrUpjgrS7mmd8tYHuCL/GME0KmnIQmOepg=";
   };
 
   patches = [ ./0001-Don-t-resolve-symlinks-when-trying-to-find-INSTALL_P.patch ];
@@ -29,15 +30,18 @@ stdenv.mkDerivation rec {
     cp -r * $out/
     ln -sf /etc/roundcube/config.inc.php $out/config/config.inc.php
     rm -rf $out/installer
-    # shut up updater
-    rm $out/composer.json-dist
   '';
 
   passthru.withPlugins =
     f:
     buildEnv {
       name = "${roundcube.name}-with-plugins";
-      paths = (f roundcubePlugins) ++ [ roundcube ];
+      paths = (f roundcubePlugins) ++ [
+        roundcube
+        (runCommand "dummy" { } ''
+          mkdir -p $out/public_html/
+        '')
+      ];
     };
 
   passthru.tests = { inherit (nixosTests) roundcube; };


### PR DESCRIPTION
ChangeLog: https://github.com/roundcube/roundcubemail/releases/tag/1.7.0
Closes https://github.com/NixOS/nixpkgs/issues/468713
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
