### PR TITLE
devede: make various improvements to the derivation

### DIFF
--- a/pkgs/by-name/de/devede/package.nix
+++ b/pkgs/by-name/de/devede/package.nix
@@ -63,10 +63,9 @@ buildPythonApplication (finalAttrs: {
   ];
 
   postPatch = ''
-    substituteInPlace setup.py --replace "'/usr'," ""
     substituteInPlace src/devedeng/configuration_data.py \
-      --replace "/usr/share" "$out/share" \
-      --replace "/usr/local/share" "$out/share"
+      --replace-fail "/usr/share" "$out/share" \
+      --replace-fail "/usr/local/share" "$out/share"
   '';
 
   # Prevent double wrapping, let the Python wrapper use the args in preFixup.

--- a/pkgs/by-name/de/devede/package.nix
+++ b/pkgs/by-name/de/devede/package.nix
@@ -69,6 +69,13 @@ buildPythonApplication (finalAttrs: {
       --replace "/usr/local/share" "$out/share"
   '';
 
+  # Prevent double wrapping, let the Python wrapper use the args in preFixup.
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   passthru.updateScript = ./update.sh;
 
   meta = {

--- a/pkgs/by-name/de/devede/package.nix
+++ b/pkgs/by-name/de/devede/package.nix
@@ -73,6 +73,7 @@ buildPythonApplication (finalAttrs: {
 
   meta = {
     description = "DVD Creator for Linux";
+    mainProgram = "devede_ng";
     homepage = "https://www.rastersoft.com/programas/devede.html";
     license = lib.licenses.gpl3;
     maintainers = [

--- a/pkgs/by-name/de/devede/package.nix
+++ b/pkgs/by-name/de/devede/package.nix
@@ -33,7 +33,7 @@ buildPythonApplication (finalAttrs: {
   src = fetchFromGitLab {
     owner = "rastersoft";
     repo = "devedeng";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-81H063PpBF/+JDsRgBLwfAevb11yNkDtH4KdtOAL/Fg=";
   };
 

--- a/pkgs/by-name/de/devede/package.nix
+++ b/pkgs/by-name/de/devede/package.nix
@@ -11,6 +11,13 @@
   wrapGAppsHook3,
   gdk-pixbuf,
   gobject-introspection,
+  # The subtitle encoder and mixer 'spumux' looks for the font 'arial' by default (hardcoded in devede)
+  # and it should be made available to that program in the user environment or it throws an error.
+  # If overrideFont is true we instead use a particular font file in the nix store,
+  # which is always available by design.
+  overrideFont ? true,
+  liberation_ttf,
+  fontPath ? "${liberation_ttf}/share/fonts/truetype/LiberationSans-Regular.ttf",
 }:
 
 let
@@ -66,6 +73,10 @@ buildPythonApplication (finalAttrs: {
     substituteInPlace src/devedeng/configuration_data.py \
       --replace-fail "/usr/share" "$out/share" \
       --replace-fail "/usr/local/share" "$out/share"
+  ''
+  + lib.optionalString overrideFont ''
+    substituteInPlace src/devedeng/subtitles_mux.py \
+      --replace-fail arial ${fontPath}
   '';
 
   # Prevent double wrapping, let the Python wrapper use the args in preFixup.


### PR DESCRIPTION
See individual commits - can be squashed if desired.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
