### PR TITLE
moxnotify: 0.1.0 -> 0.1.0-unstable-2026-05-09

### DIFF
--- a/pkgs/by-name/mo/moxnotify/package.nix
+++ b/pkgs/by-name/mo/moxnotify/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   rustPlatform,
-  fetchFromGitHub,
+  fetchFromForgejo,
   pkg-config,
   clang,
   libclang,
@@ -17,25 +17,28 @@
   sqlite,
   fontconfig,
   freetype,
+  protobuf,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "moxnotify";
-  version = "0.1.0";
+  version = "0.1.0-unstable-2026-05-09";
 
-  src = fetchFromGitHub {
+  src = fetchFromForgejo {
+    domain = "git.r0chd.pl";
     owner = "mox-desktop";
     repo = "moxnotify";
-    rev = "6726af08621072e0c95a147cf4ae63ea66c7e857";
-    hash = "sha256-tTgY/813WaW3K8QKbj6qwCVKOAA8zMqy97Q7Z5qA0JM=";
+    rev = "bc57c855579631fdd7dd755c8918827fc8405fdd";
+    hash = "sha256-N6pYVU2LPC7Kc9y6gPc+rrWSvXEYJXN/NoCXmzY3uJg=";
   };
 
-  cargoHash = "sha256-o2YyPa7bX9585lsicJjhj1xJ1jMdU5mlxbEn/6zSy8U=";
+  cargoHash = "sha256-de6gM296GMbEntIbsTrQJQWK1SQiZCN8hBS+dqtQJqA=";
 
   nativeBuildInputs = [
     pkg-config
     clang
     makeWrapper
+    protobuf
   ];
 
   buildInputs = [
@@ -65,10 +68,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   # Install both binaries with proper names
   postInstall = ''
-    # Rename binaries to have more descriptive names
-    mv $out/bin/daemon $out/bin/moxnotify
-    mv $out/bin/ctl $out/bin/moxctl
-
     # Install D-Bus service file
     mkdir -p $out/share/dbus-1/services
     substitute ${finalAttrs.src}/pl.mox.notify.service.in $out/share/dbus-1/services/pl.mox.notify.service \
@@ -99,6 +98,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ logger ];
     platforms = lib.platforms.linux; # Wayland-specific, Linux only
-    mainProgram = "moxnotify";
+    mainProgram = "client";
   };
 })


### PR DESCRIPTION
Upstream switched git server hosts.
Resolves #518365


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
