### PR TITLE
linux_7_0: Patch 'ptrace dumpable' vulnerability

### DIFF
--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -27,4 +27,13 @@
     name = "request-key-helper";
     patch = ./request-key-helper.patch;
   };
+
+  security_ptrace_dumpable = rec {
+    name = "security-ptrace-dumpable";
+    patch = fetchpatch {
+      name = name + ".patch";
+      url = "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/patch/?id=31e62c2ebbfdc3fe3dbdf5e02c92a9dc67087a3a";
+      sha256 = "sha256-fRjdobOdUN1UC+788vXhW6MXtSMg11H1E4w6TaTkJsE=";
+    };
+  };
 }

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -97,6 +97,7 @@ in
           kernelPatches = [
             kernelPatches.bridge_stp_helper
             kernelPatches.request_key_helper
+            kernelPatches.security_ptrace_dumpable
           ];
         };
 


### PR DESCRIPTION
Revert this when next 7.0.x will be released.

https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/patch/?id=31e62c2ebbfdc3fe3dbdf5e02c92a9dc67087a3a
Vulnerability allow unprivileged users to read root owned files, like host ssh keys. Because I use agenix/sops-nix I treat it as 10/10 exposing all secrets to potential attacker.

I didn't know best practices about kernel security patches, so do my best here
Patched kernel builds and boots successfully

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
