### PR TITLE
age-plugin-fido2prf: fix darwin build by patching hardcoded Homebrew paths

### DIFF
--- a/pkgs/by-name/ag/age-plugin-fido2prf/package.nix
+++ b/pkgs/by-name/ag/age-plugin-fido2prf/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   libfido2,
@@ -25,6 +26,24 @@ buildGoModule (finalAttrs: {
   ];
 
   buildInputs = [ libfido2 ];
+
+  postConfigure = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    chmod -R +w vendor/github.com/keys-pub/go-libfido2
+    substituteInPlace vendor/github.com/keys-pub/go-libfido2/fido2_static_arm64.go \
+      --replace-fail \
+        '/opt/homebrew/opt/libfido2/lib/libfido2.a /opt/homebrew/opt/openssl@3/lib/libcrypto.a ''${SRCDIR}/darwin/arm64/lib/libcbor.a' \
+        '-lfido2' \
+      --replace-fail \
+        '-I/opt/homebrew/opt/libfido2/include -I/opt/homebrew/opt/openssl@3/include' \
+        '-I${libfido2.dev}/include'
+    substituteInPlace vendor/github.com/keys-pub/go-libfido2/fido2_static_amd64.go \
+      --replace-fail \
+        '/usr/local/lib/libfido2.a /usr/local/opt/openssl@3/lib/libcrypto.a ''${SRCDIR}/darwin/amd64/lib/libcbor.a' \
+        '-lfido2' \
+      --replace-fail \
+        '-I/usr/local/opt/libfido2/include -I/usr/local/opt/openssl@3/include' \
+        '-I${libfido2.dev}/include'
+  '';
 
   meta = {
     description = "Age plugin to encrypt files with FIDO2 tokens in a way compatible to typage";


### PR DESCRIPTION
#ZHFZurich

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
