### PR TITLE
ausaxs: 1.2.0 -> 1.2.3

### DIFF
--- a/pkgs/by-name/au/ausaxs/package.nix
+++ b/pkgs/by-name/au/ausaxs/package.nix
@@ -68,13 +68,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "ausaxs";
-  version = "1.2.0";
+  version = "1.2.3";
 
   src = fetchFromGitHub {
     owner = "AUSAXS";
     repo = "AUSAXS";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-vTuQsg76p0WHPadwqBdDGBSNgNmr5TxuwlNj47P+sa8=";
+    hash = "sha256-USu0/hfccEnwMccsyQDe1l2hQq9ISQe8WjdduaLJAqs=";
   };
 
   patches = [ ./cmake-no-fetchcontent.patch ];
@@ -88,10 +88,6 @@ stdenv.mkDerivation (finalAttrs: {
     cp --recursive --no-preserve=mode ${asio} asio
     cp --recursive --no-preserve=mode ${cycfi_infra} cycfi_infra
     patch -p1 -d elements < ${./elements-cmake-no-fetchcontent.patch}
-    substituteInPlace CMakeLists.txt \
-      --replace-fail "-mavx" "${
-        lib.optionalString (stdenv.hostPlatform.isx86_64 && stdenv.hostPlatform.isLinux) "-msse3"
-      }"
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
https://github.com/AUSAXS/AUSAXS/releases/tag/v1.2.3
Diff: https://github.com/AUSAXS/AUSAXS/compare/v1.2.0...v1.2.3


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
