### PR TITLE
python3Packages.pyopengl: simplify patching, respect LD_PRELOAD_PATH

### DIFF
--- a/pkgs/development/python-modules/pyopengl/default.nix
+++ b/pkgs/development/python-modules/pyopengl/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   buildPythonPackage,
+  replaceVars,
   fetchPypi,
   setuptools,
   pkgs,
@@ -23,46 +24,20 @@ buildPythonPackage (finalAttrs: {
 
   dependencies = [ pillow ];
 
-  patchPhase =
-    let
-      ext = stdenv.hostPlatform.extensions.sharedLibrary;
-    in
-    lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
-      # Theses lines are patching the name of dynamic libraries
-      # so pyopengl can find them at runtime.
-      substituteInPlace OpenGL/platform/glx.py \
-        --replace-fail "'OpenGL'"  '"${pkgs.libGL}/lib/libOpenGL${ext}"' \
-        --replace-fail "'GL'"  '"${pkgs.libGL}/lib/libGL${ext}"' \
-        --replace-fail '"GLU",' '"${pkgs.libGLU}/lib/libGLU${ext}",' \
-        --replace-fail "'GLX'" '"${pkgs.libglvnd}/lib/libGLX${ext}"' \
-        --replace-fail '"glut",' '"${pkgs.libglut}/lib/libglut${ext}",' \
-        --replace-fail '"GLESv1_CM",' '"${pkgs.libGL}/lib/libGLESv1_CM${ext}",' \
-        --replace-fail '"GLESv2",' '"${pkgs.libGL}/lib/libGLESv2${ext}",' \
-        --replace-fail '"gle",' '"${pkgs.gle}/lib/libgle${ext}",' \
-        --replace-fail "'EGL'" "'${pkgs.libGL}/lib/libEGL${ext}'"
-      substituteInPlace OpenGL/platform/egl.py \
-        --replace-fail "('OpenGL','GL')" "('${pkgs.libGL}/lib/libOpenGL${ext}', '${pkgs.libGL}/lib/libGL${ext}')" \
-        --replace-fail "'GLU'," "'${pkgs.libGLU}/lib/libGLU${ext}'," \
-        --replace-fail "'glut'," "'${pkgs.libglut}/lib/libglut${ext}'," \
-        --replace-fail "'GLESv1_CM'," "'${pkgs.libGL}/lib/libGLESv1_CM${ext}'," \
-        --replace-fail "'GLESv2'," "'${pkgs.libGL}/lib/libGLESv2${ext}'," \
-        --replace-fail "'gle'," '"${pkgs.gle}/lib/libgle${ext}",' \
-        --replace-fail "'EGL'," "'${pkgs.libGL}/lib/libEGL${ext}',"
-      substituteInPlace OpenGL/platform/darwin.py \
-        --replace-fail "'OpenGL'," "'${pkgs.libGL}/lib/libGL${ext}'," \
-        --replace-fail "'GLUT'," "'${pkgs.libglut}/lib/libglut${ext}',"
-    ''
-    + ''
-      # https://github.com/NixOS/nixpkgs/issues/76822
-      # pyopengl introduced a new "robust" way of loading libraries in 3.1.4.
-      # The later patch of the filepath does not work anymore because
-      # pyopengl takes the "name" (for us: the path) and tries to add a
-      # few suffix during its loading phase.
-      # The following patch put back the "name" (i.e. the path) in the
-      # list of possible files.
-      substituteInPlace OpenGL/platform/ctypesloader.py \
-        --replace-fail "filenames_to_try = [base_name]" "filenames_to_try = [name]"
-    '';
+  passthru.runtimeLibs = lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    "/run/opengl-driver/lib"
+    pkgs.libglvnd
+    pkgs.libGLU
+    pkgs.libglut
+    pkgs.gle
+  ];
+
+  patches = lib.optionals (finalAttrs.passthru.runtimeLibs != [ ]) [
+    # patch OpenGL.platform.ctypesloader::_loadLibraryPosix with extra search paths
+    (replaceVars ./ld-preload-gl.patch {
+      GL_LD_LIBRARY_PATH = lib.makeLibraryPath finalAttrs.passthru.runtimeLibs;
+    })
+  ];
 
   # Need to fix test runner
   # Tests have many dependencies
@@ -70,12 +45,19 @@ buildPythonPackage (finalAttrs: {
   # Should run test suite from $out/${python.sitePackages}
   doCheck = false; # does not affect pythonImportsCheck
 
-  # OpenGL looks for libraries during import, making this a somewhat decent test of the flaky patching above.
+  # PyOpenGL looks for libraries during import, making this a somewhat decent test of our patching
+  # (these are impure deps on darwin)
   pythonImportsCheck = [
     "OpenGL"
     "OpenGL.GL"
+    "OpenGL.GLE"
+    "OpenGL.GLU"
   ]
   ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    "OpenGL.EGL"
+    "OpenGL.GLES1"
+    "OpenGL.GLES2"
+    "OpenGL.GLES3"
     "OpenGL.GLX"
   ];
 

--- a/pkgs/development/python-modules/pyopengl/default.nix
+++ b/pkgs/development/python-modules/pyopengl/default.nix
@@ -9,13 +9,13 @@
   mesa,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pyopengl";
   version = "3.1.10";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-xKAtaGa1TrEZyOmz+wT6g1qVq4At2WYHq0zbABLfgzU=";
   };
 
@@ -91,4 +91,4 @@ buildPythonPackage rec {
     license = lib.licenses.bsd3;
     inherit (mesa.meta) platforms;
   };
-}
+})

