### PR TITLE
spelling-bee: init at 0.1.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -233,6 +233,12 @@
     github = "3JlOy-PYCCKUi";
     githubId = 46464602;
   };
+  _3nln = {
+    email = "javohirtech@gmail.com";
+    github = "3nln";
+    githubId = 73842170;
+    name = "Javokhir Gulomjonov";
+  };
   _3noch = {
     email = "eacameron@gmail.com";
     github = "3noch";

--- a/pkgs/by-name/sp/spelling-bee/package.nix
+++ b/pkgs/by-name/sp/spelling-bee/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenv,
+  appstream,
+  desktop-file-utils,
+  fetchFromGitHub,
+  gjs,
+  glib,
+  gobject-introspection,
+  gtk4,
+  libadwaita,
+  meson,
+  ninja,
+  nix-update-script,
+  pkg-config,
+  wrapGAppsHook4,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "spelling-bee";
+  version = "0.1.5";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "josephmawa";
+    repo = "SpellingBee";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ZV6N4a67wW41yXCDO7WHq37rdG2W7wFc+9fXEPxn2Lc=";
+  };
+
+  # GJS uses programInvocationName basename to find the gresource files
+  # (`<name>.src.gresource`, `<name>.data.gresource`). wrapGAppsHook4 renames
+  # the wrapped binary to `.<name>-wrapped`, which breaks the lookup.
+  # Override _findEffectiveEntryPointName so the original name is used.
+  postPatch = ''
+    sed -i "/^imports.package.init/i imports.package._findEffectiveEntryPointName = () => 'io.github.josephmawa.SpellingBee';" \
+      src/bin/io.github.josephmawa.SpellingBee.in
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    appstream
+    desktop-file-utils
+    gjs
+    glib
+    gobject-introspection
+    gtk4
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    gjs
+    glib
+    gtk4
+    libadwaita
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Word puzzle game for building English vocabulary";
+    homepage = "https://github.com/josephmawa/SpellingBee";
+    changelog = "https://github.com/josephmawa/SpellingBee/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "io.github.josephmawa.SpellingBee";
+    maintainers = with lib.maintainers; [ _3nln ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Adds [Spelling Bee](https://github.com/josephmawa/SpellingBee), a GJS/GTK4/libadwaita word puzzle game where players create words from a set of given letters to build their English vocabulary. It is published on Flathub as `io.github.josephmawa.SpellingBee`.

Upstream: https://github.com/josephmawa/SpellingBee
Release: https://github.com/josephmawa/SpellingBee/releases/tag/v0.1.5
Flathub: https://flathub.org/apps/io.github.josephmawa.SpellingBee

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of the binary (`./result/bin/io.github.josephmawa.SpellingBee` launches under xvfb without runtime errors).
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.