### PR TITLE
gprojector: 3.1.0 -> 3.4.7, add updateScript, add mainProgram

### DIFF
--- a/pkgs/by-name/gp/gprojector/package.nix
+++ b/pkgs/by-name/gp/gprojector/package.nix
@@ -1,21 +1,22 @@
 {
   stdenvNoCC,
   lib,
-  fetchzip,
+  fetchurl,
   jre,
   makeDesktopItem,
   copyDesktopItems,
   makeWrapper,
+  writeScript,
   extraJavaArgs ? "-Xms512M -Xmx2000M",
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "gprojector";
-  version = "3.1.0";
+  version = "3.4.7";
 
-  src = fetchzip {
-    url = "https://www.giss.nasa.gov/tools/gprojector/download/G.ProjectorJ-${version}.tgz";
-    sha256 = "sha256-cMmjyitetXxQzfSBh5ry5tIsLWOnBaaYOD1eQg1IX+w=";
+  src = fetchurl {
+    url = "https://www.giss.nasa.gov/tools/gprojector/download/G.ProjectorJ-${finalAttrs.version}.tgz";
+    hash = "sha256-DOpRS1oJTWmakkZhR50QDb2BI5MJKQMdVLOTVeQzv7Q=";
   };
 
   desktopItems = [
@@ -23,7 +24,7 @@ stdenvNoCC.mkDerivation rec {
       name = "gprojector";
       exec = "gprojector";
       desktopName = "G.Projector";
-      comment = meta.description;
+      comment = finalAttrs.meta.description;
       categories = [ "Science" ];
       startupWMClass = "gov-nasa-giss-projector-GProjector";
     })
@@ -42,17 +43,27 @@ stdenvNoCC.mkDerivation rec {
   installPhase = ''
     runHook preInstall
     mkdir -p $out/share
-    cp -r $src/jars $out/share/java
+    cp -r ./jars $out/share/java
     makeWrapper ${jre}/bin/java $out/bin/gprojector --add-flags "-jar $out/share/java/G.Projector.jar" --add-flags "${extraJavaArgs}"
     runHook postInstall
+  '';
+
+  passthru.updateScript = writeScript "update-${finalAttrs.pname}" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p common-updater-scripts
+    version="$(list-directory-versions --pname 'G.ProjectorJ' \
+      --url https://www.giss.nasa.gov/tools/gprojector/download/ \
+      | sort -V | tail -n1)"
+    update-source-version ${finalAttrs.pname} "$version"
   '';
 
   meta = {
     description = "G.Projector transforms an input map image into any of about 200 global and regional map projections";
     homepage = "https://www.giss.nasa.gov/tools/gprojector/";
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    mainProgram = "gprojector";
     maintainers = with lib.maintainers; [ pentane ];
     license = lib.licenses.unfree;
     inherit (jre.meta) platforms;
   };
-}
+})


### PR DESCRIPTION
unbreaks the package since the old source is not available anymore

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
