### PR TITLE
noweb: 2.13 -> unstable-2026-04-19

### DIFF
--- a/pkgs/by-name/no/noweb/package.nix
+++ b/pkgs/by-name/no/noweb/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "noweb";
-  version = "2.13";
+  version = "unstable-2026-04-19";
 
   src = fetchFromGitHub {
     owner = "nrnrnr";
     repo = "noweb";
-    rev = "v${builtins.replaceStrings [ "." ] [ "_" ] finalAttrs.version}";
-    sha256 = "sha256-COcWyrYkheRaSr2gqreRRsz9SYRTX2PSl7km+g98ljs=";
+    rev = "81fd4b9a7d3fce2bf3e32ceed8eeee26a9bb6b62";
+    sha256 = "sha256-Oj6MhdnK5Nrig4H+Fxt4Th3tK9fIe8LpTjB9WNkMvM4=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/src";


### PR DESCRIPTION
#ZurichZHF

Noweb doesn't publish updates as version tags since 2023 [^1] although
the codebase is still actively maintained [^2]. The README states:

> NOTE ABOUT VERSION

> Noweb predates Semantic Versioning (semver.org) by more than 20 years.
Aside from bug fixes, all versions 2.x should be compatible.  A change
in x means either that something significant changed or that a
significant number of years elapsed since the previous release.
Minor versions get a suffix a, b, etc.

> Version 2.13 is meant to be the last numbered version; future versions
should be referred to by git commit hash.

[^1]: https://github.com/nrnrnr/noweb/releases
[^2]: https://github.com/nrnrnr/noweb/commits/master/

With the newest version of GCC, building the old 2.13 version fails due
to some failing incomparable pointer checks (-Wincompatible-pointer-types; see below).
This change updates the package to the [most recent commit on `master`](81fd4b9a7d3fce2bf3e32ceed8eeee26a9bb6b62) (committed April 19th, 2026), for which the build completes successfully.

Build failure log from Hydra:

```
[...]
ipp.c:92:17: error: initialization of 'char * (*)(void)' from incompatible pointer type 'char * (*)(char *)' [-Wincompatible-pointer-types]
   92 |    { "else",    elsedir },
      |                 ^~~~~~~
ipp.c:92:17: note: (near initialization for 'pplist[4].func')
ipp.c:71:17: note: 'elsedir' declared here
   71 | static  char *  elsedir (char *s);
      |                 ^~~~~~~
ipp.c:93:17: error: initialization of 'char * (*)(void)' from incompatible pointer type 'char * (*)(char *)' [-Wincompatible-pointer-types]
   93 |    { "endif",   endif   },
      |                 ^~~~~
ipp.c:93:17: note: (near initialization for 'pplist[5].func')
ipp.c:72:17: note: 'endif' declared here
   72 | static  char *  endif   (char *s);
      |                 ^~~~~
ipp.c:94:17: error: initialization of 'char * (*)(void)' from incompatible pointer type 'char * (*)(char *)' [-Wincompatible-pointer-types]
   94 |    { "include", include },
      |                 ^~~~~~~
ipp.c:94:17: note: (near initialization for 'pplist[6].func')
ipp.c:74:17: note: 'include' declared here
   74 | static  char *  include (char *s);
      |                 ^~~~~~~
ipp.c:95:17: error: initialization of 'char * (*)(void)' from incompatible pointer type 'char * (*)(char *)' [-Wincompatible-pointer-types]
   95 |    { "line",    setline },
      |                 ^~~~~~~
ipp.c:95:17: note: (near initialization for 'pplist[7].func')
ipp.c:75:17: note: 'setline' declared here
   75 | static  char *  setline (char *s);
      |                 ^~~~~~~
ipp.c:96:17: error: initialization of 'char * (*)(void)' from incompatible pointer type 'char * (*)(char *)' [-Wincompatible-pointer-types]
   96 |    { "error",   errdir  },
[...]
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - [x] Tested basic functionality of _some_ binaries using the examples in the upstream repo
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test