### PR TITLE
reprepro: 5.4.7 -> 5.4.8

### DIFF
--- a/pkgs/by-name/re/reprepro/package.nix
+++ b/pkgs/by-name/re/reprepro/package.nix
@@ -11,18 +11,22 @@
   libarchive,
   xz,
   zlib,
+  gcc14Stdenv,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+let
+  theStdenv = if stdenv.isDarwin then gcc14Stdenv else stdenv;
+in
+theStdenv.mkDerivation (finalAttrs: {
   pname = "reprepro";
-  version = "5.4.7";
+  version = "5.4.8";
 
   src = fetchFromGitLab {
     domain = "salsa.debian.org";
     owner = "debian";
     repo = "reprepro";
     tag = "reprepro-${finalAttrs.version}";
-    hash = "sha256-bGfVWOmcXvaE+t9jiZFrnaUTKVPJqGqbPFyThhKK8gQ=";
+    hash = "sha256-qHqRLWRbSwmpKkUQ8JenUo+CY91EY/h4yHHmq4TacMg=";
   };
 
   buildInputs = [


### PR DESCRIPTION
Update to 5.4.8

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
