### PR TITLE
hap-py: fix python3 compatibility

### DIFF
--- a/pkgs/by-name/ha/hap-py/package.nix
+++ b/pkgs/by-name/ha/hap-py/package.nix
@@ -67,6 +67,11 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Insert missing include for uint64_t
     sed -i '/#include <vector>/a #include <cstdint>' src/c++/include/helpers/Roc.hh
+
+    # pipes module was removed in Python 3.13; shlex.quote is the replacement
+    find src/python -name "*.py" -exec sed -i \
+      -e 's/import pipes/import shlex/' \
+      -e 's/pipes\.quote/shlex.quote/g' {} \;
   '';
 
   patches = [


### PR DESCRIPTION
This PR is part of 2-steps process to fix `hap-py` (see #521102 ). On a new machine, I discovered `hap-py` did not run due to pipes is no longer supported in python3.

Here we remove hap-py dependency to pipes.

Tested on real data for multiple runs.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
