### PR TITLE
python3Packages.pikepdf: 10.5.1 -> 10.6.0

### DIFF
--- a/pkgs/development/python-modules/pikepdf/default.nix
+++ b/pkgs/development/python-modules/pikepdf/default.nix
@@ -2,6 +2,7 @@
   lib,
   attrs,
   buildPythonPackage,
+  cmake,
   fetchFromGitHub,
   hypothesis,
   jbig2dec,
@@ -9,23 +10,24 @@
   lxml,
   withMupdf ? false,
   mupdf-headless,
+  nanobind,
+  ninja,
   numpy,
   packaging,
   pillow,
   psutil,
-  pybind11,
   pytest-xdist,
   pytestCheckHook,
   python-dateutil,
   python-xmp-toolkit,
   qpdf,
-  setuptools,
   replaceVars,
+  scikit-build-core,
 }:
 
 buildPythonPackage rec {
   pname = "pikepdf";
-  version = "10.5.1";
+  version = "10.6.0";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -38,7 +40,7 @@ buildPythonPackage rec {
     postFetch = ''
       rm "$out/.git_archival.txt"
     '';
-    hash = "sha256-x17cRef8rB5UQQws48G/IqeSp4B3CaLzIoUIQ8fJeUg=";
+    hash = "sha256-COEAY9/H9KZ1Tyj89CFMBl9ydTro82qk1XYWbaI9AFY=";
   };
 
   patches = [
@@ -54,17 +56,16 @@ buildPythonPackage rec {
     })
   ];
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace-fail "shims_enabled = not cflags_defined" "shims_enabled = False"
-  '';
-
   buildInputs = [ qpdf ];
 
   build-system = [
-    pybind11
-    setuptools
+    cmake
+    nanobind
+    ninja
+    scikit-build-core
   ];
+
+  dontUseCmakeConfigure = true;
 
   nativeCheckInputs = [
     attrs


### PR DESCRIPTION
Diff: https://github.com/pikepdf/pikepdf/compare/v10.5.1...v10.6.0

Changelog: https://github.com/pikepdf/pikepdf/blob/v10.6.0/docs/releasenotes/version10.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
