### PR TITLE
berglas: 2.0.12 -> 2.0.13

### DIFF
--- a/pkgs/by-name/be/berglas/package.nix
+++ b/pkgs/by-name/be/berglas/package.nix
@@ -35,16 +35,16 @@ in
 
 buildGoModule (finalAttrs: {
   pname = "berglas";
-  version = "2.0.12";
+  version = "2.0.13";
 
   src = fetchFromGitHub {
     owner = "GoogleCloudPlatform";
     repo = "berglas";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-4Y53psmHpe1JmTKfvOS5f0VHCp/GuC4kDWiHWl5ty3Q=";
+    sha256 = "sha256-p+HWZCyFouy+FycCPesKLV7UIeMogz9oKX+mynzBTKw";
   };
 
-  vendorHash = "sha256-Bz+4hlT5ZqpDnquGirooyFMG8FNUU2NO60Ih3Et3Y3o=";
+  vendorHash = "sha256-Bz+4hlT5ZqpDnquGirooyFMG8FNUU2NO60Ih3Et3Y3o";
 
   ldflags = [
     "-s"
@@ -52,7 +52,12 @@ buildGoModule (finalAttrs: {
     "-X github.com/GoogleCloudPlatform/berglas/v2/internal/version.version=${finalAttrs.version}"
   ];
 
-  postPatch = skipTestsCommand;
+  postPatch = skipTestsCommand + ''
+    substituteInPlace go.mod \
+              --replace-fail \
+                "go 1.26.3" \
+                "go 1.26"
+  '';
 
   passthru.tests = {
     version = testers.testVersion {


### PR DESCRIPTION
Update to 2.0.13

Upstream just updates go to 1.26.3 which we patch back to 1.26 (the available version in nix) - so the update is basically a no-op, but enables future automatic updates.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
