### PR TITLE
python314Packages.rosbag-resurrector: init at 0.5.0; python314Packages.mcap: init at 1.3.1; python314Packages.mcap-ros2-support: init at 1.3.1

### DIFF
--- a/pkgs/development/python-modules/mcap-ros2-support/default.nix
+++ b/pkgs/development/python-modules/mcap-ros2-support/default.nix
@@ -1,0 +1,47 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  mcap,
+  pytestCheckHook,
+  setuptools,
+  setuptools-scm,
+}:
+
+buildPythonPackage rec {
+  pname = "mcap-ros2-support";
+  version = "1.3.1"; # Replace with the specific version you need
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "foxglove";
+    repo = "mcap";
+    rev = "releases/python/mcap/v${version}";
+    hash = "sha256-3H36Q9JDxC44UnIdgtCMAkeT3+tEOloxAI7fext2YXk=";
+    fetchLFS = true;
+  };
+
+  sourceRoot = "source/python/mcap-ros2-support";
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    mcap
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  doCheck = true;
+  pythonImportsCheck = [ "mcap_ros2" ];
+
+  meta = with lib; {
+    description = "mcap-ros2-support Python library";
+    homepage = "https://mcap.dev/";
+    downloadPage = "https://github.com/foxglove/mcap/tree/main/python/mcap-ros2-support";
+    license = licenses.mit;
+    maintainers = with lib.maintainers; [ guelakais ];
+  };
+}

--- a/pkgs/development/python-modules/mcap/default.nix
+++ b/pkgs/development/python-modules/mcap/default.nix
@@ -1,0 +1,49 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  lz4,
+  pytestCheckHook,
+  setuptools,
+  setuptools-scm,
+  zstandard,
+}:
+
+buildPythonPackage rec {
+  pname = "mcap";
+  version = "1.3.1"; # Replace with the specific version you need
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "foxglove";
+    repo = "mcap";
+    rev = "releases/python/mcap/v${version}";
+    hash = "sha256-3H36Q9JDxC44UnIdgtCMAkeT3+tEOloxAI7fext2YXk=";
+    fetchLFS = true;
+  };
+
+  sourceRoot = "source/python/mcap";
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    lz4
+    zstandard
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  doCheck = true;
+  pythonImportsCheck = [ "mcap" ];
+
+  meta = {
+    description = "MCAP Python library";
+    downloadPage = "https://github.com/foxglove/mcap/tree/main/python/mcap";
+    homepage = "https://mcap.dev/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ guelakais ];
+  };
+}

--- a/pkgs/development/python-modules/rosbag-resurrector/default.nix
+++ b/pkgs/development/python-modules/rosbag-resurrector/default.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  # build-system
+  setuptools,
+  # dependencies
+  duckdb,
+  h5py,
+  fastapi,
+  numpy,
+  mcap,
+  mcap-ros2-support,
+  pandas,
+  plotly,
+  polars,
+  pyarrow,
+  rich,
+  typer,
+  uvicorn,
+  # tests
+  httpx,
+  pillow,
+  psutil,
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "rosbag-resurrector";
+  version = "0.5.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "vikramnagashoka";
+    repo = "rosbag-resurrector";
+    tag = "v${version}";
+    hash = "sha256-gYt68wVFzIPuf2siIen6yNZIegOQHby90xTAZkA391k=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    duckdb
+    h5py
+    fastapi
+    numpy
+    mcap
+    mcap-ros2-support
+    pandas
+    plotly
+    polars
+    pyarrow
+    rich
+    typer
+    uvicorn
+  ];
+
+  nativeCheckInputs = [
+    httpx
+    pillow
+    psutil
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "resurrector" ];
+
+  meta = {
+    description = "Pandas-like analysis for robotics bag files with health checks, sync, ML export, semantic search, and WebSocket bridge.";
+    homepage = "https://github.com/vikramnagashoka/rosbag-resurrector/";
+    downloadPage = "https://github.com/vikramnagashoka/rosbag-resurrector/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ guelakais ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9724,6 +9724,8 @@ self: super: with self; {
 
   mbstrdecoder = callPackage ../development/python-modules/mbstrdecoder { };
 
+  mcap = callPackage ../development/python-modules/mcap { };
+
   mccabe = callPackage ../development/python-modules/mccabe { };
 
   mcdreforged = callPackage ../development/python-modules/mcdreforged { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9726,6 +9726,8 @@ self: super: with self; {
 
   mcap = callPackage ../development/python-modules/mcap { };
 
+  mcap-ros2-support = callPackage ../development/python-modules/mcap-ros2-support { };
+
   mccabe = callPackage ../development/python-modules/mccabe { };
 
   mcdreforged = callPackage ../development/python-modules/mcdreforged { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17232,6 +17232,8 @@ self: super: with self; {
 
   ropper = callPackage ../development/python-modules/ropper { };
 
+  rosbag-resurrector = callPackage ../development/python-modules/rosbag-resurrector { };
+
   rosbags = callPackage ../development/python-modules/rosbags { };
 
   rospkg = callPackage ../development/python-modules/rospkg { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- python314Packages.rosbag-resurrector: init at 0.5.0; 
- python314Packages.mcap: init at 1.3.1; 
- python314Packages.mcap-ros2-support: init at 1.3.1

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
