### PR TITLE
turingdb: 1.30 -> 1.31

### DIFF
--- a/pkgs/by-name/tu/turingdb/package.nix
+++ b/pkgs/by-name/tu/turingdb/package.nix
@@ -4,11 +4,13 @@
   fetchFromGitHub,
   cmake,
   pkg-config,
+  python3,
   gitMinimal,
   bison,
   flex,
   inih,
   minio-cpp,
+  arrow-cpp,
   curl,
   curlpp,
   nlohmann_json,
@@ -26,18 +28,19 @@ let
 in
 turingstdenv.mkDerivation (finalAttrs: {
   pname = "turingdb";
-  version = "1.30";
+  version = "1.31";
 
   src = fetchFromGitHub {
     owner = "turing-db";
     repo = "turingdb";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-dYggkkuTC+amR/Alz+B1YCNo5kHgmrt/dNLRW5EgaZY=";
+    hash = "sha256-dorRoDWylZo/QRJbqEZOUf+JNHSKCIi/s8wxZ2HwZsI=";
 
     fetchSubmodules = true;
 
     leaveDotGit = true;
     postFetch = ''
+      git -C $out log -1 --format=%H > $out/HEAD_COMMIT_HASH
       git -C $out log -1 --format=%ct > $out/HEAD_COMMIT_TIMESTAMP
       rm -rf $out/.git
     '';
@@ -46,6 +49,20 @@ turingstdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     substituteInPlace storage/dump/DumpConfig.h \
       --replace-fail HEAD_COMMIT_TIMESTAMP "$(cat $src/HEAD_COMMIT_TIMESTAMP)"
+
+    substituteInPlace io/parquet/CMakeLists.txt \
+      --replace-fail "Parquet::parquet_static" "Parquet::parquet_shared"
+
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'COMMAND git rev-parse HEAD' 'COMMAND cat HEAD_COMMIT_HASH' \
+      --replace-fail 'COMMAND git show --no-patch --format=%at' 'COMMAND cat HEAD_COMMIT_TIMESTAMP'
+
+    substituteInPlace tools/turingdb/TuringDBTool.cpp \
+      --replace-fail '"turingdb", "1.0"' '"turingdb", "${finalAttrs.version}"'
+
+    for dir in test samples regress fuzz examples; do
+      substituteInPlace CMakeLists.txt --replace-fail "add_subdirectory($dir)" ""
+    done
   '';
 
   strictDeps = true;
@@ -56,9 +73,11 @@ turingstdenv.mkDerivation (finalAttrs: {
     flex
     gitMinimal
     pkg-config
+    python3
   ];
 
   buildInputs = [
+    arrow-cpp
     curl
     curlpp
     faiss


### PR DESCRIPTION
Update to 1.31

Changelog: https://github.com/turing-db/turingdb/releases/tag/v1.31

Added arrow-cpp and python3 dep.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
