### PR TITLE
es: 0.9.2 -> 0.10.0

### DIFF
--- a/pkgs/by-name/es/es/package.nix
+++ b/pkgs/by-name/es/es/package.nix
@@ -5,36 +5,24 @@
   fetchurl,
   readline,
   bison,
+  autoreconfHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
 
   pname = "es";
-  version = "0.9.2";
+  version = "0.10.0";
 
   src = fetchurl {
     url = "https://github.com/wryun/es-shell/releases/download/v${finalAttrs.version}/es-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-ySZIK0IITpA+uHHuHrDO/Ana5vGt64QI3Z6TMDXE9d0=";
+    sha256 = "sha256-VR7Al0gi7Agee5+O55N0xidmym3NscaFqY79w+bbxLk=";
   };
 
-  # The distribution tarball does not have a single top-level directory.
-  preUnpack = ''
-    mkdir $name
-    cd $name
-    sourceRoot=.
-  '';
-
-  patches = [
-    (fetchpatch {
-      # https://github.com/wryun/es-shell/pull/101
-      name = "new-compiler-issues.patch";
-      url = "https://github.com/wryun/es-shell/commit/1eafb5fc4be735e59c9a091cc30adbca8f86fd96.patch";
-      hash = "sha256-0CV1seEiH6PsUnq0akPLiRMy+kIb9qnAK7Ta4I47i60=";
-    })
-  ];
-
   strictDeps = true;
-  nativeBuildInputs = [ bison ];
+  nativeBuildInputs = [
+    bison
+    autoreconfHook
+  ];
   buildInputs = [ readline ];
 
   configureFlags = [ "--with-readline" ];


### PR DESCRIPTION
ZHF #516381
Failing Hydra build: https://hydra.nixos.org/build/326790858#tabs-summary

ChangeLog: https://github.com/wryun/es-shell/releases/tag/v0.10.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
