### PR TITLE
python3Packages.smpclient: 6.0.0 -> 7.0.1

### DIFF
--- a/pkgs/by-name/sm/smpmgr/package.nix
+++ b/pkgs/by-name/sm/smpmgr/package.nix
@@ -27,11 +27,14 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "smpclient"
   ];
 
-  dependencies = with python3Packages; [
-    readchar
-    smpclient
-    typer
-  ];
+  dependencies =
+    with python3Packages;
+    [
+      readchar
+      smpclient
+      typer
+    ]
+    ++ smpclient.optional-dependencies.all;
 
   nativeCheckInputs = with python3Packages; [
     pytestCheckHook

--- a/pkgs/development/python-modules/smp/default.nix
+++ b/pkgs/development/python-modules/smp/default.nix
@@ -22,6 +22,11 @@ buildPythonPackage rec {
     hash = "sha256-dATsVGG0b5SBZh7R7NT1deJFDRYi7BwtWzT7/QPjkJw=";
   };
 
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'version = "0"' 'version = "${version}"'
+  '';
+
   build-system = [
     poetry-core
   ];

--- a/pkgs/development/python-modules/smpclient/default.nix
+++ b/pkgs/development/python-modules/smpclient/default.nix
@@ -4,9 +4,9 @@
   bleak,
   buildPythonPackage,
   fetchFromGitHub,
+  hatch-vcs,
+  hatchling,
   intelhex,
-  poetry-core,
-  poetry-dynamic-versioning,
   pyserial,
   pytest-asyncio,
   pytestCheckHook,
@@ -15,38 +15,41 @@
 
 buildPythonPackage rec {
   pname = "smpclient";
-  version = "6.0.0";
+  version = "7.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "intercreate";
     repo = "smpclient";
     tag = version;
-    hash = "sha256-1FyrJivP+sOKXVFuH5NbvIlOTOkuiUO3uIRasH8D+d8=";
+    hash = "sha256-5o2z+cyOVpTNpOdc9GfFNmqcOhbGgbFM0qGng44E1xE=";
   };
 
-  pythonRelaxDeps = [
-    "bleak"
-    "smp"
-  ];
+  env.HATCH_BUILD_HOOK_VCS_VERSION = version;
 
   build-system = [
-    poetry-core
-    poetry-dynamic-versioning
+    hatchling
+    hatch-vcs
   ];
 
   dependencies = [
     async-timeout
-    bleak
     intelhex
-    pyserial
     smp
   ];
+
+  optional-dependencies = {
+    serial = [ pyserial ];
+    ble = [ bleak ];
+    udp = [ ];
+    all = lib.concatAttrValues (lib.removeAttrs optional-dependencies [ "all" ]);
+  };
 
   nativeCheckInputs = [
     pytest-asyncio
     pytestCheckHook
-  ];
+  ]
+  ++ optional-dependencies.all;
 
   pythonImportsCheck = [ "smpclient" ];
 


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [x] \`nix-build -A python3Packages.smpclient\` (182 tests pass, 14 skipped)
- [x] Tested basic functionality of all binary files
- [x] 25.11 Release Notes are up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)

## Summary

Upstream migrated from \`poetry-core\` / \`poetry-dynamic-versioning\` to \`hatchling\` / \`hatch-vcs\`. The build system inputs are updated accordingly; \`pythonRelaxDeps\` still relaxes \`smp\` because the \`smp\` package reports version \`0\` in nixpkgs.

Changelog: https://github.com/intercreate/smpclient/releases/tag/7.0.0

## Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc