### PR TITLE
python3Packages.prosemble: init at 2.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19116,6 +19116,12 @@
     github = "Naora";
     githubId = 2221163;
   };
+  naotoo1 = {
+    name = "Nana Abeka Otoo";
+    email = "nanaabekaotoo@gmail.com";
+    github = "naotoo1";
+    githubId = 82911284;
+  };
   naphta = {
     github = "naphta";
     githubId = 6709831;

--- a/pkgs/development/python-modules/prosemble/default.nix
+++ b/pkgs/development/python-modules/prosemble/default.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  # Build
+  setuptools,
+  setuptools-scm,
+  # Runtime
+  numpy,
+  scikit-learn,
+  matplotlib,
+  # Optional (JAX)
+  jax,
+  jaxlib,
+  chex,
+  optax,
+  # Tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "prosemble";
+  version = "2.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "naotoo1";
+    repo = "prosemble";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-OpaUPOfiX5fCEOijUTn/o/fpYKy5g54fZzuMX8BKKE4=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    numpy
+    scikit-learn
+    matplotlib
+  ];
+
+  optional-dependencies = {
+    jax = [
+      jax
+      jaxlib
+      chex
+      optax
+    ];
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    jax
+    jaxlib
+    chex
+    optax
+  ];
+
+  disabledTestPaths = [
+    # Requires geomstats which is not packaged
+    "tests/test_riemannian_neural_gas.py"
+  ];
+
+  pythonImportsCheck = [
+    "prosemble"
+    "prosemble.models"
+    "prosemble.core"
+  ];
+
+  meta = {
+    description = "JAX-based prototype machine learning library";
+    homepage = "https://github.com/naotoo1/prosemble";
+    changelog = "https://github.com/naotoo1/prosemble/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ naotoo1 ];
+  };
+})

--- a/pkgs/development/python-modules/prosemble/default.nix
+++ b/pkgs/development/python-modules/prosemble/default.nix
@@ -20,14 +20,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "prosemble";
-  version = "2.2.0";
+  version = "2.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "naotoo1";
     repo = "prosemble";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-296Z1lHBcOVQbkfO7KlNnWe7f7xjbKFHJRfGUPaHKWY=";
+    hash = "sha256-0wqYj3jhYWr/GPM3KCwYBT5sLYxzvopDfpMXmxy2kKM=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/prosemble/default.nix
+++ b/pkgs/development/python-modules/prosemble/default.nix
@@ -20,14 +20,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "prosemble";
-  version = "2.1.0";
+  version = "2.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "naotoo1";
     repo = "prosemble";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-OpaUPOfiX5fCEOijUTn/o/fpYKy5g54fZzuMX8BKKE4=";
+    hash = "sha256-296Z1lHBcOVQbkfO7KlNnWe7f7xjbKFHJRfGUPaHKWY=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/prosemble/default.nix
+++ b/pkgs/development/python-modules/prosemble/default.nix
@@ -20,14 +20,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "prosemble";
-  version = "2.3.0";
+  version = "2.4.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "naotoo1";
     repo = "prosemble";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-0wqYj3jhYWr/GPM3KCwYBT5sLYxzvopDfpMXmxy2kKM=";
+    hash = "sha256-mZ5I4OWatAbE0/fVUefT47NsRnBgonvPUF5oyeV2Dfg=";
   };
 
   build-system = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13059,6 +13059,8 @@ self: super: with self; {
 
   propka = callPackage ../development/python-modules/propka { };
 
+  prosemble = callPackage ../development/python-modules/prosemble { };
+
   prosemirror = callPackage ../development/python-modules/prosemirror { };
 
   protego = callPackage ../development/python-modules/protego { };


### PR DESCRIPTION
## Description

Add prosemble — a JAX-based library for research and application of prototype-based machine learning methods and other interpretable models with GPU acceleration.

- 114 models: supervised classification, one-class novelty detection, unsupervised clustering, topological learning, Riemannian manifold learning, differentiating kernels
- Pure functional JAX with JIT compilation, lax.scan training loops, mixed precision, mini-batch support
- Multi-device data parallelism, gradient checkpointing
- ONNX export for 88/114 models (including reject option support)
- Custom LVQ optimizers, curriculum learning, prototype regularization
- Published on PyPI: https://pypi.org/project/prosemble/2.3.0/
- Supersedes #518865 (accidentally closed by force-push).

## Things done

- [x] Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested via one or more of the following methods
  - [x] Built by nix-build (1522 tests passing, 7 skipped)
  - [x] Package tests at passthru.tests (pytestCheckHook with full test suite)
  - [x] Tested basic functionality of all binary files — N/A (library, no binaries)
  - [x] Tested compilation of all packages that depend on this change using nixpkgs-review
    - No reverse dependencies (new package)
- [x] Ensured that relevant documentation is up to date
- [x] Fits CONTRIBUTING.md
- [x] Added myself to maintainer list

## Notes for reviewers

- Uses fetchFromGitHub as source (per reviewer request on #518865)
- Pure Python package — works on all platforms
- JAX/jaxlib listed as optional dependencies (CPU-only sufficient for tests)
- One test file disabled (test_riemannian_neural_gas.py) due to missing geomstats dependency not yet in nixpkgs