### PR TITLE
libmodsecurity: 3.0.14 -> 3.0.15

### DIFF
--- a/pkgs/by-name/li/libmodsecurity/package.nix
+++ b/pkgs/by-name/li/libmodsecurity/package.nix
@@ -21,13 +21,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libmodsecurity";
-  version = "3.0.14";
+  version = "3.0.15";
 
   src = fetchFromGitHub {
     owner = "owasp-modsecurity";
     repo = "ModSecurity";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-SaeBO3+WvPhHiJoiOmijB0G3/QYxjAdxgeCVqESS+4U=";
+    hash = "sha256-gI874wkqy8VuwxUmIgb8d7fULJUQ+rKBBF492NtuRMY=";
     fetchSubmodules = true;
   };
 
@@ -81,6 +81,27 @@ stdenv.mkDerivation (finalAttrs: {
       --replace "ssdeep_inc_path=\"\''${path}/include\"" "ssdeep_inc_path=\"${ssdeep}/include\""
     substituteInPlace modsecurity.conf-recommended \
       --replace "SecUnicodeMapFile unicode.mapping 20127" "SecUnicodeMapFile $out/share/modsecurity/unicode.mapping 20127"
+
+    # https://github.com/owasp-modsecurity/ModSecurity/blob/v3.0.15/build.sh#L6-L25
+    cd src
+    echo "noinst_HEADERS = \\" > headers.mk
+    ls -1 \
+        actions/*.h \
+        actions/ctl/*.h \
+        actions/data/*.h \
+        actions/disruptive/*.h \
+        actions/transformations/*.h \
+        debug_log/*.h \
+        audit_log/writer/*.h \
+        collection/backend/*.h \
+        operators/*.h \
+        parser/*.h \
+        request_body_processor/*.h \
+        utils/*.h \
+        variables/*.h \
+        engine/*.h \
+        *.h | tr "\012" " " >> headers.mk
+    cd ../
   '';
 
   postInstall = ''


### PR DESCRIPTION
changelog: https://github.com/owasp-modsecurity/ModSecurity/releases/tag/v3.0.15
diff: https://github.com/owasp-modsecurity/ModSecurity/compare/v3.0.14...v3.0.15

Closes #519716

Not sure if that's the best way to generate the headers, but it's the best I could find.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
