### PR TITLE
python3Packages.hdf5plugin: avoid cpuinfo in build

### DIFF
--- a/pkgs/development/python-modules/hdf5plugin/default.nix
+++ b/pkgs/development/python-modules/hdf5plugin/default.nix
@@ -59,6 +59,16 @@ buildPythonPackage rec {
     "zstd"
   ];
 
+  # These feature defaults can enable CPU-specific code during the build:
+  # most are detected from the build host CPU, while BMI2 defaults to enabled
+  # on Linux/Darwin. Pin them to keep the output generic and machine-independent.
+  # https://github.com/silx-kit/hdf5plugin/blob/v6.0.0/doc/install.rst#available-options
+  env.HDF5PLUGIN_NATIVE = "False";
+  env.HDF5PLUGIN_SSE2 = "False";
+  env.HDF5PLUGIN_SSSE3 = "False";
+  env.HDF5PLUGIN_AVX2 = "False";
+  env.HDF5PLUGIN_AVX512 = "False";
+
   checkPhase = ''
     python test/test.py
   '';


### PR DESCRIPTION
This PR fixes the build nondeterminism for `python3Packages.hdf5plugin` that has been present since its introduction in #211851, by setting environment variables to prevent it probing CPU features during the build: https://github.com/silx-kit/hdf5plugin/blob/v6.0.0/doc/install.rst#available-options

To see the nondeterminism for yourself, if you have access to an x86-64 CPU with AVX2 and/or AVX512, you can make a virtual machine that disables access to those CPU features, and run the following command in both environments on commits fc6b4a084de1f8688352977147fb65460f8889f6 and e2eb197a4085d87c37a817ecf30705d02fcddbc6:

```sh
out=$(nix-build --no-out-link --expr 'let pkgs = import ./. {}; in pkgs.python313Packages.hdf5plugin.overridePythonAttrs (_: { doCheck = false; doInstallCheck = false; pythonImportsCheck = []; })') && narHash=$(nix path-info --json "$out" | sed -n 's/.*"narHash":"\([^"]*\)".*/\1/p') && printf '%s %s\n' "$out" "$narHash"
```

For instance, here are the output hashes I get:

| | AMD Ryzen 9 9950X | `--cpu qemu64` |
| - | - | - |
| fc6b4a084de1f8688352977147fb65460f8889f6 | `sha256-uFqX2a5a8JTz/txbMfHj6XXBEQpNO786vGkhHePTaF8=` | `sha256-ovzzMbYh13v9ep5ZczKxefrtjyOB7nFVhQoHI9GBo2M=` |
| e2eb197a4085d87c37a817ecf30705d02fcddbc6 | `sha256-M1xOrERb6U0OvlMFkoDbWpJLpxiV59KnELq8fSE3x/w=` | `sha256-M1xOrERb6U0OvlMFkoDbWpJLpxiV59KnELq8fSE3x/w=` |

ZHF: #516381

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
