### PR TITLE
putter: init at 0.1.0

### DIFF
--- a/pkgs/by-name/pu/putter/package.nix
+++ b/pkgs/by-name/pu/putter/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  fetchFromSourcehut,
+  rustPlatform,
+  nix-update-script,
+}:
+
+let
+  version = "0.1.0";
+in
+rustPlatform.buildRustPackage {
+  pname = "putter";
+  inherit version;
+
+  src = fetchFromSourcehut {
+    owner = "~rycee";
+    repo = "putter";
+    rev = "v${version}";
+    hash = "sha256-ZCI8nf7JlTMS+L0+uTBeCIsyx21FjRhP9iT+Kebqgu4=";
+  };
+
+  cargoHash = "sha256-36f4f+3vf0ZknmSwe3oNOxPgexTjizXQ73Ac3JeG6ZU=";
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Symlink or copy files according to a JSON manifest";
+    mainProgram = "putter";
+    homepage = "https://git.sr.ht/~rycee/putter";
+    changelog = "https://git.sr.ht/~rycee/putter/refs/${version}";
+    license = lib.licenses.eupl12;
+    maintainers = with lib.maintainers; [ rycee ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
Init the putter tool, a file placement tool useful, e.g., for dotfiles.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
