### PR TITLE
speedify: 15.8.2-12611 -> 16.7.0-12929

### DIFF
--- a/pkgs/by-name/sp/speedify/package.nix
+++ b/pkgs/by-name/sp/speedify/package.nix
@@ -3,17 +3,18 @@
   stdenv,
   dpkg,
   fetchurl,
-  procps,
-  net-tools,
+  libgcc,
+  libnetfilter_conntrack,
   autoPatchelfHook,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "speedify";
-  version = "15.8.2-12611";
+  # Find latest version within https://apt.connectify.me/dists/speedify/main/binary-amd64/Packages.gz
+  version = "16.7.0-12928";
 
   src = fetchurl {
     url = "https://apt.connectify.me/pool/main/s/speedify/speedify_${finalAttrs.version}_amd64.deb";
-    hash = "sha256-61GQZkXBe3EQpOUODpL60SCHJO0FGqvpL9xFn+q+kPs=";
+    hash = "sha256-A77LYBGLAgoRFV64/ZmpTL76NQx6xHq0a7leDYi9Izg=";
   };
 
   nativeBuildInputs = [
@@ -22,8 +23,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    procps
-    net-tools
+    libgcc
+    libnetfilter_conntrack
   ];
 
   installPhase = ''


### PR DESCRIPTION
Closes #520939
Left some extra instructions on how to find the newest .deb version as I struggled with it.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
