### PR TITLE
katana: 1.5.0 -> 1.6.1, adopt package

### DIFF
--- a/pkgs/by-name/ka/katana/package.nix
+++ b/pkgs/by-name/ka/katana/package.nix
@@ -29,7 +29,7 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/projectdiscovery/katana";
     changelog = "https://github.com/projectdiscovery/katana/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ iamanaws ];
     mainProgram = "katana";
   };
 })

--- a/pkgs/by-name/ka/katana/package.nix
+++ b/pkgs/by-name/ka/katana/package.nix
@@ -6,21 +6,20 @@
 
 buildGoModule (finalAttrs: {
   pname = "katana";
-  version = "1.5.0";
+  version = "1.6.1";
 
   src = fetchFromGitHub {
     owner = "projectdiscovery";
     repo = "katana";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-8Q7ZcbiOo7/HHF/1NYfoOxAQk6zUJsrz6n2HJzw9/Ic=";
+    hash = "sha256-XzJav0YGWBHNSrWiVVFOcHcAIIUjBCIUrbnfUzP9Vco=";
   };
 
-  vendorHash = "sha256-rq19948HzGgtc6bRx9PYaPoeUk+3evE0UGpgM08i/ZM=";
+  vendorHash = "sha256-xvMmBQ7am5uRbVQlAr42TqRLyfxMDF/Gygiud5LnewY=";
 
   subPackages = [ "cmd/katana" ];
 
   ldflags = [
-    "-w"
     "-s"
   ];
 


### PR DESCRIPTION
changelog
https://github.com/projectdiscovery/katana/releases/tag/v1.6.0
https://github.com/projectdiscovery/katana/releases/tag/v1.6.1

https://github.com/projectdiscovery/katana/compare/v1.5.0...v1.6.1


Merge after or superseeding https://github.com/NixOS/nixpkgs/pull/516394

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
