### PR TITLE
python3Packages.openai: 2.33.0 -> 2.41.1

### DIFF
--- a/pkgs/by-name/pd/pdftitle/package.nix
+++ b/pkgs/by-name/pd/pdftitle/package.nix
@@ -2,7 +2,6 @@
   lib,
   fetchFromGitHub,
   python3Packages,
-  openai,
   pdfminer,
 
   withOpenai ? false,

--- a/pkgs/development/python-modules/openai/default.nix
+++ b/pkgs/development/python-modules/openai/default.nix
@@ -51,14 +51,14 @@
 
 buildPythonPackage rec {
   pname = "openai";
-  version = "2.33.0";
+  version = "2.41.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "openai";
     repo = "openai-python";
     tag = "v${version}";
-    hash = "sha256-w2ejAJ+V7e4wYSQ/9+WdhO+XaYeSq8U/V5YXHSpn+rI=";
+    hash = "sha256-jSkBxZY5POlrznhBwFMR2NcL92uGRSYI6BDDC3C7RfU=";
   };
 
   postPatch = ''substituteInPlace pyproject.toml --replace-fail "hatchling==1.26.3" "hatchling"'';
@@ -129,6 +129,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/openai/openai-python/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.malo ];
-    mainProgram = "openai";
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1640,6 +1640,7 @@ mapAliases {
   open-stage-control = throw "'open-stage-control' has been removed due to being broken for more than a year; see RFC 180"; # Added 2026-05-04
   open-timeline-io = warnAlias "'open-timeline-io' has been renamed to 'opentimelineio'" opentimelineio; # Added 2025-08-10
   openafs_1_8 = throw "'openafs_1_8' has been renamed to/replaced by 'openafs'"; # Converted to throw 2025-10-27
+  openai = throw "'openai' has been removed, since upstream removed the legacy CLI in v2.35.0; use 'python3Packages.openai' instead"; # Added 2026-06-10
   openai-triton-llvm = throw "'openai-triton-llvm' has been renamed to/replaced by 'triton-llvm'"; # Converted to throw 2025-10-27
   openai-whisper-cpp = throw "'openai-whisper-cpp' has been renamed to/replaced by 'whisper-cpp'"; # Converted to throw 2025-10-27
   openalSoft = warnAlias "'openalSoft' has been renamed to 'openal-soft'" openal-soft; # Added 2026-02-09

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5506,8 +5506,6 @@ with pkgs;
     sdk = true;
   };
 
-  openai = with python3Packages; toPythonApplication openai;
-
   openai-whisper = with python3.pkgs; toPythonApplication openai-whisper;
 
   openocd-rp2040 = openocd.overrideAttrs (old: {


### PR DESCRIPTION
Update to latest version. Also drops the top-level `openai` attribute, since the legacy `openai` CLI was removed upstream in v2.35.0 — the `toPythonApplication` wrapper no longer produces any binaries. A throw alias is added pointing users at `python3Packages.openai`.

The eval failure from the previous iteration of this PR is addressed by the `pdftitle` commit: it took the top-level `openai` as a function argument (shadowing its `with python3Packages` scope), so it now uses `python3Packages.openai` like the other in-tree consumers.

- Diff: https://github.com/openai/openai-python/compare/v2.33.0...v2.41.1
- Changelog: https://github.com/openai/openai-python/blob/v2.41.1/CHANGELOG.md

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
