### PR TITLE
markless: init at 0.9.28

### DIFF
--- a/pkgs/by-name/ma/markless/package.nix
+++ b/pkgs/by-name/ma/markless/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "markless";
+  version = "0.9.29";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "jvanderberg";
+    repo = "markless";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-orjJ++948WEJ031c5Dcvmfyqw2JMRJRjoBsGU+A+B4w=";
+  };
+
+  cargoHash = "sha256-kMMglmIsc3HkCx24Zir3NtZitwrxYwa7FgLgAZ2/ffo=";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Terminal markdown viewer with image support";
+    longDescription = ''
+      Markless is a terminal markdown viewer and editor focused on fast
+      navigation, clear rendering, and sensible defaults for long documents.
+
+      Features include: markdown rendering (headings, lists, tables, block
+      quotes, code blocks, footnotes, task lists), syntax-highlighted code
+      blocks, inline images (Kitty, Sixel, iTerm2, and half-block fallback),
+      Mermaid diagram rendering, LaTeX math via Typst, CSV rendering as
+      tables, binary hex dump, built-in editor mode, directory browse mode,
+      table of contents sidebar, incremental search, file watching for live
+      reload, and auto theme detection.
+    '';
+    homepage = "https://github.com/jvanderberg/markless";
+    changelog = "https://github.com/jvanderberg/markless/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "markless";
+    maintainers = with lib.maintainers; [ fraggerfox ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Import [markless](https://github.com/jvanderberg/markless) into nixpkgs.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
