### PR TITLE
aacgain: fix build on darwin and add update script

### DIFF
--- a/pkgs/by-name/aa/aacgain/package.nix
+++ b/pkgs/by-name/aa/aacgain/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
     libtool
   ];
 
-  env.NIX_CFLAGS_COMPILE = "-Wno-error=narrowing";
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=narrowing -DHAVE_GETOPT_H=1";
 
   passthru.updateScript = nix-update-script {
     extraArgs = [ "--version=branch" ];

--- a/pkgs/by-name/aa/aacgain/package.nix
+++ b/pkgs/by-name/aa/aacgain/package.nix
@@ -6,6 +6,7 @@
   autoconf,
   automake,
   libtool,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation {
@@ -28,6 +29,10 @@ stdenv.mkDerivation {
   ];
 
   env.NIX_CFLAGS_COMPILE = "-Wno-error=narrowing";
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
 
   meta = {
     description = "ReplayGain for AAC files";


### PR DESCRIPTION
This PR fixes the build issues on darwin and adds a nix-update script tracking the master branch.

Force using getopt from the provided library instead of the shiped one. The shipped one is an old version that broke builds on darwin.

#ZHFZurich


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
