### PR TITLE
birdnet-analyzer: init at 2.4.0-unstable-2026-06-12

### DIFF
--- a/pkgs/by-name/bi/birdnet-analyzer/package.nix
+++ b/pkgs/by-name/bi/birdnet-analyzer/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  unstableGitUpdater,
+}:
+python3Packages.buildPythonApplication (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "birdnet-analyzer";
+  version = "2.4.0-unstable-2026-06-12";
+
+  # Using an unstable version because an older version was touching the
+  # RO nix store
+  src = fetchFromGitHub {
+    owner = "birdnet-team";
+    repo = "BirdNET-Analyzer";
+    rev = "80d30e60a36d809c5bc6b9e0ba830317125e8c71";
+    hash = "sha256-ucU2BU7knO6qzrjek/a2Qo8pqk/jiMpa7/KO0iuU7dY=";
+  };
+
+  pyproject = true;
+
+  build-system = [
+    python3Packages.setuptools
+  ];
+
+  # GUI doesn't work as they have not migrated to the new Gradio
+  dependencies = with python3Packages; [
+    librosa
+    resampy
+    tensorflow
+    pyarrow
+    tqdm
+    pandas
+    matplotlib
+    birdnet
+  ];
+
+  passthru.updateScript = unstableGitUpdater { tagPrefix = "v"; };
+
+  meta = {
+    homepage = "https://birdnet.cornell.edu/birdnet";
+    donationPage = "https://birdnet.cornell.edu/donate";
+    downloadPage = "https://github.com/birdnet-team/BirdNET-Analyzer/releases";
+    mainProgram = "birdnet-analyzer";
+    license = [
+      lib.licenses.mit
+    ];
+    maintainers = [
+      lib.maintainers.RossSmyth
+    ];
+  };
+
+})

--- a/pkgs/development/python-modules/birdnet/default.nix
+++ b/pkgs/development/python-modules/birdnet/default.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  fetchFromGitHub,
+  writableTmpDirAsHomeHook,
+  buildPythonPackage,
+  pytestCheckHook,
+  setuptools,
+  soundfile,
+  scipy,
+  ordered-set,
+  tqdm,
+  numpy,
+  pandas,
+  psutil,
+  pyarrow,
+  kagglehub,
+  tensorflow,
+  pytest-cov-stub,
+  pytest-xdist,
+  pytest-timeout,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "birdnet";
+  version = "0.2.16";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "birdnet-team";
+    repo = "birdnet";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-xHXuo50rx+xQoyWgr06VXkL2CnZhfvRqwzqeAcj8d9g=";
+  };
+
+  __structuredAttrs = true;
+
+  build-system = [
+    setuptools
+  ];
+
+  nativeBuildInputs = [
+    writableTmpDirAsHomeHook
+  ];
+
+  dependencies = [
+    soundfile
+    scipy
+    ordered-set
+    tqdm
+    numpy
+    pandas
+    psutil
+    pyarrow
+    kagglehub
+    tensorflow
+  ];
+
+  # Tries to download model weights during tests
+  doCheck = false;
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  checkInputs = [
+    pytest-cov-stub
+    pytest-xdist
+    pytest-timeout
+  ];
+
+  pythonImportsCheck = [
+    "birdnet"
+  ];
+
+  meta = {
+    homepage = "https://birdnet.cornell.edu/birdnet";
+    downloadPage = "https://github.com/birdnet-team/birdnet/releases";
+    changelog = "https://github.com/birdnet-team/birdnet/releases/tag/v${finalAttrs.version}";
+    license = [
+      lib.licenses.mit
+    ];
+    maintainers = [
+      lib.maintainers.RossSmyth
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2098,6 +2098,8 @@ self: super: with self; {
 
   birch = callPackage ../development/python-modules/birch { };
 
+  birdnet = callPackage ../development/python-modules/birdnet { };
+
   bitarray = callPackage ../development/python-modules/bitarray { };
 
   bitbox02 = callPackage ../development/python-modules/bitbox02 { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

The CLI tools work. The GUI does not right now because the packaged Gradio is too new. 

Uses an unstable version because the latest stable version tries to touch the nix store at runtime.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
