### PR TITLE
mangojuice: 0.8.9 -> 0.9.0

### DIFF
--- a/pkgs/by-name/ma/mangojuice/fix-vkbasalt-path.patch
+++ b/pkgs/by-name/ma/mangojuice/fix-vkbasalt-path.patch
@@ -1,12 +1,12 @@
 diff --git a/src/mangojuice.vala b/src/mangojuice.vala
-index 8c2cbef..46e7f73 100644
+index 46e7f73..8c2cbef 100644
 --- a/src/mangojuice.vala
 +++ b/src/mangojuice.vala
-@@ -2566,7 +2566,7 @@ public class MangoJuice : Adw.Application {
+@@ -3013,7 +3013,7 @@ public class MangoJuice : Adw.Application {
      }
  
      async bool check_vkbasalt_installed_async () {
--        string[] paths = { "/usr/lib/libvkbasalt.so", "/usr/lib/x86_64-linux-gnu/libvkbasalt.so", "/usr/local/lib/libvkbasalt.so", "/usr/lib64/vkbasalt/libvkbasalt.so" };
+-        string[] paths = { "/usr/lib/libvkbasalt.so", "/usr/lib/x86_64-linux-gnu/libvkbasalt.so", "/usr/lib/x86_64-linux-gnu/vkbasalt/libvkbasalt.so", "/usr/local/lib/libvkbasalt.so", "/usr/lib64/vkbasalt/libvkbasalt.so" };
 +        string[] paths = { "@vkbasalt@" };
          foreach (var path in paths) {
              if (FileUtils.test (path, FileTest.EXISTS)) {

--- a/pkgs/by-name/ma/mangojuice/package.nix
+++ b/pkgs/by-name/ma/mangojuice/package.nix
@@ -25,13 +25,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "mangojuice";
-  version = "0.8.9";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "radiolamp";
     repo = "mangojuice";
     tag = finalAttrs.version;
-    hash = "sha256-jlSEPUo2Y84xyIRmUdsIBYzZo7a8wQFOnRbb7oOPeok=";
+    hash = "sha256-TsdupoKVxqw295VrbgxgABAuAhJJGwx/ZsW4+vzGEG8=";
   };
 
   patches = [


### PR DESCRIPTION
Update to 0.9.0

Upstream changes:
Added
Smooth tab switching animations.
font_size_secondary option.
ram_temp switch with DDR5 temperature support.
Intel power fix functionality.
Improved
Drag and drop to reorder items in the advanced dialog.
Fixed
Various bugs and translations.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
