### PR TITLE
nixos/k3s,rke2: clean up manifests via linkFarm on config changes

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -261,3 +261,5 @@
 - `nix` now supports running in "daemonless" mode by setting `nix.daemon.enable = false`. Under this mode all store operations must go through the [local store type](https://nix.dev/manual/nix/latest/store/types/local-store), which typically requires root permissions.
 
 - [Hister](https://github.com/asciimoo/hister), a web history service offering blazing fast, content-based search across visited websites. Available as [services.hister](#opt-services.hister.enable).
+
+- The k3s and rke2 modules now manage manifests declaratively through a linkFarm in the Nix store, so that removing manifests from the NixOS configuration also cleans them up from the filesystem. Old symlinks in `/var/lib/rancher/${distro}/server/manifests/` must be removed manually after upgrading.

--- a/nixos/modules/services/cluster/rancher/default.nix
+++ b/nixos/modules/services/cluster/rancher/default.nix
@@ -29,7 +29,10 @@ let
       containerdConfigTemplateFile = "/var/lib/rancher/${name}/agent/etc/containerd/config.toml.tmpl";
       staticContentChartDir = "/var/lib/rancher/${name}/server/static/charts";
 
-      manifestFormat = if jsonManifests then pkgs.formats.json { } else pkgs.formats.yaml_1_2 { };
+      # Merge manifest with manifests generated from auto deploying charts, keep only enabled manifests
+      enabledManifests = lib.filterAttrs (_: v: v.enable) (cfg.autoDeployCharts // cfg.manifests);
+
+      manifestFormat = if jsonManifests then pkgs.formats.json { } else pkgs.formats.yaml { };
       # Manifests need a valid suffix to be respected
       mkManifestTarget =
         name:
@@ -837,49 +840,57 @@ let
 
         environment.systemPackages = [ config.services.${name}.package ];
 
-        # Use systemd-tmpfiles to activate content
+        # Static symlink from k3s/rke2 manifest dir to a linkFarm in the store.
+        # k3s/rke2 scan subdirectories recursively (filepath.Walk),
+        # so files under nixos/ are picked up. When manifests are removed
+        # from config, the linkFarm derivation changes, the activation
+        # script updates the symlink, and the stale files disappear.
+        system.activationScripts.rancher-manifest-symlink = ''
+          mkdir -p "${manifestDir}"
+          ln -sfn "${
+            pkgs.linkFarm "${name}-manifests" (
+              lib.mapAttrsToList (_: v: {
+                name = v.target;
+                path = v.source;
+              }) enabledManifests
+            )
+          }" "${manifestDir}/nixos"
+        '';
+
         systemd.tmpfiles.settings."10-${name}" =
+          # Make a systemd-tmpfiles rule for a container image
           let
-            # Merge manifest with manifests generated from auto deploying charts, keep only enabled manifests
-            enabledManifests = lib.filterAttrs (_: v: v.enable) (cfg.autoDeployCharts // cfg.manifests);
-            # Make a systemd-tmpfiles rule for a manifest
-            mkManifestRule = manifest: {
-              name = "${manifestDir}/${manifest.target}";
-              value = {
-                "L+".argument = "${manifest.source}";
-              };
-            };
-            # Make a systemd-tmpfiles rule for a container image
             mkImageRule = image: {
               name = "${imageDir}/${image.name}";
               value = {
                 "L+".argument = "${image}";
               };
             };
-            # Merge charts with charts contained in enabled auto deploying charts
-            helmCharts =
-              (lib.concatMapAttrs (n: v: { ${n} = v.package; }) (
-                lib.filterAttrs (_: v: v.enable) cfg.autoDeployCharts
-              ))
-              // cfg.charts;
-            # Ensure that all chart targets have a .tgz suffix
-            mkChartTarget = name: if (lib.hasSuffix ".tgz" name) then name else name + ".tgz";
-            # Make a systemd-tmpfiles rule for a chart
-            mkChartRule = target: source: {
-              name = "${staticContentChartDir}/${mkChartTarget target}";
-              value = {
-                "L+".argument = "${source}";
-              };
-            };
           in
-          (lib.mapAttrs' (_: v: mkManifestRule v) enabledManifests)
-          // (builtins.listToAttrs (map mkImageRule cfg.images))
+          builtins.listToAttrs (map mkImageRule cfg.images)
           // (lib.optionalAttrs (cfg.containerdConfigTemplate != null) {
             ${containerdConfigTemplateFile} = {
               "L+".argument = "${pkgs.writeText "config.toml.tmpl" cfg.containerdConfigTemplate}";
             };
           })
-          // (lib.mapAttrs' mkChartRule helmCharts);
+          # Merge charts with charts contained in enabled auto deploying charts
+          // (
+            let
+              helmCharts =
+                (lib.concatMapAttrs (n: v: { ${n} = v.package; }) (
+                  lib.filterAttrs (_: v: v.enable) cfg.autoDeployCharts
+                ))
+                // cfg.charts;
+              mkChartTarget = name: if (lib.hasSuffix ".tgz" name) then name else name + ".tgz";
+              mkChartRule = target: source: {
+                name = "${staticContentChartDir}/${mkChartTarget target}";
+                value = {
+                  "L+".argument = "${source}";
+                };
+              };
+            in
+            lib.mapAttrs' mkChartRule helmCharts
+          );
 
         systemd.services.${serviceName} =
           let

--- a/nixos/tests/rancher/auto-deploy.nix
+++ b/nixos/tests/rancher/auto-deploy.nix
@@ -227,19 +227,20 @@ in
       machine.wait_for_unit("${serviceName}")
 
       with subtest("Generation of manifest files"):
-        machine.succeed("test ! -e /var/lib/rancher/${rancherDistro}/server/manifests/manifest-absent.${manifestFormat}")
-        machine.succeed("test -e /var/lib/rancher/${rancherDistro}/server/manifests/foo-namespace.${manifestFormat}")
-        machine.succeed("test -e /var/lib/rancher/${rancherDistro}/server/manifests/manifest-hello.${manifestFormat}")
+        machine.succeed("test -L /var/lib/rancher/${rancherDistro}/server/manifests/nixos")
+        machine.succeed("test ! -e /var/lib/rancher/${rancherDistro}/server/manifests/nixos/manifest-absent.${manifestFormat}")
+        machine.succeed("test -e /var/lib/rancher/${rancherDistro}/server/manifests/nixos/foo-namespace.${manifestFormat}")
+        machine.succeed("test -e /var/lib/rancher/${rancherDistro}/server/manifests/nixos/manifest-hello.${manifestFormat}")
 
       with subtest("Generation of chart manifest files"):
-        machine.succeed("test ! -e /var/lib/rancher/${rancherDistro}/server/manifests/chart-disabled.${manifestFormat}")
-        machine.succeed("test -e /var/lib/rancher/${rancherDistro}/server/manifests/chart-hello.${manifestFormat}")
-        machine.succeed("test -e /var/lib/rancher/${rancherDistro}/server/manifests/chart-values-file.${manifestFormat}")
-        machine.succeed("test -e /var/lib/rancher/${rancherDistro}/server/manifests/chart-advanced.${manifestFormat}")
+        machine.succeed("test ! -e /var/lib/rancher/${rancherDistro}/server/manifests/nixos/chart-disabled.${manifestFormat}")
+        machine.succeed("test -e /var/lib/rancher/${rancherDistro}/server/manifests/nixos/chart-hello.${manifestFormat}")
+        machine.succeed("test -e /var/lib/rancher/${rancherDistro}/server/manifests/nixos/chart-values-file.${manifestFormat}")
+        machine.succeed("test -e /var/lib/rancher/${rancherDistro}/server/manifests/nixos/chart-advanced.${manifestFormat}")
 
       with subtest("Timeout of advanced chart"):
         # select only the first item in advanced.yaml
-        advancedManifest = json.loads(machine.succeed("yq -o json '.items[0]' /var/lib/rancher/${rancherDistro}/server/manifests/chart-advanced.${manifestFormat}"))
+        advancedManifest = json.loads(machine.succeed("yq -o json '.items[0]' /var/lib/rancher/${rancherDistro}/server/manifests/nixos/chart-advanced.${manifestFormat}"))
         t.assertEqual(advancedManifest["spec"]["timeout"], "69s", "unexpected value for spec.timeout")
 
       with subtest("Container image import"):

--- a/nixos/tests/rancher/configuration.nix
+++ b/nixos/tests/rancher/configuration.nix
@@ -18,13 +18,21 @@ let
   podsPerCore = 3;
   memoryThrottlingFactor = 0.69;
   containerLogMaxSize = "5Mi";
+  manifestFormat =
+    {
+      k3s = "yaml";
+      rke2 = "json";
+    }
+    .${rancherDistro};
+  manifestsRoot = "/var/lib/rancher/${rancherDistro}/server/manifests";
+  nixosDir = "${manifestsRoot}/nixos";
 in
 {
   name = "${rancherPackage.name}-configuration";
   interactive.sshBackdoor.enable = true;
 
   nodes.machine =
-    { ... }:
+    { lib, ... }:
     {
       environment.systemPackages = with pkgs; [
         kubectl
@@ -53,6 +61,28 @@ in
         extraKubeletConfig = {
           inherit podsPerCore memoryThrottlingFactor containerLogMaxSize;
         };
+        manifests = {
+          foo-namespace = {
+            target = "foo-namespace.${manifestFormat}";
+            content = {
+              apiVersion = "v1";
+              kind = "Namespace";
+              metadata.name = "foo";
+            };
+          };
+          bar-namespace = {
+            target = "bar-namespace.${manifestFormat}";
+            content = {
+              apiVersion = "v1";
+              kind = "Namespace";
+              metadata.name = "bar";
+            };
+          };
+        };
+      };
+
+      specialisation.removed-manifests.configuration = {
+        services.${rancherDistro}.manifests = lib.mkForce { };
       };
     };
 
@@ -85,6 +115,19 @@ in
         t.assertEqual(kubelet_config["podsPerCore"], ${toString podsPerCore})
         t.assertEqual(kubelet_config["memoryThrottlingFactor"], ${toString memoryThrottlingFactor})
         t.assertEqual(kubelet_config["containerLogMaxSize"],"${containerLogMaxSize}")
+
+      with subtest("Manifests are deployed via linkFarm"):
+        machine.succeed("test -L ${nixosDir}")
+        machine.succeed("readlink -f ${nixosDir} | grep -q /nix/store")
+        machine.succeed("test -f ${nixosDir}/foo-namespace.${manifestFormat}")
+        machine.succeed("test -f ${nixosDir}/bar-namespace.${manifestFormat}")
+
+      with subtest("After removing manifests from config, old files are cleaned up"):
+        machine.succeed("/run/current-system/specialisation/removed-manifests/bin/switch-to-configuration test >&2")
+        machine.succeed("test -L ${nixosDir}")
+        machine.succeed("readlink -f ${nixosDir} | grep -q /nix/store")
+        machine.succeed("test ! -e ${nixosDir}/foo-namespace.${manifestFormat}")
+        machine.succeed("test ! -e ${nixosDir}/bar-namespace.${manifestFormat}")
     '';
 
   meta.maintainers = lib.teams.k3s.members ++ pkgs.rke2.meta.maintainers;


### PR DESCRIPTION
Before, when a manifest was removed from NixOS configuration, its symlink
still remained inside `/var/lib/rancher/k3s/server/manifests`.

Manifests are now managed declaratively through a linkFarm in the Nix store:
- Static symlink: `manifests/nixos` → linkFarm in Nix store
- k3s/rke2 scan subdirectories recursively, pick up changes within 15s

When manifests are removed from the config, the linkFarm derivation
changes, the activation script updates the symlink, and the stale files
disappear naturally — no dangling symlinks.

@moduon MT-14138

> This pull request was partially written with LLM assistance (opencode). The author reviewed and maintains all generated code.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
