### PR TITLE
build-support/cmake: set system name for Android

### DIFF
--- a/pkgs/build-support/lib/cmake.nix
+++ b/pkgs/build-support/lib/cmake.nix
@@ -1,22 +1,20 @@
 { stdenv, lib }:
 
 let
-  inherit (lib)
-    findFirst
-    isString
-    optional
-    optionals
-    ;
+  inherit (lib) optionals;
+  systemName =
+    platform:
+    with platform;
+    if isCygwin then
+      "CYGWIN"
+    else if isRedox then
+      "Generic"
+    else
+      uname.system;
 
   cmakeFlags' = optionals (stdenv.hostPlatform != stdenv.buildPlatform) (
     [
-      "-DCMAKE_SYSTEM_NAME=${
-        findFirst isString "Generic" (
-          # uname -s is CYGWIN_NT[...] on cygwin, but cmake expects CYGWIN
-          optional (stdenv.hostPlatform.isCygwin) "CYGWIN"
-          ++ optional (!stdenv.hostPlatform.isRedox) stdenv.hostPlatform.uname.system
-        )
-      }"
+      "-DCMAKE_SYSTEM_NAME=${systemName stdenv.hostPlatform}"
     ]
     ++ optionals (stdenv.hostPlatform.uname.processor != null) [
       "-DCMAKE_SYSTEM_PROCESSOR=${stdenv.hostPlatform.uname.processor}"

--- a/pkgs/build-support/lib/cmake.nix
+++ b/pkgs/build-support/lib/cmake.nix
@@ -7,6 +7,8 @@ let
     with platform;
     if isCygwin then
       "CYGWIN"
+    else if isAndroid then
+      "Android"
     else if isRedox then
       "Generic"
     else
@@ -21,6 +23,13 @@ let
     ]
     ++ optionals (stdenv.hostPlatform.uname.release != null) [
       "-DCMAKE_SYSTEM_VERSION=${stdenv.hostPlatform.uname.release}"
+    ]
+    ++ optionals (stdenv.hostPlatform.uname.release == null && stdenv.hostPlatform.isAndroid) [
+      # This setting is for "Commonly used Android toolchain files that
+      # pre-date CMake upstream support" and disables CMake's way of
+      # interfering with them. Here we use it to prevent CMake from
+      # interefering with Nix's way of setting up androidsdk environments
+      "-DCMAKE_SYSTEM_VERSION=1"
     ]
     ++ optionals (stdenv.hostPlatform.isDarwin) [
       "-DCMAKE_OSX_ARCHITECTURES=${stdenv.hostPlatform.darwinArch}"


### PR DESCRIPTION
- **build-support/cmake: set system name for Android**

cmake has support for Android that is separate from Linux. This change makes
packages built using nix targeting android use this. This is especially
required for tooling which expects the unversioned shared object naming
convention used on Android.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
