### PR TITLE
apps2samsung: init at 2.7.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5614,6 +5614,12 @@
     githubId = 11145016;
     name = "J.C.";
   };
+  confused-engineer = {
+    email = "dpierce33100@gmail.com";
+    github = "Confused-Engineer";
+    githubId = 101591048;
+    name = "Confused-Engineer";
+  };
   confusedalex = {
     email = "alex@confusedalex.dev";
     github = "ConfusedAlex";

--- a/pkgs/by-name/ap/apps2samsung/package.nix
+++ b/pkgs/by-name/ap/apps2samsung/package.nix
@@ -1,0 +1,221 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  buildFHSEnv,
+  makeDesktopItem,
+  writeShellScript,
+  nix-update-script,
+
+  dejavu_fonts,
+  fontconfig,
+  freetype,
+  icu,
+  krb5,
+  libGL,
+  libice,
+  libsm,
+  libx11,
+  libxcomposite,
+  libxcursor,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxi,
+  libxinerama,
+  libxrandr,
+  libxrender,
+  libxtst,
+  net-tools,
+  openssl,
+  xdg-utils,
+  zlib,
+}:
+
+let
+  pname = "apps2samsung";
+  version = "2.7.1";
+
+  sources = {
+    x86_64-linux = fetchurl {
+      url = "https://github.com/Apps2Samsung/Apps2Samsung/releases/download/v${version}/Apps2Samsung-v${version}-linux-x64.tar.gz";
+      hash = "sha256-Qzxx441m2rma5DkP2ehR9iIlxTCOC7VANvkvItW+MCM=";
+    };
+    aarch64-linux = fetchurl {
+      url = "https://github.com/Apps2Samsung/Apps2Samsung/releases/download/v${version}/Apps2Samsung-v${version}-linux-arm64.tar.gz";
+      hash = "sha256-yyVPt7jEeqinVjIY3QoKAhwnhNfyEW5lMCoID4xIFkI=";
+    };
+  };
+
+  meta = {
+    description = "Sideload Jellyfin and other apps onto Samsung Tizen TVs, projectors and smart monitors";
+    longDescription = ''
+      Apps2Samsung (formerly Jellyfin2Samsung) side-loads applications onto Samsung
+      devices running Tizen OS. It handles device detection, Samsung developer
+      certificate provisioning and installation, so Tizen Studio or manual
+      sideloading is not needed. Jellyfin, Moonlight, Moonfin, Litefin, the
+      community package catalog and custom `.wgt` files are supported.
+
+      The target device must have Developer Mode enabled.
+    '';
+    homepage = "https://github.com/Apps2Samsung/Apps2Samsung";
+    changelog = "https://github.com/Apps2Samsung/Apps2Samsung/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ confused-engineer ];
+    platforms = lib.attrNames sources;
+    mainProgram = "apps2samsung";
+  };
+
+  apps2samsung-unwrapped = stdenv.mkDerivation (finalAttrs: {
+    pname = "${pname}-unwrapped";
+    inherit version;
+
+    src =
+      sources.${stdenv.hostPlatform.system}
+        or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+    # The release tarball has no top-level directory of its own.
+    unpackPhase = ''
+      runHook preUnpack
+
+      mkdir -p ${finalAttrs.sourceRoot}
+      tar --extract --file=$src --directory=${finalAttrs.sourceRoot}
+
+      runHook postUnpack
+    '';
+    sourceRoot = "source";
+
+    strictDeps = true;
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    # A self-contained .NET single-file publish that is only ever run inside the
+    # FHS environment below, so it must keep its /lib64 interpreter.
+    dontPatchELF = true;
+    dontStrip = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/share/${pname}
+      cp -r . $out/share/${pname}
+
+      rm $out/share/${pname}/*.pdb
+
+      # esbuild ships without the executable bit. The application chmods it on
+      # first use, which cannot work from the read-only store.
+      chmod +x $out/share/${pname}/Assets/esbuild/linux-*/esbuild
+
+      # Mount points for the writable state bind-mounted in by the wrapper.
+      # bubblewrap cannot create them inside a read-only bind mount.
+      mkdir -p $out/share/${pname}/Logs $out/share/${pname}/Downloads
+      touch $out/share/${pname}/third-party-apps.cache.json
+
+      runHook postInstall
+    '';
+
+    meta = builtins.removeAttrs meta [ "mainProgram" ];
+  });
+
+  desktopItem = makeDesktopItem {
+    name = pname;
+    desktopName = "Apps2Samsung";
+    comment = "Install any app on Samsung TVs, projectors and smart monitors";
+    exec = pname;
+    icon = pname;
+    terminal = false;
+    type = "Application";
+    categories = [
+      "Utility"
+      "Network"
+    ];
+    keywords = [
+      "jellyfin"
+      "samsung"
+      "sideload"
+      "tizen"
+      "tv"
+    ];
+    startupNotify = true;
+    startupWMClass = "Apps2Samsung";
+  };
+in
+buildFHSEnv {
+  inherit pname version meta;
+
+  targetPkgs = _: [
+    # .NET runtime: libstdc++/libgcc_s, globalization, TLS and GSSAPI, all of
+    # which the single-file bundle dlopens after unpacking itself
+    stdenv.cc.cc.lib
+    icu
+    krb5
+    openssl
+    zlib
+
+    # Skia / font rendering
+    dejavu_fonts
+    fontconfig
+    freetype
+    libGL
+
+    # Avalonia X11 backend
+    libice
+    libsm
+    libx11
+    libxcomposite
+    libxcursor
+    libxdamage
+    libxext
+    libxfixes
+    libxi
+    libxinerama
+    libxrandr
+    libxrender
+    libxtst
+
+    # `arp`, used to resolve the MAC vendor of discovered devices
+    net-tools
+    # `xdg-open`, used by the "open logs folder" and release-page buttons
+    xdg-utils
+  ];
+
+  # The application keeps logs, downloaded packages and the Tizen SDB binary it
+  # fetches at runtime next to its own executable, so those paths get a writable
+  # bind mount. Everything else it writes (settings, generated signing
+  # certificates) already goes to $XDG_CONFIG_HOME/Apps2Samsung.
+  #
+  # Installing under /opt additionally makes the application report itself as
+  # package-manager managed and skip its built-in auto-updater, which would
+  # otherwise try to replace the store path.
+  extraPreBwrapCmds = ''
+    state="''${XDG_DATA_HOME:-$HOME/.local/share}/${pname}"
+    mkdir -p "$state"/Logs "$state"/Downloads "$state"/TizenSDB
+    [ -e "$state/third-party-apps.cache.json" ] || : > "$state/third-party-apps.cache.json"
+  '';
+
+  extraBwrapArgs = [
+    "--tmpfs /opt"
+    "--ro-bind ${apps2samsung-unwrapped}/share/${pname} /opt/apps2samsung"
+    ''--bind "$state/Logs" /opt/apps2samsung/Logs''
+    ''--bind "$state/Downloads" /opt/apps2samsung/Downloads''
+    ''--bind "$state/TizenSDB" /opt/apps2samsung/Assets/TizenSDB''
+    ''--bind "$state/third-party-apps.cache.json" /opt/apps2samsung/third-party-apps.cache.json''
+  ];
+
+  runScript = writeShellScript "${pname}-run" ''
+    exec /opt/apps2samsung/Apps2Samsung "$@"
+  '';
+
+  extraInstallCommands = ''
+    install -Dm444 ${desktopItem}/share/applications/${pname}.desktop -t $out/share/applications
+    install -Dm444 ${apps2samsung-unwrapped}/share/${pname}/Assets/jelly2sams.png \
+      $out/share/icons/hicolor/256x256/apps/${pname}.png
+  '';
+
+  passthru = {
+    unwrapped = apps2samsung-unwrapped;
+    updateScript = nix-update-script { };
+  };
+}


