### PR TITLE
pcem: fix build due to C23 checks

### DIFF
--- a/pkgs/by-name/pc/pcem/package.nix
+++ b/pkgs/by-name/pc/pcem/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional withALSA "--enable-alsa";
 
   # Fix GCC 14 build
-  env.NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration -Wno-error=incompatible-pointer-types";
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration -Wno-error=incompatible-pointer-types -std=gnu17";
 
   meta = {
     description = "Emulator for IBM PC computers and clones";


### PR DESCRIPTION
#ZurichZHF

`pcem` does not build with C23 settings because of an underspecified argument list for a function pointer:

```
[...]
disc.c: In function 'disc_stop':
disc.c:286:17: error: too many arguments to function 'drives[drive].stop'; expected 0, have 1
  286 |                 drives[drive].stop(drive);
      |                 ^~~~~~             ~~~~~
In file included from disc.c:4:
disc.h:9:16: note: declared here
    9 |         void (*stop)();
      |                ^~~~
make[1]: *** [Makefile:2455: pcem-disc.o] Error 1
make[1]: Leaving directory '/build/source/src'
make: *** [Makefile:373: all-recursive] Error 1
```

Switching to `-std=gcc17` fixes this for now. I suspect future releases of `pcem` will fix this at some point, but this hasn't happened yet [^1].

[^1]: https://github.com/sarah-walker-pcem/pcem/blob/d674c4088e04a5fdc74e452c4d5284fa8920726d/includes/private/disc/disc.h#L10


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
