### PR TITLE
lib.systems.equals: fix euqality on re-elaborated platform

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -85,11 +85,12 @@ let
     let
       allArgs = systemToAttrs systemOrArgs;
 
-      # Those two will always be derived from "config", if given, so they should NOT
-      # be overridden further down with "// args".
+      # These attributes are derived from other inputs, so they should NOT be
+      # overridden further down with "// args".
       args = removeAttrs allArgs [
         "parsed"
         "system"
+        "_withoutFunctions"
       ];
 
       # TODO: deprecate args.rustc in favour of args.rust after 23.05 is EOL.

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -266,6 +266,22 @@ lib.runTests (
         }).parsed.cpu.arch;
       expected = "i686";
     };
+    test_equals_reelaborate_overridden_platform = {
+      expr =
+        let
+          base = lib.systems.elaborate "x86_64-linux";
+        in
+        lib.systems.equals base (
+          lib.systems.elaborate (
+            base
+            // {
+              useLLVM = true;
+              linker = "lld";
+            }
+          )
+        );
+      expected = false;
+    };
   }
   // {
     # equals.functionNames must list exactly the function-valued attrs of an


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix a regression introduced by https://github.com/NixOS/nixpkgs/pull/513844#issuecomment-4466805301 where `lib.systems.equals` can return the wrong result after re-elaborating an already elaborated platform that was modified with `//`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
