### PR TITLE
libopcodes_2_38: fix `gcc-15` build

### DIFF
--- a/pkgs/development/tools/misc/binutils/2.38/default.nix
+++ b/pkgs/development/tools/misc/binutils/2.38/default.nix
@@ -8,6 +8,7 @@
   buildPackages,
   fetchFromGitHub,
   fetchurl,
+  fetchpatch,
   flex,
   gettext,
   lib,
@@ -84,6 +85,15 @@ stdenv.mkDerivation {
     # https://sourceware.org/git/?p=binutils-gdb.git;a=patch;h=99852365513266afdd793289813e8e565186c9e6
     # https://github.com/NixOS/nixpkgs/issues/170946
     ./deterministic-temp-prefixes.patch
+
+    # Fix gcc-15 build:
+    # https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff;h=8ebe62f3f0d27806b1bf69f301f5e188b4acd2b4
+    (fetchpatch {
+      name = "gcc-15.patch";
+      url = "https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff_plain;h=8ebe62f3f0d27806b1bf69f301f5e188b4acd2b4";
+      hash = "sha256-Od0PXWKoo9rKhveZ1rWJsdpS17fgmU2AevcVWXvWkSA=";
+      excludes = [ "opcodes/s390-opc.c" ];
+    })
   ]
   ++ lib.optional targetPlatform.isiOS ./support-ios.patch
   ++ lib.optional stdenv.targetPlatform.isWindows ./windres-locate-gcc.patch


### PR DESCRIPTION
Without the change the build fails on `master` as https://hydra.nixos.org/build/327027927:

```
mips-opc.c: In function 'decode_mips_operand':
mips-formats.h:86:7: error: expected identifier or '(' before 'static_assert'
   86 |       static_assert[(1 << (SIZE)) == ARRAY_SIZE (MAP)]; \
      |       ^~~~~~~~~~~~~
```

Apply upstream fix to get it built.

ZHF: #516381


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
