### PR TITLE
[Backport release-25.11] shellhub-agent: 0.21.5 -> 0.24.2

### DIFF
--- a/pkgs/by-name/sh/shellhub-agent/package.nix
+++ b/pkgs/by-name/sh/shellhub-agent/package.nix
@@ -12,18 +12,18 @@
 
 buildGoModule rec {
   pname = "shellhub-agent";
-  version = "0.24.1";
+  version = "0.21.7";
 
   src = fetchFromGitHub {
     owner = "shellhub-io";
     repo = "shellhub";
     rev = "v${version}";
-    hash = "sha256-3WzB7a8RJlsiKDSpuXgXenfa1q5XG5baI57qrFS0kw8=";
+    hash = "sha256-+dU5NYEeGHU9n8PTmcU9S2XvaygMRIaN3ai7caWdE+I=";
   };
 
   modRoot = "./agent";
 
-  vendorHash = "sha256-idfUmP2LFcnjmGpA/17phpYtGBiTC/cXjlDd/dkZ1i0=";
+  vendorHash = "sha256-zBT3kQhn6RhgcP/5FBEhKo1oPl9GgFQqWGsBUgrDwW4=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/sh/shellhub-agent/package.nix
+++ b/pkgs/by-name/sh/shellhub-agent/package.nix
@@ -12,18 +12,18 @@
 
 buildGoModule rec {
   pname = "shellhub-agent";
-  version = "0.24.0";
+  version = "0.24.1";
 
   src = fetchFromGitHub {
     owner = "shellhub-io";
     repo = "shellhub";
     rev = "v${version}";
-    hash = "sha256-NV2VA/rquf0TwTAsaAA6TIHp1BwD+5jE8uOZg7tW/kI=";
+    hash = "sha256-3WzB7a8RJlsiKDSpuXgXenfa1q5XG5baI57qrFS0kw8=";
   };
 
   modRoot = "./agent";
 
-  vendorHash = "sha256-dloFaS/BUnyd9kHB0d2vsibkgFlQwTBkgRBOiBbq2ZY=";
+  vendorHash = "sha256-idfUmP2LFcnjmGpA/17phpYtGBiTC/cXjlDd/dkZ1i0=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/sh/shellhub-agent/package.nix
+++ b/pkgs/by-name/sh/shellhub-agent/package.nix
@@ -12,18 +12,18 @@
 
 buildGoModule rec {
   pname = "shellhub-agent";
-  version = "0.21.7";
+  version = "0.24.2";
 
   src = fetchFromGitHub {
     owner = "shellhub-io";
     repo = "shellhub";
     rev = "v${version}";
-    hash = "sha256-+dU5NYEeGHU9n8PTmcU9S2XvaygMRIaN3ai7caWdE+I=";
+    hash = "sha256-5lQSiN6XnZmtpIVU/FbsCzoAKGbDEe1stCiEOcUfI08=";
   };
 
   modRoot = "./agent";
 
-  vendorHash = "sha256-zBT3kQhn6RhgcP/5FBEhKo1oPl9GgFQqWGsBUgrDwW4=";
+  vendorHash = "sha256-hGUTF2USDxzb1VYVGX+BcOxFC2hSbpBJsWebjPD80Yc=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/sh/shellhub-agent/package.nix
+++ b/pkgs/by-name/sh/shellhub-agent/package.nix
@@ -12,18 +12,18 @@
 
 buildGoModule rec {
   pname = "shellhub-agent";
-  version = "0.21.5";
+  version = "0.22.0";
 
   src = fetchFromGitHub {
     owner = "shellhub-io";
     repo = "shellhub";
     rev = "v${version}";
-    hash = "sha256-0adBDz9oHb+Wo1/BucMPavX/4xZidjQYNVA3O475JEo=";
+    hash = "sha256-Ngb6n1P5Bb11et5x1mTF4rQjx/TdfE93nLc2NRz4aSg=";
   };
 
   modRoot = "./agent";
 
-  vendorHash = "sha256-zBT3kQhn6RhgcP/5FBEhKo1oPl9GgFQqWGsBUgrDwW4=";
+  vendorHash = "sha256-FlbSHLkJlOdbgfS+B5f8GLihw2KNQCh3G8kt8E+eb3w=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/sh/shellhub-agent/package.nix
+++ b/pkgs/by-name/sh/shellhub-agent/package.nix
@@ -12,18 +12,18 @@
 
 buildGoModule rec {
   pname = "shellhub-agent";
-  version = "0.22.0";
+  version = "0.24.0";
 
   src = fetchFromGitHub {
     owner = "shellhub-io";
     repo = "shellhub";
     rev = "v${version}";
-    hash = "sha256-Ngb6n1P5Bb11et5x1mTF4rQjx/TdfE93nLc2NRz4aSg=";
+    hash = "sha256-NV2VA/rquf0TwTAsaAA6TIHp1BwD+5jE8uOZg7tW/kI=";
   };
 
   modRoot = "./agent";
 
-  vendorHash = "sha256-FlbSHLkJlOdbgfS+B5f8GLihw2KNQCh3G8kt8E+eb3w=";
+  vendorHash = "sha256-dloFaS/BUnyd9kHB0d2vsibkgFlQwTBkgRBOiBbq2ZY=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
Backport of #516966 to `release-25.11`.

Brings `shellhub-agent` on `release-25.11` from 0.21.5 to 0.24.2, which
includes the upstream fixes for two cross-tenant IDOR vulnerabilities
in the ShellHub API.

## Security

Fixes #520491 — CVE-2026-44424 (CVSS 6.5 MEDIUM)
  Cross-tenant IDOR in `GET /api/devices/:uid` allows any authenticated
  user (JWT or API Key) to read device metadata from any namespace.
  Upstream advisory: GHSA-j72x-xfwg-783f.

Fixes #520493 — CVE-2026-44426 (CVSS 6.5 MEDIUM)
  Cross-tenant IDOR in `GET /api/namespaces/:tenant` via API Key
  bypasses the membership check and exposes member lists, settings,
  and device counts of any tenant.
  Upstream advisory: GHSA-vwx9-7qcf-gg7f.

Both are fixed upstream in 0.24.2.

## Backport contents

Squashed backport of the following commits from `master`:

- e1e9f3332fc4 shellhub-agent: 0.21.5 -> 0.22.0
- fe3ce400f027 shellhub-agent: 0.22.0 -> 0.24.0
- 8ec2fb028177 shellhub-agent: 0.24.0 -> 0.24.1
- 7d7f5df897e8 shellhub-agent: 0.24.1 -> 0.21.7 (upstream revert)
- fda800727186 shellhub-agent: 0.21.7 -> 0.24.2

The `buildGoModule rec` → `buildGoModule (finalAttrs: …)` migration
that landed on `master` outside the backport scope was intentionally
left out. Net diff vs. `release-25.11` is 3 lines (version, src hash,
vendorHash).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] Package tests at `passthru.tests` (`tests.version` via `testers.testVersion` passed in checkPhase).
- [x] Tested basic functionality: `agent --version` reports `v0.24.2`.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.

cc @NixOS/security