### PR TITLE
updatecli: 0.116.3 -> 0.117.0

### DIFF
--- a/pkgs/by-name/up/updatecli/package.nix
+++ b/pkgs/by-name/up/updatecli/package.nix
@@ -12,16 +12,17 @@
 
 buildGoModule (finalAttrs: {
   pname = "updatecli";
-  version = "0.116.3";
+  version = "0.117.0";
 
   src = fetchFromGitHub {
     owner = "updatecli";
     repo = "updatecli";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-5dJfbw0xoB34XuCym/TcqwdeUORZezfJNu7Plt82VPM=";
+    hash = "sha256-9nA+sOlcIm5Try0oag1Oz/ALPDaMag0jZKzHrS0Brf8=";
   };
 
-  vendorHash = "sha256-cMXepPUJoJGRlQSRSByA2/pjsQXfyH8Va320CywxxDw=";
+  proxyVendor = true;
+  vendorHash = "sha256-8WPwZjoDbRDi1IbjdZ40796JA5PRh8T75wRlWgTF7dI=";
 
   # tests require network access
   doCheck = false;


### PR DESCRIPTION
Update to 0.117.0

Changelog: https://github.com/updatecli/updatecli/releases/tag/v0.117.0

substitute required go version to available version in nix (1.26.3 -> 1.26.2)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
