### PR TITLE
[Backport release-25.11] warpgate: 0.18.0 -> 0.23.4

### DIFF
--- a/nixos/modules/services/security/warpgate.nix
+++ b/nixos/modules/services/security/warpgate.nix
@@ -283,6 +283,14 @@ in
               };
             };
             log = {
+              format = mkOption {
+                description = "The format Warpgate emits logs in.";
+                default = "text";
+                type = enum [
+                  "text"
+                  "json"
+                ];
+              };
               retention = mkOption {
                 description = "How long Warpgate keep its logs.";
                 default = "7days";

--- a/nixos/modules/services/security/warpgate.nix
+++ b/nixos/modules/services/security/warpgate.nix
@@ -105,6 +105,7 @@ in
               description = ''
                 Configure the domain name of this Warpgate instance.
                 See [HTTP domain binding](https://warpgate.null.page/http-domain-binding/).
+                This option is considered legacy, please use protocol specific `external_host` instead.
               '';
               default = null;
               type = nullOr str;
@@ -127,6 +128,11 @@ in
                 description = "Listen endpoint of SSH listener.";
                 default = "[::]:2222";
                 type = str;
+              };
+              external_host = mkOption {
+                description = "The SSH listener is reachable via this domain name externally.";
+                default = null;
+                type = nullOr str;
               };
               external_port = mkOption {
                 description = "The SSH listener is reachable via this port externally.";
@@ -163,6 +169,11 @@ in
                 description = "Listen endpoint of HTTP listener.";
                 default = "[::]:8888";
                 type = str;
+              };
+              external_host = mkOption {
+                description = "The HTTP listener is reachable via this domain name externally.";
+                default = null;
+                type = nullOr str;
               };
               external_port = mkOption {
                 description = "The HTTP listener is reachable via this port externally.";
@@ -239,6 +250,11 @@ in
                 default = "[::]:33306";
                 type = str;
               };
+              external_host = mkOption {
+                description = "The MySQL listener is reachable via this domain name externally.";
+                default = null;
+                type = nullOr str;
+              };
               external_port = mkOption {
                 description = "The MySQL listener is reachable via this port externally.";
                 default = null;
@@ -266,6 +282,11 @@ in
                 default = "[::]:55432";
                 type = str;
               };
+              external_host = mkOption {
+                description = "The PostgreSQL listener is reachable via this domain name externally.";
+                default = null;
+                type = nullOr str;
+              };
               external_port = mkOption {
                 description = "The PostgreSQL listener is reachable via this port externally.";
                 default = null;
@@ -292,6 +313,11 @@ in
                 description = "Listen endpoint of Kubernetes listener.";
                 default = "[::]:8443";
                 type = str;
+              };
+              external_host = mkOption {
+                description = "The Kubernetes listener is reachable via this domain name externally.";
+                default = null;
+                type = nullOr str;
               };
               external_port = mkOption {
                 description = "The Kubernetes listener is reachable via this port externally.";

--- a/nixos/modules/services/security/warpgate.nix
+++ b/nixos/modules/services/security/warpgate.nix
@@ -349,8 +349,13 @@ in
                   "json"
                 ];
               };
+              audit_retention = mkOption {
+                description = "How long Warpgate keeps its audit logs.";
+                default = "1year";
+                type = str;
+              };
               retention = mkOption {
-                description = "How long Warpgate keep its logs.";
+                description = "How long Warpgate keeps its non-audit logs and session recordings.";
                 default = "7days";
                 type = str;
               };

--- a/nixos/modules/services/security/warpgate.nix
+++ b/nixos/modules/services/security/warpgate.nix
@@ -305,17 +305,6 @@ in
                 type = nullOr str;
               };
             };
-            config_provider = mkOption {
-              description = ''
-                Source of truth of users.
-                DO NOT change this, Warpgate only implemented database provider.
-              '';
-              default = "database";
-              type = enum [
-                "file"
-                "database"
-              ];
-            };
           };
         };
         default = { };
@@ -379,6 +368,10 @@ in
         {
           assertion = !((cfg.databaseUrlFile == null) && (cfg.settings.database_url == null));
           message = "Either databaseUrlFile or settings.database_url must be set; Set the other to null.";
+        }
+        {
+          assertion = !(lib.hasAttr "config_provider" cfg.settings);
+          message = "`services.warpgate.settings.config_provider` is a legacy option that has been removed since 0.14.0. Please do not set this option.";
         }
       ];
 

