### PR TITLE
lib.customisation: small performance improvements for `extendDerivation`

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -406,7 +406,7 @@ rec {
         outputName:
         commonAttrs
         // {
-          inherit (drv.${outputName}) outputName;
+          inherit outputName;
           outputSpecified = true;
           drvPath =
             assert condition;

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -397,32 +397,15 @@ rec {
     ```
   */
   extendDerivation =
+    let
+      defaultOutputs = [ "out" ];
+    in
     condition: passthru: drv:
     let
-      commonAttrs =
-        drv
-        // listToAttrs (
-          outputsList
-          ++ [
-            {
-              name = "all";
-              value = map (x: x.value) outputsList;
-            }
-          ]
-        )
-        // passthru
+      mkOutput =
+        outputName:
+        commonAttrs
         // {
-          drvPath =
-            assert condition;
-            drv.drvPath;
-          outPath =
-            assert condition;
-            drv.outPath;
-        };
-
-      outputsList = map (outputName: {
-        name = outputName;
-        value = commonAttrs // {
           inherit (drv.${outputName}) type outputName;
           outputSpecified = true;
           drvPath =
@@ -438,7 +421,42 @@ rec {
           ${if passthru ? overrideAttrs then "overrideAttrs" else null} =
             f: (passthru.overrideAttrs f).${outputName};
         };
-      }) (drv.outputs or [ "out" ]);
+      commonAttrs =
+        if !drv ? outputs || drv.outputs == defaultOutputs then
+          let
+            out = mkOutput "out";
+          in
+          drv
+          // {
+            inherit out;
+            all = [ out ];
+            drvPath =
+              assert condition;
+              drv.drvPath;
+            outPath =
+              assert condition;
+              drv.outPath;
+          }
+          // passthru
+        else
+          let
+            outputsData = map (outputName: {
+              name = outputName;
+              value = mkOutput outputName;
+            }) drv.outputs;
+          in
+          drv
+          // (listToAttrs outputsData)
+          // {
+            all = map (x: x.value) outputsData;
+            drvPath =
+              assert condition;
+              drv.drvPath;
+            outPath =
+              assert condition;
+              drv.outPath;
+          }
+          // passthru;
     in
     commonAttrs;
 

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -423,13 +423,10 @@ rec {
         };
       commonAttrs =
         if !drv ? outputs || drv.outputs == defaultOutputs then
-          let
-            out = mkOutput "out";
-          in
           drv
           // {
-            inherit out;
-            all = [ out ];
+            out = mkOutput "out";
+            all = [ (mkOutput "out") ]; # all is almost never accessed, so we prefer to recompute
             drvPath =
               assert condition;
               drv.drvPath;

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -406,7 +406,7 @@ rec {
         outputName:
         commonAttrs
         // {
-          inherit (drv.${outputName}) type outputName;
+          inherit (drv.${outputName}) outputName;
           outputSpecified = true;
           drvPath =
             assert condition;


### PR DESCRIPTION
Most derivations will either have no outputs or the default ones (and with none, we default to only `out`. Because of this, we can avoid a `map` and a `listToAttrs` for the common case. 

Stats diff for `firefox`:
```json
{
  "attrset": {
    "lookups": "+0.2%",
    "merges": "-2.25%",
    "mergeCopies": "-2.17%"
  },
  "list": {
    "concats": null
  },
  "parser": {
    "expressions": "+0.02%"
  },
  "memory": {
    "envs": "-0.1%",
    "list": "-1.53%",
    "sets": "-1.8%",
    "symbols": "+0%",
    "values": "-0.6%",
    "total": "-1.35%"
  },
  "speed": {
    "primops": "-2.87%",
    "functionCalls": "-0.7%",
    "thunksMade": "-0.97%",
    "thunksAvoided": "-0.4%"
  }
}
```

Real time numbers before:
```sh
❯ hyperfine -N --warmup 20 --runs 20 "nix-instantiate --eval -E '(import ./. {}).firefox.outPath'"
Benchmark 1: nix-instantiate --eval -E '(import ./. {}).firefox.outPath'
  Time (mean ± σ):      1.140 s ±  0.012 s    [User: 0.941 s, System: 0.191 s]
  Range (min … max):    1.120 s …  1.166 s    20 runs
```
And after:
```sh
❯ hyperfine -N --warmup 20 --runs 20 "nix-instantiate --eval -E '(import ./. {}).firefox.outPath'"
Benchmark 1: nix-instantiate --eval -E '(import ./. {}).firefox.outPath'
  Time (mean ± σ):      1.119 s ±  0.011 s    [User: 0.924 s, System: 0.188 s]
  Range (min … max):    1.104 s …  1.144 s    20 runs
```
Plugging these values into 2SampTTest, we get a p-value of `0.000000605` that this difference occurred due to random noise.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
