### PR TITLE
nixos/niri: always emit niri.service override as drop-in

### DIFF
--- a/nixos/modules/programs/wayland/niri.nix
+++ b/nixos/modules/programs/wayland/niri.nix
@@ -49,6 +49,7 @@ in
           # clobbering the PATH that niri-session imported into the user
           # manager and breaking spawn actions that rely on it.
           enableDefaultPath = false;
+          overrideStrategy = "asDropin";
         };
 
         xdg.portal = {


### PR DESCRIPTION
Follow-up to #519740.

`generateUnits` only scans `$pkg/{etc,lib}/systemd/user` when collecting units from `systemd.packages`. The nixpkgs niri package installs its unit to `lib/systemd/user`, which the `move-systemd-user-units` fixup hook then relocates to `share/systemd/user` while leaving a back-symlink, so it is still picked up.

Niri builds that install the unit straight to `share/systemd/user` (such as the upstream `niri-wm/niri` flake's overlay) end up without that symlink. `systemd.packages` then contributes nothing for `niri.service` and the `asDropinIfExists` default falls through to a standalone `/etc/systemd/user/niri.service` containing only `X-RestartIfChanged=false`, shadowing the real unit that systemd was previously loading from `/run/current-system/sw/share/systemd/user`.

Force `asDropin` so the override is always written as `niri.service.d/overrides.conf` and merged with whichever base unit systemd resolves.

See https://github.com/NixOS/nixpkgs/pull/519740#issuecomment-4459052212

cc @ShadowRZ @getchoo @sodiboo

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
