### PR TITLE
swiftformat: add package test

### DIFF
--- a/pkgs/by-name/sw/swiftformat/package.nix
+++ b/pkgs/by-name/sw/swiftformat/package.nix
@@ -1,20 +1,21 @@
 {
   lib,
   fetchFromGitHub,
+  runCommand,
   swift,
   swiftpm,
   versionCheckHook,
   nix-update-script,
 }:
 
-swift.stdenv.mkDerivation rec {
+swift.stdenv.mkDerivation (finalAttrs: {
   pname = "swiftformat";
   version = "0.61.1";
 
   src = fetchFromGitHub {
     owner = "nicklockwood";
     repo = "SwiftFormat";
-    rev = version;
+    rev = finalAttrs.version;
     sha256 = "sha256-h0d/vdoKZuYJkMO+TmFFgomaSVA94P+MKclSlBlIleE=";
   };
 
@@ -34,6 +35,37 @@ swift.stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = nix-update-script { };
+
+    tests.format =
+      runCommand "swiftformat-test-format"
+        {
+          nativeBuildInputs = [ finalAttrs.finalPackage ];
+        }
+        ''
+          export CACHE_DIR=$(mktemp -d)
+          printf "class Test{\nvar a:Int=1;;\n}" > test.swift
+          swiftformat --cache $CACHE_DIR --swiftversion 5.8 --indent 2 test.swift 2> stderr.txt
+
+          grep -Fxq "Running SwiftFormat..." stderr.txt
+          grep -Fxq "1/1 files formatted." stderr.txt
+
+          cat > expected.swift <<'EOF'
+          class Test {
+            var a: Int = 1
+          }
+          EOF
+
+          cmp expected.swift test.swift
+
+          swiftformat --cache $CACHE_DIR --swiftversion 5.8 --indent 2 test.swift 2> stderr.txt
+
+          grep -Fxq "Running SwiftFormat..." stderr.txt
+          grep -Fxq "0/1 files formatted." stderr.txt
+
+          cmp expected.swift test.swift
+
+          touch $out
+        '';
   };
 
   meta = {
@@ -46,4 +78,4 @@ swift.stdenv.mkDerivation rec {
     ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
-}
+})


### PR DESCRIPTION
## Things done

Added an integration test to ensure binary is working

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
