### PR TITLE
lib.licenses: change llgpl21 to exception

### DIFF
--- a/lib/licenses/licenses.nix
+++ b/lib/licenses/licenses.nix
@@ -1012,11 +1012,6 @@ lib.mapAttrs mkLicense (
       fullName = "Licence Libre du Québec – Permissive version 1.1";
     };
 
-    llgpl21 = {
-      fullName = "Lisp LGPL; GNU Lesser General Public License version 2.1 with Franz Inc. preamble for clarification of LGPL terms in context of Lisp";
-      url = "https://opensource.franz.com/preamble.html";
-    };
-
     llgplPreamble = {
       spdxId = "LLGPL";
       fullName = "LLGPL Preamble";

--- a/lib/licenses/licenses.nix
+++ b/lib/licenses/licenses.nix
@@ -1017,6 +1017,11 @@ lib.mapAttrs mkLicense (
       url = "https://opensource.franz.com/preamble.html";
     };
 
+    llgplPreamble = {
+      spdxId = "LLGPL";
+      fullName = "LLGPL Preamble";
+    };
+
     llvm-exception = {
       spdxId = "LLVM-exception";
       fullName = "LLVM Exception"; # LLVM exceptions to the Apache 2.0 License

--- a/lib/licenses/licenses.nix
+++ b/lib/licenses/licenses.nix
@@ -315,6 +315,11 @@ lib.mapAttrs mkLicense (
       fullName = "Buddy License";
     };
 
+    bugroff = {
+      spdxId = "Bugroff";
+      fullName = "Bugroff License";
+    };
+
     bzip2 = {
       spdxId = "bzip2-1.0.6";
       fullName = "bzip2 and libbzip2 License v1.0.6";

--- a/pkgs/by-name/ac/acl2/package.nix
+++ b/pkgs/by-name/ac/acl2/package.nix
@@ -192,20 +192,22 @@ stdenv.mkDerivation (finalAttrs: {
     downloadPage = "https://github.com/acl2-devel/acl2-devel/releases";
     license =
       with lib.licenses;
-      [
-        # ACL2 itself is bsd3
-        bsd3
-      ]
-      ++ lib.optionals certifyBooks [
-        # The community books are mostly bsd3 or mit but with a few
-        # other things thrown in.
-        mit
-        gpl2
-        llgpl21
-        cc0
-        publicDomain
-        unfreeRedistributable
-      ];
+      AND (
+        [
+          # ACL2 itself is bsd3
+          bsd3
+        ]
+        ++ lib.optionals certifyBooks [
+          # The community books are mostly bsd3 or mit but with a few
+          # other things thrown in.
+          mit
+          gpl2
+          (WITH lgpl21Only llgplPreamble)
+          cc0
+          publicDomain
+          unfreeRedistributable
+        ]
+      );
     maintainers = with lib.maintainers; [
       kini
       raskin

--- a/pkgs/by-name/cl/cl-launch/package.nix
+++ b/pkgs/by-name/cl/cl-launch/package.nix
@@ -26,7 +26,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Common Lisp launcher script";
-    license = lib.licenses.llgpl21;
+    license =
+      with lib.licenses;
+      OR [
+        (WITH lgpl21Only llgplPreamble)
+        bugroff
+      ];
     maintainers = with lib.maintainers; [ raskin ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -601,7 +601,7 @@ let
         meta = {
           description = "Functional collections library";
           homepage = "https://gitlab.common-lisp.net/fset/fset/-/wikis/home";
-          license = pkgs.lib.licenses.llgpl21;
+          license = with pkgs.lib.licenses; WITH lgpl21Only llgplPreamble;
         };
       });
 


### PR DESCRIPTION
Don't use our custom license for it and make uses of the spdx included operators instead

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
