### PR TITLE
argo-workflows: 3.6.10 -> 4.0.5

### DIFF
--- a/pkgs/by-name/ar/argo-workflows/package.nix
+++ b/pkgs/by-name/ar/argo-workflows/package.nix
@@ -9,16 +9,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "argo-workflows";
-  version = "3.6.10";
+  version = "4.0.5";
 
   src = fetchFromGitHub {
     owner = "argoproj";
     repo = "argo-workflows";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-TM/eK8biMxKV4SFJ1Lys+NPPeaHVjbBo83k2RH1Xi40=";
+    hash = "sha256-UmkUFuYFeuyqgdf/ByZkkulkVRregp53bvcyyEKgZQo=";
   };
 
-  vendorHash = "sha256-Y/2+ykzcJdA5uwP1v9Z1wZtF3hBV2x7XZc7+FhPJP64=";
+  vendorHash = "sha256-UTBM1zd+HrC5bUadn0VSsO52HhqdPGzZwipQv7WOrNU=";
 
   doCheck = false;
 
@@ -30,14 +30,19 @@ buildGoModule (finalAttrs: {
     installShellFiles
   ];
 
+  preBuild = ''
+    mkdir -p ui/dist/app
+    echo "Built without static files" > ui/dist/app/index.html
+  '';
+
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/argoproj/argo-workflows/v3.buildDate=unknown"
-    "-X github.com/argoproj/argo-workflows/v3.gitCommit=${finalAttrs.src.rev}"
-    "-X github.com/argoproj/argo-workflows/v3.gitTag=${finalAttrs.src.rev}"
-    "-X github.com/argoproj/argo-workflows/v3.gitTreeState=clean"
-    "-X github.com/argoproj/argo-workflows/v3.version=${finalAttrs.version}"
+    "-X github.com/argoproj/argo-workflows/v4.buildDate=unknown"
+    "-X github.com/argoproj/argo-workflows/v4.gitCommit=${finalAttrs.src.rev}"
+    "-X github.com/argoproj/argo-workflows/v4.gitTag=${finalAttrs.src.rev}"
+    "-X github.com/argoproj/argo-workflows/v4.gitTreeState=clean"
+    "-X github.com/argoproj/argo-workflows/v4.version=${finalAttrs.version}"
   ];
 
   postInstall = ''

--- a/pkgs/by-name/ar/argo-workflows/package.nix
+++ b/pkgs/by-name/ar/argo-workflows/package.nix
@@ -9,16 +9,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "argo-workflows";
-  version = "3.6.10";
+  version = "4.0.5";
 
   src = fetchFromGitHub {
     owner = "argoproj";
     repo = "argo-workflows";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-TM/eK8biMxKV4SFJ1Lys+NPPeaHVjbBo83k2RH1Xi40=";
+    hash = "sha256-UmkUFuYFeuyqgdf/ByZkkulkVRregp53bvcyyEKgZQo=";
   };
 
-  vendorHash = "sha256-Y/2+ykzcJdA5uwP1v9Z1wZtF3hBV2x7XZc7+FhPJP64=";
+  vendorHash = "sha256-UTBM1zd+HrC5bUadn0VSsO52HhqdPGzZwipQv7WOrNU=";
 
   doCheck = false;
 
@@ -30,14 +30,23 @@ buildGoModule (finalAttrs: {
     installShellFiles
   ];
 
+  preBuild = ''
+    mkdir -p ui/dist/app
+    # This build target could act as a web server, but this is just
+    # acting as a CLI.
+    # Provide a dummy UI file to allow the build to embed something
+    # without actually building the web content
+    echo "Built without static files" > ui/dist/app/index.html
+  '';
+
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/argoproj/argo-workflows/v3.buildDate=unknown"
-    "-X github.com/argoproj/argo-workflows/v3.gitCommit=${finalAttrs.src.rev}"
-    "-X github.com/argoproj/argo-workflows/v3.gitTag=${finalAttrs.src.rev}"
-    "-X github.com/argoproj/argo-workflows/v3.gitTreeState=clean"
-    "-X github.com/argoproj/argo-workflows/v3.version=${finalAttrs.version}"
+    "-X github.com/argoproj/argo-workflows/v4.buildDate=unknown"
+    "-X github.com/argoproj/argo-workflows/v4.gitCommit=${finalAttrs.src.rev}"
+    "-X github.com/argoproj/argo-workflows/v4.gitTag=${finalAttrs.src.rev}"
+    "-X github.com/argoproj/argo-workflows/v4.gitTreeState=clean"
+    "-X github.com/argoproj/argo-workflows/v4.version=${finalAttrs.version}"
   ];
 
   postInstall = ''

--- a/pkgs/by-name/ar/argo-workflows/staticfiles.go.mod
+++ b/pkgs/by-name/ar/argo-workflows/staticfiles.go.mod
@@ -1,3 +1,0 @@
-module bou.ke/staticfiles
-
-go 1.18


### PR DESCRIPTION
Update argo-workflows CLI tool from 3.6 (which is out of support) to the latest version, 4.0.5

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
