### PR TITLE
yarnBuildHook: add `yarnBuildGlobalFlags`

### DIFF
--- a/doc/languages-frameworks/javascript.section.md
+++ b/doc/languages-frameworks/javascript.section.md
@@ -543,7 +543,8 @@ By default, `yarnConfigHook` relies upon the attribute `${yarnOfflineCache}` (or
 
 This script by default runs `yarn --offline build`, and it relies upon the project's dependencies installed at `node_modules`. Below is a list of additional `mkDerivation` arguments read by this hook:
 
-- `yarnBuildScript`: Sets a different `yarn --offline` subcommand (defaults to `build`).
+- `yarnBuildGlobalFlags`: Single string list of additional flags to pass `yarn`, or a Nix list of such additional flags (defaults to `--offline`).
+- `yarnBuildScript`: Sets a different `yarn ${yarnBuildGlobalFlags}` subcommand (defaults to `build`).
 - `yarnBuildFlags`: Single string list of additional flags to pass the above command, or a Nix list of such additional flags.
 
 ##### `yarnInstallHook` arguments {#javascript-yarninstallhook}

--- a/pkgs/build-support/node/fetch-yarn-deps/yarn-build-hook.sh
+++ b/pkgs/build-support/node/fetch-yarn-deps/yarn-build-hook.sh
@@ -10,10 +10,10 @@ yarnBuildHook() {
         echo yarnConfigHook WARNING: a node interpreter was not added to the \
             build, and is probably required to run \'yarn $yarnBuildHook\'. \
             A common symptom of this is getting \'command not found\' errors \
-            for Nodejs related tools.
+            for Node.js related tools.
     fi
 
-    yarn --offline "$yarnBuildScript" $yarnBuildFlags
+    yarn ${yarnBuildGlobalFlags:---offline} "$yarnBuildScript" $yarnBuildFlags
 
     echo "finished yarnBuildHook"
     runHook postBuild

--- a/pkgs/by-name/co/corepack/package.nix
+++ b/pkgs/by-name/co/corepack/package.nix
@@ -3,6 +3,7 @@
   stdenvNoCC,
   cacert,
   yarn-berry,
+  yarnBuildHook,
   nodejs-slim, # no need for npm
   fetchFromGitHub,
   nix-update-script,
@@ -39,6 +40,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     nodejs
     yarn-berry
     yarn-berry.yarnBerryConfigHook
+    yarnBuildHook
   ];
   buildInputs = [
     nodejs
@@ -66,13 +68,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       --replace-fail 'require.resolve(`corepack/package.json`)' "'$out/package.json'"
   '';
 
-  buildPhase = ''
-    runHook preBuild
-
-    yarn build
-
-    runHook postBuild
-  '';
+  yarnBuildGlobalFlags = " "; # override the default `--offline` which is not supported by Yarn Berry
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
So it can be used with e.g. Yarn Berry


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
