### PR TITLE
game-devices-udev-rules: 0.25 -> 1.0

### DIFF
--- a/pkgs/by-name/ga/game-devices-udev-rules/package.nix
+++ b/pkgs/by-name/ga/game-devices-udev-rules/package.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "game-devices-udev-rules";
-  version = "0.25";
+  version = "1.0";
 
   src = fetchFromCodeberg {
     owner = "fabiscafe";
     repo = "game-devices-udev";
     tag = finalAttrs.version;
-    hash = "sha256-CLQFdPr489OKZRj1v8EZypM1KOXgAOAOF0VQpeud4uo=";
+    hash = "sha256-J4LfRifTqBM+B/dryLHERaVa1UUWEbfjEUj+exCFVsU=";
   };
 
   nativeBuildInputs = [
@@ -24,8 +24,8 @@ stdenv.mkDerivation (finalAttrs: {
   doInstallCheck = true;
 
   postInstall = ''
-    install -Dm444 -t "$out/lib/udev/rules.d" *.rules
-    substituteInPlace $out/lib/udev/rules.d/71-powera-controllers.rules \
+    install -Dm444 -t "$out/lib/udev/rules.d" src/*.rules
+    substituteInPlace $out/lib/udev/rules.d/powera-gdu.rules \
       --replace-fail "/bin/sh" "${bash}/bin/bash"
   '';
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Bumped to latest version

Changelog: https://codeberg.org/fabiscafe/game-devices-udev/releases/tag/1.0
Diff: https://codeberg.org/fabiscafe/game-devices-udev/compare/0.25...1.0

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
