### PR TITLE
 mopidy-iris: build from source, turn off Google Analytics per default

### DIFF
--- a/pkgs/applications/audio/mopidy/iris.nix
+++ b/pkgs/applications/audio/mopidy/iris.nix
@@ -1,8 +1,11 @@
 {
   lib,
   pythonPackages,
-  fetchPypi,
+  fetchFromGitHub,
+  fetchNpmDeps,
   mopidy,
+  nodejs,
+  npmHooks,
 }:
 
 pythonPackages.buildPythonApplication (finalAttrs: {
@@ -10,11 +13,26 @@ pythonPackages.buildPythonApplication (finalAttrs: {
   version = "3.70.0";
   pyproject = true;
 
-  src = fetchPypi {
-    pname = "mopidy_iris";
-    inherit (finalAttrs) version;
-    hash = "sha256-md/1blTTtjiAAb/jiLE2EfiSlIUwEga8U7OiuKa466k=";
+  src = fetchFromGitHub {
+    owner = "jaedb";
+    repo = "Iris";
+    tag = finalAttrs.version;
+    hash = "sha256-Fc0LktN8pCRnrvk9uudXu10J3XfrRbdGlcDKXFNQzmQ=";
   };
+
+  npmDeps = fetchNpmDeps {
+    inherit (finalAttrs) src;
+    hash = "sha256-aQHq80SLaOPOANYV+aDTWC/bxfc1it5iDeRJ8L5iuEU=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    npmHooks.npmConfigHook
+  ];
+
+  preBuild = ''
+    npm run prod
+  '';
 
   build-system = [
     pythonPackages.setuptools

--- a/pkgs/applications/audio/mopidy/iris.nix
+++ b/pkgs/applications/audio/mopidy/iris.nix
@@ -20,6 +20,12 @@ pythonPackages.buildPythonApplication (finalAttrs: {
     hash = "sha256-Fc0LktN8pCRnrvk9uudXu10J3XfrRbdGlcDKXFNQzmQ=";
   };
 
+  postPatch = ''
+    # turn off Google Analytics per default
+    substituteInPlace src/js/store/index.js \
+      --replace-fail 'allow_reporting: true' 'allow_reporting: false'
+  '';
+
   npmDeps = fetchNpmDeps {
     inherit (finalAttrs) src;
     hash = "sha256-aQHq80SLaOPOANYV+aDTWC/bxfc1it5iDeRJ8L5iuEU=";


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
