### PR TITLE
maintainers: drop lnl7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15780,12 +15780,6 @@
     githubId = 23727619;
     name = "Luca Ruperto";
   };
-  lnl7 = {
-    email = "daiderd@gmail.com";
-    github = "LnL7";
-    githubId = 689294;
-    name = "Daiderd Jordan";
-  };
   lo1tuma = {
     email = "schreck.mathias@gmail.com";
     github = "lo1tuma";

--- a/nixos/tests/docker-tools-overlay.nix
+++ b/nixos/tests/docker-tools-overlay.nix
@@ -4,7 +4,6 @@
   name = "docker-tools-overlay";
   meta = with pkgs.lib.maintainers; {
     maintainers = [
-      lnl7
       roberth
     ];
   };

--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -91,7 +91,6 @@ in
   name = "docker-tools";
   meta = with pkgs.lib.maintainers; {
     maintainers = [
-      lnl7
       roberth
     ];
   };

--- a/nixos/tests/uwsgi.nix
+++ b/nixos/tests/uwsgi.nix
@@ -1,8 +1,8 @@
 { pkgs, ... }:
 {
   name = "uwsgi";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ lnl7 ];
+  meta = {
+    maintainers = [ ];
   };
 
   nodes.machine =

--- a/nixos/tests/vault-dev.nix
+++ b/nixos/tests/vault-dev.nix
@@ -3,7 +3,6 @@
   name = "vault-dev";
   meta = with pkgs.lib.maintainers; {
     maintainers = [
-      lnl7
       mic92
     ];
   };

--- a/nixos/tests/vault-postgresql.nix
+++ b/nixos/tests/vault-postgresql.nix
@@ -11,7 +11,6 @@
   name = "vault-postgresql";
   meta = with pkgs.lib.maintainers; {
     maintainers = [
-      lnl7
       roberth
     ];
   };

--- a/nixos/tests/vault.nix
+++ b/nixos/tests/vault.nix
@@ -1,8 +1,8 @@
 { pkgs, ... }:
 {
   name = "vault";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ lnl7 ];
+  meta = {
+    maintainers = [ ];
   };
   nodes.machine =
     { pkgs, ... }:

--- a/pkgs/applications/networking/znc/default.nix
+++ b/pkgs/applications/networking/znc/default.nix
@@ -74,8 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Advanced IRC bouncer";
     homepage = "https://wiki.znc.in/ZNC";
-    maintainers = with lib.maintainers; [
-      lnl7
+    maintainers = [
     ];
     license = lib.licenses.asl20;
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/cm/cmake/package.nix
+++ b/pkgs/by-name/cm/cmake/package.nix
@@ -207,7 +207,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
       ttuegel
-      lnl7
     ];
     platforms = lib.platforms.all;
     mainProgram = "cmake";

--- a/pkgs/by-name/cr/crunch/package.nix
+++ b/pkgs/by-name/cr/crunch/package.nix
@@ -34,6 +34,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://sourceforge.net/projects/crunch-wordlist/";
     platforms = lib.platforms.unix;
     license = with lib.licenses; [ gpl2Only ];
-    maintainers = with lib.maintainers; [ lnl7 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/gr/grpc/package.nix
+++ b/pkgs/by-name/gr/grpc/package.nix
@@ -132,7 +132,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "C based gRPC (C++, Python, Ruby, Objective-C, PHP, C#)";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ lnl7 ];
+    maintainers = [ ];
     homepage = "https://grpc.io/";
     platforms = lib.platforms.all;
     changelog = "https://github.com/grpc/grpc/releases/tag/v${finalAttrs.version}";

--- a/pkgs/by-name/ne/newrelic-sysmond/package.nix
+++ b/pkgs/by-name/ne/newrelic-sysmond/package.nix
@@ -26,6 +26,6 @@ stdenv.mkDerivation rec {
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ lnl7 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/pl/plexRaw/package.nix
+++ b/pkgs/by-name/pl/plexRaw/package.nix
@@ -95,7 +95,6 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [
       badmutex
       forkk
-      lnl7
       pjones
       thoughtpolice
       MayNiklas

--- a/pkgs/by-name/py/py-spy/package.nix
+++ b/pkgs/by-name/py/py-spy/package.nix
@@ -43,7 +43,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/benfred/py-spy";
     changelog = "https://github.com/benfred/py-spy/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ lnl7 ];
+    maintainers = [ ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     # https://github.com/benfred/py-spy/pull/330
     broken = stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux;

--- a/pkgs/by-name/re/reattach-to-user-namespace/package.nix
+++ b/pkgs/by-name/re/reattach-to-user-namespace/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Wrapper that provides access to the Mac OS X pasteboard service";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ lnl7 ];
+    maintainers = [ ];
     platforms = lib.platforms.darwin;
   };
 }

--- a/pkgs/by-name/sh/shairport-sync/package.nix
+++ b/pkgs/by-name/sh/shairport-sync/package.nix
@@ -153,7 +153,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     mainProgram = "shairport-sync";
     maintainers = with lib.maintainers; [
-      lnl7
       jordanisaacs
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/sk/skhd/package.nix
+++ b/pkgs/by-name/sk/skhd/package.nix
@@ -38,7 +38,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "skhd";
     maintainers = with lib.maintainers; [
       cmacrae
-      lnl7
       khaneliman
     ];
     platforms = lib.platforms.darwin;

--- a/pkgs/by-name/un/undmg/package.nix
+++ b/pkgs/by-name/un/undmg/package.nix
@@ -41,8 +41,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/matthewbauer/undmg";
     license = lib.licenses.gpl3;
     mainProgram = "undmg";
-    maintainers = with lib.maintainers; [
-      lnl7
+    maintainers = [
     ];
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/va/vault/package.nix
+++ b/pkgs/by-name/va/vault/package.nix
@@ -73,7 +73,6 @@ buildGoModule (finalAttrs: {
     mainProgram = "vault";
     maintainers = with lib.maintainers; [
       rushmorem
-      lnl7
       Chili-Man
       techknowlogick
     ];

--- a/pkgs/by-name/xh/xhyve/package.nix
+++ b/pkgs/by-name/xh/xhyve/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Lightweight Virtualization on macOS Based on bhyve";
     homepage = "https://github.com/mist64/xhyve";
-    maintainers = [ lib.maintainers.lnl7 ];
+    maintainers = [ ];
     license = lib.licenses.bsd2;
     platforms = lib.platforms.darwin;
     # never built on aarch64-darwin since first introduction in nixpkgs

--- a/pkgs/by-name/yc/ycmd/package.nix
+++ b/pkgs/by-name/yc/ycmd/package.nix
@@ -135,7 +135,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/ycm-core/ycmd";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [
-      lnl7
       mel
       S0AndS0
     ];

--- a/pkgs/development/python-modules/distlib/default.nix
+++ b/pkgs/development/python-modules/distlib/default.nix
@@ -40,6 +40,6 @@ buildPythonPackage rec {
     description = "Low-level components of distutils2/packaging";
     homepage = "https://distlib.readthedocs.io";
     license = lib.licenses.psfl;
-    maintainers = with lib.maintainers; [ lnl7 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/mypy-protobuf/default.nix
+++ b/pkgs/development/python-modules/mypy-protobuf/default.nix
@@ -50,6 +50,6 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/nipunn1313/mypy-protobuf";
     license = lib.licenses.asl20;
     mainProgram = "protoc-gen-mypy";
-    maintainers = with lib.maintainers; [ lnl7 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/development/python-modules/mypy/default.nix
+++ b/pkgs/development/python-modules/mypy/default.nix
@@ -139,6 +139,6 @@ buildPythonPackage rec {
     downloadPage = "https://github.com/python/mypy";
     license = lib.licenses.mit;
     mainProgram = "mypy";
-    maintainers = with lib.maintainers; [ lnl7 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/mypy/extensions.nix
+++ b/pkgs/development/python-modules/mypy/extensions.nix
@@ -37,6 +37,6 @@ buildPythonPackage rec {
     description = "Experimental type system extensions for programs checked with the mypy typechecker";
     homepage = "https://www.mypy-lang.org";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ lnl7 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/tools/haskell/vaultenv/default.nix
+++ b/pkgs/development/tools/haskell/vaultenv/default.nix
@@ -86,7 +86,6 @@ mkDerivation rec {
   homepage = "https://github.com/channable/vaultenv#readme";
   description = "Runs processes with secrets from HashiCorp Vault";
   license = lib.licenses.bsd3;
-  maintainers = with lib.maintainers; [
-    lnl7
+  maintainers = [
   ];
 }


### PR DESCRIPTION
No [comments](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+commenter%3ALnL7) since 2021 despite over 500 [review requests](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+created%3A%3E%3D2022-01-01+user-review-requested%3ALnL7). Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/33954594ec46166510795930ba8ebf0856249d4e/maintainers/README.md#losing-maintainer-status).

@LnL7 if you object to being dropped please respond saying so within a week. Even if you don't make it, you are of course welcome back whenever you would like!


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
