### PR TITLE
ronin: fix build

### DIFF
--- a/pkgs/by-name/ro/ronin/package.nix
+++ b/pkgs/by-name/ro/ronin/package.nix
@@ -26,7 +26,7 @@ bundlerEnv rec {
 
   postBuild = ''
     shopt -s extglob
-    rm $out/bin/!(ronin*)
+    rm -f $out/bin/!(ronin*)
   '';
 
   passthru.updateScript = bundlerUpdateScript "ronin";


### PR DESCRIPTION
#ZurichZHF

~The build of `ronin` currently fails because the postBuild script attempts to delete any binaries starting with a bang (!), but the current build produces no such binaries:~

(Edit: Correction; see comments below) The build of `ronin` currently fails because the postBuild script attempts to delete any binaries not starting with `ronin`, but the current build produces no such binaries:

```
structuredAttrs is enabled
created 326 symlinks in user environment
rm: missing operand
Try 'rm --help' for more information.
```

I can't really judge if this will remain true in the future, which is why I decided to re-write the postBuild script to tolerate zero existing `!*` binaries for now; if this is not a concern any longer, we should be able to get rid of the postBuild entirely in the future.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
