### PR TITLE
python3Packages.hdf5plugin: parametrize cpu features

### DIFF
--- a/pkgs/development/python-modules/hdf5plugin/default.nix
+++ b/pkgs/development/python-modules/hdf5plugin/default.nix
@@ -11,6 +11,11 @@
   lz4,
   zlib,
   zstd,
+  stdenv,
+  sse2Support ? stdenv.hostPlatform.avx2Support,
+  ssse3Support ? stdenv.hostPlatform.ssse3Support,
+  avx2Support ? stdenv.hostPlatform.avx2Support,
+  avx512Support ? stdenv.hostPlatform.avx512Support,
 }:
 
 buildPythonPackage rec {
@@ -64,10 +69,10 @@ buildPythonPackage rec {
   # on Linux/Darwin. Pin them to keep the output generic and machine-independent.
   # https://github.com/silx-kit/hdf5plugin/blob/v6.0.0/doc/install.rst#available-options
   env.HDF5PLUGIN_NATIVE = "False";
-  env.HDF5PLUGIN_SSE2 = "False";
-  env.HDF5PLUGIN_SSSE3 = "False";
-  env.HDF5PLUGIN_AVX2 = "False";
-  env.HDF5PLUGIN_AVX512 = "False";
+  env.HDF5PLUGIN_SSE2 = if sse2Support then "True" else "False";
+  env.HDF5PLUGIN_SSSE3 = if ssse3Support then "True" else "False";
+  env.HDF5PLUGIN_AVX2 = if avx2Support then "True" else "False";
+  env.HDF5PLUGIN_AVX512 = if avx512Support then "True" else "False";
 
   checkPhase = ''
     python test/test.py


### PR DESCRIPTION
Co-Authored-By: Grimmauld in https://github.com/NixOS/nixpkgs/pull/520713#issuecomment-4466874172

Did some testing in the repl to check the values, they look fine with cross

Should be 0 rebuilds


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
