### PR TITLE
armTrustedFirmwareTools: include dtc and gcc in nativeBuildInputs to fix darwin build

### DIFF
--- a/pkgs/misc/arm-trusted-firmware/default.nix
+++ b/pkgs/misc/arm-trusted-firmware/default.nix
@@ -2,6 +2,8 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  dtc,
+  gcc,
   openssl,
   pkgsCross,
   buildPackages,
@@ -61,6 +63,10 @@ let
         nativeBuildInputs = [
           pkgsCross.arm-embedded.stdenv.cc # For Cortex-M0 firmware in RK3399
           openssl # For fiptool
+        ]
+        ++ lib.optionals stdenv.hostPlatform.isDarwin [
+          dtc
+          gcc
         ];
 
         # Make the new toolchain guessing (from 2.14+) happy


### PR DESCRIPTION
#ZHFZurich

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
