### PR TITLE
opentelemetry-cpp: 1.26.0 -> 1.27.0, opentelemetry-proto: 1.8.0 -> 1.10.0

### DIFF
--- a/pkgs/by-name/op/opentelemetry-cpp/0001-Disable-tests-requiring-network-access.patch
+++ b/pkgs/by-name/op/opentelemetry-cpp/0001-Disable-tests-requiring-network-access.patch
@@ -1,8 +1,8 @@
 diff --git a/ext/test/http/curl_http_test.cc b/ext/test/http/curl_http_test.cc
-index e8299202..19dbd7b1 100644
+index 2e2cf3d41..d436f25c2 100644
 --- a/ext/test/http/curl_http_test.cc
 +++ b/ext/test/http/curl_http_test.cc
-@@ -270,7 +270,7 @@ TEST_F(BasicCurlHttpTests, HttpResponse)
+@@ -273,7 +273,7 @@ TEST_F(BasicCurlHttpTests, HttpResponse)
    ASSERT_EQ(count, 4);
  }
  
@@ -11,7 +11,7 @@ index e8299202..19dbd7b1 100644
  {
    received_requests_.clear();
    auto session_manager = http_client::HttpClientFactory::Create();
-@@ -287,7 +287,7 @@ TEST_F(BasicCurlHttpTests, SendGetRequest)
+@@ -290,7 +290,7 @@ TEST_F(BasicCurlHttpTests, SendGetRequest)
    ASSERT_TRUE(handler->got_response_.load(std::memory_order_acquire));
  }
  
@@ -20,7 +20,7 @@ index e8299202..19dbd7b1 100644
  {
    received_requests_.clear();
    auto session_manager = http_client::HttpClientFactory::Create();
-@@ -313,7 +313,7 @@ TEST_F(BasicCurlHttpTests, SendPostRequest)
+@@ -316,7 +316,7 @@ TEST_F(BasicCurlHttpTests, SendPostRequest)
    session_manager->FinishAllSessions();
  }
  
@@ -29,7 +29,34 @@ index e8299202..19dbd7b1 100644
  {
    received_requests_.clear();
    auto session_manager = http_client::HttpClientFactory::Create();
-@@ -442,7 +442,7 @@ TEST_F(BasicCurlHttpTests, ExponentialBackoffRetry)
+@@ -361,7 +361,7 @@ TEST_F(BasicCurlHttpTests, CurlHttpOperations)
+ }
+ 
+ #ifdef ENABLE_OTLP_RETRY_PREVIEW
+-TEST_F(BasicCurlHttpTests, RetryPolicyEnabled)
++TEST_F(BasicCurlHttpTests, DISABLED_RetryPolicyEnabled)
+ {
+   RetryEventHandler handler;
+   http_client::HttpSslOptions no_ssl;
+@@ -379,7 +379,7 @@ TEST_F(BasicCurlHttpTests, RetryPolicyEnabled)
+   ASSERT_TRUE(operation.IsRetryable());
+ }
+ 
+-TEST_F(BasicCurlHttpTests, RetryPolicyDisabled)
++TEST_F(BasicCurlHttpTests, DISABLED_RetryPolicyDisabled)
+ {
+   RetryEventHandler handler;
+   http_client::HttpSslOptions no_ssl;
+@@ -397,7 +397,7 @@ TEST_F(BasicCurlHttpTests, RetryPolicyDisabled)
+   ASSERT_FALSE(operation.IsRetryable());
+ }
+ 
+-TEST_F(BasicCurlHttpTests, ExponentialBackoffRetry)
++TEST_F(BasicCurlHttpTests, DISABLED_ExponentialBackoffRetry)
+ {
+   using ::testing::AllOf;
+   using ::testing::Gt;
+@@ -445,7 +445,7 @@ TEST_F(BasicCurlHttpTests, ExponentialBackoffRetry)
  }
  #endif  // ENABLE_OTLP_RETRY_PREVIEW
  
