### PR TITLE
cardwire: init and nixos/cardwired: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16986,6 +16986,17 @@
     matrix = "@lux:ontheblueplanet.com";
     name = "Lux";
   };
+  luytan = {
+    email = "luytan@khora.me";
+    github = "luytan";
+    githubId = 221864923;
+    name = "Luytan";
+    keys = [
+      {
+        fingerprint = "E7B7 215C 0DFB 3D8C 17EE  95E0 E0AD 187A 4F2B 41EF";
+      }
+    ];
+  };
   luz = {
     email = "luz666@daum.net";
     github = "Luz";

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -34,6 +34,8 @@
 
 - [tranquil](https://tangled.org/tranquil.farm/tranquil-pds) is an ATProto PDS (personal data server) implementation in Rust. A featureful, spec conscious and community driven alternative to the Bluesky reference implementation PDS. Available as [services.tranquil-pds](#opt-services.tranquil-pds.enable).
 
+- [Cardwire](https://github.com/OpenGamingCollective/cardwire), a GPU manager for Linux that uses eBPF+LSM hooks to control GPUs. Available as [services.cardwired](#opt-services.cardwired.enable).
+
 - [Moonlight Qt](https://moonlight-stream.org/), a client for playing your PC games on almost any device. Available as [programs.moonlight-qt](#opt-programs.moonlight-qt.enable).
 
 - [RomM](https://romm.app/), a self-hosted ROM manager and player. Available as [services.romm](#opt-services.romm.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -683,6 +683,7 @@
   ./services/hardware/bolt.nix
   ./services/hardware/brltty.nix
   ./services/hardware/buffyboard.nix
+  ./services/hardware/cardwired.nix
   ./services/hardware/ddccontrol.nix
   ./services/hardware/deepcool-digital-linux.nix
   ./services/hardware/dell-bios-fan-control.nix

--- a/nixos/modules/services/hardware/cardwired.nix
+++ b/nixos/modules/services/hardware/cardwired.nix
@@ -1,0 +1,134 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    types
+    mkPackageOption
+    getExe'
+    ;
+  cfg = config.services.cardwired;
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  options.services.cardwired = {
+    enable = mkEnableOption "Cardwire eBPF-based GPU manager daemon";
+
+    package = mkPackageOption pkgs "cardwire" { };
+
+    settings = mkOption {
+      type = types.submodule {
+        options = {
+          auto_apply_gpu_state = mkOption {
+            type = types.bool;
+            default = true;
+            description = ''
+              Automatically restore GPU states on manual mode.
+            '';
+          };
+          experimental_nvidia_block = mkOption {
+            type = types.bool;
+            default = false;
+            description = ''
+              Enable blocking specifics Nvidia files. This setting is experimental
+              because these files can be shared across multiple Nvidia GPUs.
+            '';
+          };
+          battery_auto_switch = mkOption {
+            type = types.bool;
+            default = false;
+            description = ''
+              Automatically switch mode on AC power.
+            '';
+          };
+          battery_auto_switch_mode = mkOption {
+            type = types.enum [
+              "integrated"
+              "hybrid"
+              "manual"
+              "smart"
+            ];
+            default = "hybrid";
+            description = ''
+              The mode cardwire switches on AC power.
+            '';
+          };
+          external_display_auto_switch = mkOption {
+            type = types.bool;
+            default = false;
+            description = ''
+              Automatically make GPUs available for displays connected to dGPU-only ports.
+            '';
+          };
+        };
+      };
+      default = { };
+      description = ''
+        Configuration for {file}`/etc/cardwire.toml`
+        See <https://opengamingcollective.github.io/cardwire/getting-started/usage>
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.etc."cardwire/cardwire.toml".source = tomlFormat.generate "cardwire.toml" cfg.settings;
+
+    services.dbus.enable = true;
+    services.dbus.packages = [ cfg.package ];
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.services.cardwired = {
+      description = "Cardwire Daemon";
+
+      restartTriggers = [ config.environment.etc."cardwire/cardwire.toml".source ];
+
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Type = "dbus";
+        BusName = "org.opengamingcollective.cardwire";
+        ExecStart = getExe' cfg.package "cardwired";
+        Restart = "on-failure";
+        RestartSec = "5s";
+        User = "root";
+        PrivateNetwork = true;
+        PrivateTmp = true;
+        ProtectHostname = true;
+        NoNewPrivileges = true;
+        ProtectClock = true;
+        ProtectSystem = "strict";
+        StateDirectory = "cardwire";
+        StateDirectoryMode = "0700";
+        ConfigurationDirectory = "cardwire";
+        ConfigurationDirectoryMode = "0700";
+        ProtectHome = "read-only";
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+        ProtectKernelModules = true;
+        RestrictAddressFamilies = [
+          "AF_UNIX"
+          "AF_NETLINK"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        LockPersonality = true;
+        UMask = "0077";
+        IPAddressDeny = "any";
+        CapabilityBoundingSet = [
+          "CAP_SYS_ADMIN"
+          "CAP_BPF"
+          "CAP_SYS_PTRACE"
+          "CAP_DAC_OVERRIDE"
+        ];
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -328,6 +328,7 @@ in
   calibre-server = import ./calibre-server.nix { inherit pkgs runTest; };
   calibre-web = runTest ./calibre-web.nix;
   canaille = runTest ./canaille.nix;
+  cardwire = runTest ./cardwire.nix;
   cassandra = runTest {
     imports = [ ./cassandra.nix ];
     _module.args.getPackage = pkgs: pkgs.cassandra;

--- a/nixos/tests/cardwire.nix
+++ b/nixos/tests/cardwire.nix
@@ -1,0 +1,65 @@
+{ pkgs, ... }:
+
+{
+  name = "cardwire";
+
+  nodes.machine =
+    { pkgs, lib, ... }:
+    {
+      services.cardwired.enable = true;
+      services.dbus.enable = true;
+
+      boot.kernelParams = [
+        "intel_iommu=on"
+        "iommu=pt"
+      ];
+
+      virtualisation.qemu.options = [
+        "-machine q35,accel=kvm,kernel-irqchip=split"
+        "-device intel-iommu,intremap=on,device-iotlb=on"
+        "-vga none"
+        "-device virtio-gpu-pci,id=igpu,max_outputs=2"
+        "-device virtio-gpu-pci,id=dgpu,max_outputs=1"
+      ];
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("default.target")
+    with subtest("Wait for boot and services"):
+        machine.wait_for_unit("multi-user.target")
+        machine.wait_for_unit("dbus.service")
+        machine.wait_for_unit("cardwired.service")
+
+    with subtest("Check for DRM Devices"):
+        dri_out = machine.succeed("ls -a /dev/dri")
+        assert "renderD128" in dri_out, "Missing DRM"
+        assert "card0" in dri_out, "Missing DRM"
+        assert "renderD129" in dri_out, "Missing DRM"
+        assert "card1" in dri_out, "Missing DRM"
+
+    with subtest("Ensure cardwire is started and dbus works"):
+        machine.wait_until_succeeds("cardwire help")
+
+    with subtest("Ensure files are present"):
+      machine.succeed("cat /etc/cardwire/cardwire.toml")
+      machine.succeed("cat /var/lib/cardwire/gpu_state.json")
+      machine.succeed("cat /var/lib/cardwire/mode.json")
+
+    with subtest("Switch to Integrated mode"):
+        assert "renderD128" in machine.succeed("cardwire list"), "Missing RenderD128 in cardwire"
+        machine.succeed("test -e /dev/dri/renderD129")
+        assert "Mode has been set to Integrated" in machine.succeed("cardwire set integrated")
+        machine.fail(": < /dev/dri/renderD129")
+        assert "integrated" in machine.succeed("cat /var/lib/cardwire/mode.json")
+
+    with subtest("Switchback to hybrid mode"):
+        assert "Mode has been set to Hybrid" in machine.succeed("cardwire set hybrid")
+        machine.succeed(": < /dev/dri/renderD129")
+        assert "hybrid" in machine.succeed("cat /var/lib/cardwire/mode.json")
+
+    with subtest("Try to block default gpu"):
+      cardwire_out = machine.fail("cardwire gpu 0 --block 2>&1")
+      assert "Per GPU block is only available on manual mode" in cardwire_out, "Default gpu got blocked"
+  '';
+}

--- a/pkgs/by-name/ca/cardwire/package.nix
+++ b/pkgs/by-name/ca/cardwire/package.nix
@@ -1,0 +1,128 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  hwdata,
+  libdrm,
+  bpf-linker,
+  pkg-config,
+  nixosTests,
+  makeBinaryWrapper,
+  udev,
+  wayland,
+  libxkbcommon,
+  vulkan-loader,
+  libGL,
+  installShellFiles,
+  libxcb,
+  libglvnd,
+  versionCheckHook,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cardwire";
+  version = "0.12.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "opengamingcollective";
+    repo = "cardwire";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-WuXFztiy6G2HYCu3KpKrjR8YCpcLePfGEZ+f71x1WnM=";
+  };
+  cargoHash = "sha256-8eJSxL9RkHtbUxXuKPvyxhvSJD/0JeNaEM/oZf0n2Q4=";
+
+  postPatch = ''
+    # Workaround to build cardwire-ebpf, when RUSTC_BOOTSTRAP is set to 1
+    # aya-build appends build_std to the cargo args, removing this
+    # make the crate builds
+    # <https://github.com/aya-rs/aya/blob/15a0de1b363e51d55d0fca4245df54a61e8d5521/aya-build/src/lib.rs#L151-L172>
+    substituteInPlace ../cardwire-*-vendor/*/aya-build-*/src/lib.rs \
+      --replace-fail "if use_build_std" "if !use_build_std"
+
+    substituteInPlace crates/cardwire-daemon/src/core/pci/pci_device.rs \
+      --replace-fail "/usr/share/hwdata/pci.ids" "${hwdata}/share/hwdata/pci.ids"
+
+    substituteInPlace crates/cardwire-daemon/src/core/gpu/device_info.rs \
+      --replace-fail "/usr/share/libdrm/amdgpu.ids" "${libdrm}/share/libdrm/amdgpu.ids"
+  '';
+
+  env = {
+    RUSTFLAGS = "-C target-feature=";
+    RUSTC_BOOTSTRAP = 1;
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    bpf-linker
+    makeBinaryWrapper
+    installShellFiles
+  ];
+
+  buildInputs = [
+    libxcb
+    udev
+  ];
+
+  postInstall = ''
+    install -Dm444 ./assets/org.opengamingcollective.cardwire.conf \
+      $out/share/dbus-1/system.d/org.opengamingcollective.cardwire.conf
+
+    install -Dm444 ./assets/org.opengamingcollective.cardwire.metainfo.xml \
+      $out/share/metainfo/org.opengamingcollective.cardwire.metainfo.xml
+
+    install -Dm444 ./assets/cardwire-gui.desktop \
+      $out/share/applications/cardwire-gui.desktop
+
+    for icon in ./assets/icons/*.svg; do
+      install -Dm444 "$icon" "$out/share/icons/hicolor/scalable/apps/$(basename "$icon")"
+    done
+
+    wrapProgram $out/bin/cardwired \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          vulkan-loader
+          libglvnd
+        ]
+      }
+
+    wrapProgram $out/bin/cardwire-gui \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          wayland
+          libxkbcommon
+          vulkan-loader
+          libGL
+        ]
+      }
+
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd cardwire \
+      --fish <($out/bin/cardwire completion fish) \
+      --bash <($out/bin/cardwire completion bash) \
+      --zsh <($out/bin/cardwire completion zsh)
+  '';
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.tests.cardwire = nixosTests.cardwire;
+
+  meta = {
+    description = "GPU manager for laptop and workstation";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    homepage = "https://opengamingcollective.github.io/cardwire/";
+    changelog = "https://github.com/OpenGamingCollective/cardwire/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      luytan
+    ];
+    mainProgram = "cardwire";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Introduces cardwire, a eBPF and LSM-based GPU manager for laptops and workstations (an alternative to tools like supergfxctl)

It includes:
- The `cardwire` package
- A NixOS module (`services.cardwired`)
- VM testing both a 2 GPU (laptop) hardware configurations

Homepage: https://github.com/OpenGamingCollective/cardwire

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [X] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
