### PR TITLE
cargo-dist: 0.30.4 -> 0.31.0

### DIFF
--- a/pkgs/by-name/ca/cargo-dist/package.nix
+++ b/pkgs/by-name/ca/cargo-dist/package.nix
@@ -9,20 +9,21 @@
   zstd,
   git,
   rustup,
+  cacert,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-dist";
-  version = "0.30.4";
+  version = "0.31.0";
 
   src = fetchFromGitHub {
     owner = "axodotdev";
     repo = "cargo-dist";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-Woaa+KNRLqTRgglGM50L8w6UXlnDTcUHQZ20AYbZPnE=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-BSE3pXo7Kk104v7VEh5WUk+Km1/n/kNf8NJGVGjUKoc=";
   };
 
-  cargoHash = "sha256-DVIckYfIf7EqqRXQbNI3msvDopSY7RxR11942w3XBjg=";
+  cargoHash = "sha256-bfX2Yt0wrPg1pbvYdr2O9VUqYlCFVRh4PIABWxZTgjg=";
 
   nativeBuildInputs = [
     pkg-config
@@ -37,10 +38,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeCheckInputs = [
     git
     rustup
+    cacert
   ];
 
   env = {
     ZSTD_SYS_USE_PKG_CONFIG = true;
+    SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
   };
 
   # remove tests that require internet access
@@ -54,7 +57,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "Tool for building final distributable artifacts and uploading them to an archive";
     mainProgram = "dist";
     homepage = "https://github.com/axodotdev/cargo-dist";
-    changelog = "https://github.com/axodotdev/cargo-dist/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/axodotdev/cargo-dist/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = with lib.licenses; [
       asl20
       mit


### PR DESCRIPTION
Update to 0.31.0

changelog: https://github.com/axodotdev/cargo-dist/releases/tag/v0.31.0

added cacert dependency

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
