### PR TITLE
resholve.mkDerivation: set `strictDeps` & `__structuredAttrs` to true

### DIFF
--- a/pkgs/by-name/lo/locate-dominating-file/package.nix
+++ b/pkgs/by-name/lo/locate-dominating-file/package.nix
@@ -31,7 +31,8 @@ resholve.mkDerivation {
     coreutils
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
+    getopt
     (bats.withLibraries (p: [
       p.bats-support
       p.bats-assert

--- a/pkgs/development/misc/resholve/resholve-utils.nix
+++ b/pkgs/development/misc/resholve/resholve-utils.nix
@@ -250,6 +250,8 @@ rec {
         ...
       }@args:
       {
+        strictDeps = true;
+        __structuredAttrs = true;
         pname = "${pname}-unresholved";
         passthru = passthru // {
           # needed to resholve in outer drv
@@ -287,8 +289,7 @@ rec {
 
         postFixup = unresholved.postResholve;
 
-        # don't break the metadata...
-        meta = unresholved.meta;
+        inherit (unresholved) meta strictDeps __structuredAttrs;
       };
   };
 }


### PR DESCRIPTION
- Came up during #516675.
- Follow-up to #519440.
- See also: #178468.
- See also: #205690

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
