### PR TITLE
stakk: init at 1.17.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29236,6 +29236,12 @@
     githubId = 45292658;
     name = "Julius Schmitt";
   };
+  voidlily = {
+    github = "voidlily";
+    githubId = 221749;
+    name = "voidlily";
+    keys = [ { fingerprint = "E735 CD3F A78C 0919 4012  ADF3 3FBF B3CC E12E 7D19"; } ];
+  };
   voidnoi = {
     email = "voidnoi@proton.me";
     github = "VoidNoi";

--- a/pkgs/by-name/st/stakk/package.nix
+++ b/pkgs/by-name/st/stakk/package.nix
@@ -2,23 +2,27 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  versionCheckHook,
   nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "stakk";
-  version = "1.15.0";
+  version = "1.17.1";
 
   src = fetchFromGitHub {
     owner = "glennib";
     repo = "stakk";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-rui/Gc21tvy9Kv56UOoErwe0b73YOtP+ggAuKpDY90o=";
+    hash = "sha256-5wEZOxXg30F0MqeszDRYrOBnsOzfXxld8iQkZSPqUIY=";
   };
 
-  cargoHash = "sha256-zypOfxYFfrp3u2+pLNFQNtqXMn01MX4Q2HlBjkZH3r8=";
+  cargoHash = "sha256-iEGrGSia/Da1bpXVAOI9M7QNNVHUAB/RFRgzl+IrFlU=";
 
   useNextest = true;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   passthru.updateScript = nix-update-script { };
   __structuredAttrs = true;
@@ -26,12 +30,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Bridge Jujutsu (jj) bookmarks to GitHub stacked pull requests";
     homepage = "https://github.com/glennib/stakk";
-    changelog = "https://github.com/glennib/stakk/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/glennib/stakk/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = with lib.licenses; [
       asl20
       mit
     ];
-    maintainers = with lib.maintainers; [ voidlily ];
+    maintainers = with lib.maintainers; [
+      voidlily
+      Br1ght0ne
+    ];
     mainProgram = "stakk";
   };
 })

--- a/pkgs/by-name/st/stakk/package.nix
+++ b/pkgs/by-name/st/stakk/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "stakk";
+  version = "1.15.0";
+
+  src = fetchFromGitHub {
+    owner = "glennib";
+    repo = "stakk";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rui/Gc21tvy9Kv56UOoErwe0b73YOtP+ggAuKpDY90o=";
+  };
+
+  cargoHash = "sha256-zypOfxYFfrp3u2+pLNFQNtqXMn01MX4Q2HlBjkZH3r8=";
+
+  useNextest = true;
+
+  passthru.updateScript = nix-update-script { };
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Bridge Jujutsu (jj) bookmarks to GitHub stacked pull requests";
+    homepage = "https://github.com/glennib/stakk";
+    changelog = "https://github.com/glennib/stakk/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [ voidlily ];
+    mainProgram = "stakk";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Stakk is a tool for pull request stacking when using Jujutsu (jj)

https://github.com/glennib/stakk

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
