### PR TITLE
musescore: 4.6.5 → 4.7.0

### DIFF
--- a/pkgs/by-name/mu/musescore/package.nix
+++ b/pkgs/by-name/mu/musescore/package.nix
@@ -42,23 +42,26 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cmakeFlags = [
-    "-DMUSE_APP_BUILD_MODE=release"
+    (lib.cmakeFeature "MUSE_APP_BUILD_MODE" "release")
     # Disable the build and usage of the `/bin/crashpad_handler` utility - it's
     # not useful on NixOS, see:
     # https://github.com/musescore/MuseScore/issues/15571
-    "-DMUSE_MODULE_DIAGNOSTICS_CRASHPAD_CLIENT=OFF"
-    # Use our versions of system libraries
-    "-DMUE_COMPILE_USE_SYSTEM_FREETYPE=ON"
-    "-DMUE_COMPILE_USE_SYSTEM_HARFBUZZ=ON"
-    "-DMUE_COMPILE_USE_SYSTEM_TINYXML=ON"
-    # Implies also -DMUE_COMPILE_USE_SYSTEM_OPUS=ON
-    "-DMUE_COMPILE_USE_SYSTEM_OPUSENC=ON"
-    "-DMUE_COMPILE_USE_SYSTEM_FLAC=ON"
+    (lib.cmakeBool "MUSE_MODULE_DIAGNOSTICS_CRASHPAD_CLIENT" false)
     # Don't bundle qt qml files, relevant really only for darwin, but we set
     # this for all platforms anyway.
-    "-DMUE_COMPILE_INSTALL_QTQML_FILES=OFF"
+    (lib.cmakeBool "MUE_COMPILE_INSTALL_QTQML_FILES" false)
     # Don't build unit tests unless we are going to run them.
     (lib.cmakeBool "MUSE_ENABLE_UNIT_TESTS" finalAttrs.finalPackage.doCheck)
+  ]
+  # Use our versions of system libraries, see:
+  # https://github.com/musescore/MuseScore/issues/11572
+  ++ map (l: lib.cmakeBool "MUE_COMPILE_USE_SYSTEM_${l}" true) [
+    "FREETYPE"
+    "HARFBUZZ"
+    "TINYXML"
+    # Implies also OPUS
+    "OPUSENC"
+    "FLAC"
   ];
 
   qtWrapperArgs = [

--- a/pkgs/by-name/mu/musescore/package.nix
+++ b/pkgs/by-name/mu/musescore/package.nix
@@ -10,7 +10,6 @@
   alsa-plugins,
   freetype,
   libjack2,
-  lame,
   libogg,
   libpulseaudio,
   libsndfile,
@@ -93,7 +92,6 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     libjack2
     freetype
-    lame
     libogg
     libpulseaudio
     libsndfile

--- a/pkgs/by-name/mu/musescore/package.nix
+++ b/pkgs/by-name/mu/musescore/package.nix
@@ -1,11 +1,15 @@
 {
-  stdenv,
   lib,
+  stdenv,
   fetchFromGitHub,
+
+  # nativeBuildInputs
   cmake,
   wrapGAppsHook3,
   pkg-config,
   ninja,
+
+  # buildInputs
   alsa-lib,
   alsa-plugins,
   freetype,
@@ -21,6 +25,8 @@
   libopus,
   tinyxml-2,
   kdePackages,
+
+  # passthru tests
   nixosTests,
 }:
 

--- a/pkgs/by-name/mu/musescore/package.nix
+++ b/pkgs/by-name/mu/musescore/package.nix
@@ -23,7 +23,7 @@
   flac,
   libopusenc,
   libopus,
-  tinyxml-2,
+  mnxdom,
   kdePackages,
 
   # passthru tests
@@ -32,13 +32,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "musescore";
-  version = "4.6.5";
+  version = "4.7.0";
 
   src = fetchFromGitHub {
     owner = "musescore";
     repo = "MuseScore";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-lfgf09gLeoiXc0xsJvvKAnSJUjy/L2Fdis/9SNjb1KM=";
+    hash = "sha256-AEYZWkcjqB2pW+oBow2oMX1HQn4kRaTBBxhyxIbG0a4=";
   };
 
   cmakeFlags = [
@@ -47,9 +47,6 @@ stdenv.mkDerivation (finalAttrs: {
     # not useful on NixOS, see:
     # https://github.com/musescore/MuseScore/issues/15571
     (lib.cmakeBool "MUSE_MODULE_DIAGNOSTICS_CRASHPAD_CLIENT" false)
-    # Don't bundle qt qml files, relevant really only for darwin, but we set
-    # this for all platforms anyway.
-    (lib.cmakeBool "MUE_COMPILE_INSTALL_QTQML_FILES" false)
     # Don't build unit tests unless we are going to run them.
     (lib.cmakeBool "MUSE_ENABLE_UNIT_TESTS" finalAttrs.finalPackage.doCheck)
   ]
@@ -58,10 +55,14 @@ stdenv.mkDerivation (finalAttrs: {
   ++ map (l: lib.cmakeBool "MUE_COMPILE_USE_SYSTEM_${l}" true) [
     "FREETYPE"
     "HARFBUZZ"
-    "TINYXML"
+    "MNXDOM"
     # Implies also OPUS
     "OPUSENC"
     "FLAC"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # https://github.com/musescore/MuseScore/issues/33467
+    (lib.cmakeBool "MUE_BUILD_MACOS_INTEGRATION" false)
   ];
 
   qtWrapperArgs = [
@@ -110,7 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
     flac
     libopusenc
     libopus
-    tinyxml-2
+    mnxdom
     kdePackages.qtbase
     kdePackages.qtdeclarative
     kdePackages.qt5compat

--- a/pkgs/by-name/mu/musescore/package.nix
+++ b/pkgs/by-name/mu/musescore/package.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   wrapGAppsHook3,
   pkg-config,


### PR DESCRIPTION
Resolves #520298


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
