### PR TITLE
openmeters: unstable-2025-12-15 -> 1.4.1

### DIFF
--- a/pkgs/by-name/op/openmeters/package.nix
+++ b/pkgs/by-name/op/openmeters/package.nix
@@ -2,7 +2,6 @@
   lib,
   fetchFromGitHub,
   rustPlatform,
-  makeWrapper,
   pkg-config,
   pipewire,
   wayland,
@@ -14,28 +13,30 @@
   libxi,
   libxcursor,
   libx11,
+  vulkan-loader,
+  nix-update-script,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "openmeters";
-  version = "0-unstable-2025-12-15";
+  version = "1.4.1";
 
   src = fetchFromGitHub {
     owner = "httpsworldview";
     repo = "openmeters";
-    rev = "701b22b40796e33b118719724a54be231144a5ac";
-    hash = "sha256-svsC0lxAnkVuyk6LZPyFSjeOL8H0yY3dRA37+K1e/xY=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7B/S3B15xfjZEFvzISBvyIzszoIQ1CRXexPrsnFQ+YM=";
   };
 
-  cargoHash = "sha256-jm/8FdJiVVh/PAyJiLA/KK4IaXi4gUBMGIKz/FL3KZ8=";
+  cargoHash = "sha256-SiXv93Bir1Qq9T3blfcFdfDkmp00OIq9odxRrwcz/50=";
 
   nativeBuildInputs = [
-    makeWrapper
     pkg-config
     rustPlatform.bindgenHook
   ];
 
   buildInputs = [
     pipewire
+    libxkbcommon
   ];
 
   postFixup = ''
@@ -50,15 +51,31 @@ rustPlatform.buildRustPackage (finalAttrs: {
         libxcursor
         libxi
         libxrandr
+        vulkan-loader
       ]
     }' $out/bin/openmeters
   '';
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
-    description = "Fast and simple audio metering/visualization program for Linux";
+    description = "Fast and professional audio metering/visualization for Linux";
+    longDescription = ''
+      OpenMeters is a fast audio metering application for Linux built with
+      Rust and PipeWire. It provides LUFS/RMS/true-peak loudness meters
+      (ITU-R BS.1770-5), a spectrogram with spectral reassignment, a
+      spectrum analyser, an oscilloscope with stable-trigger mode, a
+      stereometer (X/Y vector scope, M/S goniometer) and a waveform view,
+      with per-application and per-device capture.
+    '';
+
     homepage = "https://github.com/httpsworldview/openmeters";
-    license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.bitbloxhub ];
+    changelog = "https://github.com/httpsworldview/openmeters/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      bitbloxhub
+      magnetophon
+    ];
     platforms = lib.platforms.linux;
     mainProgram = "openmeters";
   };


### PR DESCRIPTION
- License changed upstream from MIT back to GPL-3.0-or-later[1]

[1] https://github.com/httpsworldview/openmeters/commit/1321f38


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
