### PR TITLE
nixos/tests/gnupg: fix prompt handling

### DIFF
--- a/nixos/tests/gnupg.nix
+++ b/nixos/tests/gnupg.nix
@@ -77,7 +77,7 @@
         machine.send_chars("pgp_p4ssphrase")
         machine.wait_until_tty_matches("1", "Passphrases match")
         machine.send_chars("\n")
-        machine.wait_until_tty_matches("1", "public and secret key created")
+        machine.wait_until_tty_matches("1", "secret key created and signed")
 
     with subtest("Confirm the key is in the keyring"):
         machine.wait_until_succeeds(as_alice("gpg --list-secret-keys | grep -q alice@machine"))
@@ -92,7 +92,7 @@
 
         # Note: again, this needs a tty because of pinentry
         machine.send_chars("ssh-add alice\n")
-        machine.wait_until_tty_matches("1", "Enter passphrase")
+        machine.wait_until_tty_matches("1", "passphrase for")
         machine.send_chars("ssh_p4ssphrase\n")
         machine.wait_until_tty_matches("1", "Please enter")
         machine.send_chars("ssh_agent_p4ssphrase")


### PR DESCRIPTION
Apparently the first characters are missing and therefore it never matches.

Work around this by modifying the search string.

The test has been failing since 2025-10-21: https://hydra.nixos.org/build/310359516

ZHF: #516381


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
