### PR TITLE
texlivePackages.l3build: inject path to system texmf.cnf

### DIFF
--- a/pkgs/test/texlive/default.nix
+++ b/pkgs/test/texlive/default.nix
@@ -402,6 +402,29 @@ rec {
         done
       '';
 
+  # verify that l3build works correctly
+  l3build =
+    runCommand "texlive-test-l3build"
+      {
+        nativeBuildInputs = [ (texliveSmall.withPackages (ps: [ ps.l3build ])) ];
+      }
+      ''
+        cat >>build.lua <<EOF
+        module = "texlive-test-l3build"
+        typesetfiles = {"*.tex"}
+        EOF
+
+        cat >>test-l3build.tex <<EOF
+        \documentclass{article}
+        \begin{document}
+        l3build ran successfully.
+        \end{document}
+        EOF
+
+        l3build doc
+        l3build install --full --texmfhome "$out"
+      '';
+
   # verify that the restricted mode gets enabled when
   # needed (detected by checking if it disallows --gscmd)
   repstopdf =

--- a/pkgs/tools/typesetting/tex/texlive/fixed-hashes.nix
+++ b/pkgs/tools/typesetting/tex/texlive/fixed-hashes.nix
@@ -9749,7 +9749,7 @@
     source = "12np4gmh0y5cg66ijb96kfbdq49d38rg485nql5q0n6pgn42apnc";
   };
   l3build-77170 = {
-    run = "0f3qfgm4whm1p8alx8gwca2glgx86c48w04d62zkpzgpadkyhzbq";
+    run = "18104w97ad97ki02yghqclcdv0v916h8lyp676cyg3wc7hjvs5cq";
     doc = "0i45c0bni3xx38wgcp30gh2dg0ak2snsfjrx86kwfyvmgjsm9ric";
     source = "1n2g8vcfnya74dsm8plaj0vbfwgs8a4lqpxqvxa9vgdda288534p";
   };

--- a/pkgs/tools/typesetting/tex/texlive/tlpdb-overrides.nix
+++ b/pkgs/tools/typesetting/tex/texlive/tlpdb-overrides.nix
@@ -460,6 +460,15 @@ lib.recursiveUpdate orig rec {
     substituteInPlace "$out"/bin/latexindent --replace-fail 'use FindBin;' "BEGIN { \$0 = '$scriptsFolder' . '/latexindent.pl'; }; use FindBin;"
   '';
 
+  # l3build ignores the TEXMFCNF variable to prevent user customisations from affecting the build
+  # but we rely on TEXMFCNF to find the system texmf.cnf, so we must inject its path into l3build
+  # WARNING: this relies on the system texmf.cnf being in $TEXMFSYSVAR/web2c
+  l3build.postUnpack = ''
+    if [[ -f "$out"/scripts/l3build/l3build-aux.lua ]] ; then
+      substituteInPlace "$out"/scripts/l3build/l3build-aux.lua --replace-fail '" TEXMFCNF=."' '" TEXMFCNF=." .. os_pathsep .. kpse.var_value("TEXMFSYSVAR") .. "/web2c"'
+    fi
+  '';
+
   # find files in script directory, not in binary directory
   minted.postFixup = ''
     substituteInPlace "$out"/bin/latexminted --replace-fail "__file__" "\"$scriptsFolder/latexminted.py\""


### PR DESCRIPTION
Make l3build work as intended, fixing #352194. I have added a test in case we break this again in the future (for instance, by changing the location of texmf.cnf).

Expanding a little on what the comment says: l3build very intentionally resets TEXMFCNF as it may point to some customised file, e.g. in the user's home directory. Still, Nixpkgs needs to pass a customise texmf.cnf anyway to find the location of TEXMFROOT, TEXMFDIST, and so on. I patched l3build so that it picks up texmf.cnf and texmfcnf.lua directly from TEXMFSYSVAR, which is extremely unlikely to be customised by the user.

cc @paolobrasolin
Resolves: #352194

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
