### PR TITLE
officecli: init at 1.0.92

### DIFF
--- a/pkgs/by-name/of/officecli/deps.json
+++ b/pkgs/by-name/of/officecli/deps.json
@@ -1,0 +1,27 @@
+[
+  {
+    "pname": "DocumentFormat.OpenXml",
+    "version": "3.4.1",
+    "hash": "sha256-kCsDhby6ZgVZKV43UHVZbiR1d/g6rD50C2IR4lnJPDk="
+  },
+  {
+    "pname": "DocumentFormat.OpenXml.Framework",
+    "version": "3.4.1",
+    "hash": "sha256-Qi4wz7WocNUpGqZIE6RIA0wgfbc981r6fHyz19Pn+5g="
+  },
+  {
+    "pname": "OpenMcdf",
+    "version": "3.1.3",
+    "hash": "sha256-pZvVso9+En4OjtTeb+GH+nWgjW4Kx7y1WddvWpDhSaM="
+  },
+  {
+    "pname": "System.CommandLine",
+    "version": "3.0.0-preview.2.26159.112",
+    "hash": "sha256-Al+rUmQ8/OAY1VszXMEqRpAKiTgspQjDwfaPmSI1ss4="
+  },
+  {
+    "pname": "System.IO.Packaging",
+    "version": "8.0.1",
+    "hash": "sha256-xf0BAfqQvITompBsvfpxiLts/6sRQEzdjNA3f/q/vY4="
+  }
+]

--- a/pkgs/by-name/of/officecli/package.nix
+++ b/pkgs/by-name/of/officecli/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildDotnetModule,
+  dotnetCorePackages,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+buildDotnetModule (finalAttrs: {
+  pname = "officecli";
+  version = "1.0.92";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "iOfficeAI";
+    repo = "OfficeCLI";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-g4eCgVqlW3N+pwATIsZbmjWNQ4IScUv9e40eUH9rfQw=";
+  };
+
+  projectFile = "src/officecli/officecli.csproj";
+  nugetDeps = ./deps.json;
+
+  dotnet-sdk = dotnetCorePackages.sdk_10_0;
+  dotnet-runtime = dotnetCorePackages.runtime_10_0;
+
+  selfContainedBuild = true;
+  executables = [ "officecli" ];
+
+  makeWrapperArgs = [
+    "--set"
+    "OFFICECLI_SKIP_UPDATE"
+    "1"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Command-line tool for creating, reading and editing Office documents";
+    homepage = "https://github.com/iOfficeAI/OfficeCLI";
+    changelog = "https://github.com/iOfficeAI/OfficeCLI/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    mainProgram = "officecli";
+    maintainers = with lib.maintainers; [ qrzbing ];
+    platforms = finalAttrs.dotnet-sdk.meta.platforms;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode
+    ];
+  };
+})


### PR DESCRIPTION
OfficeCLI: Command-line tool for creating, reading and editing Office documents.
<https://github.com/iOfficeAI/OfficeCLI>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
