### PR TITLE
dockerTools.buildLayeredImage: fix configureFlags syntax in nixosTests example «layered image with files owned by a user other than root»

### DIFF
--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -704,7 +704,7 @@ rec {
           finalAttrs: prevAttrs: {
             # A unique `hello` to make sure that it isn't included via another mechanism by accident.
             configureFlags = prevAttrs.configureFlags or [ ] ++ [
-              " --program-prefix=layeredImageWithFakeRootCommands-"
+              "--program-prefix=layeredImageWithFakeRootCommands-"
             ];
             doCheck = false;
             versionCheckProgram = "${placeholder "out"}/bin/${finalAttrs.meta.mainProgram}";


### PR DESCRIPTION
The string added to `configureFlags` for building `hello` for nixosTests example «layered image with files owned by a user other than root» had a leading space, leading to error

    configure flags: --disable-dependency-tracking --prefix=/nix/store/kwdkh22lfr3irggg076jpydbk1556iax-hello-2.12.3 \ --program-prefix=layeredImageWithFakeRootCommands-
    configure: error: invalid variable name: ' --program-prefix'

when running `./configure` for that custom `hello`, making `nixosTests.allDrivers.docker-tools` fail.

(Fix developed at the #ZurichZHF Hackathon 26.05 :technologist:)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
