### PR TITLE
python3Packages.nethsm: 2.0.1 -> 2.1.1, python3Packages.pynitrokey: 0.11.4 -> 0.12.2

### DIFF
--- a/pkgs/development/python-modules/nethsm/default.nix
+++ b/pkgs/development/python-modules/nethsm/default.nix
@@ -3,10 +3,8 @@
   buildPythonPackage,
   certifi,
   cryptography,
-  docker,
   fetchFromGitHub,
-  flit-core,
-  podman,
+  poetry-core,
   pycryptodome,
   pytestCheckHook,
   python-dateutil,
@@ -16,19 +14,19 @@
 
 buildPythonPackage rec {
   pname = "nethsm";
-  version = "2.0.1";
+  version = "2.1.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Nitrokey";
     repo = "nethsm-sdk-py";
     tag = "v${version}";
-    hash = "sha256-wqnyI6QmsBfQW7NbJrk92Ufw0+IFmc8/0ZsUp5XswYw=";
+    hash = "sha256-1bU3C8dlErDpHQIqsEabi92VPC91/wTNvZnx2dDHcmw=";
   };
 
   pythonRelaxDeps = true;
 
-  build-system = [ flit-core ];
+  build-system = [ poetry-core ];
 
   dependencies = [
     certifi
@@ -39,8 +37,6 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    docker
-    podman
     pycryptodome
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/pynitrokey/default.nix
+++ b/pkgs/development/python-modules/pynitrokey/default.nix
@@ -25,7 +25,7 @@
 
 let
   pname = "pynitrokey";
-  version = "0.11.4";
+  version = "0.12.2";
   mainProgram = "nitropy";
 in
 
@@ -35,7 +35,7 @@ buildPythonPackage {
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-MSqWgYuuU7uuYasxTTLRbrrAWQAwE4qQlEZIHiYB/78=";
+    hash = "sha256-fDLkYUVBdMFbHlnFSCUUlyJNP9OzRKOJM3ExFdzDEkU=";
   };
 
   nativeBuildInputs = [ installShellFiles ];


### PR DESCRIPTION
nethsm:
* https://github.com/Nitrokey/nethsm-sdk-py/releases/tag/v2.1.0
* https://github.com/Nitrokey/nethsm-sdk-py/releases/tag/v2.1.1

pynitrokey:
* https://github.com/Nitrokey/pynitrokey/releases/tag/v0.12.0
* https://github.com/Nitrokey/pynitrokey/releases/tag/v0.12.1
* https://github.com/Nitrokey/pynitrokey/releases/tag/v0.12.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `6e21ad10bc48ff661309c42c4db1220f034bf3fe`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 8 packages built:</summary>
  <ul>
    <li>pynitrokey (python313Packages.pynitrokey)</li>
    <li>pynitrokey.dist (python313Packages.pynitrokey.dist)</li>
    <li>python313Packages.nethsm</li>
    <li>python313Packages.nethsm.dist</li>
    <li>python314Packages.nethsm</li>
    <li>python314Packages.nethsm.dist</li>
    <li>python314Packages.pynitrokey</li>
    <li>python314Packages.pynitrokey.dist</li>
  </ul>
</details>