### PR TITLE
pgrok: 1.4.6 -> 1.5.0

### DIFF
--- a/pkgs/by-name/pg/pgrok/package.nix
+++ b/pkgs/by-name/pg/pgrok/package.nix
@@ -11,12 +11,12 @@
 
 let
   pname = "pgrok";
-  version = "1.4.6";
+  version = "1.5.0";
   src = fetchFromGitHub {
     owner = "pgrok";
     repo = "pgrok";
     tag = "v${version}";
-    hash = "sha256-Meavhgq0xHRAfCgzdazC1wu8aDw39qQCZrVtZUScwgs=";
+    hash = "sha256-arPFccclBie3XOBt0q6UC96fPaPc7NmgQDMsd2H2bhI=";
   };
 in
 
@@ -42,10 +42,10 @@ buildGoModule {
       ;
     pnpm = pnpm_9;
     fetcherVersion = 3;
-    hash = "sha256-gVwwLTOA8rXsy8xg4uGPJyBdQ8yUqkiul9W5oKw6kGI=";
+    hash = "sha256-D8UZoN0ZnjB8CXQiHmBZwBEt57XGb5SDLg61xxSqNus=";
   };
 
-  vendorHash = "sha256-l/tUO7fevi+zUmUp6CQoVNrzMF7LIzbo2Qsa/ez6LiA=";
+  vendorHash = "sha256-ob8s1jYL2+JGaqjCsM10jgirPiEyTY4U3IVVlHVdoGQ=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
Update to 1.5.0

Upstream changelog: https://github.com/pgrok/pgrok/compare/v1.4.6...v1.5.0

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
