### PR TITLE
nix-init: 0.3.4 -> 0.3.6

### DIFF
--- a/pkgs/by-name/ni/nix-init/package.nix
+++ b/pkgs/by-name/ni/nix-init/package.nix
@@ -9,6 +9,7 @@
   bzip2,
   libgit2,
   openssl,
+  sqlite,
   zlib,
   zstd,
   spdx-license-list-data,
@@ -26,16 +27,16 @@ in
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nix-init";
-  version = "0.3.4";
+  version = "0.3.6";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "nix-init";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-tjVdiKaa6mGIkjvG6NYnKef9VBJS26FXHGjZ+Zxb0s0=";
+    hash = "sha256-9UEGGtNm5XpcBA/80v03XEunWshgM0M35TrJ79PQNG8=";
   };
 
-  cargoHash = "sha256-PUD3c/YnxYCVf/4C++MWxejHsLSS1ysWwiTRZVOp8Vc=";
+  cargoHash = "sha256-cRnyTuUIRUFPWUle7/bcqcZ9LjvhRuK2tF++hoMl+xs=";
 
   nativeBuildInputs = [
     curl
@@ -48,6 +49,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     curl
     libgit2
     openssl
+    sqlite
     zlib
     zstd
   ];
@@ -79,6 +81,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   env = {
     GEN_ARTIFACTS = "artifacts";
     LIBGIT2_NO_VENDOR = true;
+    LIBSQLITE3_SYS_USE_PKG_CONFIG = true;
     NIX = lib.getExe nix;
     NURL = lib.getExe nurl;
     ZSTD_SYS_USE_PKG_CONFIG = true;


### PR DESCRIPTION
Diff: https://github.com/nix-community/nix-init/compare/v0.3.4...v0.3.6

Changelog: https://github.com/nix-community/nix-init/blob/v0.3.6/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
