### PR TITLE
nixos/activation: fix handling of user activation

### DIFF
--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -322,6 +322,7 @@ in
         description = "Run user-specific NixOS activation";
         script = config.system.userActivationScripts.script;
         unitConfig.ConditionUser = "!@system";
+        unitConfig.DefaultDependencies = false;
         serviceConfig.Type = "oneshot";
         wantedBy = [ "default.target" ];
       };

--- a/nixos/tests/user-activation-scripts.nix
+++ b/nixos/tests/user-activation-scripts.nix
@@ -17,8 +17,9 @@
 
   testScript = ''
     def verify_user_activation_run_count(n):
-        machine.succeed(
-            '[[ "$(find /home/alice/ -name user-activation-ran.\\* | wc -l)" == %s ]]' % n
+        t.assertEqual(
+            n,
+            int(machine.succeed('find /home/alice/ -name user-activation-ran.\\* | wc -l').rstrip())
         )
 
 

--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
@@ -169,6 +169,15 @@ impl UnitScope {
         })
     }
 
+    /// Absolute path to the currently-active unit directory for units installed via
+    /// `systemd.packages`.
+    fn units_from_pkgs_dir(&self) -> &'static Path {
+        Path::new(match self {
+            UnitScope::System => "/run/current-system/sw/share/systemd/system",
+            UnitScope::User => "/run/current-system/sw/share/systemd/user",
+        })
+    }
+
     /// Directory where unit action lists are persisted for
     /// resume-after-interrupt. The user scope uses XDG_RUNTIME_DIR so the
     /// unprivileged child can write to it.
@@ -1350,6 +1359,10 @@ fn do_user_switch(parent_exe: String) -> anyhow::Result<()> {
         .current_dir()
         .to_str()
         .expect("scope dir is valid UTF-8");
+    let fragment_prefix_packages = scope
+        .units_from_pkgs_dir()
+        .to_str()
+        .expect("units_from_pkgs_dir is valid UTF-8");
 
     // Units that are currently running from a non-/etc location (typically
     // ~/.config/systemd/user, i.e. home-manager) but that the new NixOS
@@ -1363,7 +1376,9 @@ fn do_user_switch(parent_exe: String) -> anyhow::Result<()> {
             !unit_state
                 .proxy
                 .get("org.freedesktop.systemd1.Unit", "FragmentPath")
-                .map(|p: String| p.starts_with(fragment_prefix))
+                .map(|p: String| {
+                    p.starts_with(fragment_prefix) || p.starts_with(fragment_prefix_packages)
+                })
                 .unwrap_or(false)
         })
         .map(|(unit, _)| unit.clone())


### PR DESCRIPTION
* Ensure per-user `nixos-activation.service` isn't started twice (i.e. once by the handling of user units in stc-ng and once manually by stc-ng itself)
* Fix stc-ng considering user-units in /run/current-system/sw/share/systemd/user (i.e. installed via `systemd.packages`) being migrated (causing restarts of dbus-broker.service). This caused a third run of per-user `nixos-activation.service`.

Original objective was to fix `nixosTests.user-activation-scripts` as part of ZHF #516381.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests] (switch-test, user-activation-scripts)
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
