### PR TITLE
64gram: fix darwin build with Qt 6.11

### DIFF
--- a/pkgs/by-name/_6/_64gram/package.nix
+++ b/pkgs/by-name/_6/_64gram/package.nix
@@ -20,6 +20,16 @@ telegram-desktop.override {
       fetchSubmodules = true;
     };
 
+    # Newer 64gram releases include this file. Qt 6.11 dropped the edit
+    # menu roles, and keeps those actions working through TextHeuristicRole.
+    postPatch = (old.postPatch or "") + ''
+      if [ -f Telegram/SourceFiles/platform/mac/global_menu_mac.mm ]; then
+        substituteInPlace Telegram/SourceFiles/platform/mac/global_menu_mac.mm \
+          --replace-fail '#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)' \
+                         '#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0) && QT_VERSION < QT_VERSION_CHECK(6, 11, 0)'
+      fi
+    '';
+
     meta = {
       description = "Unofficial Telegram Desktop providing Windows 64bit build and extra features";
       license = lib.licenses.gpl3Only;


### PR DESCRIPTION
Qt 6.11 dropped the edit menu roles, and keeps those actions working through TextHeuristicRole.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
