### PR TITLE
nixos/steam: allow configuration of bitness of loaded extest

### DIFF
--- a/nixos/modules/programs/steam.nix
+++ b/nixos/modules/programs/steam.nix
@@ -62,7 +62,11 @@ in
               STEAM_EXTRA_COMPAT_TOOLS_PATHS = extraCompatPaths;
             })
             // (lib.optionalAttrs cfg.extest.enable {
-              LD_PRELOAD = "${pkgs.pkgsi686Linux.extest}/lib/libextest.so";
+              LD_PRELOAD = builtins.concatStringsSep ":" (
+                builtins.map (pkg: "${pkg}/lib/libextest.so")
+                  (lib.optional cfg.extest.enable32Bit pkgs.pkgsi686Linux.extest)
+                  (lib.optional cfg.extest.enable64Bit pkgs.extest)
+              );
             })
             // (prev.extraEnv or { });
           extraLibraries =
@@ -191,10 +195,18 @@ in
       };
     };
 
-    extest.enable = lib.mkEnableOption ''
-      Load the extest library into Steam, to translate X11 input events to
-      uinput events (e.g. for using Steam Input on Wayland)
-    '';
+    extest = {
+      enable = lib.mkEnableOption ''
+        loading the extest library into Steam, to translate X11 XTEST input events to uinput events (e.g. for using Steam Input on Wayland).
+
+        The 32-bit library is loaded by default, but the 64-bit library can be loaded instead or in addition.
+      '';
+      enable32Bit = (lib.mkEnableOption "the 32-bit extest library") // {
+        default = true;
+        example = false;
+      };
+      enable64Bit = lib.mkEnableOption "the 64-bit extest library";
+    };
 
     protontricks = {
       enable = lib.mkEnableOption "protontricks, a simple wrapper for running Winetricks commands for Proton-enabled games";


### PR DESCRIPTION
As steam gets closer to a fully 64-bit environment, allowing users to load the 64-bit extest library (or both at the same time) helps future-proof the module. Specifically when using the experimental RT3 client, the 64-bit library is required for steam input to work on a wayland desktop, and I'm fairly certain that the 32-bit library isn't needed at all.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
