### PR TITLE
kdePackages.audiotube: add patch for pybind11

### DIFF
--- a/pkgs/kde/gear/audiotube/default.nix
+++ b/pkgs/kde/gear/audiotube/default.nix
@@ -1,5 +1,6 @@
 {
   mkKdeDerivation,
+  fetchpatch,
   qtdeclarative,
   qtmultimedia,
   qtsvg,
@@ -24,6 +25,16 @@ let
 in
 mkKdeDerivation {
   pname = "audiotube";
+
+  patches = [
+    # https://bugs.kde.org/show_bug.cgi?id=520142
+    # https://github.com/NixOS/nixpkgs/issues/520685
+    (fetchpatch {
+      name = "pybind11-ecm-6.26.patch";
+      url = "https://invent.kde.org/multimedia/audiotube/-/commit/273d9b926dfadb1b85a4a0d21c352bd5968ffa1f.patch";
+      hash = "sha256-V5HghJxKYMRZP4vqIhQZeRveOcfpGXwMMEgSM3ZDbUE=";
+    })
+  ];
 
   extraNativeBuildInputs = [
     ps.pybind11


### PR DESCRIPTION
Fixes #520685

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