--- a/pkgs/development/python-modules/pyopengl/ld-preload-gl.patch
+++ b/pkgs/development/python-modules/pyopengl/ld-preload-gl.patch
@@ -1,0 +1,17 @@
+diff --git a/OpenGL/platform/ctypesloader.py b/OpenGL/platform/ctypesloader.py
+index d9ff006..ce7d99e 100644
+--- a/OpenGL/platform/ctypesloader.py
++++ b/OpenGL/platform/ctypesloader.py
+@@ -59,6 +59,12 @@ def _loadLibraryPosix(dllType, name, mode):
+     ])))
+     err = None
+ 
++    filenames_to_try = [
++        (f"{prefix}/{filename}" if prefix else filename)
++        for prefix in ":@GL_LD_LIBRARY_PATH@".split(":")
++        for filename in filenames_to_try
++    ]
++
+     for filename in filenames_to_try:
+         try:
+             result = dllType(filename, mode)


### PR DESCRIPTION
- **python3Packages.pyopengl: migrate to finalAttrs**
- **python3Packages.pyopengl: simplify patching, respect LD_PRELOAD_PATH**

This makes pyopengl respect LD_PRELOAD_PATH, and may even work on fhs distros.

----

Initially I tried a patch like

```patch
diff --git a/OpenGL/platform/ctypesloader.py b/OpenGL/platform/ctypesloader.py
index d9ff006..35dadb9 100644
--- a/OpenGL/platform/ctypesloader.py
+++ b/OpenGL/platform/ctypesloader.py
@@ -35,7 +35,24 @@ def loadLibrary( dllType, name, mode = ctypes.RTLD_GLOBAL ):
     else:
         return _loadLibraryWindows(dllType, name, mode)

+import contextlib
+@contextlib.contextmanager
+def _with_nix_libs_suffixed():
+    GL_LD_LIBRARY_PATH = "@GL_LD_LIBRARY_PATH@"
+    prev_ld_library_path = os.environ.get("LD_LIBRARY_PATH", "")
+    if "LD_LIBRARY_PATH" in os.environ:
+        if prev_ld_library_path:
+            os.environ["LD_LIBRARY_PATH"] += f":{GL_LD_LIBRARY_PATH}"
+        else:
+            os.environ["LD_LIBRARY_PATH"] = GL_LD_LIBRARY_PATH
+        yield
+        os.environ["LD_LIBRARY_PATH"] = prev_ld_library_path
+    else:
+        os.environ["LD_LIBRARY_PATH"] = GL_LD_LIBRARY_PATH
+        yield
+        del os.environ["LD_LIBRARY_PATH"]

+ @_with_nix_libs_suffixed()
 def _loadLibraryPosix(dllType, name, mode):
     """Load a given library for posix systems
```

... only to learn that [dlopen(3) only reads `LD_LIBRARY_PATH` on program startup](https://manpages.debian.org/trixie/manpages-dev/dlopen.3.en.html).

My second approach (this PR) turned out way more simple.

----

@someoneserge: does adding the `/run/opengl-driver/lib` to the search list (for `libGL.so` and co, not `libGL_mesa.so`) actually make any sense, or should i just let libglvnd handle that?



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
