### PR TITLE
python3Packages.junit2html: 30.1.3 -> 31.1.3

### DIFF
--- a/pkgs/development/python-modules/junit2html/default.nix
+++ b/pkgs/development/python-modules/junit2html/default.nix
@@ -1,35 +1,38 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitLab,
   jinja2,
   setuptools,
+  pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "junit2html";
-  version = "30.1.3";
+  version = "31.1.3";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-1q6KpKdrZvp8XvxGCkoorlZDDgvGg/imTX8+NEOBbWs=";
+  src = fetchFromGitLab {
+    owner = "inorton";
+    repo = "junit2html";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TF+ifAFPn3PQwYQFruP++bWo6/6J8LEmDJYXDYSwcq0=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [ jinja2 ];
+  dependencies = [ jinja2 ];
 
-  # Tests are not shipped with PyPi and source is not tagged
-  doCheck = false;
+  nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "junit2htmlreport" ];
 
   meta = {
     description = "Generate HTML reports from Junit results";
     homepage = "https://gitlab.com/inorton/junit2html";
+    changelog = "https://gitlab.com/inorton/junit2html/-/releases/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ otavio ];
     mainProgram = "junit2html";
   };
-}
+})


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [x] `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] 25.11 Release Notes are up to date, including [release section maintenance](https://nixos.org/manual/nixos/unstable/release-notes#sec-release-notes-maintenance)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)

## Summary

Upstream stopped publishing source distributions on PyPI starting with 31.0.1; switch to \`fetchFromGitLab\` using the upstream version tags.

## Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc