### PR TITLE
librsvg: fix gdk-pixbuf SVG loader on Darwin (fixes inkscape)

### DIFF
--- a/pkgs/by-name/li/librsvg/package.nix
+++ b/pkgs/by-name/li/librsvg/package.nix
@@ -156,12 +156,31 @@ stdenv.mkDerivation (finalAttrs: {
     let
       emulator = stdenv.hostPlatform.emulator buildPackages;
     in
-    lib.optionalString withPixbufLoader ''
-      # Merge gdkpixbuf and librsvg loaders
-      GDK_PIXBUF=$out/${gdk-pixbuf.binaryDir}
-      cat ${lib.getLib gdk-pixbuf}/${gdk-pixbuf.binaryDir}/loaders.cache $GDK_PIXBUF/loaders.cache > $GDK_PIXBUF/loaders.cache.tmp
-      mv $GDK_PIXBUF/loaders.cache.tmp $GDK_PIXBUF/loaders.cache
-    ''
+    lib.optionalString withPixbufLoader (
+      lib.optionalString stdenv.hostPlatform.isDarwin ''
+        # meson installs the SVG loader as a .dylib with a stale @rpath/build-dir
+        # install_name, and gdk-pixbuf-query-loaders only scans *.so — so the
+        # generated cache silently has no SVG entry on Darwin. Mirror the
+        # workaround in gdk-pixbuf's package.nix: patch the binary, rename it
+        # to .so, then regenerate librsvg's cache before merging it.
+        for f in $out/${gdk-pixbuf.binaryDir}/loaders/*.dylib; do
+          install_name_tool \
+            -id $f \
+            -change @rpath/librsvg-2.2.dylib $out/lib/librsvg-2.2.dylib \
+            $f
+          mv $f ''${f%.dylib}.so
+        done
+        GDK_PIXBUF_MODULEDIR=$out/${gdk-pixbuf.binaryDir}/loaders \
+          ${emulator} ${lib.getDev gdk-pixbuf}/bin/gdk-pixbuf-query-loaders \
+          > $out/${gdk-pixbuf.binaryDir}/loaders.cache
+      ''
+      + ''
+        # Merge gdkpixbuf and librsvg loaders
+        GDK_PIXBUF=$out/${gdk-pixbuf.binaryDir}
+        cat ${lib.getLib gdk-pixbuf}/${gdk-pixbuf.binaryDir}/loaders.cache $GDK_PIXBUF/loaders.cache > $GDK_PIXBUF/loaders.cache.tmp
+        mv $GDK_PIXBUF/loaders.cache.tmp $GDK_PIXBUF/loaders.cache
+      ''
+    )
     + lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) ''
       installShellCompletion --cmd rsvg-convert \
         --bash <(${emulator} $out/bin/rsvg-convert --completion bash) \


### PR DESCRIPTION
Fixes #383860

I tried to get inkscape working on darwin and was fiddling with the themes. Eventually I asked Claude, who found the problem in a few minutes.

The reason why inkscape crashes with an error message about the icon is not tha the icon is missing (not any more, at least) but that the librsvg library used to load the icon was broken on darwin, and hence the image was "missing".
gdk-pixbuf famiously only loads .so files, even on darwin which otherwise commonly uses .dylib. Upstream librsvg still produces a .dylib library, which the packagers then need to rename. There has been discussions upstream about fixing this, but until they do, we need a workaround.

Mirror the workaround in gdk-pixbuf's own derivation: patch the binary, rename to .so, then regenerate the cache before merging.

This fix:
 - does not affect using librsvg without gdk-pixbuf
 - when loading through gdk-pixbuf on darwin, it was broken before and should work with this fix

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
