### PR TITLE
linux-wallpaperengine: 0-unstable-2026-03-01 -> 0-unstable-2026-05-12

### DIFF
--- a/pkgs/by-name/li/linux-wallpaperengine/package.nix
+++ b/pkgs/by-name/li/linux-wallpaperengine/package.nix
@@ -13,6 +13,7 @@
   egl-wayland,
   ffmpeg,
   fftw,
+  freetype,
   glew,
   glfw,
   glm,
@@ -30,6 +31,7 @@
   libpulseaudio,
   lz4,
   mpv,
+  pulseaudio,
   wayland,
   wayland-protocols,
   wayland-scanner,
@@ -39,7 +41,7 @@
 
 let
   cef = cef-binary.override {
-    version = "135.0.17"; # follow upstream. https://github.com/Almamu/linux-wallpaperengine/blob/7067d6ff9fd34e36eeccf44e15f86ad604244f26/CMakeLists.txt#L47
+    version = "135.0.17"; # follow upstream. https://github.com/Almamu/linux-wallpaperengine/blob/a8ce9b6aa14cc10f0396bbb74a16ca12ed3990dc/CMakeLists.txt#L47
     gitRevision = "cbc1c5b";
     chromiumVersion = "135.0.7049.52";
 
@@ -51,14 +53,14 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "linux-wallpaperengine";
-  version = "0-unstable-2026-03-01";
+  version = "0-unstable-2026-05-12";
 
   src = fetchFromGitHub {
     owner = "Almamu";
     repo = "linux-wallpaperengine";
-    rev = "7067d6ff9fd34e36eeccf44e15f86ad604244f26";
+    rev = "a8ce9b6aa14cc10f0396bbb74a16ca12ed3990dc";
     fetchSubmodules = true;
-    hash = "sha256-NjEcrytgD5KVpB4kS4Cwa2SpxSRL4Tgt2yz6Ygd2p5A=";
+    hash = "sha256-S9tPlHugYdg5dbOW4OyDPPfVhxBg6purYhc+Bgt3ovM=";
   };
 
   nativeBuildInputs = [
@@ -75,6 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
     egl-wayland
     ffmpeg
     fftw
+    freetype
     glew
     glfw
     glm
@@ -92,6 +95,7 @@ stdenv.mkDerivation (finalAttrs: {
     libpulseaudio
     lz4
     mpv
+    pulseaudio
     wayland
     wayland-protocols
     wayland-scanner


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
