### PR TITLE
sxcs: 1.1.0 -> 1.2.1

### DIFF
--- a/pkgs/by-name/sx/sxcs/package.nix
+++ b/pkgs/by-name/sx/sxcs/package.nix
@@ -4,29 +4,31 @@
   fetchFromCodeberg,
   libxcursor,
   libx11,
+  libxrender,
   installShellFiles,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sxcs";
-  version = "1.1.0";
+  version = "1.2.1";
 
   src = fetchFromCodeberg {
     owner = "NRK";
     repo = "sxcs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-rYmbbdZjeLCvGvNocI3+KVU2KBkYvRisayTyScTRay8=";
+    hash = "sha256-7Dz14gARdiHZApT20PGS5pop327XROBeAXeKUeHo7iA=";
   };
 
   buildInputs = [
     libx11
     libxcursor
+    libxrender
   ];
   nativeBuildInputs = [ installShellFiles ];
 
   buildPhase = ''
     runHook preBuild
-    ${stdenv.cc.targetPrefix}cc -o sxcs sxcs.c -O3 -s -l X11 -l Xcursor
+    ${stdenv.cc.targetPrefix}cc -o sxcs sxcs.c -O3 -s -l X11 -l Xcursor -l Xrender
     runHook postBuild
   '';
 


### PR DESCRIPTION
Update to 1.2.1

add libxrender dependency

Upstream changelog:
https://codeberg.org/NRK/sxcs/compare/v1.1.0...v1.2.1

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
