### PR TITLE
supertuxkart: updates for darwin and app experience

### DIFF
--- a/pkgs/by-name/su/supertuxkart/package.nix
+++ b/pkgs/by-name/su/supertuxkart/package.nix
@@ -23,6 +23,7 @@
   libopenglrecorder,
   sqlite,
   libsamplerate,
+  libsquish,
   shaderc,
   nix-update-script,
   serverOnly ? false,
@@ -68,6 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     mcpp
     angelscript
     sqlite
+    libsquish
   ]
   ++ lib.optionals (!serverOnly) (
     [
@@ -167,16 +169,13 @@ stdenv.mkDerivation (finalAttrs: {
       # archaic Makefiles, too complicated to switch to.
       "irrlicht"
 
-      # Not packaged to this date
-      "libsquish"
-
-      # Not packaged to this date
+      # No USE_SYSTEM_SHEENBIDI flag upstream
       "sheenbidi"
 
-      # Not packaged to this date
+      # No USE_SYSTEM_TINYGETTEXT flag upstream
       "tinygettext"
 
-      # Not packaged to this date (needed on Darwin)
+      # Used on Darwin as a static OpenAL replacement (USE_MOJOAL=ON by default on Apple)
       "mojoal"
     ];
   };

--- a/pkgs/by-name/su/supertuxkart/package.nix
+++ b/pkgs/by-name/su/supertuxkart/package.nix
@@ -24,48 +24,11 @@
   sqlite,
   libsamplerate,
   shaderc,
+  nix-update-script,
   serverOnly ? false,
   nameSuffix ? "",
 }:
-let
-  assets = fetchsvn {
-    url = "https://svn.code.sf.net/p/supertuxkart/code/stk-assets";
-    rev = "18621";
-    sha256 = "sha256-iqQSezGu0tecA53qhrtYA77SLj28WUUCcL4ZCJbK5C8=";
-    name = "stk-assets";
-  };
 
-  # List of bundled libraries in stk-code/lib to keep
-  # Those are the libraries that cannot be replaced
-  # with system packages.
-  bundledLibraries = [
-    # Bullet 2.87 is incompatible (bullet 2.79 needed whereas 2.87 is packaged)
-    # The api changed in a lot of classes, too much work to adapt
-    "bullet"
-    # Upstream Libenet doesn't yet support IPv6,
-    # So we will use the bundled libenet which
-    # has been fixed to support it.
-    "enet"
-    # Internal library of STK, nothing to do about it
-    "graphics_engine"
-    # Internal library of STK, nothing to do about it
-    "graphics_utils"
-    # Internal library.
-    "simd_wrapper"
-    # This irrlicht is bundled with cmake
-    # whereas upstream irrlicht still uses
-    # archaic Makefiles, too complicated to switch to.
-    "irrlicht"
-    # Not packaged to this date
-    "libsquish"
-    # Not packaged to this date
-    "sheenbidi"
-    # Not packaged to this date
-    "tinygettext"
-    # Not packaged to this date (needed on Darwin)
-    "mojoal"
-  ];
-in
 stdenv.mkDerivation (finalAttrs: {
 
   pname = "supertuxkart${nameSuffix}";
@@ -81,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     # Deletes all bundled libs in stk-code/lib except those
     # That couldn't be replaced with system packages
-    find lib -maxdepth 1 -type d | egrep -v "^lib$|${(lib.concatStringsSep "|" bundledLibraries)}" | xargs -n1 -L1 -r -I{} rm -rf {}
+    find lib -maxdepth 1 -type d | egrep -v "^lib$|${(lib.concatStringsSep "|" finalAttrs.passthru.bundledLibraries)}" | xargs -n1 -L1 -r -I{} rm -rf {}
 
     # Allow building with system-installed wiiuse on Darwin
     substituteInPlace CMakeLists.txt \
@@ -152,7 +115,7 @@ stdenv.mkDerivation (finalAttrs: {
   # Obtain the assets directly from the fetched store path, to avoid duplicating assets across multiple engine builds
   preFixup = ''
     wrapProgram $out/bin/supertuxkart \
-      --set-default SUPERTUXKART_ASSETS_DIR "${assets}" \
+      --set-default SUPERTUXKART_ASSETS_DIR "${finalAttrs.passthru.assets}" \
       --set-default SUPERTUXKART_DATADIR "$out/share/supertuxkart"
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
@@ -160,6 +123,57 @@ stdenv.mkDerivation (finalAttrs: {
     cp $out/bin/supertuxkart \
       $out/Applications/SuperTuxKart.app/Contents/MacOS/supertuxkart
   '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+
+    assets = fetchsvn {
+      url = "https://svn.code.sf.net/p/supertuxkart/code/stk-assets";
+      rev = "18621";
+      sha256 = "sha256-iqQSezGu0tecA53qhrtYA77SLj28WUUCcL4ZCJbK5C8=";
+      name = "stk-assets";
+    };
+
+    # List of bundled libraries in stk-code/lib to keep
+    # Those are the libraries that cannot be replaced
+    # with system packages.
+    bundledLibraries = [
+      # Bullet 2.87 is incompatible (bullet 2.79 needed whereas 2.87 is packaged)
+      # The api changed in a lot of classes, too much work to adapt
+      "bullet"
+
+      # Upstream Libenet doesn't yet support IPv6,
+      # So we will use the bundled libenet which
+      # has been fixed to support it.
+      "enet"
+
+      # Internal library of STK, nothing to do about it
+      "graphics_engine"
+
+      # Internal library of STK, nothing to do about it
+      "graphics_utils"
+
+      # Internal library.
+      "simd_wrapper"
+
+      # This irrlicht is bundled with cmake
+      # whereas upstream irrlicht still uses
+      # archaic Makefiles, too complicated to switch to.
+      "irrlicht"
+
+      # Not packaged to this date
+      "libsquish"
+
+      # Not packaged to this date
+      "sheenbidi"
+
+      # Not packaged to this date
+      "tinygettext"
+
+      # Not packaged to this date (needed on Darwin)
+      "mojoal"
+    ];
+  };
 
   meta = {
     description = "3D open-source arcade racer";

--- a/pkgs/by-name/su/supertuxkart/package.nix
+++ b/pkgs/by-name/su/supertuxkart/package.nix
@@ -163,6 +163,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       peterhoeg
+      philocalyst
       SchweGELBin
     ];
     platforms = with lib.platforms; unix;

--- a/pkgs/by-name/su/supertuxkart/package.nix
+++ b/pkgs/by-name/su/supertuxkart/package.nix
@@ -110,10 +110,10 @@ stdenv.mkDerivation (finalAttrs: {
       freetype
       libjpeg
       libpng
-      libx11
       harfbuzz
       wiiuse
     ]
+    ++ lib.optional stdenv.hostPlatform.isLinux libx11
     ++ lib.optional (stdenv.hostPlatform.isWindows || stdenv.hostPlatform.isLinux) libopenglrecorder
     ++ lib.optional stdenv.hostPlatform.isLinux openal
     ++ lib.optional stdenv.hostPlatform.isDarwin libsamplerate
@@ -137,11 +137,16 @@ stdenv.mkDerivation (finalAttrs: {
     "-include stdexcept"
   ];
 
-  # Extract binary from built app bundle
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    mkdir $out/bin
-    mv $out/{supertuxkart.app/Contents/MacOS,bin}/supertuxkart
-    rm -rf $out/supertuxkart.app
+    app=$out/Applications/SuperTuxKart.app
+
+    mkdir -p "$out"/{bin,Applications}
+    mv "$out/supertuxkart.app" "$app"
+
+    cp "$app/Contents/MacOS/supertuxkart" \
+      "$out/bin/supertuxkart"
+    ln -sfn "$out/share/supertuxkart/data" \
+      "$app/Contents/Resources/data"
   '';
 
   # Obtain the assets directly from the fetched store path, to avoid duplicating assets across multiple engine builds
@@ -149,6 +154,11 @@ stdenv.mkDerivation (finalAttrs: {
     wrapProgram $out/bin/supertuxkart \
       --set-default SUPERTUXKART_ASSETS_DIR "${assets}" \
       --set-default SUPERTUXKART_DATADIR "$out/share/supertuxkart"
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # patch the copy inside the app bundle so launching via Finder works.
+    cp $out/bin/supertuxkart \
+      $out/Applications/SuperTuxKart.app/Contents/MacOS/supertuxkart
   '';
 
   meta = {
@@ -166,7 +176,7 @@ stdenv.mkDerivation (finalAttrs: {
       philocalyst
       SchweGELBin
     ];
-    platforms = with lib.platforms; unix;
+    platforms = lib.platforms.all;
     changelog = "https://github.com/supertuxkart/stk-code/blob/${finalAttrs.version}/CHANGELOG.md";
   };
 })

--- a/pkgs/by-name/su/supertuxkart/package.nix
+++ b/pkgs/by-name/su/supertuxkart/package.nix
@@ -44,7 +44,13 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     # Deletes all bundled libs in stk-code/lib except those
     # That couldn't be replaced with system packages
-    find lib -maxdepth 1 -type d | egrep -v "^lib$|${(lib.concatStringsSep "|" finalAttrs.passthru.bundledLibraries)}" | xargs -n1 -L1 -r -I{} rm -rf {}
+    find lib -mindepth 1 -maxdepth 1 -type d \
+      ${
+        lib.concatMapStringsSep " " (
+          name: "-not -name ${lib.escapeShellArg name}"
+        ) finalAttrs.passthru.bundledLibraries
+      } \
+      -exec rm -rf {} +
 
     # Allow building with system-installed wiiuse on Darwin
     substituteInPlace CMakeLists.txt \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- Supertux kart is super awesome!
- I noticed there were a lot of deps that we were bundling that we could have in nixpkgs for future simplifications to this package and encourage a lesser maintainer burden for them. I only was able to get this done for libsquish, but the work for the others is now ready to be used!
- General cleanup and saftey fixes
- Changed platform to all (as it supports.. all)
- Fixes for darwin app bundles and darwin in general

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
