### PR TITLE
_4th: fix editor for 64bit systems

### DIFF
--- a/pkgs/by-name/_4/_4th/package.nix
+++ b/pkgs/by-name/_4/_4th/package.nix
@@ -20,6 +20,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   dontConfigure = true;
 
+  preBuild = ''
+    cp sources/include${if stdenv.hostPlatform.is64bit then "64" else "32"}/* sources/
+    make -C sources clean
+  '';
+
   makeFlags = [
     "-C sources"
     "CC:=$(CC)"


### PR DESCRIPTION
Use headers in `sources/include{32, 64}` to fix the builtin editor, as suggested by `README`.
This fixes `Bad object` error of the builtin editor on 64bit systems (also described in the FAQ section of the [manual](https://thebeez.home.xs4all.nl/4tH/4tHmanual.pdf)). Although the manual suggests regenerating the headers (section 27.8), the required headers seem to be already in the distirbution.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
