### PR TITLE
algol68g: 3.12.0 -> 3.12.1

### DIFF
--- a/pkgs/by-name/al/algol68g/package.nix
+++ b/pkgs/by-name/al/algol68g/package.nix
@@ -15,12 +15,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "algol68g";
-  version = "3.12.0";
+  version = "3.12.1";
 
   src = fetchurl {
     # Uses archive.org because the original site removes older versions.
-    url = "https://web.archive.org/web/20260503173638/https://algol68genie.nl/algol68g-3.12.0.tar.gz";
-    hash = "sha256-fYjuivr6AKRK4Nn45Q+oglpTMnp+PhO6KOkGZjwVKn0=";
+    url = "https://web.archive.org/web/20260515052918/https://algol68genie.nl/algol68g-3.12.1.tar.gz";
+    hash = "sha256-Mdoca6W1Wyyv7WrmzaAW/fn0uLkXy6MwSDImVwB+mBk";
   };
 
   outputs = [


### PR DESCRIPTION
Update to 3.12.1

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
