### PR TITLE
apbs: fix cmake build on darwin

### DIFF
--- a/pkgs/by-name/ap/apbs/package.nix
+++ b/pkgs/by-name/ap/apbs/package.nix
@@ -27,8 +27,10 @@ let
       cmake
     ];
 
-    # Required for gcc-15 compatibility
-    env.NIX_CFLAGS_COMPILE = "-std=gnu17";
+    env = lib.optionalAttrs (!stdenv.hostPlatform.isDarwin) {
+      # Required for gcc-15 compatibility
+      NIX_CFLAGS_COMPILE = "-std=gnu17";
+    };
 
     cmakeFlags = [
       "-DBLAS_LIBRARIES=${blas}/lib"


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/commit/b8b05a9010da29518fd5c1ae9edcb76e833a21a1 added a compiler argument that caused the build to fail on darwin. This PR adds an exception for darwin to build without "-std=gnu17".

#ZurichZHF

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
