### PR TITLE
google-amber: 0-unstable-2025-02-03 -> 0-unstable-2026-04-29

### DIFF
--- a/pkgs/by-name/go/google-amber/package.nix
+++ b/pkgs/by-name/go/google-amber/package.nix
@@ -96,9 +96,13 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   installPhase = ''
+    runHook preInstall
+
     install -Dm755 -t $out/bin amber image_diff
     wrapProgram $out/bin/amber \
       --suffix VK_LAYER_PATH : ${vulkan-validation-layers}/share/vulkan/explicit_layer.d
+
+    runHook postInstall
   '';
 
   passthru.tests.lavapipe =

--- a/pkgs/by-name/go/google-amber/package.nix
+++ b/pkgs/by-name/go/google-amber/package.nix
@@ -39,27 +39,27 @@ let
   spirv-headers = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Headers";
-    rev = "3f17b2af6784bfa2c5aa5dbb8e0e74a607dd8b3b";
-    hash = "sha256-MCQ+i9ymjnxRZP/Agk7rOGdHcB4p67jT4J4athWUlcI=";
+    rev = "babee77020ff82b571d723ce2c0262e2ec0ee3f1";
+    hash = "sha256-GWcNNw08XoKaZs/BTW9nPAEMHL8wqbhbUm56PUtEan4=";
   };
 
   spirv-tools = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Tools";
-    rev = "13b59bf1d84054b8ccd29cdc6b1303f69e8f9e77";
-    hash = "sha256-k/mTHiLbZdnslC24fjcrzqsZYMyVaAADGEqngqJcC2c=";
+    rev = "4c1ae3cd6f9076271cd64acde8cbef1d1287f27f";
+    hash = "sha256-x7OXe0q9ml8PIxWyTEx3j3tvSgIPp8kg5HwlLWIzNuk=";
   };
 
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "amber";
-  version = "0-unstable-2025-02-03";
+  version = "0-unstable-2026-04-29";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "amber";
-    rev = "3f078e41d86ca1a5881560f00e26198f59bb8ac0";
-    hash = "sha256-pAotVFmtEGp9GKmDD0vrbfbO+Xt2URmM8gYCjl0LEnk=";
+    rev = "fc02f9bad7ddaf5ca685ad01c3a0668d19910fbf";
+    hash = "sha256-en+q6pLBTiVRg5XdP2qmPfkPnywYqEOsm2/er3m75Jw=";
   };
 
   buildInputs = [


### PR DESCRIPTION
Diff: https://github.com/google/amber/compare/3f078e41d86ca1a5881560f00e26198f59bb8ac0...fc02f9bad7ddaf5ca685ad01c3a0668d19910fbf

This fixes the build of `google-amber`.

Hydra: https://hydra.nixos.org/build/326797920
ZHF: https://github.com/NixOS/nixpkgs/issues/516381


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
