### PR TITLE
various: foldl -> foldl'

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -3,7 +3,7 @@
 let
   inherit (lib)
     any
-    foldl
+    foldl'
     hasInfix
     isAttrs
     isList
@@ -692,7 +692,7 @@ let
       };
     in
     assert final.useAndroidPrebuilt -> final.isAndroid;
-    assert foldl (pass: { assertion, message }: if assertion final then pass else throw message) true (
+    assert foldl' (pass: { assertion, message }: if assertion final then pass else throw message) true (
       final.parsed.abi.assertions or [ ]
     );
     final;

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -17,6 +17,7 @@ let
     warn
     map
     isList
+    foldl'
     ;
 in
 
@@ -612,7 +613,7 @@ rec {
           entries
         # We do this foldl to have last-wins semantics in case of repeated entries
         else if (lib.isList entries) then
-          lib.foldl (a: b: a // { "${b.name}" = b.path; }) { } entries
+          foldl' (a: b: a // { "${b.name}" = b.path; }) { } entries
         else
           throw "linkFarm entries must be either attrs or a list!";
 

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -175,7 +175,7 @@ rec {
   # Puts all the other ones together
   makeStatic =
     stdenv:
-    lib.foldl (lib.flip lib.id) stdenv (
+    lib.foldl' (lib.flip lib.id) stdenv (
       lib.optional stdenv.hostPlatform.isDarwin makeStaticDarwin
 
       ++ [


### PR DESCRIPTION
## Things done

I'm performance profiling some NixOS configurations and noticed these calls `foldl` resulting in some very deep call stacks (& therefore flame graphs).
It's better to use `foldl'` as it runs in constant stack depth.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
