### PR TITLE
lasuite-meet: mark as linux only

### DIFF
--- a/pkgs/by-name/la/lasuite-meet/package.nix
+++ b/pkgs/by-name/la/lasuite-meet/package.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   nixosTests,
   python3,
-  stdenv,
 }:
 let
   version = "1.15.0";
@@ -21,7 +20,7 @@ let
     changelog = "https://github.com/suitenumerique/meet/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ soyouzpanda ];
-    platforms = lib.platforms.all;
+    platforms = lib.platforms.linux;
   };
 
   mail = callPackage ./mail.nix { inherit src version meta; };
@@ -48,16 +47,7 @@ python.pkgs.buildPythonApplication (finalAttrs: {
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail "uv_build>=0.10.9,<0.11.0" "uv_build"
-  ''
-  # Otherwise fails with:
-  # socket.gaierror: [Errno 8] nodename nor servname provided, or not known
-  + (lib.optionalString stdenv.hostPlatform.isDarwin ''
-    substituteInPlace impress/settings.py \
-      --replace-fail \
-        "gethostname()" \
-        "gethostname() + '.local'"
-  '');
-  __darwinAllowLocalNetworking = true;
+  '';
 
   build-system = with python.pkgs; [ uv-build ];
 


### PR DESCRIPTION
Failing Hydra build: https://hydra.nixos.org/build/328928972

Same motivation as for lasuite-docs in
https://github.com/NixOS/nixpkgs/pull/520840#issuecomment-4466658295


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
