### PR TITLE
remarkable-mouse: unstable-2024-02-23 -> 7.2.0

### DIFF
--- a/pkgs/applications/misc/remarkable/remarkable-mouse/default.nix
+++ b/pkgs/applications/misc/remarkable/remarkable-mouse/default.nix
@@ -5,26 +5,32 @@
   libevdev,
   paramiko,
   pynput,
-  setuptools,
   screeninfo,
   tkinter,
+  hatchling,
 }:
 
-buildPythonApplication {
+buildPythonApplication (finalAttrs: {
   pname = "remarkable-mouse";
-  version = "unstable-2024-02-23";
+  version = "7.2.0";
 
   src = fetchFromGitHub {
     owner = "Evidlo";
     repo = "remarkable_mouse";
-    rev = "05142ef37a8b3f9e350156a14c2dec6844ed0ea8";
-    hash = "sha256-0X/7SIfSnlEL98fxJBAYrHAkRmdtymqA7xBmVoa5VIw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/p+Vg5SzyIH2m0OWthKQ3xgV1KJlAlr1M0bdIi8O2Po=";
   };
 
-  pyproject = true;
-  build-system = [ setuptools ];
+  __structuredAttrs = true;
+  strictDeps = true;
+  enableParallelBuilding = true;
 
-  propagatedBuildInputs = [
+  pyproject = true;
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
     screeninfo
     paramiko
     pynput
@@ -39,7 +45,8 @@ buildPythonApplication {
   meta = {
     description = "Program to use a reMarkable as a graphics tablet";
     homepage = "https://github.com/evidlo/remarkable_mouse";
+    changelog = "https://github.com/Evidlo/remarkable_mouse/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.nickhu ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

supersedes #509437
closes #518002

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
