### PR TITLE
renode-dts2repl: unstable-2026-05-05 -> unstable-2026-05-13

### DIFF
--- a/pkgs/by-name/re/renode-dts2repl/package.nix
+++ b/pkgs/by-name/re/renode-dts2repl/package.nix
@@ -7,14 +7,14 @@
 
 python3.pkgs.buildPythonApplication {
   pname = "renode-dts2repl";
-  version = "0-unstable-2026-05-05";
+  version = "0-unstable-2026-05-13";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "antmicro";
     repo = "dts2repl";
-    rev = "3137db4ec2c85749cfc57bf05b460529d4e52a94";
-    hash = "sha256-PHtt31DGvOWgutgqbBcOr2vjdvnjaJmCTpRbHtx8MJw=";
+    rev = "5563a217559e9d75a97ba5753e195aa79f243fb2";
+    hash = "sha256-b/+fI9ChtV1JtcSUghl1W1D+xoTNri1vdka1Bvh3Y1g=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality (\`dts2repl --help\`)
- [x] 25.11 Release Notes are up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)

## Summary

Bumps the pinned commit to current default-branch HEAD (5563a217).

## Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc