### PR TITLE
siyuan: add myul as maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18934,6 +18934,11 @@
     githubId = 13910387;
     keys = [ { fingerprint = "086E EF20 D54E D348 E5BA  6263 16E9 43E6 596F FB4E"; } ];
   };
+  myul = {
+    github = "myul";
+    githubId = 27887735;
+    name = "myul";
+  };
   myypo = {
     email = "nikirsmcgl@gmail.com";
     github = "myypo";

--- a/pkgs/by-name/si/siyuan/package.nix
+++ b/pkgs/by-name/si/siyuan/package.nix
@@ -169,6 +169,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       tomasajt
       ltrump
+      myul
     ];
     platforms = lib.attrNames platformIds;
   };


### PR DESCRIPTION
## Things done

- Added `myul` to `maintainers/maintainer-list.nix`
- Added `myul` to `siyuan.meta.maintainers`

## Testing

- `nix-build lib/tests/maintainers.nix`
- `nix eval --raw .#siyuan.version`
- `nix eval --json .#siyuan.meta.maintainers`