### PR TITLE
libodfgen: 0.1.7 -> 0.1.8, enable unit tests

### DIFF
--- a/pkgs/by-name/li/libodfgen/package.nix
+++ b/pkgs/by-name/li/libodfgen/package.nix
@@ -2,22 +2,18 @@
   lib,
   stdenv,
   fetchurl,
-  boost,
   pkg-config,
-  cppunit,
-  zlib,
-  libwpg,
-  libwpd,
   librevenge,
+  libxml2,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libodfgen";
-  version = "0.1.7";
+  version = "0.1.8";
 
   src = fetchurl {
     url = "mirror://sourceforge/project/libwpd/libodfgen/libodfgen-${finalAttrs.version}/libodfgen-${finalAttrs.version}.tar.xz";
-    sha256 = "sha256-Mj5JH5VsjKKrsSyZjjUGcJMKMjF7+WYrBhXdSzkiuDE=";
+    hash = "sha256-VSAAJ/1GYjub3d040nXnRS0bD/iu3crW+a5twl9hBiU=";
   };
 
   patches = [
@@ -26,15 +22,25 @@ stdenv.mkDerivation (finalAttrs: {
     ./libodfgen-add-include-cstdint-gcc15.patch
   ];
 
+  enableParallelBuilding = true;
+
+  configureFlags = lib.optional finalAttrs.finalPackage.doCheck "--enable-test";
+
   nativeBuildInputs = [ pkg-config ];
+
   buildInputs = [
-    boost
-    cppunit
-    zlib
-    libwpg
-    libwpd
     librevenge
+    libxml2
   ];
+
+  doCheck = true;
+
+  checkFlags = [
+    "-C"
+    "test"
+  ];
+
+  checkTarget = "launch_all";
 
   meta = {
     description = "Base library for generating ODF documents";


### PR DESCRIPTION
libodfgen 0.1.8 was released in 2021 but apparently the pkg was never updated. I removed some unneeded dependencies.

Slightly peripheral to this PR: `git grep libodfgen` finds a number of cases where sources of libodfgen-0.1.8 are pulled directly in different other pkgs, but they seem to be generated or somehow specially curated.
* https://github.com/NixOS/nixpkgs/blob/44a22586fcf153ae08a651efecec9bb6af4af493/pkgs/applications/office/libreoffice/src-collabora-coda/deps.nix#L843
* https://github.com/NixOS/nixpkgs/blob/44a22586fcf153ae08a651efecec9bb6af4af493/pkgs/applications/office/libreoffice/src-collabora/deps.nix#L843
* https://github.com/NixOS/nixpkgs/blob/44a22586fcf153ae08a651efecec9bb6af4af493/pkgs/applications/office/libreoffice/src-fresh/deps.nix#L773
* https://github.com/NixOS/nixpkgs/blob/44a22586fcf153ae08a651efecec9bb6af4af493/pkgs/applications/office/libreoffice/src-still/deps.nix#L766

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 520525`
Commit: `b3f689e38b764bd2b4d452abb2811d135480217e`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 31 packages built:</summary>
  <ul>
    <li>collabora-desktop</li>
    <li>collabora-online</li>
    <li>convertx</li>
    <li>gotenberg</li>
    <li>gotenberg.hyphen</li>
    <li>kdePackages.calligra</li>
    <li>kdePackages.calligra.debug</li>
    <li>kdePackages.calligra.dev</li>
    <li>kdePackages.calligra.devtools</li>
    <li>libodfgen</li>
    <li>libreoffice (libreoffice-still)</li>
    <li>libreoffice-collabora</li>
    <li>libreoffice-fresh</li>
    <li>libreoffice-fresh-unwrapped</li>
    <li>libreoffice-qt (libreoffice-qt-still)</li>
    <li>libreoffice-qt-fresh</li>
    <li>libreoffice-qt-fresh-unwrapped</li>
    <li>libreoffice-qt-still-unwrapped</li>
    <li>libreoffice-still-unwrapped</li>
    <li>lomiri.lomiri-docviewer-app</li>
    <li>paperwork</li>
    <li>paperwork.dist</li>
    <li>python313Packages.paperwork-backend</li>
    <li>python313Packages.paperwork-backend.dist</li>
    <li>python313Packages.paperwork-shell</li>
    <li>python313Packages.paperwork-shell.dist</li>
    <li>python314Packages.paperwork-backend</li>
    <li>python314Packages.paperwork-backend.dist</li>
    <li>python314Packages.paperwork-shell</li>
    <li>python314Packages.paperwork-shell.dist</li>
    <li>unoconv</li>
  </ul>
</details>
