### PR TITLE
netbird: add shadow to ssh login to function on NixOS

### DIFF
--- a/nixos/modules/services/networking/netbird.nix
+++ b/nixos/modules/services/networking/netbird.nix
@@ -592,7 +592,7 @@ in
           after = [ "network.target" ];
           wantedBy = [ "multi-user.target" ];
 
-          path = optionals (!config.services.resolved.enable) [ pkgs.openresolv ];
+          path = [ pkgs.shadow ] ++ optionals (!config.services.resolved.enable) [ pkgs.openresolv ];
 
           serviceConfig = {
             ExecStart = "${getExe client.wrapper} service run";


### PR DESCRIPTION
NetBird login currently fails in the NixOS service environment because the daemon expects tools from `shadow` like `login` to be available on `PATH`.
This adds `pkgs.shadow` to the generated NetBird client systemd service `path`, so all configured NetBird client instances have the required login helper available. This is applied at the module’s per-client service definition rather than only the default client, so multi-client configurations are covered too.
No package update.
## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [x] Parsed affected module with `nix-instantiate --parse nixos/modules/services/networking/netbird.nix`
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage]. ~~( currently running )~~
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.