### PR TITLE
nixos/opensnitch: remove IFD

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -179,6 +179,8 @@
 
 - `services.crabfit` was removed because its upstream packages are unmaintained and insecure.
 
+- `services.opensnitch.settings.Rules.Path` now defaults to `/var/lib/opensnitch/rules` instead of the previous `/etc/opensnitchd/rules` because it contains mutable data.
+
 - `services.mosquitto` now generates per-listener authentication and access control via the upstream `password-file` and `acl-file` plugins instead of the deprecated `password_file` and `acl_file` options. The plugins contain the same code, so behaviour is unchanged, but [](#opt-services.mosquitto.package) must now be at least version 2.1.
 
 - `sing-box` has been updated to 1.13.0, which has removed some deprecated options.  See [upstream documentation](https://sing-box.sagernet.org/configuration/) for details and migration options.

--- a/nixos/modules/services/security/opensnitch.nix
+++ b/nixos/modules/services/security/opensnitch.nix
@@ -52,49 +52,41 @@ in
         };
       };
 
+      upstreamDefaults = lib.mkOption {
+        description = ''
+          Whether to base the config declared in {option}`services.opensnitch.settings` on the upstream example config (<https://github.com/evilsocket/opensnitch/blob/master/daemon/data/default-config.json>)
+
+          Disable this if you want to declare your opensnitch config from scratch.
+        '';
+        type = lib.types.bool;
+        default = true;
+      };
+
+      configFile = lib.mkOption {
+        description = ''
+          Path to JSON config file. See: <https://github.com/evilsocket/opensnitch/blob/master/daemon/data/default-config.json>
+          If this option is set, it will override any configuration done in options.services.opensnitch.settings.
+        '';
+        example = "/etc/opensnitchd/default-config.json";
+        type = lib.types.path;
+        default =
+          let
+            generatedConfig = format.generate "config.json" cfg.settings;
+          in
+          if cfg.upstreamDefaults then
+            pkgs.runCommand "opensnitch-config.json" { } ''
+              ${lib.getExe pkgs.jq} -s '.[0] * .[1]' ${cfg.package}/etc/opensnitchd/default-config.json ${format.generate "config.json" cfg.settings} >"$out"
+            ''
+          else
+            generatedConfig;
+        defaultText = lib.literalMD "JSON file generated from {option}`services.opensnitch.settings`";
+      };
+
       settings = lib.mkOption {
         type = lib.types.submodule {
           freeformType = format.type;
 
           options = {
-            Server = {
-
-              Address = lib.mkOption {
-                type = lib.types.str;
-                description = ''
-                  Unix socket path (unix:///tmp/osui.sock, the "unix:///" part is
-                  mandatory) or TCP socket (192.168.1.100:50051).
-                '';
-              };
-
-              LogFile = lib.mkOption {
-                type = lib.types.path;
-                description = ''
-                  File to write logs to (use /dev/stdout to write logs to standard
-                  output).
-                '';
-              };
-
-            };
-
-            DefaultAction = lib.mkOption {
-              type = lib.types.enum [
-                "allow"
-                "deny"
-              ];
-              description = ''
-                Default action whether to block or allow application internet
-                access.
-              '';
-            };
-
-            InterceptUnknown = lib.mkOption {
-              type = lib.types.bool;
-              description = ''
-                Whether to intercept spare connections.
-              '';
-            };
-
             ProcMonitorMethod = lib.mkOption {
               type = lib.types.enum [
                 "ebpf"
@@ -102,16 +94,9 @@ in
                 "ftrace"
                 "audit"
               ];
+              default = "ebpf";
               description = ''
                 Which process monitoring method to use.
-              '';
-            };
-
-            LogLevel = lib.mkOption {
-              type = lib.types.ints.between 0 4;
-              description = ''
-                Default log level from 0 to 4 (debug, info, important, warning,
-                error).
               '';
             };
 
@@ -120,29 +105,12 @@ in
                 "iptables"
                 "nftables"
               ];
+              default = if config.networking.nftables.enable then "nftables" else "iptables";
+              defaultText = lib.literalExpression ''if config.networking.nftables.enable then "nftables" else "iptables"'';
               description = ''
                 Which firewall backend to use.
               '';
             };
-
-            Stats = {
-
-              MaxEvents = lib.mkOption {
-                type = lib.types.int;
-                description = ''
-                  Max events to send to the GUI.
-                '';
-              };
-
-              MaxStats = lib.mkOption {
-                type = lib.types.int;
-                description = ''
-                  Max stats per item to keep in backlog.
-                '';
-              };
-
-            };
-
             Ebpf.ModulesPath = lib.mkOption {
               type = lib.types.nullOr lib.types.path;
               default =
@@ -152,7 +120,7 @@ in
                   null;
               defaultText = lib.literalExpression ''
                 if cfg.settings.ProcMonitorMethod == "ebpf" then
-                  "\\$\\{config.boot.kernelPackages.opensnitch-ebpf\\}/etc/opensnitchd"
+                  "''${config.boot.kernelPackages.opensnitch-ebpf}/etc/opensnitchd"
                 else null;
               '';
               description = ''
@@ -191,15 +159,6 @@ in
 
   config = lib.mkIf cfg.enable {
 
-    # pkg.opensnitch is referred to elsewhere in the module so we don't need to worry about it being garbage collected
-    services.opensnitch.settings = lib.mapAttrs (_: v: lib.mkDefault v) (
-      builtins.fromJSON (
-        builtins.unsafeDiscardStringContext (
-          builtins.readFile "${cfg.package}/etc/opensnitchd/default-config.json"
-        )
-      )
-    );
-
     security.auditd = lib.mkIf (cfg.settings.ProcMonitorMethod == "audit") {
       enable = true;
       plugins.af_unix.active = true;
@@ -211,16 +170,10 @@ in
         wantedBy = [ "multi-user.target" ];
         path = lib.optionals (cfg.settings.ProcMonitorMethod == "audit") [ pkgs.audit ];
         serviceConfig = {
-          ExecStart =
-            let
-              preparedSettings = removeAttrs cfg.settings (
-                lib.optional (cfg.settings.ProcMonitorMethod != "ebpf") "Ebpf"
-              );
-            in
-            [
-              ""
-              "${lib.getExe' cfg.package "opensnitchd"} --config-file ${format.generate "default-config.json" preparedSettings}"
-            ];
+          ExecStart = [
+            ""
+            "${lib.getExe' cfg.package "opensnitchd"} --config-file ${cfg.configFile}"
+          ];
         };
         preStart = lib.mkIf (cfg.rules != { }) (
           let


### PR DESCRIPTION
Removes the use of IFD from the opensnitch module.

Currently, this removes quite a few predefined options. An alternative would be copying the default value from upstream for each of them, although that would risk them growing outdated over time.

For testing, remember to pass `--no-allow-import-from-derivation`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
