### PR TITLE
python3Packages.dask-ml: fix build with pytest 9 and sklearn 1.8

### DIFF
--- a/pkgs/development/python-modules/dask-ml/default.nix
+++ b/pkgs/development/python-modules/dask-ml/default.nix
@@ -36,6 +36,12 @@ buildPythonPackage rec {
     hash = "sha256-DHxx0LFuJmGWYuG/WGHj+a5XHAEekBmlHUUb90rl2IY=";
   };
 
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'addopts = "-rsx -v --durations=10 --color=yes"' \
+                     'addopts = ["-rsx", "-v", "--durations=10", "--color=yes"]'
+  '';
+
   build-system = [
     hatch-vcs
     hatchling
@@ -74,6 +80,10 @@ buildPythonPackage rec {
     "tests/model_selection/test_incremental.py"
     "tests/model_selection/test_incremental_warns.py"
     "tests/model_selection/test_successive_halving.py"
+
+    # MockClassifier predates sklearn 1.6 __sklearn_tags__
+    "tests/model_selection/dask_searchcv/test_model_selection.py"
+    "tests/model_selection/dask_searchcv/test_model_selection_sklearn.py"
   ];
 
   disabledTests = [
@@ -89,6 +99,28 @@ buildPythonPackage rec {
     "test_lr_score"
     "test_ok"
     "test_scoring_string"
+
+    # sklearn 1.7+: PCA / IncrementalPCA missing power_iteration_normalizer
+    "test_pca_randomized_solver"
+    "test_pca_check_projection"
+    "test_pca_inverse"
+    "test_pca_score"
+    "test_pca_score2"
+    "test_randomized_pca_check_projection"
+    "test_randomized_pca_inverse"
+    "test_pca_int_dtype_upcast_to_double"
+    "test_incremental_pca"
+    "test_incremental_pca_against_pca_iris"
+    "test_incremental_pca_against_pca_random_data"
+    "test_singular_values"
+    "test_whitening"
+
+    # sklearn 1.8 API drift in LogisticRegression/ParallelPostFit
+    "test_predict"
+    "test_multiclass"
+
+    # XPASS becomes failure under xfail_strict (now honored on pytest 9)
+    "test_soft_voting_frame"
   ];
 
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327136087)](https://hydra.nixos.org/build/327136087)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
