### PR TITLE
waytrogen: 0.9.5 -> 0.9.6

### DIFF
--- a/pkgs/by-name/wa/waytrogen/package.nix
+++ b/pkgs/by-name/wa/waytrogen/package.nix
@@ -14,22 +14,39 @@
   sqlite,
   openssl,
   desktop-file-utils,
+  bash,
+  dbus,
+  gtk4,
+  ffmpeg,
+  gsettings-desktop-schemas,
+  libx11,
+  libxcursor,
+  libxrandr,
+  libxi,
+  libxcb,
+  libxkbcommon,
+  vulkan-loader,
+  wayland,
+  xdg-utils,
+  makeWrapper,
+  xdg-desktop-portal,
+  libGL,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "waytrogen";
-  version = "0.9.5";
+  version = "0.9.6";
 
   src = fetchFromGitHub {
     owner = "nikolaizombie1";
     repo = "waytrogen";
     tag = finalAttrs.version;
-    hash = "sha256-+1HiTmJAkhd+zbLAyRRk9tHDbR7qcslkfJ2HyGipZCo=";
+    hash = "sha256-q+44xYmxXWkYfoMQtARCIIjvxwCxNTl1mH+wxcATnAk=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-UKd/h/O9EE7gZ8B+QtFVGJEit0BIQ0OC0CG/GLYzMEo=";
+    hash = "sha256-4FGY/MS8sB3dh8iCrA5yOl0/qiP9rzXf7v43iZe6FxU=";
   };
 
   nativeBuildInputs = [
@@ -41,12 +58,38 @@ stdenv.mkDerivation (finalAttrs: {
     cargo
     rustc
     desktop-file-utils
+    glib
+    bash
+    dbus
+    makeWrapper
+    sqlite
+    gtk4
+    dbus
+    xdg-utils
+    xdg-desktop-portal
   ];
 
   buildInputs = [
     glib
     sqlite
     openssl
+    glib
+    gtk4
+    ffmpeg
+    sqlite
+    openssl
+    gsettings-desktop-schemas
+    libx11
+    libxcursor
+    libxrandr
+    libxi
+    libxcb
+    libxkbcommon
+    vulkan-loader
+    wayland
+    dbus
+    xdg-utils
+    xdg-desktop-portal
   ];
 
   preBuild = "export OUT_PATH=$out";
@@ -55,16 +98,28 @@ stdenv.mkDerivation (finalAttrs: {
     OPENSSL_NO_VENDOR = 1;
   };
 
-  mesonFlags = [ "-Dcargo_features=nixos" ];
-
   passthru.updateScript = nix-update-script { };
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --suffix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          wayland
+          libxkbcommon
+          vulkan-loader
+          libGL
+          dbus
+        ]
+      }
+    )
+  '';
 
   meta = {
     description = "Lightning fast wallpaper setter for Wayland";
     longDescription = ''
       A GUI wallpaper setter for Wayland that is a spiritual successor
       for the minimalistic wallpaper changer for X11 nitrogen. Written purely
-      in the Rust 🦀 programming language. Supports hyprpaper, swaybg, mpvpaper and swww wallpaper changers.
+      in the Rust 🦀 programming language. Supports hyprpaper, swaybg, mpvpaper, swww  and gSlapper wallpaper changers.
     '';
     homepage = "https://github.com/nikolaizombie1/waytrogen";
     changelog = "https://github.com/nikolaizombie1/waytrogen/releases/tag/${finalAttrs.version}";


### PR DESCRIPTION
<!--
Update dependencies and build process for gtk4 to iced migration. Added packages and procedures are to properly wrap and build the application for iced.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