### PR DESCRIPTION
Adds [Apps2Samsung](https://github.com/Apps2Samsung/Apps2Samsung), which side-loads applications onto Samsung devices running Tizen OS — Jellyfin, Moonlight, Moonfin, Litefin, the community package catalogue and arbitrary `.wgt` files. It handles device discovery and Samsung developer certificate provisioning, so Tizen Studio or manual sideloading is not needed.

This PR previously proposed the same application under its old name, `jellyfin2samsung`. Upstream has since renamed the project to Apps2Samsung and the attribute follows; the package has also been rewritten rather than just renamed, so it is easier to review as a fresh diff than as an incremental one.

## Packaging notes

Upstream publishes a self-contained .NET single-file build, so this is a binary repackage (`sourceProvenance = [ binaryNativeCode ]`).

**`buildFHSEnv` rather than `autoPatchelfHook`.** At runtime the application downloads the Tizen `sdb` binary from upstream's release assets and executes it. That binary hard-codes `/lib64/ld-linux-x86-64.so.2`, so it cannot be patched at build time — an FHS environment is the only way to make it runnable.

**Writable paths.** The application derives its data directory from `AppContext.BaseDirectory` — the directory of the symlink-resolved `/proc/self/exe` — and writes logs, downloaded `.wgt` packages, the `sdb` binary and a manifest cache next to its own executable. Rather than copying ~140 MB into `$HOME` on every version change, the store tree is bind-mounted read-only at `/opt/apps2samsung` and only those four paths get writable bind mounts, backed by `$XDG_DATA_HOME/apps2samsung`. Settings and generated signing certificates already go to `$XDG_CONFIG_HOME/Apps2Samsung` upstream.

Mounting under `/opt` is also deliberate: upstream's `UpdaterService.IsAutomaticUpdateSupported()` returns false for installs under `/usr` or `/opt`, so the application reports itself as package-manager-managed and disables its built-in auto-updater, which would otherwise try to overwrite the store path.

**esbuild permissions.** `Assets/esbuild/linux-*/esbuild` ships without the executable bit; upstream `chmod`s it on first use, which cannot work from a read-only store, so `installPhase` sets it instead.

## Testing

Built and run on x86_64-linux against master: the GUI launches, a network scan completes, the Tizen `sdb` helper is downloaded and executed from the writable bind mount, and settings are written to `$XDG_CONFIG_HOME/Apps2Samsung`. I have used this application regularly on my own machines.

aarch64-linux evaluates and the source hash is from upstream's published arm64 tarball, but I have no arm64 hardware to run it on.

Also run locally: `nix fmt -- --ci`, `nix-build lib/tests/maintainers.nix`, and `maintainers/scripts/check-by-name.sh master` — all pass.

## Disclosure

Per the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy): the packaging expression was written with the assistance of Claude Code (Claude Opus 5), as disclosed by the `Assisted-by:` trailer on the package commit. This pull request description was also drafted with the same tool. I have reviewed both, and have built, run and used the resulting package myself.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
