### PR TITLE
loganalyzer: Fix output binary on darwin

### DIFF
--- a/pkgs/development/tools/loganalyzer/default.nix
+++ b/pkgs/development/tools/loganalyzer/default.nix
@@ -41,9 +41,17 @@ stdenv.mkDerivation rec {
 
   installFlags = [ "INSTALL_ROOT=$(out)" ];
 
-  postInstall = ''
-    ln -s $out/bin/LogAnalyzer $out/bin/loganalyzer
-  '';
+  postInstall =
+    let
+      outBin =
+        if stdenv.hostPlatform.isDarwin then
+          "LogAnalyzer.app/Contents/MacOS/LogAnalyzer"
+        else
+          "LogAnalyzer";
+    in
+    ''
+      ln -s $out/bin/${outBin} $out/bin/loganalyzer
+    '';
 
   meta = {
     description = "Tool that helps you to analyze your log files by reducing the content with patterns you define";


### PR DESCRIPTION
On darwin, the loganalyzer build produces a LogAnalyzer.app directory in $out. The actual binary is nested in there and needs to be linked out.

#ZurichZHF

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
