### PR TITLE
supernovas: 1.5.1 -> 1.6.0

### DIFF
--- a/pkgs/by-name/su/supernovas/package.nix
+++ b/pkgs/by-name/su/supernovas/package.nix
@@ -5,16 +5,17 @@
   cmake,
   calceph,
   withCalceph ? true,
+  cppSupport ? true,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "supernovas";
-  version = "1.5.1";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
-    owner = "smithsonian";
+    owner = "Sigmyne";
     repo = "supernovas";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-2M5gBtjCPdVpLU5YsUWVJoRH1YWMZ48ADHwwc3ZJRPk=";
+    hash = "sha256-sLGl9Lh7bpvxhQ568kmwOMgVxFhH2lDRY/ftX6Oqm2w=";
   };
 
   nativeBuildInputs = [
@@ -27,7 +28,11 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
     (lib.cmakeBool "ENABLE_CALCEPH" withCalceph)
     (lib.cmakeBool "BUILD_EXAMPLES" false)
+    (lib.cmakeBool "ENABLE_CPP" cppSupport)
+    (lib.cmakeBool "BUILD_TESTING" finalAttrs.finalPackage.doCheck)
   ];
+
+  doCheck = true;
 
   meta = {
     description = "High-performance astrometry library for C/C++";


### PR DESCRIPTION
Bumps SuperNOVAS to 1.6.0

- Repo was transfered from Smithsonian to Sigmyne (not a fork, the owner switched jobs [discussion here](https://github.com/Sigmyne/SuperNOVAS/discussions/288))
- v1.6.0 adds C++ support, which we add by default. It's just another shared library
- Turn on testing as that now will work in CI

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
