### PR TITLE
ocamlPackages.ocb-stubblr: 0.1.0 -> 0.1.1

### DIFF
--- a/pkgs/development/ocaml-modules/ocb-stubblr/default.nix
+++ b/pkgs/development/ocaml-modules/ocb-stubblr/default.nix
@@ -11,12 +11,12 @@
 
 stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-ocb-stubblr";
-  version = "0.1.0";
+  version = "0.1.1";
 
   src = fetchzip {
     url = "https://github.com/pqwy/ocb-stubblr/releases/download/v${version}/ocb-stubblr-${version}.tbz";
     name = "src.tar.bz";
-    sha256 = "0hpds1lkq4j8wgslv7hnirgfrjmqi36h5rarpw9mwf24gfp5ays2";
+    hash = "sha256-Zd9a2EFT5j944xCFmWD4Td21VB7uGHZoNE4yvgfI9y0=";
   };
 
   patches = [ ./pkg-config.patch ];

--- a/pkgs/development/ocaml-modules/ocb-stubblr/pkg-config.patch
+++ b/pkgs/development/ocaml-modules/ocb-stubblr/pkg-config.patch
@@ -1,6 +1,6 @@
---- a/src/ocb_stubblr.ml	1970-01-01 00:00:01.000000000 +0000
-+++ b/src/ocb_stubblr.ml	2016-12-04 11:10:10.000000000 +0000
-@@ -31,20 +31,9 @@
+--- a/src/ocb_stubblr.ml
++++ b/src/ocb_stubblr.ml
+@@ -31,21 +31,8 @@
  
    (* XXX Would be nice to move pkg-config results to a build artefact. *)
  
@@ -12,8 +12,10 @@
 -  let var = "PKG_CONFIG_PATH"
 -
 -  let path () =
--    Lazy.force opam_prefix / "lib" / "pkgconfig" ::
--      (try [Sys.getenv var] with Not_found -> []) |> String.concat ~sep:":"
+-    let opam = Lazy.force opam_prefix
+-    and rest = try [Sys.getenv var] with Not_found -> [] in
+-    opam/"lib"/"pkgconfig" :: opam/"share"/"pkgconfig" :: rest
+-      |> String.concat ~sep:":"
 -
    let run ~flags package =
 -    let cmd = strf "%s=%s pkg-config %s %s 2>/dev/null"
@@ -22,4 +24,3 @@
 +              package (String.concat ~sep:" " flags) in
      try `Res (run_and_read cmd) with Failure _ -> `Nonexistent
  end
- 


### PR DESCRIPTION
Update to 0.1.1

Changelog
Include both lib and share in pkg-config path.
Use mirage-xen-ocaml for Xen pkg-config.
Add include dirs to cmxs linking.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
