### PR TITLE
maintainers: remove toschmidt

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28091,12 +28091,6 @@
     githubId = 50843046;
     name = "tornax";
   };
-  toschmidt = {
-    email = "tobias.schmidt@in.tum.de";
-    github = "toschmidt";
-    githubId = 27586264;
-    name = "Tobias Schmidt";
-  };
   totalchaos = {
     email = "basil.keeler@outlook.com";
     github = "totalchaos05";

--- a/pkgs/by-name/ma/mailspring/package.nix
+++ b/pkgs/by-name/ma/mailspring/package.nix
@@ -17,10 +17,7 @@ let
       Mailspring's sync engine runs locally, but its source is not open.
     '';
     mainProgram = "mailspring";
-    maintainers = with lib.maintainers; [
-      toschmidt
-      wrench-exile-legacy
-    ];
+    maintainers = with lib.maintainers; [ wrench-exile-legacy ];
     platforms = [
       "x86_64-linux"
       "aarch64-darwin"


### PR DESCRIPTION
## Reasons

- Last commented in [January 2021](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Atoschmidt)
- Hasn't created any PRs / Issues since [July 2020](https://github.com/NixOS/nixpkgs/issues?q=author%3Atoschmidt)
- About 37 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Atoschmidt%20-commenter%3Atoschmidt%20-author%3Atoschmidt%20-reviewed-by%3Atoschmidt) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.