### PR TITLE
ratpoison: change source location

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29865,6 +29865,12 @@
     githubId = 59029586;
     name = "Vitor Pavan";
   };
+  vitrial = {
+    email = "111700bh@gmail.com";
+    github = "xZecora";
+    githubId = 63205921;
+    name = "Bryant Collins";
+  };
   vizid = {
     email = "mail@vizqq.cc";
     github = "ViZiD";

--- a/pkgs/by-name/ra/ratpoison/package.nix
+++ b/pkgs/by-name/ra/ratpoison/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchgit,
   autoreconfHook,
   fontconfig,
   freetype,
@@ -21,11 +21,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ratpoison";
-  version = "1.4.9";
+  version = "1.4.9-unstable-2021-05-27";
 
-  src = fetchurl {
-    url = "mirror://savannah/ratpoison/ratpoison-${finalAttrs.version}.tar.xz";
-    hash = "sha256-2Y+kvgJezKRTxAf/MRqzlJ8p8g1tir7fjwcWuF/I0fE=";
+  src = fetchgit {
+    url = "https://git.savannah.nongnu.org/git/ratpoison.git";
+    rev = "db94d4971d8dcae736cf5246ef7d0454aa345ac0";
+    sha256 = "sha256-YRzSQVLZ1W4usRWi4xTTQweYj9tNslUidw02V47VkP4=";
   };
 
   nativeBuildInputs = [
@@ -95,7 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.gpl2Plus;
     mainProgram = "ratpoison";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ vitrial ];
     inherit (libx11.meta) platforms;
   };
 })


### PR DESCRIPTION
Changed the source for the ratpoison packages source code. The tarball version doesn't appear to have multi-monitor support but the git repo does. Confirmed this with multiple rebuilds of both sources using identical nix-shell environments as well as a package override on my system.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
