### PR TITLE
gnomeExtensions.clipboard-history: 47 -> 48, add GNOME 50 support

### DIFF
--- a/pkgs/desktops/gnome/extensions/update-extensions.py
+++ b/pkgs/desktops/gnome/extensions/update-extensions.py
@@ -33,10 +33,11 @@ supported_versions = {
     "47": "47",
     "48": "48",
     "49": "49",
+    "50": "50",
 }
 
 # shell versions that we want to put into the gnomeExtensions attr set
-versions_to_merge = ["47", "48", "49"]
+versions_to_merge = ["47", "48", "49", "50"]
 
 # Some type alias to increase readability of complex compound types
 PackageName = str


### PR DESCRIPTION
Extension v48 adds support for GNOME Shell 50 (shipped in Ubuntu 26.04 LTS). Users on GNOME 50 were unable to use the extension as v47 only targeted shells 46-49.

Resolves #516777


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests
  - [ ] Package tests
  - [ ] Tests in lib/tests or pkgs/test
- [ ] Ran nixpkgs-review on this PR
- [x] Tested basic functionality of all binary files, usually in ./result/bin/
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition
  - [ ] Module update
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
