### PR TITLE
pokefinder: 4.3.1 -> 4.3.2

### DIFF
--- a/pkgs/by-name/po/pokefinder/package.nix
+++ b/pkgs/by-name/po/pokefinder/package.nix
@@ -13,19 +13,45 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pokefinder";
-  version = "4.3.1";
+  version = "4.3.2";
 
   src = fetchFromGitHub {
     owner = "Admiral-Fish";
     repo = "PokeFinder";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-tItPvA0f2HnY7SUSnb7A5jGwbRs7eQoS4vibBomZ9pw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-viObYX9W1bUzwGyf7rI1gQeB9OHlLfj5Uny0js/1f6M=";
     fetchSubmodules = true;
   };
 
   patches = [
     ./set-desktop-file-name.patch
   ];
+
+  postPatch = ''
+        substituteInPlace CMakeLists.txt \
+          --replace-fail 'set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64")' ""
+        substituteInPlace Core/CMakeLists.txt \
+          --replace-fail 'if (APPLE)' 'if (FALSE)'
+        substituteInPlace Core/RNG/SHA1.cpp \
+          --replace-fail '#include "SHA1.hpp"' '#include "SHA1.hpp"
+    #include <algorithm>'
+
+        mkdir -p Core/Resources/compression
+        touch Core/Resources/compression/__init__.py
+        cat <<EOF > Core/Resources/compression/zstd.py
+    import zstandard as zstd
+
+    def compress(data, level=3):
+        cctx = zstd.ZstdCompressor(level=level)
+        return cctx.compress(data)
+
+    def decompress(data):
+        dctx = zstd.ZstdDecompressor()
+        return dctx.decompress(data)
+    EOF
+  '';
+
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isAarch "-flax-vector-conversions";
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
Update to 4.3.2

Upstream changelog:
```
Additions:

Added context menu to transfer settings between Generator and Searchers (thanks @SteveCookTU)
Added context menu to copy/paste IVs (thanks @SteveCookTU)
Added ability to duplicate profiles in the manager
Added Feebas to Gen 8 Wild
Changes:

Disabled unnecessary filters in Dream Radar and Hidden Grotto
Improved season selection for Gen 5 Wild
Improved filters to warn user where invalid selections
Removed soft reset from Gen 5 initial seeding
Updated Italian translations (thanks @Real96)
Updated Chinese translations (thanks @HaKu76)
Bugs:

Fix issue where Gen 4 fishing encounter slots could be wrong (thanks @Real96)
Fix issue where Munchlax trees could be wrong (thanks @Real96)
Fix issue where Hidden Grotto could have incorrect PIDs
Fix issue where extremely large cache files would crash the program
Fix issue where Dream Radar could have incorrect natures
Fix issue where Gen 5 static egg encounters would have incorrect IVs
Fix issue where Show Stats checkbox wasn't working properly
Fix issue where certain cache files would cause the program to freeze
Fix issue where certain shadow lock entries were incorrect
Fix issue where "None" wouldn't stay at the top of specific combo boxes in different languages
Fix issue where certain progress bars wouldn't update properly
Fix issue where TID/SID and TID/PID filters for IDs wouldn't filter as expected
Fix issue with incorrectly checking for Feebas tiles giving mismatch between Generator and Searcher
Fix issue where cache searching was sometimes capped to low advance numbers
Fix issue where Gen 5 Eggs were off by 2 advances
Fix issue where Gen 8 Wild could have the wrong encounter types
Fix issue where Gen 5 Static gift eggs could have the wrong shiny state displayed
Fix issue where some Gen 5 Dream Radar encounters could display the incorrect gender (thanks @Real96)
Fix issue where some Gen 5 Static encounters could have an incorrect PID
Fix issue where using "Enter" key to select items in a CheckList wouldn't work
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
