### PR TITLE
fmd-server: fix darwin

### DIFF
--- a/pkgs/by-name/fm/fmd-server/package.nix
+++ b/pkgs/by-name/fm/fmd-server/package.nix
@@ -35,6 +35,10 @@ buildGoModule (
 
     vendorHash = "sha256-cFIg9mOSQbrYHW4kg4aTeTaF+gy1jNpAlg8qepb81Jc=";
 
+    preBuild = ''
+      cp -r ${ui}/${ui.distRoot} web/
+    '';
+
     nativeInstallCheckInputs = [ versionCheckHook ];
     versionCheckProgramArg = "version";
 
@@ -73,10 +77,6 @@ buildGoModule (
         runHook postInstall
       '';
     };
-
-    postUnpack = ''
-      cp -r ${ui}/${ui.distRoot} /build/source/web/
-    '';
 
     meta = {
       description = "Server to communicate with the FindMyDevice app and save the latest (encrypted) location";


### PR DESCRIPTION
by not copying ui files to `/build` (since it doesn't exist on that platform), and instead copying them relative to `web`, before the build.

Supersedes and closes: https://github.com/NixOS/nixpkgs/pull/520732
Tracking: https://github.com/NixOS/nixpkgs/issues/516381

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform (https://github.com/eljamm/nixpkgs-review-gha/actions/runs/25959210359):
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
