### PR TITLE
hittekaart: 0.1.0 → 0.2.0

### DIFF
--- a/pkgs/by-name/hi/hittekaart/package.nix
+++ b/pkgs/by-name/hi/hittekaart/package.nix
@@ -8,17 +8,17 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "hittekaart";
-  version = "0.1.0";
+  version = "0.2.0";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "dunj3";
     repo = "hittekaart";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-bog00/pkpTaUtLDfuR9d8yEhDt9mn9YDyF17ojZMM38=";
+    hash = "sha256-Pp4biN20NWrTB11Bi14INl9g5VPPP79j9tbgXUe40qQ=";
   };
 
-  cargoHash = "sha256-Izcgxkl7QdNWYRrz9+nKMlCkEDtqiZTIAnJO/b7ZJKs=";
+  cargoHash = "sha256-bo8PnAShrQJ9qPYk/yEhD8E0DZH2uJ427w0Wr34Xz/U=";
 
   nativeBuildInputs = [ python3 ];
 


### PR DESCRIPTION
https://codeberg.org/dunj3/hittekaart/src/tag/v0.2.0/CHANGELOG.adoc

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
