### PR TITLE
display-managers: use absolute PAM module paths

### DIFF
--- a/nixos/modules/services/display-managers/ly.nix
+++ b/nixos/modules/services/display-managers/ly.nix
@@ -113,12 +113,12 @@ in
             {
               name = "nologin";
               control = "requisite";
-              modulePath = "pam_nologin.so";
+              modulePath = "${config.security.pam.package}/lib/security/pam_nologin.so";
             }
             {
               name = "ly-normal-user";
               control = "required";
-              modulePath = "pam_succeed_if.so";
+              modulePath = "${config.security.pam.package}/lib/security/pam_succeed_if.so";
               settings.quiet = true;
               args = lib.mkBefore [
                 "uid"
@@ -129,7 +129,7 @@ in
             {
               name = "permit";
               control = "required";
-              modulePath = "pam_permit.so";
+              modulePath = "${config.security.pam.package}/lib/security/pam_permit.so";
             }
           ];
 

--- a/nixos/modules/services/display-managers/plasma-login-manager.nix
+++ b/nixos/modules/services/display-managers/plasma-login-manager.nix
@@ -125,12 +125,12 @@ in
             {
               name = "nologin";
               control = "requisite";
-              modulePath = "pam_nologin.so";
+              modulePath = "${config.security.pam.package}/lib/security/pam_nologin.so";
             }
             {
               name = "permit";
               control = "required";
-              modulePath = "pam_permit.so";
+              modulePath = "${config.security.pam.package}/lib/security/pam_permit.so";
             }
           ];
 
@@ -166,7 +166,7 @@ in
               # Load environment from /etc/environment and ~/.pam_environment
               name = "env";
               control = "required";
-              modulePath = "pam_env.so";
+              modulePath = "${config.security.pam.package}/lib/security/pam_env.so";
               settings.conffile = "/etc/pam/environment";
               settings.readenv = 0;
             }
@@ -174,7 +174,7 @@ in
               # Always let the greeter start without authentication
               name = "permit";
               control = "required";
-              modulePath = "pam_permit.so";
+              modulePath = "${config.security.pam.package}/lib/security/pam_permit.so";
             }
           ];
 
@@ -183,7 +183,7 @@ in
               # No action required for account management
               name = "permit";
               control = "required";
-              modulePath = "pam_permit.so";
+              modulePath = "${config.security.pam.package}/lib/security/pam_permit.so";
             }
           ];
 
@@ -192,7 +192,7 @@ in
               # Can't change password
               name = "deny";
               control = "required";
-              modulePath = "pam_deny.so";
+              modulePath = "${config.security.pam.package}/lib/security/pam_deny.so";
             }
           ];
 
@@ -201,7 +201,7 @@ in
               # Setup session
               name = "unix";
               control = "required";
-              modulePath = "pam_unix.so";
+              modulePath = "${config.security.pam.package}/lib/security/pam_unix.so";
             }
             {
               name = "systemd";


### PR DESCRIPTION
## Summary

Fix build failure when AppArmor is enabled alongside display managers
that use relative PAM module paths.

The AppArmor PAM abstraction in `pam.nix` validates that all `modulePath`
values in `security.pam.services` are absolute paths. Both
`plasma-login-manager` and `ly` used bare filenames (e.g. `"pam_nologin.so"`)
for their PAM rules, causing:

```
error: non-absolute PAM modulePath "pam_nologin.so" is unsupported by apparmor
```

This changes all non-include PAM module paths to absolute store paths
using `${config.security.pam.package}/lib/security/pam_*.so` in both
modules.

Paths using `include`/`substack` control (`"login"`, `"plasmalogin"`,
`"ly"`) are left unchanged — they are filtered out by the assertion
in `pam.nix`.

## Changes

### `plasma-login-manager.nix` (7 rules)

| Service | Rule | Module |
|---|---|---|
| `plasmalogin-autologin` | `auth.nologin` | `pam_nologin.so` |
| `plasmalogin-autologin` | `auth.permit` | `pam_permit.so` |
| `plasmalogin-greeter` | `auth.env` | `pam_env.so` |
| `plasmalogin-greeter` | `auth.permit` | `pam_permit.so` |
| `plasmalogin-greeter` | `account.permit` | `pam_permit.so` |
| `plasmalogin-greeter` | `password.deny` | `pam_deny.so` |
| `plasmalogin-greeter` | `session.unix` | `pam_unix.so` |

### `ly.nix` (3 rules)

| Service | Rule | Module |
|---|---|---|
| `ly-autologin` | `auth.nologin` | `pam_nologin.so` |
| `ly-autologin` | `auth.ly-normal-user` | `pam_succeed_if.so` |
| `ly-autologin` | `auth.permit` | `pam_permit.so` |

## Things done

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [x] Built a full NixOS closure with AppArmor + plasma-login-manager
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).