### PR TITLE
ringboard: 0.14.0-unstable-2026-01-19 -> 0.16.2

### DIFF
--- a/nixos/tests/ringboard.nix
+++ b/nixos/tests/ringboard.nix
@@ -38,8 +38,8 @@
 
       with subtest("Wait for service startup"):
         machine.wait_for_unit("graphical.target")
-        machine.wait_for_unit("ringboard-server.service", "${user}")
-        machine.wait_for_unit("ringboard-listener.service", "${user}")
+        with gedit_running:
+          pass
 
       with subtest("Ensure clipboard is monitored"):
         with gedit_running: # type: ignore[union-attr]

--- a/pkgs/by-name/ri/ringboard/package.nix
+++ b/pkgs/by-name/ri/ringboard/package.nix
@@ -23,19 +23,16 @@ assert lib.assertOneOf "displayServer" displayServer [
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ringboard" + lib.optionalString (displayServer == "wayland") "-wayland";
-
-  # release version needs nightly, so we use a custom tree, see:
-  # https://github.com/SUPERCILEX/clipboard-history/issues/22#issuecomment-3676256971
-  version = "0.14.0-unstable-2026-01-19";
+  version = "0.16.2";
 
   src = fetchFromGitHub {
     owner = "SUPERCILEX";
     repo = "clipboard-history";
-    rev = "cb2e94add2388a68a8f015b77f9b082b1658b3b7";
-    hash = "sha256-r2632XJ/2Er1TuHCDNm6uItvdhqJ87i9p+h9M2MwKwk=";
+    tag = "${finalAttrs.version}-rust-1.95";
+    hash = "sha256-/LDxZ3bsuVwMiRzLTuLIs6y7jAS/84sXhTRhovXV8zM=";
   };
 
-  cargoHash = "sha256-c5Zdvz2xHsGh4VnOED2JiitNWwNTSkygaMFHPPLANqw=";
+  cargoHash = "sha256-ARSvWjeVWXksZ27lRJn67wXpgr8epagflOAULKmYaQ8=";
 
   nativeBuildInputs = [
     makeWrapper
@@ -103,7 +100,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   passthru = {
     tests.nixos = nixosTests.ringboard;
-    updateScript = nix-update-script { extraArgs = [ "--version=branch=stable" ]; };
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=(.*)-rust-1.95" ]; };
   };
 
   meta = {


### PR DESCRIPTION
Update to 0.16.2

Upstream changelog:
https://github.com/SUPERCILEX/clipboard-history/compare/0.14.0...0.16.2

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
