### PR TITLE
python3Packages.cloudevents: skip pydantic v1 tests on python 3.14

### DIFF
--- a/pkgs/development/python-modules/cloudevents/default.nix
+++ b/pkgs/development/python-modules/cloudevents/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonAtLeast,
   setuptools,
   deprecation,
   flask,
@@ -39,7 +40,15 @@ buildPythonPackage (finalAttrs: {
     sanic-testing
   ];
 
-  disabledTestPaths = [ "samples/http-image-cloudevents/image_sample_test.py" ];
+  disabledTestPaths = [
+    "samples/http-image-cloudevents/image_sample_test.py"
+  ]
+  # pydantic v1 doesn't work on python 3.14
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    "cloudevents/tests/test_pydantic_cloudevent.py"
+    "cloudevents/tests/test_pydantic_conversions.py"
+    "cloudevents/tests/test_pydantic_events.py"
+  ];
 
   __darwinAllowLocalNetworking = true;
 


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327134886)](https://hydra.nixos.org/build/327134886)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
