### PR TITLE
yaziPlugins.keep-preferences: init at 0-unstable-2026-05-15

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/keep-preferences/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/keep-preferences/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkYaziPlugin,
+}:
+mkYaziPlugin {
+  pname = "keep-preferences.yazi";
+  version = "0-unstable-2026-05-15";
+
+  src = fetchFromGitHub {
+    owner = "XYenon";
+    repo = "keep-preferences.yazi";
+    rev = "f6656322e059df2384b1e3b37461e362438879f9";
+    hash = "sha256-eRlF78sixUVHWuYFml65xY7W0rKGDholqpggUuatd1c=";
+  };
+
+  meta = {
+    description = "Keep Yazi manager preferences per tab and per directory";
+    homepage = "https://github.com/XYenon/keep-preferences.yazi";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ xyenon ];
+  };
+}


### PR DESCRIPTION
https://github.com/XYenon/keep-preferences.yazi

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
