### PR TITLE
nodejs_24: skip tests failing on Darwin

### DIFF
--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -518,6 +518,12 @@ let
               "test-tick-processor-arguments"
               "test-set-raw-mode-reset-signal"
             ]
+            # Apple SDK update broke something related to those tests, so skipping them for now
+            ++ lib.optionals (majorVersion == "24" && stdenv.hostPlatform.isDarwin) [
+              "test-worker-track-unmanaged-fds"
+              "test-esm-import-meta-main-eval"
+              "test-worker-debug"
+            ]
             # Those are annoyingly flaky, but not enough to be marked as such upstream.
             ++ lib.optional (majorVersion == "22") "test-child-process-stdout-flush-exit"
             ++ lib.optional (


### PR DESCRIPTION
I was able to establish that https://github.com/NixOS/nixpkgs/pull/511399 is the cause of the test failures that were reported in https://github.com/NixOS/nixpkgs/pull/517946#issuecomment-4418058199 (e.g. https://hydra.nixos.org/build/328739939#tabs-buildsteps).

Skipping the tests is not a fix, but is probably still better than leaving that derivation in a broken state. If you are hitting the bug, and switch to nodejs_22 or nodejs_26 is not an option, consider overriding the stdenv with `(import (builtins.fetchTarball { url = "https://github.com/NixOS/nixpkgs/archive/40f60e167b1c05aa5386f725eea0cbcae4f7078c.tar.gz"; sha256 = "017q2d928plhwhb6ldpmvabmy54flmiv11i5g8xs9gkwrylm3v5l"; }) { }).stdenv`.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
