### PR TITLE
[Backport release-25.11] open-webui: 0.8.12 -> 0.9.5

### DIFF
--- a/pkgs/by-name/op/open-webui/package.nix
+++ b/pkgs/by-name/op/open-webui/package.nix
@@ -9,13 +9,13 @@
 }:
 let
   pname = "open-webui";
-  version = "0.9.1";
+  version = "0.9.2";
 
   src = fetchFromGitHub {
     owner = "open-webui";
     repo = "open-webui";
     tag = "v${version}";
-    hash = "sha256-INUxpLGN+Jn2oYggA9kkp1zGY+LPQNXuRop4DaOi9Ps=";
+    hash = "sha256-NiB8V7B5H57t4NjKlAcQdK1E1dfS3nc/+8tWbSE3MBQ=";
   };
 
   frontend = buildNpmPackage rec {
@@ -32,7 +32,7 @@ let
       url = "https://github.com/pyodide/pyodide/releases/download/${pyodideVersion}/pyodide-${pyodideVersion}.tar.bz2";
     };
 
-    npmDepsHash = "sha256-tn76LGDLRaR87VM0pHgkutsbg4X4Kco04HwgGSS8Uug=";
+    npmDepsHash = "sha256-8bsC6LM+v7RTbhAjGYHKClKoiC/rLhzt+UGVp3CVDB0=";
 
     # See https://github.com/open-webui/open-webui/issues/15880
     npmFlags = [
@@ -99,7 +99,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
       argon2-cffi
       asgiref
       async-timeout
-      asyncpg
       authlib
       azure-ai-documentintelligence
       azure-identity
@@ -109,6 +108,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
       black
       boto3
       brotli
+      brotlicffi
       chardet
       chromadb
       cryptography
@@ -160,6 +160,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
       peewee-migrate
       pillow
       psutil
+      psycopg
       pyarrow
       pycrdt
       pydub
@@ -185,6 +186,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
       sentence-transformers
       sentencepiece
       soundfile
+      sqlalchemy
       starlette-compress
       starsessions
       tiktoken
@@ -194,7 +196,9 @@ python3Packages.buildPythonApplication (finalAttrs: {
       xlrd
       youtube-transcript-api
     ]
+    ++ psycopg.optional-dependencies.c
     ++ pyjwt.optional-dependencies.crypto
+    ++ sqlalchemy.optional-dependencies.asyncio
     ++ starsessions.optional-dependencies.redis;
 
   optional-dependencies = with python3Packages; {
@@ -215,7 +219,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
       azure-search-documents
       colbert-ai
       elasticsearch
-      firecrawl-py
       gcp-storage-emulator
       moto
       oracledb

--- a/pkgs/by-name/op/open-webui/package.nix
+++ b/pkgs/by-name/op/open-webui/package.nix
@@ -9,13 +9,13 @@
 }:
 let
   pname = "open-webui";
-  version = "0.9.4";
+  version = "0.9.5";
 
   src = fetchFromGitHub {
     owner = "open-webui";
     repo = "open-webui";
     tag = "v${version}";
-    hash = "sha256-J0B/N4Bb7lRK4/BiILliy/Gw7FayM3liG+4NiskOq9U=";
+    hash = "sha256-RVmFRThK6dNJyqxKepk9WfxzXIwkRoYijZjR1HEhDm8=";
   };
 
   frontend = buildNpmPackage rec {
@@ -32,7 +32,7 @@ let
       url = "https://github.com/pyodide/pyodide/releases/download/${pyodideVersion}/pyodide-${pyodideVersion}.tar.bz2";
     };
 
-    npmDepsHash = "sha256-jPGSJ+f5xuhnB4E9/FlgQkC37W6Yw2aGh8O8f8ajVC4=";
+    npmDepsHash = "sha256-kAUbFAFNo5RHMGqO7sPHSxSEZw9Ky6Pxp/vddDyw90E=";
 
     # See https://github.com/open-webui/open-webui/issues/15880
     npmFlags = [

--- a/pkgs/by-name/op/open-webui/package.nix
+++ b/pkgs/by-name/op/open-webui/package.nix
@@ -9,13 +9,13 @@
 }:
 let
   pname = "open-webui";
-  version = "0.9.2";
+  version = "0.9.4";
 
   src = fetchFromGitHub {
     owner = "open-webui";
     repo = "open-webui";
     tag = "v${version}";
-    hash = "sha256-NiB8V7B5H57t4NjKlAcQdK1E1dfS3nc/+8tWbSE3MBQ=";
+    hash = "sha256-J0B/N4Bb7lRK4/BiILliy/Gw7FayM3liG+4NiskOq9U=";
   };
 
   frontend = buildNpmPackage rec {
@@ -32,7 +32,7 @@ let
       url = "https://github.com/pyodide/pyodide/releases/download/${pyodideVersion}/pyodide-${pyodideVersion}.tar.bz2";
     };
 
-    npmDepsHash = "sha256-8bsC6LM+v7RTbhAjGYHKClKoiC/rLhzt+UGVp3CVDB0=";
+    npmDepsHash = "sha256-jPGSJ+f5xuhnB4E9/FlgQkC37W6Yw2aGh8O8f8ajVC4=";
 
     # See https://github.com/open-webui/open-webui/issues/15880
     npmFlags = [

--- a/pkgs/by-name/op/open-webui/package.nix
+++ b/pkgs/by-name/op/open-webui/package.nix
@@ -110,6 +110,7 @@ python3Packages.buildPythonApplication rec {
       chardet
       chromadb
       cryptography
+      datasets_3
       ddgs
       docx2txt
       einops

--- a/pkgs/by-name/op/open-webui/package.nix
+++ b/pkgs/by-name/op/open-webui/package.nix
@@ -9,13 +9,13 @@
 }:
 let
   pname = "open-webui";
-  version = "0.8.12";
+  version = "0.9.1";
 
   src = fetchFromGitHub {
     owner = "open-webui";
     repo = "open-webui";
     tag = "v${version}";
-    hash = "sha256-ynWv/X4IBKO09+ira+NUwbzw51MK9aEvGkeaHzCngd0=";
+    hash = "sha256-INUxpLGN+Jn2oYggA9kkp1zGY+LPQNXuRop4DaOi9Ps=";
   };
 
   frontend = buildNpmPackage rec {
@@ -32,7 +32,7 @@ let
       url = "https://github.com/pyodide/pyodide/releases/download/${pyodideVersion}/pyodide-${pyodideVersion}.tar.bz2";
     };
 
-    npmDepsHash = "sha256-UeoU7UGQ+0ViEIjK/Ze7KazB/JCyFYljHyTmxuza4v8=";
+    npmDepsHash = "sha256-tn76LGDLRaR87VM0pHgkutsbg4X4Kco04HwgGSS8Uug=";
 
     # See https://github.com/open-webui/open-webui/issues/15880
     npmFlags = [
@@ -69,7 +69,7 @@ let
     '';
   };
 in
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   inherit pname version src;
   pyproject = true;
 
@@ -92,12 +92,14 @@ python3Packages.buildPythonApplication rec {
       aiocache
       aiofiles
       aiohttp
+      aiosqlite
       alembic
       anthropic
       apscheduler
       argon2-cffi
       asgiref
       async-timeout
+      asyncpg
       authlib
       azure-ai-documentintelligence
       azure-identity
@@ -156,7 +158,6 @@ python3Packages.buildPythonApplication rec {
       pandas
       peewee
       peewee-migrate
-      pgvector
       pillow
       psutil
       pyarrow
@@ -188,7 +189,6 @@ python3Packages.buildPythonApplication rec {
       starsessions
       tiktoken
       transformers
-      unstructured
       uvicorn
       validators
       xlrd
@@ -197,14 +197,18 @@ python3Packages.buildPythonApplication rec {
     ++ pyjwt.optional-dependencies.crypto
     ++ starsessions.optional-dependencies.redis;
 
-  optional-dependencies = with python3Packages; rec {
+  optional-dependencies = with python3Packages; {
     postgres = [
       pgvector
       psycopg2-binary
     ];
 
     mariadb = [
-      python3Packages.mariadb
+      mariadb
+    ];
+
+    unstructured = [
+      unstructured
     ];
 
     all = [
@@ -222,8 +226,9 @@ python3Packages.buildPythonApplication rec {
       qdrant-client
       weaviate-client
     ]
-    ++ mariadb
-    ++ postgres
+    ++ finalAttrs.passthru.optional-dependencies.mariadb
+    ++ finalAttrs.passthru.optional-dependencies.postgres
+    ++ finalAttrs.passthru.optional-dependencies.unstructured
     ++ moto.optional-dependencies.s3;
   };
 
@@ -266,4 +271,4 @@ python3Packages.buildPythonApplication rec {
       codgician
     ];
   };
-}
+})

--- a/pkgs/development/python-modules/datasets/3.nix
+++ b/pkgs/development/python-modules/datasets/3.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  # build-system
+  setuptools,
+
+  # dependencies
+  dill,
+  filelock,
+  fsspec,
+  httpx,
+  huggingface-hub,
+  multiprocess,
+  numpy,
+  pandas,
+  pyarrow,
+  pyyaml,
+  requests,
+  tqdm,
+  xxhash,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "datasets";
+  version = "3.6.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "huggingface";
+    repo = "datasets";
+    tag = finalAttrs.version;
+    hash = "sha256-/xhu0cDKfCEwrp9IzKd0+AeQky1198f9sba/pdutvAk=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    dill
+    filelock
+    fsspec
+    httpx
+    huggingface-hub
+    multiprocess
+    numpy
+    pandas
+    pyarrow
+    pyyaml
+    requests
+    tqdm
+    xxhash
+  ]
+  ++ fsspec.optional-dependencies.http;
+
+  pythonRelaxDeps = [
+    # https://github.com/huggingface/datasets/blob/a256b85cbc67aa3f0e75d32d6586afc507cf535b/setup.py#L117
+    # "pin until dill has official support for determinism"
+    "dill"
+    # https://github.com/huggingface/datasets/blob/4.5.0/setup.py#L127
+    "multiprocess"
+    # https://github.com/huggingface/datasets/blob/4.5.0/setup.py#L130
+    "fsspec"
+  ];
+
+  # Tests require pervasive internet access
+  doCheck = false;
+
+  # Module import will attempt to create a cache directory
+  postFixup = "export HF_MODULES_CACHE=$TMPDIR";
+
+  pythonImportsCheck = [ "datasets" ];
+
+  meta = {
+    description = "Open-access datasets and evaluation metrics for natural language processing";
+    mainProgram = "datasets-cli";
+    homepage = "https://github.com/huggingface/datasets";
+    changelog = "https://github.com/huggingface/datasets/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      osbm
+      malteneuss
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3499,6 +3499,8 @@ self: super: with self; {
 
   datasets = callPackage ../development/python-modules/datasets { };
 
+  datasets_3 = callPackage ../development/python-modules/datasets/3.nix { };
+
   datasette = callPackage ../development/python-modules/datasette { };
 
   datasette-publish-fly = callPackage ../development/python-modules/datasette-publish-fly { };


### PR DESCRIPTION
Manual backport of open-webui `0.8.12 -> 0.9.5` to `release-25.11`. Cannot be performed via the backport bot because the structural refactor (`rec` → `finalAttrs`) was skipped at backport time (release-25.11 did not yet support the `finalAttrs:` argument form for `buildPythonApplication`), so the chain of master PRs no longer applies cleanly. The release branch now supports `finalAttrs:` ([`pkgs/development/interpreters/python/mk-python-derivation.nix:122-123`](https://github.com/NixOS/nixpkgs/blob/release-25.11/pkgs/development/interpreters/python/mk-python-derivation.nix#L122-L123)), making the bump feasible.

Each commit on this branch is a `-x` cherry-pick of a single commit that landed on `master` through a PR, so the chain mirrors master's `open-webui` history one-for-one:

| Commit | Master PR | Master commit |
|---|---|---|
| `python3Packages.datasets_3: init at 3.6.0` | [#509699] | `b1775fcb` |
| `open-webui: Add datasets_3 dependency local transformers text-to-speech (TTS)` | [#509699] | `b13c4240` |
| `open-webui: 0.8.12 -> 0.9.1` | [#512099] | `ea18c327` |
| `open-webui: 0.9.1 -> 0.9.2` | [#513297] | `ba2918e3` |
| `open-webui: 0.9.2 -> 0.9.4` | [#518569] | `be503645` |
| `open-webui: 0.9.4 -> 0.9.5` | [#519425] | `ec1841e7` |

The only manual conflict resolution was in the `0.8.12 -> 0.9.1` cherry-pick, where the `rec` → `finalAttrs` refactor's context lines collided with the previously-cherry-picked `datasets_3` dep addition; resolved by adopting the master `0.9.1` file state and re-inserting the `datasets_3` line that `b13c4240` had already added. After the chain finishes, `pkgs/by-name/op/open-webui/package.nix`, `pkgs/by-name/op/open-webui/update.sh`, and `pkgs/development/python-modules/datasets/3.nix` are **byte-for-byte identical to `master`**.

[#509699]: https://github.com/NixOS/nixpkgs/pull/509699
[#512099]: https://github.com/NixOS/nixpkgs/pull/512099
[#513297]: https://github.com/NixOS/nixpkgs/pull/513297
[#518569]: https://github.com/NixOS/nixpkgs/pull/518569
[#519425]: https://github.com/NixOS/nixpkgs/pull/519425

## Fixes

This backport resolves the following open-webui security-tracker issues, all patched in `<= 0.9.5`: fixes #520811, fixes #520812, fixes #520813, fixes #520814, fixes #520815, fixes #520817, fixes #520818, fixes #520819, fixes #520820, fixes #520821, fixes #520822, fixes #520823, fixes #520824, fixes #520825, fixes #520826, fixes #520827, fixes #520828, fixes #520829, fixes #520830, fixes #520831, fixes #520833, fixes #520834, fixes #520835, fixes #520836, fixes #520837, fixes #520838, fixes #520841, fixes #520843, fixes #520844, fixes #520845, fixes #520848, fixes #520849, fixes #520850, fixes #520851, fixes #520852, fixes #520855, and fixes #520856.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests]. 
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/` — `open-webui --help` returns 0 and shows the expected `main`/`serve`/`dev` subcommands.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc @shivaraj-bh
