### PR TITLE
stellar-core: 26.0.1 -> 26.1.0, enable tests

### DIFF
--- a/pkgs/by-name/st/stellar-core/package.nix
+++ b/pkgs/by-name/st/stellar-core/package.nix
@@ -48,13 +48,13 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "stellar-core";
-  version = "26.0.1";
+  version = "26.1.0";
 
   src = fetchFromGitHub {
     owner = "stellar";
     repo = "stellar-core";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-u9sipDwTBhhvcyEcdBUZjtg70a76g2e4ub+vPKzOKg8=";
+    hash = "sha256-0bdomxjx+Qwvxu6NWUTYbLvoKwCvM0e5I3qwhKLEecM=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/st/stellar-core/package.nix
+++ b/pkgs/by-name/st/stellar-core/package.nix
@@ -10,6 +10,8 @@
   libtool,
   libunwind,
   perl,
+  postgresql,
+  postgresqlTestHook,
   pkg-config,
   ripgrep,
   rustc,
@@ -113,12 +115,27 @@ stdenv.mkDerivation (finalAttrs: {
     rustPlatform.cargoSetupHook
   ];
 
+  nativeCheckInputs = [
+    postgresql
+    postgresqlTestHook
+  ];
+
   buildInputs = [
     libpq
     libunwind
   ];
 
   enableParallelBuilding = true;
+
+  doCheck = true;
+
+  postgresqlTestUserOptions = "LOGIN CREATEDB";
+
+  postgresqlTestSetupPost = ''
+    for database in $(seq 0 15); do
+      createdb "test$database"
+    done
+  '';
 
   preConfigure = ''
     # Due to https://github.com/NixOS/nixpkgs/issues/8567 we cannot rely on
@@ -140,6 +157,19 @@ stdenv.mkDerivation (finalAttrs: {
     git add .
 
     ./autogen.sh
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+
+    # The full upstream test suite is too heavy for a default package check: it
+    # includes long-running integration scenarios and Soroban tests across all
+    # p21-p26 protocol crates. Keep this focused on a basic consensus smoke test
+    # plus a PostgreSQL-backed persistence test.
+    ./src/stellar-core test --ll fatal -w NoTests -a -r simple --disable-dots "standalone"
+    ./src/stellar-core test --ll fatal -w NoTests -a -r simple --disable-dots "SCP State"
+
+    runHook postCheck
   '';
 
   meta = {


### PR DESCRIPTION
Changelog https://github.com/stellar/stellar-core/releases/tag/v26.1.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
