### PR TITLE
perlPackages.Net{Cmd,Config,Domain,FTP,FTPdataconn,Netrc,NNTP,POP3,Time}: add missing libnet modules to self.libnet

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -39683,8 +39683,17 @@ with self;
   LWPProtocolhttps = self.LWPProtocolHttps;
   LWPUserAgent = self.LWP;
   MIMEtools = self.MIMETools;
+  NetCmd = self.libnet;
+  NetConfig = self.libnet;
+  NetDomain = self.libnet;
+  NetFTP = self.libnet;
+  NetFTPdataconn = self.libnet;
   NetLDAP = self.perlldap;
+  NetNetrc = self.libnet;
+  NetNNTP = self.libnet;
+  NetPOP3 = self.libnet;
   NetSMTP = self.libnet;
+  NetTime = self.libnet;
   OLEStorageLight = self.OLEStorage_Lite; # For backwards compatibility. Please use OLEStorage_Lite instead.
   ParseCPANMeta = self.CPANMeta;
   TestMoose = self.Moose;


### PR DESCRIPTION
This pull request updates the Perl package aliases in `perl-packages.nix` to improve compatibility and ensure that various `Net::*` modules are correctly mapped to the `libnet` package. This helps maintain backwards compatibility for consumers expecting these names.

Backwards compatibility and alias updates:

* Added aliases for several `Net::*` Perl modules (`NetCmd`, `NetConfig`, `NetDomain`, `NetFTP`, `NetFTPdataconn`, `NetNetrc`, `NetNNTP`, `NetPOP3`, `NetTime`) to point to the `libnet` package, ensuring compatibility with code that references these modules directly.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
