### PR TITLE
ryubing-canary: init at 1.3.309

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26689,6 +26689,12 @@
     githubId = 332289;
     name = "Rafał Łasocha";
   };
+  swofty = {
+    email = "admin@swofty.net";
+    github = "Swofty-Developments";
+    githubId = 75875764;
+    name = "Jacob Nardella";
+  };
   sxmair = {
     email = "sumairhasan99@gmail.com";
     github = "sxmair";

--- a/pkgs/by-name/ry/ryubing-canary/deps.json
+++ b/pkgs/by-name/ry/ryubing-canary/deps.json
@@ -1,0 +1,818 @@
+[
+  {
+    "pname": "Avalonia",
+    "version": "11.3.17",
+    "hash": "sha256-rwcP29MST4gbwSxFGCgAbfgc327VLffO85+jlZKXSuA="
+  },
+  {
+    "pname": "Avalonia.Angle.Windows.Natives",
+    "version": "2.1.25547.20250602",
+    "hash": "sha256-LE/lENAHptmz6t3T/AoJwnhpda+xs7PqriNGzdcfg8M="
+  },
+  {
+    "pname": "Avalonia.BuildServices",
+    "version": "11.3.2",
+    "hash": "sha256-6wx06tjSKWQOlX2czdp6Wh0nuwVapx5qf/s8Qj5we40="
+  },
+  {
+    "pname": "Avalonia.Controls.ColorPicker",
+    "version": "11.3.12",
+    "hash": "sha256-zNpmfOTfw+gKZp8VPpfHe2hjqhrRmExf7lxqLf5OvDg="
+  },
+  {
+    "pname": "Avalonia.Controls.ColorPicker",
+    "version": "11.3.17",
+    "hash": "sha256-uFe2P/mIttNfimHpLHmfvCQ+wBsX9k/6VlHZSJKvbok="
+  },
+  {
+    "pname": "Avalonia.Controls.DataGrid",
+    "version": "11.3.13",
+    "hash": "sha256-uqpRip0O+DUk/zsytLdJhZz103har19xPqMq0hI/Ppg="
+  },
+  {
+    "pname": "Avalonia.Desktop",
+    "version": "11.3.17",
+    "hash": "sha256-/FtHI2hPpNQmJ3phfrkM2PeWm4KSNeXpQQd0fjRxb9A="
+  },
+  {
+    "pname": "Avalonia.Diagnostics",
+    "version": "11.3.17",
+    "hash": "sha256-YISmmO9Nb3rXTHFEa5/Y0AlzXMoraf2Zhz3zC05VU1A="
+  },
+  {
+    "pname": "Avalonia.FreeDesktop",
+    "version": "11.3.17",
+    "hash": "sha256-7VXu2PuOT7K/Eaj9va3XWo8vbIjBGTORwMckmZufKN0="
+  },
+  {
+    "pname": "Avalonia.Markup.Xaml.Loader",
+    "version": "11.3.17",
+    "hash": "sha256-8mxEgxGuZNrYDW48GMGcVZXEE0f1urlJH0Gjnp8rlto="
+  },
+  {
+    "pname": "Avalonia.Native",
+    "version": "11.3.17",
+    "hash": "sha256-czhZCxM8uQElHMtzNhVEWvLtJPl6u2lFpt1kWBwBAGo="
+  },
+  {
+    "pname": "Avalonia.Remote.Protocol",
+    "version": "11.3.17",
+    "hash": "sha256-I1uUXOpNZzcvmi5WqVajirz6YpR87I4pg1FqlS2wVPw="
+  },
+  {
+    "pname": "Avalonia.Skia",
+    "version": "11.3.12",
+    "hash": "sha256-gRMjH7igRIm22zQV0WxtwFHe8AiMTcaPlR0sC5lJy+w="
+  },
+  {
+    "pname": "Avalonia.Skia",
+    "version": "11.3.17",
+    "hash": "sha256-0dShNoRVB3lD3iGh3g0+8z4kq0QqC9ZuChOclTCNk0s="
+  },
+  {
+    "pname": "Avalonia.Skia",
+    "version": "11.3.9",
+    "hash": "sha256-KCL1LNUd2i+50vQpDgfI+aMkIBUWtxExyuc43QIK21o="
+  },
+  {
+    "pname": "Avalonia.Themes.Simple",
+    "version": "11.3.17",
+    "hash": "sha256-CCcwYt8URe4euZ7TgU35OD3krWICoSIUEFT7QrMmpO8="
+  },
+  {
+    "pname": "Avalonia.Win32",
+    "version": "11.3.17",
+    "hash": "sha256-5jXzBRh3VTirqoPfugOhrDQPt0CFibB3JQXfgUAfk8g="
+  },
+  {
+    "pname": "Avalonia.X11",
+    "version": "11.3.17",
+    "hash": "sha256-GAtzkLfH7wMK3D1Mqy7UmBCAv4JeyKkm4Mt5H1HgOb0="
+  },
+  {
+    "pname": "CommandLineParser",
+    "version": "2.9.1",
+    "hash": "sha256-ApU9y1yX60daSjPk3KYDBeJ7XZByKW8hse9NRZGcjeo="
+  },
+  {
+    "pname": "CommunityToolkit.Mvvm",
+    "version": "8.4.2",
+    "hash": "sha256-jLS1vo6V+fHsJs80HYT77oJE6IEC68fIgkLpYODjWAU="
+  },
+  {
+    "pname": "Concentus",
+    "version": "2.2.2",
+    "hash": "sha256-9If4kL72V1evHOz0IONX8ASIy/rAtAm6RhzLzu+BSB8="
+  },
+  {
+    "pname": "csFastFloat",
+    "version": "4.1.5",
+    "hash": "sha256-dEbMPu/EmsRodI20P15F38QInil0IPcKE03akYp8tBY="
+  },
+  {
+    "pname": "DiscordRichPresence",
+    "version": "1.6.1.70",
+    "hash": "sha256-uXTNIWfZU7Gf/JpXQ5ufKA3SQdXYSkg3yLm5yCrBDd8="
+  },
+  {
+    "pname": "DynamicData",
+    "version": "9.4.31",
+    "hash": "sha256-//0EwmfDJFDeZSDf9xOPs+Qz0CEUPEiKZS6bIBhsHdw="
+  },
+  {
+    "pname": "ExCSS",
+    "version": "4.3.1",
+    "hash": "sha256-nNn5+YEaqKSULhtDsImNEyndU/MHna7VpZNUExmo80o="
+  },
+  {
+    "pname": "FluentAvaloniaUI",
+    "version": "2.5.1",
+    "hash": "sha256-RE6keixFzExRjmq/8GzpnACbgGApm8LPHcf50WOso0M="
+  },
+  {
+    "pname": "FSharp.Core",
+    "version": "6.0.7",
+    "hash": "sha256-Cu7P3d4z1sB9ZXrykNnmIKfucrdQoqlyyBanCLDmNos="
+  },
+  {
+    "pname": "Gommon",
+    "version": "2.8.1.2",
+    "hash": "sha256-tJdDKZvu02E8XjooAvRFTOMCjse+w8BCVOwsIQ5K0zg="
+  },
+  {
+    "pname": "HarfBuzzSharp",
+    "version": "8.3.1.1",
+    "hash": "sha256-614yv6bK9ynhdUnvW4wIkgpBe2sqTh28U9cDZzdhPc0="
+  },
+  {
+    "pname": "HarfBuzzSharp.NativeAssets.Linux",
+    "version": "8.3.1.1",
+    "hash": "sha256-sBbez6fc9axVcsBbIHbpQh/MM5NHlMJgSu6FyuZzVyU="
+  },
+  {
+    "pname": "HarfBuzzSharp.NativeAssets.macOS",
+    "version": "8.3.1.1",
+    "hash": "sha256-hK20KbX2OpewIO5qG5gWw5Ih6GoLcIDgFOqCJIjXR/Q="
+  },
+  {
+    "pname": "HarfBuzzSharp.NativeAssets.WebAssembly",
+    "version": "8.3.1.1",
+    "hash": "sha256-mLKoLqI47ZHXqTMLwP1UCm7faDptUfQukNvdq6w/xxw="
+  },
+  {
+    "pname": "HarfBuzzSharp.NativeAssets.Win32",
+    "version": "8.3.1.1",
+    "hash": "sha256-Um4iwLdz9XtaDSAsthNZdev6dMiy7OBoHOrorMrMYyo="
+  },
+  {
+    "pname": "Humanizer",
+    "version": "2.14.1",
+    "hash": "sha256-1wGwf5KAmDeiH0Dz8KcTdZw+UMkiNsjKOIOt/VJnnqE="
+  },
+  {
+    "pname": "Humanizer.Core",
+    "version": "2.14.1",
+    "hash": "sha256-EXvojddPu+9JKgOG9NSQgUTfWq1RpOYw7adxDPKDJ6o="
+  },
+  {
+    "pname": "Humanizer.Core.af",
+    "version": "2.14.1",
+    "hash": "sha256-8CCgI7OweSa53cZWZBXQ8a7VVt/NPP16zHVBZvzU9KQ="
+  },
+  {
+    "pname": "Humanizer.Core.ar",
+    "version": "2.14.1",
+    "hash": "sha256-JRoP+brQgYBZI8OccH/jaM1Z482ZWBiqU2XL3KsIPw8="
+  },
+  {
+    "pname": "Humanizer.Core.az",
+    "version": "2.14.1",
+    "hash": "sha256-ubwkbes9zrrisuXTcT4ZgOAiFsUieC6OLd4pgzxsE40="
+  },
+  {
+    "pname": "Humanizer.Core.bg",
+    "version": "2.14.1",
+    "hash": "sha256-Xv6DP1xxxGVUfP44TZasWpxgQ/DkriljvmIMtHf+nGk="
+  },
+  {
+    "pname": "Humanizer.Core.bn-BD",
+    "version": "2.14.1",
+    "hash": "sha256-6JpReIc3fkExvJIXzk6fUw56wJ78aTEg1dWQ6o+dQow="
+  },
+  {
+    "pname": "Humanizer.Core.cs",
+    "version": "2.14.1",
+    "hash": "sha256-MGL86KxSbz0PkDo9+NRj6h1fDjPZXlxAtYNf0Zreg/4="
+  },
+  {
+    "pname": "Humanizer.Core.da",
+    "version": "2.14.1",
+    "hash": "sha256-Gpw8kJbgz0KQS2mGY5tmrHqpgUO4abD7dSKIy//ONYM="
+  },
+  {
+    "pname": "Humanizer.Core.de",
+    "version": "2.14.1",
+    "hash": "sha256-Eswv8aEQoxI9MZr2CvWtBUn5X9JRZTWQjRzHJkGj80g="
+  },
+  {
+    "pname": "Humanizer.Core.el",
+    "version": "2.14.1",
+    "hash": "sha256-wCK2Uy/AV6FxPUSUM0NMbV14pAP+ss25AaVAHMQIeJA="
+  },
+  {
+    "pname": "Humanizer.Core.es",
+    "version": "2.14.1",
+    "hash": "sha256-iEHiQXKwg0ABDxh//HSrzwaVOlilQBFI96+GYzzTMwQ="
+  },
+  {
+    "pname": "Humanizer.Core.fa",
+    "version": "2.14.1",
+    "hash": "sha256-2Js7k3nvwJvxAjq3yoLn7PUY2S8+vXfgESwU4SbvjaA="
+  },
+  {
+    "pname": "Humanizer.Core.fi-FI",
+    "version": "2.14.1",
+    "hash": "sha256-jOWo43r3dhiBsV9cCoDfqK/YqWj5LejZsnfkG6mlkpA="
+  },
+  {
+    "pname": "Humanizer.Core.fr",
+    "version": "2.14.1",
+    "hash": "sha256-WCbA+f4B3g/ml7KrkHkzpU2Fj38HtWc/ujoVY5F3lk4="
+  },
+  {
+    "pname": "Humanizer.Core.fr-BE",
+    "version": "2.14.1",
+    "hash": "sha256-GydVmoEy+lwEQ1nM39QXSRhYNchqM47p7qhUEimN4Cw="
+  },
+  {
+    "pname": "Humanizer.Core.he",
+    "version": "2.14.1",
+    "hash": "sha256-MMf3qjJ+yzxjMxOR7wMWf+eErxWLqpsdWKFhjNCOsyM="
+  },
+  {
+    "pname": "Humanizer.Core.hr",
+    "version": "2.14.1",
+    "hash": "sha256-kBv2I9ns6L6D4XfXfyZS1VM6+YwF4yUkCmCA5zqvsok="
+  },
+  {
+    "pname": "Humanizer.Core.hu",
+    "version": "2.14.1",
+    "hash": "sha256-vRje+kxqOsl1JCXAE0yDKvauUumzuEhNcnhNsdIdgVM="
+  },
+  {
+    "pname": "Humanizer.Core.hy",
+    "version": "2.14.1",
+    "hash": "sha256-UL7PsK4msT5c96lk70/bVAxN63B71l8VOFtvuJQH9a0="
+  },
+  {
+    "pname": "Humanizer.Core.id",
+    "version": "2.14.1",
+    "hash": "sha256-nIl64gCuZh4D527qI2hfQRvzt1mTJUCDGMIZwpS3C/A="
+  },
+  {
+    "pname": "Humanizer.Core.is",
+    "version": "2.14.1",
+    "hash": "sha256-38vUQ1aVtlhK15kP9ZlDO0Nl0DcOA5iHx6F2SPN1gYM="
+  },
+  {
+    "pname": "Humanizer.Core.it",
+    "version": "2.14.1",
+    "hash": "sha256-4ne0VRNi9OAj3bGCQgCy1BNYKMizoHykJ/lchmCsWdc="
+  },
+  {
+    "pname": "Humanizer.Core.ja",
+    "version": "2.14.1",
+    "hash": "sha256-oAilMM8J6LumV6qv3gSIBNTm7u2L4vV38cQXtME3PhM="
+  },
+  {
+    "pname": "Humanizer.Core.ko-KR",
+    "version": "2.14.1",
+    "hash": "sha256-b70HQl2IWVPATtaYGDyJ+Z6ioPtrM53vXzfTCHYgxpQ="
+  },
+  {
+    "pname": "Humanizer.Core.ku",
+    "version": "2.14.1",
+    "hash": "sha256-8LiEH7MaapMtkHFMj7Y3pG+g0QYuIa5gD3VR9nYQn+k="
+  },
+  {
+    "pname": "Humanizer.Core.lv",
+    "version": "2.14.1",
+    "hash": "sha256-zyCsE5cD++u5shNIqCQUd+66FkUWOl+NfFrs2JduCaQ="
+  },
+  {
+    "pname": "Humanizer.Core.ms-MY",
+    "version": "2.14.1",
+    "hash": "sha256-pSdZLUi9oWo78nBh2DJunPhDR7THdZSZP0msCVbPsrY="
+  },
+  {
+    "pname": "Humanizer.Core.mt",
+    "version": "2.14.1",
+    "hash": "sha256-mkX2reEvNpx9w6gtZw+6bkrnj3Di1qgVDMr9q0IeKCw="
+  },
+  {
+    "pname": "Humanizer.Core.nb",
+    "version": "2.14.1",
+    "hash": "sha256-QvYJHqjO/SrelWYgtm8Sc7axs7J8wbJE+GbTgVw5LYs="
+  },
+  {
+    "pname": "Humanizer.Core.nb-NO",
+    "version": "2.14.1",
+    "hash": "sha256-YW8y2XkmHjwqf2fztNB3rsn3+CgslF1TclITwp0fA9g="
+  },
+  {
+    "pname": "Humanizer.Core.nl",
+    "version": "2.14.1",
+    "hash": "sha256-bQM7aXNQMBY+65NfMVQz/xYz9Ad2JC+ryXoB4lcYgmA="
+  },
+  {
+    "pname": "Humanizer.Core.pl",
+    "version": "2.14.1",
+    "hash": "sha256-IrPxHI4uQvBeMM9/8PaNueKwVkbN+1zFQlNWRjNfXEA="
+  },
+  {
+    "pname": "Humanizer.Core.pt",
+    "version": "2.14.1",
+    "hash": "sha256-XrlC15HNJFmDwLpHIUHb3Bec9A79msQCRB9Dvz8w4l0="
+  },
+  {
+    "pname": "Humanizer.Core.ro",
+    "version": "2.14.1",
+    "hash": "sha256-llXtfq4Tr5V2Q4dVD7J0IKITtpiWrFs50DAtJhcSuRI="
+  },
+  {
+    "pname": "Humanizer.Core.ru",
+    "version": "2.14.1",
+    "hash": "sha256-lD0dB3mkbFfGExwVWZk6fv24MyQQ8Cdv5OrleuZeChg="
+  },
+  {
+    "pname": "Humanizer.Core.sk",
+    "version": "2.14.1",
+    "hash": "sha256-EmyE+wssZwY6tAuEiFXGn5/yzVMZe7QEuTjOcByOXaA="
+  },
+  {
+    "pname": "Humanizer.Core.sl",
+    "version": "2.14.1",
+    "hash": "sha256-sWWxh7KZ8Y3Ps6GbBOHbU2GMsNZfkM+BOnUChf3fz4s="
+  },
+  {
+    "pname": "Humanizer.Core.sr",
+    "version": "2.14.1",
+    "hash": "sha256-/bA3LULRFn5WYmCscr5R5vaFRjeHC0xjNiF7PXEJ8r0="
+  },
+  {
+    "pname": "Humanizer.Core.sr-Latn",
+    "version": "2.14.1",
+    "hash": "sha256-43+o6oj0UNRJKiFoh57MGPSzlsWAq0eRtzlCrewDmVM="
+  },
+  {
+    "pname": "Humanizer.Core.sv",
+    "version": "2.14.1",
+    "hash": "sha256-9lXrHveKDs1y/W3Qxd+MVcohhKEU7zNPx21GBVPp/rA="
+  },
+  {
+    "pname": "Humanizer.Core.th-TH",
+    "version": "2.14.1",
+    "hash": "sha256-ldCsXINSvL2xom0SCtVQy+qX1IN5//EUoyIOwXiJ3k8="
+  },
+  {
+    "pname": "Humanizer.Core.tr",
+    "version": "2.14.1",
+    "hash": "sha256-VZnO1vMXiR7egKEKJ6lBsj7eNgxhFzakFWsYYRW4u2U="
+  },
+  {
+    "pname": "Humanizer.Core.uk",
+    "version": "2.14.1",
+    "hash": "sha256-rdvleUrKbj3c06A0O2MkgAZLtXLro9SPB1YqAGE1Vyg="
+  },
+  {
+    "pname": "Humanizer.Core.uz-Cyrl-UZ",
+    "version": "2.14.1",
+    "hash": "sha256-Qso1Iz9MTLs63x4F00kK31TZAN4AoFaFsuVzM+1z38k="
+  },
+  {
+    "pname": "Humanizer.Core.uz-Latn-UZ",
+    "version": "2.14.1",
+    "hash": "sha256-sVnkZTuEaHfMJIAZmSCqsspnKkYxK9eVBQZnAAqHNW4="
+  },
+  {
+    "pname": "Humanizer.Core.vi",
+    "version": "2.14.1",
+    "hash": "sha256-5wDt72+HdNN3mt/iJkxV9LaH13Jc1qr1vB4Lz8ahIPs="
+  },
+  {
+    "pname": "Humanizer.Core.zh-CN",
+    "version": "2.14.1",
+    "hash": "sha256-Z3qfFWyovcVT4Hqy51lgW2xGwyfI//Yfv90E0Liy1sw="
+  },
+  {
+    "pname": "Humanizer.Core.zh-Hans",
+    "version": "2.14.1",
+    "hash": "sha256-BTGkMEkQYJKRp858EU7hwNOdsHRT+w6vAMa6H8JIyX4="
+  },
+  {
+    "pname": "Humanizer.Core.zh-Hant",
+    "version": "2.14.1",
+    "hash": "sha256-N3D1z5aoGwAZ6+ZxrWMtXgacvQcgDG+aLrQQI9uysmM="
+  },
+  {
+    "pname": "MicroCom.Runtime",
+    "version": "0.11.0",
+    "hash": "sha256-VdwpP5fsclvNqJuppaOvwEwv2ofnAI5ZSz2V+UEdLF0="
+  },
+  {
+    "pname": "Microsoft.CodeAnalysis.Analyzers",
+    "version": "3.3.4",
+    "hash": "sha256-qDzTfZBSCvAUu9gzq2k+LOvh6/eRvJ9++VCNck/ZpnE="
+  },
+  {
+    "pname": "Microsoft.CodeAnalysis.Common",
+    "version": "4.9.2",
+    "hash": "sha256-QU/nyiJWpdPQGHBdaOEVc+AghnGHcKBFBX0oyhRZ9CQ="
+  },
+  {
+    "pname": "Microsoft.CodeAnalysis.CSharp",
+    "version": "4.9.2",
+    "hash": "sha256-j06Q4A9E65075SBXdXVCMRgeLxA63Rv1vxarydmmVAA="
+  },
+  {
+    "pname": "Microsoft.CodeCoverage",
+    "version": "17.14.1",
+    "hash": "sha256-f8QytG8GvRoP47rO2KEmnDLxIpyesaq26TFjDdW40Gs="
+  },
+  {
+    "pname": "Microsoft.DotNet.PlatformAbstractions",
+    "version": "3.1.6",
+    "hash": "sha256-RfM2qXiqdiamPkXr4IDkNc0IZSF9iTZv4uou/E7zNS0="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "8.0.0",
+    "hash": "sha256-75KzEGWjbRELczJpCiJub+ltNUMMbz5A/1KQU+5dgP8="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyModel",
+    "version": "9.0.9",
+    "hash": "sha256-0ygY8JLOIKuYFwwdVCtDl8/8fV5IC9JgivfzXsjXXsI="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "8.0.0",
+    "hash": "sha256-Jmddjeg8U5S+iBTwRlVAVLeIHxc4yrrNgqVMOB7EjM4="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Abstractions",
+    "version": "8.18.0",
+    "hash": "sha256-mkguJA4aXIVVQvSJ9Duq9mivbGXAIkLQp3a8PKy223A="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.JsonWebTokens",
+    "version": "8.18.0",
+    "hash": "sha256-MdqY9CGRs+fTLb3HYYcSfuzqDFo4Dpho4McFWWferjA="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Logging",
+    "version": "8.18.0",
+    "hash": "sha256-09WyYskyL8gjjVDzoZBQAGXgsPmyagWftALSBCdt4gg="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Tokens",
+    "version": "8.18.0",
+    "hash": "sha256-sFhonZW9G6H4ooQ6N/78fkZvADZ2Hf5WAS3FKd/ue1E="
+  },
+  {
+    "pname": "Microsoft.IO.RecyclableMemoryStream",
+    "version": "3.0.1",
+    "hash": "sha256-unFg/5EcU/XKJbob4GtQC43Ydgi5VjeBGs7hfhj4EYo="
+  },
+  {
+    "pname": "Microsoft.NET.Test.Sdk",
+    "version": "17.14.1",
+    "hash": "sha256-mZUzDFvFp7x1nKrcnRd0hhbNu5g8EQYt8SKnRgdhT/A="
+  },
+  {
+    "pname": "Microsoft.NETCore.Platforms",
+    "version": "1.1.0",
+    "hash": "sha256-FeM40ktcObQJk4nMYShB61H/E8B7tIKfl9ObJ0IOcCM="
+  },
+  {
+    "pname": "Microsoft.TestPlatform.ObjectModel",
+    "version": "17.14.1",
+    "hash": "sha256-QMf6O+w0IT+16Mrzo7wn+N20f3L1/mDhs/qjmEo1rYs="
+  },
+  {
+    "pname": "Microsoft.TestPlatform.TestHost",
+    "version": "17.14.1",
+    "hash": "sha256-1cxHWcvHRD7orQ3EEEPPxVGEkTpxom1/zoICC9SInJs="
+  },
+  {
+    "pname": "MsgPack.Cli",
+    "version": "1.0.1",
+    "hash": "sha256-Gf0Ed9XHH4oFpJIkzhg/xhDVpenunSol65qa8IZeYrY="
+  },
+  {
+    "pname": "NetCoreServer",
+    "version": "8.0.7",
+    "hash": "sha256-RUYic8uAgJGdhUCrMJQULKlHB6xvw9H1lnNGU1axNZw="
+  },
+  {
+    "pname": "NETStandard.Library",
+    "version": "2.0.0",
+    "hash": "sha256-Pp7fRylai8JrE1O+9TGfIEJrAOmnWTJRLWE+qJBahK0="
+  },
+  {
+    "pname": "NETStandard.Library",
+    "version": "2.0.3",
+    "hash": "sha256-Prh2RPebz/s8AzHb2sPHg3Jl8s31inv9k+Qxd293ybo="
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "13.0.1",
+    "hash": "sha256-K2tSVW4n4beRPzPu3rlVaBEMdGvWSv/3Q1fxaDh4Mjo="
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "13.0.3",
+    "hash": "sha256-hy/BieY4qxBWVVsDqqOPaLy1QobiIapkbrESm6v2PHc="
+  },
+  {
+    "pname": "NUnit",
+    "version": "3.14.0",
+    "hash": "sha256-CuP/q5HovPWfAW3Cty/QxRi7VpjykJ3TDLq5TENI6KY="
+  },
+  {
+    "pname": "NUnit3TestAdapter",
+    "version": "4.6.0",
+    "hash": "sha256-9Yav2fYhC4w0OgsyUwU4/5rDy4FVDTpKnWHuwl/uKJQ="
+  },
+  {
+    "pname": "Open.NAT.Core",
+    "version": "2.1.0.5",
+    "hash": "sha256-LqG5L2APr11142fsZPQ3clk3tJfAYBMXi1rP0EM9zDg="
+  },
+  {
+    "pname": "OpenTK.Audio.OpenAL",
+    "version": "4.9.4",
+    "hash": "sha256-0W6ZRYmkfLjBbxzFwn/xc+DZ0Al/Z38GhVh6bTiViRQ="
+  },
+  {
+    "pname": "OpenTK.Core",
+    "version": "4.9.4",
+    "hash": "sha256-x6akjBEULMH0mkejjsj83tQOglJ+iQ3XVAKThSSF1CE="
+  },
+  {
+    "pname": "OpenTK.Graphics",
+    "version": "4.9.4",
+    "hash": "sha256-naMNB/Bj5fEBrKTX3tHDd7sXb0WphKTezMmNjQDhhhE="
+  },
+  {
+    "pname": "OpenTK.Mathematics",
+    "version": "4.9.4",
+    "hash": "sha256-rbZ5GckH4mNCCpL8UmU8REMb1CUuO+vbpZME47Cv/ak="
+  },
+  {
+    "pname": "OpenTK.redist.glfw",
+    "version": "3.4.0.44",
+    "hash": "sha256-xQW/0y8lg3HO1fCOVTHBJESfYOViX6YzK6F/LfWGGtU="
+  },
+  {
+    "pname": "OpenTK.Windowing.GraphicsLibraryFramework",
+    "version": "4.9.4",
+    "hash": "sha256-WpUczvbGBTkMn3HR+ansIrzDz8nhtaSZPIDZ9wxrrqw="
+  },
+  {
+    "pname": "Projektanker.Icons.Avalonia",
+    "version": "9.6.2",
+    "hash": "sha256-BMbZQ2Hj80Yxcx8mNZ8+A4fxyB/Sa0QhFX5gC6jAueA="
+  },
+  {
+    "pname": "Projektanker.Icons.Avalonia.FontAwesome",
+    "version": "9.6.2",
+    "hash": "sha256-GumFdzG2GPCxfAU47Qk8a0RI4IlSzSTmRFMJ5ZVFvDg="
+  },
+  {
+    "pname": "Projektanker.Icons.Avalonia.MaterialDesign",
+    "version": "9.6.2",
+    "hash": "sha256-CG4VZDafywR278XwZTosm0sYzJyQ6AGHEQiIDB9y81I="
+  },
+  {
+    "pname": "Ryujinx.Audio.OpenAL",
+    "version": "1.25.1",
+    "hash": "sha256-M1cy3MtbWuZ2pbe5NKe2H9BkapC/vFKdKsNC/wTd3W4="
+  },
+  {
+    "pname": "Ryujinx.Graphics.Nvdec.Dependencies.AllArch",
+    "version": "6.1.4-build6",
+    "hash": "sha256-qfQDaKBMjU/8L2UdmzxmRLOcyo3GFTqj/UISxrbyhBU="
+  },
+  {
+    "pname": "Ryujinx.Graphics.Vulkan.MoltenVK",
+    "version": "1.4.2-ryujinx.3",
+    "hash": "sha256-onBk16LKxb+4xL/QgqXcO1z2CstRC8DnFyBf13IaoZE="
+  },
+  {
+    "pname": "Ryujinx.LibHac",
+    "version": "0.21.0-alpha.133",
+    "hash": "sha256-VUvyMVNo8ZMzXArGDXPXP7jDGKrz+KE73fTvMOFgtjE=",
+    "url": "https://git.ryujinx.app/api/packages/projects/nuget/package/ryujinx.libhac/0.21.0-alpha.133/ryujinx.libhac.0.21.0-alpha.133.nupkg"
+  },
+  {
+    "pname": "Ryujinx.SDL3-CS",
+    "version": "2026.501.0",
+    "hash": "sha256-a7KPEg55dM+9Yc05sjFfMfJWos2+Wg4f/BDnZCBCHk0="
+  },
+  {
+    "pname": "Ryujinx.Systems.Update.Common",
+    "version": "2.0.6",
+    "hash": "sha256-2btWQmCwqJSxISN3N7HdRCbkfSAs4Ph+o8hT+GlySYk="
+  },
+  {
+    "pname": "Ryujinx.UpdateClient",
+    "version": "2.0.6",
+    "hash": "sha256-BNURkQqMopmpQSl33dOTK1ldsHSVVZeg/cP8zc3wvvM="
+  },
+  {
+    "pname": "securifybv.PropertyStore",
+    "version": "0.1.0",
+    "hash": "sha256-jTPT9E2LyElgJq4HMavkdwT8tA9uklnJv00mlIx66+g="
+  },
+  {
+    "pname": "securifybv.ShellLink",
+    "version": "0.1.0",
+    "hash": "sha256-Am+ZednCVJUDgB7TePyY3CTxKDQ6Lr8M8KiCVAJoouw="
+  },
+  {
+    "pname": "Sep",
+    "version": "0.14.1",
+    "hash": "sha256-Ck7tio+lflQpUy1jG8IBd/qHXpAoDqUZGzJHqTJAevk="
+  },
+  {
+    "pname": "SharpCompress",
+    "version": "0.49.1",
+    "hash": "sha256-o2IpO605TKJ2mJLKnxWBHtCFnFJPnRj6zMQJBCGgNGw="
+  },
+  {
+    "pname": "ShimSkiaSharp",
+    "version": "3.7.0",
+    "hash": "sha256-eOrKH8VI4YJTM/d3Yf8A+3JNioIdsDaEOhOUqE9YJJk="
+  },
+  {
+    "pname": "Silk.NET.Core",
+    "version": "2.23.0",
+    "hash": "sha256-LgrnZcux09Vx7JUlfH4+ycJZO5Iv6PSy+5kV+I6owwE="
+  },
+  {
+    "pname": "Silk.NET.Shaderc",
+    "version": "2.23.0",
+    "hash": "sha256-p1wzO9MRwgNLmTzby9fuQ7Zblem7ogb+3H5wtH90plM="
+  },
+  {
+    "pname": "Silk.NET.Shaderc.Native",
+    "version": "2.23.0",
+    "hash": "sha256-UPZ9Xrrv6XvVX5sO7UBE9XySVnXVUQDTWlFxjMq5SL4="
+  },
+  {
+    "pname": "Silk.NET.Vulkan",
+    "version": "2.23.0",
+    "hash": "sha256-bXlKSRPHb4tEZ8hum0gLtzLZuRPHY0iPKfZu5vnk5SE="
+  },
+  {
+    "pname": "Silk.NET.Vulkan.Extensions.EXT",
+    "version": "2.23.0",
+    "hash": "sha256-Nf71k3ZNwGV83yUEcul2HYj/8J7kGeHyWVTRaJ1kCyQ="
+  },
+  {
+    "pname": "Silk.NET.Vulkan.Extensions.KHR",
+    "version": "2.23.0",
+    "hash": "sha256-9kYroJsQohE3EN1Roxp7YeBFuCm3iq4nuS9AINZFMNw="
+  },
+  {
+    "pname": "SkiaSharp",
+    "version": "2.88.9",
+    "hash": "sha256-jZ/4nVXYJtrz9SBf6sYc/s0FxS7ReIYM4kMkrhZS+24="
+  },
+  {
+    "pname": "SkiaSharp.NativeAssets.Linux",
+    "version": "2.88.9",
+    "hash": "sha256-mQ/oBaqRR71WfS66mJCvcc3uKW7CNEHoPN2JilDbw/A="
+  },
+  {
+    "pname": "SkiaSharp.NativeAssets.Linux.NoDependencies",
+    "version": "2.88.9",
+    "hash": "sha256-WjpcM78Q6kaW0eU5iqDR5+fGcF+06/tawWHsJRK57Es="
+  },
+  {
+    "pname": "SkiaSharp.NativeAssets.macOS",
+    "version": "2.88.9",
+    "hash": "sha256-qvGuAmjXGjGKMzOPBvP9VWRVOICSGb7aNVejU0lLe/g="
+  },
+  {
+    "pname": "SkiaSharp.NativeAssets.WebAssembly",
+    "version": "2.88.9",
+    "hash": "sha256-vgFL4Pdy3O1RKBp+T9N3W4nkH9yurZ0suo8u3gPmmhY="
+  },
+  {
+    "pname": "SkiaSharp.NativeAssets.Win32",
+    "version": "2.88.9",
+    "hash": "sha256-kP5XM5GgwHGfNJfe4T2yO5NIZtiF71Ddp0pd1vG5V/4="
+  },
+  {
+    "pname": "SPB",
+    "version": "0.0.4-build32",
+    "hash": "sha256-GUzbV5rLWtXTpiddYrKnWWLujG38vBDCO4xRStwAaDo="
+  },
+  {
+    "pname": "Svg.Controls.Avalonia",
+    "version": "11.3.9.5",
+    "hash": "sha256-vyL61FM3NzuWjJIn/MN/pjCISRufmQYyGd9EyH90Tgk="
+  },
+  {
+    "pname": "Svg.Controls.Skia.Avalonia",
+    "version": "11.3.9.5",
+    "hash": "sha256-RcWFuwer62RsMHKwIFLTaxx5XkIAZXSK6zaEXjv7Bbs="
+  },
+  {
+    "pname": "Svg.Custom",
+    "version": "3.7.0",
+    "hash": "sha256-5CGY4VuLhJXE0P/FlXKtV+A0y1XjpnR+8E0B45HFfLA="
+  },
+  {
+    "pname": "Svg.Model",
+    "version": "3.7.0",
+    "hash": "sha256-AR0iiU8l3km8zjlVpSTM/485wI3Oa5cCi8hZklrGZ7Q="
+  },
+  {
+    "pname": "Svg.Skia",
+    "version": "3.7.0",
+    "hash": "sha256-CrNP9QBR8UE6esmkkbYknQGmfXsJ+1+wqNhdokdyT0g="
+  },
+  {
+    "pname": "System.Buffers",
+    "version": "4.5.1",
+    "hash": "sha256-wws90sfi9M7kuCPWkv1CEYMJtCqx9QB/kj0ymlsNaxI="
+  },
+  {
+    "pname": "System.CodeDom",
+    "version": "4.4.0",
+    "hash": "sha256-L1xyspJ8pDJNVPYKl+FMGf4Zwm0tlqtAyQCNW6pT6/0="
+  },
+  {
+    "pname": "System.Collections.Immutable",
+    "version": "8.0.0",
+    "hash": "sha256-F7OVjKNwpqbUh8lTidbqJWYi476nsq9n+6k0+QVRo3w="
+  },
+  {
+    "pname": "System.IO.Hashing",
+    "version": "9.0.15",
+    "hash": "sha256-7HytH7O+LGVzDsGu+j68kIpTPuPVM0Ts0MyT5J3gIhw="
+  },
+  {
+    "pname": "System.Memory",
+    "version": "4.5.5",
+    "hash": "sha256-EPQ9o1Kin7KzGI5O3U3PUQAZTItSbk9h/i4rViN3WiI="
+  },
+  {
+    "pname": "System.Numerics.Vectors",
+    "version": "4.4.0",
+    "hash": "sha256-auXQK2flL/JpnB/rEcAcUm4vYMCYMEMiWOCAlIaqu2U="
+  },
+  {
+    "pname": "System.Reactive",
+    "version": "6.1.0",
+    "hash": "sha256-zACYoZmKxHo0qKY8FOVa7jIsw7dN7WjdXdRRV95qY2Y="
+  },
+  {
+    "pname": "System.Reflection.Metadata",
+    "version": "8.0.0",
+    "hash": "sha256-dQGC30JauIDWNWXMrSNOJncVa1umR1sijazYwUDdSIE="
+  },
+  {
+    "pname": "System.Runtime.CompilerServices.Unsafe",
+    "version": "4.5.3",
+    "hash": "sha256-lnZMUqRO4RYRUeSO8HSJ9yBHqFHLVbmenwHWkIU20ak="
+  },
+  {
+    "pname": "System.Runtime.CompilerServices.Unsafe",
+    "version": "6.0.0",
+    "hash": "sha256-bEG1PnDp7uKYz/OgLOWs3RWwQSVYm+AnPwVmAmcgp2I="
+  },
+  {
+    "pname": "System.Text.Encoding.CodePages",
+    "version": "8.0.0",
+    "hash": "sha256-fjCLQc1PRW0Ix5IZldg0XKv+J1DqPSfu9pjMyNBp7dE="
+  },
+  {
+    "pname": "System.Threading.Tasks.Extensions",
+    "version": "4.5.4",
+    "hash": "sha256-owSpY8wHlsUXn5xrfYAiu847L6fAKethlvYx97Ri1ng="
+  },
+  {
+    "pname": "Tmds.DBus.Protocol",
+    "version": "0.21.3",
+    "hash": "sha256-HVEIHSeSe29ergHxsNvWYu3o7Ai8VZKo09yFn+miTnI="
+  },
+  {
+    "pname": "UnicornEngine.Unicorn",
+    "version": "2.1.3",
+    "hash": "sha256-0ZOTsR0/VPCbLgJKkXa/0Z9h7iw6RhflW+P23z3nwek="
+  }
+]

--- a/pkgs/by-name/ry/ryubing-canary/package.nix
+++ b/pkgs/by-name/ry/ryubing-canary/package.nix
@@ -1,0 +1,157 @@
+{
+  lib,
+  buildDotnetModule,
+  dotnetCorePackages,
+  fetchFromForgejo,
+  ffmpeg,
+  glew,
+  gtk3,
+  libGL,
+  libgdiplus,
+  libice,
+  libsm,
+  libsoundio,
+  libx11,
+  libxcursor,
+  libxext,
+  libxi,
+  libxrandr,
+  openal,
+  pulseaudio,
+  sndio,
+  SDL2,
+  SDL2_mixer,
+  stdenv,
+  udev,
+  vulkan-loader,
+  wrapGAppsHook3,
+}:
+
+buildDotnetModule rec {
+  pname = "ryubing-canary";
+  version = "1.3.309";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromForgejo {
+    domain = "git.ryujinx.app";
+    owner = "projects";
+    repo = "Ryubing";
+    tag = "Canary-${version}";
+    hash = "sha256-f2J0tlQ7n5hxwoDiS6VSy3+gfoRJZCNDlu5/g/hYPvE=";
+  };
+
+  nativeBuildInputs = [ wrapGAppsHook3 ];
+
+  enableParallelBuilding = false;
+
+  dotnet-sdk = dotnetCorePackages.sdk_10_0;
+  dotnet-runtime = dotnetCorePackages.runtime_10_0;
+
+  nugetDeps = ./deps.json;
+
+  runtimeDeps = [
+    libx11
+    libgdiplus
+    SDL2_mixer
+    openal
+    libsoundio
+    sndio
+    vulkan-loader
+    ffmpeg
+
+    # Avalonia UI
+    glew
+    libice
+    libsm
+    libxcursor
+    libxext
+    libxi
+    libxrandr
+    gtk3
+
+    # Headless executable
+    libGL
+    SDL2
+
+    udev
+    pulseaudio
+  ];
+
+  projectFile = "Ryujinx.sln";
+  testProjectFile = "src/Ryujinx.Tests/Ryujinx.Tests.csproj";
+
+  doCheck = false;
+
+  # Avalonia 11.3 (shipped in canary) requires a default font family to be set
+  # explicitly on Linux; otherwise FontManager throws on startup with
+  # "Default font family name can't be null or empty." Point it at the
+  # JetBrainsMono asset that the project already bundles.
+  postPatch = ''
+    substituteInPlace src/Ryujinx/Program.cs --replace-fail \
+      'AppBuilder.Configure<RyujinxApp>()' \
+      'AppBuilder.Configure<RyujinxApp>().With(new global::Avalonia.Media.FontManagerOptions { DefaultFamilyName = "avares://Ryujinx/Assets/Fonts/Mono/#JetBrains Mono" })'
+  '';
+
+  # MSBuild picks up global properties from the environment. Setting the
+  # property this way instead of via dotnetFlags avoids the %2C escape for
+  # the comma (the /p: parser splits on commas), because a literal % in any
+  # derivation attribute breaks nix-shell on __structuredAttrs derivations
+  # (boost::bad_format_string), which in turn breaks passthru.fetch-deps.
+  env.ExtraDefineConstants = "DISABLE_UPDATER,FORCE_EXTERNAL_BASE_DIR";
+
+  executables = [
+    "Ryujinx"
+  ];
+
+  makeWrapperArgs = [
+    # Without this Ryujinx fails to start on wayland. See https://github.com/Ryujinx/Ryujinx/issues/2714
+    "--set"
+    "SDL_VIDEODRIVER"
+    "x11"
+  ];
+
+  preInstall = ''
+    # workaround for https://github.com/Ryujinx/Ryujinx/issues/2349
+    mkdir -p $out/lib/sndio-6
+    ln -s ${sndio}/lib/libsndio.so $out/lib/sndio-6/libsndio.so.6
+  '';
+
+  preFixup = ''
+    mkdir -p $out/share/{applications,icons/hicolor/256x256/apps,mime/packages}
+
+    pushd ${src}/distribution/linux
+
+    install -D ./app.ryujinx.Ryujinx.desktop $out/share/applications/app.ryujinx.Ryujinx.desktop
+    install -D ./Ryujinx.sh       $out/bin/Ryujinx.sh
+    install -D ./mime/Ryujinx.xml $out/share/mime/packages/Ryujinx.xml
+    install -D ../misc/Logo.png   $out/share/icons/hicolor/256x256/apps/app.ryujinx.Ryujinx.png
+
+    popd
+
+    ln -s $out/bin/Ryujinx $out/bin/ryujinx
+  '';
+
+  passthru.updateScript = ./updater.sh;
+
+  meta = {
+    homepage = "https://ryujinx.app";
+    changelog = "https://git.ryujinx.app/Ryubing/Canary/releases/tag/${version}";
+    description = "Canary build of Ryubing (community Ryujinx fork) tracking the latest in-development commits";
+    longDescription = ''
+      Ryubing is the community-maintained fork of Ryujinx, the Nintendo Switch
+      emulator originally created by gdkchan. The canary branch contains
+      in-progress fixes that are not yet in stable releases (for example, the
+      audio renderer fix required by certain titles). Canary builds are
+      published per-commit; this package pins a specific snapshot.
+    '';
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      jk
+      swofty
+    ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "Ryujinx";
+  };
+}

--- a/pkgs/by-name/ry/ryubing-canary/updater.sh
+++ b/pkgs/by-name/ry/ryubing-canary/updater.sh
@@ -1,0 +1,38 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -I nixpkgs=./. -i bash -p coreutils gnused curl common-updater-scripts nix-prefetch-git jq
+# shellcheck shell=bash
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# If NEW_VERSION or COMMIT are not set, fetch the latest version
+if [ -z ${NEW_VERSION+x} ] && [ -z ${COMMIT+x} ]; then
+    RELEASE_DATA=$(curl -s "https://git.ryujinx.app/api/v1/repos/projects/Ryubing/tags")
+    if [ -z "$RELEASE_DATA" ] || [[ $RELEASE_DATA =~ "imposed ratelimits" ]]; then
+        echo "failed to get release job data" >&2
+        exit 1
+    fi
+    NEW_TAG=$(echo "$RELEASE_DATA" | jq -r '[.[] | select(.name | startswith("Canary-"))][0].name')
+    NEW_VERSION="${NEW_TAG#Canary-}"
+fi
+
+OLD_VERSION="$(sed -nE 's/\s*version = "(.*)".*/\1/p' ./package.nix)"
+
+echo "comparing versions $OLD_VERSION -> $NEW_VERSION"
+if [[ "$OLD_VERSION" == "$NEW_VERSION" ]]; then
+    echo "Already up to date!"
+    if [[ "${1-default}" != "--deps-only" ]]; then
+      exit 0
+    fi
+fi
+
+cd ../../../..
+
+if [[ "${1-default}" != "--deps-only" ]]; then
+    SHA="$(nix-prefetch-git https://git.ryujinx.app/projects/Ryubing --rev "Canary-$NEW_VERSION" --quiet | jq -r '.sha256')"
+    SRI=$(nix --experimental-features nix-command hash to-sri "sha256:$SHA")
+    update-source-version ryubing-canary "$NEW_VERSION" "$SRI"
+fi
+
+echo "building Nuget lockfile"
+
+eval "$(nix-build -A ryubing-canary.fetch-deps --no-out-link)"


### PR DESCRIPTION
## Motivation

This adds `ryubing-canary` as a sibling to the existing `ryubing` package. Ryubing is the community-maintained fork of Ryujinx, the Nintendo Switch emulator. Stable Ryubing releases are tagged and slow-moving (the current `ryubing` package pins 1.3.3), but the project also publishes per-commit canary builds that contain in-progress fixes which have not yet made it into a stable tag. Several of those fixes, notably the audio renderer changes that a number of titles depend on, currently only exist on the canary track.

Adding a separate `-canary` attribute means users can opt into the bleeding edge without us having to constantly retag `ryubing` and disrupt the reproducibility expectations of people who are happy on the stable build. This mirrors the pattern Nixpkgs already uses for other projects with rolling release cadences.

### A few notes on the implementation

The canary builds target .NET 10, so this package uses `dotnetCorePackages.sdk_10_0` and `runtime_10_0` rather than the 9.0 pair the stable package pins.

Avalonia 11.3 ships in canary, and on Linux it now requires an explicit default font family or `FontManager` throws at startup with "Default font family name can't be null or empty." There is a small `postPatch` that wires `AppBuilder.Configure` to use the JetBrains Mono asset the project already bundles. A code comment in `package.nix` explains the reason.

Platforms are restricted to `x86_64-linux` for this initial submission, since that is the surface I can actually exercise. Darwin and aarch64 can be enabled in a follow-up once someone with the hardware verifies them.

## Things done

Built on platform(s):
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin

Other:
- [x] Built locally with sandboxing enabled
- [x] Ran the resulting `Ryujinx` binary and exercised it on a number of titles that crash or hang on the stable `ryubing` build, all of which booted and played correctly on canary
- [ ] NixOS test (none exists for this package family)
- [x] Adheres to [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)

## Maintainership

Adding myself (`swofty`) as the maintainer for this package and happy to keep it current as canary releases land. Not touching the maintainership of the existing stable `ryubing` package.
