### PR TITLE
vscode-extensions.oxc.oxc-vscode: init at 1.55.0

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -3707,6 +3707,8 @@ let
 
       oracle.oracle-java = callPackage ./oracle.oracle-java { };
 
+      oxc.oxc-vscode = callPackage ./oxc.oxc-vscode { };
+
       ph-hawkins.arc-plus = callPackage ./ph-hawkins.arc-plus { };
 
       phind.phind = buildVscodeMarketplaceExtension {

--- a/pkgs/applications/editors/vscode/extensions/oxc.oxc-vscode/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/oxc.oxc-vscode/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  vscode-utils,
+  jaq,
+  moreutils,
+  oxlint,
+  oxfmt,
+}:
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    publisher = "oxc";
+    name = "oxc-vscode";
+    version = "1.55.0";
+    hash = "sha256-QAuN9Qe1AErcGIbbqsYYO6kikgaEiX0Y3ddnNhuOB6Q=";
+  };
+
+  nativeBuildInputs = [
+    jaq
+    moreutils
+  ];
+
+  postPatch = ''
+    jaq \
+      --arg oxlint "${lib.getExe oxlint}" \
+      --arg oxfmt "${lib.getExe oxfmt}" \
+      '
+        .contributes.configuration.properties."oxc.path.oxlint".default = $oxlint |
+        .contributes.configuration.properties."oxc.path.oxfmt".default = $oxfmt
+      ' package.json | sponge package.json
+  '';
+
+  meta = {
+    description = "Oxlint and Oxfmt editor integration";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=oxc.oxc-vscode";
+    homepage = "https://github.com/oxc-project/oxc-vscode";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.drupol ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
