### PR TITLE
retroarch-bare: move icon to spec-compliant location

### DIFF
--- a/pkgs/by-name/re/retroarch-bare/package.nix
+++ b/pkgs/by-name/re/retroarch-bare/package.nix
@@ -138,6 +138,10 @@ stdenv.mkDerivation (finalAttrs: {
     + lib.optionalString enableNvidiaCgToolkit ''
       wrapProgram $out/bin/retroarch-cg2glsl \
         --prefix PATH ':' ${lib.makeBinPath [ nvidia_cg_toolkit ]}
+    ''
+    + ''
+      mkdir -p $out/share/icons/hicolor/scalable
+      mv $out/share/{pixmaps,icons/hicolor/scalable/apps}
     '';
 
   preFixup = lib.optionalString (!enableNvidiaCgToolkit) ''


### PR DESCRIPTION
Part of #428824

```console
$ tree /nix/store/9pa7ss62fdjdyz3xf60gljpdiv2958jm-retroarch-bare-1.22.2/
/nix/store/9pa7ss62fdjdyz3xf60gljpdiv2958jm-retroarch-bare-1.22.2/
├── bin
│   └── retroarch
├── etc
│   └── retroarch.cfg
└── share
    ├── applications
    │   └── com.libretro.RetroArch.desktop
    ├── doc
    │   └── retroarch
    │       ├── COPYING
    │       └── README.md
    ├── icons
    │   └── hicolor
    │       └── scalable
    │           └── apps
    │               └── com.libretro.RetroArch.svg
    ├── man
    │   └── man6
    │       └── retroarch.6.gz
    └── metainfo
        └── com.libretro.RetroArch.metainfo.xml

14 directories, 8 files
```

```console
$ l /nix/store/9pa7ss62fdjdyz3xf60gljpdiv2958jm-retroarch-bare-1.22.2/share/icons/hicolor/scalable/apps
total 4.0K
-r--r--r-- 1 root root 2.7K Jan  1  1970 com.libretro.RetroArch.svg
```

<img width="622" height="418" alt="fuzzel" src="https://github.com/user-attachments/assets/3558584a-7d5c-4f43-88fe-07a5bcffe31a" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
