### PR TITLE
material-maker: package metadata and icon files

### DIFF
--- a/pkgs/by-name/ma/material-maker/package.nix
+++ b/pkgs/by-name/ma/material-maker/package.nix
@@ -73,6 +73,15 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -vp $out/bin
     ln -vs $out/share/material-maker/material-maker $out/bin/material-maker
 
+    mkdir -vp $out/share/applications
+    cp -v material_maker/misc/linux/io.github.RodZill4.Material-Maker.desktop $out/share/applications
+
+    mkdir -vp $out/share/metainfo
+    cp -v material_maker/misc/linux/io.github.RodZill4.Material-Maker.appdata.xml $out/share/metainfo
+
+    mkdir -vp $out/share/icons/hicolor/256x256/apps
+    cp -v icon.png $out/share/icons/hicolor/256x256/apps/material-maker.png
+
     runHook postInstall
   '';
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add metadata and icon files to the material-maker package. This is so that the application is accessible from application launchers and the appropriate icon is displayed in graphical shells.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
