### PR TITLE
pcb2gcode: 3.0.2 -> 3.0.4

### DIFF
--- a/pkgs/by-name/pc/pcb2gcode/boost-1.89.patch
+++ b/pkgs/by-name/pc/pcb2gcode/boost-1.89.patch
@@ -1,0 +1,20 @@
+--- a/src/units.hpp
++++ b/src/units.hpp
+@@ -370,7 +370,7 @@
+ }
+ 
+ namespace BoardSide {
+-enum BoardSide {
++enum BoardSide : int {
+   AUTO,
+   FRONT,
+   BACK
+@@ -433,7 +433,7 @@
+ } // namespace Software
+ 
+ namespace MillFeedDirection {
+-enum MillFeedDirection {
++enum MillFeedDirection : int {
+   ANY,
+   CLIMB,
+   CONVENTIONAL

--- a/pkgs/by-name/pc/pcb2gcode/package.nix
+++ b/pkgs/by-name/pc/pcb2gcode/package.nix
@@ -2,47 +2,52 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  autoreconfHook,
+  cmake,
   pkg-config,
   boost,
   glibmm,
   gtkmm2,
   gerbv,
+  geos,
   librsvg,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pcb2gcode";
-  version = "3.0.2";
+  version = "3.0.4";
 
   src = fetchFromGitHub {
     owner = "pcb2gcode";
     repo = "pcb2gcode";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-Vjv80QPrJyEYqHFbXR2n68csAWfCMMmi4NEZYe8/DcY=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-tuVEtynzC9VBBm5tNNkdSr8Rrj3Oy5QOI6jNTmsIXbs=";
   };
 
-  configureFlags = [
-    (lib.withFeatureAs true "boost" boost.dev)
+  patches = [
+    ./boost-1.89.patch
   ];
 
   nativeBuildInputs = [
-    autoreconfHook
+    cmake
     pkg-config
   ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "PCB2GCODE_COMPILE_WARNING_AS_ERROR" false)
+  ];
+
+  preConfigure = lib.optionalString stdenv.isDarwin ''
+    export CXXFLAGS="$CXXFLAGS -fpermissive -Wno-error=c++20-extensions -Wno-error=invalid-constexpr"
+  '';
 
   buildInputs = [
     boost
     glibmm
     gtkmm2
     gerbv
+    geos
     librsvg
   ];
-
-  postPatch = ''
-    substituteInPlace ./Makefile.am \
-    --replace '`git describe --dirty --always --tags`' '${finalAttrs.version}'
-  '';
 
   meta = {
     description = "Command-line tool for isolation, routing and drilling of PCBs";


### PR DESCRIPTION
Update to 3.0.4

Changelog: https://github.com/pcb2gcode/pcb2gcode/compare/v3.0.2...v3.0.4

Add geos dependency, fix build.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
