### PR TITLE
rlottie: fix build on darwin

### DIFF
--- a/pkgs/by-name/rl/rlottie/package.nix
+++ b/pkgs/by-name/rl/rlottie/package.nix
@@ -25,6 +25,11 @@ stdenv.mkDerivation {
     pkg-config
   ];
 
+  patches = [
+    # rename format to run-clang-format to avoid conflict
+    ./rename_format_to_run-clang-format.patch
+  ];
+
   env.NIX_CFLAGS_COMPILE = lib.optionalString (
     stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64
   ) "-U__ARM_NEON__";

--- a/pkgs/by-name/rl/rlottie/rename_format_to_run-clang-format.patch
+++ b/pkgs/by-name/rl/rlottie/rename_format_to_run-clang-format.patch
@@ -1,0 +1,16 @@
+From c949a713c36cd7a5cf95dd0d07a5660c0204ce0d Mon Sep 17 00:00:00 2001
+From: Mathis Antony <sveitser@gmail.com>
+Date: Sat, 16 May 2026 14:35:08 +0200
+Subject: [PATCH] rename format to run-clang-format
+
+- `format` conflicts with the C++ <format> header
+- fixes: https://hydra.nixos.org/build/327171293/nixlog/1
+---
+ format => run-clang-format | 0
+ 1 file changed, 0 insertions(+), 0 deletions(-)
+ rename format => run-clang-format (100%)
+
+diff --git a/format b/run-clang-format
+similarity index 100%
+rename from format
+rename to run-clang-format


### PR DESCRIPTION
Conflict due to use of `format` as file name. 

Upstream fix: https://github.com/Samsung/rlottie/pull/590

ZHF: https://github.com/NixOS/nixpkgs/issues/516381

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