--- a/nixos/modules/services/security/warpgate.nix
+++ b/nixos/modules/services/security/warpgate.nix
@@ -51,7 +51,10 @@ in
           freeformType = yaml.type;
           options = {
             sso_providers = mkOption {
-              description = "Configure OIDC single sign-on providers.";
+              description = ''
+                Configure OIDC single sign-on providers.
+                Main documentation can be found [here](https://warpgate.null.page/sso).
+              '';
               default = [ ];
               type = listOf (submodule {
                 freeformType = yaml.type;
@@ -62,11 +65,39 @@ in
                   };
                   label = mkOption {
                     description = "SSO provider name displayed on login page.";
-                    type = str;
+                    default = null;
+                    type = nullOr str;
+                  };
+                  auto_create_users = mkOption {
+                    description = "Whether to create user automatically at first SSO login.";
+                    default = false;
+                    type = bool;
                   };
                   provider = mkOption {
-                    description = "SSO provider configurations.";
+                    description = ''
+                      SSO provider configurations.
+                      See [here](https://github.com/warp-tech/warpgate/blob/ffc755f0137944bd39cf4cbce90f4279da500943/config-schema.json#L430) for all acceptable options.
+                    '';
                     type = attrsOf yaml.type;
+                  };
+                  return_domain_whitelist = mkOption {
+                    description = ''
+                      Controls the SSO return URL supplied to SSO provider.
+                      This will also required you to connect to this instance via whitelisted domain when doing SSO login.
+                    '';
+                    default = null;
+                    type = nullOr (listOf str);
+                  };
+                  return_url_prefix = mkOption {
+                    description = ''
+                      Controls the SSO return URL supplied to SSO provider.
+                      Useful for providers that do not allow the @ sign in the URL (e.g. Azure).
+                    '';
+                    default = "@";
+                    type = enum [
+                      "@"
+                      "_"
+                    ];
                   };
                 };
               });

--- a/nixos/modules/services/security/warpgate.nix
+++ b/nixos/modules/services/security/warpgate.nix
@@ -282,6 +282,38 @@ in
                 type = str;
               };
             };
