### PR TITLE
redlib: 0.36.0-unstable-2025-12-16 -> 0.36.0-unstable-2026-04-24

### DIFF
--- a/nixos/tests/redlib.nix
+++ b/nixos/tests/redlib.nix
@@ -36,6 +36,9 @@ in
       port = 80;
 
       settings = {
+        # wreq needs a path to the self-signed CA
+        SSL_CERT_FILE = "${certs.ca.cert}";
+
         REDLIB_DEFAULT_USE_HLS = true;
       };
     };

--- a/nixos/tests/redlib.nix
+++ b/nixos/tests/redlib.nix
@@ -1,14 +1,13 @@
-{ lib, pkgs, ... }:
+{ pkgs, ... }:
 let
   certs = import redlib/snakeoil-certs.nix;
   redditDomain = certs.domain;
 in
 {
   name = "redlib";
-  meta.maintainers = with lib.maintainers; [
-    bpeetz
-    Guanran928
-  ];
+  meta = {
+    inherit (pkgs.redlib.meta) maintainers;
+  };
 
   nodes.machine = {
     # The test will hang if Redlib can't initialize its OAuth client, so we

--- a/pkgs/by-name/re/redlib/native-roots.patch
+++ b/pkgs/by-name/re/redlib/native-roots.patch
@@ -1,0 +1,54 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index fed126a..9caf27d 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1807,12 +1807,6 @@ dependencies = [
+  "windows-sys 0.59.0",
+ ]
+ 
+-[[package]]
+-name = "rustls-pki-types"
+-version = "1.14.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+-
+ [[package]]
+ name = "rustversion"
+ version = "1.0.20"
+@@ -2605,15 +2599,6 @@ dependencies = [
+  "wasm-bindgen",
+ ]
+ 
+-[[package]]
+-name = "webpki-root-certs"
+-version = "1.0.6"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+-dependencies = [
+- "rustls-pki-types",
+-]
+-
+ [[package]]
+ name = "winapi"
+ version = "0.3.9"
+@@ -2796,7 +2781,6 @@ dependencies = [
+  "tower-http",
+  "url",
+  "want",
+- "webpki-root-certs",
+  "zstd",
+ ]
+ 
+diff --git a/Cargo.toml b/Cargo.toml
+index b47bd05..89b6455 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -59,7 +59,7 @@ bincode = "1.3.3"
+ base2048 = "2.0.2"
+ revision = "0.17.0"
+ fake_user_agent = "0.2.2"
+-wreq = { version = "6.0.0-rc.28", features = ["brotli", "gzip", "deflate", "zstd", "json", "stream", "socks"] }
++wreq = { version = "6.0.0-rc.28", default-features = false, features = ["brotli", "gzip", "deflate", "zstd", "json", "stream", "socks"] }
+ wreq-util = { version = "3.0.0-rc.10" }
+ 
+ [dev-dependencies]

--- a/pkgs/by-name/re/redlib/package.nix
+++ b/pkgs/by-name/re/redlib/package.nix
@@ -4,21 +4,33 @@
   nixosTests,
   rustPlatform,
   fetchFromGitHub,
+
+  cmake,
+  gitMinimal,
+
   nix-update-script,
 }:
 
 rustPlatform.buildRustPackage {
   pname = "redlib";
-  version = "0.36.0-unstable-2025-12-16";
+  version = "0.36.0-unstable-2026-04-24";
 
   src = fetchFromGitHub {
     owner = "redlib-org";
     repo = "redlib";
-    rev = "ba98178bbce0f62265095ba085128c7022e51a1f";
-    hash = "sha256-ERTEoT7w8oGA0ztrzc9r9Bl/7OOay+APg3pW+h3tgvM=";
+    rev = "a4d36e954cf1bd64f209cd8868c5a29edc81b374";
+    hash = "sha256-siyD6A12UALQIV7BMd7zu1TaojleTEYtpxPszuhx1/Y=";
   };
 
-  cargoHash = "sha256-ageSjIX0BLVYlLAjeojQq5N6/VASOIpwXNR/3msl/p4=";
+  cargoPatches = [ ./native-roots.patch ];
+
+  cargoHash = "sha256-qDcDrZFWcFb0LRwumOc/+boIxmc6HYz+YqmP+kqK05E=";
+
+  nativeBuildInputs = [
+    cmake
+    gitMinimal
+    rustPlatform.bindgenHook
+  ];
 
   postInstall = ''
     install --mode=444 -D contrib/redlib.service $out/lib/systemd/system/redlib.service
@@ -56,8 +68,8 @@ rustPlatform.buildRustPackage {
     "--skip=test_oauth_client_refresh"
     "--skip=test_oauth_token_exists"
     "--skip=test_oauth_headers_len"
-    "--skip=oauth::test_generic_web_backend"
-    "--skip=oauth::test_mobile_spoof_backend"
+    "--skip=oauth::tests::test_generic_web_backend"
+    "--skip=oauth::tests::test_mobile_spoof_backend"
   ];
 
   env = {

--- a/pkgs/by-name/re/redlib/package.nix
+++ b/pkgs/by-name/re/redlib/package.nix
@@ -89,6 +89,7 @@ rustPlatform.buildRustPackage {
     maintainers = with lib.maintainers; [
       bpeetz
       Guanran928
+      ryand56
     ];
   };
 }


### PR DESCRIPTION
Diff: https://github.com/redlib-org/redlib/compare/ba98178bbce0f62265095ba085128c7022e51a1f...a4d36e954cf1bd64f209cd8868c5a29edc81b374

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
