### PR TITLE
python3Packages.mlflow: 3.11.1 -> 3.12.0

### DIFF
--- a/pkgs/by-name/ml/mlflow-server/package.nix
+++ b/pkgs/by-name/ml/mlflow-server/package.nix
@@ -1,37 +1,10 @@
-{ python3Packages, writers }:
+{ python3Packages }:
 
-let
-  py = python3Packages;
-
-  gunicornScript = writers.writePython3 "gunicornMlflow" { } ''
-    import re
-    import sys
-    from gunicorn.app.wsgiapp import run
-    if __name__ == '__main__':
-        sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', ''', sys.argv[0])
-        sys.exit(run())
-  '';
-in
-py.toPythonApplication (
-  py.mlflow.overridePythonAttrs (old: {
-
-    propagatedBuildInputs = old.dependencies ++ [
-      py.boto3
-      py.mysqlclient
+python3Packages.toPythonApplication (
+  python3Packages.mlflow.overridePythonAttrs (old: {
+    propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [
+      python3Packages.boto3
+      python3Packages.mysqlclient
     ];
-
-    postPatch = (old.postPatch or "") + ''
-      cat mlflow/utils/process.py
-
-      substituteInPlace mlflow/utils/process.py --replace-fail \
-        "process = subprocess.Popen(" \
-        "cmd[0]='${gunicornScript}'; process = subprocess.Popen("
-    '';
-
-    postInstall = ''
-      gpath=$out/bin/gunicornMlflow
-      cp ${gunicornScript} $gpath
-      chmod 555 $gpath
-    '';
   })
 )

--- a/pkgs/development/python-modules/mlflow/default.nix
+++ b/pkgs/development/python-modules/mlflow/default.nix
@@ -1,10 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
-
-  # build-system
-  setuptools,
+  fetchPypi,
 
   # dependencies
   aiohttp,
@@ -34,70 +31,48 @@
   pandas,
   protobuf,
   pyarrow,
+  pydantic,
   python-dotenv,
   pyyaml,
   requests,
   scikit-learn,
   scipy,
+  shap,
   skops,
   sqlalchemy,
   sqlparse,
   uvicorn,
-
-  # tests
-  azure-core,
-  azure-storage-blob,
-  azure-storage-file,
-  boto3,
-  botocore,
-  catboost,
-  datasets,
-  google-cloud-storage,
-  httpx,
-  jwt,
-  keras,
-  langchain,
-  librosa,
-  moto,
-  opentelemetry-exporter-otlp,
-  optuna,
-  pydantic,
-  pyspark,
-  pytestCheckHook,
-  pytorch-lightning,
-  sentence-transformers,
-  shap,
-  starlette,
-  statsmodels,
-  tensorflow,
-  torch,
-  transformers,
-  xgboost,
 }:
 
 buildPythonPackage rec {
   pname = "mlflow";
   version = "3.11.1";
-  pyproject = true;
+  format = "wheel";
 
-  src = fetchFromGitHub {
-    owner = "mlflow";
-    repo = "mlflow";
-    tag = "v${version}";
-    hash = "sha256-Oe6nBnnOz7MvGUNCcCGhHl6ZbyDfAhQ0LlfMBF4p6Hc=";
+  src = fetchPypi {
+    pname = "mlflow";
+    inherit version;
+    format = "wheel";
+    dist = "py3";
+    python = "py3";
+    hash = "sha256-j2vxI4rAT5dmTCKd1IA4DFwlSni9s8DkM+OgOXUIsa8=";
   };
 
-  pythonRelaxDeps = [
-    "cryptography"
-    "gunicorn"
-    "importlib_metadata"
-    "packaging"
-    "protobuf"
-    "pytz"
-    "pyarrow"
-  ];
+  # Nix-wrapped python populates sys.path via NIX_PYTHONPATH/site hooks,
+  # but PYTHONPATH stays unset in os.environ. mlflow spawns the server
+  # in a subprocess with a curated env, so without this patch the child
+  # interpreter cannot import uvicorn / mlflow itself.
+  postInstall = ''
+    patch -p1 -d "$out/lib/python"*/site-packages < ${./subprocess-pythonpath.patch}
+  '';
 
-  build-system = [ setuptools ];
+  # mlflow on PyPI is three overlapping wheels (mlflow-skinny, mlflow-tracing,
+  # mlflow). The full wheel declares the other two as runtime deps, so we strip
+  # those declarations and inline their requirements into dependencies below.
+  pythonRemoveDeps = [
+    "mlflow-skinny"
+    "mlflow-tracing"
+  ];
 
   dependencies = [
     aiohttp
@@ -140,75 +115,19 @@ buildPythonPackage rec {
     uvicorn
   ];
 
+  pythonRelaxDeps = [
+    "importlib_metadata"
+  ];
+
   pythonImportsCheck = [ "mlflow" ];
 
-  nativeCheckInputs = [
-    aiohttp
-    azure-core
-    azure-storage-blob
-    azure-storage-file
-    boto3
-    botocore
-    catboost
-    datasets
-    google-cloud-storage
-    httpx
-    jwt
-    keras
-    langchain
-    librosa
-    moto
-    opentelemetry-exporter-otlp
-    optuna
-    pydantic
-    pyspark
-    pytestCheckHook
-    pytorch-lightning
-    sentence-transformers
-    starlette
-    statsmodels
-    tensorflow
-    torch
-    transformers
-    uvicorn
-    xgboost
-  ];
-
-  disabledTestPaths = [
-    # Requires unpackaged `autogen`
-    "tests/autogen/test_autogen_autolog.py"
-
-    # Requires unpackaged `diviner`
-    "tests/diviner/test_diviner_model_export.py"
-
-    # Requires unpackaged `sktime`
-    "examples/sktime/test_sktime_model_export.py"
-
-    # Requires `fastai` which would cause a circular dependency
-    "tests/fastai/test_fastai_autolog.py"
-    "tests/fastai/test_fastai_model_export.py"
-
-    # Requires `spacy` which would cause a circular dependency
-    "tests/spacy/test_spacy_model_export.py"
-
-    # Requires `tensorflow.keras` which is not included in our outdated version of `tensorflow` (2.13.0)
-    "tests/gateway/providers/test_ai21labs.py"
-    "tests/tensorflow/test_keras_model_export.py"
-    "tests/tensorflow/test_keras_pyfunc_model_works_with_all_input_types.py"
-    "tests/tensorflow/test_mlflow_callback.py"
-  ];
-
-  # I (@GaetanLepage) gave up at enabling tests:
-  # - They require a lot of dependencies (some unpackaged);
-  # - Many errors occur at collection time;
-  # - Most (all ?) tests require internet access anyway.
   doCheck = false;
 
   meta = {
     description = "Open source platform for the machine learning lifecycle";
     mainProgram = "mlflow";
     homepage = "https://github.com/mlflow/mlflow";
-    changelog = "https://github.com/mlflow/mlflow/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/mlflow/mlflow/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };

--- a/pkgs/development/python-modules/mlflow/default.nix
+++ b/pkgs/development/python-modules/mlflow/default.nix
@@ -39,6 +39,7 @@
   scipy,
   shap,
   skops,
+  starlette,
   sqlalchemy,
   sqlparse,
   uvicorn,
@@ -46,7 +47,7 @@
 
 buildPythonPackage rec {
   pname = "mlflow";
-  version = "3.11.1";
+  version = "3.12.0";
   format = "wheel";
 
   src = fetchPypi {
@@ -55,7 +56,7 @@ buildPythonPackage rec {
     format = "wheel";
     dist = "py3";
     python = "py3";
-    hash = "sha256-j2vxI4rAT5dmTCKd1IA4DFwlSni9s8DkM+OgOXUIsa8=";
+    hash = "sha256-4cKO1MSFV8xSx2bxfxylgmdT3fJB1D8w+ZxF9+prPOA=";
   };
 
   # Nix-wrapped python populates sys.path via NIX_PYTHONPATH/site hooks,
@@ -110,6 +111,7 @@ buildPythonPackage rec {
     scipy
     shap
     skops
+    starlette
     sqlalchemy
     sqlparse
     uvicorn

--- a/pkgs/development/python-modules/mlflow/subprocess-pythonpath.patch
+++ b/pkgs/development/python-modules/mlflow/subprocess-pythonpath.patch
@@ -1,0 +1,14 @@
+--- a/mlflow/server/__init__.py
++++ b/mlflow/server/__init__.py
+@@ -471,6 +471,11 @@
+             else tempfile.mkdtemp()
+         )
++    # In Nix-packaged environments sys.path is populated by wrappers but
++    # PYTHONPATH is never set in os.environ, so subprocesses (uvicorn,
++    # gunicorn) cannot find packages. Propagate it when not already set.
++    if "PYTHONPATH" not in os.environ:
++        env_map.setdefault("PYTHONPATH", os.pathsep.join(p for p in sys.path if p))
+
+     server_proc = _exec_cmd(
+         full_command,
+         extra_env=env_map,


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Depends on #519345.

pbsds edit: closes https://github.com/NixOS/nixpkgs/pull/520048 closes https://github.com/NixOS/nixpkgs/pull/518925

## Things done

Changelog: https://github.com/mlflow/mlflow/releases/tag/v3.12.0

Similar to https://github.com/mlflow/mlflow/pull/22837, `starlette` is also now added as an explicit dependency. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
