### PR TITLE
scip: 0.6.1 -> 0.7.1

### DIFF
--- a/pkgs/by-name/sc/scip/package.nix
+++ b/pkgs/by-name/sc/scip/package.nix
@@ -10,16 +10,20 @@
 
 buildGo125Module (finalAttrs: {
   pname = "scip";
-  version = "0.6.1";
+  version = "0.7.1";
 
   src = fetchFromGitHub {
     owner = "sourcegraph";
     repo = "scip";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-l68xhOMgwt+ySChk7BCyklcuC6r51GgobAg3lRLvOCU=";
+    hash = "sha256-lpzGrTvWUXUFfmyn5z4rsqJEcAOA8D1qfN1assRAdn4=";
   };
 
-  vendorHash = "sha256-8HgeG/SXkM7ptOwKSi/PUH3VySxFqqoIpXI7bZtbO4A=";
+  vendorHash = "sha256-ARfsSW/d2bb4Lp6hedSmMerr3LrkuTfUCi569hI6eYY=";
+
+  subPackages = [ "cmd/scip" ];
+
+  env.GOWORK = "off";
 
   ldflags = [
     "-s"
@@ -27,15 +31,6 @@ buildGo125Module (finalAttrs: {
   ];
 
   nativeCheckInputs = lib.optionals stdenv.hostPlatform.isDarwin [ libredirect.hook ];
-
-  checkFlags =
-    let
-      skippedTests = [
-        "TestParseCompat" # could not locate sample indexes directory starting from parents of working directory
-        "TestParseSymbol_ZeroAllocationsIfMemoryAvailable"
-      ];
-    in
-    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   __darwinAllowLocalNetworking = true;
 


### PR DESCRIPTION
Update to 0.7.1

build fixes for Go workspace

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
