### PR TITLE
qrupdate: fix test failures on aarch64-linux

### DIFF
--- a/pkgs/by-name/qr/qrupdate/package.nix
+++ b/pkgs/by-name/qr/qrupdate/package.nix
@@ -7,6 +7,7 @@
   which,
   gfortran,
   blas,
+  ctestCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -42,16 +43,6 @@ stdenv.mkDerivation (finalAttrs: {
       "-DBLA_VENDOR=Generic"
     ];
 
-  patches =
-    # https://github.com/mpimd-csc/qrupdate-ng/issues/4
-    lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
-      ./disable-zch1dn-test.patch
-    ]
-    # https://github.com/mpimd-csc/qrupdate-ng/issues/7
-    ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
-      ./disable-aarch64-single-precision-tests.patch
-    ];
-
   postPatch = ''
     sed '/^cmake_minimum_required/Is/VERSION [0-9]\.[0-9]/VERSION 3.5/' -i ./CMakeLists.txt
   '';
@@ -63,10 +54,25 @@ stdenv.mkDerivation (finalAttrs: {
     which
     gfortran
   ];
+
   buildInputs = [
     blas
     lapack
   ];
+
+  nativeCheckInputs = [
+    ctestCheckHook
+  ];
+
+  disabledTests =
+    lib.optionals (stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux) [
+      # https://github.com/mpimd-csc/qrupdate-ng/issues/7
+      "test_tchshx"
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.isx86_64 && stdenv.hostPlatform.isDarwin) [
+      # https://github.com/mpimd-csc/qrupdate-ng/issues/4
+      "test_tch1dn"
+    ];
 
   meta = {
     description = "Library for fast updating of qr and cholesky decompositions";


### PR DESCRIPTION
I think keeping the patch files around is a bit too difficult to maintain.  Instead, I think relying on CTest to skip the tests is a better way forward.  Perhaps it's a bit overeager on which tests it skips, but I think it makes  sense.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
