### PR TITLE
buildkite-cli: 3.40.0 -> 3.42.0

### DIFF
--- a/pkgs/by-name/bu/buildkite-cli/package.nix
+++ b/pkgs/by-name/bu/buildkite-cli/package.nix
@@ -11,16 +11,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "buildkite-cli";
-  version = "3.40.0";
+  version = "3.42.0";
 
   src = fetchFromGitHub {
     owner = "buildkite";
     repo = "cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-8Fij2SG6dLnyc4U2Q+jIx2ZDzbGd6ETTWiiz3ciRaE8=";
+    hash = "sha256-dk/25ujJ83+FlactIoDXOmLpyOlE0eEnruV4hGWVfwc=";
   };
 
-  vendorHash = "sha256-pxVSzEc/pgPaMMBOl5LYjbmPVpjr1M2obFmeiGqfgik=";
+  vendorHash = "sha256-GGIjZ3Fc40JN6STP9h+0AER5PcTL4zf/SYa22vqrj6k=";
 
   ldflags = [
     "-s"
@@ -40,6 +40,8 @@ buildGoModule (finalAttrs: {
 
         # Requires a git repository (which is removed by nix after fetching the source)
         "TestResolvePipelinesFromPath"
+        "TestPreflightCmd_Run"
+        "TestSnapshotContext_CancelsPush"
       ]
       ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
         # Expected timeout error but got none


### PR DESCRIPTION
Update to 3.42.0

https://github.com/buildkite/cli/compare/v3.40.0...v3.42.0

Skip tests requiring git repo.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