+            kubernetes = {
+              enable = mkOption {
+                description = "Whether to enable Kubernetes listener.";
+                default = false;
+                type = bool;
+              };
+              listen = mkOption {
+                description = "Listen endpoint of Kubernetes listener.";
+                default = "[::]:8443";
+                type = str;
+              };
+              external_port = mkOption {
+                description = "The Kubernetes listener is reachable via this port externally.";
+                default = null;
+                type = nullOr str;
+              };
+              certificate = mkOption {
+                description = "Path to Kubernetes listener certificate.";
+                default = "/var/lib/warpgate/tls.certificate.pem";
+                type = str;
+              };
+              key = mkOption {
+                description = "Path to Kubernetes listener private key.";
+                default = "/var/lib/warpgate/tls.key.pem";
+                type = str;
+              };
+              session_max_age = mkOption {
+                description = "How long until a logged in session expires.";
+                default = "30m";
+                type = str;
+              };
+            };
             log = {
               format = mkOption {
                 description = "The format Warpgate emits logs in.";

--- a/pkgs/by-name/wa/warpgate/hardcode-version.patch
+++ b/pkgs/by-name/wa/warpgate/hardcode-version.patch
@@ -1,11 +1,11 @@
 diff --git a/warpgate-common/src/version.rs b/warpgate-common/src/version.rs
-index 07db547..2a7967f 100644
+index 0e7985a..62c2b67 100644
 --- a/warpgate-common/src/version.rs
 +++ b/warpgate-common/src/version.rs
 @@ -1,8 +1,3 @@
 -use git_version::git_version;
 -
- pub fn warpgate_version() -> &'static str {
+ pub const fn warpgate_version() -> &'static str {
 -    git_version!(
 -        args = ["--tags", "--always", "--dirty=-modified"],
 -        fallback = "unknown"

--- a/pkgs/by-name/wa/warpgate/package.nix
+++ b/pkgs/by-name/wa/warpgate/package.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage (
 
       patches = [ ./web-ui-package-json.patch ];
 
-      npmDepsHash = "sha256-bsVlE0uOJu3JRAn5Hjt2PUhpgJXbQBUKO+6nl0EZkyc=";
+      npmDepsHash = "sha256-0AhbX+NhKGvWbOHwkIGE1pwJbD/ZLrOJCoWnCm8lYoY=";
 
       nativeBuildInputs = [ openapi-generator-cli ];
 
@@ -35,16 +35,16 @@ rustPlatform.buildRustPackage (
   in
   {
     pname = "warpgate";
-    version = "0.19.0";
+    version = "0.19.1";
 
     src = fetchFromGitHub {
       owner = "warp-tech";
       repo = "warpgate";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-PBDAZDoCFwrO1/zfQwy1MOhDDx4xHHOSvKsIYk2ayM8=";
+      hash = "sha256-0eaN91Uu1kCOZLblXmY9qLP8L8+UBlZWuArICQkBBk4=";
     };
 
-    cargoHash = "sha256-8m2NznKIME1UywQxmaQm+TJhhro095oU0WM7JxIyMxU=";
+    cargoHash = "sha256-w6VMtqmo5TiMHY3x77UPXn0TJUT62/gBIVkjZ/WxgaE=";
 
     patches = [
       (replaceVars ./hardcode-version.patch { inherit (finalAttrs) version; })

--- a/pkgs/by-name/wa/warpgate/package.nix
+++ b/pkgs/by-name/wa/warpgate/package.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage (
 
       patches = [ ./web-ui-package-json.patch ];
 
-      npmDepsHash = "sha256-jRY3vR9rwqQc1WjxIuPb797ZXXrgDYNZ947fERxJ0zA=";
+      npmDepsHash = "sha256-JW3nibMIETj5PQcaNRS5UVZgguSvGd9Bw8uGD3kb5uM=";
 
       nativeBuildInputs = [ openapi-generator-cli ];
 
@@ -35,16 +35,16 @@ rustPlatform.buildRustPackage (
   in
   {
     pname = "warpgate";
-    version = "0.23.1";
+    version = "0.23.4";
 
     src = fetchFromGitHub {
       owner = "warp-tech";
       repo = "warpgate";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-GayjhHkD9LtuR7dz7tw1smz4fPwOl8R9X9QTgx9snnM=";
+      hash = "sha256-/IhnDBQq7Ed5vaGiCHNTcE7Uu9b9VrBN1ipCd2Tai1o=";
     };
 
-    cargoHash = "sha256-Y3oVvQkZDmGmmxUYrWSP6qKZ4hgjly+t98PRmi88oaY=";
+    cargoHash = "sha256-PRR+bzvmWcWUVdV1HqDqD08SwvDCvGXMvkIVoFEnaQI=";
 
     patches = [
       (replaceVars ./hardcode-version.patch { inherit (finalAttrs) version; })

--- a/pkgs/by-name/wa/warpgate/package.nix
+++ b/pkgs/by-name/wa/warpgate/package.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage (
 
       patches = [ ./web-ui-package-json.patch ];
 
-      npmDepsHash = "sha256-0AhbX+NhKGvWbOHwkIGE1pwJbD/ZLrOJCoWnCm8lYoY=";
+      npmDepsHash = "sha256-MwcQL4nLN0kCMSubHbgtX3rGcA4xJjUuGv6nFgDXQtw=";
 
       nativeBuildInputs = [ openapi-generator-cli ];
 
@@ -35,16 +35,16 @@ rustPlatform.buildRustPackage (
   in
   {
     pname = "warpgate";
-    version = "0.19.1";
+    version = "0.21.1";
 
     src = fetchFromGitHub {
       owner = "warp-tech";
       repo = "warpgate";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-0eaN91Uu1kCOZLblXmY9qLP8L8+UBlZWuArICQkBBk4=";
+      hash = "sha256-j2F+Y3rEiAOybiNXD0vdo1kSdJQs78wnKD8n4JuR9VA=";
     };
 
-    cargoHash = "sha256-w6VMtqmo5TiMHY3x77UPXn0TJUT62/gBIVkjZ/WxgaE=";
+    cargoHash = "sha256-HQdBBd+XX+7OgYrxuP+scmnG2unBVryPfA5/inflqMw=";
 
     patches = [
       (replaceVars ./hardcode-version.patch { inherit (finalAttrs) version; })

--- a/pkgs/by-name/wa/warpgate/package.nix
+++ b/pkgs/by-name/wa/warpgate/package.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage (
 
       patches = [ ./web-ui-package-json.patch ];
 
-      npmDepsHash = "sha256-MwcQL4nLN0kCMSubHbgtX3rGcA4xJjUuGv6nFgDXQtw=";
+      npmDepsHash = "sha256-jRY3vR9rwqQc1WjxIuPb797ZXXrgDYNZ947fERxJ0zA=";
 
       nativeBuildInputs = [ openapi-generator-cli ];
 
@@ -35,19 +35,20 @@ rustPlatform.buildRustPackage (
   in
   {
     pname = "warpgate";
-    version = "0.21.1";
+    version = "0.23.1";
 
     src = fetchFromGitHub {
       owner = "warp-tech";
       repo = "warpgate";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-j2F+Y3rEiAOybiNXD0vdo1kSdJQs78wnKD8n4JuR9VA=";
+      hash = "sha256-GayjhHkD9LtuR7dz7tw1smz4fPwOl8R9X9QTgx9snnM=";
     };
 
-    cargoHash = "sha256-HQdBBd+XX+7OgYrxuP+scmnG2unBVryPfA5/inflqMw=";
+    cargoHash = "sha256-Y3oVvQkZDmGmmxUYrWSP6qKZ4hgjly+t98PRmi88oaY=";
 
     patches = [
       (replaceVars ./hardcode-version.patch { inherit (finalAttrs) version; })
+      ./remove-nightly-rustflags.patch
     ];
 
     RUSTFLAGS = "--cfg tokio_unstable";

--- a/pkgs/by-name/wa/warpgate/package.nix
+++ b/pkgs/by-name/wa/warpgate/package.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage (
 
       patches = [ ./web-ui-package-json.patch ];
 
-      npmDepsHash = "sha256-jgsNF93DkEVgPGzdi192HKoSHPYhdrtog28jZvOLK6E=";
+      npmDepsHash = "sha256-bsVlE0uOJu3JRAn5Hjt2PUhpgJXbQBUKO+6nl0EZkyc=";
 
       nativeBuildInputs = [ openapi-generator-cli ];
 
@@ -35,16 +35,16 @@ rustPlatform.buildRustPackage (
   in
   {
     pname = "warpgate";
-    version = "0.18.0";
+    version = "0.19.0";
 
     src = fetchFromGitHub {
       owner = "warp-tech";
       repo = "warpgate";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-GLY/VGEKB6gFNTbBlbhpmqQZ62pk2wd6JwWwy4Tz0FE=";
+      hash = "sha256-PBDAZDoCFwrO1/zfQwy1MOhDDx4xHHOSvKsIYk2ayM8=";
     };
 
-    cargoHash = "sha256-hwAtj8tTDsYgzuDobMg97wepKKIpohSVClyRiaDd+8w=";
+    cargoHash = "sha256-8m2NznKIME1UywQxmaQm+TJhhro095oU0WM7JxIyMxU=";
 
     patches = [
       (replaceVars ./hardcode-version.patch { inherit (finalAttrs) version; })

--- a/pkgs/by-name/wa/warpgate/remove-nightly-rustflags.patch
+++ b/pkgs/by-name/wa/warpgate/remove-nightly-rustflags.patch
@@ -1,0 +1,26 @@
+diff --git a/Cargo.toml b/Cargo.toml
+index 0e92acb..d187ebc 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -100,21 +100,3 @@ strip = "debuginfo"
+ [profile.coverage]
+ inherits = "dev"
+ # rustflags = ["-Cinstrument-coverage"]
+-
+-[profile.dev.package.aws-sdk-ec2]
+-rustflags = ["-Zhint-mostly-unused"]
+-
+-[profile.release.package.aws-sdk-ec2]
+-rustflags = ["-Zhint-mostly-unused"]
+-
+-[profile.dev.package.aws-sdk-rds]
+-rustflags = ["-Zhint-mostly-unused"]
+-
+-[profile.release.package.aws-sdk-rds]
+-rustflags = ["-Zhint-mostly-unused"]
+-
+-[profile.dev.package.aws-sdk-eks]
+-rustflags = ["-Zhint-mostly-unused"]
+-
+-[profile.release.package.aws-sdk-eks]
+-rustflags = ["-Zhint-mostly-unused"]


### PR DESCRIPTION
Manual backport of #520120.

cc @NyCodeGHG, thanks.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
