### PR TITLE
nixos/nvidia: option for open kernel modules is no longer nullable

### DIFF
--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -360,12 +360,8 @@ in
 
       open = lib.mkOption {
         example = true;
-        description = "Whether to enable the open source NVIDIA kernel module.";
-        type = lib.types.nullOr lib.types.bool;
-        default = if lib.versionOlder nvidia_x11.version "560" then false else null;
-        defaultText = lib.literalExpression ''
-          if lib.versionOlder config.hardware.nvidia.package.version "560" then false else null
-        '';
+        description = "Whether to enable the open source NVIDIA kernel module. Must be set.";
+        type = lib.types.bool;
       };
 
       gsp.enable =
@@ -414,19 +410,15 @@ in
               message = "You cannot configure both X11 and Data Center drivers at the same time.";
             }
             {
-              assertion = cfg.open != null || cfg.datacenter.enable;
-              message = ''
-                You must configure `hardware.nvidia.open` on NVIDIA driver versions >= 560.
-                It is suggested to use the open source kernel modules on Turing or later GPUs (RTX series, GTX 16xx), and the closed source modules otherwise.
-              '';
-            }
-            {
               assertion = !cfg.open || (nvidia_x11.open != null);
               message = ''
                 The selected NVIDIA package does not provide open kernel modules.
                 Set hardware.nvidia.open = false or choose a package branch with open module support.
               '';
             }
+          ];
+          warnings = lib.optional (cfg.open && (lib.versionOlder nvidia_x11.version "560")) [
+            "Open kernel modules older than version 560 lack many features and are not recommended for use."
           ];
           boot = {
             blacklistedKernelModules = [


### PR DESCRIPTION
you would get an eval error if it was set to null anyway


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
