### PR TITLE
blazingjj: init at 0.8.0

### DIFF
--- a/pkgs/by-name/bl/blazingjj/package.nix
+++ b/pkgs/by-name/bl/blazingjj/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  jujutsu,
+  versionCheckHook,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "blazingjj";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "blazingjj";
+    repo = "blazingjj";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-vefD93gzT6WEplpnYiENtzXLSeXBo+9K3/RYpSBafDs=";
+  };
+
+  cargoHash = "sha256-E/xddxdvCDWH1xPn/CPXFyJIHg1Dy6EG3VZMZouWHQY=";
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  nativeCheckInputs = [
+    jujutsu
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/blazingjj \
+      --prefix PATH : ${lib.makeBinPath [ jujutsu ]}
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "TUI for Jujutsu/jj";
+    homepage = "https://github.com/blazingjj/blazingjj";
+    changelog = "https://github.com/blazingjj/blazingjj/releases/tag/v${finalAttrs.version}";
+    mainProgram = "blazingjj";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      peret
+    ];
+  };
+})


### PR DESCRIPTION
Init blazingjj, a TUI for  the jujutsu/jj VCS

https://github.com/blazingjj/blazingjj

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
