### PR TITLE
python313Packages.nominal-api-protos: fix runtime dependencies

### DIFF
--- a/pkgs/development/python-modules/nominal-api-protos/default.nix
+++ b/pkgs/development/python-modules/nominal-api-protos/default.nix
@@ -4,6 +4,8 @@
   fetchPypi,
   setuptools,
   protobuf,
+  grpcio,
+  grpcio-tools,
 }:
 
 buildPythonPackage rec {
@@ -20,7 +22,11 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  dependencies = [ protobuf ];
+  dependencies = [
+    protobuf
+    grpcio
+    grpcio-tools
+  ];
 
   pythonImportsCheck = [ "nominal_api_protos" ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Added `grpcio` and `grpcio-tools` to runtime dependencies.
ZHF: #516381

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] pythonImportsCheck
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  
`nixpkgs-review rev HEAD` on x86_64-linux:
- `python313Packages.nominal-api-protos` built successfully
- `python314Packages.nominal-api-protos` built successfull
- `python313Packages.nominal` and `python314Packages.nominal` failed independently
  in their own `pythonRuntimeDepsCheckHook`

- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
