### PR TITLE
rhvoice: 1.16.5 -> 1.18.4

### DIFF
--- a/pkgs/by-name/rh/rhvoice/cstdint.patch
+++ b/pkgs/by-name/rh/rhvoice/cstdint.patch
@@ -1,0 +1,25 @@
+diff --git a/src/audio/file_playback_stream_impl.hpp b/src/audio/file_playback_stream_impl.hpp
+index 952fc6a..a411934 100644
+--- a/src/audio/file_playback_stream_impl.hpp
++++ b/src/audio/file_playback_stream_impl.hpp
+@@ -18,6 +18,7 @@
+ 
+ #include <string>
+ #include <fstream>
++#include <cstdint>
+ #include "playback_stream_impl.hpp"
+ 
+ namespace RHVoice
+diff --git a/src/audio/playback_stream_impl.hpp b/src/audio/playback_stream_impl.hpp
+index 37c4de3..2506e7f 100644
+--- a/src/audio/playback_stream_impl.hpp
++++ b/src/audio/playback_stream_impl.hpp
+@@ -18,6 +18,8 @@
+ 
+ #include "audio.hpp"
+ 
++#include <cstdint>
++
+ namespace RHVoice
+ {
+   namespace audio

--- a/pkgs/by-name/rh/rhvoice/package.nix
+++ b/pkgs/by-name/rh/rhvoice/package.nix
@@ -13,7 +13,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rhvoice";
-  version = "1.16.5";
+  version = "1.18.4";
 
   src = fetchFromGitHub {
     owner = "RHVoice";

--- a/pkgs/by-name/rh/rhvoice/package.nix
+++ b/pkgs/by-name/rh/rhvoice/package.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
     #     - PKG_CONFIG_PATH, to find available (sound) libraries
     #     - RPATH, to link to the newly built libraries
     ./honor_nix_environment.patch
+    ./cstdint.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

I both fixed the build and updated the version as the current one is at least one year behind by now.

#ZurichZHF