@@ -38,7 +65,7 @@ index e8299202..19dbd7b1 100644
  {
    received_requests_.clear();
    curl::HttpClientSync http_client;
-@@ -467,7 +467,7 @@ TEST_F(BasicCurlHttpTests, SendGetRequestSyncTimeout)
+@@ -470,7 +470,7 @@ TEST_F(BasicCurlHttpTests, SendGetRequestSyncTimeout)
                result.GetSessionState() == http_client::SessionState::SendFailed);
  }
  
@@ -47,7 +74,7 @@ index e8299202..19dbd7b1 100644
  {
    received_requests_.clear();
    curl::HttpClientSync http_client;
-@@ -570,7 +570,7 @@ TEST_F(BasicCurlHttpTests, SendGetRequestAsyncTimeout)
+@@ -576,7 +576,7 @@ TEST_F(BasicCurlHttpTests, SendGetRequestAsyncTimeout)
    }
  }
  
@@ -56,7 +83,7 @@ index e8299202..19dbd7b1 100644
  {
    curl::HttpClient http_client;
  
-@@ -609,7 +609,7 @@ TEST_F(BasicCurlHttpTests, SendPostRequestAsync)
+@@ -615,7 +615,7 @@ TEST_F(BasicCurlHttpTests, SendPostRequestAsync)
    }
  }
  
@@ -65,7 +92,7 @@ index e8299202..19dbd7b1 100644
  {
    curl::HttpClient http_client;
  
-@@ -647,7 +647,7 @@ TEST_F(BasicCurlHttpTests, FinishInAsyncCallback)
+@@ -653,7 +653,7 @@ TEST_F(BasicCurlHttpTests, FinishInAsyncCallback)
    }
  }
  

--- a/pkgs/by-name/op/opentelemetry-cpp/package.nix
+++ b/pkgs/by-name/op/opentelemetry-cpp/package.nix
@@ -16,24 +16,26 @@
   enablePrometheus ? false,
   enableElasticSearch ? false,
   enableZipkin ? false,
+  # for passthru.tests
+  opentelemetry-cpp,
 }:
 let
   opentelemetry-proto = fetchFromGitHub {
     owner = "open-telemetry";
     repo = "opentelemetry-proto";
-    rev = "v1.8.0";
-    hash = "sha256-5rNJDMjRFIOY/3j+PkAujbippBmxtAudU9busK0q8p0=";
+    rev = "v1.10.0";
+    hash = "sha256-RJrS0C4GZfUdETff+ZlbJr67Z+JObrLsDvyGqobf4UI=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "opentelemetry-cpp";
-  version = "1.26.0";
+  version = "1.27.0";
 
   src = fetchFromGitHub {
     owner = "open-telemetry";
     repo = "opentelemetry-cpp";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-jYYTPcTFIrgMn1NUjwacZC1J26TZRKdGlq+5yw7NNsU=";
+    hash = "sha256-7G9uHMlV7/rHvD/g+ktxT6RTfDRSfsXQO7QHk26XVKs=";
   };
 
   patches = [
@@ -98,6 +100,18 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru.updateScript = nix-update-script { };
+
+  passthru.tests = {
+    # Unfortunately there is no such thing as finalAttrs.finalPackage.override,
+    # so we have to resort to this.
+    full = opentelemetry-cpp.override {
+      enableHttp = true;
+      enableGrpc = true;
+      enablePrometheus = true;
+      enableElasticSearch = true;
+      enableZipkin = true;
+    };
+  };
 
   meta = {
     description = "OpenTelemetry C++ Client Library";


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-cpp/releases/tag/v1.27.0
* Fixes CVE-2026-44967

* Closes #519889
* Fix unit tests when optional features are enabled

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `2039437c0f1a765c557885f2b5308f3de609bc3f`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 6 packages built:</summary>
  <ul>
    <li>azure-sdk-for-cpp.core-tracing-opentelemetry</li>
    <li>azure-sdk-for-cpp.core-tracing-opentelemetry.dev</li>
    <li>opentelemetry-cpp</li>
    <li>opentelemetry-cpp.dev</li>
    <li>tango-cpp</li>
    <li>tango-database</li>
  </ul>
</details>