### PR TITLE
llvmPackages.lldb add cross-compilation support

### DIFF
--- a/pkgs/development/compilers/llvm/common/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/common/lldb/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  buildLlvmPackages,
   llvm_meta,
   release_version,
   cmake,
@@ -35,6 +36,12 @@ let
     name = "lldb-dap";
     version = "0.2.0";
   };
+  tblgen = buildLlvmPackages.tblgen.override {
+    targets = [
+      "lldb-tblgen"
+      "llvm-tblgen"
+    ];
+  };
 in
 
 stdenv.mkDerivation (
@@ -43,6 +50,8 @@ stdenv.mkDerivation (
     passthru.monorepoSrc = monorepoSrc;
     pname = "lldb";
     inherit version;
+
+    __structuredAttrs = true;
 
     src =
       if monorepoSrc != null then
@@ -73,11 +82,17 @@ stdenv.mkDerivation (
     patches = [
       ./gnu-install-dirs.patch
     ]
-    ++ lib.optional (lib.versions.major release_version == "18") [
-      # Fix build with gcc15
-      # https://github.com/llvm/llvm-project/commit/bb59f04e7e75dcbe39f1bf952304a157f0035314
-      ./lldb-add-include-cstdint.patch
-    ];
+    # Fix build with gcc15
+    # https://github.com/llvm/llvm-project/commit/bb59f04e7e75dcbe39f1bf952304a157f0035314
+    ++ lib.optional (lib.versions.major release_version == "18") ./lldb-add-include-cstdint.patch;
+
+    postPatch = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+      # The cpython setup-hook correctly sets the _PYTHON_SYSCONFIGDATA_NAME
+      # and _PYTHON_HOST_PLATFORM environment variables so the script which
+      # interogates sysconfig works correctly in the cross environment
+      substituteInPlace CMakeLists.txt \
+        --replace-fail 'NOT DEFINED ''${var} AND NOT CMAKE_CROSSCOMPILING' 'NOT DEFINED ''${var}'
+    '';
 
     nativeBuildInputs = [
       cmake
@@ -95,6 +110,7 @@ stdenv.mkDerivation (
     ];
 
     buildInputs = [
+      python3
       ncurses
       zlib
       libedit
@@ -138,6 +154,10 @@ stdenv.mkDerivation (
     ++ lib.optionals finalAttrs.finalPackage.doCheck [
       (lib.cmakeFeature "LLDB_TEST_C_COMPILER" "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc")
       (lib.cmakeFeature "-DLLDB_TEST_CXX_COMPILER" "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}c++")
+    ]
+    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+      (lib.cmakeFeature "LLVM_TABLEGEN" "${tblgen}/bin/llvm-tblgen")
+      (lib.cmakeFeature "LLDB_TABLEGEN_EXE" "${tblgen}/bin/lldb-tblgen")
     ]
     ++ devExtraCmakeFlags;
 

--- a/pkgs/development/compilers/llvm/common/tblgen.nix
+++ b/pkgs/development/compilers/llvm/common/tblgen.nix
@@ -14,6 +14,16 @@
   stdenv,
   version,
   clangPatches,
+  # List of tablegen targets.
+  targets ? [
+    "clang-tblgen"
+    "clang-tidy-confusable-chars-gen"
+    "llvm-tblgen"
+    "mlir-tblgen"
+  ]
+  ++ lib.optionals (lib.versionOlder release_version "20") [
+    "clang-pseudo-gen" # Removed in LLVM 20 @ ed8f78827895050442f544edef2933a60d4a7935.
+  ],
 }:
 
 let
@@ -34,32 +44,56 @@ let
   # don't need a native LLVM, only a native copy of the tools which run at
   # build time. This is only tablegen and related tooling, which are cheap
   # to build.
+  inherit (lib)
+    concatMap
+    concatStringsSep
+    naturalSort
+    subtractLists
+    unique
+    ;
+
   pname = "llvm-tblgen";
+
+  targetsSorted = naturalSort targets;
+
+  requiredProjectsPerTarget = {
+    "clang-tblgen" = [ "clang" ];
+    "lldb-tblgen" = [
+      "clang"
+      "lldb"
+    ];
+    "llvm-tblgen" = [ "llvm" ];
+    "mlir-tblgen" = [ "mlir" ];
+    "clang-pseudo-gen" = [
+      "clang"
+      "clang-tools-extra"
+    ];
+    "clang-tidy-confusable-chars-gen" = [
+      "clang"
+      "clang-tools-extra"
+    ];
+  };
+
+  projects = unique (naturalSort (concatMap (t: requiredProjectsPerTarget."${t}") targetsSorted));
 
   src' =
     if monorepoSrc != null then
+      let
+        requiredDirs = [
+          "cmake"
+          "third-party"
+          "llvm"
+        ];
+        sourcePaths = concatStringsSep " " (
+          map (p: "${monorepoSrc}/${p}") (requiredDirs ++ (subtractLists requiredDirs projects))
+        );
+      in
       runCommand "${pname}-src-${version}" { } ''
         mkdir -p "$out"
-        cp -r ${monorepoSrc}/cmake "$out"
-        cp -r ${monorepoSrc}/third-party "$out"
-        cp -r ${monorepoSrc}/llvm "$out"
-        cp -r ${monorepoSrc}/clang "$out"
-        cp -r ${monorepoSrc}/clang-tools-extra "$out"
-        cp -r ${monorepoSrc}/mlir "$out"
+        cp -r -t "$out" ${sourcePaths}
       ''
     else
       src;
-
-  # List of tablegen targets.
-  targets = [
-    "clang-tblgen"
-    "llvm-tblgen"
-    "clang-tidy-confusable-chars-gen"
-    "mlir-tblgen"
-  ]
-  ++ lib.optionals (lib.versionOlder release_version "20") [
-    "clang-pseudo-gen" # Removed in LLVM 20 @ ed8f78827895050442f544edef2933a60d4a7935.
-  ];
 
   self = stdenv.mkDerivation (finalAttrs: {
     inherit pname version patches;
@@ -70,14 +104,16 @@ let
     __structuredAttrs = true;
 
     postPatch = ''
-      (
-        cd ../clang
-        chmod u+rwX -R .
-        for p in ${toString clangPatches}
-        do
-          patch -p1 < $p
-        done
-      )
+      if [ -d ../clang ]; then
+        (
+          cd ../clang
+          chmod u+rwX -R .
+          for p in ${toString clangPatches}
+          do
+            patch -p1 < $p
+          done
+        )
+      fi
     '';
 
     nativeBuildInputs = [
@@ -92,20 +128,13 @@ let
 
     cmakeFlags = [
       # Projects with tablegen-like tools.
-      "-DLLVM_ENABLE_PROJECTS=${
-        lib.concatStringsSep ";" [
-          "llvm"
-          "clang"
-          "clang-tools-extra"
-          "mlir"
-        ]
-      }"
+      "-DLLVM_ENABLE_PROJECTS=${concatStringsSep ";" projects}"
     ]
     ++ devExtraCmakeFlags;
 
-    ninjaFlags = targets;
+    ninjaFlags = finalAttrs.targets;
 
-    inherit targets;
+    targets = targetsSorted;
 
     installPhase = ''
       mkdir -p $out/bin


### PR DESCRIPTION
- **llvmPackages.tblgen: build lldb-tblgen**
- **llvmPackages.lldb add cross-compilation support**

Enable structuredAttrs for lldb.
Rework llvm-tblgen so that adding or removing targets potentially causes less rebuilds.
lldb requires lldb-tblgen for buildPlatform during build.
The upstream CMake build assumes that python isn't properly setup to work during cross builds, so this check has to be disabled.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
    - [x] pkgsCross.aarch64-multiplatform
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
