### PR TITLE
postgresql: security patches of 2026-05-14

### DIFF
--- a/pkgs/servers/sql/postgresql/14.nix
+++ b/pkgs/servers/sql/postgresql/14.nix
@@ -1,7 +1,7 @@
 import ./generic.nix {
-  version = "14.22";
-  rev = "refs/tags/REL_14_22";
-  hash = "sha256-0vZEdsrj2WAdXFpZAli5sd0liAfvp9/Os93GjVTy7wk=";
+  version = "14.23";
+  rev = "refs/tags/REL_14_23";
+  hash = "sha256-fjoboaUhrHFDqusmIXzSS5ZnIpSRHO9+qcqvkchl2dM=";
   muslPatches = {
     disable-test-collate-icu-utf8 = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql14/disable-test-collate.icu.utf8.patch?id=56999e6d0265ceff5c5239f85fdd33e146f06cb7";

--- a/pkgs/servers/sql/postgresql/15.nix
+++ b/pkgs/servers/sql/postgresql/15.nix
@@ -1,7 +1,7 @@
 import ./generic.nix {
-  version = "15.17";
-  rev = "refs/tags/REL_15_17";
-  hash = "sha256-IxvCNJfTbbKT/2dFnNLk3fNUYDaRwHQeeAmvGc1w/OY=";
+  version = "15.18";
+  rev = "refs/tags/REL_15_18";
+  hash = "sha256-tw1zzgLXx7Jr4bi8rMKRmTJzOSQFGvrP2nHr9FcVrjs=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql15/dont-use-locale-a-on-musl.patch?id=f424e934e6d076c4ae065ce45e734aa283eecb9c";

--- a/pkgs/servers/sql/postgresql/16.nix
+++ b/pkgs/servers/sql/postgresql/16.nix
@@ -1,7 +1,7 @@
 import ./generic.nix {
-  version = "16.13";
-  rev = "refs/tags/REL_16_13";
-  hash = "sha256-Ue117xTq4RMQfq70mnXRBwqJ+IUigW27FvHY7I519ng=";
+  version = "16.14";
+  rev = "refs/tags/REL_16_14";
+  hash = "sha256-g2+OdB2dGIKBSFJ24Z3Yy7oRAFywNMSVDdWfnsaeJJQ=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql16/dont-use-locale-a-on-musl.patch?id=08a24be262339fd093e641860680944c3590238e";

--- a/pkgs/servers/sql/postgresql/17.nix
+++ b/pkgs/servers/sql/postgresql/17.nix
@@ -1,7 +1,7 @@
 import ./generic.nix {
-  version = "17.9";
-  rev = "refs/tags/REL_17_9";
-  hash = "sha256-kmESMgxYL5FsDjg3MLHaginIu6IWMo20kNdOLMM1x4w=";
+  version = "17.10";
+  rev = "refs/tags/REL_17_10";
+  hash = "sha256-3ZAqlT3R8ywhNH13oqz2VUbSwpOJ2JaICbxZ29awaMw=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql17/dont-use-locale-a-on-musl.patch?id=d69ead2c87230118ae7f72cef7d761e761e1f37e";

--- a/pkgs/servers/sql/postgresql/18.nix
+++ b/pkgs/servers/sql/postgresql/18.nix
@@ -1,7 +1,7 @@
 import ./generic.nix {
-  version = "18.3";
-  rev = "refs/tags/REL_18_3";
-  hash = "sha256-3cu3oyPJ5q6ewv7RFY7Nys5l+10dsQv5f1HNIoYtrO8=";
+  version = "18.4";
+  rev = "refs/tags/REL_18_4";
+  hash = "sha256-Ac/Dqcj8vjcW3my5vsnKaMiQqTq/HPtUzckJ3SMyrfA=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql17/dont-use-locale-a-on-musl.patch?id=d69ead2c87230118ae7f72cef7d761e761e1f37e";


### PR DESCRIPTION
https://www.postgresql.org/about/news/postgresql-184-1710-1614-1518-and-1423-released-3297/

- **postgres_14: 14.22 -> 14.23**
- **postgres_15: 15.17 -> 15.18**
- **postgres_16: 16.13 -> 16.14**
- **postgres_17: 17.9 -> 17.10**
- **postgres_18: 18.3 -> 18.4**

This fixes the following vulnerabilities:

- [CVE-2026-6472](https://nvd.nist.gov/vuln/detail/CVE-2026-6472)
- [CVE-2026-6473](https://nvd.nist.gov/vuln/detail/CVE-2026-6473)
- [CVE-2026-6474](https://nvd.nist.gov/vuln/detail/CVE-2026-6474)
- [CVE-2026-6475](https://nvd.nist.gov/vuln/detail/CVE-2026-6475)
- [CVE-2026-6476](https://nvd.nist.gov/vuln/detail/CVE-2026-6476)
- [CVE-2026-6477](https://nvd.nist.gov/vuln/detail/CVE-2026-6477)
- [CVE-2026-6478](https://nvd.nist.gov/vuln/detail/CVE-2026-6478)
- [CVE-2026-6479](https://nvd.nist.gov/vuln/detail/CVE-2026-6479)
- [CVE-2026-6637](https://nvd.nist.gov/vuln/detail/CVE-2026-6637)
- [CVE-2026-6638](https://nvd.nist.gov/vuln/detail/CVE-2026-6638)

Postgres 14 has been announced to be EOL as well, we should drop this afterwards IMHO, but I'll leave this desicion to the maintainers.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
