### PR TITLE
nixos/unifi: pass Java version via passthru

### DIFF
--- a/nixos/modules/services/networking/unifi.nix
+++ b/nixos/modules/services/networking/unifi.nix
@@ -4,6 +4,7 @@
   lib,
   pkgs,
   utils,
+  jdk25_headless,
   ...
 }:
 let
@@ -29,21 +30,16 @@ let
   );
 in
 {
-
   options = {
+    services.unifi.enable = lib.mkEnableOption "UniFi controller service";
 
-    services.unifi.enable = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
+    services.unifi.jrePackage = lib.mkOption {
+      type = lib.types.package;
+      default = cfg.unifiPackage.passthru.jrePackage or jdk25_headless;
+      defaultText = lib.literalExpression "unifiPackage.passthru.jrePackage";
+
       description = ''
-        Whether or not to enable the unifi controller service.
-      '';
-    };
-
-    services.unifi.jrePackage = lib.mkPackageOption pkgs "jdk" {
-      default = "jdk25_headless";
-      extraDescription = ''
-        Check the UniFi controller release notes to ensure it is supported.
+        Which Java runtime to use.
       '';
     };
 
@@ -56,6 +52,7 @@ in
     services.unifi.openFirewall = lib.mkOption {
       type = lib.types.bool;
       default = false;
+
       description = ''
         Whether or not to open the minimum required ports on the firewall.
 
@@ -69,6 +66,7 @@ in
       type = with lib.types; nullOr int;
       default = null;
       example = 1024;
+
       description = ''
         Set the initial heap size for the JVM in MB. If this option isn't set, the
         JVM will decide this value at runtime.
@@ -79,6 +77,7 @@ in
       type = with lib.types; nullOr int;
       default = null;
       example = 4096;
+
       description = ''
         Set the maximum heap size for the JVM in MB. If this option isn't set, the
         JVM will decide this value at runtime.
@@ -89,15 +88,14 @@ in
       type = with lib.types; listOf str;
       default = [ ];
       example = lib.literalExpression ''["-Xlog:gc"]'';
+
       description = ''
         Set extra options to pass to the JVM.
       '';
     };
-
   };
 
   config = lib.mkIf cfg.enable {
-
     assertions = [
       {
         assertion =
@@ -128,16 +126,18 @@ in
       description = "UniFi controller daemon user";
       home = "${stateDir}";
     };
+
     users.groups.unifi = { };
 
+    # https://help.ubnt.com/hc/en-us/articles/218506997
     networking.firewall = lib.mkIf cfg.openFirewall {
-      # https://help.ubnt.com/hc/en-us/articles/218506997
       allowedTCPPorts = [
         8080 # Port for UAP to inform controller.
         8880 # Port for HTTP portal redirect, if guest portal is enabled.
         8843 # Port for HTTPS portal redirect, ditto.
         6789 # Port for UniFi mobile speed test.
       ];
+
       allowedUDPPorts = [
         3478 # UDP port used for STUN.
         10001 # UDP port used for device discovery.
@@ -151,6 +151,7 @@ in
 
       # This a HACK to fix missing dependencies of dynamic libs extracted from jars
       environment.LD_LIBRARY_PATH = with pkgs.stdenv; "${cc.cc.lib}/lib";
+
       # Make sure package upgrades trigger a service restart
       restartTriggers = [
         cfg.unifiPackage
@@ -220,12 +221,13 @@ in
 
         # Needs network access
         PrivateNetwork = false;
+
         # Cannot be true due to OpenJDK
         MemoryDenyWriteExecute = false;
       };
     };
-
   };
+
   imports = [
     (lib.mkRemovedOptionModule [
       "services"

--- a/pkgs/by-name/un/unifi/package.nix
+++ b/pkgs/by-name/un/unifi/package.nix
@@ -6,13 +6,17 @@
   nixosTests,
   systemd,
   autoPatchelfHook,
+  jdk25_headless,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "unifi-controller";
   version = "10.2.105";
 
-  # see https://community.ui.com/releases / https://www.ui.com/download/unifi
+  # See https://community.ui.com/releases or https://www.ui.com/download/unifi.
+  #
+  # When upgrading, make sure we don't need to bump `passthru.jrePackage` below
+  # as well.
   src = fetchurl {
     url = "https://dl.ui.com/unifi/${finalAttrs.version}/unifi_sysvinit_all.deb";
     hash = "sha256-MBTFxNwrIbx6UKZYCcZ+BjYjSlfdxL60Ogei/ba4O+U=";
@@ -36,7 +40,13 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.tests = { inherit (nixosTests) unifi; };
+  passthru = {
+    jrePackage = jdk25_headless;
+
+    tests = {
+      inherit (nixosTests) unifi;
+    };
+  };
 
   meta = {
     homepage = "https://www.ui.com";


### PR DESCRIPTION
UniFi works with a specific Java version and currently this version is defined in a different place than UniFi package itself: JDK gets defined only as a part of the UniFi service, in `nixos/modules/services/networking/unifi.nix`.

This commit moves UniFi service's `jrePackage` to `unifi.passthru.jrePackage` - thanks to this:

- it's clearer we might have to upgrade `jrePackage` when UniFi's package gets upgraded,
- when you overwrite  `services.unifi.unifiPackage`, the module will automatically pull the correct version of JDK (at least from now on 😄, ofc. - for nixpkgs before this change we'll fall back to `jdk25_headless`).

Closes #516063.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
