### PR TITLE
lrs: add darwin support

### DIFF
--- a/pkgs/by-name/lr/lrs/package.nix
+++ b/pkgs/by-name/lr/lrs/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   gmp,
+  llvmPackages,
 }:
 
 stdenv.mkDerivation {
@@ -19,7 +20,18 @@ stdenv.mkDerivation {
     ./fix-signal-handler-type.patch
   ];
 
-  buildInputs = [ gmp ];
+  # https://github.com/macports/macports-ports/blob/master/math/lrslib/Portfile
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace Makefile \
+      --replace-fail "-shared -Wl,-soname=" "-dynamiclib -install_name $out/lib/"
+  '';
+
+  buildInputs = [
+    gmp
+  ]
+  ++ lib.optionals stdenv.cc.isClang [
+    llvmPackages.openmp
+  ];
 
   makeFlags = [
     "prefix=${placeholder "out"}"
@@ -30,7 +42,7 @@ stdenv.mkDerivation {
     description = "Implementation of the reverse search algorithm for vertex enumeration/convex hull problems";
     license = lib.licenses.gpl2;
     maintainers = [ lib.maintainers.raskin ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
     homepage = "http://cgm.cs.mcgill.ca/~avis/C/lrs.html";
   };
 }


### PR DESCRIPTION
Split from #519802, as the Macaulay2 PR needs some extra care.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
