### PR TITLE
Add package "marathon" to nixpkgs.

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22651,6 +22651,12 @@
     github = "Ra77a3l3-jar";
     githubId = 175424218;
   };
+  raas = {
+    email = "andras.horvath@gmail.com";
+    github = "raas";
+    githubId = 126327;
+    name = "Andras Horvath";
+  };
   raboof = {
     email = "arnout@bzzt.net";
     matrix = "@raboof:matrix.org";

--- a/pkgs/by-name/ma/marathon/package.nix
+++ b/pkgs/by-name/ma/marathon/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitLab,
+  installShellFiles,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "marathon";
+  version = "1.00";
+
+  src = fetchFromGitLab {
+    owner = "andras.horvath1";
+    repo = "marathon";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0z0LrsSQFwoJZlMfEGPZei/dhFwOitfNmc7QBlJ+tiM=";
+  };
+
+  vendorHash = "sha256-U77l3cmqnseVotXw/qJIbL7ZR2UHkKFPddJ8Q6Q37iE=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installManPage marathon.1
+  '';
+
+  meta = {
+    description = "Personal task runner for long-running workflows";
+    homepage = "https://gitlab.com/andras.horvath1/marathon";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ raas ];
+    mainProgram = "marathon";
+  };
+})


### PR DESCRIPTION
<!--

Add new package "marathon" to nixpkgs, with myself as new maintainer.

Marathon is a workflow runner for long-running workflows, cf https://gitlab.com/andras.horvath1/marathon .

-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
