### PR TITLE
uhexen2: fix build

### DIFF
--- a/pkgs/by-name/uh/uhexen2/package.nix
+++ b/pkgs/by-name/uh/uhexen2/package.nix
@@ -45,6 +45,8 @@ stdenv.mkDerivation {
     )
   '';
 
+  NIX_CFLAGS_COMPILE = "-std=gnu17";
+
   buildPhase = ''
     runHook preBuild
     for makefile in "''${makeFiles[@]}"; do


### PR DESCRIPTION
#ZurichZHF

uhexen2 isn't C23 conform because it defines its own `true` and `false` values (which have been declared keywords in the latest C standard). This causes build failures with the newest versions of GCC unless one tells the compiler to use an older standard:

```
In file included from ./quakeinc.h:29,
                 from ./quakedef.h:224,
                 from ../h2shared/gl_rlight.c:25:
../../common/q_stdinc.h:128:9: error: cannot use keyword 'false' as enumeration constant
  128 |         false = 0,
      |         ^~~~~
../../common/q_stdinc.h:128:9: note: 'false' is a keyword with '-std=c23' onwards
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test