### PR TITLE
openscreen: 1.3.0 -> 1.4.0

### DIFF
--- a/pkgs/by-name/op/openscreen/package.nix
+++ b/pkgs/by-name/op/openscreen/package.nix
@@ -6,33 +6,38 @@
   copyDesktopItems,
   makeWrapper,
   makeDesktopItem,
-  electron_39,
+  xcbuild,
+  electron_41,
   nodejs_22,
   nix-update-script,
-
-  nodejs ? nodejs_22,
-  electron ? electron_39,
 }:
+let
+  electron = electron_41;
+  nodejs = nodejs_22;
+in
 buildNpmPackage (finalAttrs: {
   inherit nodejs;
 
   pname = "openscreen";
-  version = "1.3.0";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "siddharthvaddem";
     repo = "openscreen";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-0L+SGbhKNvSH5IpjHjS5G1uhnoWV5oIaSs2mRSAl/mM=";
+    hash = "sha256-ZBWDQVYDXJ/IQGhlmscmCOMjpl03kVIdMoJXOW8OjUI=";
   };
 
-  npmDepsHash = "sha256-pKfOxRzVfMNVHxA9oM9naWz024api8jxiTJwy0+6W9A=";
+  npmDepsHash = "sha256-SMAYgOwlZg9+/KZBUhVviOxEdMeL3Z2YdC8Hx8Q/ioY=";
 
   npmRebuildFlags = [ "--ignore-scripts" ]; # Prevent running `node-gyp build`
 
   nativeBuildInputs = [
     makeWrapper
     copyDesktopItems
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
+    xcbuild
   ];
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
@@ -60,7 +65,8 @@ buildNpmPackage (finalAttrs: {
       npm exec electron-builder -- \
         --dir \
         -c.electronDist=${electron.dist} \
-        -c.electronVersion=${electron.version}
+        -c.electronVersion=${electron.version} \
+        -c.npmRebuild=false
     ''}
 
     runHook postBuild


### PR DESCRIPTION
Update openscreen from 1.3.0 to 1.4.0

https://github.com/siddharthvaddem/openscreen/releases/tag/v1.4.0

related tracking issue: https://github.com/NixOS/nixpkgs/issues/521305

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
