### PR TITLE
brush-splat: 0.2.0 -> 0.3.0

### DIFF
--- a/pkgs/by-name/br/brush-splat/package.nix
+++ b/pkgs/by-name/br/brush-splat/package.nix
@@ -3,58 +3,62 @@
   rustPlatform,
   fetchFromGitHub,
   pkg-config,
-  bzip2,
   libxkbcommon,
-  sqlite,
   vulkan-loader,
   zstd,
   stdenv,
   wayland,
   nix-update-script,
   versionCheckHook,
+  libx11,
+  libxcursor,
+  libxi,
+  libxrandr,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "brush-splat";
-  version = "0.2.0";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "ArthurBrussee";
     repo = "brush";
-    tag = finalAttrs.version;
-    hash = "sha256-IvsHYCM/M2hHozzKwovgXpcW1b7MSEGneU62y1k8U9U=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-xVYZrQUgHxaefAMmSXG/rrVlCr0H5lRmyyXtRmOtbTU=";
   };
 
-  cargoHash = "sha256-7cJj5L8ggkBP9SDaYMtY9xIAHVAhi8cTD/0pncUaHbI=";
-
-  # Force linking to libEGL, which is always dlopen()ed, and to
-  # libwayland-client & libxkbcommon, which is dlopen()ed based on the
-  # winit backend.
-  env.NIX_LDFLAGS = toString [
-    "--no-as-needed"
-    "-lvulkan"
-    "-lwayland-client"
-    "-lxkbcommon"
-  ];
+  cargoHash = "sha256-KBgE0fiaUEsGuAYGhBjqMX7ftj5JnGggH86brxq6280=";
 
   nativeBuildInputs = [
     pkg-config
   ];
 
   buildInputs = [
-    bzip2
-    libxkbcommon
-    sqlite
-    vulkan-loader
     zstd
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
+    libx11
+    libxcursor
+    libxi
+    libxkbcommon
+    libxrandr
+    vulkan-loader
     wayland
   ];
 
   env = {
     ZSTD_SYS_USE_PKG_CONFIG = true;
   };
+
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    patchelf --add-rpath "${
+      lib.makeLibraryPath [
+        vulkan-loader
+        wayland
+        libxkbcommon
+      ]
+    }" $out/bin/brush_app
+  '';
 
   nativeInstallCheckInputs = [
     versionCheckHook


### PR DESCRIPTION
Bumps to latest version of brush-splat https://github.com/ArthurBrussee/brush/releases/tag/v0.3.0

Should also fix https://github.com/NixOS/nixpkgs/issues/490540

Tested training with a nerfstudio format dataset and viewed some gaussian splats, seems to work nicely :)

<img width="1120" height="1396" alt="image" src="https://github.com/user-attachments/assets/48b6d7bc-d57b-4757-8bcc-448708521246" />


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
