### PR TITLE
Fix build for blast on darwin

### DIFF
--- a/pkgs/by-name/bl/blast/package.nix
+++ b/pkgs/by-name/bl/blast/package.nix
@@ -11,6 +11,7 @@
   coreutils,
   curl,
   sqlite,
+  llvmPackages,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "blast";
@@ -103,6 +104,9 @@ stdenv.mkDerivation (finalAttrs: {
     zlib
     bzip2
     sqlite
+  ]
+  ++ lib.optionals stdenv.isDarwin [
+    llvmPackages.openmp
   ];
 
   strictDeps = true;
@@ -128,9 +132,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://blast.ncbi.nlm.nih.gov/Blast.cgi";
     license = lib.licenses.publicDomain;
 
-    # Version 2.10.0 fails on Darwin
-    # See https://github.com/NixOS/nixpkgs/pull/61430
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ [ "aarch64-darwin" ];
     maintainers = with lib.maintainers; [
       luispedro
       mulatta


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

As I only have a mac based on Apple Silicon, I cannot test on darwin platforms of other architectures, but as they should be available for the same software behavior, they should be available. But for safety sake, this pull request will only be used to fix the aarch64-darwin build. We have implemented the link option to remove the libomp, and we have tried to fix the ANSI C Header detection. All binaries have been tested on my mac and pass.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
