### PR TITLE
home-assistant-custom-components.entity-notes: init at 3.3.4

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/entity-notes/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/entity-notes/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  voluptuous,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "martindell";
+  domain = "entity_notes";
+  version = "3.3.4";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = "ha-entity-notes";
+    tag = "v${version}";
+    hash = "sha256-5JKZ/KC2sSDQQeg3taLyuZdF6QJHdc7pJ1jaFD9S3kc=";
+  };
+
+  dependencies = [
+    voluptuous
+  ];
+
+  meta = {
+    description = "Home Assistant custom component for adding notes to entities";
+    homepage = "https://github.com/martindell/ha-entity-notes";
+    changelog = "https://github.com/martindell/ha-entity-notes/releases/tag/${src.tag}";
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+    license = lib.licenses.mit;
+  };
+}


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
