### PR TITLE
dcrd: 1.8.1 -> 2.1.5

### DIFF
--- a/pkgs/by-name/dc/dcrd/package.nix
+++ b/pkgs/by-name/dc/dcrd/package.nix
@@ -7,24 +7,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "dcrd";
-  version = "1.8.1";
+  version = "2.1.5";
 
   src = fetchFromGitHub {
     owner = "decred";
     repo = "dcrd";
     tag = "release-v${finalAttrs.version}";
-    hash = "sha256-nSocqwXgJhvfbdElddbb1gGxoygmtVtK6DbiSuMxYew=";
+    hash = "sha256-EzNohMu0jLhQJwI16xKupH/riLKvtC1edMw5l6Bxj/I=";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "dcrd-appdata-env-variable.patch";
-      url = "https://github.com/decred/dcrd/pull/3152/commits/216132d7d852f3f2e2a6bf7f739f47ed62ac9387.patch";
-      hash = "sha256-R1GzP0qVP5XW1GnSJqFOpJVnwrVi/62tL1L2mc33+Dw=";
-    })
-  ];
-
-  vendorHash = "sha256-Napcfj1+KjQ21Jb/qpIzg2W/grzun2Pz5FV5yIBXoTo=";
+  vendorHash = "sha256-iUfTHzwjG+TyaHyhs4MGBCvfxah+Wv1+syFkiiaMLeU=";
 
   subPackages = [
     "."


### PR DESCRIPTION
Update to 2.1.5

Remove outdated patch

Upstream changes: https://github.com/decred/dcrd/compare/release-v1.8.1...release-v2.1.5

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
