### PR TITLE
python3Packages.libarcus: fix build for GCC 15

### DIFF
--- a/pkgs/development/python-modules/libarcus/default.nix
+++ b/pkgs/development/python-modules/libarcus/default.nix
@@ -29,6 +29,9 @@ buildPythonPackage rec {
       url = "https://raw.githubusercontent.com/coryan/vcpkg/f69b85aa403b04e7d442c90db3418d484e44024f/ports/arcus/0001-fix-protobuf-deprecated.patch";
       sha256 = "0bqj7pxzpwsamknd6gadj419x6mwx8wnlfzg4zqn6cax3cmasjb2";
     })
+    # Fix build with GCC 15: https://github.com/Ultimaker/libArcus/pull/160
+    # That PR is on top of v5.3.0 which refactored things, so we must vendor it.
+    ./gcc-15-cstdint.patch
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/libarcus/gcc-15-cstdint.patch
+++ b/pkgs/development/python-modules/libarcus/gcc-15-cstdint.patch
@@ -1,0 +1,86 @@
+diff --git a/src/MessageTypeStore.cpp b/src/MessageTypeStore.cpp
+index 1d9b624..e9df3e0 100644
+--- a/src/MessageTypeStore.cpp
++++ b/src/MessageTypeStore.cpp
+@@ -17,6 +17,7 @@
+ 
+ #include "MessageTypeStore.h"
+ 
++#include <cstdint>
+ #include <unordered_map>
+ #include <sstream>
+ #include <iostream>
+diff --git a/src/MessageTypeStore.h b/src/MessageTypeStore.h
+index a0d4c08..d740681 100644
+--- a/src/MessageTypeStore.h
++++ b/src/MessageTypeStore.h
+@@ -20,6 +20,7 @@
+ #define ARCUS_MESSAGE_TYPE_STORE_H
+ 
+ #include <memory>
++#include <cstdint>
+ 
+ #include "ArcusExport.h"
+ #include "Types.h"
+diff --git a/src/PlatformSocket.cpp b/src/PlatformSocket.cpp
+index 4fa53bf..c3148a8 100644
+--- a/src/PlatformSocket.cpp
++++ b/src/PlatformSocket.cpp
+@@ -17,6 +17,8 @@
+  * along with this program. If not, see <http://www.gnu.org/licenses/>.
+  */
+ 
++#include <cstdint>
++
+ #include "PlatformSocket_p.h"
+ 
+ #ifdef _WIN32
+diff --git a/src/PlatformSocket_p.h b/src/PlatformSocket_p.h
+index e34a5e1..c95abe0 100644
+--- a/src/PlatformSocket_p.h
++++ b/src/PlatformSocket_p.h
+@@ -21,6 +21,7 @@
+ #define ARCUS_PLATFORM_SOCKET_P_H
+ 
+ #include <memory>
++#include <cstdint>
+ #include <string>
+ 
+ namespace Arcus
+diff --git a/src/Socket_p.h b/src/Socket_p.h
+index 09db6a8..f5761e8 100644
+--- a/src/Socket_p.h
++++ b/src/Socket_p.h
+@@ -17,6 +17,7 @@
+  * along with this program. If not, see <http://www.gnu.org/licenses/>.
+  */
+ 
++#include <cstdint>
+ #include <thread>
+ #include <mutex>
+ #include <string>
+diff --git a/src/Types.h b/src/Types.h
+index ef33f5d..527237c 100644
+--- a/src/Types.h
++++ b/src/Types.h
+@@ -19,6 +19,7 @@
+ #define ARCUS_TYPES_H
+ 
+ #include <string>
++#include <cstdint>
+ #include <memory>
+ 
+ namespace google
+diff --git a/src/WireMessage_p.h b/src/WireMessage_p.h
+index 3cf4594..319a6ac 100644
+--- a/src/WireMessage_p.h
++++ b/src/WireMessage_p.h
+@@ -20,6 +20,8 @@
+ #ifndef ARCUS_WIRE_MESSAGE_P_H
+ #define ARCUS_WIRE_MESSAGE_P_H
+ 
++#include <cstdint>
++
+ #include "Types.h"
+ 
+ namespace Arcus


### PR DESCRIPTION
This PR fixes the `python3Packages.libarcus` build failure (caused by #471587) via a backport of Ultimaker/libArcus#160 from v5 to the v4 we currently have in Nixpkgs.

ZHF: #516381

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
