### PR TITLE
dexed: Fix darwin build

### DIFF
--- a/pkgs/by-name/de/dexed/package.nix
+++ b/pkgs/by-name/de/dexed/package.nix
@@ -5,6 +5,7 @@
   gitUpdater,
   cmake,
   pkg-config,
+  fetchpatch,
   libx11,
   libxrandr,
   libxinerama,
@@ -26,6 +27,15 @@ stdenv.mkDerivation (finalAttrs: {
     fetchSubmodules = true;
     hash = "sha256-9EbaME3kw2ptCWpaV9CnM0j5HOof264s5iFoOTcjwNg=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-min-macos-version";
+      # https://github.com/asb2m10/dexed/pull/523
+      url = "https://github.com/asb2m10/dexed/commit/e41f1b8147bb6a5b7e9330a7ec6a598a1e74a524.patch";
+      sha256 = "sha256-8ZrAirXUACk8BJUPfA/LQORCUOqjSTsKoS9HFyrkvV8=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \


### PR DESCRIPTION
Opened a PR upstream to bump minimum macOS versions which resolves the build issues: https://github.com/asb2m10/dexed/pull/523

#ZurichZHF

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
