### PR TITLE
croaring: 3.6.1 -> 4.7.0

### DIFF
--- a/pkgs/by-name/cr/croaring/package.nix
+++ b/pkgs/by-name/cr/croaring/package.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "croaring";
-  version = "4.6.1";
+  version = "4.7.0";
 
   src = fetchFromGitHub {
     owner = "RoaringBitmap";
     repo = "CRoaring";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-wks7kkF0va7RUJXY74ku/yWTSsHQKlFczfhAHyuNudM=";
+    hash = "sha256-YXEEiWbbP6G7x/rQiihAq20OEMxJNSgky+JTEaKlNDU=";
   };
 
   # roaring.pc.in cannot handle absolute CMAKE_INSTALL_*DIRs, nor
@@ -27,27 +27,6 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [ cmocka ];
 
   doCheck = true;
-
-  postPatch = ''
-    # Fixes the build of dependent projects by updating the supported
-    # CMake version.
-    # Issue: https://github.com/RoaringBitmap/CRoaring/issues/793
-    # PR: https://github.com/RoaringBitmap/CRoaring/pull/794
-    substituteInPlace CMakeLists.txt \
-      --replace-fail '2.8...3.15' '3.15'
-  '';
-
-  preConfigure = ''
-    mkdir -p dependencies/.cache
-    ln -s ${
-      fetchFromGitHub {
-        owner = "clibs";
-        repo = "cmocka";
-        rev = "f5e2cd77c88d9f792562888d2b70c5a396bfbf7a";
-        hash = "sha256-Oq0nFsZhl8IF7kQN/LgUq8VBy+P7gO98ep/siy5A7Js=";
-      }
-    } dependencies/.cache/cmocka
-  '';
 
   cmakeFlags = [ (lib.cmakeBool "ROARING_USE_CPM" false) ];
 


### PR DESCRIPTION
changelog: https://github.com/RoaringBitmap/CRoaring/releases/tag/v4.7.0
diff: https://github.com/RoaringBitmap/CRoaring/compare/v4.6.1...v4.7.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
