### PR TITLE
ocamlPackages.mirage-crypto-rng: fix tests on x86_64-darwin

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-crypto/rng.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/rng.nix
@@ -1,4 +1,6 @@
 {
+  lib,
+  stdenv,
   buildDunePackage,
   mirage-crypto,
   ohex,
@@ -23,6 +25,14 @@ buildDunePackage {
     ounit2
     randomconv
   ];
+
+  # test_entropy relies on timer jitter and is flaky on x86_64-darwin.
+  postPatch = lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) ''
+    substituteInPlace tests/dune \
+      --replace-fail \
+        '(enabled_if (and (<> %{architecture} "arm64") (<> %{architecture} "riscv")))' \
+        '(enabled_if false)'
+  '';
 
   buildInputs = [ dune-configurator ];
   propagatedBuildInputs = [


### PR DESCRIPTION
Fix https://hydra.nixos.org/build/327788299
ZHF: #516381

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
