### PR TITLE
xmrig: 6.25.0 -> 6.26.0, make parametrizable

### DIFF
--- a/pkgs/by-name/xm/xmrig/package.nix
+++ b/pkgs/by-name/xm/xmrig/package.nix
@@ -9,17 +9,44 @@
   hwloc,
   kmod,
   donateLevel ? 0,
+
+  # Algorithms
+  enableCnLite ? true,
+  enableCnHeavy ? true,
+  enableCnPico ? true,
+  enableCnFemto ? true,
+  enableRandomx ? true,
+  enableArgon2 ? true,
+  enableKawpow ? true,
+  enableGhostrider ? true,
+
+  # Features requiring external dependencies
+  withHwloc ? true,
+  withHttp ? true,
+  withTls ? true,
+
+  # Features (build toggles)
+  enableAsm ? true,
+  enableMsr ? true,
+  enableProfiling ? false,
+  enableSse4_1 ? true,
+  enableBenchmark ? true,
+  enableDmi ? true,
+
+  # Debug options
+  enableDebugLog ? false,
+  enableHwlocDebug ? false,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xmrig";
-  version = "6.25.0";
+  version = "6.26.0";
 
   src = fetchFromGitHub {
     owner = "xmrig";
     repo = "xmrig";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-X34djxUeSDwopwsipgrdFFFUP+tQ/uCNvupYzbegkEE=";
+    hash = "sha256-ZJKayM1kTLCXlQqqfN3MbAKPShi5OYafOdDbsMa0QIs=";
   };
 
   patches = [
@@ -28,10 +55,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     substituteAllInPlace src/donate.h
+  ''
+  + lib.optionalString withTls ''
     substituteInPlace cmake/OpenSSL.cmake \
       --replace "set(OPENSSL_USE_STATIC_LIBS TRUE)" "set(OPENSSL_USE_STATIC_LIBS FALSE)"
   ''
-  + lib.optionalString stdenv.hostPlatform.isLinux ''
+  + lib.optionalString (stdenv.hostPlatform.isLinux && enableMsr) ''
     substituteInPlace src/hw/msr/Msr_linux.cpp \
       --replace "/sbin/modprobe" "${kmod}/bin/modprobe"
   '';
@@ -42,9 +71,34 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     libuv
-    libmicrohttpd
-    openssl
-    hwloc
+  ]
+  ++ lib.optional withHttp libmicrohttpd
+  ++ lib.optional withTls openssl
+  ++ lib.optional withHwloc hwloc;
+
+  cmakeFlags = [
+    (lib.cmakeBool "WITH_CN_LITE" enableCnLite)
+    (lib.cmakeBool "WITH_CN_HEAVY" enableCnHeavy)
+    (lib.cmakeBool "WITH_CN_PICO" enableCnPico)
+    (lib.cmakeBool "WITH_CN_FEMTO" enableCnFemto)
+    (lib.cmakeBool "WITH_RANDOMX" enableRandomx)
+    (lib.cmakeBool "WITH_ARGON2" enableArgon2)
+    (lib.cmakeBool "WITH_KAWPOW" enableKawpow)
+    (lib.cmakeBool "WITH_GHOSTRIDER" enableGhostrider)
+
+    (lib.cmakeBool "WITH_HWLOC" withHwloc)
+    (lib.cmakeBool "WITH_HTTP" withHttp)
+    (lib.cmakeBool "WITH_TLS" withTls)
+
+    (lib.cmakeBool "WITH_ASM" enableAsm)
+    (lib.cmakeBool "WITH_MSR" enableMsr)
+    (lib.cmakeBool "WITH_PROFILING" enableProfiling)
+    (lib.cmakeBool "WITH_SSE4_1" enableSse4_1)
+    (lib.cmakeBool "WITH_BENCHMARK" enableBenchmark)
+    (lib.cmakeBool "WITH_DMI" enableDmi)
+
+    (lib.cmakeBool "WITH_DEBUG_LOG" enableDebugLog)
+    (lib.cmakeBool "HWLOC_DEBUG" enableHwlocDebug)
   ];
 
   inherit donateLevel;
@@ -52,7 +106,7 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    install -vD xmrig $out/bin/xmrig
+    install -vD ${if withTls then "xmrig" else "xmrig-notls"} $out/bin/xmrig
 
     runHook postInstall
   '';


### PR DESCRIPTION
This introduces top-level arguments to customize the xmrig build,
exposing most of the available CMake options.

Users can now:
- Disable specific mining algorithms (e.g., KawPow, Argon2) to reduce binary size.
- Toggle core features like the HTTP API, TLS support, and MSR.
- Enable debug logging for troubleshooting.

The new arguments follow Nixpkgs conventions, using `with...` for options
that pull in external dependencies and `enable...` for build-time toggles.

The installPhase is also updated to correctly handle the `xmrig-notls`
binary name when TLS support is disabled.

Also, the version was updated from xmrig 6.25.0 to 6.26.0, because the merge https://github.com/NixOS/nixpkgs/pull/504442 strangely hung.

nixpkgs-review touched two packages `xmrig` and `xmrig-mo`, the build was successful.

Closes #504442

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
