### PR TITLE
zulu25: 25.0.0 -> 25.0.2

### DIFF
--- a/pkgs/development/compilers/zulu/25.nix
+++ b/pkgs/development/compilers/zulu/25.nix
@@ -6,7 +6,7 @@
 
 let
   # For Zulu 25, FX and non-FX versions can differ
-  zuluVersion = if enableJavaFX then "25.28.85" else "25.28.85";
+  zuluVersion = if enableJavaFX then "25.32.21" else "25.32.21";
 in
 callPackage ./common.nix (
   {
@@ -15,42 +15,42 @@ callPackage ./common.nix (
     dists = {
       x86_64-linux = {
         inherit zuluVersion;
-        jdkVersion = "25.0.0";
+        jdkVersion = "25.0.2";
         hash =
           if enableJavaFX then
-            "sha256-5Hhob86uCxrrdrFEvNaqPaQEaGrF47jpgUibKkNs1AQ="
+            "sha256-KpdyDAQxZjgftuHniElprJ2RSRB2eOwvQk1QaXxV+kk="
           else
-            "sha256-Fk2QHlokC4wYUW9atVvBH8lomrboKQRa6oRnNW3Ns0A=";
+            "sha256-lGrZdm2Y/Gq0laGhIAchl9tUmX9pJfuWaA8ezVWR204=";
       };
 
       aarch64-linux = {
         inherit zuluVersion;
-        jdkVersion = "25.0.0";
+        jdkVersion = "25.0.2";
         hash =
           if enableJavaFX then
-            "sha256-HmfKOh0X2jcLrEMmKV81nQebtOOJjzpHWe1Ca+qIFYI="
+            "sha256-kLusgsgOD2HVasawwjsDF6b8M4BxVO+Kzs/rta4IAnw="
           else
-            "sha256-tg651UyXukFZVHg0qYzF0BYoHdKz5g50dcukkRMkvLQ=";
+            "sha256-mQPGsZGDozclyh39rltyQAydAJlcdvr8Sg0xxRUvM/c=";
       };
 
       x86_64-darwin = {
         inherit zuluVersion;
-        jdkVersion = "25.0.0";
+        jdkVersion = "25.0.2";
         hash =
           if enableJavaFX then
-            "sha256-J5Akv28y3XoJgw5q2Rh4xHv1AV1I33jnPslhxDrTc0E="
+            "sha256-8iIkfaV+BhEjdUrXMrOxg5XmcfJOLmHVFlE+UlKynzc="
           else
-            "sha256-ws3h0xPZBLeTw3YCFO76IH7Mp98E58QISr3x9rvrwno=";
+            "sha256-PT6eVE6g0bBCulI0RTPpIF74JyP/BXgCYsyxcayYDVU=";
       };
 
       aarch64-darwin = {
         inherit zuluVersion;
-        jdkVersion = "25.0.0";
+        jdkVersion = "25.0.2";
         hash =
           if enableJavaFX then
-            "sha256-urxxVoayeNW0g0g80eefmG+FMVzVBaBvmMKj+S3URNE="
+            "sha256-sGl624HftGDuwCfvgZLUaNJOBUQU9y6I1BLROL0HlPc="
           else
-            "sha256-c/ZPa618PfMfunQPvLu+98Glzt7/u13zht15vHKrqbY=";
+            "sha256-WZL+3hKV/d9uGc0HPCTmETW0L3n/v9pbzsVEIGJGoHk=";
       };
     };
   }


### PR DESCRIPTION
Note: there is currently a 25.0.3 release available, but the macos tarball contains breaking changes that will require changes to zulu/common.nix. This commit updates to the latest non-breaking version.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
