### PR TITLE
snagboot: 2.4 -> 2.6.1

### DIFF
--- a/pkgs/by-name/sn/snagboot/package.nix
+++ b/pkgs/by-name/sn/snagboot/package.nix
@@ -11,14 +11,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "snagboot";
-  version = "2.4";
+  version = "2.6.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "bootlin";
     repo = "snagboot";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ZjN4k5prOoEdAT4z37XiHdnUgLsz3zeR3+0zxY+2420=";
+    hash = "sha256-FOFvRzYk25M2P2T9TLRrhJDMyIe9troJ2DAP0at3aNY=";
   };
 
   build-system = with python3Packages; [
@@ -39,17 +39,15 @@ python3Packages.buildPythonApplication (finalAttrs: {
     pyserial
     tftpy
     crccheck
+    kivy
     libfdt
     # swig
     packaging
+    pyfatfs
     xmodem
   ];
 
   pythonRelaxDeps = [ "pylibfdt" ];
-
-  optional-dependencies = with python3Packages; {
-    gui = [ kivy ];
-  };
 
   postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
     rules="src/snagrecover/50-snagboot.rules"


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality (\`snagrecover --version\` reports \`Snagboot v2.6.1\`)
- [x] 25.11 Release Notes are up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)

## Summary

Adds \`pyfatfs\` to runtime dependencies (new requirement in upstream 2.6.x).

Changelog: https://github.com/bootlin/snagboot/blob/v2.6.1/CHANGELOG.md

## Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc