### PR TITLE
cdktn-cli: 0.22.1 -> 0.23

### DIFF
--- a/pkgs/by-name/cd/cdktn-cli/package.nix
+++ b/pkgs/by-name/cd/cdktn-cli/package.nix
@@ -8,7 +8,7 @@
   fixup-yarn-lock,
   go,
   makeWrapper,
-  nodejs_22,
+  nodejs,
   nix-update-script,
   patchelf,
   removeReferencesTo,
@@ -19,18 +19,18 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "cdktn-cli";
-  version = "0.22.1";
+  version = "0.23.0";
 
   src = fetchFromGitHub {
     owner = "open-constructs";
     repo = "cdk-terrain";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-yBCLxp7w/M2y7vDEI1ceAAJbyYpPT4mN4hZ3FKpaiJ0=";
+    hash = "sha256-qBpdeIa4V5hfVbkwa+5gHszSwqXJej0k0BdVImTdwt8=";
   };
 
   offlineCache = fetchYarnDeps {
     yarnLock = "${finalAttrs.src}/yarn.lock";
-    hash = "sha256-c5WQXZLbOuvy6Jj6TchV00HThFIePMdsGW1rWAUKnvo=";
+    hash = "sha256-H8UnrCZx9yjKn7YxRqv+uJ73fw/ngPFI6zdayUizo1k=";
   };
 
   hcl2json-go-modules =
@@ -63,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
     fixup-yarn-lock
     go
     makeWrapper
-    nodejs_22
+    nodejs
     patchelf
     removeReferencesTo
     yarn
@@ -129,7 +129,7 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p "$out/lib/node_modules/cdktn-cli"
     cp -rL node_modules packages/cdktn-cli/bundle packages/cdktn-cli/package.json "$out/lib/node_modules/cdktn-cli/"
 
-    makeWrapper "${lib.getExe nodejs_22}" "$out/bin/cdktn" \
+    makeWrapper "${lib.getExe nodejs}" "$out/bin/cdktn" \
       --add-flags "--no-warnings=DEP0040" \
       --add-flags "$out/lib/node_modules/cdktn-cli/bundle/bin/cdktn.js"
 
@@ -151,7 +151,13 @@ stdenv.mkDerivation (finalAttrs: {
   # even with writableTmpDirAsHomeHook and CHECKPOINT_DISABLE=1
   doInstallCheck = stdenv.hostPlatform.isLinux;
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script {
+    # Skip pre-releases
+    extraArgs = [
+      "--version-regex"
+      "^v([\\d.]+)$"
+    ];
+  };
 
   meta = {
     description = "CDK for Terraform CLI";
@@ -161,7 +167,5 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "cdktn";
     maintainers = with lib.maintainers; [ deejayem ];
     platforms = lib.platforms.unix;
-    # Uses @cdktf/node-pty-prebuilt-multiarch which is not yet available for node 22 on aarch64-linux
-    broken = stdenv.hostPlatform.system == "aarch64-linux";
   };
 })


### PR DESCRIPTION
Update cdktn-cli to the latest version. It no longer uses node-pty (and node-pty-prebuilt-multiarch), which means we no longer need a particular node version, and it's no longer broken on aarch64-linux

I also made the update script skip the prerelease versions that it usually matches.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
