### PR TITLE
acgtk: fix build on darwin and add update-script

### DIFF
--- a/pkgs/by-name/ac/acgtk/package.nix
+++ b/pkgs/by-name/ac/acgtk/package.nix
@@ -3,8 +3,10 @@
   stdenv,
   fetchFromGitLab,
   ocamlPackages,
+  darwin,
   dune,
   nix-update-script,
+  writableTmpDirAsHomeHook,
 }:
 
 stdenv.mkDerivation {
@@ -22,12 +24,16 @@ stdenv.mkDerivation {
 
   strictDeps = true;
 
-  nativeBuildInputs = with ocamlPackages; [
-    dune
-    findlib
-    menhir
-    ocaml
-  ];
+  nativeBuildInputs =
+    with ocamlPackages;
+    [
+      dune
+      findlib
+      menhir
+      ocaml
+      writableTmpDirAsHomeHook
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.sigtool ];
 
   buildInputs = with ocamlPackages; [
     ansiterminal

--- a/pkgs/by-name/ac/acgtk/package.nix
+++ b/pkgs/by-name/ac/acgtk/package.nix
@@ -2,9 +2,9 @@
   lib,
   stdenv,
   fetchFromGitLab,
-  fetchpatch,
   ocamlPackages,
   dune,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation {
@@ -53,6 +53,13 @@ stdenv.mkDerivation {
   installPhase = ''
     dune install -p acgtk --prefix $out --libdir $OCAMLFIND_DESTDIR
   '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^release-(\\d+\\.\\d+\\.\\d+)$"
+    ];
+  };
 
   meta = {
     homepage = "https://acg.loria.fr/";


### PR DESCRIPTION
This PR adds support for writing cache to the home directory during builds and provides macOS code signing capabilities.

#ZHFZurich

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
