### PR TITLE
slopsmith: init at 0.2.8

### DIFF
--- a/pkgs/by-name/sl/slopsmith/package.nix
+++ b/pkgs/by-name/sl/slopsmith/package.nix
@@ -1,0 +1,68 @@
+{
+  appimageTools,
+  fetchurl,
+  makeDesktopItem,
+  lib,
+  libxshmfence,
+  wayland,
+  wayland-protocols,
+}:
+let
+  pname = "slopsmith";
+  version = "0.2.8";
+  strictDeps = true;
+
+  src = fetchurl {
+    url = "https://github.com/byrongamatos/slopsmith-desktop/releases/download/v${version}/Slopsmith-${version}.AppImage";
+    hash = "sha256-VYO/lUEBbunAom4S3JxqwDrIY2E8hllBL3Qdfgv0OF8=";
+  };
+
+  desktopItem = makeDesktopItem {
+    name = "Slopsmith";
+    comment = "Browse, play and practice CDLC from CustomsForge";
+    desktopName = "Slopsmith";
+    noDisplay = false;
+    exec = "slopsmith";
+    terminal = false;
+    mimeTypes = [ ];
+    categories = [
+      "Game"
+      "Education"
+      "Audio"
+    ];
+    keywords = [
+      "guitar"
+      "music"
+      "vst"
+    ];
+  };
+
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  extraArgs = {
+    strictDeps = true;
+  };
+
+  extraInstallCommands = ''
+    install -Dm444 -t $out/share/applications ${desktopItem}/share/applications/*
+  '';
+
+  extraPkgs = _: [
+    libxshmfence
+    wayland
+    wayland-protocols
+  ];
+
+  meta = with lib; {
+    description = "Browse, play and practice CDLC from CustomsForge";
+    homepage = "https://github.com/byrongamatos/slopsmith";
+    license = lib.licenses.agpl3Only;
+    maintainers = with maintainers; [ tarinaky ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "slopsmith";
+  };
+}


### PR DESCRIPTION
Adds Slopsmith-Desktop from the upstream AppImage.

Slopsmith is a cross platform and FOSS alternative to Rocksmith 2014. Further information about the project can be found here:
https://github.com/byrongamatos/slopsmith
https://github.com/byrongamatos/slopsmith-desktop

AFAIK  this is the only home page available for the project, but I am super-excited as this should 'just work' with JACK/Pipewire without the WINE and DLL based faff that Rocksmith 2014 on Steam needs.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
