### PR TITLE
rtg-tools: fix runtime error

### DIFF
--- a/pkgs/by-name/rt/rtg-tools/package.nix
+++ b/pkgs/by-name/rt/rtg-tools/package.nix
@@ -50,7 +50,9 @@ stdenv.mkDerivation (finalAttrs: {
        --replace-fail 'RTG_JAVA="java"' 'RTG_JAVA="${lib.getExe jdk}"' \
       --replace-fail uname ${lib.getExe' coreutils "uname"} \
       --replace-fail awk ${lib.getExe gawk} \
-      --replace-fail "hostname -s" "${lib.getExe hostname} -s"
+      --replace-fail "hostname -s" "${lib.getExe hostname} -s" \
+      --replace-fail dirname ${lib.getExe' coreutils "dirname"} \
+      --replace-fail readlink ${lib.getExe' coreutils "readlink"}
 
     sed -i '/USER_JAVA_OPTS=$RTG_JAVA_OPTS/a mkdir -p $HOME/.config/rtg-tools'  installer/rtg
   '';


### PR DESCRIPTION
On a new testing machine, dirname is not available in the PATH  during execution. `rtg-tools` is used by `hap-py` and this PR is a joint effort with #521099 to make `hap-py` run again.

Tested on real data for multiple runs.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage]. -> *fails with `https://github.com/NixOS/nixpkgs/pull/521102 failed to build: Failed to list packages: nix-env failed with exit code -9`*
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
