### PR TITLE
opencode: 1.14.48 -> 1.15.3

### DIFF
--- a/pkgs/by-name/op/opencode-desktop/package.nix
+++ b/pkgs/by-name/op/opencode-desktop/package.nix
@@ -54,6 +54,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     OPENCODE_CHANNEL = "prod";
     MODELS_DEV_API_JSON = "${models-dev}/dist/_api.json";
     OPENCODE_DISABLE_MODELS_FETCH = true;
+  }
+  # Disable code signing on macOS. Public build hosts don't have Apple Developer
+  # certificates, so electron-builder's `security find-identity` spawns produce
+  # EPERM inside the nix sandbox.
+  // lib.optionalAttrs stdenvNoCC.hostPlatform.isDarwin {
+    CSC_IDENTITY_AUTO_DISCOVERY = "false";
   };
 
   postPatch = ''
@@ -71,6 +77,18 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     patchShebangs packages/*/node_modules
 
     runHook postConfigure
+  '';
+
+  preBuild = lib.optionalString stdenvNoCC.hostPlatform.isDarwin ''
+    # Patch electron-builder to skip code signing on macOS.
+    # The nix sandbox on public Darwin builders cannot spawn
+    # `security find-identity` — trying gives spawn EPERM.
+    # We patch the compiled JS to make getValidIdentities a no-op.
+    for f in $(find node_modules -path "*/app-builder-lib/out/codeSign/macCodeSign.js" -type f 2>/dev/null); do
+      substituteInPlace "$f" \
+        --replace-fail "async function getValidIdentities" \
+        "async function getValidIdentities() { return []; }; async function getValidIdentities_DISABLED"
+    done
   '';
 
   buildPhase = ''
@@ -98,7 +116,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       --config=electron-builder.config.ts \
       --config.electronDist="$HOME/.electron-dist" \
       --config.electronVersion=${electron.version} \
-      --config.asarUnpack='**/*.node'
+      --config.asarUnpack='**/*.node' \
+      ${lib.optionalString stdenvNoCC.hostPlatform.isDarwin "--config.mac.identity=null"}
 
     cd ../..
 

--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -16,13 +16,13 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "opencode";
-  version = "1.14.48";
+  version = "1.15.3";
 
   src = fetchFromGitHub {
     owner = "anomalyco";
     repo = "opencode";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-gyybqabTco+5ZeWv4lCX8t/R9Jm3tYsA8wVvkrxkEYQ=";
+    hash = "sha256-OKQR76q7trKQTvlMxH8tG2jNnRtBe3YeFfvNw8c3+8I=";
   };
 
   node_modules = stdenvNoCC.mkDerivation {
@@ -75,7 +75,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     # NOTE: Required else we get errors that our fixed-output derivation references store paths
     dontFixup = true;
 
-    outputHash = "sha256-94uXrhyGqW016U6LPE/xIfZGoDOzyUto5DyQrYYePds=";
+    outputHash = "sha256-O6czNd9n6b0TTIsPseZn9qOlxsPzRTrePu3L6gM13oM=";
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
   };


### PR DESCRIPTION
- https://github.com/anomalyco/opencode/releases/tag/v1.15.3
- https://github.com/anomalyco/opencode/releases/tag/v1.15.2
- https://github.com/anomalyco/opencode/releases/tag/v1.15.1
- https://github.com/anomalyco/opencode/releases/tag/v1.15.0
- https://github.com/anomalyco/opencode/releases/tag/v1.14.51
- https://github.com/anomalyco/opencode/releases/tag/v1.14.50
- https://github.com/anomalyco/opencode/releases/tag/v1.14.49

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR (launched async, results will post as comment). See [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage).
- [x] Tested basic functionality of all binary files (version verified).
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.

## Disclaimer on Darwin

- The Darwin fix is AI generated: `OpenCode + DeepSeek-v4-Flash`
- I claim no Darwin expertise. Just don't blame me. =D