### PR TITLE
oelint-adv: 8.2.2 -> 9.7.1

### DIFF
--- a/pkgs/by-name/oe/oelint-adv/package.nix
+++ b/pkgs/by-name/oe/oelint-adv/package.nix
@@ -7,18 +7,18 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "oelint-adv";
-  version = "8.2.2";
+  version = "9.7.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "priv-kweihmann";
     repo = "oelint-adv";
     tag = finalAttrs.version;
-    hash = "sha256-W8W+hNgRVxBVkEDyKtFVx2mCyvbMA4CPjR1NrehClJs=";
+    hash = "sha256-44ebctMX7QfF459RvjJM4oz+ByBF3cz4e+02GnY9h1s=";
   };
 
   postPatch = ''
-    substituteInPlace setup.cfg \
+    substituteInPlace pyproject.toml \
       --replace-fail "--random-order-bucket=global" "" \
       --replace-fail "--random-order"               "" \
       --replace-fail "--force-sugar"                "" \

--- a/pkgs/development/python-modules/oelint-parser/default.nix
+++ b/pkgs/development/python-modules/oelint-parser/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "oelint-parser";
-  version = "8.9.1";
+  version = "8.11.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "priv-kweihmann";
     repo = "oelint-parser";
     tag = finalAttrs.version;
-    hash = "sha256-k/8NESePMe70PbqZNaMJu3aPSDMfT1JkixWYBvnmR9I=";
+    hash = "sha256-wzC9tXhPuGtyD2pQ2hO4sfERNOH8+sCNvXUcrqqlEAM=";
   };
 
   pythonRelaxDeps = [ "regex" ];


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - [x] \`nix-build -A python3Packages.oelint-parser\` (177 tests pass)
  - [x] \`nix-build -A oelint-adv\` (4021 tests pass)
- [x] 25.11 Release Notes are up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)

## Summary

- Bumps \`python3Packages.oelint-parser\` to 8.11.2 (needed by oelint-adv 9.7.1 which requires \`oelint-parser ~= 8.11\`). Supersedes #506486.
- Bumps \`oelint-adv\` to 9.7.1. Upstream replaced \`setup.cfg\` with \`pyproject.toml\`, so the \`postPatch\` substitution target is updated accordingly.

Changelog: https://github.com/priv-kweihmann/oelint-adv/releases/tag/9.7.1

## Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc