### PR TITLE
fastent: init at 1.1

### DIFF
--- a/pkgs/by-name/fa/fastent/package.nix
+++ b/pkgs/by-name/fa/fastent/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fastent";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "iczelia";
+    repo = "fastent";
+    rev = finalAttrs.version;
+    hash = "sha256-OxK/5CiQO8mAgRQbP51naHFvo2ZqVrNt55mCnz0klpY=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  preConfigure = lib.optionalString stdenv.hostPlatform.isLinux ''
+    # for LTO
+    export AR="${stdenv.cc.targetPrefix}gcc-ar"
+    export NM="${stdenv.cc.targetPrefix}gcc-nm"
+    export RANLIB="${stdenv.cc.targetPrefix}gcc-ranlib"
+  '';
+
+  configureFlags = [
+    "--enable-lto"
+  ];
+
+  meta = {
+    description = "A faster utility for entropy estimation";
+    homepage = "https://github.com/iczelia/fastent";
+    changelog = "https://github.com/iczelia/fastent/blob/${finalAttrs.version}/NEWS";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ mrbenjadmin ];
+    platforms = lib.platforms.all;
+    mainProgram = "fastent";
+  };
+})


### PR DESCRIPTION
`fastent` is a faster alternative to `ent`, used for estimating the entropy of a given file.
[https://github.com/iczelia/fastent](https://github.com/iczelia/fastent)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
