### PR TITLE
spades: fix build with gcc 15

### DIFF
--- a/pkgs/by-name/sp/spades/package.nix
+++ b/pkgs/by-name/sp/spades/package.nix
@@ -25,8 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Add missing <cstdint> for uint{8,64}_t to fix build with gcc 15.
     (fetchpatch2 {
       url = "https://github.com/ablab/spades/commit/10b6af96ead72fdb19e8e524aa24bdcff9986e76.patch?full_index=1";
-      stripLen = 2;
-      extraPrefix = "";
+      relative = "src";
       hash = "sha256-yAQVqE6DwPe+GZ4VR1cGytaO8NmHz6TUG7EdtbxIuTU=";
     })
   ];

--- a/pkgs/by-name/sp/spades/package.nix
+++ b/pkgs/by-name/sp/spades/package.nix
@@ -4,6 +4,7 @@
   bzip2,
   cmake,
   fetchFromGitHub,
+  fetchpatch2,
   ncurses,
   python3,
   readline,
@@ -19,6 +20,16 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-BlZjfZKtCm1kWNPjdth3pYFN0plU7xfTsFotPefzzMY=";
   };
+
+  patches = [
+    # Add missing <cstdint> for uint{8,64}_t to fix build with gcc 15.
+    (fetchpatch2 {
+      url = "https://github.com/ablab/spades/commit/10b6af96ead72fdb19e8e524aa24bdcff9986e76.patch?full_index=1";
+      stripLen = 2;
+      extraPrefix = "";
+      hash = "sha256-yAQVqE6DwPe+GZ4VR1cGytaO8NmHz6TUG7EdtbxIuTU=";
+    })
+  ];
 
   sourceRoot = "${finalAttrs.src.name}/src";
 


### PR DESCRIPTION
GCC 15 Regression Tracking: #475479
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327184555)](https://hydra.nixos.org/build/327184555)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
