### PR TITLE
git-team: 1.8.1 -> 2.0.0

### DIFF
--- a/pkgs/by-name/gi/git-team/package.nix
+++ b/pkgs/by-name/gi/git-team/package.nix
@@ -8,16 +8,17 @@
 
 buildGoModule (finalAttrs: {
   pname = "git-team";
-  version = "1.8.1";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "hekmekk";
     repo = "git-team";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-+j5d1tImVHaTx63uzLdh2YNCFa1ErAVv4OMwxOutBQ4=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0nDt4i6RK6/guLVNpgZE1HRJjIu9YIzaA296s5aAKF4=";
   };
 
-  vendorHash = "sha256-NTOUL1oE2IhgLyYYHwRCMW5yCxIRxUwqkfuhSSBXf6A=";
+  proxyVendor = true;
+  vendorHash = "sha256-5rS4EgY4x6zSoBF4ylg4R9rcI6Ia5bmx04k+Bc+8PlQ=";
 
   nativeBuildInputs = [
     go-mockery_2


### PR DESCRIPTION
Update to 2.0.0

Upstream changes: https://github.com/hekmekk/git-team/compare/v1.8.1...v2.0.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
