### PR TITLE
linear: init at 1.30.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11643,6 +11643,12 @@
     name = "Silvan Mosberger";
     keys = [ { fingerprint = "6C2B 55D4 4E04 8266 6B7D  DA1A 422E 9EDA E015 7170"; } ];
   };
+  iniw = {
+    email = "git@vini.cat";
+    github = "iniw";
+    githubId = 30220881;
+    name = "Vinicius Deolindo";
+  };
   insipx = {
     email = "github@andrewplaza.dev";
     github = "insipx";

--- a/pkgs/by-name/li/linear/package.nix
+++ b/pkgs/by-name/li/linear/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  _7zz,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "linear";
+  version = "1.30.2";
+
+  src = fetchurl {
+    url = "https://releases.linear.app/Linear-${finalAttrs.version}-universal.dmg";
+    hash = "sha256-udtN7sOnbT1B684q/JhPFGq8mYvhc5CbTxuJi6NYFac=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [ _7zz ];
+
+  sourceRoot = "Linear";
+
+  # -snld prevents "ERROR: Dangerous symbolic link path was ignored".
+  # -xr'!*:com.apple.*' prevents macOS extended attributes from being
+  # extracted as regular files, which corrupts the .app bundle.
+  unpackCmd = "7zz x -snld -xr'!*:com.apple.*' $curSrc";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications"
+    cp -R Linear.app "$out/Applications"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "App to manage software development and track bugs";
+    homepage = "https://linear.app/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ iniw ];
+    platforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/li/linear/update.sh
+++ b/pkgs/by-name/li/linear/update.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p coreutils curl gnugrep common-updater-scripts
+#shellcheck shell=bash
+
+set -eu -o pipefail
+
+source_url="https://releases.linear.app/mac"
+
+version="$(curl -L -I "$source_url" | grep -ioE 'filename="Linear-[0-9]+(\.[0-9]+)*-universal\.dmg"' | grep -oE '[0-9]+(\.[0-9]+)*')"
+
+if [[ -z $version ]]; then
+  echo "Could not find the latest Linear version in release headers" >&2
+  exit 1
+fi
+
+hash=$(nix --extra-experimental-features nix-command hash convert --to sri --hash-algo sha256 "$(nix-prefetch-url --type sha256 "https://releases.linear.app/Linear-${version}-universal.dmg")")
+
+update-source-version linear "$version" "$hash" --ignore-same-version


### PR DESCRIPTION
Mostly based on [homebrew's module](https://github.com/Homebrew/homebrew-cask/blob/b4305343436136b79599f5f5d7c936a2307550bd/Casks/l/linear.rb) of this package and the [orbstack module](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/or/orbstack/package.nix) in nixpkgs, which is also a binary, darwin-only application.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
