### PR TITLE
lib.trivial: save attrset lookups in highly used functions

### DIFF
--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -1123,7 +1123,11 @@ in
     isFunction : Any -> Bool
     ```
   */
-  isFunction = f: builtins.isFunction f || (f ? __functor && isFunction (f.__functor f));
+  isFunction =
+    let
+      isFunction = builtins.isFunction;
+    in
+    f: isFunction f || (f ? __functor && isFunction (f.__functor f));
 
   /**
     `mirrorFunctionArgs f g` creates a new function `g'` with the same behavior as `g` (`g' x == g x`)

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -1101,11 +1101,10 @@ in
     ```
   */
   functionArgs =
-    f:
-    if f ? __functor then
-      f.__functionArgs or (functionArgs (f.__functor f))
-    else
-      builtins.functionArgs f;
+    let
+      functionArgs = builtins.functionArgs;
+    in
+    f: if f ? __functor then f.__functionArgs or (functionArgs (f.__functor f)) else functionArgs f;
 
   /**
     Check whether something is a function or something


### PR DESCRIPTION
These are used by mkDerivation, so savings are meaningful. Attrset lookups are cheap, but might as well.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
