### PR TITLE
storj-uplink: 1.142.7 -> 1.153.2

### DIFF
--- a/pkgs/by-name/st/storj-uplink/package.nix
+++ b/pkgs/by-name/st/storj-uplink/package.nix
@@ -6,20 +6,28 @@
 
 buildGoModule (finalAttrs: {
   pname = "storj-uplink";
-  version = "1.142.7";
+  version = "1.153.2";
 
   src = fetchFromGitHub {
     owner = "storj";
     repo = "storj";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Y0pnketYzKC7xzndIceFk7dwyUwSjMzvvJF1EqSSD7s=";
+    hash = "sha256-Wk8oYlwhTPGETie0t6adzkyq5lcshWjyaKXzLsMVrho=";
   };
 
   subPackages = [ "cmd/uplink" ];
 
-  vendorHash = "sha256-sdLobkctLiehei9J2vxc/IH3whGeqxq6T+AadrIuPRs=";
+  vendorHash = "sha256-yKqUus5dcE2k588E8xKMIwcdQnmocuDmFh3wcue0IwA=";
 
-  ldflags = [ "-s" ];
+  ldflags = [
+    "-s"
+    "-X storj.io/common/version.buildVersion=v${finalAttrs.version}"
+    "-X storj.io/common/version.buildRelease=true"
+  ];
+
+  checkFlags = [
+    "-skip=TestMove"
+  ];
 
   # Tests fail with 'listen tcp 127.0.0.1:0: bind: operation not permitted'.
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
Update to 1.153.2

Set correct version and skip the move tests that fail in the sandbox.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
