### PR TITLE
perlPackages.*: switch to single source of truth for version

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -37471,11 +37471,11 @@ with self;
     };
   };
 
-  UNIVERSALcan = buildPerlPackage {
+  UNIVERSALcan = buildPerlPackage rec {
     pname = "UNIVERSAL-can";
     version = "1.20140328";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHROMATIC/UNIVERSAL-can-1.20140328.tar.gz";
+      url = "mirror://cpan/authors/id/C/CH/CHROMATIC/UNIVERSAL-can-${version}.tar.gz";
       hash = "sha256-Ui2p8nR4b+LLqZvHfMHIHSFhlHkD1/rRC9Yt+38RmQ8=";
     };
     meta = {
@@ -37488,11 +37488,11 @@ with self;
     };
   };
 
-  UNIVERSALisa = buildPerlPackage {
+  UNIVERSALisa = buildPerlPackage rec {
     pname = "UNIVERSAL-isa";
     version = "1.20171012";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/UNIVERSAL-isa-1.20171012.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/UNIVERSAL-isa-${version}.tar.gz";
       hash = "sha256-0WlWA2ywHIGd7H0pT274kb4Ltkh2mJYBNUspMWTafys=";
     };
     meta = {
@@ -37505,11 +37505,11 @@ with self;
     };
   };
 
-  UNIVERSALrequire = buildPerlPackage {
+  UNIVERSALrequire = buildPerlPackage rec {
     pname = "UNIVERSAL-require";
     version = "0.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/UNIVERSAL-require-0.19.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/UNIVERSAL-require-${version}.tar.gz";
       hash = "sha256-1GfNJuBsjDsgP9O8B5aubIN6xeMQCTyCJn/134UPGgM=";
     };
     meta = {
@@ -37521,11 +37521,11 @@ with self;
     };
   };
 
-  UnicodeCaseFold = buildPerlModule {
+  UnicodeCaseFold = buildPerlModule rec {
     pname = "Unicode-CaseFold";
     version = "1.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AR/ARODLAND/Unicode-CaseFold-1.01.tar.gz";
+      url = "mirror://cpan/authors/id/A/AR/ARODLAND/Unicode-CaseFold-${version}.tar.gz";
       hash = "sha256-QYohKAj50Li7MwrJBQltLdNkl2dT1McVNNq5g2pjGU0=";
     };
     meta = {
@@ -37538,11 +37538,11 @@ with self;
     };
   };
 
-  UnicodeCheckUTF8 = buildPerlPackage {
+  UnicodeCheckUTF8 = buildPerlPackage rec {
     pname = "Unicode-CheckUTF8";
     version = "1.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BR/BRADFITZ/Unicode-CheckUTF8-1.03.tar.gz";
+      url = "mirror://cpan/authors/id/B/BR/BRADFITZ/Unicode-CheckUTF8-${version}.tar.gz";
       hash = "sha256-l/hNrwM+ubSc2P4x2yIf7wNaXC7h11fzEiyIz5diQUw=";
     };
     meta = {
@@ -37555,11 +37555,11 @@ with self;
     };
   };
 
-  UnicodeLineBreak = buildPerlPackage {
+  UnicodeLineBreak = buildPerlPackage rec {
     pname = "Unicode-LineBreak";
     version = "2019.001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEZUMI/Unicode-LineBreak-2019.001.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEZUMI/Unicode-LineBreak-${version}.tar.gz";
       hash = "sha256-SGdi5MrN3Md7E5ifl5oCn4RjC4F15/7xeYnhV9S2MYo=";
     };
     propagatedBuildInputs = [ MIMECharset ];
@@ -37572,11 +37572,11 @@ with self;
     };
   };
 
-  UnicodeString = buildPerlPackage {
+  UnicodeString = buildPerlPackage rec {
     pname = "Unicode-String";
     version = "2.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GA/GAAS/GAAS/Unicode-String-2.10.tar.gz";
+      url = "mirror://cpan/authors/id/G/GA/GAAS/GAAS/Unicode-String-${version}.tar.gz";
       hash = "sha256-iUoRDs5HlUaviv7Aly7scyDIbE3qTms1Tf88dSa6m2g=";
     };
     meta = {
@@ -37588,11 +37588,11 @@ with self;
     };
   };
 
-  UnicodeStringprep = buildPerlModule {
+  UnicodeStringprep = buildPerlModule rec {
     pname = "Unicode-Stringprep";
     version = "1.105";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CF/CFAERBER/Unicode-Stringprep-1.105.tar.gz";
+      url = "mirror://cpan/authors/id/C/CF/CFAERBER/Unicode-Stringprep-${version}.tar.gz";
       hash = "sha256-5r67xYQIIx/RMX25ECRJs+faT6Q3559jc4LTYxPv0BE=";
     };
     buildInputs = [ TestNoWarnings ];
@@ -37606,11 +37606,11 @@ with self;
     };
   };
 
-  UnicodeUTF8 = buildPerlPackage {
+  UnicodeUTF8 = buildPerlPackage rec {
     pname = "Unicode-UTF8";
     version = "0.62";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHANSEN/Unicode-UTF8-0.62.tar.gz";
+      url = "mirror://cpan/authors/id/C/CH/CHANSEN/Unicode-UTF8-${version}.tar.gz";
       hash = "sha256-+oci0LdGluMy/d1EKZRDbqk9O/x5gtS6vc7f3dZX0PY=";
     };
     buildInputs = [ TestFatal ];
@@ -37625,11 +37625,11 @@ with self;
     };
   };
 
-  UnixGetrusage = buildPerlPackage {
+  UnixGetrusage = buildPerlPackage rec {
     pname = "Unix-Getrusage";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TA/TAFFY/Unix-Getrusage-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/T/TA/TAFFY/Unix-Getrusage-${version}.tar.gz";
       hash = "sha256-ds3hzuJFMmC4WrvdwnzcmHXwHSRX4XbgPcq/BftETRI=";
     };
     meta = {
@@ -37641,11 +37641,11 @@ with self;
     };
   };
 
-  URI = buildPerlPackage {
+  URI = buildPerlPackage rec {
     pname = "URI";
     version = "5.21";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OA/OALDERS/URI-5.21.tar.gz";
+      url = "mirror://cpan/authors/id/O/OA/OALDERS/URI-${version}.tar.gz";
       hash = "sha256-liZYYM1hveFuhBXc+/EIBW3hYsqgrDf4HraVydLgq3c=";
     };
     buildInputs = [
@@ -37663,11 +37663,11 @@ with self;
     };
   };
 
-  URIdb = buildPerlModule {
+  URIdb = buildPerlModule rec {
     pname = "URI-db";
     version = "0.21";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DW/DWHEELER/URI-db-0.21.tar.gz";
+      url = "mirror://cpan/authors/id/D/DW/DWHEELER/URI-db-${version}.tar.gz";
       hash = "sha256-pkM9wVF6kH4YmRKkx2td/HYzLj/X/Is4oTfkAZx4CzQ=";
     };
     propagatedBuildInputs = [ URINested ];
@@ -37681,11 +37681,11 @@ with self;
     };
   };
 
-  URIFind = buildPerlModule {
+  URIFind = buildPerlModule rec {
     pname = "URI-Find";
     version = "20160806";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSCHWERN/URI-Find-20160806.tar.gz";
+      url = "mirror://cpan/authors/id/M/MS/MSCHWERN/URI-Find-${version}.tar.gz";
       hash = "sha256-4hOkJaUbX1UyQhHzeQnXh0nQus3qJZulGphV0NGWY9Y=";
     };
     propagatedBuildInputs = [ URI ];
@@ -37700,11 +37700,11 @@ with self;
     };
   };
 
-  URIFromHash = buildPerlPackage {
+  URIFromHash = buildPerlPackage rec {
     pname = "URI-FromHash";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/URI-FromHash-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/URI-FromHash-${version}.tar.gz";
       hash = "sha256-p8rFvM7p8uLYrQ9gVAAWNxLNCsZN8vuDT3YPtJ8vb9A=";
     };
     propagatedBuildInputs = [
@@ -37719,11 +37719,11 @@ with self;
     };
   };
 
-  UriGoogleChart = buildPerlPackage {
+  UriGoogleChart = buildPerlPackage rec {
     pname = "URI-GoogleChart";
     version = "1.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GA/GAAS/URI-GoogleChart-1.02.tar.gz";
+      url = "mirror://cpan/authors/id/G/GA/GAAS/URI-GoogleChart-${version}.tar.gz";
       hash = "sha256-WoLCLsYBejXQ/IJv7xNBIiaHL8SiPA4sAUqfqS8rGAI=";
     };
     propagatedBuildInputs = [ URI ];
@@ -37736,11 +37736,11 @@ with self;
     };
   };
 
-  UserIdentity = buildPerlPackage {
+  UserIdentity = buildPerlPackage rec {
     pname = "User-Identity";
     version = "1.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARKOV/User-Identity-1.02.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MARKOV/User-Identity-${version}.tar.gz";
       hash = "sha256-OySu5/UnjGXD8EEVsHyG5kaTTpnqQJJANj8wiZE+uJk=";
     };
     propagatedBuildInputs = [ HashOrdered ];
@@ -37754,11 +37754,11 @@ with self;
     };
   };
 
-  URIIMAP = buildPerlPackage {
+  URIIMAP = buildPerlPackage rec {
     pname = "URI-imap";
     version = "1.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CW/CWEST/URI-imap-1.01.tar.gz";
+      url = "mirror://cpan/authors/id/C/CW/CWEST/URI-imap-${version}.tar.gz";
       hash = "sha256-uxSZiW7ONKe08JFinC5yw2imcwDoVzqyIZjJ2HI1uy0=";
     };
     propagatedBuildInputs = [ URI ];
@@ -37771,11 +37771,11 @@ with self;
     };
   };
 
-  URINested = buildPerlModule {
+  URINested = buildPerlModule rec {
     pname = "URI-Nested";
     version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DW/DWHEELER/URI-Nested-0.10.tar.gz";
+      url = "mirror://cpan/authors/id/D/DW/DWHEELER/URI-Nested-${version}.tar.gz";
       hash = "sha256-4ZcTOaZfusY6uHFC1LWdPSWdUUF3U8d8tY6jGoIz768=";
     };
     propagatedBuildInputs = [ URI ];
@@ -37789,11 +37789,11 @@ with self;
     };
   };
 
-  URISmartURI = buildPerlPackage {
+  URISmartURI = buildPerlPackage rec {
     pname = "URI-SmartURI";
     version = "0.032";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RK/RKITOVER/URI-SmartURI-0.032.tar.gz";
+      url = "mirror://cpan/authors/id/R/RK/RKITOVER/URI-SmartURI-${version}.tar.gz";
       hash = "sha256-6xdLeUYi4UK30JT2p+Nqe6T8i7zySF4QPuPaNevMTyw=";
     };
     propagatedBuildInputs = [
@@ -37817,11 +37817,11 @@ with self;
     };
   };
 
-  URITemplate = buildPerlPackage {
+  URITemplate = buildPerlPackage rec {
     pname = "URI-Template";
     version = "0.24";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BR/BRICAS/URI-Template-0.24.tar.gz";
+      url = "mirror://cpan/authors/id/B/BR/BRICAS/URI-Template-${version}.tar.gz";
       hash = "sha256-aK4tYbV+FNytD4Kvr/3F7AW1B6HpyN9aphOKqipbEd4=";
     };
     propagatedBuildInputs = [ URI ];
@@ -37834,11 +37834,11 @@ with self;
     };
   };
 
-  URIcpan = buildPerlPackage {
+  URIcpan = buildPerlPackage rec {
     pname = "URI-cpan";
     version = "1.009";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/URI-cpan-1.009.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/URI-cpan-${version}.tar.gz";
       hash = "sha256-JFV5sCW2P1d8cndDARmEcjhxykDcNezsjq05riSkjhI=";
     };
     propagatedBuildInputs = [
@@ -37855,11 +37855,11 @@ with self;
     };
   };
 
-  URIws = buildPerlPackage {
+  URIws = buildPerlPackage rec {
     pname = "URI-ws";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/URI-ws-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/URI-ws-${version}.tar.gz";
       hash = "sha256-bmsOQXKstqU8IiY5wABgjC3WHVCEhkdIKshgDVDlQe8=";
     };
     propagatedBuildInputs = [ URI ];
@@ -37873,11 +37873,11 @@ with self;
     };
   };
 
-  UUID4Tiny = buildPerlPackage {
+  UUID4Tiny = buildPerlPackage rec {
     pname = "UUID4-Tiny";
     version = "0.003";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CV/CVLIBRARY/UUID4-Tiny-0.003.tar.gz";
+      url = "mirror://cpan/authors/id/C/CV/CVLIBRARY/UUID4-Tiny-${version}.tar.gz";
       hash = "sha256-4S9sgrg1dcORd3O0HA+1HPeDx8bPcuDJkWks4u8Hg2I=";
     };
     postPatch =
@@ -37901,11 +37901,11 @@ with self;
     };
   };
 
-  UUIDTiny = buildPerlPackage {
+  UUIDTiny = buildPerlPackage rec {
     pname = "UUID-Tiny";
     version = "1.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CA/CAUGUSTIN/UUID-Tiny-1.04.tar.gz";
+      url = "mirror://cpan/authors/id/C/CA/CAUGUSTIN/UUID-Tiny-${version}.tar.gz";
       hash = "sha256-bc2SYE1k6WzGwYgZSuFqnTpGVWIk93tvPR0TEraPmj0=";
     };
     meta = {
@@ -37917,11 +37917,11 @@ with self;
     };
   };
 
-  UUIDURandom = buildPerlPackage {
+  UUIDURandom = buildPerlPackage rec {
     pname = "UUID-URandom";
     version = "0.001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/UUID-URandom-0.001.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/UUID-URandom-${version}.tar.gz";
       hash = "sha256-PxNjGxO5YE+0ieKYlJDJnxA3Q6g3I5va+unWuvVfj0Y=";
     };
     propagatedBuildInputs = [ CryptURandom ];
@@ -37932,11 +37932,11 @@ with self;
     };
   };
 
-  VariableMagic = buildPerlPackage {
+  VariableMagic = buildPerlPackage rec {
     pname = "Variable-Magic";
     version = "0.64";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/V/VP/VPIT/Variable-Magic-0.64.tar.gz";
+      url = "mirror://cpan/authors/id/V/VP/VPIT/Variable-Magic-${version}.tar.gz";
       hash = "sha256-n3hTJJyeo7TfkvtreQwDpgaA/AKfRMi/mJTczwGVFr0=";
     };
     meta = {
@@ -37949,11 +37949,11 @@ with self;
     };
   };
 
-  Version = buildPerlPackage {
+  Version = buildPerlPackage rec {
     pname = "version";
     version = "0.9930";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/version-0.9930.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/version-${version}.tar.gz";
       hash = "sha256-YduVX7yzn1kC+myLlXrrJ0HiPUhA+Eq/hGrx9nCu7jA=";
     };
     meta = {
@@ -37965,11 +37965,11 @@ with self;
     };
   };
 
-  vidir = buildPerlPackage {
+  vidir = buildPerlPackage rec {
     pname = "App-vidir";
     version = "0.052";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/W/WO/WOLDRICH/App-vidir-0.052.tar.gz";
+      url = "mirror://cpan/authors/id/W/WO/WOLDRICH/App-vidir-${version}.tar.gz";
       hash = "sha256-GSKQdqXxPvGe1sEbu5Bcrc4iYH+pDoXJrxqqKbWsFQo=";
     };
     outputs = [ "out" ];
@@ -37984,11 +37984,11 @@ with self;
     };
   };
 
-  VMEC2 = buildPerlModule {
+  VMEC2 = buildPerlModule rec {
     pname = "VM-EC2";
     version = "1.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LD/LDS/VM-EC2-1.28.tar.gz";
+      url = "mirror://cpan/authors/id/L/LD/LDS/VM-EC2-${version}.tar.gz";
       hash = "sha256-srazF0XFdDH8oO+5udC48WjWCBdV4Ej9nWxEab0Qis0=";
     };
     propagatedBuildInputs = [
@@ -38007,11 +38007,11 @@ with self;
     };
   };
 
-  VMEC2SecurityCredentialCache = buildPerlPackage {
+  VMEC2SecurityCredentialCache = buildPerlPackage rec {
     pname = "VM-EC2-Security-CredentialCache";
     version = "0.25";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RC/RCONOVER/VM-EC2-Security-CredentialCache-0.25.tar.gz";
+      url = "mirror://cpan/authors/id/R/RC/RCONOVER/VM-EC2-Security-CredentialCache-${version}.tar.gz";
       hash = "sha256-/H6cFS/ytyHMsiGsQAiZNHdc9YNmrttcwWk2CfhAk3s=";
     };
     propagatedBuildInputs = [
@@ -38028,11 +38028,11 @@ with self;
     };
   };
 
-  W3CLinkChecker = buildPerlPackage {
+  W3CLinkChecker = buildPerlPackage rec {
     pname = "W3C-LinkChecker";
     version = "5.0.0";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DH/DHM/W3C-LinkChecker-5.0.0.tar.gz";
+      url = "mirror://cpan/authors/id/D/DH/DHM/W3C-LinkChecker-${version}.tar.gz";
       hash = "sha256-CvdY0ZUMswTdqvqnoDmHaHTYjC/teL2KYx6zkG5U+6Y=";
     };
     outputs = [ "out" ];
@@ -38107,11 +38107,11 @@ with self;
     };
   };
 
-  WWWFormUrlEncoded = buildPerlModule {
+  WWWFormUrlEncoded = buildPerlModule rec {
     pname = "WWW-Form-UrlEncoded";
     version = "0.26";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KAZEBURO/WWW-Form-UrlEncoded-0.26.tar.gz";
+      url = "mirror://cpan/authors/id/K/KA/KAZEBURO/WWW-Form-UrlEncoded-${version}.tar.gz";
       hash = "sha256-wEgLXx8VtxFj7DJ7jnhCKY8Ms6zpfmPXA0rx6UotkPQ=";
     };
     meta = {
@@ -38124,11 +38124,11 @@ with self;
     };
   };
 
-  WWWMechanize = buildPerlPackage {
+  WWWMechanize = buildPerlPackage rec {
     pname = "WWW-Mechanize";
     version = "2.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SI/SIMBABQUE/WWW-Mechanize-2.17.tar.gz";
+      url = "mirror://cpan/authors/id/S/SI/SIMBABQUE/WWW-Mechanize-${version}.tar.gz";
       hash = "sha256-nAIAPoRiHeoSyYDEEB555PjK5OOCzT2iOfqovRmPBjo=";
     };
     propagatedBuildInputs = [
@@ -38157,11 +38157,11 @@ with self;
     };
   };
 
-  WWWMechanizeCGI = buildPerlPackage {
+  WWWMechanizeCGI = buildPerlPackage rec {
     pname = "WWW-Mechanize-CGI";
     version = "0.3";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MR/MRAMBERG/WWW-Mechanize-CGI-0.3.tar.gz";
+      url = "mirror://cpan/authors/id/M/MR/MRAMBERG/WWW-Mechanize-CGI-${version}.tar.gz";
       hash = "sha256-weBNi/Hh8NfP9Rl7I2Z2kyrLgCgJNq7a5PngSFGo0hA=";
     };
     propagatedBuildInputs = [
@@ -38182,11 +38182,11 @@ with self;
     };
   };
 
-  WWWRobotRules = buildPerlPackage {
+  WWWRobotRules = buildPerlPackage rec {
     pname = "WWW-RobotRules";
     version = "6.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GA/GAAS/WWW-RobotRules-6.02.tar.gz";
+      url = "mirror://cpan/authors/id/G/GA/GAAS/WWW-RobotRules-${version}.tar.gz";
       hash = "sha256-RrUC56KI1VlCmJHutdl5Rh3T7MalxJHq2F0WW24DpR4=";
     };
     propagatedBuildInputs = [ URI ];
@@ -38199,11 +38199,11 @@ with self;
     };
   };
 
-  WWWTwilioAPI = buildPerlPackage {
+  WWWTwilioAPI = buildPerlPackage rec {
     pname = "WWW-Twilio-API";
     version = "0.21";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SC/SCOTTW/WWW-Twilio-API-0.21.tar.gz";
+      url = "mirror://cpan/authors/id/S/SC/SCOTTW/WWW-Twilio-API-${version}.tar.gz";
       hash = "sha256-WC21OgkfjaNnDAN3MzFPJRCvXo7gukKg45Hi8uPKdzQ=";
     };
     prePatch = "rm examples.pl";
@@ -38219,11 +38219,11 @@ with self;
 
   WWWYoutubeViewer = callPackage ../development/perl-modules/WWW-YoutubeViewer { };
 
-  Want = buildPerlPackage {
+  Want = buildPerlPackage rec {
     pname = "Want";
     version = "0.29";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RO/ROBIN/Want-0.29.tar.gz";
+      url = "mirror://cpan/authors/id/R/RO/ROBIN/Want-${version}.tar.gz";
       hash = "sha256-tOR0C41Mt4NZEnPGNr1oMEiS4o2J6Iq/knOx3hf1Uvc=";
     };
     meta = {
@@ -38235,11 +38235,11 @@ with self;
     };
   };
 
-  Win32ShellQuote = buildPerlPackage {
+  Win32ShellQuote = buildPerlPackage rec {
     pname = "Win32-ShellQuote";
     version = "0.003001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/Win32-ShellQuote-0.003001.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Win32-ShellQuote-${version}.tar.gz";
       hash = "sha256-qnSw49wtQc1j9i+FPlIf/Xa42CNHmiYZ4i7bQEm0wNw=";
     };
     meta = {
@@ -38251,11 +38251,11 @@ with self;
     };
   };
 
-  Workflow = buildPerlPackage {
+  Workflow = buildPerlPackage rec {
     pname = "Workflow";
     version = "1.62";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JO/JONASBN/Workflow-1.62.tar.gz";
+      url = "mirror://cpan/authors/id/J/JO/JONASBN/Workflow-${version}.tar.gz";
       hash = "sha256-WNNokAm4j+Gp2DcWfTKaoe4xTzFZeeVik2OGVFs80pU=";
     };
     buildInputs = [
@@ -38291,24 +38291,24 @@ with self;
     };
   };
 
-  Wx = buildPerlPackage {
+  Wx = buildPerlPackage rec {
     pname = "Wx";
     version = "0.9932";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MD/MDOOTSON/Wx-0.9932.tar.gz";
+      url = "mirror://cpan/authors/id/M/MD/MDOOTSON/Wx-${version}.tar.gz";
       hash = "sha256-HP22U1oPRnbm8aqyydjhbVd74+s7fMBMgHTWheZlG3A=";
     };
     patches = [
       (fetchpatch {
-        url = "https://sources.debian.org/data/main/libw/libwx-perl/1%3A0.9932-8/debian/patches/gtk3.patch";
+        url = "https://sources.debian.org/data/main/libw/libwx-perl/1%3A${version}-8/debian/patches/gtk3.patch";
         hash = "sha256-CokmRzDTFmEMN/jTKw9ECCPvi0mHt5+h8Ojg4Jgd7D4=";
       })
       (fetchpatch {
-        url = "https://sources.debian.org/data/main/libw/libwx-perl/1%3A0.9932-8/debian/patches/wxWidgets_3.2_MakeMaker.patch";
+        url = "https://sources.debian.org/data/main/libw/libwx-perl/1%3A${version}-8/debian/patches/wxWidgets_3.2_MakeMaker.patch";
         hash = "sha256-kTJiCGv8yxQbgMych9yT2cOt+2bL1G4oJ0gehNcu0Rc=";
       })
       (fetchpatch {
-        url = "https://sources.debian.org/data/main/libw/libwx-perl/1%3A0.9932-8/debian/patches/wxWidgets_3.2_port.patch";
+        url = "https://sources.debian.org/data/main/libw/libwx-perl/1%3A${version}-8/debian/patches/wxWidgets_3.2_port.patch";
         hash = "sha256-y9LMpcbm7p8+LZ2Hw3PA2jc7bHAFEu0QRa170XuseKw=";
       })
     ];
@@ -38335,11 +38335,11 @@ with self;
     };
   };
 
-  WxGLCanvas = buildPerlPackage {
+  WxGLCanvas = buildPerlPackage rec {
     pname = "Wx-GLCanvas";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MB/MBARBON/Wx-GLCanvas-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/M/MB/MBARBON/Wx-GLCanvas-${version}.tar.gz";
       hash = "sha256-atLCn/Bv+Apci0udHWvwrtV0iegxvlnJRJT09ojcj+A=";
     };
     propagatedBuildInputs = [
@@ -38360,11 +38360,11 @@ with self;
     };
   };
 
-  X11IdleTime = buildPerlPackage {
+  X11IdleTime = buildPerlPackage rec {
     pname = "X11-IdleTime";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AW/AWENDT/X11-IdleTime-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/A/AW/AWENDT/X11-IdleTime-${version}.tar.gz";
       hash = "sha256-2P3cB455ge4xt2CMZTZFyyDwFr3dx8VQtNUn79NiR0g=";
     };
     buildInputs = [
@@ -38383,11 +38383,11 @@ with self;
     };
   };
 
-  X11Protocol = buildPerlPackage {
+  X11Protocol = buildPerlPackage rec {
     pname = "X11-Protocol";
     version = "0.56";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SM/SMCCAM/X11-Protocol-0.56.tar.gz";
+      url = "mirror://cpan/authors/id/S/SM/SMCCAM/X11-Protocol-${version}.tar.gz";
       hash = "sha256-3pbdbHwfJfMoeqevZJAr+ErKqo4MO7dqoWdjZ+BKCLc=";
     };
     doCheck = false; # requires an X server
@@ -38400,11 +38400,11 @@ with self;
     };
   };
 
-  X11ProtocolOther = buildPerlPackage {
+  X11ProtocolOther = buildPerlPackage rec {
     pname = "X11-Protocol-Other";
     version = "31";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KR/KRYDE/X11-Protocol-Other-31.tar.gz";
+      url = "mirror://cpan/authors/id/K/KR/KRYDE/X11-Protocol-Other-${version}.tar.gz";
       hash = "sha256-PGJZk9x6jrHQLgcQimZjAkWcb8b589J2FfdJUVjcc/Q=";
     };
     propagatedBuildInputs = [ X11Protocol ];
@@ -38422,11 +38422,11 @@ with self;
     };
   };
 
-  X11GUITest = buildPerlPackage {
+  X11GUITest = buildPerlPackage rec {
     pname = "X11-GUITest";
     version = "0.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CT/CTRONDLP/X11-GUITest-0.28.tar.gz";
+      url = "mirror://cpan/authors/id/C/CT/CTRONDLP/X11-GUITest-${version}.tar.gz";
       hash = "sha256-3O7eU3AGEP/xQtydXE5M0DcMiKTysTcfnL9NjYzm9ks=";
     };
     buildInputs = [
@@ -38443,11 +38443,11 @@ with self;
     };
   };
 
-  X11XCB = buildPerlPackage {
+  X11XCB = buildPerlPackage rec {
     pname = "X11-XCB";
     version = "0.24";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZH/ZHMYLOVE/X11-XCB-0.24.tar.gz";
+      url = "mirror://cpan/authors/id/Z/ZH/ZHMYLOVE/X11-XCB-${version}.tar.gz";
       hash = "sha256-eIUZZzpDxHUecwYaiCG2WPyV8G1cGcnx3rtgX7ILoEU=";
     };
     patches = [
@@ -38489,11 +38489,11 @@ with self;
     };
   };
 
-  XMLCanonicalizeXML = buildPerlPackage {
+  XMLCanonicalizeXML = buildPerlPackage rec {
     pname = "XML-CanonicalizeXML";
     version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SJ/SJZASADA/XML-CanonicalizeXML-0.10.tar.gz";
+      url = "mirror://cpan/authors/id/S/SJ/SJZASADA/XML-CanonicalizeXML-${version}.tar.gz";
       hash = "sha256-5yhGSIDLtMHz/XceCQOoUmzWV7OUuzchYDUkXPHihu4=";
     };
     buildInputs = [ pkgs.libxml2 ];
@@ -38536,11 +38536,11 @@ with self;
     };
   };
 
-  XMLDescent = buildPerlModule {
+  XMLDescent = buildPerlModule rec {
     pname = "XML-Descent";
     version = "1.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AN/ANDYA/XML-Descent-1.04.tar.gz";
+      url = "mirror://cpan/authors/id/A/AN/ANDYA/XML-Descent-${version}.tar.gz";
       hash = "sha256-pxG4VvjN9eZHpExx+WfUjAlgNbnb0/Hvvb6kBgWvvVA=";
     };
     buildInputs = [ TestDifferences ];
@@ -38554,11 +38554,11 @@ with self;
     };
   };
 
-  XMLEncoding = buildPerlPackage {
+  XMLEncoding = buildPerlPackage rec {
     pname = "XML-Encoding";
     version = "2.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHAY/XML-Encoding-2.11.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHAY/XML-Encoding-${version}.tar.gz";
       hash = "sha256-pQ5Brwp5uILUiBa5VoHzilWvHmqIgo3NljdKi94jBaE=";
     };
     propagatedBuildInputs = [ XMLParser ];
@@ -38571,11 +38571,11 @@ with self;
     };
   };
 
-  XMLEntities = buildPerlPackage {
+  XMLEntities = buildPerlPackage rec {
     pname = "XML-Entities";
     version = "1.0002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SI/SIXTEASE/XML-Entities-1.0002.tar.gz";
+      url = "mirror://cpan/authors/id/S/SI/SIXTEASE/XML-Entities-${version}.tar.gz";
       hash = "sha256-wyqk8wlXPXZIqy5Bb2K2sgZS8q2c/T7sgv1REB/nMQ0=";
     };
     propagatedBuildInputs = [ LWP ];
@@ -38588,11 +38588,11 @@ with self;
     };
   };
 
-  XMLDOM = buildPerlPackage {
+  XMLDOM = buildPerlPackage rec {
     pname = "XML-DOM";
     version = "1.46";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TJ/TJMATHER/XML-DOM-1.46.tar.gz";
+      url = "mirror://cpan/authors/id/T/TJ/TJMATHER/XML-DOM-${version}.tar.gz";
       hash = "sha256-i6JLC0WbAdbF5bBAiCnH1d/kf/ebNUjIE3WQSAmbF14=";
     };
     propagatedBuildInputs = [
@@ -38605,11 +38605,11 @@ with self;
     };
   };
 
-  XMLFeedPP = buildPerlPackage {
+  XMLFeedPP = buildPerlPackage rec {
     pname = "XML-FeedPP";
     version = "0.95";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARKOV/XML-FeedPP-0.95.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MARKOV/XML-FeedPP-${version}.tar.gz";
       hash = "sha256-kMOVm/GmC3aimnSac5QfOgx7mllUwTZbyB2vyrsBqPQ=";
     };
     propagatedBuildInputs = [ XMLTreePP ];
@@ -38623,11 +38623,11 @@ with self;
     };
   };
 
-  XMLFilterBufferText = buildPerlPackage {
+  XMLFilterBufferText = buildPerlPackage rec {
     pname = "XML-Filter-BufferText";
     version = "1.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RB/RBERJON/XML-Filter-BufferText-1.01.tar.gz";
+      url = "mirror://cpan/authors/id/R/RB/RBERJON/XML-Filter-BufferText-${version}.tar.gz";
       hash = "sha256-j9ISbTvuxVTfhSkZ9HOeaJICy7pqF1Bum2bqFlhBp1w=";
     };
     doCheck = false;
@@ -38640,11 +38640,11 @@ with self;
     };
   };
 
-  XMLFilterXInclude = buildPerlPackage {
+  XMLFilterXInclude = buildPerlPackage rec {
     pname = "XML-Filter-XInclude";
     version = "1.0";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSERGEANT/XML-Filter-XInclude-1.0.tar.gz";
+      url = "mirror://cpan/authors/id/M/MS/MSERGEANT/XML-Filter-XInclude-${version}.tar.gz";
       hash = "sha256-mHRvPB9vBJSR/sID1FW7j4ycbiUPBBkE3aXXjiEYf5M=";
     };
     doCheck = false;
@@ -38657,11 +38657,11 @@ with self;
     };
   };
 
-  XMLFilterSort = buildPerlPackage {
+  XMLFilterSort = buildPerlPackage rec {
     pname = "XML-Filter-Sort";
     version = "1.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GR/GRANTM/XML-Filter-Sort-1.01.tar.gz";
+      url = "mirror://cpan/authors/id/G/GR/GRANTM/XML-Filter-Sort-${version}.tar.gz";
       hash = "sha256-UQWF85pJFszV+o1UXpYXnJHq9vx8l6QBp1aOhBFi+l8=";
     };
     propagatedBuildInputs = [
@@ -38678,11 +38678,11 @@ with self;
     };
   };
 
-  XMLGrove = buildPerlPackage {
+  XMLGrove = buildPerlPackage rec {
     pname = "XML-Grove";
     version = "0.46alpha";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KM/KMACLEOD/XML-Grove-0.46alpha.tar.gz";
+      url = "mirror://cpan/authors/id/K/KM/KMACLEOD/XML-Grove-${version}.tar.gz";
       hash = "sha256-/LZtffSsKcsO3B6mLBdQcCyqaob8lHkKlPyxo2vQ0Rc=";
     };
     buildInputs = [ pkgs.libxml2 ];
@@ -38699,11 +38699,11 @@ with self;
     };
   };
 
-  XMLHandlerYAWriter = buildPerlPackage {
+  XMLHandlerYAWriter = buildPerlPackage rec {
     pname = "XML-Handler-YAWriter";
     version = "0.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KR/KRAEHE/XML-Handler-YAWriter-0.23.tar.gz";
+      url = "mirror://cpan/authors/id/K/KR/KRAEHE/XML-Handler-YAWriter-${version}.tar.gz";
       hash = "sha256-50y7vl41wapyYZC/re8cePN7ThV3+JyT2sKgr4MqpIU=";
     };
     propagatedBuildInputs = [ libxml_perl ];
@@ -38714,11 +38714,11 @@ with self;
     };
   };
 
-  XMLLibXML = buildPerlPackage {
+  XMLLibXML = buildPerlPackage rec {
     pname = "XML-LibXML";
     version = "2.0210";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/XML-LibXML-2.0210.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/XML-LibXML-${version}.tar.gz";
       hash = "sha256-opvz8Aq5ye4EIYFU4K/I95m/I2dOuZwantTeH0BZpI0=";
     };
     env.SKIP_SAX_INSTALL = 1;
@@ -38747,11 +38747,11 @@ with self;
     };
   };
 
-  XMLLibXMLSimple = buildPerlPackage {
+  XMLLibXMLSimple = buildPerlPackage rec {
     pname = "XML-LibXML-Simple";
     version = "1.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARKOV/XML-LibXML-Simple-1.01.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MARKOV/XML-LibXML-Simple-${version}.tar.gz";
       hash = "sha256-zZjIEEtw12cr+ia0UTt4rfK0uSIOWGqovrGlCFADZaY=";
     };
     propagatedBuildInputs = [ XMLLibXML ];
@@ -38764,11 +38764,11 @@ with self;
     };
   };
 
-  XMLLibXSLT = buildPerlPackage {
+  XMLLibXSLT = buildPerlPackage rec {
     pname = "XML-LibXSLT";
     version = "2.002001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/XML-LibXSLT-2.002001.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/XML-LibXSLT-${version}.tar.gz";
       hash = "sha256-34knxP8ZSfYlgNHB5vAPDNVrU9OpV+5LFxtZv/pjssA=";
     };
     nativeBuildInputs = [ pkgs.pkg-config ];
@@ -38787,11 +38787,11 @@ with self;
     };
   };
 
-  XMLMini = buildPerlPackage {
+  XMLMini = buildPerlPackage rec {
     pname = "XML-Mini";
     version = "1.38";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PD/PDEEGAN/XML-Mini-1.38.tar.gz";
+      url = "mirror://cpan/authors/id/P/PD/PDEEGAN/XML-Mini-${version}.tar.gz";
       hash = "sha256-r4A9OANqMYThJKaC5UZvG8EH9IqJ7zWwx2R+EaBz/i0=";
     };
     meta = {
@@ -38800,11 +38800,11 @@ with self;
     };
   };
 
-  XMLNamespaceSupport = buildPerlPackage {
+  XMLNamespaceSupport = buildPerlPackage rec {
     pname = "XML-NamespaceSupport";
     version = "1.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PERIGRIN/XML-NamespaceSupport-1.12.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PERIGRIN/XML-NamespaceSupport-${version}.tar.gz";
       hash = "sha256-R+mVhZ+N0EE6o/ItNQxKYtplLoVCZ6oFhq5USuK65e8=";
     };
     meta = {
@@ -38816,11 +38816,11 @@ with self;
     };
   };
 
-  XMLParser = buildPerlPackage {
+  XMLParser = buildPerlPackage rec {
     pname = "XML-Parser";
     version = "2.46";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TODDR/XML-Parser-2.46.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TODDR/XML-Parser-${version}.tar.gz";
       hash = "sha256-0zEzJJHFHMz7TLlP/ET5zXM3jmGEmNSjffngQ2YcUV0=";
     };
     patches = [ ../development/perl-modules/xml-parser-0001-HACK-Assumes-Expat-paths-are-good.patch ];
@@ -38845,11 +38845,11 @@ with self;
     };
   };
 
-  XMLParserLite = buildPerlPackage {
+  XMLParserLite = buildPerlPackage rec {
     pname = "XML-Parser-Lite";
     version = "0.722";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PH/PHRED/XML-Parser-Lite-0.722.tar.gz";
+      url = "mirror://cpan/authors/id/P/PH/PHRED/XML-Parser-Lite-${version}.tar.gz";
       hash = "sha256-b5CgJ+FTGg5UBs8d4Txwm1IWlm349z0Lq5q5GSCXY+4=";
     };
     buildInputs = [ TestRequires ];
@@ -38862,11 +38862,11 @@ with self;
     };
   };
 
-  XMLXPath = buildPerlPackage {
+  XMLXPath = buildPerlPackage rec {
     pname = "XML-XPath";
     version = "1.48";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MANWAR/XML-XPath-1.48.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MANWAR/XML-XPath-${version}.tar.gz";
       hash = "sha256-e8db42sjnlsucAqVcNK1O0MJPUZ/Kr5qdD+f+Qk3kM0=";
     };
     buildInputs = [ PathTiny ];
@@ -38878,11 +38878,11 @@ with self;
     };
   };
 
-  XMLXPathEngine = buildPerlPackage {
+  XMLXPathEngine = buildPerlPackage rec {
     pname = "XML-XPathEngine";
     version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIROD/XML-XPathEngine-0.14.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIROD/XML-XPathEngine-${version}.tar.gz";
       hash = "sha256-0v57y70L66FET0pzNAHnuKpSgvrUJm1Cc13XRYKy4mQ=";
     };
     meta = {
@@ -38894,11 +38894,11 @@ with self;
     };
   };
 
-  XMLRegExp = buildPerlPackage {
+  XMLRegExp = buildPerlPackage rec {
     pname = "XML-RegExp";
     version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TJ/TJMATHER/XML-RegExp-0.04.tar.gz";
+      url = "mirror://cpan/authors/id/T/TJ/TJMATHER/XML-RegExp-${version}.tar.gz";
       hash = "sha256-3xmQCWA2CFyOLUWQT+GA+Cv+1A8afgUkPzNOoQCQ/FQ=";
     };
     meta = {
@@ -38907,11 +38907,11 @@ with self;
     };
   };
 
-  XMLRPCLite = buildPerlPackage {
+  XMLRPCLite = buildPerlPackage rec {
     pname = "XMLRPC-Lite";
     version = "0.717";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PH/PHRED/XMLRPC-Lite-0.717.tar.gz";
+      url = "mirror://cpan/authors/id/P/PH/PHRED/XMLRPC-Lite-${version}.tar.gz";
       hash = "sha256-Op+l8ssfr4t8ZrTDhuqzXKxgiK/E28dX1Pd9KE2rRSQ=";
     };
     propagatedBuildInputs = [ SOAPLite ];
@@ -38926,11 +38926,11 @@ with self;
     };
   };
 
-  XMLRSS = buildPerlModule {
+  XMLRSS = buildPerlModule rec {
     pname = "XML-RSS";
     version = "1.62";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/XML-RSS-1.62.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/XML-RSS-${version}.tar.gz";
       hash = "sha256-0ycGNELH/3FDmTqgwtFv3lEhSRyXFmHrbLcA0uBDi04=";
     };
     propagatedBuildInputs = [
@@ -38948,11 +38948,11 @@ with self;
     };
   };
 
-  XMLRules = buildPerlModule {
+  XMLRules = buildPerlModule rec {
     pname = "XML-Rules";
     version = "1.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JE/JENDA/XML-Rules-1.16.tar.gz";
+      url = "mirror://cpan/authors/id/J/JE/JENDA/XML-Rules-${version}.tar.gz";
       hash = "sha256-N4glXAev5BlaDecs4FBlIyDYF1KP8tEMYR9uOSBDhos=";
     };
     propagatedBuildInputs = [ XMLParser ];
@@ -38965,11 +38965,11 @@ with self;
     };
   };
 
-  XMLSAX = buildPerlPackage {
+  XMLSAX = buildPerlPackage rec {
     pname = "XML-SAX";
     version = "1.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GR/GRANTM/XML-SAX-1.02.tar.gz";
+      url = "mirror://cpan/authors/id/G/GR/GRANTM/XML-SAX-${version}.tar.gz";
       hash = "sha256-RQbDhwQ6pqd7RV8A9XQJ83IKp+VTSVqyU1JjtO0eoSo=";
     };
     propagatedBuildInputs = [
@@ -38989,11 +38989,11 @@ with self;
     };
   };
 
-  XMLSAXBase = buildPerlPackage {
+  XMLSAXBase = buildPerlPackage rec {
     pname = "XML-SAX-Base";
     version = "1.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GR/GRANTM/XML-SAX-Base-1.09.tar.gz";
+      url = "mirror://cpan/authors/id/G/GR/GRANTM/XML-SAX-Base-${version}.tar.gz";
       hash = "sha256-Zss1W6TvR8EMpzi9NZmXI2RDhqyFOrvrUTKEH16KKtA=";
     };
     meta = {
@@ -39006,11 +39006,11 @@ with self;
     };
   };
 
-  XMLSAXExpat = buildPerlPackage {
+  XMLSAXExpat = buildPerlPackage rec {
     pname = "XML-SAX-Expat";
     version = "0.51";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BJ/BJOERN/XML-SAX-Expat-0.51.tar.gz";
+      url = "mirror://cpan/authors/id/B/BJ/BJOERN/XML-SAX-Expat-${version}.tar.gz";
       hash = "sha256-TAFiE9DOfbLElOMAhrWZF7MC24wpLc0h853uvZeAyD8=";
     };
     propagatedBuildInputs = [
@@ -39028,11 +39028,11 @@ with self;
     };
   };
 
-  XMLSAXWriter = buildPerlPackage {
+  XMLSAXWriter = buildPerlPackage rec {
     pname = "XML-SAX-Writer";
     version = "0.57";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PERIGRIN/XML-SAX-Writer-0.57.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PERIGRIN/XML-SAX-Writer-${version}.tar.gz";
       hash = "sha256-PWHQfvQ7ASb1tN5PQVolb6hZ+ojcT9q6rXC3vnxoLPA=";
     };
     propagatedBuildInputs = [
@@ -39050,11 +39050,11 @@ with self;
     };
   };
 
-  XMLSemanticDiff = buildPerlModule {
+  XMLSemanticDiff = buildPerlModule rec {
     pname = "XML-SemanticDiff";
     version = "1.0007";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PERIGRIN/XML-SemanticDiff-1.0007.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PERIGRIN/XML-SemanticDiff-${version}.tar.gz";
       hash = "sha256-Bf3v77vD9rYvx8m1+rr7a2le1o8KPZWFdyUdHwQCoPU=";
     };
     propagatedBuildInputs = [ XMLParser ];
@@ -39067,11 +39067,11 @@ with self;
     };
   };
 
-  XMLSimple = buildPerlPackage {
+  XMLSimple = buildPerlPackage rec {
     pname = "XML-Simple";
     version = "2.25";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GR/GRANTM/XML-Simple-2.25.tar.gz";
+      url = "mirror://cpan/authors/id/G/GR/GRANTM/XML-Simple-${version}.tar.gz";
       hash = "sha256-Ux/drr6iQWdD61xP36sCj1AhI9miIEBaQQDmj8SA2/g=";
     };
     propagatedBuildInputs = [ XMLSAXExpat ];
@@ -39084,11 +39084,11 @@ with self;
     };
   };
 
-  XMLTokeParser = buildPerlPackage {
+  XMLTokeParser = buildPerlPackage rec {
     pname = "XML-TokeParser";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PO/PODMASTER/XML-TokeParser-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/P/PO/PODMASTER/XML-TokeParser-${version}.tar.gz";
       hash = "sha256-hTm0+YQ2sabQiDQai0Uwt5IqzWUfPyk3f4sZSMfi18I=";
     };
     propagatedBuildInputs = [ XMLParser ];
@@ -39101,11 +39101,11 @@ with self;
     };
   };
 
-  XMLTreePP = buildPerlPackage {
+  XMLTreePP = buildPerlPackage rec {
     pname = "XML-TreePP";
     version = "0.43";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KAWASAKI/XML-TreePP-0.43.tar.gz";
+      url = "mirror://cpan/authors/id/K/KA/KAWASAKI/XML-TreePP-${version}.tar.gz";
       hash = "sha256-f74tZDCGAFmJSu7r911MrPG/jXt1KU64fY4VAvgb12A=";
     };
     propagatedBuildInputs = [ LWP ];
@@ -39118,11 +39118,11 @@ with self;
     };
   };
 
-  XMLTwig = buildPerlPackage {
+  XMLTwig = buildPerlPackage rec {
     pname = "XML-Twig";
     version = "3.52";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIROD/XML-Twig-3.52.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIROD/XML-Twig-${version}.tar.gz";
       hash = "sha256-/vdYJsJPK4d9Cg0mRSEvxPuXVu1NJxFhSsFcSX6GgK0=";
     };
     postInstall = ''
@@ -39141,11 +39141,11 @@ with self;
     };
   };
 
-  XMLValidatorSchema = buildPerlPackage {
+  XMLValidatorSchema = buildPerlPackage rec {
     pname = "XML-Validator-Schema";
     version = "1.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SA/SAMTREGAR/XML-Validator-Schema-1.10.tar.gz";
+      url = "mirror://cpan/authors/id/S/SA/SAMTREGAR/XML-Validator-Schema-${version}.tar.gz";
       hash = "sha256-YUJnlYAVCokffTIjK14x4rTl5T6Kb6nL7stcI4FPFCI=";
     };
     propagatedBuildInputs = [
@@ -39162,11 +39162,11 @@ with self;
     };
   };
 
-  XMLWriter = buildPerlPackage {
+  XMLWriter = buildPerlPackage rec {
     pname = "XML-Writer";
     version = "0.900";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JO/JOSEPHW/XML-Writer-0.900.tar.gz";
+      url = "mirror://cpan/authors/id/J/JO/JOSEPHW/XML-Writer-${version}.tar.gz";
       hash = "sha256-c8j1vT7PKzUPStrm1mdtUuCOzC199KnwifpoNg1ADR8=";
     };
     meta = {
@@ -39175,11 +39175,11 @@ with self;
     };
   };
 
-  XSObjectMagic = buildPerlPackage {
+  XSObjectMagic = buildPerlPackage rec {
     pname = "XS-Object-Magic";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/XS-Object-Magic-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/XS-Object-Magic-${version}.tar.gz";
       hash = "sha256-PcnkYM7pLhF0QGJ1RkOjN3jKUqVNIF/K/6SrDzzxXlo=";
     };
     buildInputs = [
@@ -39196,11 +39196,11 @@ with self;
     };
   };
 
-  XSParseKeyword = buildPerlModule {
+  XSParseKeyword = buildPerlModule rec {
     pname = "XS-Parse-Keyword";
     version = "0.48";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/XS-Parse-Keyword-0.48.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/XS-Parse-Keyword-${version}.tar.gz";
       hash = "sha256-hXoHC6Rlq1uJ1NjTbZI1jt1m5ee0qRWEYR2FElrJqcc=";
     };
     buildInputs = [
@@ -39217,11 +39217,11 @@ with self;
     };
   };
 
-  XSParseSublike = buildPerlModule {
+  XSParseSublike = buildPerlModule rec {
     pname = "XS-Parse-Sublike";
     version = "0.37";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/XS-Parse-Sublike-0.37.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/XS-Parse-Sublike-${version}.tar.gz";
       hash = "sha256-c2UoyIjqe2phkQEeXVp4JOw4pWIFB95u9F5LxuHPDak=";
     };
     buildInputs = [ Test2Suite ];
@@ -39235,11 +39235,11 @@ with self;
     };
   };
 
-  XXX = buildPerlPackage {
+  XXX = buildPerlPackage rec {
     pname = "XXX";
     version = "0.38";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IN/INGY/XXX-0.38.tar.gz";
+      url = "mirror://cpan/authors/id/I/IN/INGY/XXX-${version}.tar.gz";
       hash = "sha256-0QUQ6gD2Gav0erKZ8Ui9WzYM+gfcDtUYE4t87HJpLSo=";
     };
     propagatedBuildInputs = [ YAMLPP ];
@@ -39253,11 +39253,11 @@ with self;
     };
   };
 
-  YAML = buildPerlPackage {
+  YAML = buildPerlPackage rec {
     pname = "YAML";
     version = "1.30";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TI/TINITA/YAML-1.30.tar.gz";
+      url = "mirror://cpan/authors/id/T/TI/TINITA/YAML-${version}.tar.gz";
       hash = "sha256-UDCm1sv/rxJYMFC/VSqoANRkbKlnjBh63WSSJ/V0ec0=";
     };
 
@@ -39277,11 +39277,11 @@ with self;
     };
   };
 
-  YAMLOld = buildPerlPackage {
+  YAMLOld = buildPerlPackage rec {
     pname = "YAML-Old";
     version = "1.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IN/INGY/YAML-Old-1.23.tar.gz";
+      url = "mirror://cpan/authors/id/I/IN/INGY/YAML-Old-${version}.tar.gz";
       hash = "sha256-+lRvzZrMWjm8iHGQL3/B66UOfceBxc1cCr8a7ObRfs0=";
     };
     buildInputs = [
@@ -39298,11 +39298,11 @@ with self;
     };
   };
 
-  YAMLSyck = buildPerlPackage {
+  YAMLSyck = buildPerlPackage rec {
     pname = "YAML-Syck";
     version = "1.45";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TODDR/YAML-Syck-1.45.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TODDR/YAML-Syck-${version}.tar.gz";
       hash = "sha256-8t4a+08MVsNubVJgqgvSyPGOTYUAnc9YQiBOoqf7w98=";
     };
     env.NIX_CFLAGS_COMPILE = "-std=gnu11";
@@ -39313,11 +39313,11 @@ with self;
     };
   };
 
-  YAMLTiny = buildPerlPackage {
+  YAMLTiny = buildPerlPackage rec {
     pname = "YAML-Tiny";
     version = "1.74";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/YAML-Tiny-1.74.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/YAML-Tiny-${version}.tar.gz";
       hash = "sha256-ezjKn1084kIwpri9wfR/Wy2zSOf3+WZsJvWVVjbjPWw=";
     };
     meta = {
@@ -39329,11 +39329,11 @@ with self;
     };
   };
 
-  YAMLLibYAML = buildPerlPackage {
+  YAMLLibYAML = buildPerlPackage rec {
     pname = "YAML-LibYAML";
     version = "0.89";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TI/TINITA/YAML-LibYAML-0.89.tar.gz";
+      url = "mirror://cpan/authors/id/T/TI/TINITA/YAML-LibYAML-${version}.tar.gz";
       hash = "sha256-FVq4NnU0XFCt0DMRrPndkVlVcH+Qmiq9ixfXeShZsuw=";
     };
     meta = {
@@ -39345,11 +39345,11 @@ with self;
     };
   };
 
-  YAMLPP = buildPerlPackage {
+  YAMLPP = buildPerlPackage rec {
     pname = "YAML-PP";
     version = "0.38.0";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TI/TINITA/YAML-PP-v0.38.0.tar.gz";
+      url = "mirror://cpan/authors/id/T/TI/TINITA/YAML-PP-v${version}.tar.gz";
       hash = "sha256-qBlGXFL2o0EEmjlCdCwI4E8olLKmZILkOn9AfOELTqA=";
     };
     buildInputs = [
@@ -39365,11 +39365,11 @@ with self;
     };
   };
 
-  Yancy = buildPerlPackage {
+  Yancy = buildPerlPackage rec {
     pname = "Yancy";
     version = "1.088";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PR/PREACTION/Yancy-1.088.tar.gz";
+      url = "mirror://cpan/authors/id/P/PR/PREACTION/Yancy-${version}.tar.gz";
       hash = "sha256-addqs5ilrGiQc0Paisybr9UZ+0x4WrAU7CagUhA2vSo=";
     };
     buildInputs = [ FileShareDirInstall ];
@@ -39391,11 +39391,11 @@ with self;
     };
   };
 
-  WebMachine = buildPerlPackage {
+  WebMachine = buildPerlPackage rec {
     pname = "Web-Machine";
     version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Web-Machine-0.17.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Web-Machine-${version}.tar.gz";
       hash = "sha256-8TnSsxFMVJ6RhH2qq4t1y2meV9r1u/Db0TKT8z/l4io=";
     };
     buildInputs = [
@@ -39423,11 +39423,11 @@ with self;
     };
   };
 
-  WebScraper = buildPerlModule {
+  WebScraper = buildPerlModule rec {
     pname = "Web-Scraper";
     version = "0.38";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Web-Scraper-0.38.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Web-Scraper-${version}.tar.gz";
       hash = "sha256-+VtuX41/7r4RbQW/WaK3zxpR7Z0wvKgBI0MOxFZ1Q78=";
     };
     buildInputs = [
@@ -39457,11 +39457,11 @@ with self;
     };
   };
 
-  WebServiceLinode = buildPerlModule {
+  WebServiceLinode = buildPerlModule rec {
     pname = "WebService-Linode";
     version = "0.29";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIKEGRB/WebService-Linode-0.29.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIKEGRB/WebService-Linode-${version}.tar.gz";
       hash = "sha256-EDqrJFME8I6eh6x7yITdtEpjDea6wHfckh9xbXEVSSI=";
     };
     buildInputs = [ ModuleBuildTiny ];
@@ -39479,11 +39479,11 @@ with self;
     };
   };
 
-  WebServiceValidatorHTMLW3C = buildPerlModule {
+  WebServiceValidatorHTMLW3C = buildPerlModule rec {
     pname = "WebService-Validator-HTML-W3C";
     version = "0.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/ST/STRUAN/WebService-Validator-HTML-W3C-0.28.tar.gz";
+      url = "mirror://cpan/authors/id/S/ST/STRUAN/WebService-Validator-HTML-W3C-${version}.tar.gz";
       hash = "sha256-zLB60zegOuyBob6gqJzSlUaR/1uzZ9+aMrnZEw8XURA=";
     };
     buildInputs = [
@@ -39499,11 +39499,11 @@ with self;
     };
   };
 
-  ZonemasterCLI = buildPerlPackage {
+  ZonemasterCLI = buildPerlPackage rec {
     pname = "Zonemaster-CLI";
-    version = "6.000003";
+    version = "6.0.3";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZN/ZNMSTR/Zonemaster-CLI-v6.0.3.tar.gz";
+      url = "mirror://cpan/authors/id/Z/ZN/ZNMSTR/Zonemaster-CLI-v${version}.tar.gz";
       hash = "sha256-oYDBYVygvPUZ9vrGX/y5A0MAQ6zgSsrf6AtUdFcZG4Q=";
     };
     propagatedBuildInputs = [
@@ -39526,11 +39526,11 @@ with self;
     };
   };
 
-  ZonemasterEngine = buildPerlPackage {
+  ZonemasterEngine = buildPerlPackage rec {
     pname = "Zonemaster-Engine";
     version = "4.6.1";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZN/ZNMSTR/Zonemaster-Engine-v4.6.1.tar.gz";
+      url = "mirror://cpan/authors/id/Z/ZN/ZNMSTR/Zonemaster-Engine-v${version}.tar.gz";
       hash = "sha256-4AXo3bZTOLnnPjjX5KNb/2O7MRqcAtlqpz5sPwNN9b0=";
     };
     buildInputs = [
@@ -39566,11 +39566,11 @@ with self;
     };
   };
 
-  ZonemasterLDNS = buildPerlPackage {
+  ZonemasterLDNS = buildPerlPackage rec {
     pname = "Zonemaster-LDNS";
     version = "3.2.0";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZN/ZNMSTR/Zonemaster-LDNS-3.2.0.tar.gz";
+      url = "mirror://cpan/authors/id/Z/ZN/ZNMSTR/Zonemaster-LDNS-${version}.tar.gz";
       hash = "sha256-BpsWQRcpX6gtJSlAocqLMIrYsfPocjvk6CaqqX9wbWw=";
     };
     env.NIX_CFLAGS_COMPILE = "-I${pkgs.openssl.dev}/include -I${pkgs.libidn2}.dev}/include";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -24930,11 +24930,11 @@ with self;
     };
   };
 
-  namespaceautoclean = buildPerlPackage {
+  namespaceautoclean = buildPerlPackage rec {
     pname = "namespace-autoclean";
     version = "0.29";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/namespace-autoclean-0.29.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/namespace-autoclean-${version}.tar.gz";
       hash = "sha256-RevY5kpUqG+I2OAa5VISlnyKqP7VfoFAhd73YIrGWAQ=";
     };
     buildInputs = [ TestNeeds ];
@@ -24952,11 +24952,11 @@ with self;
     };
   };
 
-  namespaceclean = buildPerlPackage {
+  namespaceclean = buildPerlPackage rec {
     pname = "namespace-clean";
     version = "0.27";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RI/RIBASUSHI/namespace-clean-0.27.tar.gz";
+      url = "mirror://cpan/authors/id/R/RI/RIBASUSHI/namespace-clean-${version}.tar.gz";
       hash = "sha256-ihCoPD4YPcePnnt6pNCbR8EftOfTozuaEpEv0i4xr50=";
     };
     propagatedBuildInputs = [
@@ -25007,11 +25007,11 @@ with self;
     };
   };
 
-  NetDNSNative = buildPerlPackage {
+  NetDNSNative = buildPerlPackage rec {
     pname = "Net-DNS-Native";
     version = "0.22";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OL/OLEG/Net-DNS-Native-0.22.tar.gz";
+      url = "mirror://cpan/authors/id/O/OL/OLEG/Net-DNS-Native-${version}.tar.gz";
       hash = "sha256-EI2d7bq5/69qDQFSVSbeGJSITpUL/YM3F+XNOJBcMNU=";
     };
     meta = {
@@ -25024,11 +25024,11 @@ with self;
     };
   };
 
-  NetIdent = buildPerlPackage {
+  NetIdent = buildPerlPackage rec {
     pname = "Net-Ident";
     version = "1.25";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TODDR/Net-Ident-1.25.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TODDR/Net-Ident-${version}.tar.gz";
       hash = "sha256-LlvViwHCpm6ASaL42ck+G19tzlPg7jpIHOam9BHyyPg=";
     };
     meta = {
@@ -25038,11 +25038,11 @@ with self;
     };
   };
 
-  NetINET6Glue = buildPerlPackage {
+  NetINET6Glue = buildPerlPackage rec {
     pname = "Net-INET6Glue";
     version = "0.604";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SU/SULLR/Net-INET6Glue-0.604.tar.gz";
+      url = "mirror://cpan/authors/id/S/SU/SULLR/Net-INET6Glue-${version}.tar.gz";
       hash = "sha256-kMNjmPlQFBTMzaiynyOn908vK09VLhLevxYhjHNbuxc=";
     };
     meta = {
@@ -25055,11 +25055,11 @@ with self;
     };
   };
 
-  NetAddrIP = buildPerlPackage {
+  NetAddrIP = buildPerlPackage rec {
     pname = "NetAddr-IP";
     version = "4.079";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIKER/NetAddr-IP-4.079.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIKER/NetAddr-IP-${version}.tar.gz";
       hash = "sha256-7FqC37cCi80ouz1Wn5XYfdQWbMGYZ/IYTtOln21soOc=";
     };
     meta = {
@@ -25071,11 +25071,11 @@ with self;
     };
   };
 
-  NetAmazonAWSSign = buildPerlPackage {
+  NetAmazonAWSSign = buildPerlPackage rec {
     pname = "Net-Amazon-AWSSign";
     version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NA/NATON/Net-Amazon-AWSSign-0.12.tar.gz";
+      url = "mirror://cpan/authors/id/N/NA/NATON/Net-Amazon-AWSSign-${version}.tar.gz";
       hash = "sha256-HQQMazseorVlkFefnBjgUAtsaiF7WdiDHw2WBMqX7T4=";
     };
     propagatedBuildInputs = [ URI ];
@@ -25088,11 +25088,11 @@ with self;
     };
   };
 
-  NetAmazonEC2 = buildPerlPackage {
+  NetAmazonEC2 = buildPerlPackage rec {
     pname = "Net-Amazon-EC2";
     version = "0.36";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MALLEN/Net-Amazon-EC2-0.36.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MALLEN/Net-Amazon-EC2-${version}.tar.gz";
       hash = "sha256-Tig2kufwZsJBjtrpIz47YkAPk1X01SH5lRXlL3t9cvE=";
     };
     propagatedBuildInputs = [
@@ -25112,11 +25112,11 @@ with self;
     };
   };
 
-  NetAmazonMechanicalTurk = buildPerlModule {
+  NetAmazonMechanicalTurk = buildPerlModule rec {
     pname = "Net-Amazon-MechanicalTurk";
     version = "1.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MT/MTURK/Net-Amazon-MechanicalTurk-1.02.tar.gz";
+      url = "mirror://cpan/authors/id/M/MT/MTURK/Net-Amazon-MechanicalTurk-${version}.tar.gz";
       hash = "sha256-jQlewUjglLJ/TMzHnhyvnDHzzA5t2CzoqORCyNx7D44=";
     };
     patches = [ ../development/perl-modules/net-amazon-mechanicalturk.patch ];
@@ -25132,11 +25132,11 @@ with self;
     };
   };
 
-  NetAmazonS3 = buildPerlPackage {
+  NetAmazonS3 = buildPerlPackage rec {
     pname = "Net-Amazon-S3";
     version = "0.991";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BA/BARNEY/Net-Amazon-S3-0.991.tar.gz";
+      url = "mirror://cpan/authors/id/B/BA/BARNEY/Net-Amazon-S3-${version}.tar.gz";
       hash = "sha256-+3r4umSUjRo/MdgJ13EFImiA8GmYrH8Rn4JITmijI9M=";
     };
     patches = [
@@ -25181,11 +25181,11 @@ with self;
     };
   };
 
-  NetAmazonS3Policy = buildPerlModule {
+  NetAmazonS3Policy = buildPerlModule rec {
     pname = "Net-Amazon-S3-Policy";
     version = "0.1.6";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PO/POLETTIX/Net-Amazon-S3-Policy-0.1.6.tar.gz";
+      url = "mirror://cpan/authors/id/P/PO/POLETTIX/Net-Amazon-S3-Policy-${version}.tar.gz";
       hash = "sha256-0rFukwhnSHQ0tHdHhooAP0scyECy15WfiPw2vQ2G2RQ=";
     };
     propagatedBuildInputs = [ JSON ];
@@ -25198,11 +25198,11 @@ with self;
     };
   };
 
-  NetAsyncHTTP = buildPerlModule {
+  NetAsyncHTTP = buildPerlModule rec {
     pname = "Net-Async-HTTP";
     version = "0.49";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Net-Async-HTTP-0.49.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Net-Async-HTTP-${version}.tar.gz";
       hash = "sha256-OSBtBpSV0bhq7jeqitPJM0025ZzObPec04asDPN5jNs=";
     };
     buildInputs = [
@@ -25232,11 +25232,11 @@ with self;
     };
   };
 
-  NetAsyncHTTPServer = buildPerlModule {
+  NetAsyncHTTPServer = buildPerlModule rec {
     pname = "Net-Async-HTTP-Server";
     version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Net-Async-HTTP-Server-0.14.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Net-Async-HTTP-Server-${version}.tar.gz";
       hash = "sha256-6nG3kcEtD6X3JubMA/Zuo20bRhNxj2xb84EzvRinsrY=";
     };
     buildInputs = [
@@ -25259,11 +25259,11 @@ with self;
     };
   };
 
-  NetAsyncPing = buildPerlPackage {
+  NetAsyncPing = buildPerlPackage rec {
     pname = "Net-Async-Ping";
     version = "0.004001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AB/ABRAXXA/Net-Async-Ping-0.004001.tar.gz";
+      url = "mirror://cpan/authors/id/A/AB/ABRAXXA/Net-Async-Ping-${version}.tar.gz";
       hash = "sha256-kFfoUHYMcT2rB6DBycj4isEfbnTop0gcEObyc12K6Vs=";
     };
     propagatedBuildInputs = [
@@ -25284,11 +25284,11 @@ with self;
     };
   };
 
-  NetAsyncWebSocket = buildPerlModule {
+  NetAsyncWebSocket = buildPerlModule rec {
     pname = "Net-Async-WebSocket";
     version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Net-Async-WebSocket-0.14.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Net-Async-WebSocket-${version}.tar.gz";
       hash = "sha256-DuagrDLXM/3w4jlMl2DNRWO6zSi2qOH6TmPGcf93yCc=";
     };
     buildInputs = [ Test2Suite ];
@@ -25312,11 +25312,11 @@ with self;
     };
   };
 
-  NetAMQP = buildPerlModule {
+  NetAMQP = buildPerlModule rec {
     pname = "Net-AMQP";
     version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHIPS/Net-AMQP-0.06.tar.gz";
+      url = "mirror://cpan/authors/id/C/CH/CHIPS/Net-AMQP-${version}.tar.gz";
       hash = "sha256-Cyun3izX3dX+ECouKueuuiHqqxB4vzv9PFpyKTclY4A=";
     };
     doCheck = false; # failures on 32bit
@@ -25335,11 +25335,11 @@ with self;
     };
   };
 
-  NetCIDR = buildPerlPackage {
+  NetCIDR = buildPerlPackage rec {
     pname = "Net-CIDR";
     version = "0.27";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MR/MRSAM/Net-CIDR-0.27.tar.gz";
+      url = "mirror://cpan/authors/id/M/MR/MRSAM/Net-CIDR-${version}.tar.gz";
       hash = "sha256-npUP70QiJk3I76sw27084r4SXmGz9cUBEdFVBtO1cOM=";
     };
     meta = {
@@ -25352,11 +25352,11 @@ with self;
     };
   };
 
-  NetCIDRLite = buildPerlPackage {
+  NetCIDRLite = buildPerlPackage rec {
     pname = "Net-CIDR-Lite";
     version = "0.24";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/ST/STIGTSP/Net-CIDR-Lite-0.24.tar.gz";
+      url = "mirror://cpan/authors/id/S/ST/STIGTSP/Net-CIDR-Lite-${version}.tar.gz";
       hash = "sha256-+rBqxO5gqYFhxmwQUPofJPa5lwmtD0sO3chOxxynrRc=";
     };
     meta = {
@@ -25369,11 +25369,11 @@ with self;
     };
   };
 
-  NetCoverArtArchive = buildPerlPackage {
+  NetCoverArtArchive = buildPerlPackage rec {
     pname = "Net-CoverArtArchive";
     version = "1.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CY/CYCLES/Net-CoverArtArchive-1.02.tar.gz";
+      url = "mirror://cpan/authors/id/C/CY/CYCLES/Net-CoverArtArchive-${version}.tar.gz";
       hash = "sha256-VyXiCCZDVq1rP6++uXVqz8Kny5WDiMpcCHqsJzNF3dE=";
     };
     buildInputs = [ FileFindRule ];
@@ -25393,11 +25393,11 @@ with self;
     };
   };
 
-  NetCUPS = buildPerlPackage {
+  NetCUPS = buildPerlPackage rec {
     pname = "Net-CUPS";
     version = "0.64";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NI/NINE/Net-CUPS-0.64.tar.gz";
+      url = "mirror://cpan/authors/id/N/NI/NINE/Net-CUPS-${version}.tar.gz";
       hash = "sha256-17x3/w9iv4dMhDxZDrEqgLvUR0mi+3Tb7URcNdDoWoU=";
     };
     patches = [
@@ -25421,11 +25421,11 @@ with self;
     };
   };
 
-  NetDBus = buildPerlPackage {
+  NetDBus = buildPerlPackage rec {
     pname = "Net-DBus";
     version = "1.2.0";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DANBERR/Net-DBus-1.2.0.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DANBERR/Net-DBus-${version}.tar.gz";
       hash = "sha256-56GsnvShI1s/29WIj4bDRxgjBkZ715q8mwdWpktEHLw=";
     };
     nativeBuildInputs = [ buildPackages.pkg-config ];
@@ -25456,11 +25456,11 @@ with self;
     };
   };
 
-  NetDNS = buildPerlPackage {
+  NetDNS = buildPerlPackage rec {
     pname = "Net-DNS";
     version = "1.48";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NL/NLNETLABS/Net-DNS-1.48.tar.gz";
+      url = "mirror://cpan/authors/id/N/NL/NLNETLABS/Net-DNS-${version}.tar.gz";
       hash = "sha256-5V8+caMcK4VgJL9QYbEWCwP4edgBNUFPONgiBHaUR1M=";
     };
     propagatedBuildInputs = [ DigestHMAC ];
@@ -25471,11 +25471,11 @@ with self;
     };
   };
 
-  NetDNSResolverMock = buildPerlPackage {
+  NetDNSResolverMock = buildPerlPackage rec {
     pname = "Net-DNS-Resolver-Mock";
     version = "1.20230216";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MB/MBRADSHAW/Net-DNS-Resolver-Mock-1.20230216.tar.gz";
+      url = "mirror://cpan/authors/id/M/MB/MBRADSHAW/Net-DNS-Resolver-Mock-${version}.tar.gz";
       hash = "sha256-7UkwV3/Rop1kNbWHVTPTso9cElijWDP+bKLLaiaFpJs=";
     };
     propagatedBuildInputs = [ NetDNS ];
@@ -25489,11 +25489,11 @@ with self;
     };
   };
 
-  NetDomainTLD = buildPerlPackage {
+  NetDomainTLD = buildPerlPackage rec {
     pname = "Net-Domain-TLD";
     version = "1.75";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AL/ALEXP/Net-Domain-TLD-1.75.tar.gz";
+      url = "mirror://cpan/authors/id/A/AL/ALEXP/Net-Domain-TLD-${version}.tar.gz";
       hash = "sha256-TDf4ERhNaKxBedSMEOoxki3V/KLBv/zc2VxaKjtAAu4=";
     };
     meta = {
@@ -25505,11 +25505,11 @@ with self;
     };
   };
 
-  NetFastCGI = buildPerlPackage {
+  NetFastCGI = buildPerlPackage rec {
     pname = "Net-FastCGI";
     version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHANSEN/Net-FastCGI-0.14.tar.gz";
+      url = "mirror://cpan/authors/id/C/CH/CHANSEN/Net-FastCGI-${version}.tar.gz";
       hash = "sha256-EZOQCk/V6eupzNBuE4+RCSG3Ugf/i1JLZDqIyD61WWo=";
     };
     buildInputs = [
@@ -25525,11 +25525,11 @@ with self;
     };
   };
 
-  NetFrame = buildPerlModule {
+  NetFrame = buildPerlModule rec {
     pname = "Net-Frame";
     version = "1.21";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GO/GOMOR/Net-Frame-1.21.tar.gz";
+      url = "mirror://cpan/authors/id/G/GO/GOMOR/Net-Frame-${version}.tar.gz";
       hash = "sha256-vLNXootjnwyvfWLTPS5g/wv8z4lNAHzmAfY1UTiD1zk=";
     };
     propagatedBuildInputs = [
@@ -25544,11 +25544,11 @@ with self;
     };
   };
 
-  NetFrameLayerIPv6 = buildPerlModule {
+  NetFrameLayerIPv6 = buildPerlModule rec {
     pname = "Net-Frame-Layer-IPv6";
     version = "1.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GO/GOMOR/Net-Frame-Layer-IPv6-1.08.tar.gz";
+      url = "mirror://cpan/authors/id/G/GO/GOMOR/Net-Frame-Layer-IPv6-${version}.tar.gz";
       hash = "sha256-ui2FK+jzf1iE4wfagriqPNeU4YoVyAdSGsLKKtE599c=";
     };
     propagatedBuildInputs = [ NetFrame ];
@@ -25558,11 +25558,11 @@ with self;
     };
   };
 
-  NetFreeDB = buildPerlPackage {
+  NetFreeDB = buildPerlPackage rec {
     pname = "Net-FreeDB";
     version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DS/DSHULTZ/Net-FreeDB-0.10.tar.gz";
+      url = "mirror://cpan/authors/id/D/DS/DSHULTZ/Net-FreeDB-${version}.tar.gz";
       hash = "sha256-90PhIjjrFslIBK+0sxCwJUj3C8rxeRZOrlZ/i0mIroU=";
     };
     patches = [
@@ -25589,11 +25589,11 @@ with self;
     };
   };
 
-  NetHTTP = buildPerlPackage {
+  NetHTTP = buildPerlPackage rec {
     pname = "Net-HTTP";
     version = "6.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OA/OALDERS/Net-HTTP-6.23.tar.gz";
+      url = "mirror://cpan/authors/id/O/OA/OALDERS/Net-HTTP-${version}.tar.gz";
       hash = "sha256-DWXAndbIWJsq4RGBdNPBphcDtuz8FKNEKox0r2XgyU4=";
     };
     propagatedBuildInputs = [ URI ];
@@ -25609,11 +25609,11 @@ with self;
     };
   };
 
-  NetHTTPSNB = buildPerlPackage {
+  NetHTTPSNB = buildPerlPackage rec {
     pname = "Net-HTTPS-NB";
     version = "0.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OL/OLEG/Net-HTTPS-NB-0.15.tar.gz";
+      url = "mirror://cpan/authors/id/O/OL/OLEG/Net-HTTPS-NB-${version}.tar.gz";
       hash = "sha256-amnPT6Vfuju70iYu4UKC7YMQc22PWslNGmxZfNEnjE8=";
     };
     propagatedBuildInputs = [
@@ -25630,11 +25630,11 @@ with self;
     };
   };
 
-  NetIDNEncode = buildPerlModule {
+  NetIDNEncode = buildPerlModule rec {
     pname = "Net-IDN-Encode";
     version = "2.500";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CF/CFAERBER/Net-IDN-Encode-2.500.tar.gz";
+      url = "mirror://cpan/authors/id/C/CF/CFAERBER/Net-IDN-Encode-${version}.tar.gz";
       hash = "sha256-VUU2M+P/JM4yWzS8LIFXuYWZYqMatc8ov3zMHJs6Pqo=";
     };
     patches = [
@@ -25657,11 +25657,11 @@ with self;
     };
   };
 
-  NetIMAPClient = buildPerlPackage {
+  NetIMAPClient = buildPerlPackage rec {
     pname = "Net-IMAP-Client";
     version = "0.9507";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GA/GANGLION/Net-IMAP-Client-0.9507.tar.gz";
+      url = "mirror://cpan/authors/id/G/GA/GANGLION/Net-IMAP-Client-${version}.tar.gz";
       hash = "sha256-QE5vW7xQjPFnxAUqXhRwXv7sb7eTvPm1xCniX0cYNUk=";
     };
     propagatedBuildInputs = [
@@ -25677,11 +25677,11 @@ with self;
     };
   };
 
-  NetIP = buildPerlPackage {
+  NetIP = buildPerlPackage rec {
     pname = "Net-IP";
     version = "1.26";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MANU/Net-IP-1.26.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MANU/Net-IP-${version}.tar.gz";
       hash = "sha256-BA8W8wZmR9dhtySjtwdU0oy9Hm/l6gHGPtHNhXEX1jk=";
     };
     meta = {
@@ -25693,11 +25693,11 @@ with self;
     };
   };
 
-  NetIPLite = buildPerlPackage {
+  NetIPLite = buildPerlPackage rec {
     pname = "Net-IP-Lite";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AL/ALEXKOM/Net-IP-Lite-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/A/AL/ALEXKOM/Net-IP-Lite-${version}.tar.gz";
       hash = "sha256-yZFubPqlO+J1N5zksqVQrhdt36tQ2tQ7Q+1D6CZ4Aqk=";
     };
     buildInputs = [ TestException ];
@@ -25712,11 +25712,11 @@ with self;
     };
   };
 
-  NetIPv4Addr = buildPerlPackage {
+  NetIPv4Addr = buildPerlPackage rec {
     pname = "Net-IPv4Addr";
     version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FR/FRAJULAC/Net-IPv4Addr-0.10.tar.gz";
+      url = "mirror://cpan/authors/id/F/FR/FRAJULAC/Net-IPv4Addr-${version}.tar.gz";
       hash = "sha256-OEXeTzCxfIQrGSys6Iedu2IU3paSz6cPCq8JgUIqY/4=";
     };
     meta = {
@@ -25729,11 +25729,11 @@ with self;
     };
   };
 
-  NetIPv6Addr = buildPerlPackage {
+  NetIPv6Addr = buildPerlPackage rec {
     pname = "Net-IPv6Addr";
     version = "1.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BK/BKB/Net-IPv6Addr-1.02.tar.gz";
+      url = "mirror://cpan/authors/id/B/BK/BKB/Net-IPv6Addr-${version}.tar.gz";
       hash = "sha256-sjQBwSJv7o3+Yn9a4OkMVaxUcBDso5gRDcFjH0HJ7H0=";
     };
     propagatedBuildInputs = [
@@ -25749,11 +25749,11 @@ with self;
     };
   };
 
-  NetIPXS = buildPerlPackage {
+  NetIPXS = buildPerlPackage rec {
     pname = "Net-IP-XS";
     version = "0.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOMHRR/Net-IP-XS-0.23.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TOMHRR/Net-IP-XS-${version}.tar.gz";
       hash = "sha256-c7E+E68xWC/whLgNUK+LOeGStGc6wvfWj+4Mpa9txX8=";
     };
     propagatedBuildInputs = [
@@ -25767,11 +25767,11 @@ with self;
     };
   };
 
-  NetLDAPServer = buildPerlPackage {
+  NetLDAPServer = buildPerlPackage rec {
     pname = "Net-LDAP-Server";
     version = "0.43";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AA/AAR/Net-LDAP-Server-0.43.tar.gz";
+      url = "mirror://cpan/authors/id/A/AA/AAR/Net-LDAP-Server-${version}.tar.gz";
       hash = "sha256-3WxMtNMLwyEUsHh/qioeK0/t0bkcLvN5Zey6ETMbsGI=";
     };
     propagatedBuildInputs = [
@@ -25787,11 +25787,11 @@ with self;
     };
   };
 
-  NetLDAPSID = buildPerlPackage {
+  NetLDAPSID = buildPerlPackage rec {
     pname = "Net-LDAP-SID";
     version = "0.001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KARMAN/Net-LDAP-SID-0.001.tar.gz";
+      url = "mirror://cpan/authors/id/K/KA/KARMAN/Net-LDAP-SID-${version}.tar.gz";
       hash = "sha256-qMLNQGeQl/w7hCV24bU+w1/UNIGoalA4PutOJOu81tY=";
     };
     meta = {
@@ -25804,11 +25804,11 @@ with self;
     };
   };
 
-  NetLDAPServerTest = buildPerlPackage {
+  NetLDAPServerTest = buildPerlPackage rec {
     pname = "Net-LDAP-Server-Test";
     version = "0.22";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KARMAN/Net-LDAP-Server-Test-0.22.tar.gz";
+      url = "mirror://cpan/authors/id/K/KA/KARMAN/Net-LDAP-Server-Test-${version}.tar.gz";
       hash = "sha256-sSBxe18fb2sTsxQ3/dIY7g/GnrASGN4U2SL5Kc+NLY4=";
     };
     propagatedBuildInputs = [
@@ -25827,11 +25827,11 @@ with self;
     };
   };
 
-  NetLibIDN2 = buildPerlModule {
+  NetLibIDN2 = buildPerlModule rec {
     pname = "Net-LibIDN2";
     version = "1.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TH/THOR/Net-LibIDN2-1.02.tar.gz";
+      url = "mirror://cpan/authors/id/T/TH/THOR/Net-LibIDN2-${version}.tar.gz";
       hash = "sha256-0fMK/GrPplQbAMCafkx059jkuknjJ3wLvEGuNcE5DQc=";
     };
     propagatedBuildInputs = [ pkgs.libidn2 ];
@@ -25845,11 +25845,11 @@ with self;
     };
   };
 
-  NetNetmask = buildPerlPackage {
+  NetNetmask = buildPerlPackage rec {
     pname = "Net-Netmask";
     version = "2.0002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JM/JMASLAK/Net-Netmask-2.0002.tar.gz";
+      url = "mirror://cpan/authors/id/J/JM/JMASLAK/Net-Netmask-${version}.tar.gz";
       hash = "sha256-JKmy58a8wTAteXROukwCG/PeR/FJqvrM2U+bBC/dv5Q=";
     };
     buildInputs = [
@@ -25866,12 +25866,12 @@ with self;
     };
   };
 
-  NetMPD = buildPerlModule {
+  NetMPD = buildPerlModule rec {
     pname = "Net-MPD";
     version = "0.07";
     buildInputs = [ ModuleBuildTiny ];
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AB/ABERNDT/Net-MPD-0.07.tar.gz";
+      url = "mirror://cpan/authors/id/A/AB/ABERNDT/Net-MPD-${version}.tar.gz";
       hash = "sha256-M4L7nG9cJd4mKPVhRCn6igB5FSFnjELaBoyZ57KU6VM=";
     };
     meta = {
@@ -25881,11 +25881,11 @@ with self;
     };
   };
 
-  NetMQTTSimple = buildPerlPackage {
+  NetMQTTSimple = buildPerlPackage rec {
     pname = "Net-MQTT-Simple";
     version = "1.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JU/JUERD/Net-MQTT-Simple-1.28.tar.gz";
+      url = "mirror://cpan/authors/id/J/JU/JUERD/Net-MQTT-Simple-${version}.tar.gz";
       hash = "sha256-Sp6hB+a8IuJrUzZ4oKPMbEI7N4TsP8ROjjM5t8Vr7gM=";
     };
     propagatedBuildInputs = [
@@ -25900,11 +25900,11 @@ with self;
     };
   };
 
-  NetNVD = buildPerlPackage {
+  NetNVD = buildPerlPackage rec {
     pname = "Net-NVD";
     version = "0.0.3";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GA/GARU/Net-NVD-0.0.3.tar.gz";
+      url = "mirror://cpan/authors/id/G/GA/GARU/Net-NVD-${version}.tar.gz";
       hash = "sha256-uKZXEg+UsO7R2OvbA4i8M2DSj6Xw+CNrnNjNrovv5Bg=";
     };
     propagatedBuildInputs = [
@@ -25920,11 +25920,11 @@ with self;
     };
   };
 
-  NetOAuth = buildPerlModule {
+  NetOAuth = buildPerlModule rec {
     pname = "Net-OAuth";
     version = "0.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KG/KGRENNAN/Net-OAuth-0.28.tar.gz";
+      url = "mirror://cpan/authors/id/K/KG/KGRENNAN/Net-OAuth-${version}.tar.gz";
       hash = "sha256-e/wxnaCsV44Ali81o1DPUREKOjEwFtH9wwciAooikEw=";
     };
     buildInputs = [ TestWarn ];
@@ -25944,11 +25944,11 @@ with self;
     };
   };
 
-  NetPatricia = buildPerlPackage {
+  NetPatricia = buildPerlPackage rec {
     pname = "Net-Patricia";
     version = "1.24";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GR/GRUBER/Net-Patricia-1.24.tar.gz";
+      url = "mirror://cpan/authors/id/G/GR/GRUBER/Net-Patricia-${version}.tar.gz";
       hash = "sha256-2U9SCATiVBsc0g5zNmcgqXPK9d0tJiODj8jWOYr9fts=";
     };
     propagatedBuildInputs = [
@@ -25961,11 +25961,11 @@ with self;
     };
   };
 
-  NetPing = buildPerlPackage {
+  NetPing = buildPerlPackage rec {
     pname = "Net-Ping";
     version = "2.75";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RU/RURBAN/Net-Ping-2.75.tar.gz";
+      url = "mirror://cpan/authors/id/R/RU/RURBAN/Net-Ping-${version}.tar.gz";
       hash = "sha256-tH3zz9lpLM0Aca05/nRxjrwy9ZcBVWpgT9FaCfCeDXQ=";
     };
     preCheck = ''
@@ -25982,11 +25982,11 @@ with self;
     };
   };
 
-  NetDNSResolverProgrammable = buildPerlPackage {
+  NetDNSResolverProgrammable = buildPerlPackage rec {
     pname = "Net-DNS-Resolver-Programmable";
     version = "0.009";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BI/BIGPRESH/Net-DNS-Resolver-Programmable-0.009.tar.gz";
+      url = "mirror://cpan/authors/id/B/BI/BIGPRESH/Net-DNS-Resolver-Programmable-${version}.tar.gz";
       hash = "sha256-gICiq3dmKVhZEa8Reb23xNwr6/1LXv13sR0drGJFS/g=";
     };
     propagatedBuildInputs = [ NetDNS ];
@@ -26000,11 +26000,11 @@ with self;
     };
   };
 
-  NetPrometheus = buildPerlModule {
+  NetPrometheus = buildPerlModule rec {
     pname = "Net-Prometheus";
     version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Net-Prometheus-0.12.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Net-Prometheus-${version}.tar.gz";
       hash = "sha256-rs73NJygSW/yNahKkQ+KBDZtB/WqQfrieixKxbip6SM=";
     };
     propagatedBuildInputs = [
@@ -26025,11 +26025,11 @@ with self;
     };
   };
 
-  NetSCP = buildPerlPackage {
+  NetSCP = buildPerlPackage rec {
     pname = "Net-SCP";
     version = "0.08.reprise";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IV/IVAN/Net-SCP-0.08.reprise.tar.gz";
+      url = "mirror://cpan/authors/id/I/IV/IVAN/Net-SCP-${version}.tar.gz";
       hash = "sha256-iKmy32nnaeWFWkCLGfYZFbguj+Bwq1z01SXdO4u+McE=";
     };
     propagatedBuildInputs = [ pkgs.openssl ];
@@ -26051,11 +26051,11 @@ with self;
 
   NetRemctl = callPackage ../development/perl-modules/NetRemctl { };
 
-  NetServer = buildPerlPackage {
+  NetServer = buildPerlPackage rec {
     pname = "Net-Server";
     version = "2.014";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RH/RHANDOM/Net-Server-2.014.tar.gz";
+      url = "mirror://cpan/authors/id/R/RH/RHANDOM/Net-Server-${version}.tar.gz";
       hash = "sha256-NAa5ylpmKgB17tR/t43hMWtgHJT2Kg7jSlVE25uqNyA=";
     };
     doCheck = false; # seems to hang waiting for connections
@@ -26069,11 +26069,11 @@ with self;
     };
   };
 
-  NetSFTPForeign = buildPerlPackage {
+  NetSFTPForeign = buildPerlPackage rec {
     pname = "Net-SFTP-Foreign";
     version = "1.93";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SA/SALVA/Net-SFTP-Foreign-1.93.tar.gz";
+      url = "mirror://cpan/authors/id/S/SA/SALVA/Net-SFTP-Foreign-${version}.tar.gz";
       hash = "sha256-bH1kJQh2hz2kNIAOUGCovvekZFHYH4F+N+Q8/aUaD3o=";
     };
     propagatedBuildInputs = [ pkgs.openssl ];
@@ -26089,11 +26089,11 @@ with self;
     };
   };
 
-  NetServerCoro = buildPerlPackage {
+  NetServerCoro = buildPerlPackage rec {
     pname = "Net-Server-Coro";
     version = "1.3";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AL/ALEXMV/Net-Server-Coro-1.3.tar.gz";
+      url = "mirror://cpan/authors/id/A/AL/ALEXMV/Net-Server-Coro-${version}.tar.gz";
       hash = "sha256-HhpwKw3TkMPmKfip6EzKY7eU0eInlX9Cm2dgEHV3+4Y=";
     };
     propagatedBuildInputs = [
@@ -26137,11 +26137,11 @@ with self;
     };
   };
 
-  NetSMTPSSL = buildPerlPackage {
+  NetSMTPSSL = buildPerlPackage rec {
     pname = "Net-SMTP-SSL";
     version = "1.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Net-SMTP-SSL-1.04.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Net-SMTP-SSL-${version}.tar.gz";
       hash = "sha256-eynEWt0Z09UIS3Ufe6iajkBHmkRs4hz9nMdB5VgzKgA=";
     };
     propagatedBuildInputs = [ IOSocketSSL ];
@@ -26154,11 +26154,11 @@ with self;
     };
   };
 
-  NetSMTPTLS = buildPerlPackage {
+  NetSMTPTLS = buildPerlPackage rec {
     pname = "Net-SMTP-TLS";
     version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AW/AWESTHOLM/Net-SMTP-TLS-0.12.tar.gz";
+      url = "mirror://cpan/authors/id/A/AW/AWESTHOLM/Net-SMTP-TLS-${version}.tar.gz";
       hash = "sha256-7+dyZnrDdwK5a221KXzIJ0J6Ozo4GbekMVsIudRE5KU=";
     };
     propagatedBuildInputs = [
@@ -26174,11 +26174,11 @@ with self;
     };
   };
 
-  NetSMTPTLSButMaintained = buildPerlPackage {
+  NetSMTPTLSButMaintained = buildPerlPackage rec {
     pname = "Net-SMTP-TLS-ButMaintained";
     version = "0.24";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FA/FAYLAND/Net-SMTP-TLS-ButMaintained-0.24.tar.gz";
+      url = "mirror://cpan/authors/id/F/FA/FAYLAND/Net-SMTP-TLS-ButMaintained-${version}.tar.gz";
       hash = "sha256-a5XAj3FXnYUcAYP1AqcAyGof7O9XDjzugybF5M5mJW4=";
     };
     propagatedBuildInputs = [
@@ -26194,32 +26194,32 @@ with self;
     };
   };
 
-  NetSNMP = buildPerlModule {
+  NetSNMP = buildPerlModule rec {
     pname = "Net-SNMP";
     version = "6.0.1";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DT/DTOWN/Net-SNMP-v6.0.1.tar.gz";
+      url = "mirror://cpan/authors/id/D/DT/DTOWN/Net-SNMP-v${version}.tar.gz";
       hash = "sha256-FMN7wcuz883H1sE+DyeoWfFM3P1epUoEZ6iLwlmwt0E=";
     };
     patches = [
       (fetchpatch2 {
-        url = "https://src.fedoraproject.org/rpms/perl-Net-SNMP/raw/6e1d3e8ff2b9bd38dab48301a9d8b5d81ef3b7fe/f/Net-SNMP-v6.0.1-Switch_from_Socket6_to_Socket.patch";
+        url = "https://src.fedoraproject.org/rpms/perl-Net-SNMP/raw/6e1d3e8ff2b9bd38dab48301a9d8b5d81ef3b7fe/f/Net-SNMP-v${version}-Switch_from_Socket6_to_Socket.patch";
         hash = "sha256-IpVhqI+dXqzauTkLF0Doulg5U33FxHUhqFTp0jeMtMY=";
       })
       (fetchpatch2 {
-        url = "https://src.fedoraproject.org/rpms/perl-Net-SNMP/raw/6e1d3e8ff2b9bd38dab48301a9d8b5d81ef3b7fe/f/Net-SNMP-v6.0.1-Simple_rewrite_to_Digest-HMAC-helpers.patch";
+        url = "https://src.fedoraproject.org/rpms/perl-Net-SNMP/raw/6e1d3e8ff2b9bd38dab48301a9d8b5d81ef3b7fe/f/Net-SNMP-v${version}-Simple_rewrite_to_Digest-HMAC-helpers.patch";
         hash = "sha256-ZXo9w2YLtPmM1SJLvIiLWefw7SwrTFyTo4eX6DG1yfA=";
       })
       (fetchpatch2 {
-        url = "https://src.fedoraproject.org/rpms/perl-Net-SNMP/raw/6e1d3e8ff2b9bd38dab48301a9d8b5d81ef3b7fe/f/Net-SNMP-v6.0.1-Split_usm.t_to_two_parts.patch";
+        url = "https://src.fedoraproject.org/rpms/perl-Net-SNMP/raw/6e1d3e8ff2b9bd38dab48301a9d8b5d81ef3b7fe/f/Net-SNMP-v${version}-Split_usm.t_to_two_parts.patch";
         hash = "sha256-A2gsD6DIX1aFSVLbSL/1zKSM1xiM6hWBadJJH7f5E8o=";
       })
       (fetchpatch2 {
-        url = "https://src.fedoraproject.org/rpms/perl-Net-SNMP/raw/6e1d3e8ff2b9bd38dab48301a9d8b5d81ef3b7fe/f/Net-SNMP-v6.0.1-Add_tests_for_another_usm_scenarios.patch";
+        url = "https://src.fedoraproject.org/rpms/perl-Net-SNMP/raw/6e1d3e8ff2b9bd38dab48301a9d8b5d81ef3b7fe/f/Net-SNMP-v${version}-Add_tests_for_another_usm_scenarios.patch";
         hash = "sha256-U7nNuL35l/zdSzx1jgjp1PmLQn3xzzDw9DGnyeydi2E=";
       })
       (fetchpatch2 {
-        url = "https://src.fedoraproject.org/rpms/perl-Net-SNMP/raw/6e1d3e8ff2b9bd38dab48301a9d8b5d81ef3b7fe/f/Net-SNMP-v6.0.1-Rewrite_from_Digest-SHA1-to-Digest-SHA.patch";
+        url = "https://src.fedoraproject.org/rpms/perl-Net-SNMP/raw/6e1d3e8ff2b9bd38dab48301a9d8b5d81ef3b7fe/f/Net-SNMP-v${version}-Rewrite_from_Digest-SHA1-to-Digest-SHA.patch";
         hash = "sha256-dznhj1Fcy0iBBl92p825InjkNZixR2MURVQ/b9bVjtc=";
       })
       ../development/perl-modules/net-snmp-add-sha-algorithms.patch
@@ -26243,11 +26243,11 @@ with self;
     };
   };
 
-  NetSNPP = buildPerlPackage {
+  NetSNPP = buildPerlPackage rec {
     pname = "Net-SNPP";
     version = "1.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOBEYA/Net-SNPP-1.17.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TOBEYA/Net-SNPP-${version}.tar.gz";
       hash = "sha256-BrhR1kWWYl6GY1n7AX3Q0Ilz4OvFDDI/Sh1Q7N2GjnY=";
     };
 
@@ -26261,11 +26261,11 @@ with self;
     };
   };
 
-  NetSSH = buildPerlPackage {
+  NetSSH = buildPerlPackage rec {
     pname = "Net-SSH";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IV/IVAN/Net-SSH-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/I/IV/IVAN/Net-SSH-${version}.tar.gz";
       hash = "sha256-fHHHw8vpUyNN/iW8wa1+2w4fWgV4YB9VI7xgcCYqOBc=";
     };
     propagatedBuildInputs = [ pkgs.openssl ];
@@ -26281,11 +26281,11 @@ with self;
     };
   };
 
-  NetSSHPerl = buildPerlPackage {
+  NetSSHPerl = buildPerlPackage rec {
     pname = "Net-SSH-Perl";
     version = "2.142";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/Net-SSH-Perl-2.142.tar.gz";
+      url = "mirror://cpan/authors/id/B/BD/BDFOY/Net-SSH-Perl-${version}.tar.gz";
       hash = "sha256-UAHbPllS/BjYXDF5Uhr2kT0VQ+tP30/ZfcYDpHSMLJY=";
     };
     propagatedBuildInputs = [
@@ -26307,11 +26307,11 @@ with self;
     };
   };
 
-  NetSSLeay = buildPerlPackage {
+  NetSSLeay = buildPerlPackage rec {
     pname = "Net-SSLeay";
     version = "1.92";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHRISN/Net-SSLeay-1.92.tar.gz";
+      url = "mirror://cpan/authors/id/C/CH/CHRISN/Net-SSLeay-${version}.tar.gz";
       hash = "sha256-R8LyswDy5xYtcdaZ9jPdajWwYloAy9qMUKwBFEqTlqk=";
     };
     buildInputs = [
@@ -26332,11 +26332,11 @@ with self;
     };
   };
 
-  NetStatsd = buildPerlPackage {
+  NetStatsd = buildPerlPackage rec {
     pname = "Net-Statsd";
     version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CO/COSIMO/Net-Statsd-0.12.tar.gz";
+      url = "mirror://cpan/authors/id/C/CO/COSIMO/Net-Statsd-${version}.tar.gz";
       hash = "sha256-Y+RTYD2hZbxtHEygtV7aPSIE8EDFkwSkd4LFqniGVlw=";
     };
     meta = {
@@ -26349,11 +26349,11 @@ with self;
     };
   };
 
-  NetTelnet = buildPerlPackage {
+  NetTelnet = buildPerlPackage rec {
     pname = "Net-Telnet";
     version = "3.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JR/JROGERS/Net-Telnet-3.05.tar.gz";
+      url = "mirror://cpan/authors/id/J/JR/JROGERS/Net-Telnet-${version}.tar.gz";
       hash = "sha256-Z39ouizSqCT64yP6guGDv349A8PEmckdkjvWKDeWp0M=";
     };
     meta = {
@@ -26365,11 +26365,11 @@ with self;
     };
   };
 
-  NetTwitterLite = buildPerlModule {
+  NetTwitterLite = buildPerlModule rec {
     pname = "Net-Twitter-Lite";
     version = "0.12008";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MM/MMIMS/Net-Twitter-Lite-0.12008.tar.gz";
+      url = "mirror://cpan/authors/id/M/MM/MMIMS/Net-Twitter-Lite-${version}.tar.gz";
       hash = "sha256-suq+Hyo/LGTezWDye8O0buZSVgsCTExWgRVhbI1KRo4=";
     };
     buildInputs = [
@@ -26391,11 +26391,11 @@ with self;
     };
   };
 
-  NetWhoisIP = buildPerlPackage {
+  NetWhoisIP = buildPerlPackage rec {
     pname = "Net-Whois-IP";
     version = "1.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BS/BSCHMITZ/Net-Whois-IP-1.19.tar.gz";
+      url = "mirror://cpan/authors/id/B/BS/BSCHMITZ/Net-Whois-IP-${version}.tar.gz";
       hash = "sha256-8JvfoPHSZltTSCa186hmI0mTDu0pmO/k2Nv5iBMUciI=";
     };
     doCheck = false;
@@ -26414,11 +26414,11 @@ with self;
     };
   };
 
-  NetWorks = buildPerlPackage {
+  NetWorks = buildPerlPackage rec {
     pname = "Net-Works";
     version = "0.22";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MAXMIND/Net-Works-0.22.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MAXMIND/Net-Works-${version}.tar.gz";
       hash = "sha256-CsmyPfvKGE4ocpskU5S8ZpOq22/EUcqplbS3GewO6f8=";
     };
     propagatedBuildInputs = [
@@ -26437,11 +26437,11 @@ with self;
     };
   };
 
-  NumberBytesHuman = buildPerlPackage {
+  NumberBytesHuman = buildPerlPackage rec {
     pname = "Number-Bytes-Human";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FE/FERREIRA/Number-Bytes-Human-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/F/FE/FERREIRA/Number-Bytes-Human-${version}.tar.gz";
       hash = "sha256-X8ecSbC0DfeAR5xDaWOBND4ratH+UoWfYLxltm6+byw=";
     };
     meta = {
@@ -26453,11 +26453,11 @@ with self;
     };
   };
 
-  NumberCompare = buildPerlPackage {
+  NumberCompare = buildPerlPackage rec {
     pname = "Number-Compare";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RC/RCLAMP/Number-Compare-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/R/RC/RCLAMP/Number-Compare-${version}.tar.gz";
       hash = "sha256-gyk3N+gDtDESgwRD+1II7FIIoubqUS7VTvjk3SuICCc=";
     };
     meta = {
@@ -26469,11 +26469,11 @@ with self;
     };
   };
 
-  NumberFormat = buildPerlPackage {
+  NumberFormat = buildPerlPackage rec {
     pname = "Number-Format";
     version = "1.76";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Number-Format-1.76.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Number-Format-${version}.tar.gz";
       hash = "sha256-DgBg6zY2NaiFcGxqJvX8qv6udZ97Ksrkndpw4ZXdRNY=";
     };
     meta = {
@@ -26485,11 +26485,11 @@ with self;
     };
   };
 
-  NumberFraction = buildPerlModule {
+  NumberFraction = buildPerlModule rec {
     pname = "Number-Fraction";
     version = "3.0.4";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAVECROSS/Number-Fraction-v3.0.4.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAVECROSS/Number-Fraction-v${version}.tar.gz";
       hash = "sha256-xkGcird4/XKbENfmp487ewf8CJV8H3nlZm3Ny01iwIU=";
     };
     propagatedBuildInputs = [
@@ -26505,11 +26505,11 @@ with self;
     };
   };
 
-  NumberMisc = buildPerlModule {
+  NumberMisc = buildPerlModule rec {
     pname = "Number-Misc";
     version = "1.2";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIKO/Number-Misc-1.2.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIKO/Number-Misc-${version}.tar.gz";
       hash = "sha256-d7m2jGAKBpzxb02BJuyzIVHmvNNLDtsXt4re5onckdg=";
     };
     meta = {
@@ -26521,11 +26521,11 @@ with self;
     };
   };
 
-  NumberPhone = buildPerlPackage {
+  NumberPhone = buildPerlPackage rec {
     pname = "Number-Phone";
     version = "4.0000";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/Number-Phone-4.0000.tar.gz";
+      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/Number-Phone-${version}.tar.gz";
       hash = "sha256-H0mX/oMJSrDNgUDwvn/cHz+JGQKareajOYH4fLBIZjQ=";
     };
     buildInputs = [
@@ -26559,11 +26559,11 @@ with self;
     };
   };
 
-  NumberWithError = buildPerlPackage {
+  NumberWithError = buildPerlPackage rec {
     pname = "Number-WithError";
     version = "1.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SM/SMUELLER/Number-WithError-1.01.tar.gz";
+      url = "mirror://cpan/authors/id/S/SM/SMUELLER/Number-WithError-${version}.tar.gz";
       hash = "sha256-3/agcn54ROpng3vfrdVSuG9rIW0Y7o7kaEKyLM7w9VQ=";
     };
     propagatedBuildInputs = [
@@ -26580,11 +26580,11 @@ with self;
     };
   };
 
-  NTLM = buildPerlPackage {
+  NTLM = buildPerlPackage rec {
     pname = "NTLM";
     version = "1.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NB/NBEBOUT/NTLM-1.09.tar.gz";
+      url = "mirror://cpan/authors/id/N/NB/NBEBOUT/NTLM-${version}.tar.gz";
       hash = "sha256-yCPjDNp2vBVjblhDAslg4rXu75UXwkSPdFRJiJMVH4U=";
     };
     propagatedBuildInputs = [ DigestHMAC ];
@@ -26598,11 +26598,11 @@ with self;
     };
   };
 
-  ObjectAccessor = buildPerlPackage {
+  ObjectAccessor = buildPerlPackage rec {
     pname = "Object-Accessor";
     version = "0.48";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BI/BINGOS/Object-Accessor-0.48.tar.gz";
+      url = "mirror://cpan/authors/id/B/BI/BINGOS/Object-Accessor-${version}.tar.gz";
       hash = "sha256-dsuCSie2tOVgQJ/Pb9Wzv7vTi3Lx89N+0LVL2cC66t4=";
     };
     meta = {
@@ -26634,11 +26634,11 @@ with self;
     };
   };
 
-  ObjectInsideOut = buildPerlModule {
+  ObjectInsideOut = buildPerlModule rec {
     pname = "Object-InsideOut";
     version = "4.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JD/JDHEDDEN/Object-InsideOut-4.05.tar.gz";
+      url = "mirror://cpan/authors/id/J/JD/JDHEDDEN/Object-InsideOut-${version}.tar.gz";
       hash = "sha256-nf1sooInJDR+DrZ1nQBwlCWBRwOtXGa9tiFFeYaLysQ=";
     };
     propagatedBuildInputs = [ ExceptionClass ];
@@ -26651,11 +26651,11 @@ with self;
     };
   };
 
-  ObjectPad = buildPerlModule {
+  ObjectPad = buildPerlModule rec {
     pname = "Object-Pad";
     version = "0.821";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Object-Pad-0.821.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Object-Pad-${version}.tar.gz";
       hash = "sha256-tdUF+PoWLg5r4q5YsPM0SUxPeRs6BA8va4kBTwSEUgw=";
     };
     buildInputs = [
@@ -26676,11 +26676,11 @@ with self;
     };
   };
 
-  ObjectSignature = buildPerlPackage {
+  ObjectSignature = buildPerlPackage rec {
     pname = "Object-Signature";
     version = "1.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Object-Signature-1.08.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Object-Signature-${version}.tar.gz";
       hash = "sha256-hCFTyU2pPiucs7VN7lcrUGS79JmjanPDiiN5mgIDaYo=";
     };
     meta = {
@@ -26693,11 +26693,11 @@ with self;
     };
   };
 
-  OggVorbisHeaderPurePerl = buildPerlPackage {
+  OggVorbisHeaderPurePerl = buildPerlPackage rec {
     pname = "Ogg-Vorbis-Header-PurePerl";
     version = "1.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAVECROSS/Ogg-Vorbis-Header-PurePerl-1.05.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAVECROSS/Ogg-Vorbis-Header-PurePerl-${version}.tar.gz";
       hash = "sha256-Uh04CPQtcSKmsGwzpurm18OZR6q1fEyMyvzE9gP9pT4=";
     };
 
@@ -26709,11 +26709,11 @@ with self;
     };
   };
 
-  OLEStorage_Lite = buildPerlPackage {
+  OLEStorage_Lite = buildPerlPackage rec {
     pname = "OLE-Storage_Lite";
     version = "0.22";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JM/JMCNAMARA/OLE-Storage_Lite-0.22.tar.gz";
+      url = "mirror://cpan/authors/id/J/JM/JMCNAMARA/OLE-Storage_Lite-${version}.tar.gz";
       hash = "sha256-0FZtbCnTl+pzY3ncUVw2hJ9rlxB89wC6glBQXJhM+WU=";
     };
     meta = {
@@ -26725,11 +26725,11 @@ with self;
     };
   };
 
-  Opcodes = buildPerlPackage {
+  Opcodes = buildPerlPackage rec {
     pname = "Opcodes";
     version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RU/RURBAN/Opcodes-0.14.tar.gz";
+      url = "mirror://cpan/authors/id/R/RU/RURBAN/Opcodes-${version}.tar.gz";
       hash = "sha256-f3NlRH5NHFuHtDCRRI8EiOZ8nwNrJsAipUCc1z00OJM=";
     };
     meta = {
@@ -26741,11 +26741,11 @@ with self;
     };
   };
 
-  OpenAPIClient = buildPerlPackage {
+  OpenAPIClient = buildPerlPackage rec {
     pname = "OpenAPI-Client";
     version = "1.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/OpenAPI-Client-1.07.tar.gz";
+      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/OpenAPI-Client-${version}.tar.gz";
       hash = "sha256-Ue1kHSg7j0u7wG0BwVZzm9K5qItO+Et7hPlQ+g7hTbM=";
     };
     propagatedBuildInputs = [ MojoliciousPluginOpenAPI ];
@@ -26800,11 +26800,11 @@ with self;
     };
   };
 
-  OpenOfficeOODoc = buildPerlPackage {
+  OpenOfficeOODoc = buildPerlPackage rec {
     pname = "OpenOffice-OODoc";
     version = "2.125";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JM/JMGDOC/OpenOffice-OODoc-2.125.tar.gz";
+      url = "mirror://cpan/authors/id/J/JM/JMGDOC/OpenOffice-OODoc-${version}.tar.gz";
       hash = "sha256-wRRIlwaTxCqLnpPaSMrJE1Fs4zqdRKZGhAD3rYeR2rY=";
     };
     propagatedBuildInputs = [
@@ -26818,11 +26818,11 @@ with self;
     };
   };
 
-  NetOpenIDCommon = buildPerlPackage {
+  NetOpenIDCommon = buildPerlPackage rec {
     pname = "Net-OpenID-Common";
     version = "1.20";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/W/WR/WROG/Net-OpenID-Common-1.20.tar.gz";
+      url = "mirror://cpan/authors/id/W/WR/WROG/Net-OpenID-Common-${version}.tar.gz";
       hash = "sha256-q06X10pHcQ4NtKwMgi9/32Iq+GpgpSunIlWoicKdq8k=";
     };
     propagatedBuildInputs = [
@@ -26838,11 +26838,11 @@ with self;
     };
   };
 
-  NetOpenIDConsumer = buildPerlPackage {
+  NetOpenIDConsumer = buildPerlPackage rec {
     pname = "Net-OpenID-Consumer";
     version = "1.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/W/WR/WROG/Net-OpenID-Consumer-1.18.tar.gz";
+      url = "mirror://cpan/authors/id/W/WR/WROG/Net-OpenID-Consumer-${version}.tar.gz";
       hash = "sha256-Dhw4b+fBhDBx3Zlr3KymEJEGZK5LXRJ8lf6u/Zk2Tzg=";
     };
     propagatedBuildInputs = [
@@ -26859,11 +26859,11 @@ with self;
     };
   };
 
-  NetOpenSSH = buildPerlPackage {
+  NetOpenSSH = buildPerlPackage rec {
     pname = "Net-OpenSSH";
     version = "0.84";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SA/SALVA/Net-OpenSSH-0.84.tar.gz";
+      url = "mirror://cpan/authors/id/S/SA/SALVA/Net-OpenSSH-${version}.tar.gz";
       hash = "sha256-h4DmLwGxzw20PJy3BclP9JSbAyIzvkvpH8kavHkVOfg=";
     };
     meta = {
@@ -26912,12 +26912,12 @@ with self;
     };
   };
 
-  nsdiff = buildPerlPackage {
+  nsdiff = buildPerlPackage rec {
     pname = "nsdiff";
     version = "1.85";
 
     src = fetchurl {
-      url = "https://dotat.at/prog/nsdiff/DNS-nsdiff-1.85.tar.gz";
+      url = "https://dotat.at/prog/nsdiff/DNS-nsdiff-${version}.tar.gz";
       hash = "sha256-yo4WDa/xZL+5m+i3RnqDBZkGcl+tqR118laRez0xNAA=";
     };
 
@@ -26949,11 +26949,11 @@ with self;
     };
   };
 
-  PackageConstants = buildPerlPackage {
+  PackageConstants = buildPerlPackage rec {
     pname = "Package-Constants";
     version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BI/BINGOS/Package-Constants-0.06.tar.gz";
+      url = "mirror://cpan/authors/id/B/BI/BINGOS/Package-Constants-${version}.tar.gz";
       hash = "sha256-C1i+eHBszE5L2butQXZ0cEJ/17LPrXSUid4QH4W8XfU=";
     };
     meta = {
@@ -26965,11 +26965,11 @@ with self;
     };
   };
 
-  PackageDeprecationManager = buildPerlPackage {
+  PackageDeprecationManager = buildPerlPackage rec {
     pname = "Package-DeprecationManager";
     version = "0.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Package-DeprecationManager-0.18.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Package-DeprecationManager-${version}.tar.gz";
       hash = "sha256-to0/DO1Vt2Ff3btgKbifkqNP4N2Mb9a87/wVfVaDT+g=";
     };
     buildInputs = [
@@ -26989,11 +26989,11 @@ with self;
     };
   };
 
-  PatchReader = buildPerlPackage {
+  PatchReader = buildPerlPackage rec {
     pname = "PatchReader";
     version = "0.9.6";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TM/TMANNERM/PatchReader-0.9.6.tar.gz";
+      url = "mirror://cpan/authors/id/T/TM/TMANNERM/PatchReader-${version}.tar.gz";
       hash = "sha256-uN43RgNHu1R03AGRbMsx3S/gzZIkLEoy1zDo6wh8Mjw=";
     };
     meta = {
@@ -27002,11 +27002,11 @@ with self;
     };
   };
 
-  PackageStash = buildPerlPackage {
+  PackageStash = buildPerlPackage rec {
     pname = "Package-Stash";
     version = "0.40";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Package-Stash-0.40.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Package-Stash-${version}.tar.gz";
       hash = "sha256-WpcixtnLKe4TPl97CKU2J2KgtWM/9RcGQqWwaG6V4GY=";
     };
     buildInputs = [
@@ -27030,11 +27030,11 @@ with self;
     };
   };
 
-  PackageStashXS = buildPerlPackage {
+  PackageStashXS = buildPerlPackage rec {
     pname = "Package-Stash-XS";
     version = "0.30";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Package-Stash-XS-0.30.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Package-Stash-XS-${version}.tar.gz";
       hash = "sha256-JrrWXBlZxXN5s+E53HdvvsX3ApBmF+8nzcKT3fEjkjE=";
     };
     buildInputs = [
@@ -27082,11 +27082,11 @@ with self;
     };
   };
 
-  Pango = buildPerlPackage {
+  Pango = buildPerlPackage rec {
     pname = "Pango";
     version = "1.227";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XA/XAOC/Pango-1.227.tar.gz";
+      url = "mirror://cpan/authors/id/X/XA/XAOC/Pango-${version}.tar.gz";
       hash = "sha256-NLCkIt8/7NdZdYcEhVJFfUiudkxDu+/SqdYs62yLrHE=";
     };
     buildInputs = [ pkgs.pango ];
@@ -27101,11 +27101,11 @@ with self;
     };
   };
 
-  ParallelForkManager = buildPerlPackage {
+  ParallelForkManager = buildPerlPackage rec {
     pname = "Parallel-ForkManager";
     version = "2.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Y/YA/YANICK/Parallel-ForkManager-2.02.tar.gz";
+      url = "mirror://cpan/authors/id/Y/YA/YANICK/Parallel-ForkManager-${version}.tar.gz";
       hash = "sha256-wbKXCou2ZsPefKrEqPTbzAQ6uBm7wzdpLse/J62uRAQ=";
     };
     buildInputs = [ TestWarn ];
@@ -27120,11 +27120,11 @@ with self;
     };
   };
 
-  ParallelLoops = buildPerlPackage {
+  ParallelLoops = buildPerlPackage rec {
     pname = "Parallel-Loops";
     version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PM/PMORCH/Parallel-Loops-0.12.tar.gz";
+      url = "mirror://cpan/authors/id/P/PM/PMORCH/Parallel-Loops-${version}.tar.gz";
       hash = "sha256-tmyP4v1RmHPIp7atHRoE3yAmkSJZteKKQeUdnJsVQVA=";
     };
     propagatedBuildInputs = [ ParallelForkManager ];
@@ -27139,11 +27139,11 @@ with self;
     };
   };
 
-  ParallelPipes = buildPerlModule {
+  ParallelPipes = buildPerlModule rec {
     pname = "Parallel-Pipes";
     version = "0.200";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SK/SKAJI/Parallel-Pipes-0.200.tar.gz";
+      url = "mirror://cpan/authors/id/S/SK/SKAJI/Parallel-Pipes-${version}.tar.gz";
       hash = "sha256-iLmFDqzJ1hjz6RpRyqOGxKZOgswYc1AzUkTjSbgREQY=";
     };
     buildInputs = [ ModuleBuildTiny ];
@@ -27157,11 +27157,11 @@ with self;
     };
   };
 
-  ParallelPrefork = buildPerlPackage {
+  ParallelPrefork = buildPerlPackage rec {
     pname = "Parallel-Prefork";
     version = "0.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KAZUHO/Parallel-Prefork-0.18.tar.gz";
+      url = "mirror://cpan/authors/id/K/KA/KAZUHO/Parallel-Prefork-${version}.tar.gz";
       hash = "sha256-8cH0jxrhR6WLyI+csvVw1rsV6kwNWJq9TDCE3clhWW4=";
     };
     buildInputs = [
@@ -27184,11 +27184,11 @@ with self;
     };
   };
 
-  ParamsClassify = buildPerlModule {
+  ParamsClassify = buildPerlModule rec {
     pname = "Params-Classify";
     version = "0.015";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Params-Classify-0.015.tar.gz";
+      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Params-Classify-${version}.tar.gz";
       hash = "sha256-OY7BXNiZ/Ni+89ueoXSL9jHxX2wyviA+R1tn31EKWRQ=";
     };
     meta = {
@@ -27200,11 +27200,11 @@ with self;
     };
   };
 
-  ParamsUtil = buildPerlPackage {
+  ParamsUtil = buildPerlPackage rec {
     pname = "Params-Util";
     version = "1.102";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RE/REHSACK/Params-Util-1.102.tar.gz";
+      url = "mirror://cpan/authors/id/R/RE/REHSACK/Params-Util-${version}.tar.gz";
       hash = "sha256-SZuxtILbJP2id6UVJVlq0JLCvVHdUI+o/sLp+EkJdAI=";
     };
     meta = {
@@ -27217,11 +27217,11 @@ with self;
     };
   };
 
-  ParamsValidate = buildPerlModule {
+  ParamsValidate = buildPerlModule rec {
     pname = "Params-Validate";
     version = "1.31";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Params-Validate-1.31.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Params-Validate-${version}.tar.gz";
       hash = "sha256-G/JRjvLEhp+RWQ4hn1RcjvEu1TzzE+DrVwSt9/Gylh4=";
     };
     buildInputs = [
@@ -27236,11 +27236,11 @@ with self;
     };
   };
 
-  ParamsValidationCompiler = buildPerlPackage {
+  ParamsValidationCompiler = buildPerlPackage rec {
     pname = "Params-ValidationCompiler";
     version = "0.31";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Params-ValidationCompiler-0.31.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Params-ValidationCompiler-${version}.tar.gz";
       hash = "sha256-e2SXFz8batsp9dUdjPnsNtLxIZQStLJBDp13qQHoSm0=";
     };
     propagatedBuildInputs = [
@@ -27260,11 +27260,11 @@ with self;
     };
   };
 
-  Paranoid = buildPerlPackage {
+  Paranoid = buildPerlPackage rec {
     pname = "Paranoid";
     version = "2.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CO/CORLISS/Paranoid/Paranoid-2.10.tar.gz";
+      url = "mirror://cpan/authors/id/C/CO/CORLISS/Paranoid/Paranoid-${version}.tar.gz";
       hash = "sha256-vvS25l1cmk72C8qjF0hvOg0jm/2rRQqnEgLCl5i4dSk=";
     };
     patches = [ ../development/perl-modules/Paranoid-blessed-path.patch ];
@@ -27282,11 +27282,11 @@ with self;
     };
   };
 
-  PARDist = buildPerlPackage {
+  PARDist = buildPerlPackage rec {
     pname = "PAR-Dist";
     version = "0.52";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RS/RSCHUPP/PAR-Dist-0.52.tar.gz";
+      url = "mirror://cpan/authors/id/R/RS/RSCHUPP/PAR-Dist-${version}.tar.gz";
       hash = "sha256-y+ljAJ6nnSRUqF/heU9CW33cHoa3F0nIhNsp1gHqj4g=";
     };
     meta = {
@@ -27298,11 +27298,11 @@ with self;
     };
   };
 
-  PAUSEPermissions = buildPerlPackage {
+  PAUSEPermissions = buildPerlPackage rec {
     pname = "PAUSE-Permissions";
     version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/PAUSE-Permissions-0.17.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/PAUSE-Permissions-${version}.tar.gz";
       hash = "sha256-ek6SDeODL5CfJV1aMj942M0hXGCMlJbNbJVwEsi0MQg=";
     };
     propagatedBuildInputs = [
@@ -27323,11 +27323,11 @@ with self;
     };
   };
 
-  Parent = buildPerlPackage {
+  Parent = buildPerlPackage rec {
     pname = "parent";
     version = "0.241";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CO/CORION/parent-0.241.tar.gz";
+      url = "mirror://cpan/authors/id/C/CO/CORION/parent-${version}.tar.gz";
       hash = "sha256-sQs5YKs5l9q3Vx/+l1ukYtl50IZFB0Ch4Is5WedRKP4=";
     };
     meta = {
@@ -27339,11 +27339,11 @@ with self;
     };
   };
 
-  ParseWin32Registry = buildPerlPackage {
+  ParseWin32Registry = buildPerlPackage rec {
     pname = "ParseWin32Registry";
     version = "1.1";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JM/JMACFARLA/Parse-Win32Registry-1.1.tar.gz";
+      url = "mirror://cpan/authors/id/J/JM/JMACFARLA/Parse-Win32Registry-${version}.tar.gz";
       hash = "sha256-wWOyAr5q17WPSEZJT/crjJqXloPKmU5DgOmsZWTcBbo=";
     };
     meta = {
@@ -27355,11 +27355,11 @@ with self;
     };
   };
 
-  ParseEDID = buildPerlPackage {
+  ParseEDID = buildPerlPackage rec {
     pname = "Parse-Edid";
     version = "1.0.7";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GR/GROUSSE/Parse-EDID-1.0.7.tar.gz";
+      url = "mirror://cpan/authors/id/G/GR/GROUSSE/Parse-EDID-${version}.tar.gz";
       hash = "sha256-GtwPEFoyGYoqK02lsOD5hfBe/tmc42YZCnkOFl1nW/E=";
     };
     buildInputs = [ TestWarn ];
@@ -27369,11 +27369,11 @@ with self;
     };
   };
 
-  ParseDebControl = buildPerlPackage {
+  ParseDebControl = buildPerlPackage rec {
     pname = "Parse-DebControl";
     version = "2.005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JA/JAYBONCI/Parse-DebControl-2.005.tar.gz";
+      url = "mirror://cpan/authors/id/J/JA/JAYBONCI/Parse-DebControl-${version}.tar.gz";
       hash = "sha256-tkvOH/IS1+PvnUNo57YnSc8ndR+oNgzfU+lpEjNGpyk=";
     };
     propagatedBuildInputs = [
@@ -27389,11 +27389,11 @@ with self;
     };
   };
 
-  ParseDistname = buildPerlPackage {
+  ParseDistname = buildPerlPackage rec {
     pname = "Parse-Distname";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/Parse-Distname-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/Parse-Distname-${version}.tar.gz";
       hash = "sha256-pfqTvsLat22IPaEtTzRLc7+L6wzEtmwkN28+Dzh67wc=";
     };
     buildInputs = [
@@ -27410,11 +27410,11 @@ with self;
     };
   };
 
-  ParseIRC = buildPerlPackage {
+  ParseIRC = buildPerlPackage rec {
     pname = "Parse-IRC";
     version = "1.22";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BI/BINGOS/Parse-IRC-1.22.tar.gz";
+      url = "mirror://cpan/authors/id/B/BI/BINGOS/Parse-IRC-${version}.tar.gz";
       hash = "sha256-RXsJiX8304pwVPlWMkc2VCf+JBAWIu1MfwVHI6RbWNU=";
     };
     meta = {
@@ -27428,11 +27428,11 @@ with self;
     };
   };
 
-  ParseLocalDistribution = buildPerlPackage {
+  ParseLocalDistribution = buildPerlPackage rec {
     pname = "Parse-LocalDistribution";
     version = "0.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/Parse-LocalDistribution-0.19.tar.gz";
+      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/Parse-LocalDistribution-${version}.tar.gz";
       hash = "sha256-awvDLE6NnoHz8qzB0qdMKi+IepHBUisxzkyNSaQV6Z4=";
     };
     propagatedBuildInputs = [ ParsePMFile ];
@@ -27449,11 +27449,11 @@ with self;
     };
   };
 
-  ParsePlainConfig = buildPerlPackage {
+  ParsePlainConfig = buildPerlPackage rec {
     pname = "Parse-PlainConfig";
     version = "3.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CO/CORLISS/Parse-PlainConfig/Parse-PlainConfig-3.06.tar.gz";
+      url = "mirror://cpan/authors/id/C/CO/CORLISS/Parse-PlainConfig/Parse-PlainConfig-${version}.tar.gz";
       hash = "sha256-8ffT5OWawrbPbJjaDKpBxdTl2GVcIQdRSBlplS/+G4c=";
     };
     propagatedBuildInputs = [
@@ -27473,11 +27473,11 @@ with self;
     };
   };
 
-  ParsePMFile = buildPerlPackage {
+  ParsePMFile = buildPerlPackage rec {
     pname = "Parse-PMFile";
     version = "0.44";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/Parse-PMFile-0.44.tar.gz";
+      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/Parse-PMFile-${version}.tar.gz";
       hash = "sha256-4I8PVkVbOsEtzNjHEWUGErfTzRUPim+K5rQ7LaR9+ZQ=";
     };
     buildInputs = [ ExtUtilsMakeMakerCPANfile ];
@@ -27490,11 +27490,11 @@ with self;
     };
   };
 
-  ParseRecDescent = buildPerlModule {
+  ParseRecDescent = buildPerlModule rec {
     pname = "Parse-RecDescent";
     version = "1.967015";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JT/JTBRAUN/Parse-RecDescent-1.967015.tar.gz";
+      url = "mirror://cpan/authors/id/J/JT/JTBRAUN/Parse-RecDescent-${version}.tar.gz";
       hash = "sha256-GUMzaky1TxeIpzPwgnwMVdtDENXq4V5UJjnJ3YVlbjc=";
     };
     meta = {
@@ -27506,11 +27506,11 @@ with self;
     };
   };
 
-  ParseSyslog = buildPerlPackage {
+  ParseSyslog = buildPerlPackage rec {
     pname = "Parse-Syslog";
     version = "1.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DS/DSCHWEI/Parse-Syslog-1.10.tar.gz";
+      url = "mirror://cpan/authors/id/D/DS/DSCHWEI/Parse-Syslog-${version}.tar.gz";
       hash = "sha256-ZZohRUQe822YNd7K+D2jCPzQP0kTjLPZCSjov8nxOdk=";
     };
     meta = {
@@ -27522,11 +27522,11 @@ with self;
     };
   };
 
-  ParserMGC = buildPerlModule {
+  ParserMGC = buildPerlModule rec {
     pname = "Parser-MGC";
     version = "0.21";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Parser-MGC-0.21.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Parser-MGC-${version}.tar.gz";
       hash = "sha256-DmGIpydqn5B1fGIEc98W08mGGRO6viWvIJz0RhWgKk8=";
     };
     buildInputs = [ TestFatal ];
@@ -27540,11 +27540,11 @@ with self;
     };
   };
 
-  ParseYapp = buildPerlPackage {
+  ParseYapp = buildPerlPackage rec {
     pname = "Parse-Yapp";
     version = "1.21";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/W/WB/WBRASWELL/Parse-Yapp-1.21.tar.gz";
+      url = "mirror://cpan/authors/id/W/WB/WBRASWELL/Parse-Yapp-${version}.tar.gz";
       hash = "sha256-OBDpmDCPui4PTyYEMDUDKwJ85RzlyKUqi440DKZfE+U=";
     };
     meta = {
@@ -27557,11 +27557,11 @@ with self;
     };
   };
 
-  PathClass = buildPerlModule {
+  PathClass = buildPerlModule rec {
     pname = "Path-Class";
     version = "0.37";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KW/KWILLIAMS/Path-Class-0.37.tar.gz";
+      url = "mirror://cpan/authors/id/K/KW/KWILLIAMS/Path-Class-${version}.tar.gz";
       hash = "sha256-ZUeBlIYCOG8ssuRHOnOfF9xpU9kqq8JJikyiVhvCSM4=";
     };
     meta = {
@@ -27573,11 +27573,11 @@ with self;
     };
   };
 
-  PathDispatcher = buildPerlPackage {
+  PathDispatcher = buildPerlPackage rec {
     pname = "Path-Dispatcher";
     version = "1.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Path-Dispatcher-1.08.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Path-Dispatcher-${version}.tar.gz";
       hash = "sha256-ean2HCdAi0/R7SNNrCRpdN3q+n/mNaGP5B7HeDEwrio=";
     };
     buildInputs = [
@@ -27600,11 +27600,11 @@ with self;
     };
   };
 
-  PathIteratorRule = buildPerlPackage {
+  PathIteratorRule = buildPerlPackage rec {
     pname = "Path-Iterator-Rule";
     version = "1.015";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Path-Iterator-Rule-1.015.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Path-Iterator-Rule-${version}.tar.gz";
       hash = "sha256-87Bixo4Hx29o3lvDOHfP6eB4tjUaYboWUOM+CfUeyyk=";
     };
     propagatedBuildInputs = [
@@ -27625,11 +27625,11 @@ with self;
     };
   };
 
-  PathTiny = buildPerlPackage {
+  PathTiny = buildPerlPackage rec {
     pname = "Path-Tiny";
     version = "0.144";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Path-Tiny-0.144.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Path-Tiny-${version}.tar.gz";
       hash = "sha256-9uoJTs6EXJUqAsJ4kzJXk1TejUEKcH+bcEW9JBIGSH0=";
     };
     preConfigure = ''
@@ -27646,14 +27646,14 @@ with self;
     };
   };
 
-  PathTools = buildPerlPackage {
+  PathTools = buildPerlPackage rec {
     pname = "PathTools";
     version = "3.75";
     preConfigure = ''
       substituteInPlace Cwd.pm --replace '/usr/bin/pwd' '${pkgs.coreutils}/bin/pwd'
     '';
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XS/XSAWYERX/PathTools-3.75.tar.gz";
+      url = "mirror://cpan/authors/id/X/XS/XSAWYERX/PathTools-${version}.tar.gz";
       hash = "sha256-pVhQOqax+McnwAczOQgad4iGBqpwGtoa1i3Z2MP5RaI=";
     };
     # cwd() and fastgetcwd() does not work with taint due to PATH in nixpkgs
@@ -27667,11 +27667,11 @@ with self;
     };
   };
 
-  PBKDF2Tiny = buildPerlPackage {
+  PBKDF2Tiny = buildPerlPackage rec {
     pname = "PBKDF2-Tiny";
     version = "0.005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/PBKDF2-Tiny-0.005.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/PBKDF2-Tiny-${version}.tar.gz";
       hash = "sha256-tOIdxZswJl6qpBtwUIfsA0R9nGVaFKxA/0bk3inqv44=";
     };
     meta = {
@@ -27682,11 +27682,11 @@ with self;
     };
   };
 
-  PDFAPI2 = buildPerlPackage {
+  PDFAPI2 = buildPerlPackage rec {
     pname = "PDF-API2";
     version = "2.045";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SS/SSIMMS/PDF-API2-2.045.tar.gz";
+      url = "mirror://cpan/authors/id/S/SS/SSIMMS/PDF-API2-${version}.tar.gz";
       hash = "sha256-tr204NDNZSYQP91YwXHgVgw2uEO3/jyk3cm7HkyDJAY=";
     };
     buildInputs = [
@@ -27700,11 +27700,11 @@ with self;
     };
   };
 
-  PDFBuilder = buildPerlPackage {
+  PDFBuilder = buildPerlPackage rec {
     pname = "PDF-Builder";
     version = "3.025";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PM/PMPERRY/PDF-Builder-3.025.tar.gz";
+      url = "mirror://cpan/authors/id/P/PM/PMPERRY/PDF-Builder-${version}.tar.gz";
       hash = "sha256-qb6076DsKXWpFFzvBSEYsgmPRtnBUQ3WV4agPQ2j49U=";
     };
     nativeCheckInputs = [
@@ -27719,11 +27719,11 @@ with self;
     };
   };
 
-  PDL = buildPerlPackage {
+  PDL = buildPerlPackage rec {
     pname = "PDL";
     version = "2.100";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETJ/PDL-2.100.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETJ/PDL-${version}.tar.gz";
       hash = "sha256-iqpu35AlWj0LTQBH1icOESS/HhrNJBSATocxC2s5vkA=";
     };
 
@@ -27774,11 +27774,11 @@ with self;
     };
   };
 
-  Pegex = buildPerlPackage {
+  Pegex = buildPerlPackage rec {
     pname = "Pegex";
     version = "0.75";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IN/INGY/Pegex-0.75.tar.gz";
+      url = "mirror://cpan/authors/id/I/IN/INGY/Pegex-${version}.tar.gz";
       hash = "sha256-TcjTNd6AslJHzbP5RvDRDZugs8NLDtfQAxb9Bo/QXtw=";
     };
     buildInputs = [
@@ -27801,11 +27801,11 @@ with self;
 
   PerconaToolkit = callPackage ../development/perl-modules/Percona-Toolkit { };
 
-  Perl5lib = buildPerlPackage {
+  Perl5lib = buildPerlPackage rec {
     pname = "perl5lib";
     version = "1.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NO/NOBULL/perl5lib-1.02.tar.gz";
+      url = "mirror://cpan/authors/id/N/NO/NOBULL/perl5lib-${version}.tar.gz";
       hash = "sha256-JLlpJYQBU8REJBOYs2/Il24IX9sNh5yRc0cJz5F+zqw=";
     };
     meta = {
@@ -27817,11 +27817,11 @@ with self;
     };
   };
 
-  Perlosnames = buildPerlPackage {
+  Perlosnames = buildPerlPackage rec {
     pname = "Perl-osnames";
     version = "0.122";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PERLANCAR/Perl-osnames-0.122.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PERLANCAR/Perl-osnames-${version}.tar.gz";
       hash = "sha256-cHWTnXR+N1F40ANI0AxS/52yzrsYuudHPcsJ34JRGKA=";
     };
     meta = {
@@ -27834,11 +27834,11 @@ with self;
     };
   };
 
-  PerlCritic = buildPerlModule {
+  PerlCritic = buildPerlModule rec {
     pname = "Perl-Critic";
     version = "1.150";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PETDANCE/Perl-Critic-1.150.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PETDANCE/Perl-Critic-${version}.tar.gz";
       hash = "sha256-5c2V3j5DvOcHdRdidLqkBfMm/IdA3wBUu4FpdcyNNJs=";
     };
     buildInputs = [ TestDeep ];
@@ -27875,11 +27875,11 @@ with self;
     };
   };
 
-  PerlCriticCommunity = buildPerlModule {
+  PerlCriticCommunity = buildPerlModule rec {
     pname = "Perl-Critic-Community";
     version = "1.0.4";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DB/DBOOK/Perl-Critic-Community-v1.0.4.tar.gz";
+      url = "mirror://cpan/authors/id/D/DB/DBOOK/Perl-Critic-Community-v${version}.tar.gz";
       hash = "sha256-OzFiTqDPQ5K49Dl6UpUVJIgUohZml/GkU9WKtvES0gk=";
     };
     buildInputs = [ ModuleBuildTiny ];
@@ -27916,11 +27916,11 @@ with self;
     };
   };
 
-  PerlCriticPolicyPliceaseProhibitArrayAssignAref = buildPerlPackage {
+  PerlCriticPolicyPliceaseProhibitArrayAssignAref = buildPerlPackage rec {
     pname = "Perl-Critic-Policy-Plicease-ProhibitArrayAssignAref";
     version = "100.00";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Perl-Critic-Policy-Plicease-ProhibitArrayAssignAref-100.00.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Perl-Critic-Policy-Plicease-ProhibitArrayAssignAref-${version}.tar.gz";
       hash = "sha256-2LcyMNK4vyuAEE/Ap1jHSLn/N7CL+Buqc/jXCeIM/r4=";
     };
     propagatedBuildInputs = [ PerlCritic ];
@@ -27931,11 +27931,11 @@ with self;
     };
   };
 
-  PerlCriticPolicyVariablesProhibitLoopOnHash = buildPerlPackage {
+  PerlCriticPolicyVariablesProhibitLoopOnHash = buildPerlPackage rec {
     pname = "Perl-Critic-Policy-Variables-ProhibitLoopOnHash";
     version = "0.008";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XS/XSAWYERX/Perl-Critic-Policy-Variables-ProhibitLoopOnHash-0.008.tar.gz";
+      url = "mirror://cpan/authors/id/X/XS/XSAWYERX/Perl-Critic-Policy-Variables-ProhibitLoopOnHash-${version}.tar.gz";
       hash = "sha256-EvXwvpbqG9x4KAWFd70cXGPKI8F/rJw3CUUrPf9bhOA=";
     };
     propagatedBuildInputs = [ PerlCritic ];
@@ -27948,11 +27948,11 @@ with self;
     };
   };
 
-  PerlCriticPulp = buildPerlPackage {
+  PerlCriticPulp = buildPerlPackage rec {
     pname = "Perl-Critic-Pulp";
     version = "99";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KR/KRYDE/Perl-Critic-Pulp-99.tar.gz";
+      url = "mirror://cpan/authors/id/K/KR/KRYDE/Perl-Critic-Pulp-${version}.tar.gz";
       hash = "sha256-uP2oQvy+100hAlfAooS23HsdBVSkej3l2X59VC4j5/4=";
     };
     propagatedBuildInputs = [
@@ -27969,11 +27969,11 @@ with self;
     };
   };
 
-  PerlDestructLevel = buildPerlPackage {
+  PerlDestructLevel = buildPerlPackage rec {
     pname = "Perl-Destruct-Level";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RG/RGARCIA/Perl-Destruct-Level-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/R/RG/RGARCIA/Perl-Destruct-Level-${version}.tar.gz";
       hash = "sha256-QLSsCykrYM47h956o5vC+yWhnRDlyfaYZpYchLP20Ts=";
     };
     meta = {
@@ -27985,11 +27985,11 @@ with self;
     };
   };
 
-  PerlIOLayers = buildPerlModule {
+  PerlIOLayers = buildPerlModule rec {
     pname = "PerlIO-Layers";
     version = "0.012";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/PerlIO-Layers-0.012.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/PerlIO-Layers-${version}.tar.gz";
       hash = "sha256-VC2lQvo2uz/de4d24jDTzMAqpnRM6bd7Tu9MyufASt8=";
     };
     meta = {
@@ -28001,11 +28001,11 @@ with self;
     };
   };
 
-  PerlIOeol = buildPerlPackage {
+  PerlIOeol = buildPerlPackage rec {
     pname = "PerlIO-eol";
     version = "0.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/PerlIO-eol-0.19.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/PerlIO-eol-${version}.tar.gz";
       hash = "sha256-/3O+xgRP2EepbEGZZPNw5Qn9Nv1XH3o7fDUXX1iviFk=";
     };
     meta = {
@@ -28017,11 +28017,11 @@ with self;
     };
   };
 
-  PerlIOgzip = buildPerlPackage {
+  PerlIOgzip = buildPerlPackage rec {
     pname = "PerlIO-gzip";
     version = "0.20";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NW/NWCLARK/PerlIO-gzip-0.20.tar.gz";
+      url = "mirror://cpan/authors/id/N/NW/NWCLARK/PerlIO-gzip-${version}.tar.gz";
       hash = "sha256-SEhnmj8gHj87DF9vlSbmAq9Skj/6RxoqNlfbeGvTvcU=";
     };
     buildInputs = [ pkgs.zlib ];
@@ -28035,11 +28035,11 @@ with self;
     };
   };
 
-  PerlIOutf8_strict = buildPerlPackage {
+  PerlIOutf8_strict = buildPerlPackage rec {
     pname = "PerlIO-utf8_strict";
     version = "0.010";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/PerlIO-utf8_strict-0.010.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/PerlIO-utf8_strict-${version}.tar.gz";
       hash = "sha256-vNKEi3LfKQtemE+uixpsqW9tByADzyIjiajJ6OHFcM0=";
     };
     buildInputs = [ TestException ];
@@ -28052,11 +28052,11 @@ with self;
     };
   };
 
-  PerlIOviadynamic = buildPerlPackage {
+  PerlIOviadynamic = buildPerlPackage rec {
     pname = "PerlIO-via-dynamic";
     version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AL/ALEXMV/PerlIO-via-dynamic-0.14.tar.gz";
+      url = "mirror://cpan/authors/id/A/AL/ALEXMV/PerlIO-via-dynamic-${version}.tar.gz";
       hash = "sha256-is169NivIdKLnBWuE3/nbNBk2tfSbrqKMLl+vG4fa0k=";
     };
     meta = {
@@ -28068,11 +28068,11 @@ with self;
     };
   };
 
-  PerlIOviasymlink = buildPerlPackage {
+  PerlIOviasymlink = buildPerlPackage rec {
     pname = "PerlIO-via-symlink";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CL/CLKAO/PerlIO-via-symlink-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/C/CL/CLKAO/PerlIO-via-symlink-${version}.tar.gz";
       hash = "sha256-QQfUw0pqNilFNEjCVpXZL4JSKv9k4ptxa1alr1hrLVI=";
     };
 
@@ -28092,11 +28092,11 @@ with self;
     };
   };
 
-  PerlIOviaTimeout = buildPerlModule {
+  PerlIOviaTimeout = buildPerlModule rec {
     pname = "PerlIO-via-Timeout";
     version = "0.32";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAMS/PerlIO-via-Timeout-0.32.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAMS/PerlIO-via-Timeout-${version}.tar.gz";
       hash = "sha256-knj572aIUNkT2Y+kwNfn1mfP81AzkfSk6uc6JG8ueRY=";
     };
     buildInputs = [
@@ -28113,11 +28113,11 @@ with self;
     };
   };
 
-  PerlLanguageServer = buildPerlPackage {
+  PerlLanguageServer = buildPerlPackage rec {
     pname = "Perl-LanguageServer";
     version = "2.6.1";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GR/GRICHTER/Perl-LanguageServer-2.6.1.tar.gz";
+      url = "mirror://cpan/authors/id/G/GR/GRICHTER/Perl-LanguageServer-${version}.tar.gz";
       hash = "sha256-IDM0uwsEXMeHAu9DA0CdCB87aN3XRoNEdGOIJ8NMsZg=";
     };
     propagatedBuildInputs = [
@@ -28139,11 +28139,11 @@ with self;
     };
   };
 
-  perlldap = buildPerlPackage {
+  perlldap = buildPerlPackage rec {
     pname = "perl-ldap";
     version = "0.68";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARSCHAP/perl-ldap-0.68.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MARSCHAP/perl-ldap-${version}.tar.gz";
       hash = "sha256-4vOJ/j56nkthSIaSkZrXI7mPO0ebUoj2ENqownmVs1E=";
     };
     # ldapi socket location should match the one compiled into the openldap package
@@ -28183,11 +28183,11 @@ with self;
     };
   };
 
-  PerlTidy = buildPerlPackage {
+  PerlTidy = buildPerlPackage rec {
     pname = "Perl-Tidy";
     version = "20250711";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHANCOCK/Perl-Tidy-20250711.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHANCOCK/Perl-Tidy-${version}.tar.gz";
       hash = "sha256-NHqpC8773itZDa9I04fvH9m3pzqZawQCafEatvuLpEg=";
     };
     meta = {
@@ -28197,11 +28197,11 @@ with self;
     };
   };
 
-  PHPSerialization = buildPerlPackage {
+  PHPSerialization = buildPerlPackage rec {
     pname = "PHP-Serialization";
     version = "0.34";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOBTFISH/PHP-Serialization-0.34.tar.gz";
+      url = "mirror://cpan/authors/id/B/BO/BOBTFISH/PHP-Serialization-${version}.tar.gz";
       hash = "sha256-uRLUJumuulSRpeUC58XAOcXapXVCism9yCr/857G8Ho=";
     };
     meta = {
@@ -28237,11 +28237,11 @@ with self;
     };
   };
 
-  Plack = buildPerlPackage {
+  Plack = buildPerlPackage rec {
     pname = "Plack";
     version = "1.0053";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Plack-1.0053.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Plack-${version}.tar.gz";
       hash = "sha256-QPxEA0wWTpr3DdCP++5AjCQwLsDbMQ0pAd9xdTuxZ9o=";
     };
     buildInputs = [
@@ -28286,11 +28286,11 @@ with self;
     };
   };
 
-  PlackAppProxy = buildPerlPackage {
+  PlackAppProxy = buildPerlPackage rec {
     pname = "Plack-App-Proxy";
     version = "0.29";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEEDO/Plack-App-Proxy-0.29.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEEDO/Plack-App-Proxy-${version}.tar.gz";
       hash = "sha256-BKqanbVKmpAn/nBLyjU/jl6fAr5AhytB0jX86c3ypg8=";
     };
     propagatedBuildInputs = [
@@ -28312,11 +28312,11 @@ with self;
     };
   };
 
-  PlackMiddlewareAuthDigest = buildPerlModule {
+  PlackMiddlewareAuthDigest = buildPerlModule rec {
     pname = "Plack-Middleware-Auth-Digest";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Plack-Middleware-Auth-Digest-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Plack-Middleware-Auth-Digest-${version}.tar.gz";
       hash = "sha256-mr0/kpQ2zV7N+28/DX/foRuUB6OMfWAAYWpQ7eYQFes=";
     };
     propagatedBuildInputs = [
@@ -28339,11 +28339,11 @@ with self;
     };
   };
 
-  PlackMiddlewareConsoleLogger = buildPerlModule {
+  PlackMiddlewareConsoleLogger = buildPerlModule rec {
     pname = "Plack-Middleware-ConsoleLogger";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Plack-Middleware-ConsoleLogger-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Plack-Middleware-ConsoleLogger-${version}.tar.gz";
       hash = "sha256-VWc6ylBN4sw0AWpF8yyPft2k7k0oArctZ4TSxBuH+9k=";
     };
     propagatedBuildInputs = [
@@ -28364,11 +28364,11 @@ with self;
     };
   };
 
-  PlackMiddlewareDebug = buildPerlModule {
+  PlackMiddlewareDebug = buildPerlModule rec {
     pname = "Plack-Middleware-Debug";
     version = "0.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Plack-Middleware-Debug-0.18.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Plack-Middleware-Debug-${version}.tar.gz";
       hash = "sha256-GS73nlIckMbv9vQUmtLkv8kR0sld94k1hV6Q1lnprJo=";
     };
     buildInputs = [
@@ -28392,11 +28392,11 @@ with self;
     };
   };
 
-  PlackMiddlewareDeflater = buildPerlPackage {
+  PlackMiddlewareDeflater = buildPerlPackage rec {
     pname = "Plack-Middleware-Deflater";
     version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KAZEBURO/Plack-Middleware-Deflater-0.12.tar.gz";
+      url = "mirror://cpan/authors/id/K/KA/KAZEBURO/Plack-Middleware-Deflater-${version}.tar.gz";
       hash = "sha256-KNqV59pMi1WRrEVFCckhds0IQpYM4HT94w+aEHXcwnU=";
     };
     propagatedBuildInputs = [ Plack ];
@@ -28414,11 +28414,11 @@ with self;
     };
   };
 
-  PlackMiddlewareFixMissingBodyInRedirect = buildPerlPackage {
+  PlackMiddlewareFixMissingBodyInRedirect = buildPerlPackage rec {
     pname = "Plack-Middleware-FixMissingBodyInRedirect";
     version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SW/SWEETKID/Plack-Middleware-FixMissingBodyInRedirect-0.12.tar.gz";
+      url = "mirror://cpan/authors/id/S/SW/SWEETKID/Plack-Middleware-FixMissingBodyInRedirect-${version}.tar.gz";
       hash = "sha256-bCLQafWlesIG1GWbKLiGm7knBkC7lV793UUdzFjNs5E=";
     };
     propagatedBuildInputs = [
@@ -28435,11 +28435,11 @@ with self;
     };
   };
 
-  PlackMiddlewareHeader = buildPerlPackage {
+  PlackMiddlewareHeader = buildPerlPackage rec {
     pname = "Plack-Middleware-Header";
     version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHIBA/Plack-Middleware-Header-0.04.tar.gz";
+      url = "mirror://cpan/authors/id/C/CH/CHIBA/Plack-Middleware-Header-${version}.tar.gz";
       hash = "sha256-Xra5/3Ly09VpUOI+K8AnFQqcXnVg1zo0GhZeGu3qXV4=";
     };
     propagatedBuildInputs = [ Plack ];
@@ -28452,11 +28452,11 @@ with self;
     };
   };
 
-  PlackMiddlewareMethodOverride = buildPerlPackage {
+  PlackMiddlewareMethodOverride = buildPerlPackage rec {
     pname = "Plack-Middleware-MethodOverride";
     version = "0.20";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Plack-Middleware-MethodOverride-0.20.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Plack-Middleware-MethodOverride-${version}.tar.gz";
       hash = "sha256-2/taLvtIv+sByzrh4cZ34VXce/4hDH5/IhuuPLaqtfE=";
     };
     propagatedBuildInputs = [ Plack ];
@@ -28469,11 +28469,11 @@ with self;
     };
   };
 
-  PlackMiddlewareRemoveRedundantBody = buildPerlPackage {
+  PlackMiddlewareRemoveRedundantBody = buildPerlPackage rec {
     pname = "Plack-Middleware-RemoveRedundantBody";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SW/SWEETKID/Plack-Middleware-RemoveRedundantBody-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/S/SW/SWEETKID/Plack-Middleware-RemoveRedundantBody-${version}.tar.gz";
       hash = "sha256-gNRfk9a3KQsL2LPO3YSjf8UBRWzD3sAux6rYHAAYCH4=";
     };
     propagatedBuildInputs = [ Plack ];
@@ -28487,11 +28487,11 @@ with self;
     };
   };
 
-  PlackMiddlewareReverseProxy = buildPerlPackage {
+  PlackMiddlewareReverseProxy = buildPerlPackage rec {
     pname = "Plack-Middleware-ReverseProxy";
     version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Plack-Middleware-ReverseProxy-0.16.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Plack-Middleware-ReverseProxy-${version}.tar.gz";
       hash = "sha256-h0kx030HZnug0PN5A7lFEQcfQZH+tz+kV2XaK4wVoSg=";
     };
     propagatedBuildInputs = [ Plack ];
@@ -28505,11 +28505,11 @@ with self;
     };
   };
 
-  PlackMiddlewareSession = buildPerlModule {
+  PlackMiddlewareSession = buildPerlModule rec {
     pname = "Plack-Middleware-Session";
     version = "0.33";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Plack-Middleware-Session-0.33.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Plack-Middleware-Session-${version}.tar.gz";
       hash = "sha256-T/miydGK2ASbRd/ze5vdQSIeLC8eFrr7gb/tyIxRpO4=";
     };
     propagatedBuildInputs = [
@@ -28535,11 +28535,11 @@ with self;
     };
   };
 
-  PlackTestExternalServer = buildPerlPackage {
+  PlackTestExternalServer = buildPerlPackage rec {
     pname = "Plack-Test-ExternalServer";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Plack-Test-ExternalServer-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Plack-Test-ExternalServer-${version}.tar.gz";
       hash = "sha256-W69cV/4MBkEt7snFq+eVKrigT4xHtLvY6emYImiQPtA=";
     };
     buildInputs = [
@@ -28558,11 +28558,11 @@ with self;
     };
   };
 
-  PLS = buildPerlPackage {
+  PLS = buildPerlPackage rec {
     pname = "PLS";
     version = "0.905";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MR/MREISNER/PLS-0.905.tar.gz";
+      url = "mirror://cpan/authors/id/M/MR/MREISNER/PLS-${version}.tar.gz";
       hash = "sha256-RVW1J5nBZBXDy/5eMB6gLKDrvDQhTH/lLx19ykUwLik=";
     };
     propagatedBuildInputs = [
@@ -28595,11 +28595,11 @@ with self;
 
   Po4a = callPackage ../development/perl-modules/Po4a { };
 
-  PodMinimumVersion = buildPerlPackage {
+  PodMinimumVersion = buildPerlPackage rec {
     pname = "Pod-MinimumVersion";
     version = "50";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KR/KRYDE/Pod-MinimumVersion-50.tar.gz";
+      url = "mirror://cpan/authors/id/K/KR/KRYDE/Pod-MinimumVersion-${version}.tar.gz";
       hash = "sha256-C9KBLZqsvZm7cfoQOkuxKelVwTi6dZhzQgfcn7Z7Wm8=";
     };
     propagatedBuildInputs = [
@@ -28614,11 +28614,11 @@ with self;
     };
   };
 
-  POE = buildPerlPackage {
+  POE = buildPerlPackage rec {
     pname = "POE";
     version = "1.370";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BI/BINGOS/POE-1.370.tar.gz";
+      url = "mirror://cpan/authors/id/B/BI/BINGOS/POE-${version}.tar.gz";
       hash = "sha256-V94rY1sV+joxqeVd1REiFJ5UFOEVjugiNQYmNO4YppM=";
     };
     # N.B. removing TestPodLinkCheck from buildInputs because tests requiring
@@ -28660,11 +28660,11 @@ with self;
     };
   };
 
-  POETestLoops = buildPerlPackage {
+  POETestLoops = buildPerlPackage rec {
     pname = "POE-Test-Loops";
     version = "1.360";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RC/RCAPUTO/POE-Test-Loops-1.360.tar.gz";
+      url = "mirror://cpan/authors/id/R/RC/RCAPUTO/POE-Test-Loops-${version}.tar.gz";
       hash = "sha256-vtDJb+kcmP035utZqASqrJzEqekoRQt21L9VJ6nmpHs=";
     };
     meta = {
@@ -28678,11 +28678,11 @@ with self;
     };
   };
 
-  PPI = buildPerlPackage {
+  PPI = buildPerlPackage rec {
     pname = "PPI";
     version = "1.277";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MITHALDU/PPI-1.277.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MITHALDU/PPI-${version}.tar.gz";
       hash = "sha256-h8efg7aHbiBgUZZdUBnSUHxVH4GahnUAgOx+xDsuCvg=";
     };
 
@@ -28719,11 +28719,11 @@ with self;
     };
   };
 
-  PPIxQuoteLike = buildPerlModule {
+  PPIxQuoteLike = buildPerlModule rec {
     pname = "PPIx-QuoteLike";
     version = "0.023";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/W/WY/WYANT/PPIx-QuoteLike-0.023.tar.gz";
+      url = "mirror://cpan/authors/id/W/WY/WYANT/PPIx-QuoteLike-${version}.tar.gz";
       hash = "sha256-NXajFJ0sU+B+lze3iSvlz7hKSZpu8d8JC3E7BUQjTSE=";
     };
     propagatedBuildInputs = [
@@ -28739,11 +28739,11 @@ with self;
     };
   };
 
-  PPIxRegexp = buildPerlModule {
+  PPIxRegexp = buildPerlModule rec {
     pname = "PPIx-Regexp";
     version = "0.088";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/W/WY/WYANT/PPIx-Regexp-0.088.tar.gz";
+      url = "mirror://cpan/authors/id/W/WY/WYANT/PPIx-Regexp-${version}.tar.gz";
       hash = "sha256-iFQz+bEC+tT9NrIccyC7A2A2ERyvmYExv0FvfNXul2Q=";
     };
     propagatedBuildInputs = [ PPI ];
@@ -28756,11 +28756,11 @@ with self;
     };
   };
 
-  PPIxUtilities = buildPerlModule {
+  PPIxUtilities = buildPerlModule rec {
     pname = "PPIx-Utilities";
     version = "1.001000";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EL/ELLIOTJS/PPIx-Utilities-1.001000.tar.gz";
+      url = "mirror://cpan/authors/id/E/EL/ELLIOTJS/PPIx-Utilities-${version}.tar.gz";
       hash = "sha256-A6SDOG/WosgI8Jd41E2wawLDFA+yS6S/EvhR9G07y5s=";
     };
     buildInputs = [ TestDeep ];
@@ -28778,11 +28778,11 @@ with self;
     };
   };
 
-  PPIxUtils = buildPerlPackage {
+  PPIxUtils = buildPerlPackage rec {
     pname = "PPIx-Utils";
     version = "0.003";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DB/DBOOK/PPIx-Utils-0.003.tar.gz";
+      url = "mirror://cpan/authors/id/D/DB/DBOOK/PPIx-Utils-${version}.tar.gz";
       hash = "sha256-KpvM/I6tA74BtnJI/o4VJSIED3mChvpO9EMrfy79uhE=";
     };
     propagatedBuildInputs = [
@@ -28799,11 +28799,11 @@ with self;
     };
   };
 
-  PPR = buildPerlPackage {
+  PPR = buildPerlPackage rec {
     pname = "PPR";
     version = "0.001008";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCONWAY/PPR-0.001008.tar.gz";
+      url = "mirror://cpan/authors/id/D/DC/DCONWAY/PPR-${version}.tar.gz";
       hash = "sha256-EQ5xwF8uLJDrAfCgaU5VqdvpHIV+SBJeF0LRflzbHkk=";
     };
     meta = {
@@ -28813,11 +28813,11 @@ with self;
     };
   };
 
-  ProcBackground = buildPerlPackage {
+  ProcBackground = buildPerlPackage rec {
     pname = "Proc-Background";
     version = "1.32";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NERDVANA/Proc-Background-1.32.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NERDVANA/Proc-Background-${version}.tar.gz";
       hash = "sha256-Wxp4DduSnKQnJeuQtRgyFCX/d4tKE3+G+sldn7nNKWc=";
     };
     meta = {
@@ -28830,11 +28830,11 @@ with self;
     };
   };
 
-  ProcProcessTable = buildPerlPackage {
+  ProcProcessTable = buildPerlPackage rec {
     pname = "Proc-ProcessTable";
     version = "0.636";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JW/JWB/Proc-ProcessTable-0.636.tar.gz";
+      url = "mirror://cpan/authors/id/J/JW/JWB/Proc-ProcessTable-${version}.tar.gz";
       hash = "sha256-lEIk/7APwe81BpYzdwoK/ahiO1x1MtHkq0ip3zlIkP0=";
     };
     meta = {
@@ -28843,11 +28843,11 @@ with self;
     };
   };
 
-  ProcDaemon = buildPerlPackage {
+  ProcDaemon = buildPerlPackage rec {
     pname = "Proc-Daemon";
     version = "0.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AK/AKREAL/Proc-Daemon-0.23.tar.gz";
+      url = "mirror://cpan/authors/id/A/AK/AKREAL/Proc-Daemon-${version}.tar.gz";
       hash = "sha256-NMC4W3lItDHLq8l87lgINeUVzPQ7rb2DOesQlHQIm2k=";
     };
     buildInputs = [ ProcProcessTable ];
@@ -28861,11 +28861,11 @@ with self;
     };
   };
 
-  ProcPIDFile = buildPerlPackage {
+  ProcPIDFile = buildPerlPackage rec {
     pname = "Proc-PID-File";
     version = "1.29";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DM/DMITRI/Proc-PID-File-1.29.tar.gz";
+      url = "mirror://cpan/authors/id/D/DM/DMITRI/Proc-PID-File-${version}.tar.gz";
       hash = "sha256-O87aSd8YLT2BaLcMKlGyBW8v1FlQptBCipmS/TVc1KQ=";
     };
     meta = {
@@ -28878,11 +28878,11 @@ with self;
     };
   };
 
-  ProcFind = buildPerlPackage {
+  ProcFind = buildPerlPackage rec {
     pname = "Proc-Find";
     version = "0.051";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PERLANCAR/Proc-Find-0.051.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PERLANCAR/Proc-Find-${version}.tar.gz";
       hash = "sha256-ZNOQceyU17ZqfKtalQJG8P/wE7WiAKY9EXZDKYfloTU=";
     };
     propagatedBuildInputs = [ ProcProcessTable ];
@@ -28896,11 +28896,11 @@ with self;
     };
   };
 
-  ProcSafeExec = buildPerlPackage {
+  ProcSafeExec = buildPerlPackage rec {
     pname = "Proc-SafeExec";
     version = "1.5";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BI/BILBO/Proc-SafeExec-1.5.tar.gz";
+      url = "mirror://cpan/authors/id/B/BI/BILBO/Proc-SafeExec-${version}.tar.gz";
       hash = "sha256-G00JCLysVj00p+W+YcXaPu6Y5KbH+mjCZwzFhEtaLXg=";
     };
     meta = {
@@ -28912,11 +28912,11 @@ with self;
     };
   };
 
-  ProcSimple = buildPerlPackage {
+  ProcSimple = buildPerlPackage rec {
     pname = "Proc-Simple";
     version = "1.32";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSCHILLI/Proc-Simple-1.32.tar.gz";
+      url = "mirror://cpan/authors/id/M/MS/MSCHILLI/Proc-Simple-${version}.tar.gz";
       hash = "sha256-TI8KkksZrXihPac/4PswbTKnudEKMyxSMIf8g6IJqMQ=";
     };
     meta = {
@@ -28928,11 +28928,11 @@ with self;
     };
   };
 
-  ProcWait3 = buildPerlPackage {
+  ProcWait3 = buildPerlPackage rec {
     pname = "Proc-Wait3";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CT/CTILMES/Proc-Wait3-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/C/CT/CTILMES/Proc-Wait3-${version}.tar.gz";
       hash = "sha256-GpB/XbaTPcKTm7/v/hnurn7TnvG5eivJtyPy8l+ByvM=";
     };
     meta = {
@@ -28944,11 +28944,11 @@ with self;
     };
   };
 
-  ProcWaitStat = buildPerlPackage {
+  ProcWaitStat = buildPerlPackage rec {
     pname = "Proc-WaitStat";
     version = "1.00";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RO/ROSCH/Proc-WaitStat-1.00.tar.gz";
+      url = "mirror://cpan/authors/id/R/RO/ROSCH/Proc-WaitStat-${version}.tar.gz";
       hash = "sha256-0HVj9eeHkJ0W5zkCQeh39Jq3ObHenQ4uoaQb0L9EdLw=";
     };
     propagatedBuildInputs = [ IPCSignal ];
@@ -28961,11 +28961,11 @@ with self;
     };
   };
 
-  PrometheusTiny = buildPerlPackage {
+  PrometheusTiny = buildPerlPackage rec {
     pname = "Prometheus-Tiny";
     version = "0.011";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RO/ROBN/Prometheus-Tiny-0.011.tar.gz";
+      url = "mirror://cpan/authors/id/R/RO/ROBN/Prometheus-Tiny-${version}.tar.gz";
       hash = "sha256-jbFIDzyJ64bUFM9fR/7tjfMRKzjEY8uPZbTAZOILHhM=";
     };
     buildInputs = [
@@ -28984,11 +28984,11 @@ with self;
     };
   };
 
-  PrometheusTinyShared = buildPerlPackage {
+  PrometheusTinyShared = buildPerlPackage rec {
     pname = "Prometheus-Tiny-Shared";
     version = "0.027";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RO/ROBN/Prometheus-Tiny-Shared-0.027.tar.gz";
+      url = "mirror://cpan/authors/id/R/RO/ROBN/Prometheus-Tiny-Shared-${version}.tar.gz";
       hash = "sha256-egULqhjKfA0gsoih1L0nJ3E6lFg/Qmskn5XcjUDty9E=";
     };
     buildInputs = [
@@ -29014,11 +29014,11 @@ with self;
     };
   };
 
-  ProtocolRedis = buildPerlPackage {
+  ProtocolRedis = buildPerlPackage rec {
     pname = "Protocol-Redis";
     version = "1.0011";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/U/UN/UNDEF/Protocol-Redis-1.0011.tar.gz";
+      url = "mirror://cpan/authors/id/U/UN/UNDEF/Protocol-Redis-${version}.tar.gz";
       hash = "sha256-fOtr2ABnyQRGXU/R8XFXJDiMm9w3xsLAA6IM5Wm39Og=";
     };
     meta = {
@@ -29032,11 +29032,11 @@ with self;
     };
   };
 
-  ProtocolRedisFaster = buildPerlPackage {
+  ProtocolRedisFaster = buildPerlPackage rec {
     pname = "Protocol-Redis-Faster";
     version = "0.003";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DB/DBOOK/Protocol-Redis-Faster-0.003.tar.gz";
+      url = "mirror://cpan/authors/id/D/DB/DBOOK/Protocol-Redis-Faster-${version}.tar.gz";
       hash = "sha256-a5r7PelOwczX20+eai6rolSld5AwHBe8sTuz7f4YULc=";
     };
     propagatedBuildInputs = [ ProtocolRedis ];
@@ -29048,11 +29048,11 @@ with self;
     };
   };
 
-  ProtocolWebSocket = buildPerlModule {
+  ProtocolWebSocket = buildPerlModule rec {
     pname = "Protocol-WebSocket";
     version = "0.26";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/V/VT/VTI/Protocol-WebSocket-0.26.tar.gz";
+      url = "mirror://cpan/authors/id/V/VT/VTI/Protocol-WebSocket-${version}.tar.gz";
       hash = "sha256-WDfQNxGnoyVPCv7LfkCeiwk3YGDDiluClejumvdXVSI=";
     };
     buildInputs = [ ModuleBuildTiny ];
@@ -29065,11 +29065,11 @@ with self;
     };
   };
 
-  ProtocolHTTP2 = buildPerlModule {
+  ProtocolHTTP2 = buildPerlModule rec {
     pname = "Protocol-HTTP2";
     version = "1.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CR/CRUX/Protocol-HTTP2-1.11.tar.gz";
+      url = "mirror://cpan/authors/id/C/CR/CRUX/Protocol-HTTP2-${version}.tar.gz";
       hash = "sha256-Vp8Fsavpl7UHyCUVMMyB0e6WvZMsxoJTS2zkhlNQCRM=";
     };
     buildInputs = [
@@ -29090,11 +29090,11 @@ with self;
     };
   };
 
-  PSGI = buildPerlPackage {
+  PSGI = buildPerlPackage rec {
     pname = "PSGI";
     version = "1.102";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/PSGI-1.102.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/PSGI-${version}.tar.gz";
       hash = "sha256-pWxEZ0CRfahpJcKfxmM7nfg5shz5j2onCGWY7ZDuH0c=";
     };
     meta = {
@@ -29103,11 +29103,11 @@ with self;
     };
   };
 
-  PadWalker = buildPerlPackage {
+  PadWalker = buildPerlPackage rec {
     pname = "PadWalker";
     version = "2.5";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RO/ROBIN/PadWalker-2.5.tar.gz";
+      url = "mirror://cpan/authors/id/R/RO/ROBIN/PadWalker-${version}.tar.gz";
       hash = "sha256-B7Jqu4QRRq8yByqNaMuQF2/7F2/ZJo5vL30Qb4F6DNA=";
     };
     meta = {
@@ -29119,11 +29119,11 @@ with self;
     };
   };
 
-  Perl6Junction = buildPerlPackage {
+  Perl6Junction = buildPerlPackage rec {
     pname = "Perl6-Junction";
     version = "1.60000";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CF/CFRANKS/Perl6-Junction-1.60000.tar.gz";
+      url = "mirror://cpan/authors/id/C/CF/CFRANKS/Perl6-Junction-${version}.tar.gz";
       hash = "sha256-0CN16FGX6PkbTLLTM0rpqJ9gAi949c1gdtzU7G+ycWQ=";
     };
     meta = {
@@ -29135,11 +29135,11 @@ with self;
     };
   };
 
-  PerlMinimumVersion = buildPerlPackage {
+  PerlMinimumVersion = buildPerlPackage rec {
     pname = "Perl-MinimumVersion";
     version = "1.40";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DB/DBOOK/Perl-MinimumVersion-1.40.tar.gz";
+      url = "mirror://cpan/authors/id/D/DB/DBOOK/Perl-MinimumVersion-${version}.tar.gz";
       hash = "sha256-dYmleMtg1wykdVw5WzWStECgzWobB05OzqyTsDGhvpA=";
     };
     buildInputs = [ TestScript ];
@@ -29158,11 +29158,11 @@ with self;
     };
   };
 
-  PerlPrereqScanner = buildPerlPackage {
+  PerlPrereqScanner = buildPerlPackage rec {
     pname = "Perl-PrereqScanner";
     version = "1.100";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Perl-PrereqScanner-1.100.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Perl-PrereqScanner-${version}.tar.gz";
       hash = "sha256-ARgdOKLnr/g40mISJWPFBja6SzZS7l0dT471uj9bGGs=";
     };
     buildInputs = [ TryTiny ];
@@ -29187,11 +29187,11 @@ with self;
     };
   };
 
-  PerlPrereqScannerNotQuiteLite = buildPerlPackage {
+  PerlPrereqScannerNotQuiteLite = buildPerlPackage rec {
     pname = "Perl-PrereqScanner-NotQuiteLite";
     version = "0.9917";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/Perl-PrereqScanner-NotQuiteLite-0.9917.tar.gz";
+      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/Perl-PrereqScanner-NotQuiteLite-${version}.tar.gz";
       hash = "sha256-O6fuF9lfDJqNkqLkwYVLZKcH0cAihGIm3Q36Qvfeud0=";
     };
     propagatedBuildInputs = [
@@ -29217,11 +29217,11 @@ with self;
     };
   };
 
-  PerlVersion = buildPerlPackage {
+  PerlVersion = buildPerlPackage rec {
     pname = "Perl-Version";
     version = "1.013";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/Perl-Version-1.013.tar.gz";
+      url = "mirror://cpan/authors/id/B/BD/BDFOY/Perl-Version-${version}.tar.gz";
       hash = "sha256-GIdBTRyGidhkyEARQQHgQ+mdfdW5zKaTaaYOgh460Pc=";
     };
     propagatedBuildInputs = [ FileSlurpTiny ];
@@ -29235,11 +29235,11 @@ with self;
     };
   };
 
-  PerlStrip = buildPerlPackage {
+  PerlStrip = buildPerlPackage rec {
     pname = "Perl-Strip";
     version = "1.2";
     src = pkgs.fetchurl {
-      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/Perl-Strip-1.2.tar.gz";
+      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/Perl-Strip-${version}.tar.gz";
       sha256 = "sha256-PI7buDcjZwzD/RIEFVUW+a18N2nzPnnan4xlxQItixo=";
     };
     buildInputs = [
@@ -29255,11 +29255,11 @@ with self;
     };
   };
 
-  PodAbstract = buildPerlPackage {
+  PodAbstract = buildPerlPackage rec {
     pname = "Pod-Abstract";
     version = "0.20";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BL/BLILBURNE/Pod-Abstract-0.20.tar.gz";
+      url = "mirror://cpan/authors/id/B/BL/BLILBURNE/Pod-Abstract-${version}.tar.gz";
       hash = "sha256-lW73u4hMVUVuL7bn8in5qH3VCmHXAFAMc4248ronf4c=";
     };
     propagatedBuildInputs = [
@@ -29277,11 +29277,11 @@ with self;
     };
   };
 
-  PodChecker = buildPerlPackage {
+  PodChecker = buildPerlPackage rec {
     pname = "Pod-Checker";
     version = "1.75";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MAREKR/Pod-Checker-1.75.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MAREKR/Pod-Checker-${version}.tar.gz";
       hash = "sha256-82O1dOxmCvbtvT5dTJ/8UVodRsvxx8ytmkbO0oh5wiE=";
     };
     preCheck = ''
@@ -29298,11 +29298,11 @@ with self;
     };
   };
 
-  PodCoverage = buildPerlPackage {
+  PodCoverage = buildPerlPackage rec {
     pname = "Pod-Coverage";
     version = "0.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RC/RCLAMP/Pod-Coverage-0.23.tar.gz";
+      url = "mirror://cpan/authors/id/R/RC/RCLAMP/Pod-Coverage-${version}.tar.gz";
       hash = "sha256-MLegsMlC9Ep1UsDTTpsfLgugtnlVxh47FYnsNpB0sQc=";
     };
     propagatedBuildInputs = [
@@ -29319,11 +29319,11 @@ with self;
     };
   };
 
-  PodCoverageTrustPod = buildPerlPackage {
+  PodCoverageTrustPod = buildPerlPackage rec {
     pname = "Pod-Coverage-TrustPod";
     version = "0.100006";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Pod-Coverage-TrustPod-0.100006.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Pod-Coverage-TrustPod-${version}.tar.gz";
       hash = "sha256-NYrcJQTwOetpCYqpm93mrp3JNTZKjhRPZAXoKTs6fKM=";
     };
     propagatedBuildInputs = [
@@ -29340,11 +29340,11 @@ with self;
     };
   };
 
-  PodElemental = buildPerlPackage {
+  PodElemental = buildPerlPackage rec {
     pname = "Pod-Elemental";
     version = "0.103006";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Pod-Elemental-0.103006.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Pod-Elemental-${version}.tar.gz";
       hash = "sha256-dQw6edjhgkdYpu99LdB33N3KUDVCuMNOzNWsu3edxCM=";
     };
     buildInputs = [
@@ -29367,11 +29367,11 @@ with self;
     };
   };
 
-  PodElementalPerlMunger = buildPerlPackage {
+  PodElementalPerlMunger = buildPerlPackage rec {
     pname = "Pod-Elemental-PerlMunger";
     version = "0.200007";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Pod-Elemental-PerlMunger-0.200007.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Pod-Elemental-PerlMunger-${version}.tar.gz";
       hash = "sha256-UYleTEGgeere+fJPXcSOMkWlwG40BO15yF+lzv63lak=";
     };
     buildInputs = [ TestDifferences ];
@@ -29389,11 +29389,11 @@ with self;
     };
   };
 
-  PodEventual = buildPerlPackage {
+  PodEventual = buildPerlPackage rec {
     pname = "Pod-Eventual";
     version = "0.094003";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Pod-Eventual-0.094003.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Pod-Eventual-${version}.tar.gz";
       hash = "sha256-fwYMw00RZWzgadsGHj1g7cDKvI+JpKLcfqrpXayFbS0=";
     };
     propagatedBuildInputs = [ MixinLinewise ];
@@ -29412,11 +29412,11 @@ with self;
     };
   };
 
-  PodParser = buildPerlPackage {
+  PodParser = buildPerlPackage rec {
     pname = "Pod-Parser";
     version = "1.66";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MAREKR/Pod-Parser-1.66.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MAREKR/Pod-Parser-${version}.tar.gz";
       hash = "sha256-IpKKe//mG0UsBbu7j1IW1LnPn+KoSbd2wlUA0k0g33w=";
     };
     meta = {
@@ -29426,11 +29426,11 @@ with self;
     };
   };
 
-  PodPOM = buildPerlPackage {
+  PodPOM = buildPerlPackage rec {
     pname = "Pod-POM";
     version = "2.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/Pod-POM-2.01.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/Pod-POM-${version}.tar.gz";
       hash = "sha256-G1D7qbvd4+rRkr7roOrd0MYU46+xdD+m//gF9XxW9/Q=";
     };
     buildInputs = [
@@ -29449,11 +29449,11 @@ with self;
     };
   };
 
-  PodPOMViewTOC = buildPerlPackage {
+  PodPOMViewTOC = buildPerlPackage rec {
     pname = "Pod-POM-View-TOC";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PERLER/Pod-POM-View-TOC-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PERLER/Pod-POM-View-TOC-${version}.tar.gz";
       hash = "sha256-zLQicsdQM3nLETE5RiDuUCdtcoRODoDrSwB6nVj4diM=";
     };
     propagatedBuildInputs = [ PodPOM ];
@@ -29466,11 +29466,11 @@ with self;
     };
   };
 
-  PodSection = buildPerlModule {
+  PodSection = buildPerlModule rec {
     pname = "Pod-Section";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KT/KTAT/Pod-Section-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/K/KT/KTAT/Pod-Section-${version}.tar.gz";
       hash = "sha256-ydHXUpLzIYgRhOxWmDwW9Aj9LTEtWnIPj7DSyvpykjg=";
     };
     propagatedBuildInputs = [ PodAbstract ];
@@ -29485,11 +29485,11 @@ with self;
     };
   };
 
-  PodLaTeX = buildPerlModule {
+  PodLaTeX = buildPerlModule rec {
     pname = "Pod-LaTeX";
     version = "0.61";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TJ/TJENNESS/Pod-LaTeX-0.61.tar.gz";
+      url = "mirror://cpan/authors/id/T/TJ/TJENNESS/Pod-LaTeX-${version}.tar.gz";
       hash = "sha256-FahA6hyKds08hl+78v7DOwNhXA2qUPnIAMVODPBlnUY=";
     };
     propagatedBuildInputs = [ PodParser ];
@@ -29504,11 +29504,11 @@ with self;
     };
   };
 
-  podlators = buildPerlPackage {
+  podlators = buildPerlPackage rec {
     pname = "podlators";
     version = "5.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RR/RRA/podlators-5.01.tar.gz";
+      url = "mirror://cpan/authors/id/R/RR/RRA/podlators-${version}.tar.gz";
       hash = "sha256-zP0d+fGkfwlbzm1xj61a9A94ziSR8scjlibhW3AgvHE=";
     };
     preCheck = ''
@@ -29525,11 +29525,11 @@ with self;
     };
   };
 
-  podlinkcheck = buildPerlPackage {
+  podlinkcheck = buildPerlPackage rec {
     pname = "podlinkcheck";
     version = "15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KR/KRYDE/podlinkcheck-15.tar.gz";
+      url = "mirror://cpan/authors/id/K/KR/KRYDE/podlinkcheck-${version}.tar.gz";
       hash = "sha256-Tjvr7Bv4Lb+FCpSuJqJTZEz1gG7EGvx05D4XEKNzIds=";
     };
     propagatedBuildInputs = [
@@ -29547,11 +29547,11 @@ with self;
     };
   };
 
-  prefork = buildPerlPackage {
+  prefork = buildPerlPackage rec {
     pname = "prefork";
     version = "1.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/prefork-1.05.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/prefork-${version}.tar.gz";
       hash = "sha256-bYe836Y7KM78+ocIA6UZtlkOPqGcMA+YzssOGQuxkwU=";
     };
     meta = {
@@ -29564,11 +29564,11 @@ with self;
     };
   };
 
-  PodPerldoc = buildPerlPackage {
+  PodPerldoc = buildPerlPackage rec {
     pname = "Pod-Perldoc";
     version = "3.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MALLEN/Pod-Perldoc-3.28.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MALLEN/Pod-Perldoc-${version}.tar.gz";
       hash = "sha256-zEHmBbjhPECo7mUE/0Y0e1un+9kiA7O7BVQiBRvvxk0=";
     };
     meta = {
@@ -29581,11 +29581,11 @@ with self;
     };
   };
 
-  PodPlainer = buildPerlPackage {
+  PodPlainer = buildPerlPackage rec {
     pname = "Pod-Plainer";
     version = "1.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RM/RMBARKER/Pod-Plainer-1.04.tar.gz";
+      url = "mirror://cpan/authors/id/R/RM/RMBARKER/Pod-Plainer-${version}.tar.gz";
       hash = "sha256-G7+/fR1IceWoO6shN+ItCJB4IGgVGQ6x1cEmCjSZRW8=";
     };
     propagatedBuildInputs = [ PodParser ];
@@ -29598,11 +29598,11 @@ with self;
     };
   };
 
-  PodMarkdown = buildPerlPackage {
+  PodMarkdown = buildPerlPackage rec {
     pname = "Pod-Markdown";
     version = "3.300";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RW/RWSTAUNER/Pod-Markdown-3.300.tar.gz";
+      url = "mirror://cpan/authors/id/R/RW/RWSTAUNER/Pod-Markdown-${version}.tar.gz";
       hash = "sha256-7HnpkIo2BXScT+tQVHY+toEt0ztUzoWlEzmqfPmZG3k=";
     };
     buildInputs = [ TestDifferences ];
@@ -29618,11 +29618,11 @@ with self;
     };
   };
 
-  PodMarkdownGithub = buildPerlPackage {
+  PodMarkdownGithub = buildPerlPackage rec {
     pname = "Pod-Markdown-Github";
     version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MINIMAL/Pod-Markdown-Github-0.04.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MINIMAL/Pod-Markdown-Github-${version}.tar.gz";
       hash = "sha256-s34vAJxMzkkk+yPuQxRuUGcilxvqa87S2sFdCAo7xhM=";
     };
     propagatedBuildInputs = [ PodMarkdown ];
@@ -29637,11 +29637,11 @@ with self;
     };
   };
 
-  PodSimple = buildPerlPackage {
+  PodSimple = buildPerlPackage rec {
     pname = "Pod-Simple";
     version = "3.45";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KH/KHW/Pod-Simple-3.45.tar.gz";
+      url = "mirror://cpan/authors/id/K/KH/KHW/Pod-Simple-${version}.tar.gz";
       hash = "sha256-hIO7lc0+QwfWbe8JKjd5+EOvdySCv9wCTj4A0MTbDPo=";
     };
     meta = {
@@ -29653,11 +29653,11 @@ with self;
     };
   };
 
-  PodSpell = buildPerlPackage {
+  PodSpell = buildPerlPackage rec {
     pname = "Pod-Spell";
     version = "1.26";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/Pod-Spell-1.26.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Pod-Spell-${version}.tar.gz";
       hash = "sha256-LwW/yc+wS5b8v6LIVE0eaukIWW02lsRuDiZVa3UK+78=";
     };
     propagatedBuildInputs = [
@@ -29679,11 +29679,11 @@ with self;
     };
   };
 
-  PodStrip = buildPerlModule {
+  PodStrip = buildPerlModule rec {
     pname = "Pod-Strip";
     version = "1.100";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DO/DOMM/Pod-Strip-1.100.tar.gz";
+      url = "mirror://cpan/authors/id/D/DO/DOMM/Pod-Strip-${version}.tar.gz";
       hash = "sha256-Z1BqZh+pyuzv57pPQvC8FbCm8JZ8eWB3QPbLaXSu1M0=";
     };
     meta = {
@@ -29696,11 +29696,11 @@ with self;
     };
   };
 
-  PodTidy = buildPerlModule {
+  PodTidy = buildPerlModule rec {
     pname = "Pod-Tidy";
     version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JH/JHOBLITT/Pod-Tidy-0.10.tar.gz";
+      url = "mirror://cpan/authors/id/J/JH/JHOBLITT/Pod-Tidy-${version}.tar.gz";
       hash = "sha256-iG7hQ+p81Tm0O+16KHmJ0Wc211y/ofheLMzq+eiVnb0=";
     };
     propagatedBuildInputs = [
@@ -29720,11 +29720,11 @@ with self;
     };
   };
 
-  PodWeaver = buildPerlPackage {
+  PodWeaver = buildPerlPackage rec {
     pname = "Pod-Weaver";
     version = "4.019";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Pod-Weaver-4.019.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Pod-Weaver-${version}.tar.gz";
       hash = "sha256-aUatHwTq+aoR8kzFRJTh1Xli9Y4FkS82S3T5WT595/c=";
     };
     buildInputs = [
@@ -29749,11 +29749,11 @@ with self;
     };
   };
 
-  PodWrap = buildPerlModule {
+  PodWrap = buildPerlModule rec {
     pname = "Pod-Wrap";
     version = "0.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NU/NUFFIN/Pod-Wrap-0.01.tar.gz";
+      url = "mirror://cpan/authors/id/N/NU/NUFFIN/Pod-Wrap-${version}.tar.gz";
       hash = "sha256-UMrL4v/7tccNG6XpQn1cit7mGENuxz+W7QU5Iy4si2M=";
     };
     propagatedBuildInputs = [ PodParser ];
@@ -29767,11 +29767,11 @@ with self;
     };
   };
 
-  ProbePerl = buildPerlPackage {
+  ProbePerl = buildPerlPackage rec {
     pname = "Probe-Perl";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KW/KWILLIAMS/Probe-Perl-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/K/KW/KWILLIAMS/Probe-Perl-${version}.tar.gz";
       hash = "sha256-2eTSHi53Y4VZBF+gkEaxtv/2xAO5SZKdshPjCr6KPDE=";
     };
     meta = {
@@ -29783,11 +29783,11 @@ with self;
     };
   };
 
-  POSIXAtFork = buildPerlPackage {
+  POSIXAtFork = buildPerlPackage rec {
     pname = "POSIX-AtFork";
     version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors//id/N/NI/NIKOLAS/POSIX-AtFork-0.04.tar.gz";
+      url = "mirror://cpan/authors//id/N/NI/NIKOLAS/POSIX-AtFork-${version}.tar.gz";
       hash = "sha256-wuIpOobUhxRLyPe6COfEt2sRsOTf3EGAmEXTDvoH5g4=";
     };
     buildInputs = [ TestSharedFork ];
@@ -29800,11 +29800,11 @@ with self;
     };
   };
 
-  POSIXstrftimeCompiler = buildPerlModule {
+  POSIXstrftimeCompiler = buildPerlModule rec {
     pname = "POSIX-strftime-Compiler";
     version = "0.44";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KAZEBURO/POSIX-strftime-Compiler-0.44.tar.gz";
+      url = "mirror://cpan/authors/id/K/KA/KAZEBURO/POSIX-strftime-Compiler-${version}.tar.gz";
       hash = "sha256-39PJc5jc/lHII2uF49woA1Znt2Ux96oKZTXzqlQFs1o=";
     };
     # We cannot change timezones on the fly.
@@ -29823,11 +29823,11 @@ with self;
     };
   };
 
-  Apprainbarf = buildPerlModule {
+  Apprainbarf = buildPerlModule rec {
     pname = "App-rainbarf";
     version = "1.4";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SY/SYP/App-rainbarf-1.4.tar.gz";
+      url = "mirror://cpan/authors/id/S/SY/SYP/App-rainbarf-${version}.tar.gz";
       hash = "sha256-TxOa01+q8t4GI9wLsd2J+lpDHlSL/sh97hlM8OJcyX0=";
     };
     meta = {
@@ -29841,11 +29841,11 @@ with self;
     };
   };
 
-  Razor2ClientAgent = buildPerlPackage {
+  Razor2ClientAgent = buildPerlPackage rec {
     pname = "Razor2-Client-Agent";
     version = "2.86";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TODDR/Razor2-Client-Agent-2.86.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TODDR/Razor2-Client-Agent-${version}.tar.gz";
       hash = "sha256-XgYuAuu2XiS3COfu+lMAxD1vZXvyDQj+xMqKCjuUhF8=";
     };
     propagatedBuildInputs = [
@@ -29862,11 +29862,11 @@ with self;
     };
   };
 
-  Readonly = buildPerlModule {
+  Readonly = buildPerlModule rec {
     pname = "Readonly";
     version = "2.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SA/SANKO/Readonly-2.05.tar.gz";
+      url = "mirror://cpan/authors/id/S/SA/SANKO/Readonly-${version}.tar.gz";
       hash = "sha256-SyNUJJGvAQ1EpcfIYSRHOKzHSrq65riDjTVN+xlGK14=";
     };
     buildInputs = [ ModuleBuildTiny ];
@@ -29877,11 +29877,11 @@ with self;
     };
   };
 
-  ReadonlyX = buildPerlModule {
+  ReadonlyX = buildPerlModule rec {
     pname = "ReadonlyX";
     version = "1.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SA/SANKO/ReadonlyX-1.04.tar.gz";
+      url = "mirror://cpan/authors/id/S/SA/SANKO/ReadonlyX-${version}.tar.gz";
       hash = "sha256-gbuX26k6xrXMvOBKQsNZDrBFV9dQGHc+4Y1aMPz0gYg=";
     };
     buildInputs = [
@@ -29895,11 +29895,11 @@ with self;
     };
   };
 
-  ReadonlyXS = buildPerlPackage {
+  ReadonlyXS = buildPerlPackage rec {
     pname = "Readonly-XS";
     version = "1.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RO/ROODE/Readonly-XS-1.05.tar.gz";
+      url = "mirror://cpan/authors/id/R/RO/ROODE/Readonly-XS-${version}.tar.gz";
       hash = "sha256-iuXE6FKZ5ci93RsZby7qOPAHCeDcDLYEVNyRFK4//w0=";
     };
     propagatedBuildInputs = [ Readonly ];
@@ -29912,11 +29912,11 @@ with self;
     };
   };
 
-  Redis = buildPerlModule {
+  Redis = buildPerlModule rec {
     pname = "Redis";
     version = "2.000";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAMS/Redis-2.000.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAMS/Redis-${version}.tar.gz";
       hash = "sha256-FMuJl5chJhW06T+Rbcva+0jQHF6qsgOP5ssXm/lcb+s=";
     };
     buildInputs = [
@@ -29938,11 +29938,11 @@ with self;
     };
   };
 
-  RefUtil = buildPerlPackage {
+  RefUtil = buildPerlPackage rec {
     pname = "Ref-Util";
     version = "0.204";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AR/ARC/Ref-Util-0.204.tar.gz";
+      url = "mirror://cpan/authors/id/A/AR/ARC/Ref-Util-${version}.tar.gz";
       hash = "sha256-QV+nPbrPRPPV15wUiIzJlFYnIKtGjm9x+RzR92nxBeE=";
     };
     meta = {
@@ -29951,11 +29951,11 @@ with self;
     };
   };
 
-  RegexpAssemble = buildPerlPackage {
+  RegexpAssemble = buildPerlPackage rec {
     pname = "Regexp-Assemble";
     version = "0.38";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RS/RSAVAGE/Regexp-Assemble-0.38.tgz";
+      url = "mirror://cpan/authors/id/R/RS/RSAVAGE/Regexp-Assemble-${version}.tgz";
       hash = "sha256-oGvn+a4bc8m/1bZmKxQcDXBGnpwZu0QTpu5W+Cra5EI=";
     };
     meta = {
@@ -29967,11 +29967,11 @@ with self;
     };
   };
 
-  RegexpCommon = buildPerlPackage {
+  RegexpCommon = buildPerlPackage rec {
     pname = "Regexp-Common";
     version = "2017060201";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AB/ABIGAIL/Regexp-Common-2017060201.tar.gz";
+      url = "mirror://cpan/authors/id/A/AB/ABIGAIL/Regexp-Common-${version}.tar.gz";
       hash = "sha256-7geFOu4G8xDgQLa/GgGZoY2BiW0yGbmzXJYw0OtpCJs=";
     };
     meta = {
@@ -29980,11 +29980,11 @@ with self;
     };
   };
 
-  RegexpCommonnetCIDR = buildPerlPackage {
+  RegexpCommonnetCIDR = buildPerlPackage rec {
     pname = "Regexp-Common-net-CIDR";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BP/BPS/Regexp-Common-net-CIDR-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/B/BP/BPS/Regexp-Common-net-CIDR-${version}.tar.gz";
       hash = "sha256-OWBqV6qyDU9EaDAPLsP6KrVX/MnLeIDsfG4H2AFi2jM=";
     };
     propagatedBuildInputs = [ RegexpCommon ];
@@ -29997,11 +29997,11 @@ with self;
     };
   };
 
-  RegexpCommontime = buildPerlPackage {
+  RegexpCommontime = buildPerlPackage rec {
     pname = "Regexp-Common-time";
     version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MANWAR/Regexp-Common-time-0.16.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MANWAR/Regexp-Common-time-${version}.tar.gz";
       hash = "sha256-HIEHpQq1XHK/ePsRbJGIxM3xYsGGwVhsH5qu5V/xSso=";
     };
     propagatedBuildInputs = [ RegexpCommon ];
@@ -30017,11 +30017,11 @@ with self;
     };
   };
 
-  RegexpGrammars = buildPerlModule {
+  RegexpGrammars = buildPerlModule rec {
     pname = "Regexp-Grammars";
     version = "1.058";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCONWAY/Regexp-Grammars-1.058.tar.gz";
+      url = "mirror://cpan/authors/id/D/DC/DCONWAY/Regexp-Grammars-${version}.tar.gz";
       hash = "sha256-6ojVjiUWdPrjm0n007U0LqzLj8tVhWzTBKoaX/PUHJI=";
     };
     meta = {
@@ -30033,11 +30033,11 @@ with self;
     };
   };
 
-  RegexpIPv6 = buildPerlPackage {
+  RegexpIPv6 = buildPerlPackage rec {
     pname = "Regexp-IPv6";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SA/SALVA/Regexp-IPv6-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/S/SA/SALVA/Regexp-IPv6-${version}.tar.gz";
       hash = "sha256-1ULRfXXOk2Md6LohVtoOC1inVcQJzUoNJ6OHOiZxLOI=";
     };
     meta = {
@@ -30049,11 +30049,11 @@ with self;
     };
   };
 
-  RegexpParser = buildPerlPackage {
+  RegexpParser = buildPerlPackage rec {
     pname = "Regexp-Parser";
     version = "0.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TODDR/Regexp-Parser-0.23.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TODDR/Regexp-Parser-${version}.tar.gz";
       hash = "sha256-9znauN8rBqrlxI+ZcSUbc3BEZKMtB9jQJfPA+GlUTok=";
     };
     meta = {
@@ -30066,11 +30066,11 @@ with self;
     };
   };
 
-  RegexpTrie = buildPerlPackage {
+  RegexpTrie = buildPerlPackage rec {
     pname = "Regexp-Trie";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DANKOGAI/Regexp-Trie-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DANKOGAI/Regexp-Trie-${version}.tar.gz";
       hash = "sha256-+yv5TtjbwfSpXZ/I9xDLZ7P3lsbvycS7TCz6Prqhxfo=";
     };
     meta = {
@@ -30082,11 +30082,11 @@ with self;
     };
   };
 
-  RESTClient = buildPerlPackage {
+  RESTClient = buildPerlPackage rec {
     pname = "REST-Client";
     version = "281";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AK/AKHUETTEL/REST-Client-281.tar.gz";
+      url = "mirror://cpan/authors/id/A/AK/AKHUETTEL/REST-Client-${version}.tar.gz";
       hash = "sha256-+hDSGgA35oJgHv5mc4p1j/dSEJSqASKek8iIpnmyyPY=";
     };
     propagatedBuildInputs = [ LWPProtocolHttps ];
@@ -30100,11 +30100,11 @@ with self;
     };
   };
 
-  RESTUtils = buildPerlModule {
+  RESTUtils = buildPerlModule rec {
     pname = "REST-Utils";
     version = "0.6";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JA/JALDHAR/REST-Utils-0.6.tar.gz";
+      url = "mirror://cpan/authors/id/J/JA/JALDHAR/REST-Utils-${version}.tar.gz";
       hash = "sha256-1OlK3YetMf71h8RxFceIx88+EiyS85YyWuLmEsZwuf0=";
     };
     buildInputs = [
@@ -30122,11 +30122,11 @@ with self;
     };
   };
 
-  RpcXML = buildPerlPackage {
+  RpcXML = buildPerlPackage rec {
     pname = "RPC-XML";
     version = "0.82";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJRAY/RPC-XML-0.82.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJRAY/RPC-XML-${version}.tar.gz";
       hash = "sha256-UnnrDRNsUz/4l/aTTDqtbyBQS5l/smBuUsXbvZJ1jnM=";
     };
     propagatedBuildInputs = [ XMLParser ];
@@ -30142,11 +30142,11 @@ with self;
     };
   };
 
-  ReturnMultiLevel = buildPerlPackage {
+  ReturnMultiLevel = buildPerlPackage rec {
     pname = "Return-MultiLevel";
     version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Return-MultiLevel-0.08.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Return-MultiLevel-${version}.tar.gz";
       hash = "sha256-UbGu8wxcQAn2QCZ6CFiSEuh9zRAYAPDSD5xjXJ/+iKE=";
     };
     buildInputs = [ TestFatal ];
@@ -30160,11 +30160,11 @@ with self;
     };
   };
 
-  ReturnValue = buildPerlPackage {
+  ReturnValue = buildPerlPackage rec {
     pname = "Return-Value";
     version = "1.666005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Return-Value-1.666005.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Return-Value-${version}.tar.gz";
       hash = "sha256-jiJgqWUx6TaGIAuciFDr4AXYjONp/2vHD/GnQFt1UKw=";
     };
     meta = {
@@ -30176,11 +30176,11 @@ with self;
     };
   };
 
-  RoleBasic = buildPerlModule {
+  RoleBasic = buildPerlModule rec {
     pname = "Role-Basic";
     version = "0.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OV/OVID/Role-Basic-0.13.tar.gz";
+      url = "mirror://cpan/authors/id/O/OV/OVID/Role-Basic-${version}.tar.gz";
       hash = "sha256-OKCVnvnxk/925ywyWp6SEbxIaGib0OKwBXePU/i282o=";
     };
     meta = {
@@ -30192,11 +30192,11 @@ with self;
     };
   };
 
-  RoleHasMessage = buildPerlPackage {
+  RoleHasMessage = buildPerlPackage rec {
     pname = "Role-HasMessage";
     version = "0.007";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Role-HasMessage-0.007.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Role-HasMessage-${version}.tar.gz";
       hash = "sha256-XiZ6TXYgs2hIEgTIjqIES4sqWP+LBVd/JxeydUwEFM4=";
     };
     propagatedBuildInputs = [
@@ -30213,11 +30213,11 @@ with self;
     };
   };
 
-  RoleHooks = buildPerlPackage {
+  RoleHooks = buildPerlPackage rec {
     pname = "Role-Hooks";
     version = "0.008";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOBYINK/Role-Hooks-0.008.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TOBYINK/Role-Hooks-${version}.tar.gz";
       hash = "sha256-KNZuoKjcMGt22oP/CHlJPYCPcxhbz5xO03LzlG+1Q+w=";
     };
     buildInputs = [ TestRequires ];
@@ -30232,11 +30232,11 @@ with self;
     };
   };
 
-  RoleIdentifiable = buildPerlPackage {
+  RoleIdentifiable = buildPerlPackage rec {
     pname = "Role-Identifiable";
     version = "0.009";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Role-Identifiable-0.009.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Role-Identifiable-${version}.tar.gz";
       hash = "sha256-WnNen3F3+euuBH63uuKbfsKewCCuN2N66lNQ0wwIe3Y=";
     };
     propagatedBuildInputs = [ Moose ];
@@ -30250,11 +30250,11 @@ with self;
     };
   };
 
-  RoleTiny = buildPerlPackage {
+  RoleTiny = buildPerlPackage rec {
     pname = "Role-Tiny";
     version = "2.002004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/Role-Tiny-2.002004.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Role-Tiny-${version}.tar.gz";
       hash = "sha256-173unhOKT4OqUtCpgWJWRL2of/FmQt+oRdy0TZokK0U=";
     };
     meta = {
@@ -30266,11 +30266,11 @@ with self;
     };
   };
 
-  RPCEPCService = buildPerlModule {
+  RPCEPCService = buildPerlModule rec {
     pname = "RPC-EPC-Service";
     version = "0.0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KI/KIWANAMI/RPC-EPC-Service-v0.0.11.tar.gz";
+      url = "mirror://cpan/authors/id/K/KI/KIWANAMI/RPC-EPC-Service-v${version}.tar.gz";
       hash = "sha256-l19BNDZSWPtH+pIZGQU1E625EB8r1CD87+NF8gkSi+M=";
     };
     propagatedBuildInputs = [
@@ -30290,11 +30290,11 @@ with self;
     };
   };
 
-  RPM2 = buildPerlModule {
+  RPM2 = buildPerlModule rec {
     pname = "RPM2";
     version = "1.4";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LK/LKUNDRAK/RPM2-1.4.tar.gz";
+      url = "mirror://cpan/authors/id/L/LK/LKUNDRAK/RPM2-${version}.tar.gz";
       hash = "sha256-XstCqmkyTm9AiKv64HMTkG5aq/L0bxIE8/HeWRVbtjY=";
     };
     nativeBuildInputs = [ pkgs.pkg-config ];
@@ -30310,11 +30310,11 @@ with self;
     };
   };
 
-  RSSParserLite = buildPerlPackage {
+  RSSParserLite = buildPerlPackage rec {
     pname = "RSS-Parser-Lite";
     version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TF/TFPBL/RSS-Parser-Lite-0.12.tar.gz";
+      url = "mirror://cpan/authors/id/T/TF/TFPBL/RSS-Parser-Lite-${version}.tar.gz";
       hash = "sha256-idw0vKixqp/uC8QK7d5eLBYCL8eYssOryH3gczG5lbk=";
     };
     propagatedBuildInputs = [ locallib ];
@@ -30328,11 +30328,11 @@ with self;
     };
   };
 
-  RTClientREST = buildPerlModule {
+  RTClientREST = buildPerlModule rec {
     pname = "RT-Client-REST";
     version = "0.72";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DJ/DJZORT/RT-Client-REST-0.72.tar.gz";
+      url = "mirror://cpan/authors/id/D/DJ/DJZORT/RT-Client-REST-${version}.tar.gz";
       hash = "sha256-KPIBWKD3sfNLdM423lvdVimeuUAUBHLISXyVNYIm/bM=";
     };
     buildInputs = [
@@ -30356,11 +30356,11 @@ with self;
     };
   };
 
-  SafeIsa = buildPerlPackage {
+  SafeIsa = buildPerlPackage rec {
     pname = "Safe-Isa";
     version = "1.000010";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Safe-Isa-1.000010.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Safe-Isa-${version}.tar.gz";
       hash = "sha256-h/QUiqD/HV5lJyMyLqt9r6OAHJZ9b5GskUejxGe4pmo=";
     };
     meta = {
@@ -30372,11 +30372,11 @@ with self;
     };
   };
 
-  ScalarListUtils = buildPerlPackage {
+  ScalarListUtils = buildPerlPackage rec {
     pname = "Scalar-List-Utils";
     version = "1.63";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Scalar-List-Utils-1.63.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Scalar-List-Utils-${version}.tar.gz";
       hash = "sha256-yvvfIS9oJ9yaDdO1e27lDoYFhtcZgiijMmLVXFWesqk=";
     };
     meta = {
@@ -30388,11 +30388,11 @@ with self;
     };
   };
 
-  ScalarString = buildPerlModule {
+  ScalarString = buildPerlModule rec {
     pname = "Scalar-String";
     version = "0.003";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Scalar-String-0.003.tar.gz";
+      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Scalar-String-${version}.tar.gz";
       hash = "sha256-9UoXybeHE7AsxDrfrfYLSUZ+djTTExfouenpfCbWi1I=";
     };
     meta = {
@@ -30404,11 +30404,11 @@ with self;
     };
   };
 
-  ScalarType = buildPerlPackage {
+  ScalarType = buildPerlPackage rec {
     pname = "Scalar-Type";
     version = "0.3.2";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/Scalar-Type-0.3.2.tar.gz";
+      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/Scalar-Type-${version}.tar.gz";
       hash = "sha256-WQyv6gz1RZmSoEiFYsDb1vnfdYtfAH8OQ6uhMLRe7oY=";
     };
     propagatedBuildInputs = [
@@ -30424,11 +30424,11 @@ with self;
     };
   };
 
-  SCGI = buildPerlModule {
+  SCGI = buildPerlModule rec {
     pname = "SCGI";
     version = "0.6";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/V/VI/VIPERCODE/SCGI-0.6.tar.gz";
+      url = "mirror://cpan/authors/id/V/VI/VIPERCODE/SCGI-${version}.tar.gz";
       hash = "sha256-WLeMWvTuReQ38Hro87DZRckf0sAlFW7pFtgRWA+R2aQ=";
     };
     preConfigure = "export HOME=$(mktemp -d)";
@@ -30441,11 +30441,11 @@ with self;
     };
   };
 
-  ScopeGuard = buildPerlPackage {
+  ScopeGuard = buildPerlPackage rec {
     pname = "Scope-Guard";
     version = "0.21";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHOCOLATE/Scope-Guard-0.21.tar.gz";
+      url = "mirror://cpan/authors/id/C/CH/CHOCOLATE/Scope-Guard-${version}.tar.gz";
       hash = "sha256-jJsb6lxWRI4sP63GXQW+nkaQo4I6gPOdLxD92Pd30ng=";
     };
     meta = {
@@ -30457,11 +30457,11 @@ with self;
     };
   };
 
-  ScopeUpper = buildPerlPackage {
+  ScopeUpper = buildPerlPackage rec {
     pname = "Scope-Upper";
     version = "0.34";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/V/VP/VPIT/Scope-Upper-0.34.tar.gz";
+      url = "mirror://cpan/authors/id/V/VP/VPIT/Scope-Upper-${version}.tar.gz";
       hash = "sha256-WB2LxRDevQxFal/HlSy3E4rmZ78486d+ltdz3DGWpB4=";
     };
     meta = {
@@ -30474,11 +30474,11 @@ with self;
     };
   };
 
-  SeleniumRemoteDriver = buildPerlPackage {
+  SeleniumRemoteDriver = buildPerlPackage rec {
     pname = "Selenium-Remote-Driver";
     version = "1.49";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TE/TEODESIAN/Selenium-Remote-Driver-1.49.tar.gz";
+      url = "mirror://cpan/authors/id/T/TE/TEODESIAN/Selenium-Remote-Driver-${version}.tar.gz";
       hash = "sha256-yg7/7s6kK72vOVqI5j5EkoWKAAZAfJTRz8QY1BOX+mI=";
     };
     buildInputs = [
@@ -30509,11 +30509,11 @@ with self;
     };
   };
 
-  SerealDecoder = buildPerlPackage {
+  SerealDecoder = buildPerlPackage rec {
     pname = "Sereal-Decoder";
     version = "5.004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Y/YV/YVES/Sereal-Decoder-5.004.tar.gz";
+      url = "mirror://cpan/authors/id/Y/YV/YVES/Sereal-Decoder-${version}.tar.gz";
       hash = "sha256-aO8DFNh9Gm5guw9m/PQ+ssrN6xdUQy9eJeeE450+Z4Q=";
     };
     buildInputs = [
@@ -30534,11 +30534,11 @@ with self;
     };
   };
 
-  SerealEncoder = buildPerlPackage {
+  SerealEncoder = buildPerlPackage rec {
     pname = "Sereal-Encoder";
     version = "5.004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Y/YV/YVES/Sereal-Encoder-5.004.tar.gz";
+      url = "mirror://cpan/authors/id/Y/YV/YVES/Sereal-Encoder-${version}.tar.gz";
       hash = "sha256-XlqGzNMtrjTtgJMuy+XGjil1K13g6bCnk6t+sspVyxs=";
     };
     buildInputs = [
@@ -30559,11 +30559,11 @@ with self;
     };
   };
 
-  Sereal = buildPerlPackage {
+  Sereal = buildPerlPackage rec {
     pname = "Sereal";
     version = "5.004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Y/YV/YVES/Sereal-5.004.tar.gz";
+      url = "mirror://cpan/authors/id/Y/YV/YVES/Sereal-${version}.tar.gz";
       hash = "sha256-nCW7euS9c20ksa0dk9dzlbDGXKh0HiZr/Ay+VCJh128=";
     };
     buildInputs = [
@@ -30585,11 +30585,11 @@ with self;
     };
   };
 
-  DeviceSerialPort = buildPerlPackage {
+  DeviceSerialPort = buildPerlPackage rec {
     pname = "Device-SerialPort";
     version = "1.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CO/COOK/Device-SerialPort-1.04.tar.gz";
+      url = "mirror://cpan/authors/id/C/CO/COOK/Device-SerialPort-${version}.tar.gz";
       hash = "sha256-05JWfLObTqYGwOCsr9jtcjIDEbmVM27OX878+bFQ6dc=";
     };
     meta = {
@@ -30602,11 +30602,11 @@ with self;
     };
   };
 
-  ServerStarter = buildPerlModule {
+  ServerStarter = buildPerlModule rec {
     pname = "Server-Starter";
     version = "0.35";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KAZUHO/Server-Starter-0.35.tar.gz";
+      url = "mirror://cpan/authors/id/K/KA/KAZUHO/Server-Starter-${version}.tar.gz";
       hash = "sha256-Z23A1s/0ZIU4Myxjwy+4itCe2GghPqnmLj8Z+tQbnEA=";
     };
     buildInputs = [
@@ -30626,11 +30626,11 @@ with self;
     };
   };
 
-  SessionToken = buildPerlPackage {
+  SessionToken = buildPerlPackage rec {
     pname = "Session-Token";
     version = "1.503";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FR/FRACTAL/Session-Token-1.503.tar.gz";
+      url = "mirror://cpan/authors/id/F/FR/FRACTAL/Session-Token-${version}.tar.gz";
       hash = "sha256-MsPflu9FXHGHA2Os2VDdxPvISMWU9LxVshtEz5efeaE=";
     };
     patches = [
@@ -30651,11 +30651,11 @@ with self;
     };
   };
 
-  SetInfinite = buildPerlPackage {
+  SetInfinite = buildPerlPackage rec {
     pname = "Set-Infinite";
     version = "0.65";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FG/FGLOCK/Set-Infinite-0.65.tar.gz";
+      url = "mirror://cpan/authors/id/F/FG/FGLOCK/Set-Infinite-${version}.tar.gz";
       hash = "sha256-B7yIBzRJLeQLSjqLWjMXYvZOabRikCn9mp01eyW4fh8=";
     };
     meta = {
@@ -30667,11 +30667,11 @@ with self;
     };
   };
 
-  SetIntSpan = buildPerlPackage {
+  SetIntSpan = buildPerlPackage rec {
     pname = "Set-IntSpan";
     version = "1.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SW/SWMCD/Set-IntSpan-1.19.tar.gz";
+      url = "mirror://cpan/authors/id/S/SW/SWMCD/Set-IntSpan-${version}.tar.gz";
       hash = "sha256-EbdUmxPsXYfMaV3Ux3fNApg91f6YZgEod/tTD0iz39A=";
     };
 
@@ -30684,11 +30684,11 @@ with self;
     };
   };
 
-  SetObject = buildPerlPackage {
+  SetObject = buildPerlPackage rec {
     pname = "Set-Object";
     version = "1.42";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RU/RURBAN/Set-Object-1.42.tar.gz";
+      url = "mirror://cpan/authors/id/R/RU/RURBAN/Set-Object-${version}.tar.gz";
       hash = "sha256-0YxaiiM+q70CBs89pbAPzdezf+vxKpPcw9HAJub97EU=";
     };
     meta = {
@@ -30697,11 +30697,11 @@ with self;
     };
   };
 
-  SetScalar = buildPerlPackage {
+  SetScalar = buildPerlPackage rec {
     pname = "Set-Scalar";
     version = "1.29";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAVIDO/Set-Scalar-1.29.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAVIDO/Set-Scalar-${version}.tar.gz";
       hash = "sha256-o9wVJvPd5y08ZOoAAHuGzmCM3Nk1Z89ubkLcEP3EUR0=";
     };
     meta = {
@@ -30713,11 +30713,11 @@ with self;
     };
   };
 
-  SmartComments = buildPerlPackage {
+  SmartComments = buildPerlPackage rec {
     pname = "Smart-Comments";
     version = "1.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/Smart-Comments-1.06.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/Smart-Comments-${version}.tar.gz";
       hash = "sha256-3PijEhNKfGuCkmoBFdk7aSRypmLSjNw6m98omEranuM=";
     };
     meta = {
@@ -30731,11 +30731,11 @@ with self;
     };
   };
 
-  SGMLSpm = buildPerlModule {
+  SGMLSpm = buildPerlModule rec {
     pname = "SGMLSpm";
     version = "1.1";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RA/RAAB/SGMLSpm-1.1.tar.gz";
+      url = "mirror://cpan/authors/id/R/RA/RAAB/SGMLSpm-${version}.tar.gz";
       hash = "sha256-VQySRSkcjfIkL36I95IaD2NsfuySxkRBjn2Jz+pwsr0=";
     };
     meta = {
@@ -30745,11 +30745,11 @@ with self;
     };
   };
 
-  SignalMask = buildPerlPackage {
+  SignalMask = buildPerlPackage rec {
     pname = "Signal-Mask";
     version = "0.008";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/Signal-Mask-0.008.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/Signal-Mask-${version}.tar.gz";
       hash = "sha256-BD2ZW2sknZ68BMRn2zG7fdwuVfqgjohb2wULHyM2tz8=";
     };
     propagatedBuildInputs = [ IPCSignal ];
@@ -30762,11 +30762,11 @@ with self;
     };
   };
 
-  SnowballNorwegian = buildPerlModule {
+  SnowballNorwegian = buildPerlModule rec {
     pname = "Snowball-Norwegian";
     version = "1.2";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AS/ASKSH/Snowball-Norwegian-1.2.tar.gz";
+      url = "mirror://cpan/authors/id/A/AS/ASKSH/Snowball-Norwegian-${version}.tar.gz";
       hash = "sha256-Hc+NfyazdSCgENzVGXAU4KWDhe5muDtP3gfqtQrZ5Rg=";
     };
     meta = {
@@ -30779,11 +30779,11 @@ with self;
     };
   };
 
-  SnowballSwedish = buildPerlModule {
+  SnowballSwedish = buildPerlModule rec {
     pname = "Snowball-Swedish";
     version = "1.2";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AS/ASKSH/Snowball-Swedish-1.2.tar.gz";
+      url = "mirror://cpan/authors/id/A/AS/ASKSH/Snowball-Swedish-${version}.tar.gz";
       hash = "sha256-76qSNVhZj06IjZelEtYPvMRIHB+cXn3tUnWWKUVg/Ck=";
     };
     meta = {
@@ -30796,11 +30796,11 @@ with self;
     };
   };
 
-  SOAPLite = buildPerlPackage {
+  SOAPLite = buildPerlPackage rec {
     pname = "SOAP-Lite";
     version = "1.27";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PH/PHRED/SOAP-Lite-1.27.tar.gz";
+      url = "mirror://cpan/authors/id/P/PH/PHRED/SOAP-Lite-${version}.tar.gz";
       hash = "sha256-41kQa6saRaFgRKTC+ASfrQNOXe0VF5kLybX42G3d0wE=";
     };
     propagatedBuildInputs = [
@@ -30824,11 +30824,11 @@ with self;
     };
   };
 
-  Socket6 = buildPerlPackage {
+  Socket6 = buildPerlPackage rec {
     pname = "Socket6";
     version = "0.29";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/U/UM/UMEMOTO/Socket6-0.29.tar.gz";
+      url = "mirror://cpan/authors/id/U/UM/UMEMOTO/Socket6-${version}.tar.gz";
       hash = "sha256-RokV+joE3PZXT8lX7/SVkV4kVpQ0lwyR7o5OFFn8kRQ=";
     };
     setOutputFlags = false;
@@ -30844,11 +30844,11 @@ with self;
     };
   };
 
-  SocketNetlink = buildPerlPackage {
+  SocketNetlink = buildPerlPackage rec {
     pname = "Socket-Netlink";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Socket-Netlink-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Socket-Netlink-${version}.tar.gz";
       hash = "sha256-2EfbWbFI0I1A/gndoswlfvcvsetaDWgVX77csfWF2L0=";
     };
     buildInputs = [
@@ -30867,11 +30867,11 @@ with self;
     };
   };
 
-  SoftwareLicense = buildPerlPackage {
+  SoftwareLicense = buildPerlPackage rec {
     pname = "Software-License";
     version = "0.104004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/Software-License-0.104004.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/Software-License-${version}.tar.gz";
       hash = "sha256-of2iTsh3UhmAlzgPuTAMFLV0gmJwzFgNr3UONYX8Jww=";
     };
     buildInputs = [ TryTiny ];
@@ -30889,11 +30889,11 @@ with self;
     };
   };
 
-  SoftwareLicenseCCpack = buildPerlPackage {
+  SoftwareLicenseCCpack = buildPerlPackage rec {
     pname = "Software-License-CCpack";
     version = "1.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BB/BBYRD/Software-License-CCpack-1.11.tar.gz";
+      url = "mirror://cpan/authors/id/B/BB/BBYRD/Software-License-CCpack-${version}.tar.gz";
       hash = "sha256-WU9carwhbJXNRYd8Qd7FbSvDDh0DFq04VbCiqo5dU7E=";
     };
     propagatedBuildInputs = [ SoftwareLicense ];
@@ -30905,11 +30905,11 @@ with self;
     };
   };
 
-  SortKey = buildPerlPackage {
+  SortKey = buildPerlPackage rec {
     pname = "Sort-Key";
     version = "1.33";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SA/SALVA/Sort-Key-1.33.tar.gz";
+      url = "mirror://cpan/authors/id/S/SA/SALVA/Sort-Key-${version}.tar.gz";
       hash = "sha256-7WpMz6sJTJzRZPVkAk6YvSHZT0MSzKxNYkbSKzQIGs8=";
     };
     meta = {
@@ -30921,11 +30921,11 @@ with self;
     };
   };
 
-  SortVersions = buildPerlPackage {
+  SortVersions = buildPerlPackage rec {
     pname = "Sort-Versions";
     version = "1.62";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/Sort-Versions-1.62.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/Sort-Versions-${version}.tar.gz";
       hash = "sha256-v18zB0BuviWBI38CWYLoyE9vZiXdd05FfAP4mU79Lqo=";
     };
     meta = {
@@ -30937,11 +30937,11 @@ with self;
     };
   };
 
-  Specio = buildPerlPackage {
+  Specio = buildPerlPackage rec {
     pname = "Specio";
     version = "0.48";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Specio-0.48.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Specio-${version}.tar.gz";
       hash = "sha256-DIV5NYDxJ07wgXMHkTHRAfd7IqzOp6+oJVIC8IEWgrI=";
     };
     propagatedBuildInputs = [
@@ -30964,11 +30964,11 @@ with self;
     };
   };
 
-  SpecioLibraryPathTiny = buildPerlPackage {
+  SpecioLibraryPathTiny = buildPerlPackage rec {
     pname = "Specio-Library-Path-Tiny";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Specio-Library-Path-Tiny-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Specio-Library-Path-Tiny-${version}.tar.gz";
       hash = "sha256-YN8Lubza6yxmoHi/bfmVTqT5Qz1stoCImULlQsfCelE=";
     };
     propagatedBuildInputs = [
@@ -30986,11 +30986,11 @@ with self;
     };
   };
 
-  Spiffy = buildPerlPackage {
+  Spiffy = buildPerlPackage rec {
     pname = "Spiffy";
     version = "0.46";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IN/INGY/Spiffy-0.46.tar.gz";
+      url = "mirror://cpan/authors/id/I/IN/INGY/Spiffy-${version}.tar.gz";
       hash = "sha256-j1hiCoQgJVxJtsQ8X/WAK9JeTwkkDFHlvysCKDPUHaM=";
     };
     meta = {
@@ -31002,11 +31002,11 @@ with self;
     };
   };
 
-  SpreadsheetCSV = buildPerlPackage {
+  SpreadsheetCSV = buildPerlPackage rec {
     pname = "Spreadsheet-CSV";
     version = "0.20";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DD/DDICK/Spreadsheet-CSV-0.20.tar.gz";
+      url = "mirror://cpan/authors/id/D/DD/DDICK/Spreadsheet-CSV-${version}.tar.gz";
       hash = "sha256-BwuyUqj+i5OKHOT8kFJfgz1OYZttRnOwrgojQI1RSrY=";
     };
     nativeBuildInputs = [ CGI ];
@@ -31025,11 +31025,11 @@ with self;
     };
   };
 
-  SpreadsheetParseExcel = buildPerlPackage {
+  SpreadsheetParseExcel = buildPerlPackage rec {
     pname = "Spreadsheet-ParseExcel";
     version = "0.66";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JM/JMCNAMARA/Spreadsheet-ParseExcel-0.66.tar.gz";
+      url = "mirror://cpan/authors/id/J/JM/JMCNAMARA/Spreadsheet-ParseExcel-${version}.tar.gz";
       hash = "sha256-v9dqz7qYhgHcBRvac7S7JfaDmgBt2WC2p0AcJJJF9ls=";
     };
     propagatedBuildInputs = [
@@ -31048,11 +31048,11 @@ with self;
     };
   };
 
-  SpreadsheetWriteExcel = buildPerlPackage {
+  SpreadsheetWriteExcel = buildPerlPackage rec {
     pname = "Spreadsheet-WriteExcel";
     version = "2.40";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JM/JMCNAMARA/Spreadsheet-WriteExcel-2.40.tar.gz";
+      url = "mirror://cpan/authors/id/J/JM/JMCNAMARA/Spreadsheet-WriteExcel-${version}.tar.gz";
       hash = "sha256-41aq1oZs8TVzEmjuDpeaGXRDwVoEh46c8+gNAirWwH4=";
     };
     propagatedBuildInputs = [
@@ -31069,11 +31069,11 @@ with self;
     };
   };
 
-  SpreadsheetXLSX = buildPerlPackage {
+  SpreadsheetXLSX = buildPerlPackage rec {
     pname = "Spreadsheet-XLSX";
     version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AS/ASB/Spreadsheet-XLSX-0.17.tar.gz";
+      url = "mirror://cpan/authors/id/A/AS/ASB/Spreadsheet-XLSX-${version}.tar.gz";
       hash = "sha256-M7d4knz/FjCQZbdOuMRpawNxZg0szf5FvkYFCSrO6XY=";
     };
     buildInputs = [
@@ -31094,11 +31094,11 @@ with self;
     };
   };
 
-  SQLAbstract = buildPerlPackage {
+  SQLAbstract = buildPerlPackage rec {
     pname = "SQL-Abstract";
     version = "2.000001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSTROUT/SQL-Abstract-2.000001.tar.gz";
+      url = "mirror://cpan/authors/id/M/MS/MSTROUT/SQL-Abstract-${version}.tar.gz";
       hash = "sha256-NaZCZiw0lCDUS+bg732HZep0PrEq0UOZqjojK7lObpo=";
     };
     buildInputs = [
@@ -31121,11 +31121,11 @@ with self;
     };
   };
 
-  SQLAbstractClassic = buildPerlPackage {
+  SQLAbstractClassic = buildPerlPackage rec {
     pname = "SQL-Abstract-Classic";
     version = "1.91";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RI/RIBASUSHI/SQL-Abstract-Classic-1.91.tar.gz";
+      url = "mirror://cpan/authors/id/R/RI/RIBASUSHI/SQL-Abstract-Classic-${version}.tar.gz";
       hash = "sha256-Tj0d/QlbISMmhYa7BrhpKepXE4jU6UGszL3NoeEI7yg=";
     };
     buildInputs = [
@@ -31143,11 +31143,11 @@ with self;
     };
   };
 
-  SQLAbstractLimit = buildPerlPackage {
+  SQLAbstractLimit = buildPerlPackage rec {
     pname = "SQL-Abstract-Limit";
     version = "0.143";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AS/ASB/SQL-Abstract-Limit-0.143.tar.gz";
+      url = "mirror://cpan/authors/id/A/AS/ASB/SQL-Abstract-Limit-${version}.tar.gz";
       hash = "sha256-0Yr9eIk72DC6JGXArmozQlRgFZADhk3tO1rc9RGJyuk=";
     };
     propagatedBuildInputs = [
@@ -31167,11 +31167,11 @@ with self;
     };
   };
 
-  SQLAbstractPg = buildPerlPackage {
+  SQLAbstractPg = buildPerlPackage rec {
     pname = "SQL-Abstract-Pg";
     version = "1.0";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SR/SRI/SQL-Abstract-Pg-1.0.tar.gz";
+      url = "mirror://cpan/authors/id/S/SR/SRI/SQL-Abstract-Pg-${version}.tar.gz";
       hash = "sha256-Pic2DfN7jYjzxS2smwNJP5vT7v9sjYj5sIbScRVT9Uc=";
     };
     buildInputs = [ TestDeep ];
@@ -31183,11 +31183,11 @@ with self;
     };
   };
 
-  SQLSplitStatement = buildPerlPackage {
+  SQLSplitStatement = buildPerlPackage rec {
     pname = "SQL-SplitStatement";
     version = "1.00023";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/V/VE/VEESH/SQL-SplitStatement-1.00023.tar.gz";
+      url = "mirror://cpan/authors/id/V/VE/VEESH/SQL-SplitStatement-${version}.tar.gz";
       hash = "sha256-GnSEIM0q00HCUk7xGFt273Fylp8XqeS6tvQ3bw3p814=";
     };
     buildInputs = [
@@ -31209,11 +31209,11 @@ with self;
     };
   };
 
-  SQLStatement = buildPerlPackage {
+  SQLStatement = buildPerlPackage rec {
     pname = "SQL-Statement";
     version = "1.414";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RE/REHSACK/SQL-Statement-1.414.tar.gz";
+      url = "mirror://cpan/authors/id/R/RE/REHSACK/SQL-Statement-${version}.tar.gz";
       hash = "sha256-3ei9z6ahNu7doGUZug8++uwIXDnbDfnEctwOxs14Gkk=";
     };
     buildInputs = [
@@ -31235,11 +31235,11 @@ with self;
     };
   };
 
-  SQLTokenizer = buildPerlPackage {
+  SQLTokenizer = buildPerlPackage rec {
     pname = "SQL-Tokenizer";
     version = "0.24";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IZ/IZUT/SQL-Tokenizer-0.24.tar.gz";
+      url = "mirror://cpan/authors/id/I/IZ/IZUT/SQL-Tokenizer-${version}.tar.gz";
       hash = "sha256-+qhpvEJlc2QVNqCfU1AuVA1ePjrWp6oaxiXT9pdrQuE=";
     };
     meta = {
@@ -31251,11 +31251,11 @@ with self;
     };
   };
 
-  SQLTranslator = buildPerlPackage {
+  SQLTranslator = buildPerlPackage rec {
     pname = "SQL-Translator";
     version = "1.63";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/V/VE/VEESH/SQL-Translator-1.63.tar.gz";
+      url = "mirror://cpan/authors/id/V/VE/VEESH/SQL-Translator-${version}.tar.gz";
       hash = "sha256-WIWwTJNJi+MqGX3JcjlHUdXeYJNBiTqWZW3oikJgMTM=";
     };
     buildInputs = [
@@ -31292,11 +31292,11 @@ with self;
     };
   };
 
-  PackageVariant = buildPerlPackage {
+  PackageVariant = buildPerlPackage rec {
     pname = "Package-Variant";
     version = "1.003002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSTROUT/Package-Variant-1.003002.tar.gz";
+      url = "mirror://cpan/authors/id/M/MS/MSTROUT/Package-Variant-${version}.tar.gz";
       hash = "sha256-su2EnS9M3WZGdRLao/FDJm1t+BDF+ukXWyUsV7wVNtw=";
     };
     buildInputs = [ TestFatal ];
@@ -31313,11 +31313,11 @@ with self;
     };
   };
 
-  SortNaturally = buildPerlPackage {
+  SortNaturally = buildPerlPackage rec {
     pname = "Sort-Naturally";
     version = "1.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BI/BINGOS/Sort-Naturally-1.03.tar.gz";
+      url = "mirror://cpan/authors/id/B/BI/BINGOS/Sort-Naturally-${version}.tar.gz";
       hash = "sha256-6qscXIdXWngmCJMEqx+P+n8Y5s2LOTdiPpmOhl7B50Y=";
     };
     meta = {
@@ -31329,11 +31329,11 @@ with self;
     };
   };
 
-  Starlet = buildPerlPackage {
+  Starlet = buildPerlPackage rec {
     pname = "Starlet";
     version = "0.31";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KAZUHO/Starlet-0.31.tar.gz";
+      url = "mirror://cpan/authors/id/K/KA/KAZUHO/Starlet-${version}.tar.gz";
       hash = "sha256-uWA7jmKIDLRYL2p5Oer+xl5u/T2QDyx900Ll9MaNYtg=";
     };
     buildInputs = [
@@ -31356,11 +31356,11 @@ with self;
     };
   };
 
-  Starman = buildPerlModule {
+  Starman = buildPerlModule rec {
     pname = "Starman";
     version = "0.4018";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Starman-0.4018.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Starman-${version}.tar.gz";
       hash = "sha256-bY2yl9hRFB+k/3dI3/BVG+K6j5pELtnKrGRNvMmjbt0=";
     };
     buildInputs = [
@@ -31390,11 +31390,11 @@ with self;
     };
   };
 
-  StatisticsBasic = buildPerlPackage {
+  StatisticsBasic = buildPerlPackage rec {
     pname = "Statistics-Basic";
     version = "1.6611";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JE/JETTERO/Statistics-Basic-1.6611.tar.gz";
+      url = "mirror://cpan/authors/id/J/JE/JETTERO/Statistics-Basic-${version}.tar.gz";
       hash = "sha256-aFXOVhX9Phr0z8RRqb9E/ymjFAtOcTADTx8K8lEalPs=";
     };
     propagatedBuildInputs = [ NumberFormat ];
@@ -31404,11 +31404,11 @@ with self;
     };
   };
 
-  StatisticsCaseResampling = buildPerlPackage {
+  StatisticsCaseResampling = buildPerlPackage rec {
     pname = "Statistics-CaseResampling";
     version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SM/SMUELLER/Statistics-CaseResampling-0.17.tar.gz";
+      url = "mirror://cpan/authors/id/S/SM/SMUELLER/Statistics-CaseResampling-${version}.tar.gz";
       hash = "sha256-buZtDu2BiC7E+kj//hY6BP2YxNVqwejNwUqfg70YObw=";
     };
     meta = {
@@ -31420,11 +31420,11 @@ with self;
     };
   };
 
-  StatisticsChiSquare = buildPerlPackage {
+  StatisticsChiSquare = buildPerlPackage rec {
     pname = "Statistics-ChiSquare";
     version = "1.0000";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/Statistics-ChiSquare-1.0000.tar.gz";
+      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/Statistics-ChiSquare-${version}.tar.gz";
       hash = "sha256-JVpaODNtBI3bkHciJpHgAJhOkHquCaTqaVqc/Umh3dA=";
     };
     meta = {
@@ -31436,11 +31436,11 @@ with self;
     };
   };
 
-  StatisticsDescriptive = buildPerlModule {
+  StatisticsDescriptive = buildPerlModule rec {
     pname = "Statistics-Descriptive";
     version = "3.0801";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Statistics-Descriptive-3.0801.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Statistics-Descriptive-${version}.tar.gz";
       hash = "sha256-BHtwpj/cqpFhaOD/LVjhVeDrvGjtTMvXOnIT3KMCj2U=";
     };
     propagatedBuildInputs = [ ListMoreUtils ];
@@ -31454,11 +31454,11 @@ with self;
     };
   };
 
-  StatisticsDistributions = buildPerlPackage {
+  StatisticsDistributions = buildPerlPackage rec {
     pname = "Statistics-Distributions";
     version = "1.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIKEK/Statistics-Distributions-1.02.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIKEK/Statistics-Distributions-${version}.tar.gz";
       hash = "sha256-+Z85ar+EyjeqLOoxrUXXOq7kh1LJmRNsS5E4lCjXM8g=";
     };
     meta = {
@@ -31470,11 +31470,11 @@ with self;
     };
   };
 
-  StatisticsTTest = buildPerlPackage {
+  StatisticsTTest = buildPerlPackage rec {
     pname = "Statistics-TTest";
     version = "1.1.0";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Y/YU/YUNFANG/Statistics-TTest-1.1.0.tar.gz";
+      url = "mirror://cpan/authors/id/Y/YU/YUNFANG/Statistics-TTest-${version}.tar.gz";
       hash = "sha256-stlZ0ljHKEebfYYu4BRuWtjuqYm+JWN8vFdlUv9zcWY=";
     };
     propagatedBuildInputs = [
@@ -31490,11 +31490,11 @@ with self;
     };
   };
 
-  StreamBuffered = buildPerlPackage {
+  StreamBuffered = buildPerlPackage rec {
     pname = "Stream-Buffered";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DO/DOY/Stream-Buffered-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/D/DO/DOY/Stream-Buffered-${version}.tar.gz";
       hash = "sha256-my1DkLXeawz0VY5K0EMXpzxeE90ZrykUnE5Hw3+yQjs=";
     };
     meta = {
@@ -31507,11 +31507,11 @@ with self;
     };
   };
 
-  strictures = buildPerlPackage {
+  strictures = buildPerlPackage rec {
     pname = "strictures";
     version = "2.000006";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/strictures-2.000006.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/strictures-${version}.tar.gz";
       hash = "sha256-CdV5dKbRsjgMgChw/tRxEI9RFw2oFFjidRhZ8nFPjVc=";
     };
     meta = {
@@ -31524,11 +31524,11 @@ with self;
     };
   };
 
-  StringApprox = buildPerlPackage {
+  StringApprox = buildPerlPackage rec {
     pname = "String-Approx";
     version = "3.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JH/JHI/String-Approx-3.28.tar.gz";
+      url = "mirror://cpan/authors/id/J/JH/JHI/String-Approx-${version}.tar.gz";
       hash = "sha256-QyAedi2GmcsKwsB2SlRUvcIwbAdxAU1sj7qCFIBjE0I=";
     };
     meta = {
@@ -31540,11 +31540,11 @@ with self;
     };
   };
 
-  StringBinaryInterpolation = buildPerlPackage {
+  StringBinaryInterpolation = buildPerlPackage rec {
     pname = "String-Binary-Interpolation";
     version = "1.0.0";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/String-Binary-Interpolation-1.0.0.tar.gz";
+      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/String-Binary-Interpolation-${version}.tar.gz";
       hash = "sha256-2lXYmCTBrdniqpWP8OpILyaCLkJI7TOo1rT7vXdYivE=";
     };
     meta = {
@@ -31556,11 +31556,11 @@ with self;
     };
   };
 
-  StringCamelCase = buildPerlPackage {
+  StringCamelCase = buildPerlPackage rec {
     pname = "String-CamelCase";
     version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HI/HIO/String-CamelCase-0.04.tar.gz";
+      url = "mirror://cpan/authors/id/H/HI/HIO/String-CamelCase-${version}.tar.gz";
       hash = "sha256-icPevO7Orodk9F10Aj+Pvu4tiDma9nVB29qgsr8nEak=";
     };
     meta = {
@@ -31572,11 +31572,11 @@ with self;
     };
   };
 
-  StringCompareConstantTime = buildPerlPackage {
+  StringCompareConstantTime = buildPerlPackage rec {
     pname = "String-Compare-ConstantTime";
     version = "0.321";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FR/FRACTAL/String-Compare-ConstantTime-0.321.tar.gz";
+      url = "mirror://cpan/authors/id/F/FR/FRACTAL/String-Compare-ConstantTime-${version}.tar.gz";
       hash = "sha256-Cya6KxIdgARCXUSF0dRvWQAcg3Y6omYk3/YiDXc11/c=";
     };
     meta = {
@@ -31588,11 +31588,11 @@ with self;
     };
   };
 
-  StringCRC32 = buildPerlPackage {
+  StringCRC32 = buildPerlPackage rec {
     pname = "String-CRC32";
     version = "2.100";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEEJO/String-CRC32-2.100.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEEJO/String-CRC32-${version}.tar.gz";
       hash = "sha256-lwYJOy0Gi2cV01tMWPUVWON5YAgyAhKfuwClfhmnRxM=";
     };
     meta = {
@@ -31601,11 +31601,11 @@ with self;
     };
   };
 
-  StringDiff = buildPerlModule {
+  StringDiff = buildPerlModule rec {
     pname = "String-Diff";
     version = "0.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Y/YA/YAPPO/String-Diff-0.07.tar.gz";
+      url = "mirror://cpan/authors/id/Y/YA/YAPPO/String-Diff-${version}.tar.gz";
       hash = "sha256-chW2fLwyJuLQ4Ys47FjJO+C/YJAnhpi++VU0iCbNCvM=";
     };
     patches = [
@@ -31635,11 +31635,11 @@ with self;
     };
   };
 
-  StringErrf = buildPerlPackage {
+  StringErrf = buildPerlPackage rec {
     pname = "String-Errf";
     version = "0.009";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/String-Errf-0.009.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/String-Errf-${version}.tar.gz";
       hash = "sha256-4f7b+bT9ZLZOqBA43bdqTGzYX12xW8IfEGVqKYNJ3B8=";
     };
     buildInputs = [
@@ -31657,11 +31657,11 @@ with self;
     };
   };
 
-  StringEscape = buildPerlPackage {
+  StringEscape = buildPerlPackage rec {
     pname = "String-Escape";
     version = "2010.002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EV/EVO/String-Escape-2010.002.tar.gz";
+      url = "mirror://cpan/authors/id/E/EV/EVO/String-Escape-${version}.tar.gz";
       hash = "sha256-/WRfizNiJNIKha5/saOEV26sMp963DkjwyQego47moo=";
     };
     meta = {
@@ -31673,11 +31673,11 @@ with self;
     };
   };
 
-  StringFlogger = buildPerlPackage {
+  StringFlogger = buildPerlPackage rec {
     pname = "String-Flogger";
     version = "1.101246";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/String-Flogger-1.101246.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/String-Flogger-${version}.tar.gz";
       hash = "sha256-FfhJHgeBi7PPqfa9Oqv2QwuptOMJ8YEUNYvj2Bv/Og8=";
     };
     propagatedBuildInputs = [
@@ -31694,11 +31694,11 @@ with self;
     };
   };
 
-  StringFormat = buildPerlPackage {
+  StringFormat = buildPerlPackage rec {
     pname = "String-Format";
     version = "1.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SR/SREZIC/String-Format-1.18.tar.gz";
+      url = "mirror://cpan/authors/id/S/SR/SREZIC/String-Format-${version}.tar.gz";
       hash = "sha256-nkF6j42epiO+6i0TpHwNWmlvyGAsBQm4Js1F+Xt253g=";
     };
     meta = {
@@ -31707,11 +31707,11 @@ with self;
     };
   };
 
-  StringFormatter = buildPerlPackage {
+  StringFormatter = buildPerlPackage rec {
     pname = "String-Formatter";
     version = "1.235";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/String-Formatter-1.235.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/String-Formatter-${version}.tar.gz";
       hash = "sha256-CCNqkTuRHOZSzwhZjnwH0t8/Np/Ee/QBpIWlBKFmB4M=";
     };
     propagatedBuildInputs = [ SubExporter ];
@@ -31721,11 +31721,11 @@ with self;
     };
   };
 
-  StringInterpolate = buildPerlPackage {
+  StringInterpolate = buildPerlPackage rec {
     pname = "String-Interpolate";
     version = "0.33";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/String-Interpolate-0.33.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/String-Interpolate-${version}.tar.gz";
       hash = "sha256-qH7Qk4kH0xr32qltc6BjL1xko40d4N6HxLRCWDEpxBM=";
     };
     meta = {
@@ -31739,11 +31739,11 @@ with self;
     ];
   };
 
-  StringInterpolateNamed = buildPerlPackage {
+  StringInterpolateNamed = buildPerlPackage rec {
     pname = "String-Interpolate-Named";
     version = "1.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JV/JV/String-Interpolate-Named-1.03.tar.gz";
+      url = "mirror://cpan/authors/id/J/JV/JV/String-Interpolate-Named-${version}.tar.gz";
       hash = "sha256-on13VgcnX2jtkqQT85SsAJLn3hzZPWJHnUf7pwF6Jtw=";
     };
     meta = {
@@ -31755,11 +31755,11 @@ with self;
     };
   };
 
-  StringMkPasswd = buildPerlPackage {
+  StringMkPasswd = buildPerlPackage rec {
     pname = "String-MkPasswd";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CG/CGRAU/String-MkPasswd-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/C/CG/CGRAU/String-MkPasswd-${version}.tar.gz";
       hash = "sha256-UxD4NGAEVHUHFma1Qj2y8KqC1mhcgC7Hq+bCxBBjm5Y=";
     };
     meta = {
@@ -31773,11 +31773,11 @@ with self;
     };
   };
 
-  StringRandom = buildPerlModule {
+  StringRandom = buildPerlModule rec {
     pname = "String-Random";
     version = "0.32";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/String-Random-0.32.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/String-Random-${version}.tar.gz";
       hash = "sha256-nZPGeaNP+ibTtPoIN8rtHNLmfXZXKBi5HpfepzRwUkY=";
     };
     meta = {
@@ -31789,11 +31789,11 @@ with self;
     };
   };
 
-  StringRewritePrefix = buildPerlPackage {
+  StringRewritePrefix = buildPerlPackage rec {
     pname = "String-RewritePrefix";
     version = "0.009";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/String-RewritePrefix-0.009.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/String-RewritePrefix-${version}.tar.gz";
       hash = "sha256-RJGL7JalSvjKN8qJfkNnCewoSgeyhRbvPM5GZoaWRtU=";
     };
     propagatedBuildInputs = [ SubExporter ];
@@ -31807,11 +31807,11 @@ with self;
     };
   };
 
-  StringShellQuote = buildPerlPackage {
+  StringShellQuote = buildPerlPackage rec {
     pname = "String-ShellQuote";
     version = "1.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RO/ROSCH/String-ShellQuote-1.04.tar.gz";
+      url = "mirror://cpan/authors/id/R/RO/ROSCH/String-ShellQuote-${version}.tar.gz";
       hash = "sha256-5gY2UDjOINZG0lXIBe/90y+GR18Y1DynVFWwDk2G3TU=";
     };
     doCheck = !stdenv.hostPlatform.isDarwin;
@@ -31825,11 +31825,11 @@ with self;
     };
   };
 
-  StringSimilarity = buildPerlPackage {
+  StringSimilarity = buildPerlPackage rec {
     pname = "String-Similarity";
     version = "1.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/String-Similarity-1.04.tar.gz";
+      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/String-Similarity-${version}.tar.gz";
       hash = "sha256-H47aIpC7y3Ia7wzhsL/hOwEgHdPaphijN/LwLikcMkU=";
     };
     doCheck = true;
@@ -31839,11 +31839,11 @@ with self;
     };
   };
 
-  ShellCommand = buildPerlPackage {
+  ShellCommand = buildPerlPackage rec {
     pname = "Shell-Command";
     version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FL/FLORA/Shell-Command-0.06.tar.gz";
+      url = "mirror://cpan/authors/id/F/FL/FLORA/Shell-Command-${version}.tar.gz";
       hash = "sha256-8+Te71d5RL5G+nr1rBGKwoKJEXiLAbx2p0SVNVYW7NE=";
     };
     meta = {
@@ -31855,11 +31855,11 @@ with self;
     };
   };
 
-  ShellConfigGenerate = buildPerlPackage {
+  ShellConfigGenerate = buildPerlPackage rec {
     pname = "Shell-Config-Generate";
     version = "0.34";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Shell-Config-Generate-0.34.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Shell-Config-Generate-${version}.tar.gz";
       hash = "sha256-hPRR8iIV3WjpwYqj992wOoIAfRZs+toAPQ8Wb1ceBWI=";
     };
     buildInputs = [ Test2Suite ];
@@ -31874,11 +31874,11 @@ with self;
     };
   };
 
-  ShellGuess = buildPerlPackage {
+  ShellGuess = buildPerlPackage rec {
     pname = "Shell-Guess";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Shell-Guess-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Shell-Guess-${version}.tar.gz";
       hash = "sha256-QGn6JjfkQxGO2VbXECMdFmgj0jsqZOuHuKRocuhloSs=";
     };
     meta = {
@@ -31891,11 +31891,11 @@ with self;
     };
   };
 
-  StringToIdentifierEN = buildPerlPackage {
+  StringToIdentifierEN = buildPerlPackage rec {
     pname = "String-ToIdentifier-EN";
     version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RK/RKITOVER/String-ToIdentifier-EN-0.12.tar.gz";
+      url = "mirror://cpan/authors/id/R/RK/RKITOVER/String-ToIdentifier-EN-${version}.tar.gz";
       hash = "sha256-OvuEIykwuaxbGto4PI3VkHrk4jrsWrsBb3D56AU83Io=";
     };
     propagatedBuildInputs = [
@@ -31912,11 +31912,11 @@ with self;
     };
   };
 
-  StringTruncate = buildPerlPackage {
+  StringTruncate = buildPerlPackage rec {
     pname = "String-Truncate";
     version = "1.100603";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/String-Truncate-1.100603.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/String-Truncate-${version}.tar.gz";
       hash = "sha256-q0VgLM4t2VFe37sublzeGc3VSY1hojr9jEbB8R+O7GI=";
     };
     propagatedBuildInputs = [ SubExporter ];
@@ -31930,11 +31930,11 @@ with self;
     };
   };
 
-  StringTT = buildPerlPackage {
+  StringTT = buildPerlPackage rec {
     pname = "String-TT";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOBTFISH/String-TT-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/B/BO/BOBTFISH/String-TT-${version}.tar.gz";
       hash = "sha256-92BfCgT5+hI9Ot9PNFeaFMkLfai5O2XS5IkyzNPJUqs=";
     };
     buildInputs = [
@@ -31955,11 +31955,11 @@ with self;
     };
   };
 
-  StringUtil = buildPerlModule {
+  StringUtil = buildPerlModule rec {
     pname = "String-Util";
     version = "1.34";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BA/BAKERSCOT/String-Util-1.34.tar.gz";
+      url = "mirror://cpan/authors/id/B/BA/BAKERSCOT/String-Util-${version}.tar.gz";
       hash = "sha256-MZzozWZTQeVlIfoVXZYqGTKOkNn3A2dlklzN4mclxGk=";
     };
     buildInputs = [ ModuleBuildTiny ];
@@ -31975,11 +31975,11 @@ with self;
 
   strip-nondeterminism = callPackage ../development/perl-modules/strip-nondeterminism { };
 
-  StructDumb = buildPerlModule {
+  StructDumb = buildPerlModule rec {
     pname = "Struct-Dumb";
     version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Struct-Dumb-0.14.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Struct-Dumb-${version}.tar.gz";
       hash = "sha256-E8FIU2sQ4oxuC04TLynkym5ptXSQWcRBV6J+hKVFlDY=";
     };
     buildInputs = [ Test2Suite ];
@@ -31992,11 +31992,11 @@ with self;
     };
   };
 
-  SubExporter = buildPerlPackage {
+  SubExporter = buildPerlPackage rec {
     pname = "Sub-Exporter";
     version = "0.990";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Sub-Exporter-0.990.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Sub-Exporter-${version}.tar.gz";
       hash = "sha256-vGTsWgaGX5zGdiFcBqlEizoMizl0/7I6JPjirQkFRPw=";
     };
     propagatedBuildInputs = [ DataOptList ];
@@ -32010,11 +32010,11 @@ with self;
     };
   };
 
-  SubExporterForMethods = buildPerlPackage {
+  SubExporterForMethods = buildPerlPackage rec {
     pname = "Sub-Exporter-ForMethods";
     version = "0.100055";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Sub-Exporter-ForMethods-0.100055.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Sub-Exporter-ForMethods-${version}.tar.gz";
       hash = "sha256-eR9CA7p8D32DgLwBvsICFffIvHDX7QPlUu7kRUGr6U4=";
     };
     buildInputs = [ namespaceautoclean ];
@@ -32032,11 +32032,11 @@ with self;
     };
   };
 
-  SubExporterGlobExporter = buildPerlPackage {
+  SubExporterGlobExporter = buildPerlPackage rec {
     pname = "Sub-Exporter-GlobExporter";
     version = "0.006";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Sub-Exporter-GlobExporter-0.006.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Sub-Exporter-GlobExporter-${version}.tar.gz";
       hash = "sha256-3nQ/CAJnAcKmoiKotBxM3CVLGkr+fvmJh806ukzlJpY=";
     };
     propagatedBuildInputs = [ SubExporter ];
@@ -32050,11 +32050,11 @@ with self;
     };
   };
 
-  SubExporterProgressive = buildPerlPackage {
+  SubExporterProgressive = buildPerlPackage rec {
     pname = "Sub-Exporter-Progressive";
     version = "0.001013";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FR/FREW/Sub-Exporter-Progressive-0.001013.tar.gz";
+      url = "mirror://cpan/authors/id/F/FR/FREW/Sub-Exporter-Progressive-${version}.tar.gz";
       hash = "sha256-1TW3lU1k2hrBMFsfrfmCAnaeNZk3aFSyztkMOCvqwFY=";
     };
     meta = {
@@ -32067,11 +32067,11 @@ with self;
     };
   };
 
-  SubHandlesVia = buildPerlPackage {
+  SubHandlesVia = buildPerlPackage rec {
     pname = "Sub-HandlesVia";
     version = "0.050002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOBYINK/Sub-HandlesVia-0.050002.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TOBYINK/Sub-HandlesVia-${version}.tar.gz";
       hash = "sha256-PMWPrjBcCOEZziwz44SHBD5odSE4JkRBw1oxATTrUDg=";
     };
     propagatedBuildInputs = [
@@ -32095,11 +32095,11 @@ with self;
     };
   };
 
-  SubIdentify = buildPerlPackage {
+  SubIdentify = buildPerlPackage rec {
     pname = "Sub-Identify";
     version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RG/RGARCIA/Sub-Identify-0.14.tar.gz";
+      url = "mirror://cpan/authors/id/R/RG/RGARCIA/Sub-Identify-${version}.tar.gz";
       hash = "sha256-Bo0nIIZRTdHoQrakCxvtuv7mOQDlsIiQ72cAA53vrW8=";
     };
     preCheck = ''
@@ -32116,11 +32116,11 @@ with self;
     };
   };
 
-  SubInfo = buildPerlPackage {
+  SubInfo = buildPerlPackage rec {
     pname = "Sub-Info";
     version = "0.002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EX/EXODIST/Sub-Info-0.002.tar.gz";
+      url = "mirror://cpan/authors/id/E/EX/EXODIST/Sub-Info-${version}.tar.gz";
       hash = "sha256-6jBW1pa97/IamdNA1VcIh9OajMR7/yOt/ILfZ1jN0Oo=";
     };
     propagatedBuildInputs = [ Importer ];
@@ -32133,11 +32133,11 @@ with self;
     };
   };
 
-  SubInstall = buildPerlPackage {
+  SubInstall = buildPerlPackage rec {
     pname = "Sub-Install";
     version = "0.929";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Sub-Install-0.929.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Sub-Install-${version}.tar.gz";
       hash = "sha256-gLHigdjNOysx2scR9cihZXqHzYC75przkkvL605dsHc=";
     };
     meta = {
@@ -32150,11 +32150,11 @@ with self;
     };
   };
 
-  SubName = buildPerlPackage {
+  SubName = buildPerlPackage rec {
     pname = "Sub-Name";
     version = "0.27";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Sub-Name-0.27.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Sub-Name-${version}.tar.gz";
       hash = "sha256-7PNvuhxHypPh2qOUlo7TnEGGhnRZ2c0XPEIeK5cgQ+g=";
     };
     buildInputs = [
@@ -32171,11 +32171,11 @@ with self;
     };
   };
 
-  SubOverride = buildPerlPackage {
+  SubOverride = buildPerlPackage rec {
     pname = "Sub-Override";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OV/OVID/Sub-Override-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/O/OV/OVID/Sub-Override-${version}.tar.gz";
       hash = "sha256-k5pnwfcplo4MyBt0lY23UOG9t8AgvuGiYzMvQiwuJbU=";
     };
     buildInputs = [ TestFatal ];
@@ -32188,11 +32188,11 @@ with self;
     };
   };
 
-  SubQuote = buildPerlPackage {
+  SubQuote = buildPerlPackage rec {
     pname = "Sub-Quote";
     version = "2.006008";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/Sub-Quote-2.006008.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Sub-Quote-${version}.tar.gz";
       hash = "sha256-lL69UAr1V2LoPqLyvFlNh6+CgHI3DHEQxgwjioANFbI=";
     };
     buildInputs = [ TestFatal ];
@@ -32205,11 +32205,11 @@ with self;
     };
   };
 
-  SubStrictDecl = buildPerlModule {
+  SubStrictDecl = buildPerlModule rec {
     pname = "Sub-StrictDecl";
     version = "0.005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Sub-StrictDecl-0.005.tar.gz";
+      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Sub-StrictDecl-${version}.tar.gz";
       hash = "sha256-oSfa52RcGpVwzZopcMbcST1SL/BzGKNKOeQJCY9pESU=";
     };
     propagatedBuildInputs = [ LexicalSealRequireHints ];
@@ -32222,11 +32222,11 @@ with self;
     };
   };
 
-  SubUplevel = buildPerlPackage {
+  SubUplevel = buildPerlPackage rec {
     pname = "Sub-Uplevel";
     version = "0.2800";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Sub-Uplevel-0.2800.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Sub-Uplevel-${version}.tar.gz";
       hash = "sha256-tPP2O4D2gKQhMy2IUd2+Wo5y/Kp01dHZjzyMxKPs4pM=";
     };
     meta = {
@@ -32239,11 +32239,11 @@ with self;
     };
   };
 
-  SVNSimple = buildPerlPackage {
+  SVNSimple = buildPerlPackage rec {
     pname = "SVN-Simple";
     version = "0.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CL/CLKAO/SVN-Simple-0.28.tar.gz";
+      url = "mirror://cpan/authors/id/C/CL/CLKAO/SVN-Simple-${version}.tar.gz";
       hash = "sha256-1jzBaeQ2m+mKU5q+nMFhG/zCs2lmplF+Z2aI/tGIT/s=";
     };
     propagatedBuildInputs = [ (pkgs.subversionClient.override { inherit perl; }) ];
@@ -32256,11 +32256,11 @@ with self;
     };
   };
 
-  SafeHole = buildPerlModule {
+  SafeHole = buildPerlModule rec {
     pname = "Safe-Hole";
     version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TODDR/Safe-Hole-0.14.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TODDR/Safe-Hole-${version}.tar.gz";
       hash = "sha256-9PVui70GxP5K4G2xIYbeyt+6wep3XqGMbAKJSB0V7AU=";
     };
     meta = {
@@ -32273,11 +32273,11 @@ with self;
     };
   };
 
-  Swim = buildPerlPackage {
+  Swim = buildPerlPackage rec {
     pname = "Swim";
     version = "0.1.48";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IN/INGY/Swim-0.1.48.tar.gz";
+      url = "mirror://cpan/authors/id/I/IN/INGY/Swim-${version}.tar.gz";
       hash = "sha256-pfcv0vIpF/orSsuy7iw9MpA9l+5bDkSbDzhwGMd/Tww=";
     };
     propagatedBuildInputs = [
@@ -32299,11 +32299,11 @@ with self;
     };
   };
 
-  Switch = buildPerlPackage {
+  Switch = buildPerlPackage rec {
     pname = "Switch";
     version = "2.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHORNY/Switch-2.17.tar.gz";
+      url = "mirror://cpan/authors/id/C/CH/CHORNY/Switch-${version}.tar.gz";
       hash = "sha256-MTVJdRQP5iNawTChCUlkka0z3UL5xiGJ4j9J91+TbXU=";
     };
     doCheck = false; # FIXME: 2/293 test failures
@@ -32316,11 +32316,11 @@ with self;
     };
   };
 
-  SymbolGet = buildPerlPackage {
+  SymbolGet = buildPerlPackage rec {
     pname = "Symbol-Get";
     version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FE/FELIPE/Symbol-Get-0.10.tar.gz";
+      url = "mirror://cpan/authors/id/F/FE/FELIPE/Symbol-Get-${version}.tar.gz";
       hash = "sha256-DuVWjFrjVzyodOCeTQUkRmz8Gtmiwk0LyR1MewbyHZw=";
     };
     buildInputs = [
@@ -32338,11 +32338,11 @@ with self;
     };
   };
 
-  SymbolGlobalName = buildPerlPackage {
+  SymbolGlobalName = buildPerlPackage rec {
     pname = "Symbol-Global-Name";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AL/ALEXMV/Symbol-Global-Name-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/A/AL/ALEXMV/Symbol-Global-Name-${version}.tar.gz";
       hash = "sha256-D3Yj6dckdgqmQEAiLaHYLxGIWGeRMpJhzGDa0dYNapI=";
     };
     meta = {
@@ -32354,11 +32354,11 @@ with self;
     };
   };
 
-  SymbolUtil = buildPerlModule {
+  SymbolUtil = buildPerlModule rec {
     pname = "Symbol-Util";
     version = "0.0203";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DE/DEXTER/Symbol-Util-0.0203.tar.gz";
+      url = "mirror://cpan/authors/id/D/DE/DEXTER/Symbol-Util-${version}.tar.gz";
       hash = "sha256-VbZh3SL5zpub5afgo/UomsAM0lTCHj2GAyiaVlrm3DI=";
     };
     preCheck = ''
@@ -32374,11 +32374,11 @@ with self;
     };
   };
 
-  syntax = buildPerlPackage {
+  syntax = buildPerlPackage rec {
     pname = "syntax";
     version = "0.004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PH/PHAYLON/syntax-0.004.tar.gz";
+      url = "mirror://cpan/authors/id/P/PH/PHAYLON/syntax-${version}.tar.gz";
       hash = "sha256-/hm22oqPQ6WqLuVxRBvA4zn7FW0AgcFXoaJOmBLH02U=";
     };
     propagatedBuildInputs = [
@@ -32395,11 +32395,11 @@ with self;
     };
   };
 
-  SyntaxKeywordJunction = buildPerlPackage {
+  SyntaxKeywordJunction = buildPerlPackage rec {
     pname = "Syntax-Keyword-Junction";
     version = "0.003008";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FR/FREW/Syntax-Keyword-Junction-0.003008.tar.gz";
+      url = "mirror://cpan/authors/id/F/FR/FREW/Syntax-Keyword-Junction-${version}.tar.gz";
       hash = "sha256-i0l18hsZkqfmwt9dzJKyVMYZJVle3c368LFJhxeqle8=";
     };
     buildInputs = [ TestRequires ];
@@ -32414,11 +32414,11 @@ with self;
     };
   };
 
-  SyntaxKeywordTry = buildPerlModule {
+  SyntaxKeywordTry = buildPerlModule rec {
     pname = "Syntax-Keyword-Try";
     version = "0.30";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Syntax-Keyword-Try-0.30.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Syntax-Keyword-Try-${version}.tar.gz";
       hash = "sha256-8Gjwuccf/4/vbYqentaVHLelK5djIr2VUYHMXnsX5pI=";
     };
     buildInputs = [ Test2Suite ];
@@ -32432,11 +32432,11 @@ with self;
     };
   };
 
-  SysMmap = buildPerlPackage {
+  SysMmap = buildPerlPackage rec {
     pname = "Sys-Mmap";
     version = "0.20";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TODDR/Sys-Mmap-0.20.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TODDR/Sys-Mmap-${version}.tar.gz";
       hash = "sha256-GCDOLInxq3NXZE+NsPSfFC9UUmJQ+x4jXbEKqA8V4s8=";
     };
     meta = {
@@ -32446,11 +32446,11 @@ with self;
     };
   };
 
-  SysMemInfo = buildPerlPackage {
+  SysMemInfo = buildPerlPackage rec {
     pname = "Sys-MemInfo";
     version = "0.99";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SC/SCRESTO/Sys-MemInfo-0.99.tar.gz";
+      url = "mirror://cpan/authors/id/S/SC/SCRESTO/Sys-MemInfo-${version}.tar.gz";
       hash = "sha256-B4YxnTo6i65dcnk5JEvxfhQLcU9Sc01en2JyA+TPPjs=";
     };
     meta = {
@@ -32460,11 +32460,11 @@ with self;
     };
   };
 
-  SysCPU = buildPerlPackage {
+  SysCPU = buildPerlPackage rec {
     pname = "Sys-CPU";
     version = "0.61";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MZ/MZSANFORD/Sys-CPU-0.61.tar.gz";
+      url = "mirror://cpan/authors/id/M/MZ/MZSANFORD/Sys-CPU-${version}.tar.gz";
       hash = "sha256-JQqGt5wjEAHErnHS9mQoCSpPuyBwlxrK/UcapJc5yeQ=";
     };
     patches = [
@@ -32489,11 +32489,11 @@ with self;
     };
   };
 
-  SysCpuAffinity = buildPerlModule {
+  SysCpuAffinity = buildPerlModule rec {
     pname = "Sys-CpuAffinity";
     version = "1.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MO/MOB/Sys-CpuAffinity-1.12.tar.gz";
+      url = "mirror://cpan/authors/id/M/MO/MOB/Sys-CpuAffinity-${version}.tar.gz";
       hash = "sha256-/jLAXz6wWXCMZH8ruFslBFhZHyupBR2Nhm9Uajh+6Eg=";
     };
     doCheck = false; # Would run checks for all supported systems
@@ -32507,11 +32507,11 @@ with self;
     };
   };
 
-  SysHostnameLong = buildPerlPackage {
+  SysHostnameLong = buildPerlPackage rec {
     pname = "Sys-Hostname-Long";
     version = "1.5";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SC/SCOTT/Sys-Hostname-Long-1.5.tar.gz";
+      url = "mirror://cpan/authors/id/S/SC/SCOTT/Sys-Hostname-Long-${version}.tar.gz";
       hash = "sha256-6Rht83Bqh379YUnyxxHWz4fdbPcvark1uoEhsiWyZcs=";
     };
     doCheck = false; # no `hostname' in stdenv
@@ -32524,11 +32524,11 @@ with self;
     };
   };
 
-  SysSigAction = buildPerlPackage {
+  SysSigAction = buildPerlPackage rec {
     pname = "Sys-SigAction";
     version = "0.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LB/LBAXTER/Sys-SigAction-0.23.tar.gz";
+      url = "mirror://cpan/authors/id/L/LB/LBAXTER/Sys-SigAction-${version}.tar.gz";
       hash = "sha256-xO9sk0VTQDH8u+Ktw0f8cZTUevyUXnpE+sfpVjCV01M=";
     };
     doCheck = !stdenv.hostPlatform.isAarch64; # it hangs on Aarch64
@@ -32541,11 +32541,11 @@ with self;
     };
   };
 
-  SysSyslog = buildPerlPackage {
+  SysSyslog = buildPerlPackage rec {
     pname = "Sys-Syslog";
     version = "0.36";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SA/SAPER/Sys-Syslog-0.36.tar.gz";
+      url = "mirror://cpan/authors/id/S/SA/SAPER/Sys-Syslog-${version}.tar.gz";
       hash = "sha256-7UKp5boErUhWzAy1040onDxdN2RUPsBO+vxK9+M3jfg=";
     };
     meta = {
@@ -32557,11 +32557,11 @@ with self;
     };
   };
 
-  SystemCommand = buildPerlPackage {
+  SystemCommand = buildPerlPackage rec {
     pname = "System-Command";
     version = "1.122";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOOK/System-Command-1.122.tar.gz";
+      url = "mirror://cpan/authors/id/B/BO/BOOK/System-Command-${version}.tar.gz";
       hash = "sha256-2bgjsmYZqmn3oGFmUKeBDolajfBi3p0iQNZdvlz+dHo=";
     };
     propagatedBuildInputs = [ IPCRun ];
@@ -32607,11 +32607,11 @@ with self;
     };
   };
 
-  TAPParserSourceHandlerpgTAP = buildPerlModule {
+  TAPParserSourceHandlerpgTAP = buildPerlModule rec {
     pname = "TAP-Parser-SourceHandler-pgTAP";
-    version = "3.36";
+    version = "3.37";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DW/DWHEELER/TAP-Parser-SourceHandler-pgTAP-3.37.tar.gz";
+      url = "mirror://cpan/authors/id/D/DW/DWHEELER/TAP-Parser-SourceHandler-pgTAP-${version}.tar.gz";
       hash = "sha256-bpKFgUQqHmhxMfe11vT/RLf43N95jS0Ha9zQfYt6WX0=";
     };
     doCheck = !stdenv.hostPlatform.isDarwin;
@@ -32625,11 +32625,11 @@ with self;
     };
   };
 
-  TaskCatalystTutorial = buildPerlPackage {
+  TaskCatalystTutorial = buildPerlPackage rec {
     pname = "Task-Catalyst-Tutorial";
     version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MR/MRAMBERG/Task-Catalyst-Tutorial-0.06.tar.gz";
+      url = "mirror://cpan/authors/id/M/MR/MRAMBERG/Task-Catalyst-Tutorial-${version}.tar.gz";
       hash = "sha256-dbGy2WFVZHhCWHFGzv0N4wlDuFGV6OPspR4PC4ZC1h4=";
     };
     propagatedBuildInputs = [
@@ -32654,11 +32654,11 @@ with self;
     };
   };
 
-  TaskFreecellSolverTesting = buildPerlModule {
+  TaskFreecellSolverTesting = buildPerlModule rec {
     pname = "Task-FreecellSolver-Testing";
     version = "0.0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Task-FreecellSolver-Testing-0.0.12.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Task-FreecellSolver-Testing-${version}.tar.gz";
       hash = "sha256-PRkQt64SVBfG4HeUeOtK8/yc+J4iGVhfiiBBFGP5k6c=";
     };
     buildInputs = [
@@ -32690,11 +32690,11 @@ with self;
     };
   };
 
-  TaskPlack = buildPerlModule {
+  TaskPlack = buildPerlModule rec {
     pname = "Task-Plack";
     version = "0.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Task-Plack-0.28.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Task-Plack-${version}.tar.gz";
       hash = "sha256-edUriAZUjz+Vro1qyRW6Q524SJ/mOxOdCsFym7KfXCo=";
     };
     propagatedBuildInputs = [
@@ -32734,11 +32734,11 @@ with self;
     };
   };
 
-  TaskTestRunAllPlugins = buildPerlModule {
+  TaskTestRunAllPlugins = buildPerlModule rec {
     pname = "Task-Test-Run-AllPlugins";
     version = "0.0106";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Task-Test-Run-AllPlugins-0.0106.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Task-Test-Run-AllPlugins-${version}.tar.gz";
       hash = "sha256-G40L8IhYBmWbwpiBDw1VCq/2gEWtwjepSaymshp9zng=";
     };
     buildInputs = [
@@ -32757,11 +32757,11 @@ with self;
     };
   };
 
-  TaskWeaken = buildPerlPackage {
+  TaskWeaken = buildPerlPackage rec {
     pname = "Task-Weaken";
     version = "1.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Task-Weaken-1.06.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Task-Weaken-${version}.tar.gz";
       hash = "sha256-I4P+252672RkaOqCSvv3yAEHZyDPug3yp6B0cm3NZr4=";
     };
     meta = {
@@ -32774,11 +32774,11 @@ with self;
     };
   };
 
-  Tcl = buildPerlPackage {
+  Tcl = buildPerlPackage rec {
     pname = "Tcl";
     version = "1.27";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/V/VK/VKON/Tcl-1.27.tar.gz";
+      url = "mirror://cpan/authors/id/V/VK/VKON/Tcl-${version}.tar.gz";
       hash = "sha256-+DhYd6Sp7Z89OQPS0PfNcPrDzmgyxg9gCmghzuP7WHI=";
     };
     propagatedBuildInputs = [
@@ -32800,11 +32800,11 @@ with self;
     };
   };
 
-  TclpTk = buildPerlPackage {
+  TclpTk = buildPerlPackage rec {
     pname = "Tcl-pTk";
     version = "1.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CA/CAC/Tcl-pTk-1.11.tar.gz";
+      url = "mirror://cpan/authors/id/C/CA/CAC/Tcl-pTk-${version}.tar.gz";
       hash = "sha256-05PxKxzN7I8ZbN27WJHZSEx5qpQQWmN22f+cRg2CDN0=";
     };
     propagatedBuildInputs = [
@@ -32833,11 +32833,11 @@ with self;
     };
   };
 
-  TemplatePluginAutoformat = buildPerlPackage {
+  TemplatePluginAutoformat = buildPerlPackage rec {
     pname = "Template-Plugin-Autoformat";
     version = "2.77";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KARMAN/Template-Plugin-Autoformat-2.77.tar.gz";
+      url = "mirror://cpan/authors/id/K/KA/KARMAN/Template-Plugin-Autoformat-${version}.tar.gz";
       hash = "sha256-vd+0kZ8Kuyor56lmUzPg1OCYAy8OOD268ExNiWx0hu0=";
     };
     propagatedBuildInputs = [
@@ -32854,11 +32854,11 @@ with self;
     };
   };
 
-  TemplatePluginClass = buildPerlPackage {
+  TemplatePluginClass = buildPerlPackage rec {
     pname = "Template-Plugin-Class";
     version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RC/RCLAMP/Template-Plugin-Class-0.14.tar.gz";
+      url = "mirror://cpan/authors/id/R/RC/RCLAMP/Template-Plugin-Class-${version}.tar.gz";
       hash = "sha256-BgT+iue/OtlnnmTZsa1MnpAUwXeqgOg11SqG942XB8M=";
     };
     propagatedBuildInputs = [ TemplateToolkit ];
@@ -32871,11 +32871,11 @@ with self;
     };
   };
 
-  TemplatePluginIOAll = buildPerlPackage {
+  TemplatePluginIOAll = buildPerlPackage rec {
     pname = "Template-Plugin-IO-All";
     version = "0.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XE/XERN/Template-Plugin-IO-All-0.01.tar.gz";
+      url = "mirror://cpan/authors/id/X/XE/XERN/Template-Plugin-IO-All-${version}.tar.gz";
       hash = "sha256-H3RFQiohky4Ju++TV2bgr2t8zrCI6djgMM16hLzcXuQ=";
     };
     propagatedBuildInputs = [
@@ -32892,11 +32892,11 @@ with self;
     };
   };
 
-  TemplatePluginJavaScript = buildPerlPackage {
+  TemplatePluginJavaScript = buildPerlPackage rec {
     pname = "Template-Plugin-JavaScript";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Template-Plugin-JavaScript-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Template-Plugin-JavaScript-${version}.tar.gz";
       hash = "sha256-6iDYBq1lIoLQNTSY4oYN+BJcgLZJFjDCXSY72IDGGNc=";
     };
     propagatedBuildInputs = [ TemplateToolkit ];
@@ -32909,11 +32909,11 @@ with self;
     };
   };
 
-  TemplatePluginJSONEscape = buildPerlPackage {
+  TemplatePluginJSONEscape = buildPerlPackage rec {
     pname = "Template-Plugin-JSON-Escape";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NA/NANTO/Template-Plugin-JSON-Escape-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/N/NA/NANTO/Template-Plugin-JSON-Escape-${version}.tar.gz";
       hash = "sha256-BRqLHTvGAdWPxR4kYGfTZFDP6XAnigRW6KthlA8TzYY=";
     };
     propagatedBuildInputs = [
@@ -32926,11 +32926,11 @@ with self;
     };
   };
 
-  TemplateTimer = buildPerlPackage {
+  TemplateTimer = buildPerlPackage rec {
     pname = "Template-Timer";
     version = "1.00";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PETDANCE/Template-Timer-1.00.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PETDANCE/Template-Timer-${version}.tar.gz";
       hash = "sha256-tzFMs2UgnZNVe4BU4DEa6MPLXRydIo0es+P8GTpbd7Q=";
     };
     propagatedBuildInputs = [ TemplateToolkit ];
@@ -32943,11 +32943,11 @@ with self;
     };
   };
 
-  TemplateTiny = buildPerlPackage {
+  TemplateTiny = buildPerlPackage rec {
     pname = "Template-Tiny";
     version = "1.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Template-Tiny-1.14.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Template-Tiny-${version}.tar.gz";
       hash = "sha256-gZz6tgREg8/ijOsof938MXaiAlsbbw6YCy3MJtImm0w=";
     };
     meta = {
@@ -32960,11 +32960,11 @@ with self;
     };
   };
 
-  TemplateToolkit = buildPerlPackage {
+  TemplateToolkit = buildPerlPackage rec {
     pname = "Template-Toolkit";
     version = "3.101";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AB/ABW/Template-Toolkit-3.101.tar.gz";
+      url = "mirror://cpan/authors/id/A/AB/ABW/Template-Toolkit-${version}.tar.gz";
       hash = "sha256-0qMt1sIeSzfGqT34CHyp6IDPrmE6Pl766jB7C9yu21g=";
     };
     doCheck = !stdenv.hostPlatform.isDarwin;
@@ -32983,11 +32983,11 @@ with self;
     };
   };
 
-  TemplateGD = buildPerlPackage {
+  TemplateGD = buildPerlPackage rec {
     pname = "Template-GD";
     version = "2.66";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AB/ABW/Template-GD-2.66.tar.gz";
+      url = "mirror://cpan/authors/id/A/AB/ABW/Template-GD-${version}.tar.gz";
       hash = "sha256-mFI8gZLy6BhAQuWi4XK9dnrCid0uSA819oDc4yFgkFs=";
     };
     propagatedBuildInputs = [
@@ -33003,11 +33003,11 @@ with self;
     };
   };
 
-  TermEncoding = buildPerlPackage {
+  TermEncoding = buildPerlPackage rec {
     pname = "Term-Encoding";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Term-Encoding-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Term-Encoding-${version}.tar.gz";
       hash = "sha256-lbqWh9c10lo8vmRQjXiU8AnH+ioXJsPnhuniHaIlHQs=";
     };
     meta = {
@@ -33020,11 +33020,11 @@ with self;
     };
   };
 
-  TermProgressBar = buildPerlPackage {
+  TermProgressBar = buildPerlPackage rec {
     pname = "Term-ProgressBar";
     version = "2.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MANWAR/Term-ProgressBar-2.23.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MANWAR/Term-ProgressBar-${version}.tar.gz";
       hash = "sha256-3vwD+59KwcnfE1nTEr/zwIZd3vvzq6ZM1CppqGIV1J0=";
     };
     buildInputs = [
@@ -33045,11 +33045,11 @@ with self;
     };
   };
 
-  TermProgressBarQuiet = buildPerlPackage {
+  TermProgressBarQuiet = buildPerlPackage rec {
     pname = "Term-ProgressBar-Quiet";
     version = "0.31";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LB/LBROCARD/Term-ProgressBar-Quiet-0.31.tar.gz";
+      url = "mirror://cpan/authors/id/L/LB/LBROCARD/Term-ProgressBar-Quiet-${version}.tar.gz";
       hash = "sha256-JWdSkvWIvCnTLnEM82Z9qaKhdR4TmAF3Cp/bGM0hhKY=";
     };
     propagatedBuildInputs = [
@@ -33066,11 +33066,11 @@ with self;
     };
   };
 
-  TermProgressBarSimple = buildPerlPackage {
+  TermProgressBarSimple = buildPerlPackage rec {
     pname = "Term-ProgressBar-Simple";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EV/EVDB/Term-ProgressBar-Simple-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/E/EV/EVDB/Term-ProgressBar-Simple-${version}.tar.gz";
       hash = "sha256-og2zxn1b39DB+rOSxtHCaICn7oQ69gKvT5tTpwQ1eaY=";
     };
     propagatedBuildInputs = [ TermProgressBarQuiet ];
@@ -33088,11 +33088,11 @@ with self;
     let
       cross = stdenv.hostPlatform != stdenv.buildPlatform;
     in
-    buildPerlPackage {
+    buildPerlPackage rec {
       pname = "TermReadKey";
       version = "2.38";
       src = fetchurl {
-        url = "mirror://cpan/authors/id/J/JS/JSTOWE/TermReadKey-2.38.tar.gz";
+        url = "mirror://cpan/authors/id/J/JS/JSTOWE/TermReadKey-${version}.tar.gz";
         hash = "sha256-WmRYeNxXCsM2YVgfuwkP8k684X1D6lP9IuEFqFakcpA=";
       };
 
@@ -33122,11 +33122,11 @@ with self;
       };
     };
 
-  TermReadLineGnu = buildPerlPackage {
+  TermReadLineGnu = buildPerlPackage rec {
     pname = "Term-ReadLine-Gnu";
     version = "1.47";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAYASHI/Term-ReadLine-Gnu-1.47.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAYASHI/Term-ReadLine-Gnu-${version}.tar.gz";
       hash = "sha256-OwesiptJTFCqh6QNzKs/h5uS65UnrA8t7V1HQ9Fmtkk=";
     };
     buildInputs = [
@@ -33159,11 +33159,11 @@ with self;
     };
   };
 
-  TermReadLineTTYtter = buildPerlPackage {
+  TermReadLineTTYtter = buildPerlPackage rec {
     pname = "Term-ReadLine-TTYtter";
     version = "1.4";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CK/CKAISER/Term-ReadLine-TTYtter-1.4.tar.gz";
+      url = "mirror://cpan/authors/id/C/CK/CKAISER/Term-ReadLine-TTYtter-${version}.tar.gz";
       hash = "sha256-rDcxM87hshIqgnP+e0JEYT0O7O/oi2aL2Y/nHR7ErJM=";
     };
 
@@ -33198,11 +33198,11 @@ with self;
     };
   };
 
-  TermShell = buildPerlModule {
+  TermShell = buildPerlModule rec {
     pname = "Term-Shell";
     version = "0.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Term-Shell-0.13.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Term-Shell-${version}.tar.gz";
       hash = "sha256-U6C9smVokcUIpHDZPLfhz+qzjuqeWClWCn2LX2APa/I=";
     };
     propagatedBuildInputs = [
@@ -33219,11 +33219,11 @@ with self;
     };
   };
 
-  TermShellUI = buildPerlPackage {
+  TermShellUI = buildPerlPackage rec {
     pname = "Term-ShellUI";
     version = "0.92";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BR/BRONSON/Term-ShellUI-0.92.tar.gz";
+      url = "mirror://cpan/authors/id/B/BR/BRONSON/Term-ShellUI-${version}.tar.gz";
       hash = "sha256-MnnAHHYiczXu/wkDKkD0sCsoUVGzV2wEys0VvgWUK9s=";
     };
     meta = {
@@ -33232,11 +33232,11 @@ with self;
     };
   };
 
-  TermSizeAny = buildPerlPackage {
+  TermSizeAny = buildPerlPackage rec {
     pname = "Term-Size-Any";
     version = "0.002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FE/FERREIRA/Term-Size-Any-0.002.tar.gz";
+      url = "mirror://cpan/authors/id/F/FE/FERREIRA/Term-Size-Any-${version}.tar.gz";
       hash = "sha256-ZPpf2xrjqCMTSqqVrsdTVLwXvdnKEroKeuNKflGz3tI=";
     };
     propagatedBuildInputs = [
@@ -33252,11 +33252,11 @@ with self;
     };
   };
 
-  TermSizePerl = buildPerlPackage {
+  TermSizePerl = buildPerlPackage rec {
     pname = "Term-Size-Perl";
     version = "0.031";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FE/FERREIRA/Term-Size-Perl-0.031.tar.gz";
+      url = "mirror://cpan/authors/id/F/FE/FERREIRA/Term-Size-Perl-${version}.tar.gz";
       hash = "sha256-rppnRssbMF3cj42MpGh4VSucESNiiXHhOidRg4IvIJ4=";
     };
     meta = {
@@ -33268,11 +33268,11 @@ with self;
     };
   };
 
-  TermTable = buildPerlPackage {
+  TermTable = buildPerlPackage rec {
     pname = "Term-Table";
     version = "0.017";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EX/EXODIST/Term-Table-0.017.tar.gz";
+      url = "mirror://cpan/authors/id/E/EX/EXODIST/Term-Table-${version}.tar.gz";
       hash = "sha256-8R20JorYBE9uGhrJU0ygzTrXecQAb/83+uUA25j6yRo=";
     };
     propagatedBuildInputs = [ Importer ];
@@ -33285,11 +33285,11 @@ with self;
     };
   };
 
-  TermSk = buildPerlPackage {
+  TermSk = buildPerlPackage rec {
     pname = "Term-Sk";
     version = "0.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KE/KEICHNER/Term-Sk-0.18.tar.gz";
+      url = "mirror://cpan/authors/id/K/KE/KEICHNER/Term-Sk-${version}.tar.gz";
       hash = "sha256-8uSReWBhIFsIaIgCsod5LX2AOwiXIzn7EHC6BWEq+IU=";
     };
     meta = {
@@ -33301,11 +33301,11 @@ with self;
     };
   };
 
-  TermUI = buildPerlPackage {
+  TermUI = buildPerlPackage rec {
     pname = "Term-UI";
     version = "0.50";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BI/BINGOS/Term-UI-0.50.tar.gz";
+      url = "mirror://cpan/authors/id/B/BI/BINGOS/Term-UI-${version}.tar.gz";
       hash = "sha256-YL/dbUwVi4jTcBM/xlsgSFo2pFsS2QYAC4HHjKUkFj0=";
     };
     propagatedBuildInputs = [ LogMessageSimple ];
@@ -33318,11 +33318,11 @@ with self;
     };
   };
 
-  TermVT102 = buildPerlPackage {
+  TermVT102 = buildPerlPackage rec {
     pname = "Term-VT102";
     version = "0.91";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AJ/AJWOOD/Term-VT102-0.91.tar.gz";
+      url = "mirror://cpan/authors/id/A/AJ/AJWOOD/Term-VT102-${version}.tar.gz";
       hash = "sha256-+VTgMQlB1FwPw+tKQPXToA1oEZ4nfTA6HmrxHe1vvZQ=";
     };
     meta = {
@@ -33331,11 +33331,11 @@ with self;
     };
   };
 
-  TermVT102Boundless = buildPerlPackage {
+  TermVT102Boundless = buildPerlPackage rec {
     pname = "Term-VT102-Boundless";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FB/FBARRIOS/Term-VT102-Boundless-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/F/FB/FBARRIOS/Term-VT102-Boundless-${version}.tar.gz";
       hash = "sha256-4d7YWuPXa1nAO4aX9KbLAa4xvWKpNU9bt9GPnpJ7SF8=";
     };
     propagatedBuildInputs = [ TermVT102 ];
@@ -33348,11 +33348,11 @@ with self;
     };
   };
 
-  TermAnimation = buildPerlPackage {
+  TermAnimation = buildPerlPackage rec {
     pname = "Term-Animation";
     version = "2.6";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KB/KBAUCOM/Term-Animation-2.6.tar.gz";
+      url = "mirror://cpan/authors/id/K/KB/KBAUCOM/Term-Animation-${version}.tar.gz";
       hash = "sha256-fVw8LU+bZXqLHc5/Xiy74CraLpfHLzoDBL88mdCEsEU=";
     };
     propagatedBuildInputs = [ Curses ];
@@ -33408,11 +33408,11 @@ with self;
     };
   };
 
-  Test2PluginMemUsage = buildPerlPackage {
+  Test2PluginMemUsage = buildPerlPackage rec {
     pname = "Test2-Plugin-MemUsage";
     version = "0.002003";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EX/EXODIST/Test2-Plugin-MemUsage-0.002003.tar.gz";
+      url = "mirror://cpan/authors/id/E/EX/EXODIST/Test2-Plugin-MemUsage-${version}.tar.gz";
       hash = "sha256-XgZi1agjrggWQfXOgoQxEe7BgxzTH4g6bG3lSv34fCU=";
     };
     buildInputs = [ Test2Suite ];
@@ -33425,11 +33425,11 @@ with self;
     };
   };
 
-  Test2PluginUUID = buildPerlPackage {
+  Test2PluginUUID = buildPerlPackage rec {
     pname = "Test2-Plugin-UUID";
     version = "0.002001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EX/EXODIST/Test2-Plugin-UUID-0.002001.tar.gz";
+      url = "mirror://cpan/authors/id/E/EX/EXODIST/Test2-Plugin-UUID-${version}.tar.gz";
       hash = "sha256-TGyNSE1xU9h3ncFVqZKyAwlbXFqhz7Hui87c0GAYeMk=";
     };
     buildInputs = [ Test2Suite ];
@@ -33443,11 +33443,11 @@ with self;
     };
   };
 
-  Test2PluginNoWarnings = buildPerlPackage {
+  Test2PluginNoWarnings = buildPerlPackage rec {
     pname = "Test2-Plugin-NoWarnings";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Test2-Plugin-NoWarnings-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Test2-Plugin-NoWarnings-${version}.tar.gz";
       hash = "sha256-vj3YAAQu7zYr8X0gVs+ek03ukczOmOTxeLj7V3Ly+3Q=";
     };
     buildInputs = [
@@ -33461,11 +33461,11 @@ with self;
     };
   };
 
-  Test2Suite = buildPerlPackage {
+  Test2Suite = buildPerlPackage rec {
     pname = "Test2-Suite";
     version = "0.000156";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EX/EXODIST/Test2-Suite-0.000156.tar.gz";
+      url = "mirror://cpan/authors/id/E/EX/EXODIST/Test2-Suite-${version}.tar.gz";
       hash = "sha256-vzgq5y86k79+02iFEY+uL/qw/xF3Q/WQON8lTv7yyU4=";
     };
     propagatedBuildInputs = [
@@ -33483,11 +33483,11 @@ with self;
     };
   };
 
-  Test2ToolsFFI = buildPerlPackage {
+  Test2ToolsFFI = buildPerlPackage rec {
     pname = "Test2-Tools-FFI";
     version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Test2-Tools-FFI-0.06.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Test2-Tools-FFI-${version}.tar.gz";
       hash = "sha256-MA28QKEubG+7y7lv05uQK+bZZXJtrx5qtzuKCv0lLy8=";
     };
     buildInputs = [
@@ -33511,11 +33511,11 @@ with self;
     };
   };
 
-  Test2ToolsMemoryCycle = buildPerlPackage {
+  Test2ToolsMemoryCycle = buildPerlPackage rec {
     pname = "Test2-Tools-MemoryCycle";
     version = "0.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Test2-Tools-MemoryCycle-0.01.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Test2-Tools-MemoryCycle-${version}.tar.gz";
       hash = "sha256-U1s9ylQqMyUVEq3ktafb6+PESNg/iA0ZjkPcEnl5aYs=";
     };
     buildInputs = [ Test2Suite ];
@@ -33534,11 +33534,11 @@ with self;
     };
   };
 
-  TestAbortable = buildPerlPackage {
+  TestAbortable = buildPerlPackage rec {
     pname = "Test-Abortable";
     version = "0.003";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Test-Abortable-0.003.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Test-Abortable-${version}.tar.gz";
       hash = "sha256-TVPDXvPLf5wXUrqfEdOpeiETt9hMJg6rj5p8G4Aba40=";
     };
     propagatedBuildInputs = [ SubExporter ];
@@ -33553,11 +33553,11 @@ with self;
     };
   };
 
-  TestAssert = buildPerlModule {
+  TestAssert = buildPerlModule rec {
     pname = "Test-Assert";
     version = "0.0504";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DE/DEXTER/Test-Assert-0.0504.tar.gz";
+      url = "mirror://cpan/authors/id/D/DE/DEXTER/Test-Assert-${version}.tar.gz";
       hash = "sha256-z6NtqWxQQzH/ICZ0e6R9R37+g1z2zyNO4QywX6n7i6Q=";
     };
     buildInputs = [
@@ -33577,11 +33577,11 @@ with self;
     };
   };
 
-  TestAssertions = buildPerlPackage {
+  TestAssertions = buildPerlPackage rec {
     pname = "Test-Assertions";
     version = "1.054";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BB/BBC/Test-Assertions-1.054.tar.gz";
+      url = "mirror://cpan/authors/id/B/BB/BBC/Test-Assertions-${version}.tar.gz";
       hash = "sha256-/NzkHVcnOIFYGt9oCiCmrfUaTDt+McP2mGb7kQk3AoA=";
     };
     propagatedBuildInputs = [ LogTrace ];
@@ -33595,11 +33595,11 @@ with self;
     };
   };
 
-  TestAggregate = buildPerlModule {
+  TestAggregate = buildPerlModule rec {
     pname = "Test-Aggregate";
     version = "0.375";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RW/RWSTAUNER/Test-Aggregate-0.375.tar.gz";
+      url = "mirror://cpan/authors/id/R/RW/RWSTAUNER/Test-Aggregate-${version}.tar.gz";
       hash = "sha256-xswKv9DU/OhTcazKk+wkU4GEHTK0yqLWR15LyBMEJ9E=";
     };
     buildInputs = [
@@ -33617,11 +33617,11 @@ with self;
     };
   };
 
-  TestBase = buildPerlPackage {
+  TestBase = buildPerlPackage rec {
     pname = "Test-Base";
     version = "0.89";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IN/INGY/Test-Base-0.89.tar.gz";
+      url = "mirror://cpan/authors/id/I/IN/INGY/Test-Base-${version}.tar.gz";
       hash = "sha256-J5Shqq6x06KH3SxyhiWGY3llYvfbnMxrQkvE8d6K0BQ=";
     };
     propagatedBuildInputs = [ Spiffy ];
@@ -33638,11 +33638,11 @@ with self;
     };
   };
 
-  TestBits = buildPerlPackage {
+  TestBits = buildPerlPackage rec {
     pname = "Test-Bits";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Test-Bits-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Test-Bits-${version}.tar.gz";
       hash = "sha256-qYJvVkg6J+LGMVZZDzKKNjPjA3XBDfyJ9mkOOSneC8M=";
     };
     propagatedBuildInputs = [ ListAllUtils ];
@@ -33654,11 +33654,11 @@ with self;
     };
   };
 
-  TestCheckDeps = buildPerlPackage {
+  TestCheckDeps = buildPerlPackage rec {
     pname = "Test-CheckDeps";
     version = "0.010";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/Test-CheckDeps-0.010.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/Test-CheckDeps-${version}.tar.gz";
       hash = "sha256-ZvzMpsbzMOfsyJi9alGEbiFFs+AteMSZe6a33iO1Ue4=";
     };
     propagatedBuildInputs = [ CPANMetaCheck ];
@@ -33671,11 +33671,11 @@ with self;
     };
   };
 
-  TestClass = buildPerlPackage {
+  TestClass = buildPerlPackage rec {
     pname = "Test-Class";
     version = "0.52";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SZ/SZABGAB/Test-Class-0.52.tar.gz";
+      url = "mirror://cpan/authors/id/S/SZ/SZABGAB/Test-Class-${version}.tar.gz";
       hash = "sha256-QMGx04jwqGdHacJ1KfDMNjTKD9nY9ysZbAUxYRk0vII=";
     };
     buildInputs = [ TestException ];
@@ -33701,11 +33701,11 @@ with self;
     };
   };
 
-  TestClassMost = buildPerlModule {
+  TestClassMost = buildPerlModule rec {
     pname = "Test-Class-Most";
     version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OV/OVID/Test-Class-Most-0.08.tar.gz";
+      url = "mirror://cpan/authors/id/O/OV/OVID/Test-Class-Most-${version}.tar.gz";
       hash = "sha256-Y0ze2Gu6Xd4Hztcv+4pGcF/5OqhEuY6WveBVQCNMff8=";
     };
     buildInputs = [
@@ -33725,11 +33725,11 @@ with self;
     };
   };
 
-  TestCleanNamespaces = buildPerlPackage {
+  TestCleanNamespaces = buildPerlPackage rec {
     pname = "Test-CleanNamespaces";
     version = "0.24";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Test-CleanNamespaces-0.24.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Test-CleanNamespaces-${version}.tar.gz";
       hash = "sha256-M41VaejommVJNfhD7AvISqpIb+jdGJj7nKs+zOzVMno=";
     };
     buildInputs = [
@@ -33757,11 +33757,11 @@ with self;
     };
   };
 
-  TestCmd = buildPerlPackage {
+  TestCmd = buildPerlPackage rec {
     pname = "Test-Cmd";
     version = "1.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/Test-Cmd-1.09.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/Test-Cmd-${version}.tar.gz";
       hash = "sha256-zzMg7N3nkeC4lFogwfbyZdkPHj2rGPHiPLZ3x51yloQ=";
     };
     doCheck = false; # test fails
@@ -33775,11 +33775,11 @@ with self;
     };
   };
 
-  TestCommand = buildPerlModule {
+  TestCommand = buildPerlModule rec {
     pname = "Test-Command";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DANBOO/Test-Command-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DANBOO/Test-Command-${version}.tar.gz";
       hash = "sha256-KKP8b+pzoZ9WPxG9DygYZ1bUx0IHvm3qyq0m0ggblTM=";
     };
     meta = {
@@ -33792,11 +33792,11 @@ with self;
     };
   };
 
-  TestCompile = buildPerlModule {
+  TestCompile = buildPerlModule rec {
     pname = "Test-Compile";
     version = "3.3.1";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EG/EGILES/Test-Compile-v3.3.1.tar.gz";
+      url = "mirror://cpan/authors/id/E/EG/EGILES/Test-Compile-v${version}.tar.gz";
       hash = "sha256-gIRQ89Ref0GapNZo4pgodonp6jY4hpO/8YDXhwzj5iE=";
     };
     propagatedBuildInputs = [ UNIVERSALrequire ];
@@ -33809,11 +33809,11 @@ with self;
     };
   };
 
-  TestCPANMeta = buildPerlPackage {
+  TestCPANMeta = buildPerlPackage rec {
     pname = "Test-CPAN-Meta";
     version = "0.25";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BA/BARBIE/Test-CPAN-Meta-0.25.tar.gz";
+      url = "mirror://cpan/authors/id/B/BA/BARBIE/Test-CPAN-Meta-${version}.tar.gz";
       hash = "sha256-9VtPnPa8OW0P6AJyZ2hcsqxK/86JfQlnoxf6xttajbU=";
     };
     meta = {
@@ -33822,11 +33822,11 @@ with self;
     };
   };
 
-  TestCPANMetaJSON = buildPerlPackage {
+  TestCPANMetaJSON = buildPerlPackage rec {
     pname = "Test-CPAN-Meta-JSON";
     version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BA/BARBIE/Test-CPAN-Meta-JSON-0.16.tar.gz";
+      url = "mirror://cpan/authors/id/B/BA/BARBIE/Test-CPAN-Meta-JSON-${version}.tar.gz";
       hash = "sha256-Z6xQmt/7HSslao+MBSPgB2HZYBZhksYHApj3CIqa6ck=";
     };
     propagatedBuildInputs = [ JSON ];
@@ -33836,11 +33836,11 @@ with self;
     };
   };
 
-  TestDataSplit = buildPerlModule {
+  TestDataSplit = buildPerlModule rec {
     pname = "Test-Data-Split";
     version = "0.2.2";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Test-Data-Split-0.2.2.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Test-Data-Split-${version}.tar.gz";
       hash = "sha256-5Qg4kK2tMNfeUHA1adX1zvF0oZhZNSLqe0bOOHuCgCI=";
     };
     buildInputs = [ TestDifferences ];
@@ -33857,11 +33857,11 @@ with self;
     };
   };
 
-  TestDeep = buildPerlPackage {
+  TestDeep = buildPerlPackage rec {
     pname = "Test-Deep";
     version = "1.204";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Test-Deep-1.204.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Test-Deep-${version}.tar.gz";
       hash = "sha256-tlkfbM3YU8fvyf88V1Y3BAMhHP/kYEfwgrHNFhGoTl8=";
     };
     meta = {
@@ -33874,11 +33874,11 @@ with self;
     };
   };
 
-  TestDeepJSON = buildPerlModule {
+  TestDeepJSON = buildPerlModule rec {
     pname = "Test-Deep-JSON";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MO/MOTEMEN/Test-Deep-JSON-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/M/MO/MOTEMEN/Test-Deep-JSON-${version}.tar.gz";
       hash = "sha256-rshXG54xtzAeJhMsEyxoAJUtwInGRddpVKOtGms1CFg=";
     };
     buildInputs = [ ModuleBuildTiny ];
@@ -33897,11 +33897,11 @@ with self;
     };
   };
 
-  TestDeepType = buildPerlPackage {
+  TestDeepType = buildPerlPackage rec {
     pname = "Test-Deep-Type";
     version = "0.008";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Test-Deep-Type-0.008.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Test-Deep-Type-${version}.tar.gz";
       hash = "sha256-bnvqGi8edTGaItHFGZbrrFDKXjZj0bwiMTCIfmLpWfE=";
     };
     buildInputs = [
@@ -33922,11 +33922,11 @@ with self;
     };
   };
 
-  TestDiagINC = buildPerlPackage {
+  TestDiagINC = buildPerlPackage rec {
     pname = "Test-DiagINC";
     version = "0.010";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Test-DiagINC-0.010.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Test-DiagINC-${version}.tar.gz";
       hash = "sha256-W8uNNWxQnjWdU9hpwH79qo/uXWz5mJcBi5qRTOshIi4=";
     };
     buildInputs = [ CaptureTiny ];
@@ -33937,11 +33937,11 @@ with self;
     };
   };
 
-  TestDir = buildPerlPackage {
+  TestDir = buildPerlPackage rec {
     pname = "Test-Dir";
     version = "1.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MT/MTHURN/Test-Dir-1.16.tar.gz";
+      url = "mirror://cpan/authors/id/M/MT/MTHURN/Test-Dir-${version}.tar.gz";
       hash = "sha256-czKzI5E+tqJoTQlHVRljBLL4YG9w6quRNlTKkfJz6sI=";
     };
     meta = {
@@ -33953,11 +33953,11 @@ with self;
     };
   };
 
-  TestDifferences = buildPerlPackage {
+  TestDifferences = buildPerlPackage rec {
     pname = "Test-Differences";
     version = "0.70";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/Test-Differences-0.70.tar.gz";
+      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/Test-Differences-${version}.tar.gz";
       hash = "sha256-vuG1GGqpuif+0r8bBnRSDQvQzQUdkTOH+QhsH5SlaFQ=";
     };
     propagatedBuildInputs = [
@@ -33973,11 +33973,11 @@ with self;
     };
   };
 
-  TestDistManifest = buildPerlModule {
+  TestDistManifest = buildPerlModule rec {
     pname = "Test-DistManifest";
     version = "1.014";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Test-DistManifest-1.014.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Test-DistManifest-${version}.tar.gz";
       hash = "sha256-PSbCDfQmKJgcv8+lscoCjGzq2zRMHc+XolrWqItz18U=";
     };
     buildInputs = [ ModuleBuildTiny ];
@@ -33992,11 +33992,11 @@ with self;
     };
   };
 
-  TestEOL = buildPerlPackage {
+  TestEOL = buildPerlPackage rec {
     pname = "Test-EOL";
     version = "2.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Test-EOL-2.02.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Test-EOL-${version}.tar.gz";
       hash = "sha256-KDGZ1/sngH/iImr3sSVxxtwlCNjlwP61BdCJ0xcgr8Q=";
     };
     meta = {
@@ -34009,11 +34009,11 @@ with self;
     };
   };
 
-  TestException = buildPerlPackage {
+  TestException = buildPerlPackage rec {
     pname = "Test-Exception";
     version = "0.43";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EX/EXODIST/Test-Exception-0.43.tar.gz";
+      url = "mirror://cpan/authors/id/E/EX/EXODIST/Test-Exception-${version}.tar.gz";
       hash = "sha256-FWsT8Hdk92bYtFpDco8kOa+Bo1EmJUON6reDt4g+tTM=";
     };
     propagatedBuildInputs = [ SubUplevel ];
@@ -34030,11 +34030,11 @@ with self;
     };
   };
 
-  TestExit = buildPerlPackage {
+  TestExit = buildPerlPackage rec {
     pname = "Test-Exit";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AR/ARODLAND/Test-Exit-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/A/AR/ARODLAND/Test-Exit-${version}.tar.gz";
       hash = "sha256-+9qS034EgdGO68geSNAlIotXGExZstWm9r34cELox7I=";
     };
     propagatedBuildInputs = [ ReturnMultiLevel ];
@@ -34047,11 +34047,11 @@ with self;
     };
   };
 
-  TestExpect = buildPerlPackage {
+  TestExpect = buildPerlPackage rec {
     pname = "Test-Expect";
     version = "0.34";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BP/BPS/Test-Expect-0.34.tar.gz";
+      url = "mirror://cpan/authors/id/B/BP/BPS/Test-Expect-${version}.tar.gz";
       hash = "sha256-Jij87N2l9km9JTI/ZGuWoaB+RVfK3LMnybrU3EG7uZk=";
     };
     propagatedBuildInputs = [
@@ -34067,11 +34067,11 @@ with self;
     };
   };
 
-  TestFailWarnings = buildPerlPackage {
+  TestFailWarnings = buildPerlPackage rec {
     pname = "Test-FailWarnings";
     version = "0.008";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Test-FailWarnings-0.008.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Test-FailWarnings-${version}.tar.gz";
       hash = "sha256-2jTvkCn2hJ1gJiAdSRJ9BU7mrEuXnIIhAxX1chlkqW8=";
     };
     buildInputs = [ CaptureTiny ];
@@ -34082,11 +34082,11 @@ with self;
     };
   };
 
-  TestFakeHTTPD = buildPerlModule {
+  TestFakeHTTPD = buildPerlModule rec {
     pname = "Test-Fake-HTTPD";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MASAKI/Test-Fake-HTTPD-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MASAKI/Test-Fake-HTTPD-${version}.tar.gz";
       hash = "sha256-FPecsGepCSLpvlVPjks509aXeK5Mj/9E9WD2N/tvLR4=";
     };
     propagatedBuildInputs = [
@@ -34111,11 +34111,11 @@ with self;
     };
   };
 
-  TestFatal = buildPerlPackage {
+  TestFatal = buildPerlPackage rec {
     pname = "Test-Fatal";
     version = "0.017";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Test-Fatal-0.017.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Test-Fatal-${version}.tar.gz";
       hash = "sha256-N9//2vuEt2Lv6WsC+yqkHzcCbHPmuDWQ23YilpfzxKY=";
     };
     propagatedBuildInputs = [ TryTiny ];
@@ -34129,11 +34129,11 @@ with self;
     };
   };
 
-  TestFile = buildPerlPackage {
+  TestFile = buildPerlPackage rec {
     pname = "Test-File";
     version = "1.993";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/Test-File-1.993.tar.gz";
+      url = "mirror://cpan/authors/id/B/BD/BDFOY/Test-File-${version}.tar.gz";
       hash = "sha256-7y/+Gq7HtC2HStQR7GR1R7m5vC9fuT5J4zmUiEVq/Ho=";
     };
     meta = {
@@ -34143,11 +34143,11 @@ with self;
     };
   };
 
-  TestFileContents = buildPerlPackage {
+  TestFileContents = buildPerlPackage rec {
     pname = "Test-File-Contents";
     version = "0.242";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AR/ARISTOTLE/Test-File-Contents-0.242.tar.gz";
+      url = "mirror://cpan/authors/id/A/AR/ARISTOTLE/Test-File-Contents-${version}.tar.gz";
       hash = "sha256-qDisC29uEOiWE7UMphdzzbqbpHh7qC57tl2q9whKpQs=";
     };
     propagatedBuildInputs = [ TextDiff ];
@@ -34160,11 +34160,11 @@ with self;
     };
   };
 
-  TestFileShareDir = buildPerlPackage {
+  TestFileShareDir = buildPerlPackage rec {
     pname = "Test-File-ShareDir";
     version = "1.001002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KE/KENTNL/Test-File-ShareDir-1.001002.tar.gz";
+      url = "mirror://cpan/authors/id/K/KE/KENTNL/Test-File-ShareDir-${version}.tar.gz";
       hash = "sha256-szZHy7Sy8vz73k+LtDg9CslcL4nExXcOtpHxZDozeq0=";
     };
     buildInputs = [ TestFatal ];
@@ -34185,11 +34185,11 @@ with self;
     };
   };
 
-  TestFilename = buildPerlPackage {
+  TestFilename = buildPerlPackage rec {
     pname = "Test-Filename";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Test-Filename-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Test-Filename-${version}.tar.gz";
       hash = "sha256-akUMxMYoHtESnzKhwHQfIoln/touMqKRX/Yhw2Ul/L4=";
     };
     propagatedBuildInputs = [ PathTiny ];
@@ -34200,11 +34200,11 @@ with self;
     };
   };
 
-  TestFork = buildPerlModule {
+  TestFork = buildPerlModule rec {
     pname = "Test-Fork";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSCHWERN/Test-Fork-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/M/MS/MSCHWERN/Test-Fork-${version}.tar.gz";
       hash = "sha256-/P77+yT4havoJ8KtB6w9Th/s8hOhRxf8rzw3F1BF0D4=";
     };
     meta = {
@@ -34216,11 +34216,11 @@ with self;
     };
   };
 
-  TestFutureIOImpl = buildPerlModule {
+  TestFutureIOImpl = buildPerlModule rec {
     pname = "Test-Future-IO-Impl";
     version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Test-Future-IO-Impl-0.14.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Test-Future-IO-Impl-${version}.tar.gz";
       hash = "sha256-AH22GdPUljQyXFbvvKDh5Vdt0z95RV8t6llb5u344jU=";
     };
     propagatedBuildInputs = [ Test2Suite ];
@@ -34233,11 +34233,11 @@ with self;
     };
   };
 
-  TestHarnessStraps = buildPerlModule {
+  TestHarnessStraps = buildPerlModule rec {
     pname = "Test-Harness-Straps";
     version = "0.30";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSCHWERN/Test-Harness-Straps-0.30.tar.gz";
+      url = "mirror://cpan/authors/id/M/MS/MSCHWERN/Test-Harness-Straps-${version}.tar.gz";
       hash = "sha256-iwDvqjVyPBo1yMj1+kapnkvFKN+lIDUrVKxBjvbRz6g=";
     };
     meta = {
@@ -34249,11 +34249,11 @@ with self;
     };
   };
 
-  TestHexDifferences = buildPerlPackage {
+  TestHexDifferences = buildPerlPackage rec {
     pname = "Test-HexDifferences";
     version = "1.001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/ST/STEFFENW/Test-HexDifferences-1.001.tar.gz";
+      url = "mirror://cpan/authors/id/S/ST/STEFFENW/Test-HexDifferences-${version}.tar.gz";
       hash = "sha256-pjlF7N1CCvwxEJT5OiIM+zXfIyQt5hnlO6Z0d6E2kKI=";
     };
     propagatedBuildInputs = [
@@ -34273,11 +34273,11 @@ with self;
     };
   };
 
-  TestHexString = buildPerlModule {
+  TestHexString = buildPerlModule rec {
     pname = "Test-HexString";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Test-HexString-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Test-HexString-${version}.tar.gz";
       hash = "sha256-fUxM3BkvJZTceP916yz00FYfeUs27g6s7oxKGqigP0A=";
     };
     meta = {
@@ -34289,11 +34289,11 @@ with self;
     };
   };
 
-  TestIdentity = buildPerlModule {
+  TestIdentity = buildPerlModule rec {
     pname = "Test-Identity";
     version = "0.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Test-Identity-0.01.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Test-Identity-${version}.tar.gz";
       hash = "sha256-LwIFAJrtFSZoGCqvoWNXqx9HtMvAAeiYcbZzh++OXyM=";
     };
     meta = {
@@ -34305,11 +34305,11 @@ with self;
     };
   };
 
-  TestHTTPServerSimple = buildPerlPackage {
+  TestHTTPServerSimple = buildPerlPackage rec {
     pname = "Test-HTTP-Server-Simple";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AL/ALEXMV/Test-HTTP-Server-Simple-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/A/AL/ALEXMV/Test-HTTP-Server-Simple-${version}.tar.gz";
       hash = "sha256-hcl+vU3rgFKRsXJ3Ay2kiAcijyT4mxzi+zwJ96iWu3g=";
     };
     propagatedBuildInputs = [ HTTPServerSimple ];
@@ -34322,11 +34322,11 @@ with self;
     };
   };
 
-  TestJSON = buildPerlModule {
+  TestJSON = buildPerlModule rec {
     pname = "Test-JSON";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OV/OVID/Test-JSON-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/O/OV/OVID/Test-JSON-${version}.tar.gz";
       hash = "sha256-B8CKsvzBKFDRrVT89q/prRoloJgxDD5xQq8dPLgh17M=";
     };
     propagatedBuildInputs = [ JSONAny ];
@@ -34340,11 +34340,11 @@ with self;
     };
   };
 
-  TestKwalitee = buildPerlPackage {
+  TestKwalitee = buildPerlPackage rec {
     pname = "Test-Kwalitee";
     version = "1.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Test-Kwalitee-1.28.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Test-Kwalitee-${version}.tar.gz";
       hash = "sha256-tFNs3XVbWXciMtQyXae9T7f1vlC0WF27r3WO7DBiQ6M=";
     };
     propagatedBuildInputs = [ ModuleCPANTSAnalyse ];
@@ -34364,11 +34364,11 @@ with self;
     };
   };
 
-  TestLWPUserAgent = buildPerlPackage {
+  TestLWPUserAgent = buildPerlPackage rec {
     pname = "Test-LWP-UserAgent";
     version = "0.036";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Test-LWP-UserAgent-0.036.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Test-LWP-UserAgent-${version}.tar.gz";
       hash = "sha256-BTJ1MNNGuAphpulD+9dJmGvcqJIRpOswHAjC0XkxThE=";
     };
     propagatedBuildInputs = [
@@ -34395,11 +34395,11 @@ with self;
     };
   };
 
-  TestLeakTrace = buildPerlPackage {
+  TestLeakTrace = buildPerlPackage rec {
     pname = "Test-LeakTrace";
     version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEEJO/Test-LeakTrace-0.17.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEEJO/Test-LeakTrace-${version}.tar.gz";
       hash = "sha256-d31k0pOPXqWGMA7vl+8D6stD1MGFPJw7EJHrMxFGeXA=";
     };
     preCheck = ''
@@ -34417,11 +34417,11 @@ with self;
     };
   };
 
-  TestLectroTest = buildPerlPackage {
+  TestLectroTest = buildPerlPackage rec {
     pname = "Test-LectroTest";
     version = "0.5001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TM/TMOERTEL/Test-LectroTest-0.5001.tar.gz";
+      url = "mirror://cpan/authors/id/T/TM/TMOERTEL/Test-LectroTest-${version}.tar.gz";
       hash = "sha256-rCtPDZWJmvGhoex4TLdAsrkCVqvuEcg+eykRA+ye1zU=";
     };
     preCheck = ''
@@ -34437,11 +34437,11 @@ with self;
     };
   };
 
-  TestLoadAllModules = buildPerlPackage {
+  TestLoadAllModules = buildPerlPackage rec {
     pname = "Test-LoadAllModules";
     version = "0.022";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KI/KITANO/Test-LoadAllModules-0.022.tar.gz";
+      url = "mirror://cpan/authors/id/K/KI/KITANO/Test-LoadAllModules-${version}.tar.gz";
       hash = "sha256-G4YfVVAgZIp0gdStKBqJ5iQYf4lDepizRjVpGyZeXP4=";
     };
     propagatedBuildInputs = [
@@ -34457,11 +34457,11 @@ with self;
     };
   };
 
-  TestLongString = buildPerlPackage {
+  TestLongString = buildPerlPackage rec {
     pname = "Test-LongString";
     version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RG/RGARCIA/Test-LongString-0.17.tar.gz";
+      url = "mirror://cpan/authors/id/R/RG/RGARCIA/Test-LongString-${version}.tar.gz";
       hash = "sha256-q8Q0nq8E0b7B5GQWajAYWR6oRtjzxcnIr0rEkF0+l08=";
     };
     meta = {
@@ -34473,11 +34473,11 @@ with self;
     };
   };
 
-  TestMemoryCycle = buildPerlPackage {
+  TestMemoryCycle = buildPerlPackage rec {
     pname = "Test-Memory-Cycle";
     version = "1.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PETDANCE/Test-Memory-Cycle-1.06.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PETDANCE/Test-Memory-Cycle-${version}.tar.gz";
       hash = "sha256-nVPd/clkzYRUyw2kxpW2o65HtFg5KRw0y52NHPqrMgI=";
     };
     propagatedBuildInputs = [
@@ -34490,11 +34490,11 @@ with self;
     };
   };
 
-  TestMemoryGrowth = buildPerlModule {
+  TestMemoryGrowth = buildPerlModule rec {
     pname = "Test-MemoryGrowth";
     version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Test-MemoryGrowth-0.04.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Test-MemoryGrowth-${version}.tar.gz";
       hash = "sha256-oGWFJ1Kr1J5BFbmPbbRsdSy71ePkjtAUXO45L3k9LtA=";
     };
     meta = {
@@ -34507,11 +34507,11 @@ with self;
     };
   };
 
-  TestMetricsAny = buildPerlModule {
+  TestMetricsAny = buildPerlModule rec {
     pname = "Test-Metrics-Any";
     version = "0.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Test-Metrics-Any-0.01.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Test-Metrics-Any-${version}.tar.gz";
       hash = "sha256-JQbIjU6yGydLEIX4BskY3Ml//2nhbRJJ5uGdlDYl5Gg=";
     };
     propagatedBuildInputs = [ MetricsAny ];
@@ -34524,11 +34524,11 @@ with self;
     };
   };
 
-  TestMockClass = buildPerlModule {
+  TestMockClass = buildPerlModule rec {
     pname = "Test-Mock-Class";
     version = "0.0303";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DE/DEXTER/Test-Mock-Class-0.0303.tar.gz";
+      url = "mirror://cpan/authors/id/D/DE/DEXTER/Test-Mock-Class-${version}.tar.gz";
       hash = "sha256-zS5S/inKCrtsLmGvvDP7Qui+tCGzhL5rwGSs8xl28wI=";
     };
     buildInputs = [
@@ -34547,11 +34547,11 @@ with self;
     };
   };
 
-  TestMockGuard = buildPerlModule {
+  TestMockGuard = buildPerlModule rec {
     pname = "Test-Mock-Guard";
     version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XA/XAICRON/Test-Mock-Guard-0.10.tar.gz";
+      url = "mirror://cpan/authors/id/X/XA/XAICRON/Test-Mock-Guard-${version}.tar.gz";
       hash = "sha256-fyKKY/jWzrkqp4QIChPoUHMSGyg17KBteU+XCZUNvT0=";
     };
     propagatedBuildInputs = [ ClassLoad ];
@@ -34565,11 +34565,11 @@ with self;
     };
   };
 
-  TestMockHTTPTiny = buildPerlPackage {
+  TestMockHTTPTiny = buildPerlPackage rec {
     pname = "Test-Mock-HTTP-Tiny";
     version = "0.002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OD/ODYNIEC/Test-Mock-HTTP-Tiny-0.002.tar.gz";
+      url = "mirror://cpan/authors/id/O/OD/ODYNIEC/Test-Mock-HTTP-Tiny-${version}.tar.gz";
       hash = "sha256-+c+tfYUEZQvtNJO8bSyoLXuRvDcTyGxDXnXriKxb5eY=";
     };
     propagatedBuildInputs = [
@@ -34586,11 +34586,11 @@ with self;
     };
   };
 
-  TestMockModule = buildPerlModule {
+  TestMockModule = buildPerlModule rec {
     pname = "Test-MockModule";
     version = "0.177.0";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GF/GFRANKS/Test-MockModule-v0.177.0.tar.gz";
+      url = "mirror://cpan/authors/id/G/GF/GFRANKS/Test-MockModule-v${version}.tar.gz";
       hash = "sha256-G9p6SdzqdgdtQKe2psPz4V5rGchLYXHfRFNNkROPEEU=";
     };
     propagatedBuildInputs = [ SUPER ];
@@ -34604,11 +34604,11 @@ with self;
     };
   };
 
-  SUPER = buildPerlModule {
+  SUPER = buildPerlModule rec {
     pname = "SUPER";
     version = "1.20190531";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHROMATIC/SUPER-1.20190531.tar.gz";
+      url = "mirror://cpan/authors/id/C/CH/CHROMATIC/SUPER-${version}.tar.gz";
       hash = "sha256-aF0e525/DpAGlCkjv334sRwQcTKZKRdZPc9zl9QX05o=";
     };
     propagatedBuildInputs = [ SubIdentify ];
@@ -34621,11 +34621,11 @@ with self;
     };
   };
 
-  TestMockObject = buildPerlPackage {
+  TestMockObject = buildPerlPackage rec {
     pname = "Test-MockObject";
     version = "1.20200122";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHROMATIC/Test-MockObject-1.20200122.tar.gz";
+      url = "mirror://cpan/authors/id/C/CH/CHROMATIC/Test-MockObject-${version}.tar.gz";
       hash = "sha256-K3+A2of1pv4DYNnuUhBRBTAXRCw6Juhdto36yfgwdiM=";
     };
     buildInputs = [
@@ -34645,11 +34645,11 @@ with self;
     };
   };
 
-  TestMockTime = buildPerlPackage {
+  TestMockTime = buildPerlPackage rec {
     pname = "Test-MockTime";
     version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DD/DDICK/Test-MockTime-0.17.tar.gz";
+      url = "mirror://cpan/authors/id/D/DD/DDICK/Test-MockTime-${version}.tar.gz";
       hash = "sha256-M2PhGLJgbx1qvJVvIrDQkQl3K3CGFV+1ycf5gzUGAvk=";
     };
     meta = {
@@ -34661,11 +34661,11 @@ with self;
     };
   };
 
-  TestMockTimeHiRes = buildPerlModule {
+  TestMockTimeHiRes = buildPerlModule rec {
     pname = "Test-MockTime-HiRes";
     version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TA/TARAO/Test-MockTime-HiRes-0.08.tar.gz";
+      url = "mirror://cpan/authors/id/T/TA/TARAO/Test-MockTime-HiRes-${version}.tar.gz";
       hash = "sha256-X0n3rviV0yfa/fJ0TznBdsirDkuCJ9LW495omiWb3sE=";
     };
     buildInputs = [
@@ -34685,11 +34685,11 @@ with self;
     };
   };
 
-  TestMojibake = buildPerlPackage {
+  TestMojibake = buildPerlPackage rec {
     pname = "Test-Mojibake";
     version = "1.3";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SY/SYP/Test-Mojibake-1.3.tar.gz";
+      url = "mirror://cpan/authors/id/S/SY/SYP/Test-Mojibake-${version}.tar.gz";
       hash = "sha256-j/51/5tpNSSIcn3Kc9uR+KoUtZ8voQTrdxfA1xpfGzM=";
     };
     preCheck = ''
@@ -34707,11 +34707,11 @@ with self;
     };
   };
 
-  TestMoreUTF8 = buildPerlPackage {
+  TestMoreUTF8 = buildPerlPackage rec {
     pname = "Test-More-UTF8";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MO/MONS/Test-More-UTF8-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/M/MO/MONS/Test-More-UTF8-${version}.tar.gz";
       hash = "sha256-ufHEs2qXzf76pT7REV3Tj0tIMDd3X2VZ7h3xSs/RzgQ=";
     };
     meta = {
@@ -34723,11 +34723,11 @@ with self;
     };
   };
 
-  TestMost = buildPerlPackage {
+  TestMost = buildPerlPackage rec {
     pname = "Test-Most";
     version = "0.38";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OV/OVID/Test-Most-0.38.tar.gz";
+      url = "mirror://cpan/authors/id/O/OV/OVID/Test-Most-${version}.tar.gz";
       hash = "sha256-CJ64lPe6zkw3xjNODikOsgM47hAiOvDILL5ygceDgt8=";
     };
     propagatedBuildInputs = [ ExceptionClass ];
@@ -34746,11 +34746,11 @@ with self;
     };
   };
 
-  Testmysqld = buildPerlModule {
+  Testmysqld = buildPerlModule rec {
     pname = "Test-mysqld";
     version = "1.0013";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SO/SONGMU/Test-mysqld-1.0013.tar.gz";
+      url = "mirror://cpan/authors/id/S/SO/SONGMU/Test-mysqld-${version}.tar.gz";
       hash = "sha256-V61BoJBXyWO1gsgaB276UPpW664hd9gwd33oOGBePu8=";
     };
     buildInputs = [
@@ -34774,11 +34774,11 @@ with self;
     };
   };
 
-  TestNeeds = buildPerlPackage {
+  TestNeeds = buildPerlPackage rec {
     pname = "Test-Needs";
     version = "0.002010";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/Test-Needs-0.002010.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Test-Needs-${version}.tar.gz";
       hash = "sha256-kj/9x4/LqWYJdT5LriawugGGiT3kpjzVI24BLHyQ4gg=";
     };
     meta = {
@@ -34790,11 +34790,11 @@ with self;
     };
   };
 
-  TestNoTabs = buildPerlPackage {
+  TestNoTabs = buildPerlPackage rec {
     pname = "Test-NoTabs";
     version = "2.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Test-NoTabs-2.02.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Test-NoTabs-${version}.tar.gz";
       hash = "sha256-+3XGo4ch8BaeEcHn2+UyntchaIWgsBEj80LdhtM1YDA=";
     };
     meta = {
@@ -34807,11 +34807,11 @@ with self;
     };
   };
 
-  TestNoWarnings = buildPerlPackage {
+  TestNoWarnings = buildPerlPackage rec {
     pname = "Test-NoWarnings";
     version = "1.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/Test-NoWarnings-1.06.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Test-NoWarnings-${version}.tar.gz";
       hash = "sha256-wtxRFDt+tjIxIQ4n3yDSyDk3cuCjM1R+yLeiBe1i9zc=";
     };
     meta = {
@@ -34820,11 +34820,11 @@ with self;
     };
   };
 
-  TestObject = buildPerlPackage {
+  TestObject = buildPerlPackage rec {
     pname = "Test-Object";
     version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Test-Object-0.08.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Test-Object-${version}.tar.gz";
       hash = "sha256-ZSeJZBR4NzE/QQjlW1lnboo2TW7fAbPcGYruiUqx0Ls=";
     };
     meta = {
@@ -34836,11 +34836,11 @@ with self;
     };
   };
 
-  TestOutput = buildPerlPackage {
+  TestOutput = buildPerlPackage rec {
     pname = "Test-Output";
     version = "1.034";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/Test-Output-1.034.tar.gz";
+      url = "mirror://cpan/authors/id/B/BD/BDFOY/Test-Output-${version}.tar.gz";
       hash = "sha256-zULigBwNK0gtGMn7SwbHVwVIGLy7KCTl378zrXo9aaA=";
     };
     propagatedBuildInputs = [ CaptureTiny ];
@@ -34850,11 +34850,11 @@ with self;
     };
   };
 
-  TestPAUSEPermissions = buildPerlPackage {
+  TestPAUSEPermissions = buildPerlPackage rec {
     pname = "Test-PAUSE-Permissions";
     version = "0.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SK/SKAJI/Test-PAUSE-Permissions-0.07.tar.gz";
+      url = "mirror://cpan/authors/id/S/SK/SKAJI/Test-PAUSE-Permissions-${version}.tar.gz";
       hash = "sha256-VXDBu/KbxjeoRWcIuaJ0bPT8usE3SF7f82D48I5xBz4=";
     };
     propagatedBuildInputs = [
@@ -34875,11 +34875,11 @@ with self;
     };
   };
 
-  TestPerlCritic = buildPerlModule {
+  TestPerlCritic = buildPerlModule rec {
     pname = "Test-Perl-Critic";
     version = "1.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PETDANCE/Test-Perl-Critic-1.04.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PETDANCE/Test-Perl-Critic-${version}.tar.gz";
       hash = "sha256-KPgGtUEseQi1bPFnMIS4tEzhy1TJQX14TZFCjhoECW4=";
     };
     propagatedBuildInputs = [
@@ -34895,11 +34895,11 @@ with self;
     };
   };
 
-  TestPerlTidy = buildPerlModule {
+  TestPerlTidy = buildPerlModule rec {
     pname = "Test-PerlTidy";
     version = "20230226";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Test-PerlTidy-20230226.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Test-PerlTidy-${version}.tar.gz";
       hash = "sha256-wOJCEQeVeV1Nu2xEFmzlV09cftuninidG8rnZoXYA8E=";
     };
     propagatedBuildInputs = [
@@ -34925,11 +34925,11 @@ with self;
     };
   };
 
-  TestPod = buildPerlPackage {
+  TestPod = buildPerlPackage rec {
     pname = "Test-Pod";
     version = "1.52";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Test-Pod-1.52.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Test-Pod-${version}.tar.gz";
       hash = "sha256-YKjbzGAWi/HapcwjUCNt+TQ+mHj0q5gwlwpd3m/o5fw=";
     };
     meta = {
@@ -34942,11 +34942,11 @@ with self;
     };
   };
 
-  TestPodCoverage = buildPerlPackage {
+  TestPodCoverage = buildPerlPackage rec {
     pname = "Test-Pod-Coverage";
     version = "1.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/Test-Pod-Coverage-1.10.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/Test-Pod-Coverage-${version}.tar.gz";
       hash = "sha256-SMnMqffZnu50EXZEW0Ma3wnAKeGqV8RwPJ9G92AdQNQ=";
     };
     propagatedBuildInputs = [ PodCoverage ];
@@ -34956,11 +34956,11 @@ with self;
     };
   };
 
-  TestPodLinkCheck = buildPerlModule {
+  TestPodLinkCheck = buildPerlModule rec {
     pname = "Test-Pod-LinkCheck";
     version = "0.008";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AP/APOCAL/Test-Pod-LinkCheck-0.008.tar.gz";
+      url = "mirror://cpan/authors/id/A/AP/APOCAL/Test-Pod-LinkCheck-${version}.tar.gz";
       hash = "sha256-K/53EXPDi2nusIlQTj92URuOReap5trD5hbkAOpnvPA=";
     };
     buildInputs = [
@@ -34982,11 +34982,11 @@ with self;
     };
   };
 
-  TestPodNo404s = buildPerlModule {
+  TestPodNo404s = buildPerlModule rec {
     pname = "Test-Pod-No404s";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AP/APOCAL/Test-Pod-No404s-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/A/AP/APOCAL/Test-Pod-No404s-${version}.tar.gz";
       hash = "sha256-EcYGBW/WK9ROB5977wbEWapYnuhc3tv6DMMl6jV8jnk=";
     };
     propagatedBuildInputs = [
@@ -35007,11 +35007,11 @@ with self;
     };
   };
 
-  TestPortabilityFiles = buildPerlPackage {
+  TestPortabilityFiles = buildPerlPackage rec {
     pname = "Test-Portability-Files";
     version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AB/ABRAXXA/Test-Portability-Files-0.10.tar.gz";
+      url = "mirror://cpan/authors/id/A/AB/ABRAXXA/Test-Portability-Files-${version}.tar.gz";
       hash = "sha256-COS0MkktwbRLVdXbV5Uut2N5x/Q07o8WrKZNSR9AGhY=";
     };
     meta = {
@@ -35023,11 +35023,11 @@ with self;
     };
   };
 
-  TestRefcount = buildPerlModule {
+  TestRefcount = buildPerlModule rec {
     pname = "Test-Refcount";
     version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Test-Refcount-0.10.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Test-Refcount-${version}.tar.gz";
       hash = "sha256-BFfCCklWRz0VfE+q/4gUFUvJP24rVDwoEqGf+OM3DrI=";
     };
     meta = {
@@ -35039,11 +35039,11 @@ with self;
     };
   };
 
-  TestRequires = buildPerlPackage {
+  TestRequires = buildPerlPackage rec {
     pname = "Test-Requires";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOKUHIROM/Test-Requires-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TOKUHIROM/Test-Requires-${version}.tar.gz";
       hash = "sha256-S4jeVJWX7s3ffDw4pNAgShb1mtgEV3tnGJasBOJOBA8=";
     };
     meta = {
@@ -35056,11 +35056,11 @@ with self;
     };
   };
 
-  TestRequiresGit = buildPerlPackage {
+  TestRequiresGit = buildPerlPackage rec {
     pname = "Test-Requires-Git";
     version = "1.008";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOOK/Test-Requires-Git-1.008.tar.gz";
+      url = "mirror://cpan/authors/id/B/BO/BOOK/Test-Requires-Git-${version}.tar.gz";
       hash = "sha256-cJFiEJcNhNdJFFEVmri2fhUlHIwNrnw99sjYhULqQqY=";
     };
     propagatedBuildInputs = [ GitVersionCompare ];
@@ -35073,11 +35073,11 @@ with self;
     };
   };
 
-  TestRequiresInternet = buildPerlPackage {
+  TestRequiresInternet = buildPerlPackage rec {
     pname = "Test-RequiresInternet";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MALLEN/Test-RequiresInternet-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MALLEN/Test-RequiresInternet-${version}.tar.gz";
       hash = "sha256-u6ezKhzA1Yzi7CCyAKc0fGljFkHoyuj/RWetJO8egz4=";
     };
     meta = {
@@ -35090,11 +35090,11 @@ with self;
     };
   };
 
-  TestRoo = buildPerlPackage {
+  TestRoo = buildPerlPackage rec {
     pname = "Test-Roo";
     version = "1.004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Test-Roo-1.004.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Test-Roo-${version}.tar.gz";
       hash = "sha256-IRKaPOy1B7AJSOFs8V/N5dxNsjWrqEr9f0fSIBOp3tY=";
     };
 
@@ -35111,11 +35111,11 @@ with self;
     };
   };
 
-  TestRoutine = buildPerlPackage {
+  TestRoutine = buildPerlPackage rec {
     pname = "Test-Routine";
     version = "0.031";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Test-Routine-0.031.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Test-Routine-${version}.tar.gz";
       hash = "sha256-f9kp7TPyVMoJkCJQGSYInHeU71d7uoYHbn2YFlYPXAc=";
     };
     buildInputs = [
@@ -35136,11 +35136,11 @@ with self;
     };
   };
 
-  TestRun = buildPerlModule {
+  TestRun = buildPerlModule rec {
     pname = "Test-Run";
     version = "0.0305";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Test-Run-0.0305.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Test-Run-${version}.tar.gz";
       hash = "sha256-+Jpx3WD44qd26OYBd8ntXlkJbUAF1QvSmJuSeeCHwkg=";
     };
     buildInputs = [ TestTrap ];
@@ -35158,11 +35158,11 @@ with self;
     };
   };
 
-  TestRunCmdLine = buildPerlModule {
+  TestRunCmdLine = buildPerlModule rec {
     pname = "Test-Run-CmdLine";
     version = "0.0132";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Test-Run-CmdLine-0.0132.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Test-Run-CmdLine-${version}.tar.gz";
       hash = "sha256-ssORzVRjV378dti/so6tKz1OOm+pLbDvNMANyfTPpwc=";
     };
     buildInputs = [
@@ -35183,11 +35183,11 @@ with self;
     };
   };
 
-  TestRunPluginAlternateInterpreters = buildPerlModule {
+  TestRunPluginAlternateInterpreters = buildPerlModule rec {
     pname = "Test-Run-Plugin-AlternateInterpreters";
     version = "0.0125";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Test-Run-Plugin-AlternateInterpreters-0.0125.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Test-Run-Plugin-AlternateInterpreters-${version}.tar.gz";
       hash = "sha256-UsNomxRdgh8XCj8uXPM6DCkoKE3d6W1sN88VAA8ymbs=";
     };
     buildInputs = [
@@ -35204,11 +35204,11 @@ with self;
     };
   };
 
-  TestRunPluginBreakOnFailure = buildPerlModule {
+  TestRunPluginBreakOnFailure = buildPerlModule rec {
     pname = "Test-Run-Plugin-BreakOnFailure";
     version = "0.0.6";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Test-Run-Plugin-BreakOnFailure-v0.0.6.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Test-Run-Plugin-BreakOnFailure-v${version}.tar.gz";
       hash = "sha256-oBgO4+LwwUQSkFXaBeKTFRC59QcXTQ+6yjwMndBNE6k=";
     };
     buildInputs = [
@@ -35225,11 +35225,11 @@ with self;
     };
   };
 
-  TestRunPluginColorFileVerdicts = buildPerlModule {
+  TestRunPluginColorFileVerdicts = buildPerlModule rec {
     pname = "Test-Run-Plugin-ColorFileVerdicts";
     version = "0.0125";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Test-Run-Plugin-ColorFileVerdicts-0.0125.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Test-Run-Plugin-ColorFileVerdicts-${version}.tar.gz";
       hash = "sha256-HCQaLBSm/WZLRy5Lb2iP1gyHlzsxjITgFIccBn8uHkY=";
     };
     buildInputs = [
@@ -35247,11 +35247,11 @@ with self;
     };
   };
 
-  TestRunPluginColorSummary = buildPerlModule {
+  TestRunPluginColorSummary = buildPerlModule rec {
     pname = "Test-Run-Plugin-ColorSummary";
     version = "0.0203";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Test-Run-Plugin-ColorSummary-0.0203.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Test-Run-Plugin-ColorSummary-${version}.tar.gz";
       hash = "sha256-e9l5N5spa1EPxVuxwAuKEM00hQ5OIZf1cBtUYAY/iv0=";
     };
     buildInputs = [
@@ -35268,11 +35268,11 @@ with self;
     };
   };
 
-  TestRunPluginTrimDisplayedFilenames = buildPerlModule {
+  TestRunPluginTrimDisplayedFilenames = buildPerlModule rec {
     pname = "Test-Run-Plugin-TrimDisplayedFilenames";
     version = "0.0126";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Test-Run-Plugin-TrimDisplayedFilenames-0.0126.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Test-Run-Plugin-TrimDisplayedFilenames-${version}.tar.gz";
       hash = "sha256-ioZJw8anmIp3N65KcW1g4MazIXMBtAFT6tNquPTqkCg=";
     };
     buildInputs = [
@@ -35289,11 +35289,11 @@ with self;
     };
   };
 
-  TestRunValgrind = buildPerlModule {
+  TestRunValgrind = buildPerlModule rec {
     pname = "Test-RunValgrind";
     version = "0.2.2";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Test-RunValgrind-0.2.2.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Test-RunValgrind-${version}.tar.gz";
       hash = "sha256-aRPRTK3CUbI8W3I1+NSsPeKHE41xK3W9lLACrwuPpe4=";
     };
     buildInputs = [ TestTrap ];
@@ -35305,11 +35305,11 @@ with self;
     };
   };
 
-  TestScript = buildPerlPackage {
+  TestScript = buildPerlPackage rec {
     pname = "Test-Script";
     version = "1.29";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Test-Script-1.29.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Test-Script-${version}.tar.gz";
       hash = "sha256-iS5+bB6nsWcQkJlCz1wL2rcO7i79SqnBbqlS4rkPiVA=";
     };
     buildInputs = [ Test2Suite ];
@@ -35330,11 +35330,11 @@ with self;
     };
   };
 
-  TestScriptRun = buildPerlPackage {
+  TestScriptRun = buildPerlPackage rec {
     pname = "Test-Script-Run";
     version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SU/SUNNAVY/Test-Script-Run-0.08.tar.gz";
+      url = "mirror://cpan/authors/id/S/SU/SUNNAVY/Test-Script-Run-${version}.tar.gz";
       hash = "sha256-H+8hbnC8QlrOPixDcN/N3bXnmLCZ77omeSRKTVvBqwo=";
     };
     propagatedBuildInputs = [
@@ -35350,11 +35350,11 @@ with self;
     };
   };
 
-  TestSharedFork = buildPerlPackage {
+  TestSharedFork = buildPerlPackage rec {
     pname = "Test-SharedFork";
     version = "0.35";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EX/EXODIST/Test-SharedFork-0.35.tar.gz";
+      url = "mirror://cpan/authors/id/E/EX/EXODIST/Test-SharedFork-${version}.tar.gz";
       hash = "sha256-KTLoZWEOgHWPdkxYZ1fvjhHbEoTZWOJeS3qFCYQUxZ8=";
     };
     buildInputs = [ TestRequires ];
@@ -35368,11 +35368,11 @@ with self;
     };
   };
 
-  TestSnapshot = buildPerlPackage {
+  TestSnapshot = buildPerlPackage rec {
     pname = "Test-Snapshot";
     version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETJ/Test-Snapshot-0.06.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETJ/Test-Snapshot-${version}.tar.gz";
       hash = "sha256-9N16mlW6oiR1QK40IQzQWgT50QYb7+yXockO2pW/rkU=";
     };
     buildInputs = [ CaptureTiny ];
@@ -35383,11 +35383,11 @@ with self;
     };
   };
 
-  TestSpec = buildPerlPackage {
+  TestSpec = buildPerlPackage rec {
     pname = "Test-Spec";
     version = "0.54";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AK/AKZHAN/Test-Spec-0.54.tar.gz";
+      url = "mirror://cpan/authors/id/A/AK/AKZHAN/Test-Spec-${version}.tar.gz";
       hash = "sha256-CjHPEmXc7pC7xCRWrWC7Njr8f6xml//7D9SbupKhZdI=";
     };
     propagatedBuildInputs = [
@@ -35408,11 +35408,11 @@ with self;
     };
   };
 
-  TestStrict = buildPerlPackage {
+  TestStrict = buildPerlPackage rec {
     pname = "Test-Strict";
     version = "0.54";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MANWAR/Test-Strict-0.54.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MANWAR/Test-Strict-${version}.tar.gz";
       hash = "sha256-9oB1F4I6kKlrQN7q7ZqggAgt7UtQpRIE9b4efOd0yFw=";
     };
     buildInputs = [ IOStringy ];
@@ -35425,11 +35425,11 @@ with self;
     };
   };
 
-  TestSubCalls = buildPerlPackage {
+  TestSubCalls = buildPerlPackage rec {
     pname = "Test-SubCalls";
     version = "1.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Test-SubCalls-1.10.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Test-SubCalls-${version}.tar.gz";
       hash = "sha256-y8Hps1oF5x/rwT5e9UejHIJJiZu2AR29ydn/Nm3atsI=";
     };
     propagatedBuildInputs = [ HookLexWrap ];
@@ -35442,11 +35442,11 @@ with self;
     };
   };
 
-  TestSynopsis = buildPerlPackage {
+  TestSynopsis = buildPerlPackage rec {
     pname = "Test-Synopsis";
     version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZO/ZOFFIX/Test-Synopsis-0.17.tar.gz";
+      url = "mirror://cpan/authors/id/Z/ZO/ZOFFIX/Test-Synopsis-${version}.tar.gz";
       hash = "sha256-0mjJizPS+hTbsisg1lYbq0ie6CWH374ZrSd2IMe4tt4=";
     };
     meta = {
@@ -35459,11 +35459,11 @@ with self;
     };
   };
 
-  TestTableDriven = buildPerlPackage {
+  TestTableDriven = buildPerlPackage rec {
     pname = "Test-TableDriven";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JR/JROCKWAY/Test-TableDriven-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/J/JR/JROCKWAY/Test-TableDriven-${version}.tar.gz";
       hash = "sha256-Qlh4r88qFOBHyviRsZFen1/7A2lBYJxDjg370bWxhZo=";
     };
     meta = {
@@ -35475,11 +35475,11 @@ with self;
     };
   };
 
-  TestTempDirTiny = buildPerlPackage {
+  TestTempDirTiny = buildPerlPackage rec {
     pname = "Test-TempDir-Tiny";
     version = "0.018";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Test-TempDir-Tiny-0.018.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Test-TempDir-Tiny-${version}.tar.gz";
       hash = "sha256-17eh/X/M4BaNRPuIdpGP6KmvSa4OuLCWJbZ7GNcfXoE=";
     };
     meta = {
@@ -35489,11 +35489,11 @@ with self;
     };
   };
 
-  TestTCP = buildPerlPackage {
+  TestTCP = buildPerlPackage rec {
     pname = "Test-TCP";
     version = "2.22";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Test-TCP-2.22.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Test-TCP-${version}.tar.gz";
       hash = "sha256-PlPDwG1tCYCiv+uRVgK3FOaC7iEa6IwRdIzyzHFOe1c=";
     };
     buildInputs = [ TestSharedFork ];
@@ -35529,11 +35529,11 @@ with self;
     };
   };
 
-  TestTime = buildPerlPackage {
+  TestTime = buildPerlPackage rec {
     pname = "Test-Time";
     version = "0.092";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AN/ANATOFUZ/Test-Time-0.092.tar.gz";
+      url = "mirror://cpan/authors/id/A/AN/ANATOFUZ/Test-Time-${version}.tar.gz";
       hash = "sha256-MNkPVM6ECJPHuiysKk0e7NTJzfgFkQxZXjronf1kRzg=";
     };
     meta = {
@@ -35546,11 +35546,11 @@ with self;
     };
   };
 
-  TestToolbox = buildPerlModule {
+  TestToolbox = buildPerlModule rec {
     pname = "Test-Toolbox";
     version = "0.4";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIKO/Test-Toolbox-0.4.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIKO/Test-Toolbox-${version}.tar.gz";
       hash = "sha256-QCC1x/OhWsmxh9Bd/ZgWuAMOwNSkf/g3P3Yzu2FOvcM=";
     };
     meta = {
@@ -35562,11 +35562,11 @@ with self;
     };
   };
 
-  TestTrailingSpace = buildPerlModule {
+  TestTrailingSpace = buildPerlModule rec {
     pname = "Test-TrailingSpace";
     version = "0.0601";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Test-TrailingSpace-0.0601.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Test-TrailingSpace-${version}.tar.gz";
       hash = "sha256-q7jOdEg6Y9c/4e9gO3zgptR8mO3nMZVdc1eE+tHcT8w=";
     };
     buildInputs = [ FileTreeCreate ];
@@ -35578,11 +35578,11 @@ with self;
     };
   };
 
-  TestUnitLite = buildPerlModule {
+  TestUnitLite = buildPerlModule rec {
     pname = "Test-Unit-Lite";
     version = "0.1202";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DE/DEXTER/Test-Unit-Lite-0.1202.tar.gz";
+      url = "mirror://cpan/authors/id/D/DE/DEXTER/Test-Unit-Lite-${version}.tar.gz";
       hash = "sha256-NR0l7nExYoqvfjmV/h//uJOuf+bvWM8zcO0yCVP1sqg=";
     };
     meta = {
@@ -35594,11 +35594,11 @@ with self;
     };
   };
 
-  TestWarn = buildPerlPackage {
+  TestWarn = buildPerlPackage rec {
     pname = "Test-Warn";
     version = "0.37";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BI/BIGJ/Test-Warn-0.37.tar.gz";
+      url = "mirror://cpan/authors/id/B/BI/BIGJ/Test-Warn-${version}.tar.gz";
       hash = "sha256-mMoy5/L16om4v7mgYJl389FT4kLi5RcFEmy5VPGga1c=";
     };
     propagatedBuildInputs = [ SubUplevel ];
@@ -35614,11 +35614,11 @@ with self;
     };
   };
 
-  TestWarnings = buildPerlPackage {
+  TestWarnings = buildPerlPackage rec {
     pname = "Test-Warnings";
     version = "0.032";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Test-Warnings-0.032.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Test-Warnings-${version}.tar.gz";
       hash = "sha256-Ryfa4kFunwfkHi3DqRQ7pq/8HsV2UhF8mdUAOOMT6dk=";
     };
     buildInputs = [
@@ -35635,11 +35635,11 @@ with self;
     };
   };
 
-  TestWeaken = buildPerlPackage {
+  TestWeaken = buildPerlPackage rec {
     pname = "Test-Weaken";
     version = "3.022000";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KR/KRYDE/Test-Weaken-3.022000.tar.gz";
+      url = "mirror://cpan/authors/id/K/KR/KRYDE/Test-Weaken-${version}.tar.gz";
       hash = "sha256-JjGocSExAmLg6WEHpvoO1pSHt3AVIHc77l+prMwpX1s=";
     };
     propagatedBuildInputs = [ ScalarListUtils ];
@@ -35652,11 +35652,11 @@ with self;
     };
   };
 
-  TestWithoutModule = buildPerlPackage {
+  TestWithoutModule = buildPerlPackage rec {
     pname = "Test-Without-Module";
     version = "0.21";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CO/CORION/Test-Without-Module-0.21.tar.gz";
+      url = "mirror://cpan/authors/id/C/CO/CORION/Test-Without-Module-${version}.tar.gz";
       hash = "sha256-PN6vraxIU+vq/miTRtVV2l36PPqdTITj5ee/7lC+7EY=";
     };
     meta = {
@@ -35668,11 +35668,11 @@ with self;
     };
   };
 
-  TestWWWMechanize = buildPerlPackage {
+  TestWWWMechanize = buildPerlPackage rec {
     pname = "Test-WWW-Mechanize";
     version = "1.60";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PETDANCE/Test-WWW-Mechanize-1.60.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PETDANCE/Test-WWW-Mechanize-${version}.tar.gz";
       hash = "sha256-I/1y5+0b553h0CotFfDfCTQV4Oq2/GFf9rtoh0Emhnc=";
     };
     buildInputs = [ TestLongString ];
@@ -35688,11 +35688,11 @@ with self;
     };
   };
 
-  TestWWWMechanizeCatalyst = buildPerlPackage {
+  TestWWWMechanizeCatalyst = buildPerlPackage rec {
     pname = "Test-WWW-Mechanize-Catalyst";
     version = "0.62";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSTROUT/Test-WWW-Mechanize-Catalyst-0.62.tar.gz";
+      url = "mirror://cpan/authors/id/M/MS/MSTROUT/Test-WWW-Mechanize-Catalyst-${version}.tar.gz";
       hash = "sha256-GDveGuerpw3LPtd3xVSCN/QsPtVR/VvGWM7obQIWrLE=";
     };
     doCheck = false; # listens on an external port
@@ -35716,11 +35716,11 @@ with self;
     };
   };
 
-  TestWWWMechanizeCGI = buildPerlPackage {
+  TestWWWMechanizeCGI = buildPerlPackage rec {
     pname = "Test-WWW-Mechanize-CGI";
     version = "0.1";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MR/MRAMBERG/Test-WWW-Mechanize-CGI-0.1.tar.gz";
+      url = "mirror://cpan/authors/id/M/MR/MRAMBERG/Test-WWW-Mechanize-CGI-${version}.tar.gz";
       hash = "sha256-pXagsi470a/JJ0/FY7A3ru53cThJyev2pq1EFcFsnC8=";
     };
     propagatedBuildInputs = [ WWWMechanizeCGI ];
@@ -35737,11 +35737,11 @@ with self;
     };
   };
 
-  TestWWWMechanizePSGI = buildPerlPackage {
+  TestWWWMechanizePSGI = buildPerlPackage rec {
     pname = "Test-WWW-Mechanize-PSGI";
     version = "0.39";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OA/OALDERS/Test-WWW-Mechanize-PSGI-0.39.tar.gz";
+      url = "mirror://cpan/authors/id/O/OA/OALDERS/Test-WWW-Mechanize-PSGI-${version}.tar.gz";
       hash = "sha256-R2s6s7R9U05Nag9JkAIdXTTGnsk3rAcW5mzop7yHmVg=";
     };
     buildInputs = [
@@ -35760,11 +35760,11 @@ with self;
     };
   };
 
-  TestXPath = buildPerlPackage {
+  TestXPath = buildPerlPackage rec {
     pname = "Test-XPath";
     version = "0.20";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MANWAR/Test-XPath-0.20.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MANWAR/Test-XPath-${version}.tar.gz";
       hash = "sha256-36phHnFGrZyXabW89oiUmXa4Ny3354ekC5M6FI2JIDk=";
     };
     propagatedBuildInputs = [ XMLLibXML ];
@@ -35781,11 +35781,11 @@ with self;
     };
   };
 
-  TestYAML = buildPerlPackage {
+  TestYAML = buildPerlPackage rec {
     pname = "Test-YAML";
     version = "1.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TI/TINITA/Test-YAML-1.07.tar.gz";
+      url = "mirror://cpan/authors/id/T/TI/TINITA/Test-YAML-${version}.tar.gz";
       hash = "sha256-HzANA09GKYy5KWCRLMBLrDP7J/BbiFLY8FHhELnNmV8=";
     };
     buildInputs = [ TestBase ];
@@ -35799,11 +35799,11 @@ with self;
     };
   };
 
-  TextAligner = buildPerlModule {
+  TextAligner = buildPerlModule rec {
     pname = "Text-Aligner";
     version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Text-Aligner-0.16.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Text-Aligner-${version}.tar.gz";
       hash = "sha256-XIV9vOWG9X+j18Tr0yACOrOyljsgSUKK4BvTvE8hVyU=";
     };
     meta = {
@@ -35813,11 +35813,11 @@ with self;
     };
   };
 
-  TextAspell = buildPerlPackage {
+  TextAspell = buildPerlPackage rec {
     pname = "Text-Aspell";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HANK/Text-Aspell-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HANK/Text-Aspell-${version}.tar.gz";
       hash = "sha256-K+oyCfGOJzsZPjF1pC0mk5GRnkmrEGtuJSOV0nIYL2U=";
     };
     propagatedBuildInputs = [ pkgs.aspell ];
@@ -35833,11 +35833,11 @@ with self;
     };
   };
 
-  TextAutoformat = buildPerlPackage {
+  TextAutoformat = buildPerlPackage rec {
     pname = "Text-Autoformat";
     version = "1.75";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/Text-Autoformat-1.75.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/Text-Autoformat-${version}.tar.gz";
       hash = "sha256-ndT0zj2uxLTb9bWdrEVoqJRq7RLCi05ZiMjoxgLGt3E=";
     };
     propagatedBuildInputs = [ TextReform ];
@@ -35851,11 +35851,11 @@ with self;
     };
   };
 
-  TextBalanced = buildPerlPackage {
+  TextBalanced = buildPerlPackage rec {
     pname = "Text-Balanced";
     version = "2.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHAY/Text-Balanced-2.06.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHAY/Text-Balanced-${version}.tar.gz";
       hash = "sha256-dz4PDyHAyyz2ZM7muij/cCWbq8yJL5tlD5y9oAvgkq0=";
     };
     meta = {
@@ -35867,7 +35867,7 @@ with self;
     };
   };
 
-  TextBibTeX = buildPerlModule {
+  TextBibTeX = buildPerlModule rec {
     pname = "Text-BibTeX";
     version = "0.91";
     buildInputs = [
@@ -35876,7 +35876,7 @@ with self;
       ExtUtilsLibBuilder
     ];
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AM/AMBS/Text-BibTeX-0.91.tar.gz";
+      url = "mirror://cpan/authors/id/A/AM/AMBS/Text-BibTeX-${version}.tar.gz";
       hash = "sha256-PwETz4/nHcdIRjbcjipYFjfsvMgtC+KbvUbQvz+M2zc=";
     };
     # libbtparse.so: cannot open shared object file
@@ -35900,11 +35900,11 @@ with self;
     };
   };
 
-  TextBrew = buildPerlPackage {
+  TextBrew = buildPerlPackage rec {
     pname = "Text-Brew";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KC/KCIVEY/Text-Brew-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/K/KC/KCIVEY/Text-Brew-${version}.tar.gz";
       hash = "sha256-qhuFhBz5/G/jODZrvIcKTpMEonZB5j+Sof2Wvujr9kw=";
     };
     meta = {
@@ -35916,11 +35916,11 @@ with self;
     };
   };
 
-  TextCharWidth = buildPerlPackage {
+  TextCharWidth = buildPerlPackage rec {
     pname = "Text-CharWidth";
     version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KU/KUBOTA/Text-CharWidth-0.04.tar.gz";
+      url = "mirror://cpan/authors/id/K/KU/KUBOTA/Text-CharWidth-${version}.tar.gz";
       hash = "sha256-q97V9P3ZM46J/S8dgnHESYna5b9Qrs5BthedjiMHBPg=";
     };
     meta = {
@@ -35932,11 +35932,11 @@ with self;
     };
   };
 
-  TextCSV = buildPerlPackage {
+  TextCSV = buildPerlPackage rec {
     pname = "Text-CSV";
     version = "2.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/Text-CSV-2.03.tar.gz";
+      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/Text-CSV-${version}.tar.gz";
       hash = "sha256-SLvOnyNJNaiFlWGOBN0UFigkbWUPKnJgJN8cE34LZfs=";
     };
     meta = {
@@ -35948,11 +35948,11 @@ with self;
     };
   };
 
-  TextCSVEncoded = buildPerlPackage {
+  TextCSVEncoded = buildPerlPackage rec {
     pname = "Text-CSV-Encoded";
     version = "0.25";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZA/ZARQUON/Text-CSV-Encoded-0.25.tar.gz";
+      url = "mirror://cpan/authors/id/Z/ZA/ZARQUON/Text-CSV-Encoded-${version}.tar.gz";
       hash = "sha256-JIpZg6IN1XeGY56I2v3WVPO5OSVJASDW1xLaayvludA=";
     };
     propagatedBuildInputs = [ TextCSV ];
@@ -35966,11 +35966,11 @@ with self;
     };
   };
 
-  TextCSV_XS = buildPerlPackage {
+  TextCSV_XS = buildPerlPackage rec {
     pname = "Text-CSV_XS";
     version = "1.62";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HM/HMBRAND/Text-CSV_XS-1.62.tgz";
+      url = "mirror://cpan/authors/id/H/HM/HMBRAND/Text-CSV_XS-${version}.tgz";
       hash = "sha256-FxBpPt2u/dVudNpCuqntZ25+rtKOvTA60jyYL+8rFBU=";
     };
     meta = {
@@ -35983,11 +35983,11 @@ with self;
     };
   };
 
-  TextDiff = buildPerlPackage {
+  TextDiff = buildPerlPackage rec {
     pname = "Text-Diff";
     version = "1.45";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/Text-Diff-1.45.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/Text-Diff-${version}.tar.gz";
       hash = "sha256-6Lqgexs/U+AK82NomLv3OuyaD/OPlFNu3h2+lu8IbwQ=";
     };
     propagatedBuildInputs = [ AlgorithmDiff ];
@@ -36000,11 +36000,11 @@ with self;
     };
   };
 
-  TextFormat = buildPerlModule {
+  TextFormat = buildPerlModule rec {
     pname = "Text-Format";
     version = "0.62";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Text-Format-0.62.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Text-Format-${version}.tar.gz";
       hash = "sha256-fUKQVzGeEjxZC6B2UzTwreSl656o23wOxNOQLeX5BAQ=";
     };
     meta = {
@@ -36018,11 +36018,11 @@ with self;
     };
   };
 
-  TextDiffFormattedHTML = buildPerlPackage {
+  TextDiffFormattedHTML = buildPerlPackage rec {
     pname = "Text-Diff-FormattedHTML";
     version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AM/AMBS/Text-Diff-FormattedHTML-0.08.tar.gz";
+      url = "mirror://cpan/authors/id/A/AM/AMBS/Text-Diff-FormattedHTML-${version}.tar.gz";
       hash = "sha256-Oat3WlwFZ0Xyq9jMfBy8VJbf735SqfS9itpqpsnHtw0=";
     };
     propagatedBuildInputs = [
@@ -36039,11 +36039,11 @@ with self;
     };
   };
 
-  TextFuzzy = buildPerlPackage {
+  TextFuzzy = buildPerlPackage rec {
     pname = "Text-Fuzzy";
     version = "0.29";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BK/BKB/Text-Fuzzy-0.29.tar.gz";
+      url = "mirror://cpan/authors/id/B/BK/BKB/Text-Fuzzy-${version}.tar.gz";
       hash = "sha256-PfXP0soaTFyn/3urPMjVOtIGThNMvxEATzz4xLkFW/8=";
     };
     meta = {
@@ -36055,11 +36055,11 @@ with self;
     };
   };
 
-  TextGerman = buildPerlPackage {
+  TextGerman = buildPerlPackage rec {
     pname = "Text-German";
     version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/U/UL/ULPFR/Text-German-0.06.tar.gz";
+      url = "mirror://cpan/authors/id/U/UL/ULPFR/Text-German-${version}.tar.gz";
       hash = "sha256-ki1PGQEtl3OxH0pvZCEF6fkT9YZvRGG2BZymdNW7B90=";
     };
     meta = {
@@ -36071,11 +36071,11 @@ with self;
     };
   };
 
-  TextGlob = buildPerlPackage {
+  TextGlob = buildPerlPackage rec {
     pname = "Text-Glob";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RC/RCLAMP/Text-Glob-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/R/RC/RCLAMP/Text-Glob-${version}.tar.gz";
       hash = "sha256-BpzNSdPwot7bEV9L3J+6wHqDWShAlT0fzfw5650wUoc=";
     };
     meta = {
@@ -36087,11 +36087,11 @@ with self;
     };
   };
 
-  TextHogan = buildPerlPackage {
+  TextHogan = buildPerlPackage rec {
     pname = "Text-Hogan";
     version = "2.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KAORU/Text-Hogan-2.03.tar.gz";
+      url = "mirror://cpan/authors/id/K/KA/KAORU/Text-Hogan-${version}.tar.gz";
       hash = "sha256-WNkj7eTFmEiI75u7JW2IVMxdIqRwikd0sxPLU4jFYXo=";
     };
     propagatedBuildInputs = [
@@ -36114,11 +36114,11 @@ with self;
     };
   };
 
-  TextIconv = buildPerlPackage {
+  TextIconv = buildPerlPackage rec {
     pname = "Text-Iconv";
     version = "1.7";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MP/MPIOTR/Text-Iconv-1.7.tar.gz";
+      url = "mirror://cpan/authors/id/M/MP/MPIOTR/Text-Iconv-${version}.tar.gz";
       hash = "sha256-W4C31ecJ00OTvLqIlxhkoXtEpb8PnkvO44PQKefS1cM=";
     };
     meta = {
@@ -36130,11 +36130,11 @@ with self;
     };
   };
 
-  TestInDistDir = buildPerlPackage {
+  TestInDistDir = buildPerlPackage rec {
     pname = "Test-InDistDir";
     version = "1.112071";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MITHALDU/Test-InDistDir-1.112071.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MITHALDU/Test-InDistDir-${version}.tar.gz";
       hash = "sha256-kixcYzFPQG9MuzXsQjrCFU0sK3GmWt23cyydJAqD/vs=";
     };
     meta = {
@@ -36145,11 +36145,11 @@ with self;
     };
   };
 
-  TestInter = buildPerlPackage {
+  TestInter = buildPerlPackage rec {
     pname = "Test-Inter";
     version = "1.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SB/SBECK/Test-Inter-1.10.tar.gz";
+      url = "mirror://cpan/authors/id/S/SB/SBECK/Test-Inter-${version}.tar.gz";
       hash = "sha256-cewRXqwm+2aJGb1mQLQcNzInUuvUjBx222a3O679O10=";
     };
     buildInputs = [
@@ -36166,11 +36166,11 @@ with self;
     };
   };
 
-  TextLayout = buildPerlPackage {
+  TextLayout = buildPerlPackage rec {
     pname = "Text-Layout";
     version = "0.037";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JV/JV/Text-Layout-0.037.tar.gz";
+      url = "mirror://cpan/authors/id/J/JV/JV/Text-Layout-${version}.tar.gz";
       hash = "sha256-WCeTQSR8SBh0BIdkAPBq19qm/nFilVgYXfNnPfCbnOo=";
     };
     buildInputs = [
@@ -36187,11 +36187,11 @@ with self;
     };
   };
 
-  TextLevenshteinXS = buildPerlPackage {
+  TextLevenshteinXS = buildPerlPackage rec {
     pname = "Text-LevenshteinXS";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JG/JGOLDBERG/Text-LevenshteinXS-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/J/JG/JGOLDBERG/Text-LevenshteinXS-${version}.tar.gz";
       hash = "sha256-43T/eyN5Gc5eqSRfNW0ctSzIf9JrOlo4s/Pl/4KgFJE=";
     };
     meta = {
@@ -36203,11 +36203,11 @@ with self;
     };
   };
 
-  TextLorem = buildPerlPackage {
+  TextLorem = buildPerlPackage rec {
     pname = "Text-Lorem";
     version = "0.34";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AD/ADEOLA/Text-Lorem-0.34.tar.gz";
+      url = "mirror://cpan/authors/id/A/AD/ADEOLA/Text-Lorem-${version}.tar.gz";
       hash = "sha256-DOajwZkXsjI0JKGqdC2YiwY8OUQEJ6MQGkzsbb2EcVc=";
     };
     meta = {
@@ -36221,11 +36221,11 @@ with self;
     };
   };
 
-  TestManifest = buildPerlPackage {
+  TestManifest = buildPerlPackage rec {
     pname = "Test-Manifest";
     version = "2.023";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/Test-Manifest-2.023.tar.gz";
+      url = "mirror://cpan/authors/id/B/BD/BDFOY/Test-Manifest-${version}.tar.gz";
       hash = "sha256-0k5SVT58uc2oH5L/6MkrPkNGcY5HEIAaWzW38lGnceI=";
     };
     meta = {
@@ -36235,11 +36235,11 @@ with self;
     };
   };
 
-  TextMarkdown = buildPerlPackage {
+  TextMarkdown = buildPerlPackage rec {
     pname = "Text-Markdown";
     version = "1.000031";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOBTFISH/Text-Markdown-1.000031.tar.gz";
+      url = "mirror://cpan/authors/id/B/BO/BOBTFISH/Text-Markdown-${version}.tar.gz";
       hash = "sha256-wZHG1ezrjLdcBWUZI2BmLSAtcWutB6IzxLMppChNxxs=";
     };
     nativeCheckInputs = [
@@ -36254,11 +36254,11 @@ with self;
     };
   };
 
-  TextMarkdownHoedown = buildPerlModule {
+  TextMarkdownHoedown = buildPerlModule rec {
     pname = "Text-Markdown-Hoedown";
     version = "1.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOKUHIROM/Text-Markdown-Hoedown-1.03.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TOKUHIROM/Text-Markdown-Hoedown-${version}.tar.gz";
       hash = "sha256-U6cw/29IgrmavYVW8mqRH1gvZ1tZ8OFnJe0ey8CE7lA=";
     };
     buildInputs = [ Filepushd ];
@@ -36272,11 +36272,11 @@ with self;
     };
   };
 
-  TestMinimumVersion = buildPerlPackage {
+  TestMinimumVersion = buildPerlPackage rec {
     pname = "Test-MinimumVersion";
     version = "0.101083";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Test-MinimumVersion-0.101083.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Test-MinimumVersion-${version}.tar.gz";
       hash = "sha256-MqHrzYA/oQ7vylU7w87dQ1lqdZ3Dl1revSJoiCPDauo=";
     };
     propagatedBuildInputs = [ PerlMinimumVersion ];
@@ -36290,11 +36290,11 @@ with self;
     };
   };
 
-  TextMicroTemplate = buildPerlPackage {
+  TextMicroTemplate = buildPerlPackage rec {
     pname = "Text-MicroTemplate";
     version = "0.24";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KAZUHO/Text-MicroTemplate-0.24.tar.gz";
+      url = "mirror://cpan/authors/id/K/KA/KAZUHO/Text-MicroTemplate-${version}.tar.gz";
       hash = "sha256-MoAecfNe6Kqg1XbOwSXO5Gs9SRWuZCvGSWISDU+XtMg=";
     };
     meta = {
@@ -36306,11 +36306,11 @@ with self;
     };
   };
 
-  TextMultiMarkdown = buildPerlPackage {
+  TextMultiMarkdown = buildPerlPackage rec {
     pname = "Text-MultiMarkdown";
     version = "1.001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/Text-MultiMarkdown-1.001.tar.gz";
+      url = "mirror://cpan/authors/id/B/BD/BDFOY/Text-MultiMarkdown-${version}.tar.gz";
       hash = "sha256-UB1ErH2lSUSZzqhR6bL7UlOAgLDB6TYjDIwm1n4EhDM=";
     };
     buildInputs = [
@@ -36328,11 +36328,11 @@ with self;
     };
   };
 
-  TestNumberDelta = buildPerlPackage {
+  TestNumberDelta = buildPerlPackage rec {
     pname = "Test-Number-Delta";
     version = "1.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Test-Number-Delta-1.06.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Test-Number-Delta-${version}.tar.gz";
       hash = "sha256-U1QwkZ5v32zlX/dumJKvzLo7fUFg20XzrEOw+S/80Ek=";
     };
     meta = {
@@ -36342,11 +36342,11 @@ with self;
     };
   };
 
-  TextParsewords = buildPerlPackage {
+  TextParsewords = buildPerlPackage rec {
     pname = "Text-ParseWords";
     version = "3.31";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/Text-ParseWords-3.31.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/Text-ParseWords-${version}.tar.gz";
       hash = "sha256-KuVVughNdbK4/u640aAJESdoFa2oa8yxRSI2lk1aL8c=";
     };
     meta = {
@@ -36358,11 +36358,11 @@ with self;
     };
   };
 
-  TextPasswordPronounceable = buildPerlPackage {
+  TextPasswordPronounceable = buildPerlPackage rec {
     pname = "Text-Password-Pronounceable";
     version = "0.30";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TS/TSIBLEY/Text-Password-Pronounceable-0.30.tar.gz";
+      url = "mirror://cpan/authors/id/T/TS/TSIBLEY/Text-Password-Pronounceable-${version}.tar.gz";
       hash = "sha256-wYalAlbgvt+vsX584VfnxS8ZUDu3nhjr8GJVkR9urRo=";
     };
     meta = {
@@ -36374,11 +36374,11 @@ with self;
     };
   };
 
-  TextPatch = buildPerlPackage {
+  TextPatch = buildPerlPackage rec {
     pname = "Text-Patch";
     version = "1.8";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CA/CADE/Text-Patch-1.8.tar.gz";
+      url = "mirror://cpan/authors/id/C/CA/CADE/Text-Patch-${version}.tar.gz";
       hash = "sha256-6vGOYbpqPhQ4RqfMZvCM5YoMT72pKssxrt4lyztcPcw=";
     };
     propagatedBuildInputs = [ TextDiff ];
@@ -36388,11 +36388,11 @@ with self;
     };
   };
 
-  TextPDF = buildPerlPackage {
+  TextPDF = buildPerlPackage rec {
     pname = "Text-PDF";
     version = "0.31";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BH/BHALLISSY/Text-PDF-0.31.tar.gz";
+      url = "mirror://cpan/authors/id/B/BH/BHALLISSY/Text-PDF-${version}.tar.gz";
       hash = "sha256-359RXuFZgEsNWnXVrbk8RYTH7EAdjFnCfp9zkl2NrGg=";
     };
     meta = {
@@ -36404,11 +36404,11 @@ with self;
     };
   };
 
-  TextQuoted = buildPerlPackage {
+  TextQuoted = buildPerlPackage rec {
     pname = "Text-Quoted";
     version = "2.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BP/BPS/Text-Quoted-2.10.tar.gz";
+      url = "mirror://cpan/authors/id/B/BP/BPS/Text-Quoted-${version}.tar.gz";
       hash = "sha256-CBv5XskiCvJs7IkWHmG/c/n7y/7uHZrxUTnl17cI9EU=";
     };
     propagatedBuildInputs = [ TextAutoformat ];
@@ -36421,11 +36421,11 @@ with self;
     };
   };
 
-  TextRecordParser = buildPerlPackage {
+  TextRecordParser = buildPerlPackage rec {
     pname = "Text-RecordParser";
     version = "1.6.5";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KC/KCLARK/Text-RecordParser-1.6.5.tar.gz";
+      url = "mirror://cpan/authors/id/K/KC/KCLARK/Text-RecordParser-${version}.tar.gz";
       hash = "sha256-2juBQUxj+NkhjRFnRaiLlIxGyYsYdjT2KYkuVAAbw1o=";
     };
 
@@ -36447,11 +36447,11 @@ with self;
     };
   };
 
-  TextReflow = buildPerlPackage {
+  TextReflow = buildPerlPackage rec {
     pname = "Text-Reflow";
     version = "1.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MW/MWARD/Text-Reflow-1.17.tar.gz";
+      url = "mirror://cpan/authors/id/M/MW/MWARD/Text-Reflow-${version}.tar.gz";
       hash = "sha256-S/ITn/YX1uWcwOWc3s18tyPs/SjVrDh6+1U//cBxuGA=";
     };
     meta = {
@@ -36463,11 +36463,11 @@ with self;
     };
   };
 
-  TextReform = buildPerlModule {
+  TextReform = buildPerlModule rec {
     pname = "Text-Reform";
     version = "1.20";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHORNY/Text-Reform-1.20.tar.gz";
+      url = "mirror://cpan/authors/id/C/CH/CHORNY/Text-Reform-${version}.tar.gz";
       hash = "sha256-qHkt2MGqyXABAyM3s2o1a+luLXTE8DnvmjY7ZB20rmE=";
     };
     meta = {
@@ -36479,11 +36479,11 @@ with self;
     };
   };
 
-  TextRoman = buildPerlPackage {
+  TextRoman = buildPerlPackage rec {
     pname = "Text-Roman";
     version = "3.5";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SY/SYP/Text-Roman-3.5.tar.gz";
+      url = "mirror://cpan/authors/id/S/SY/SYP/Text-Roman-${version}.tar.gz";
       hash = "sha256-y0oIo7FRgC/7L84yWKQWVCq4HbD3Oe5HSpWD/7c+BGo=";
     };
     meta = {
@@ -36496,11 +36496,11 @@ with self;
     };
   };
 
-  TextSimpleTable = buildPerlPackage {
+  TextSimpleTable = buildPerlPackage rec {
     pname = "Text-SimpleTable";
     version = "2.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MR/MRAMBERG/Text-SimpleTable-2.07.tar.gz";
+      url = "mirror://cpan/authors/id/M/MR/MRAMBERG/Text-SimpleTable-${version}.tar.gz";
       hash = "sha256-JW0/OHZOljMxWLFKsYJXuS8xVcYNZYyvuAOJ9y9GGe0=";
     };
     propagatedBuildInputs = [ UnicodeLineBreak ];
@@ -36510,11 +36510,11 @@ with self;
     };
   };
 
-  TextSoundex = buildPerlPackage {
+  TextSoundex = buildPerlPackage rec {
     pname = "Text-Soundex";
     version = "3.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Text-Soundex-3.05.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Text-Soundex-${version}.tar.gz";
       hash = "sha256-9t1VtCgLJd6peCIYOYZDglYAdOHWkzOV+u4lEMLbYO0=";
     };
     meta = {
@@ -36526,11 +36526,11 @@ with self;
     };
   };
 
-  TextSprintfNamed = buildPerlModule {
+  TextSprintfNamed = buildPerlModule rec {
     pname = "Text-Sprintf-Named";
     version = "0.0405";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Text-Sprintf-Named-0.0405.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Text-Sprintf-Named-${version}.tar.gz";
       hash = "sha256-m0cNeP/PxAqz+ZgjGzNrnTQXIw+3zlW0fNewVXOnD/w=";
     };
     buildInputs = [ TestWarn ];
@@ -36541,11 +36541,11 @@ with self;
     };
   };
 
-  TextTable = buildPerlModule {
+  TextTable = buildPerlModule rec {
     pname = "Text-Table";
     version = "1.135";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Text-Table-1.135.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Text-Table-${version}.tar.gz";
       hash = "sha256-/KPBboMSf3xE3ePT9+PHPqUNEJoQVERd6Agv6nlMpdI=";
     };
     propagatedBuildInputs = [ TextAligner ];
@@ -36556,11 +36556,11 @@ with self;
     };
   };
 
-  TextTabularDisplay = buildPerlPackage {
+  TextTabularDisplay = buildPerlPackage rec {
     pname = "Text-TabularDisplay";
     version = "1.38";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DARREN/Text-TabularDisplay-1.38.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DARREN/Text-TabularDisplay-${version}.tar.gz";
       hash = "sha256-6wmQ+vpWtmfyPbdkvdpaTcX0sd3EsTg6pe7W8i7Rhug=";
     };
     meta = {
@@ -36569,11 +36569,11 @@ with self;
     };
   };
 
-  TextTemplate = buildPerlPackage {
+  TextTemplate = buildPerlPackage rec {
     pname = "Text-Template";
     version = "1.61";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSCHOUT/Text-Template-1.61.tar.gz";
+      url = "mirror://cpan/authors/id/M/MS/MSCHOUT/Text-Template-${version}.tar.gz";
       hash = "sha256-opXqfR7yQa4mQMH3hktij45vmewU+x2ngbL18haNzwk=";
     };
     buildInputs = [
@@ -36589,11 +36589,11 @@ with self;
     };
   };
 
-  TestTrap = buildPerlModule {
+  TestTrap = buildPerlModule rec {
     pname = "Test-Trap";
     version = "0.3.5";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EB/EBHANSSEN/Test-Trap-v0.3.5.tar.gz";
+      url = "mirror://cpan/authors/id/E/EB/EBHANSSEN/Test-Trap-v${version}.tar.gz";
       hash = "sha256-VPmQFlYrWx1yEQEA8fK+Q3F4zfhDdvSV/9A3bx1+y5o=";
     };
     propagatedBuildInputs = [ DataDump ];
@@ -36606,11 +36606,11 @@ with self;
     };
   };
 
-  TestVars = buildPerlModule {
+  TestVars = buildPerlModule rec {
     pname = "Test-Vars";
     version = "0.015";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GF/GFUJI/Test-Vars-0.015.tar.gz";
+      url = "mirror://cpan/authors/id/G/GF/GFUJI/Test-Vars-${version}.tar.gz";
       hash = "sha256-4Y3RWCcuTsmTnh37M8dDGrTnXGtAsoDDi16AT9pHGlQ=";
     };
     buildInputs = [ ModuleBuildTiny ];
@@ -36628,11 +36628,11 @@ with self;
     };
   };
 
-  TestVersion = buildPerlPackage {
+  TestVersion = buildPerlPackage rec {
     pname = "Test-Version";
     version = "2.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Test-Version-2.09.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Test-Version-${version}.tar.gz";
       hash = "sha256-nOHdKJel8w4bf4lm7Gb1fY2PKA9gXyjHyiIfp5rKOOA=";
     };
     buildInputs = [ TestException ];
@@ -36643,11 +36643,11 @@ with self;
     };
   };
 
-  TextTrim = buildPerlPackage {
+  TextTrim = buildPerlPackage rec {
     pname = "Text-Trim";
     version = "1.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJT/Text-Trim-1.04.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJT/Text-Trim-${version}.tar.gz";
       hash = "sha256-1YeKkHnTPNF2bParxEzWJb0AoCE9LOjjFD/mlEq6qhE=";
     };
     meta = {
@@ -36686,11 +36686,11 @@ with self;
     };
   };
 
-  TextUnidecode = buildPerlPackage {
+  TextUnidecode = buildPerlPackage rec {
     pname = "Text-Unidecode";
     version = "1.30";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SB/SBURKE/Text-Unidecode-1.30.tar.gz";
+      url = "mirror://cpan/authors/id/S/SB/SBURKE/Text-Unidecode-${version}.tar.gz";
       hash = "sha256-bCTxTdwdIOJhYcIHtzyhhO7S71fwi1+y7hlubi6IscY=";
     };
     meta = {
@@ -36702,11 +36702,11 @@ with self;
     };
   };
 
-  Testutf8 = buildPerlPackage {
+  Testutf8 = buildPerlPackage rec {
     pname = "Test-utf8";
     version = "1.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARKF/Test-utf8-1.02.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MARKF/Test-utf8-${version}.tar.gz";
       hash = "sha256-34LwnFlAgwslpJ8cgWL6JNNx5gKIDt742aTUv9Zri9c=";
     };
     meta = {
@@ -36719,11 +36719,11 @@ with self;
     };
   };
 
-  TextNSP = buildPerlPackage {
+  TextNSP = buildPerlPackage rec {
     pname = "Text-NSP";
     version = "1.31";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TP/TPEDERSE/Text-NSP-1.31.tar.gz";
+      url = "mirror://cpan/authors/id/T/TP/TPEDERSE/Text-NSP-${version}.tar.gz";
       hash = "sha256-oBIBvrKWNrPkHs2ips9lIv0mVBa9bZlPrQL1n7Sc9ZU=";
     };
     meta = {
@@ -36733,11 +36733,11 @@ with self;
     };
   };
 
-  TextvFileasData = buildPerlPackage {
+  TextvFileasData = buildPerlPackage rec {
     pname = "Text-vFile-asData";
     version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RC/RCLAMP/Text-vFile-asData-0.08.tar.gz";
+      url = "mirror://cpan/authors/id/R/RC/RCLAMP/Text-vFile-asData-${version}.tar.gz";
       hash = "sha256-spGrXg+YfFFyVgppIjRxGnXkWW2DR19y0BJ4NpUy+Co=";
     };
     propagatedBuildInputs = [ ClassAccessorChained ];
@@ -36750,11 +36750,11 @@ with self;
     };
   };
 
-  TextWikiFormat = buildPerlModule {
+  TextWikiFormat = buildPerlModule rec {
     pname = "Text-WikiFormat";
     version = "0.81";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CY/CYCLES/Text-WikiFormat-0.81.tar.gz";
+      url = "mirror://cpan/authors/id/C/CY/CYCLES/Text-WikiFormat-${version}.tar.gz";
       hash = "sha256-5DzZla2RV6foOdmT7ntsTRhUlH5VfQltnVqvdFB/qzM=";
     };
     propagatedBuildInputs = [ URI ];
@@ -36767,11 +36767,11 @@ with self;
     };
   };
 
-  TextWordDiff = buildPerlPackage {
+  TextWordDiff = buildPerlPackage rec {
     pname = "Text-WordDiff";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TI/TIMK/Text-WordDiff-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/T/TI/TIMK/Text-WordDiff-${version}.tar.gz";
       hash = "sha256-/uaZynY63KL04Y9KioNv0hArwoIK9wj460M1bVrg1Q4=";
     };
     propagatedBuildInputs = [
@@ -36788,11 +36788,11 @@ with self;
     };
   };
 
-  TextWrapI18N = buildPerlPackage {
+  TextWrapI18N = buildPerlPackage rec {
     pname = "Text-WrapI18N";
     version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KU/KUBOTA/Text-WrapI18N-0.06.tar.gz";
+      url = "mirror://cpan/authors/id/K/KU/KUBOTA/Text-WrapI18N-${version}.tar.gz";
       hash = "sha256-S9KaF/DCx5LRLBAFs8J28qsPrjnACFmuF0HXlBhGpIg=";
     };
     buildInputs = lib.optionals (!stdenv.hostPlatform.isDarwin) [ pkgs.glibcLocales ];
@@ -36809,11 +36809,11 @@ with self;
     };
   };
 
-  TextWrapper = buildPerlPackage {
+  TextWrapper = buildPerlPackage rec {
     pname = "Text-Wrapper";
     version = "1.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CJ/CJM/Text-Wrapper-1.05.tar.gz";
+      url = "mirror://cpan/authors/id/C/CJ/CJM/Text-Wrapper-${version}.tar.gz";
       hash = "sha256-ZCaOFZg6nfR+HZGZpJHzlOifVC5Ur7M/S3jz8xjgmrk=";
     };
     buildInputs = [ TestDifferences ];
@@ -36826,11 +36826,11 @@ with self;
     };
   };
 
-  Throwable = buildPerlPackage {
+  Throwable = buildPerlPackage rec {
     pname = "Throwable";
     version = "1.001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Throwable-1.001.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Throwable-${version}.tar.gz";
       hash = "sha256-0MtenX0G1w8sxW7s+FeoOkXqykOFDc3akdP+tN3eTFE=";
     };
     propagatedBuildInputs = [
@@ -36847,11 +36847,11 @@ with self;
     };
   };
 
-  TieCacheLRU = buildPerlPackage {
+  TieCacheLRU = buildPerlPackage rec {
     pname = "Tie-Cache-LRU";
     version = "20150301";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSCHWERN/Tie-Cache-LRU-20150301.tar.gz";
+      url = "mirror://cpan/authors/id/M/MS/MSCHWERN/Tie-Cache-LRU-${version}.tar.gz";
       hash = "sha256-G/dARQ06bXwStIwl99pZZOROfMOLKFcs+3b/IkZPRGk=";
     };
     propagatedBuildInputs = [
@@ -36867,11 +36867,11 @@ with self;
     };
   };
 
-  TieCacheLRUExpires = buildPerlPackage {
+  TieCacheLRUExpires = buildPerlPackage rec {
     pname = "Tie-Cache-LRU-Expires";
     version = "0.55";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OE/OESTERHOL/Tie-Cache-LRU-Expires-0.55.tar.gz";
+      url = "mirror://cpan/authors/id/O/OE/OESTERHOL/Tie-Cache-LRU-Expires-${version}.tar.gz";
       hash = "sha256-sxbYSazSXyQ0bVWplQ0oH+4HRjmHZ8YBI0EiFZVz65o=";
     };
     propagatedBuildInputs = [ TieCacheLRU ];
@@ -36881,11 +36881,11 @@ with self;
     };
   };
 
-  TieCycle = buildPerlPackage {
+  TieCycle = buildPerlPackage rec {
     pname = "Tie-Cycle";
     version = "1.227";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/Tie-Cycle-1.227.tar.gz";
+      url = "mirror://cpan/authors/id/B/BD/BDFOY/Tie-Cycle-${version}.tar.gz";
       hash = "sha256-eDgzV5HnGjszuKGd4wUpSeGJCkgj3vY5eCPJkiL6Hdg=";
     };
     meta = {
@@ -36895,11 +36895,11 @@ with self;
     };
   };
 
-  TieEncryptedHash = buildPerlPackage {
+  TieEncryptedHash = buildPerlPackage rec {
     pname = "Tie-EncryptedHash";
     version = "1.24";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/V/VI/VIPUL/Tie-EncryptedHash-1.24.tar.gz";
+      url = "mirror://cpan/authors/id/V/VI/VIPUL/Tie-EncryptedHash-${version}.tar.gz";
       hash = "sha256-qpoIOiMeQEYXCliUZE48WWecfb0KotEhfchRUN8sHiE=";
     };
     propagatedBuildInputs = [
@@ -36917,11 +36917,11 @@ with self;
     };
   };
 
-  TieFile = buildPerlPackage {
+  TieFile = buildPerlPackage rec {
     pname = "Tie-File";
     version = "1.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TODDR/Tie-File-1.07.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TODDR/Tie-File-${version}.tar.gz";
       hash = "sha256-S1NUpB/pVBvc6lK0/VMBRPMVME0D8F3Q/vwynYHCawg=";
     };
     meta = {
@@ -36933,11 +36933,11 @@ with self;
     };
   };
 
-  TieIxHash = buildPerlModule {
+  TieIxHash = buildPerlModule rec {
     pname = "Tie-IxHash";
     version = "1.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHORNY/Tie-IxHash-1.23.tar.gz";
+      url = "mirror://cpan/authors/id/C/CH/CHORNY/Tie-IxHash-${version}.tar.gz";
       hash = "sha256-+rsLjJfmfJs0tswY7Wb2xeAcVbJX3PAHVV4LAn1Mr1Y=";
     };
     meta = {
@@ -36949,11 +36949,11 @@ with self;
     };
   };
 
-  TieHandleOffset = buildPerlPackage {
+  TieHandleOffset = buildPerlPackage rec {
     pname = "Tie-Handle-Offset";
     version = "0.004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Tie-Handle-Offset-0.004.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Tie-Handle-Offset-${version}.tar.gz";
       hash = "sha256-7p85BV3GlaokSiUvVv/Tf4vgcgmzN604eCRyEgbSqJ4=";
     };
     meta = {
@@ -36963,11 +36963,11 @@ with self;
     };
   };
 
-  TieHashIndexed = buildPerlPackage {
+  TieHashIndexed = buildPerlPackage rec {
     pname = "Tie-Hash-Indexed";
     version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MH/MHX/Tie-Hash-Indexed-0.08.tar.gz";
+      url = "mirror://cpan/authors/id/M/MH/MHX/Tie-Hash-Indexed-${version}.tar.gz";
       hash = "sha256-N7xigV9ahIrHeRK5v0eIqfJyiE6DpS4gk9q0qDpKexA=";
     };
     doCheck = false; # test fails on some machines
@@ -36980,11 +36980,11 @@ with self;
     };
   };
 
-  TieHashMethod = buildPerlPackage {
+  TieHashMethod = buildPerlPackage rec {
     pname = "Tie-Hash-Method";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Y/YV/YVES/Tie-Hash-Method-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/Y/YV/YVES/Tie-Hash-Method-${version}.tar.gz";
       hash = "sha256-1RP7tRQT98oeZKG9zmGU337GB23qVQZtZ7lQGR7sMqk=";
     };
     meta = {
@@ -36993,11 +36993,11 @@ with self;
     };
   };
 
-  TieRefHash = buildPerlPackage {
+  TieRefHash = buildPerlPackage rec {
     pname = "Tie-RefHash";
     version = "1.40";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Tie-RefHash-1.40.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Tie-RefHash-${version}.tar.gz";
       hash = "sha256-Ws8fUY0vtfYgyq16Gy/x9vdRb++PQLprdD7si5aSftc=";
     };
     meta = {
@@ -37009,11 +37009,11 @@ with self;
     };
   };
 
-  TieRegexpHash = buildPerlPackage {
+  TieRegexpHash = buildPerlPackage rec {
     pname = "Tie-RegexpHash";
     version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AL/ALTREUS/Tie-RegexpHash-0.17.tar.gz";
+      url = "mirror://cpan/authors/id/A/AL/ALTREUS/Tie-RegexpHash-${version}.tar.gz";
       hash = "sha256-DCB4UOd++xZhjgqgFVB5JqNCWzSq1apuPkDYOYmghaM=";
     };
     meta = {
@@ -37022,11 +37022,11 @@ with self;
     };
   };
 
-  TieSimple = buildPerlPackage {
+  TieSimple = buildPerlPackage rec {
     pname = "Tie-Simple";
     version = "1.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HANENKAMP/Tie-Simple-1.04.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HANENKAMP/Tie-Simple-${version}.tar.gz";
       hash = "sha256-KeniEzlRBGx48gXxs+jfYskOEU8OCPoGuBd2ag+AixI=";
     };
     meta = {
@@ -37038,11 +37038,11 @@ with self;
     };
   };
 
-  TieSub = buildPerlPackage {
+  TieSub = buildPerlPackage rec {
     pname = "Tie-Sub";
     version = "1.001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/ST/STEFFENW/Tie-Sub-1.001.tar.gz";
+      url = "mirror://cpan/authors/id/S/ST/STEFFENW/Tie-Sub-${version}.tar.gz";
       hash = "sha256-73GgSCbRNisrduyyHOFzw304pHqf7Cg6qYJDWJD08bE=";
     };
     propagatedBuildInputs = [ ParamsValidate ];
@@ -37061,11 +37061,11 @@ with self;
     };
   };
 
-  TieToObject = buildPerlPackage {
+  TieToObject = buildPerlPackage rec {
     pname = "Tie-ToObject";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NU/NUFFIN/Tie-ToObject-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/N/NU/NUFFIN/Tie-ToObject-${version}.tar.gz";
       hash = "sha256-oxoNRDD+FPWWIvMdt/JbInXa0uxS8QQL6wMNPoOtOvQ=";
     };
     meta = {
@@ -37077,11 +37077,11 @@ with self;
     };
   };
 
-  TimeDate = buildPerlPackage {
+  TimeDate = buildPerlPackage rec {
     pname = "TimeDate";
     version = "2.33";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AT/ATOOMIC/TimeDate-2.33.tar.gz";
+      url = "mirror://cpan/authors/id/A/AT/ATOOMIC/TimeDate-${version}.tar.gz";
       hash = "sha256-wLacSwOd5vUBsNnxPsWMhrBAwffpsn7ySWUcFD1gXrI=";
     };
     meta = {
@@ -37093,11 +37093,11 @@ with self;
     };
   };
 
-  TimeDuration = buildPerlPackage {
+  TimeDuration = buildPerlPackage rec {
     pname = "Time-Duration";
     version = "1.21";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/Time-Duration-1.21.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/Time-Duration-${version}.tar.gz";
       hash = "sha256-/jQOuodl+SY2lGdOXf8UgzRD4Zhl5f9Ce715t7X4qbg=";
     };
     meta = {
@@ -37110,11 +37110,11 @@ with self;
     };
   };
 
-  TimeDurationParse = buildPerlPackage {
+  TimeDurationParse = buildPerlPackage rec {
     pname = "Time-Duration-Parse";
     version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/Time-Duration-Parse-0.16.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/Time-Duration-Parse-${version}.tar.gz";
       hash = "sha256-EISmRj7ieQ+ZIVvXaxNcpFr+K/ppmPpv1UcLaeG6vBI=";
     };
     buildInputs = [ TimeDuration ];
@@ -37129,11 +37129,11 @@ with self;
     };
   };
 
-  TimeLocal = buildPerlPackage {
+  TimeLocal = buildPerlPackage rec {
     pname = "Time-Local";
     version = "1.35";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Time-Local-1.35.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Time-Local-${version}.tar.gz";
       hash = "sha256-HRNrcb0EHL5vZsQxgO555nW3KtWjWWq9akTSEQcq2ik=";
     };
     meta = {
@@ -37146,11 +37146,11 @@ with self;
     };
   };
 
-  TimeMoment = buildPerlPackage {
+  TimeMoment = buildPerlPackage rec {
     pname = "Time-Moment";
     version = "0.44";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHANSEN/Time-Moment-0.44.tar.gz";
+      url = "mirror://cpan/authors/id/C/CH/CHANSEN/Time-Moment-${version}.tar.gz";
       hash = "sha256-ZKz6BC9jT8742t9V5/QrpOqriq631SEuuJgVox949v0=";
     };
     buildInputs = [
@@ -37167,11 +37167,11 @@ with self;
     };
   };
 
-  TimeOut = buildPerlPackage {
+  TimeOut = buildPerlPackage rec {
     pname = "Time-Out";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PA/PATL/Time-Out-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/P/PA/PATL/Time-Out-${version}.tar.gz";
       hash = "sha256-k5baaY/UUtnOYNZCzaIQjxHyDtdsiWF3muEbiXroFdI=";
     };
     meta = {
@@ -37183,11 +37183,11 @@ with self;
     };
   };
 
-  TimeParseDate = buildPerlPackage {
+  TimeParseDate = buildPerlPackage rec {
     pname = "Time-ParseDate";
     version = "2015.103";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MU/MUIR/modules/Time-ParseDate-2015.103.tar.gz";
+      url = "mirror://cpan/authors/id/M/MU/MUIR/modules/Time-ParseDate-${version}.tar.gz";
       hash = "sha256-LBoGI1v4EYE8qsnqqdqnGvdYZnzfewgstZhjIg/K7tE=";
     };
     doCheck = false;
@@ -37197,11 +37197,11 @@ with self;
     };
   };
 
-  TimePeriod = buildPerlPackage {
+  TimePeriod = buildPerlPackage rec {
     pname = "Time-Period";
     version = "1.25";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PB/PBOYD/Time-Period-1.25.tar.gz";
+      url = "mirror://cpan/authors/id/P/PB/PBOYD/Time-Period-${version}.tar.gz";
       hash = "sha256-0H+lgFKb6sapyCdMa/IgtMOq3mhd9lwWadUzOb9u8eg=";
     };
     meta = {
@@ -37214,11 +37214,11 @@ with self;
     };
   };
 
-  TimePiece = buildPerlPackage {
+  TimePiece = buildPerlPackage rec {
     pname = "Time-Piece";
     version = "1.3401";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ES/ESAYM/Time-Piece-1.3401.tar.gz";
+      url = "mirror://cpan/authors/id/E/ES/ESAYM/Time-Piece-${version}.tar.gz";
       hash = "sha256-S1W3uw6rRc8jmlTf6tJ336BhIaQ+Y7P84IU67P2wTCc=";
     };
     meta = {
@@ -37234,11 +37234,11 @@ with self;
 
   Tirex = callPackage ../development/perl-modules/Tirex { };
 
-  Tk = buildPerlPackage {
+  Tk = buildPerlPackage rec {
     pname = "Tk";
     version = "804.036";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SR/SREZIC/Tk-804.036.tar.gz";
+      url = "mirror://cpan/authors/id/S/SR/SREZIC/Tk-${version}.tar.gz";
       hash = "sha256-Mqpycaa9/twzMBGbOCXa3dCqS1yTb4StdOq7kyogCl4=";
     };
     patches = [
@@ -37279,11 +37279,11 @@ with self;
     };
   };
 
-  TkToolBar = buildPerlPackage {
+  TkToolBar = buildPerlPackage rec {
     pname = "Tk-ToolBar";
     version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AS/ASB/Tk-ToolBar-0.12.tar.gz";
+      url = "mirror://cpan/authors/id/A/AS/ASB/Tk-ToolBar-${version}.tar.gz";
       hash = "sha256-Rj4oTsRxN+fEJclpGwKo3sXOJytY6h9jWa6AQaI53Q8=";
     };
     makeMakerFlags = [
@@ -37301,11 +37301,11 @@ with self;
     };
   };
 
-  TreeDAGNode = buildPerlPackage {
+  TreeDAGNode = buildPerlPackage rec {
     pname = "Tree-DAG_Node";
     version = "1.32";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RS/RSAVAGE/Tree-DAG_Node-1.32.tgz";
+      url = "mirror://cpan/authors/id/R/RS/RSAVAGE/Tree-DAG_Node-${version}.tgz";
       hash = "sha256-ItnePW5vSv2J5tglxmT5SCh4vUninLgTQqcHr0BULT0=";
     };
     propagatedBuildInputs = [ FileSlurpTiny ];
@@ -37318,11 +37318,11 @@ with self;
     };
   };
 
-  TreeSimple = buildPerlPackage {
+  TreeSimple = buildPerlPackage rec {
     pname = "Tree-Simple";
     version = "1.34";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RS/RSAVAGE/Tree-Simple-1.34.tgz";
+      url = "mirror://cpan/authors/id/R/RS/RSAVAGE/Tree-Simple-${version}.tgz";
       hash = "sha256-t+l5m9Iiu5TP+ZP312WYDL6hts0qql7L6tY1q99H0pw=";
     };
     buildInputs = [ TestException ];
@@ -37335,11 +37335,11 @@ with self;
     };
   };
 
-  TreeSimpleVisitorFactory = buildPerlPackage {
+  TreeSimpleVisitorFactory = buildPerlPackage rec {
     pname = "Tree-Simple-VisitorFactory";
     version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RS/RSAVAGE/Tree-Simple-VisitorFactory-0.16.tgz";
+      url = "mirror://cpan/authors/id/R/RS/RSAVAGE/Tree-Simple-VisitorFactory-${version}.tgz";
       hash = "sha256-nPU4+qEsVP+0qRQ5lF5IjxhW9iuJrFByqSIRngGIDaY=";
     };
     propagatedBuildInputs = [ TreeSimple ];
@@ -37353,11 +37353,11 @@ with self;
     };
   };
 
-  TryTiny = buildPerlPackage {
+  TryTiny = buildPerlPackage rec {
     pname = "Try-Tiny";
     version = "0.31";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Try-Tiny-0.31.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Try-Tiny-${version}.tar.gz";
       hash = "sha256-MwDTHYpAdbJtj0bOhkodkT4OhGfO66ZlXV0rLiBsEb4=";
     };
     buildInputs = [
@@ -37371,11 +37371,11 @@ with self;
     };
   };
 
-  TryTinyByClass = buildPerlPackage {
+  TryTinyByClass = buildPerlPackage rec {
     pname = "Try-Tiny-ByClass";
     version = "0.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MAUKE/Try-Tiny-ByClass-0.01.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MAUKE/Try-Tiny-ByClass-${version}.tar.gz";
       hash = "sha256-A45O9SkpXyacKA/vmZpeTbkVaULwkaw8rXabHkVw8UY=";
     };
     propagatedBuildInputs = [
@@ -37391,11 +37391,11 @@ with self;
     };
   };
 
-  Twiggy = buildPerlPackage {
+  Twiggy = buildPerlPackage rec {
     pname = "Twiggy";
     version = "0.1026";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Twiggy-0.1026.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Twiggy-${version}.tar.gz";
       hash = "sha256-TZHqbtmumo70MU3Cp89S6wJrNlvmg4azXqaGTfrFf54=";
     };
     propagatedBuildInputs = [
@@ -37418,11 +37418,11 @@ with self;
     };
   };
 
-  TypeTiny = buildPerlPackage {
+  TypeTiny = buildPerlPackage rec {
     pname = "Type-Tiny";
     version = "2.004000";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOBYINK/Type-Tiny-2.004000.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TOBYINK/Type-Tiny-${version}.tar.gz";
       hash = "sha256-aX5/d17fyF9M8HeS0E/RmwnCUoX5j1k46O/E90UHoSg=";
     };
     propagatedBuildInputs = [ ExporterTiny ];
@@ -37437,11 +37437,11 @@ with self;
     };
   };
 
-  TypeTinyXS = buildPerlPackage {
+  TypeTinyXS = buildPerlPackage rec {
     pname = "Type-Tiny-XS";
     version = "0.025";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOBYINK/Type-Tiny-XS-0.025.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TOBYINK/Type-Tiny-XS-${version}.tar.gz";
       hash = "sha256-mmFFDdqQKU9gbNej+kTzsaNmvNiKQZkXsFTuXiPRSL0=";
     };
     meta = {
@@ -37454,11 +37454,11 @@ with self;
     };
   };
 
-  TypesSerialiser = buildPerlPackage {
+  TypesSerialiser = buildPerlPackage rec {
     pname = "Types-Serialiser";
     version = "1.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/Types-Serialiser-1.01.tar.gz";
+      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/Types-Serialiser-${version}.tar.gz";
       hash = "sha256-+McXOwkU0OPZVyggd7Nm8MjHAlZxXq7zKY/zK5I4ioA=";
     };
     propagatedBuildInputs = [ commonsense ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -14592,11 +14592,11 @@ with self;
     };
   };
 
-  GamesSolitaireVerify = buildPerlModule {
+  GamesSolitaireVerify = buildPerlModule rec {
     pname = "Games-Solitaire-Verify";
     version = "0.2403";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Games-Solitaire-Verify-0.2403.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Games-Solitaire-Verify-${version}.tar.gz";
       hash = "sha256-5atHXIK6HLCIrSj0I8pRTUaUTWrjw+tV6WNunn8dyJM=";
     };
     buildInputs = [
@@ -14618,11 +14618,11 @@ with self;
     };
   };
 
-  GD = buildPerlPackage {
+  GD = buildPerlPackage rec {
     pname = "GD";
     version = "2.78";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RU/RURBAN/GD-2.78.tar.gz";
+      url = "mirror://cpan/authors/id/R/RU/RURBAN/GD-${version}.tar.gz";
       hash = "sha256-aDEFS/VCS09cI9NifT0UhEgPb5wsZmMiIpFfKFG+buQ=";
     };
 
@@ -14664,11 +14664,11 @@ with self;
     };
   };
 
-  GDGraph = buildPerlPackage {
+  GDGraph = buildPerlPackage rec {
     pname = "GDGraph";
     version = "1.56";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BP/BPS/GDGraph-1.56.tar.gz";
+      url = "mirror://cpan/authors/id/B/BP/BPS/GDGraph-${version}.tar.gz";
       hash = "sha256-b0nMTlkBVIDbnJtrGK/YxQvjCIZoe2lBFRPQbziXERM=";
     };
     propagatedBuildInputs = [ GDText ];
@@ -14685,11 +14685,11 @@ with self;
     };
   };
 
-  GDSecurityImage = buildPerlPackage {
+  GDSecurityImage = buildPerlPackage rec {
     pname = "GD-SecurityImage";
     version = "1.75";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BU/BURAK/GD-SecurityImage-1.75.tar.gz";
+      url = "mirror://cpan/authors/id/B/BU/BURAK/GD-SecurityImage-${version}.tar.gz";
       hash = "sha256-Pd4k2ay6lRzd5bVp0eQsrZRs/bUSgORGnzNv1f4MjqY=";
     };
     propagatedBuildInputs = [ GD ];
@@ -14702,11 +14702,11 @@ with self;
     };
   };
 
-  GDText = buildPerlPackage {
+  GDText = buildPerlPackage rec {
     pname = "GDTextUtil";
     version = "0.86";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MV/MVERB/GDTextUtil-0.86.tar.gz";
+      url = "mirror://cpan/authors/id/M/MV/MVERB/GDTextUtil-${version}.tar.gz";
       hash = "sha256-iG7L+Fz+lPQTXuVonEhHqa54PsuZ5nWeEsc08t1hFrw=";
     };
     propagatedBuildInputs = [ GD ];
@@ -14719,11 +14719,11 @@ with self;
     };
   };
 
-  GeoIP = buildPerlPackage {
+  GeoIP = buildPerlPackage rec {
     pname = "Geo-IP";
     version = "1.51";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MAXMIND/Geo-IP-1.51.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MAXMIND/Geo-IP-${version}.tar.gz";
       hash = "sha256-FjAgMV1cVEGDaseeCKd7Qo8nf9CQvqT6gNpwd7JDaro=";
     };
     makeMakerFlags = [
@@ -14740,11 +14740,11 @@ with self;
     };
   };
 
-  GeoIP2 = buildPerlPackage {
+  GeoIP2 = buildPerlPackage rec {
     pname = "GeoIP2";
     version = "2.006002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MAXMIND/GeoIP2-2.006002.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MAXMIND/GeoIP2-${version}.tar.gz";
       hash = "sha256-CQVCqO7pvTwS5ZxLZWJMidAf/ZQgTx8Hah20CybAmDQ=";
     };
     propagatedBuildInputs = [
@@ -14770,11 +14770,11 @@ with self;
     };
   };
 
-  GetoptArgvFile = buildPerlPackage {
+  GetoptArgvFile = buildPerlPackage rec {
     pname = "Getopt-ArgvFile";
     version = "1.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JS/JSTENZEL/Getopt-ArgvFile-1.11.tar.gz";
+      url = "mirror://cpan/authors/id/J/JS/JSTENZEL/Getopt-ArgvFile-${version}.tar.gz";
       hash = "sha256-NwmqUTzm/XHRpVoC400vCQAX1TUKm9RHAFZTybCDWyI=";
     };
     meta = {
@@ -14784,11 +14784,11 @@ with self;
     };
   };
 
-  GetoptLong = buildPerlPackage {
+  GetoptLong = buildPerlPackage rec {
     pname = "Getopt-Long";
     version = "2.58";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JV/JV/Getopt-Long-2.58.tar.gz";
+      url = "mirror://cpan/authors/id/J/JV/JV/Getopt-Long-${version}.tar.gz";
       hash = "sha256-EwXtRuoh95QwTpeqPc06OFGQWXhenbdBXa8sIYUGxWk=";
     };
     meta = {
@@ -14800,11 +14800,11 @@ with self;
     };
   };
 
-  GetoptLongDescriptive = buildPerlPackage {
+  GetoptLongDescriptive = buildPerlPackage rec {
     pname = "Getopt-Long-Descriptive";
     version = "0.114";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Getopt-Long-Descriptive-0.114.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Getopt-Long-Descriptive-${version}.tar.gz";
       hash = "sha256-QQ6EIRSpy/0/06X9JIqWcDwHxdh5sqpfnbAzPyMnYBY=";
     };
     buildInputs = [
@@ -14827,11 +14827,11 @@ with self;
     };
   };
 
-  GetoptTabular = buildPerlPackage {
+  GetoptTabular = buildPerlPackage rec {
     pname = "Getopt-Tabular";
     version = "0.3";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GW/GWARD/Getopt-Tabular-0.3.tar.gz";
+      url = "mirror://cpan/authors/id/G/GW/GWARD/Getopt-Tabular-${version}.tar.gz";
       hash = "sha256-m98GdjO1kTEngg9OgDXtxT0INy+qzla6a/oAyWiiU3c=";
     };
     meta = {
@@ -14843,11 +14843,11 @@ with self;
     };
   };
 
-  Git = buildPerlPackage {
+  Git = buildPerlPackage rec {
     pname = "Git";
     version = "0.42";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSOUTH/Git-0.42.tar.gz";
+      url = "mirror://cpan/authors/id/M/MS/MSOUTH/Git-${version}.tar.gz";
       hash = "sha256-lGmp85jzor8rBQBWbuQdP/b65GBBKhNxhXZ6HMR4Om0=";
     };
     propagatedBuildInputs = [ Error ];
@@ -14861,11 +14861,11 @@ with self;
     };
   };
 
-  GitAutofixup = buildPerlPackage {
+  GitAutofixup = buildPerlPackage rec {
     pname = "App-Git-Autofixup";
-    version = "0.005000";
+    version = "0.005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TORBIAK/App-Git-Autofixup-0.005.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TORBIAK/App-Git-Autofixup-${version}.tar.gz";
       hash = "sha256-4mPAOzbD+mDZ7co5xyMyA2x1u6645pYw4Q4yHRqYUTM=";
     };
     meta = {
@@ -14876,11 +14876,11 @@ with self;
     };
   };
 
-  GitPurePerl = buildPerlPackage {
+  GitPurePerl = buildPerlPackage rec {
     pname = "Git-PurePerl";
     version = "0.53";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BR/BROQ/Git-PurePerl-0.53.tar.gz";
+      url = "mirror://cpan/authors/id/B/BR/BROQ/Git-PurePerl-${version}.tar.gz";
       hash = "sha256-mHx0NmzEw37ghAUPmF+iVDWcicElB/W4v8ZgfeU41ag=";
     };
     buildInputs = [ Testutf8 ];
@@ -14904,11 +14904,11 @@ with self;
     };
   };
 
-  GitRepository = buildPerlPackage {
+  GitRepository = buildPerlPackage rec {
     pname = "Git-Repository";
     version = "1.325";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOOK/Git-Repository-1.325.tar.gz";
+      url = "mirror://cpan/authors/id/B/BO/BOOK/Git-Repository-${version}.tar.gz";
       hash = "sha256-mypPoZT0oOtFI1XQyAhyfl6cFsFFrH0kw+qW0Kvv7UM=";
     };
     buildInputs = [ TestRequiresGit ];
@@ -14926,11 +14926,11 @@ with self;
     };
   };
 
-  GitVersionCompare = buildPerlPackage {
+  GitVersionCompare = buildPerlPackage rec {
     pname = "Git-Version-Compare";
     version = "1.005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOOK/Git-Version-Compare-1.005.tar.gz";
+      url = "mirror://cpan/authors/id/B/BO/BOOK/Git-Version-Compare-${version}.tar.gz";
       hash = "sha256-NX/e2eVflesvUWoY9dwbRyCp3u+eLA52vNX+SuubPLs=";
     };
     buildInputs = [ TestNoWarnings ];
@@ -14943,11 +14943,11 @@ with self;
     };
   };
 
-  Glib = buildPerlPackage {
+  Glib = buildPerlPackage rec {
     pname = "Glib";
     version = "1.3294";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XA/XAOC/Glib-1.3294.tar.gz";
+      url = "mirror://cpan/authors/id/X/XA/XAOC/Glib-${version}.tar.gz";
       hash = "sha256-1xX1qGvMGHB13oXnrlvAewcU1u3BlqktpDmG76ROXLs=";
     };
     nativeBuildInputs = [
@@ -14967,11 +14967,11 @@ with self;
     };
   };
 
-  GlibObjectIntrospection = buildPerlPackage {
+  GlibObjectIntrospection = buildPerlPackage rec {
     pname = "Glib-Object-Introspection";
     version = "0.051";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XA/XAOC/Glib-Object-Introspection-0.051.tar.gz";
+      url = "mirror://cpan/authors/id/X/XA/XAOC/Glib-Object-Introspection-${version}.tar.gz";
       hash = "sha256-ZWlhHcyArBSCx8IiZLGujJw1HUmDUR65psX0ehAVAIk=";
     };
     patches = [
@@ -15012,11 +15012,11 @@ with self;
     };
   };
 
-  GnuPGInterface = buildPerlPackage {
+  GnuPGInterface = buildPerlPackage rec {
     pname = "GnuPG-Interface";
     version = "1.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BP/BPS/GnuPG-Interface-1.03.tar.gz";
+      url = "mirror://cpan/authors/id/B/BP/BPS/GnuPG-Interface-${version}.tar.gz";
       hash = "sha256-WvVmMPD6wpDXJCGD9kSaoOAoKfRhHcYrxunps4CPGHo=";
     };
     buildInputs = [
@@ -15037,11 +15037,11 @@ with self;
     };
   };
 
-  GoferTransporthttp = buildPerlPackage {
+  GoferTransporthttp = buildPerlPackage rec {
     pname = "GoferTransport-http";
     version = "1.017";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TI/TIMB/GoferTransport-http-1.017.tar.gz";
+      url = "mirror://cpan/authors/id/T/TI/TIMB/GoferTransport-http-${version}.tar.gz";
       hash = "sha256-9z7/4+p6+hkHzol3yHOHq7DUQE+FpySuJjeymnMVSps=";
     };
     propagatedBuildInputs = [
@@ -15059,11 +15059,11 @@ with self;
     };
   };
 
-  GooCanvas = buildPerlPackage {
+  GooCanvas = buildPerlPackage rec {
     pname = "Goo-Canvas";
     version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Y/YE/YEWENBIN/Goo-Canvas-0.06.tar.gz";
+      url = "mirror://cpan/authors/id/Y/YE/YEWENBIN/Goo-Canvas-${version}.tar.gz";
       hash = "sha256-DFiMUH7tXmLRLtHMHkkcb/Oh9ZxPs9Q14UIUs3qzklE=";
     };
     propagatedBuildInputs = [
@@ -15081,11 +15081,11 @@ with self;
     };
   };
 
-  GooCanvas2 = buildPerlPackage {
+  GooCanvas2 = buildPerlPackage rec {
     pname = "GooCanvas2";
     version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PERLMAX/GooCanvas2-0.06.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PERLMAX/GooCanvas2-${version}.tar.gz";
       hash = "sha256-4kyHhz4ZBj3U1eLHCcqs+MCuiIEEQ5W7hl3CtP3WO1A=";
     };
     buildInputs = [ pkgs.gtk3 ];
@@ -15122,11 +15122,11 @@ with self;
     };
   };
 
-  GoogleProtocolBuffers = buildPerlPackage {
+  GoogleProtocolBuffers = buildPerlPackage rec {
     pname = "Google-ProtocolBuffers";
     version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SA/SAXJAZMAN/protobuf/Google-ProtocolBuffers-0.12.tar.gz";
+      url = "mirror://cpan/authors/id/S/SA/SAXJAZMAN/protobuf/Google-ProtocolBuffers-${version}.tar.gz";
       hash = "sha256-s4RJxguaJxLd5IFIXMerA7KgrBw/1ICzhT5BEawpTXE=";
     };
     propagatedBuildInputs = [
@@ -15145,11 +15145,11 @@ with self;
     };
   };
 
-  gotofile = buildPerlPackage {
+  gotofile = buildPerlPackage rec {
     pname = "goto-file";
     version = "0.005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EX/EXODIST/goto-file-0.005.tar.gz";
+      url = "mirror://cpan/authors/id/E/EX/EXODIST/goto-file-${version}.tar.gz";
       hash = "sha256-xs3V7kps3L2/MU2SpPmYXbzfnkJYBIyudhJcBSqjH3c=";
     };
     buildInputs = [ Test2Suite ];
@@ -15162,11 +15162,11 @@ with self;
     };
   };
 
-  Graph = buildPerlPackage {
+  Graph = buildPerlPackage rec {
     pname = "Graph";
     version = "0.9727";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETJ/Graph-0.9727.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETJ/Graph-${version}.tar.gz";
       hash = "sha256-OSqJFtyVExq+jJE9/Kx2mEhL9IZrQq9fcEPABi50Iik=";
     };
     propagatedBuildInputs = [
@@ -15182,11 +15182,11 @@ with self;
     };
   };
 
-  GraphicsColor = buildPerlPackage {
+  GraphicsColor = buildPerlPackage rec {
     pname = "Graphics-Color";
     version = "0.31";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GP/GPHAT/Graphics-Color-0.31.tar.gz";
+      url = "mirror://cpan/authors/id/G/GP/GPHAT/Graphics-Color-${version}.tar.gz";
       hash = "sha256-+qj+1bLYDlFgr5duXbIkLAs1VVQs4QQldf9raUWHoz0=";
     };
     buildInputs = [
@@ -15211,11 +15211,11 @@ with self;
     };
   };
 
-  GraphicsTIFF = buildPerlPackage {
+  GraphicsTIFF = buildPerlPackage rec {
     pname = "Graphics-TIFF";
     version = "20";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RA/RATCLIFFE/Graphics-TIFF-20.tar.gz";
+      url = "mirror://cpan/authors/id/R/RA/RATCLIFFE/Graphics-TIFF-${version}.tar.gz";
       hash = "sha256-PlXMIJRl4GQBmiFaUvBf9RBAKX0CA5P+n7PeJ60CDjU=";
     };
     nativeBuildInputs = [ pkgs.pkg-config ];
@@ -15239,11 +15239,11 @@ with self;
     };
   };
 
-  GraphicsToolkitColor = buildPerlPackage {
+  GraphicsToolkitColor = buildPerlPackage rec {
     pname = "Graphics-Toolkit-Color";
     version = "1.71";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LI/LICHTKIND/Graphics-Toolkit-Color-1.71.tar.gz";
+      url = "mirror://cpan/authors/id/L/LI/LICHTKIND/Graphics-Toolkit-Color-${version}.tar.gz";
       hash = "sha256-NOiLb2hY9H2ZYQHxWC8esA23+G4Snl8dYb9/m922LvI=";
     };
     buildInputs = [ TestWarn ];
@@ -15256,11 +15256,11 @@ with self;
     };
   };
 
-  GraphViz = buildPerlPackage {
+  GraphViz = buildPerlPackage rec {
     pname = "GraphViz";
     version = "2.26";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETJ/GraphViz-2.26.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETJ/GraphViz-${version}.tar.gz";
       hash = "sha256-ml0lILMmK/MEdSct12SkRfjn+TG++Ivg49O/9EXacyg=";
     };
 
@@ -15283,11 +15283,11 @@ with self;
     };
   };
 
-  GraphViz2 = buildPerlPackage {
+  GraphViz2 = buildPerlPackage rec {
     pname = "GraphViz2";
     version = "2.67";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETJ/GraphViz2-2.67.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETJ/GraphViz2-${version}.tar.gz";
       hash = "sha256-h8hcbt/86k+W5rSAD2+VEq6rGeuNOzSDAachMxvLhYA=";
     };
 
@@ -15320,11 +15320,11 @@ with self;
     };
   };
 
-  grepmail = buildPerlPackage {
+  grepmail = buildPerlPackage rec {
     pname = "grepmail";
     version = "5.3111";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCOPPIT/grepmail-5.3111.tar.gz";
+      url = "mirror://cpan/authors/id/D/DC/DCOPPIT/grepmail-${version}.tar.gz";
       hash = "sha256-0JhOP3ob4XrgFFdfcMFngVGlvMliIYXcWgUstjJxp2E=";
     };
     buildInputs = [
@@ -15347,11 +15347,11 @@ with self;
     };
   };
 
-  GrowlGNTP = buildPerlModule {
+  GrowlGNTP = buildPerlModule rec {
     pname = "Growl-GNTP";
     version = "0.21";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MATTN/Growl-GNTP-0.21.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MATTN/Growl-GNTP-${version}.tar.gz";
       hash = "sha256-KHl/jkJ0BnIFhMr9EOeAp47CtWnFVaGHQ9dFU9X1CD8=";
     };
     buildInputs = [ ModuleBuildTiny ];
@@ -15368,11 +15368,11 @@ with self;
     };
   };
 
-  GSSAPI = buildPerlPackage {
+  GSSAPI = buildPerlPackage rec {
     pname = "GSSAPI";
     version = "0.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AG/AGROLMS/GSSAPI-0.28.tar.gz";
+      url = "mirror://cpan/authors/id/A/AG/AGROLMS/GSSAPI-${version}.tar.gz";
       hash = "sha256-fY8se2F2L7TsctLsKBKQ8vh/nH0pgnPaRSVDKmXncNY=";
     };
     propagatedBuildInputs = [ pkgs.krb5.dev ];
@@ -15393,11 +15393,11 @@ with self;
     };
   };
 
-  Gtk2 = buildPerlPackage {
+  Gtk2 = buildPerlPackage rec {
     pname = "Gtk2";
     version = "1.24993";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XA/XAOC/Gtk2-1.24993.tar.gz";
+      url = "mirror://cpan/authors/id/X/XA/XAOC/Gtk2-${version}.tar.gz";
       hash = "sha256-ScRDdDsu7+EadoACck9/akxI78lP8806VZ+357aTyWc=";
     };
 
@@ -15421,11 +15421,11 @@ with self;
     };
   };
 
-  Gtk2TrayIcon = buildPerlPackage {
+  Gtk2TrayIcon = buildPerlPackage rec {
     pname = "Gtk2-TrayIcon";
     version = "0.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XA/XAOC/Gtk2-TrayIcon-0.07.tar.gz";
+      url = "mirror://cpan/authors/id/X/XA/XAOC/Gtk2-TrayIcon-${version}.tar.gz";
       hash = "sha256-OfwrmabmE9qeqXfYy1MD+l4H5poVJIk03hIXqXuWRVQ=";
     };
     propagatedBuildInputs = [
@@ -15439,11 +15439,11 @@ with self;
     };
   };
 
-  Gtk2AppIndicator = buildPerlPackage {
+  Gtk2AppIndicator = buildPerlPackage rec {
     pname = "Gtk2-AppIndicator";
     version = "0.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OE/OESTERHOL/Gtk2-AppIndicator-0.15.tar.gz";
+      url = "mirror://cpan/authors/id/O/OE/OESTERHOL/Gtk2-AppIndicator-${version}.tar.gz";
       hash = "sha256-olywceIU+4m0RQqkYFAx6uibeWHhSbDW6PSRwZwUqQo=";
     };
     propagatedBuildInputs = [
@@ -15462,11 +15462,11 @@ with self;
     };
   };
 
-  Gtk2ImageView = buildPerlPackage {
+  Gtk2ImageView = buildPerlPackage rec {
     pname = "Gtk2-ImageView";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RA/RATCLIFFE/Gtk2-ImageView-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/R/RA/RATCLIFFE/Gtk2-ImageView-${version}.tar.gz";
       hash = "sha256-CHGGw2k6zxlkUc9ZzIt/XPmnsFq+INMty8uggilT+4A=";
     };
     buildInputs = [
@@ -15484,11 +15484,11 @@ with self;
     };
   };
 
-  Gtk2Unique = buildPerlPackage {
+  Gtk2Unique = buildPerlPackage rec {
     pname = "Gtk2-Unique";
     version = "0.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XA/XAOC/Gtk2-Unique-0.07.tar.gz";
+      url = "mirror://cpan/authors/id/X/XA/XAOC/Gtk2-Unique-${version}.tar.gz";
       hash = "sha256-nOX2ikFgC8z31u/eMMBwqxFOk57XqKx8O3rZE5mJGGc=";
     };
     propagatedBuildInputs = [
@@ -15568,11 +15568,11 @@ with self;
     };
   };
 
-  Gtk3SimpleList = buildPerlPackage {
+  Gtk3SimpleList = buildPerlPackage rec {
     pname = "Gtk3-SimpleList";
     version = "0.21";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TV/TVIGNAUD/Gtk3-SimpleList-0.21.tar.gz";
+      url = "mirror://cpan/authors/id/T/TV/TVIGNAUD/Gtk3-SimpleList-${version}.tar.gz";
       hash = "sha256-HURlEAvzvAR0opRppAb9AzVituNzYYgSEAA3KrKtqIQ=";
     };
     propagatedBuildInputs = [ Gtk3 ];
@@ -15583,11 +15583,11 @@ with self;
     };
   };
 
-  Guard = buildPerlPackage {
+  Guard = buildPerlPackage rec {
     pname = "Guard";
     version = "1.023";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/Guard-1.023.tar.gz";
+      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/Guard-${version}.tar.gz";
       hash = "sha256-NMTd+R/JPRCQ2G2hTfcG0XWxYQxnNywB4SzpVV1N0dw=";
     };
     meta = {
@@ -15599,11 +15599,11 @@ with self;
     };
   };
 
-  HamAPRSFAP = buildPerlPackage {
+  HamAPRSFAP = buildPerlPackage rec {
     pname = "Ham-APRS-FAP";
     version = "1.21";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HE/HESSU/Ham-APRS-FAP-1.21.tar.gz";
+      url = "mirror://cpan/authors/id/H/HE/HESSU/Ham-APRS-FAP-${version}.tar.gz";
       hash = "sha256-4BtFXUb0RxDbzyG2+oQ/CTWM5g7uHEFBvHTgogTToCA=";
     };
     propagatedBuildInputs = [ DateCalc ];
@@ -15617,11 +15617,11 @@ with self;
     };
   };
 
-  Hailo = buildPerlPackage {
+  Hailo = buildPerlPackage rec {
     pname = "Hailo";
     version = "0.75";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AV/AVAR/Hailo-0.75.tar.gz";
+      url = "mirror://cpan/authors/id/A/AV/AVAR/Hailo-${version}.tar.gz";
       hash = "sha256-u6mcsM+j7oYy3YmQbG5voF/muzZ/IoLoiQnO/Y+RdMI=";
     };
     buildInputs = [
@@ -15671,11 +15671,11 @@ with self;
     };
   };
 
-  HashDiff = buildPerlPackage {
+  HashDiff = buildPerlPackage rec {
     pname = "Hash-Diff";
     version = "0.010";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOLAV/Hash-Diff-0.010.tar.gz";
+      url = "mirror://cpan/authors/id/B/BO/BOLAV/Hash-Diff-${version}.tar.gz";
       hash = "sha256-vJpKo47JjwqYKJ41q/mhfC8qMjmiIJoymADglwqi4MU=";
     };
     propagatedBuildInputs = [ HashMerge ];
@@ -15690,11 +15690,11 @@ with self;
     };
   };
 
-  HashFlatten = buildPerlPackage {
+  HashFlatten = buildPerlPackage rec {
     pname = "Hash-Flatten";
     version = "1.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BB/BBC/Hash-Flatten-1.19.tar.gz";
+      url = "mirror://cpan/authors/id/B/BB/BBC/Hash-Flatten-${version}.tar.gz";
       hash = "sha256-cMbEnYtsRgdGQXpQmO3SoP0x/YuGxUv4SS6FPB9OS5g=";
     };
     buildInputs = [ TestAssertions ];
@@ -15705,11 +15705,11 @@ with self;
     };
   };
 
-  HashMerge = buildPerlPackage {
+  HashMerge = buildPerlPackage rec {
     pname = "Hash-Merge";
     version = "0.302";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HE/HERMES/Hash-Merge-0.302.tar.gz";
+      url = "mirror://cpan/authors/id/H/HE/HERMES/Hash-Merge-${version}.tar.gz";
       hash = "sha256-rgUi92U5YIth3eFGcOeWd+DzkQNoMvcKIfMa3eJThkQ=";
     };
     propagatedBuildInputs = [ CloneChoose ];
@@ -15727,11 +15727,11 @@ with self;
     };
   };
 
-  HashMergeSimple = buildPerlPackage {
+  HashMergeSimple = buildPerlPackage rec {
     pname = "Hash-Merge-Simple";
     version = "0.051";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RO/ROKR/Hash-Merge-Simple-0.051.tar.gz";
+      url = "mirror://cpan/authors/id/R/RO/ROKR/Hash-Merge-Simple-${version}.tar.gz";
       hash = "sha256-HFYyeHPS8E1XInd/BEhj2WiRBGaZd0DVWnVAccYoe3M=";
     };
     buildInputs = [
@@ -15751,11 +15751,11 @@ with self;
     };
   };
 
-  HashMoreUtils = buildPerlPackage {
+  HashMoreUtils = buildPerlPackage rec {
     pname = "Hash-MoreUtils";
     version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RE/REHSACK/Hash-MoreUtils-0.06.tar.gz";
+      url = "mirror://cpan/authors/id/R/RE/REHSACK/Hash-MoreUtils-${version}.tar.gz";
       hash = "sha256-25qPuGfVB1PDgIiaXlQHVlG14IybO3IctyIMCINUfeg=";
     };
     meta = {
@@ -15768,11 +15768,11 @@ with self;
     };
   };
 
-  HashMultiValue = buildPerlPackage {
+  HashMultiValue = buildPerlPackage rec {
     pname = "Hash-MultiValue";
     version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AR/ARISTOTLE/Hash-MultiValue-0.16.tar.gz";
+      url = "mirror://cpan/authors/id/A/AR/ARISTOTLE/Hash-MultiValue-${version}.tar.gz";
       hash = "sha256-Zhgd96po4nhvr2iVyIsYuVyACo5Ob7TAf9F2QQo8c/Q=";
     };
     meta = {
@@ -15785,11 +15785,11 @@ with self;
     };
   };
 
-  HashOrdered = buildPerlPackage {
+  HashOrdered = buildPerlPackage rec {
     pname = "Hash-Ordered";
     version = "0.014";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Hash-Ordered-0.014.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Hash-Ordered-${version}.tar.gz";
       hash = "sha256-jcNs15FVrjerij3l/ZEg/7qaMeQJJYwoUp7FJRxZdHs=";
     };
     buildInputs = [
@@ -15804,11 +15804,11 @@ with self;
     };
   };
 
-  HashSafeKeys = buildPerlPackage {
+  HashSafeKeys = buildPerlPackage rec {
     pname = "Hash-SafeKeys";
     version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MO/MOB/Hash-SafeKeys-0.04.tar.gz";
+      url = "mirror://cpan/authors/id/M/MO/MOB/Hash-SafeKeys-${version}.tar.gz";
       hash = "sha256-pSStO/naZ3wfi+bhWXG3ZXVAj3RJI9onZHro8dPDfMw=";
     };
     meta = {
@@ -15820,11 +15820,11 @@ with self;
     };
   };
 
-  HashSharedMem = buildPerlModule {
+  HashSharedMem = buildPerlModule rec {
     pname = "Hash-SharedMem";
     version = "0.005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Hash-SharedMem-0.005.tar.gz";
+      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Hash-SharedMem-${version}.tar.gz";
       hash = "sha256-Mkd2gIYC973EStqpN4lTZUVAKakm+mEfMhyb9rlAu14=";
     };
     env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isAarch64 "-mno-outline-atomics";
@@ -15839,11 +15839,11 @@ with self;
     };
   };
 
-  HashStoredIterator = buildPerlModule {
+  HashStoredIterator = buildPerlModule rec {
     pname = "Hash-StoredIterator";
     version = "0.008";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSCHWERN/Hash-StoredIterator-0.008.tar.gz";
+      url = "mirror://cpan/authors/id/M/MS/MSCHWERN/Hash-StoredIterator-${version}.tar.gz";
       hash = "sha256-ucvE3NgjPo0dfxSB3beaSl+dtxgMs+8CtLy+4F5l6gw=";
     };
     buildInputs = [ Test2Suite ];
@@ -15856,11 +15856,11 @@ with self;
     };
   };
 
-  HashUtilFieldHashCompat = buildPerlPackage {
+  HashUtilFieldHashCompat = buildPerlPackage rec {
     pname = "Hash-Util-FieldHash-Compat";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Hash-Util-FieldHash-Compat-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Hash-Util-FieldHash-Compat-${version}.tar.gz";
       hash = "sha256-ZC5Gp1tTe6EUILMPiwNAPJCgahVFjNgAnzOf6eXzdBs=";
     };
     meta = {
@@ -15872,11 +15872,11 @@ with self;
     };
   };
 
-  HeapFibonacci = buildPerlPackage {
+  HeapFibonacci = buildPerlPackage rec {
     pname = "Heap";
     version = "0.80";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JM/JMM/Heap-0.80.tar.gz";
+      url = "mirror://cpan/authors/id/J/JM/JMM/Heap-${version}.tar.gz";
       hash = "sha256-zNop88kxdq0P3/9N1vXkrJCzcMuksCg4a3NDv2QTm94=";
     };
     meta = {
@@ -15888,11 +15888,11 @@ with self;
     };
   };
 
-  HookLexWrap = buildPerlPackage {
+  HookLexWrap = buildPerlPackage rec {
     pname = "Hook-LexWrap";
     version = "0.26";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Hook-LexWrap-0.26.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Hook-LexWrap-${version}.tar.gz";
       hash = "sha256-tgvcX5j5T5KUsGre+CsdmW2hktXxg/n0NLYQ/RE37C0=";
     };
     buildInputs = [ pkgs.unzip ];
@@ -15906,11 +15906,11 @@ with self;
     };
   };
 
-  HTMLClean = buildPerlPackage {
+  HTMLClean = buildPerlPackage rec {
     pname = "HTML-Clean";
     version = "1.4";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AZ/AZJADFTRE/HTML-Clean-1.4.tar.gz";
+      url = "mirror://cpan/authors/id/A/AZ/AZJADFTRE/HTML-Clean-${version}.tar.gz";
       hash = "sha256-pn1KvadR/DxrSjUYU3eoi8pbZRxgszN5gEtOkKF4hwY=";
     };
     meta = {
@@ -15923,11 +15923,11 @@ with self;
     };
   };
 
-  HTMLElementExtended = buildPerlPackage {
+  HTMLElementExtended = buildPerlPackage rec {
     pname = "HTML-Element-Extended";
     version = "1.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSISK/HTML-Element-Extended-1.18.tar.gz";
+      url = "mirror://cpan/authors/id/M/MS/MSISK/HTML-Element-Extended-${version}.tar.gz";
       hash = "sha256-8+8a8Qjyf+8V6+xmR58lHOCKpJvQCwRiycgMhrS2sys=";
     };
     propagatedBuildInputs = [ HTMLTree ];
@@ -15940,11 +15940,11 @@ with self;
     };
   };
 
-  HTMLEscape = buildPerlModule {
+  HTMLEscape = buildPerlModule rec {
     pname = "HTML-Escape";
     version = "1.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOKUHIROM/HTML-Escape-1.11.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TOKUHIROM/HTML-Escape-${version}.tar.gz";
       hash = "sha256-Wl7viWUA0epsJKkIXs++mkOr7mjPxmwD+InSostoml0=";
     };
     buildInputs = [
@@ -15961,11 +15961,11 @@ with self;
     };
   };
 
-  HTMLFromANSI = buildPerlPackage {
+  HTMLFromANSI = buildPerlPackage rec {
     pname = "HTML-FromANSI";
     version = "2.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NU/NUFFIN/HTML-FromANSI-2.03.tar.gz";
+      url = "mirror://cpan/authors/id/N/NU/NUFFIN/HTML-FromANSI-${version}.tar.gz";
       hash = "sha256-IXdjRe1wGywEx7CTgK+UP5mEzH+ZYkCHrqRdtfwJw1k=";
     };
     propagatedBuildInputs = [
@@ -15982,11 +15982,11 @@ with self;
     };
   };
 
-  HTMLForm = buildPerlPackage {
+  HTMLForm = buildPerlPackage rec {
     pname = "HTML-Form";
     version = "6.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SI/SIMBABQUE/HTML-Form-6.11.tar.gz";
+      url = "mirror://cpan/authors/id/S/SI/SIMBABQUE/HTML-Form-${version}.tar.gz";
       hash = "sha256-Q7+qcIc5NIfS1RJhoap/b4Gpex2P73pI/PbvMrFtZFQ=";
     };
     buildInputs = [ TestWarnings ];
@@ -16004,11 +16004,11 @@ with self;
     };
   };
 
-  HTMLFormatter = buildPerlPackage {
+  HTMLFormatter = buildPerlPackage rec {
     pname = "HTML-Formatter";
     version = "2.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NI/NIGELM/HTML-Formatter-2.16.tar.gz";
+      url = "mirror://cpan/authors/id/N/NI/NIGELM/HTML-Formatter-${version}.tar.gz";
       hash = "sha256-ywoN2Kpei6nKIUzkUb9N8zqgnBPpB+jTCC3a/rMBUcw=";
     };
     buildInputs = [
@@ -16029,11 +16029,11 @@ with self;
     };
   };
 
-  HTMLFormatExternal = buildPerlPackage {
+  HTMLFormatExternal = buildPerlPackage rec {
     pname = "HTML-FormatExternal";
     version = "26";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KR/KRYDE/HTML-FormatExternal-26.tar.gz";
+      url = "mirror://cpan/authors/id/K/KR/KRYDE/HTML-FormatExternal-${version}.tar.gz";
       hash = "sha256-PFnyM9CxBoaoWu0MmUARzsaGJtoBKN6pC1xP3BdGz8M=";
     };
     propagatedBuildInputs = [
@@ -16048,11 +16048,11 @@ with self;
     };
   };
 
-  HTMLFormatTextWithLinks = buildPerlModule {
+  HTMLFormatTextWithLinks = buildPerlModule rec {
     pname = "HTML-FormatText-WithLinks";
     version = "0.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/ST/STRUAN/HTML-FormatText-WithLinks-0.15.tar.gz";
+      url = "mirror://cpan/authors/id/S/ST/STRUAN/HTML-FormatText-WithLinks-${version}.tar.gz";
       hash = "sha256-f8wat561j7l9Q+W90U4heRolCiBJmJGMYtahcRMYM7E=";
     };
     propagatedBuildInputs = [ HTMLFormatter ];
@@ -16065,11 +16065,11 @@ with self;
     };
   };
 
-  HTMLFormatTextWithLinksAndTables = buildPerlPackage {
+  HTMLFormatTextWithLinksAndTables = buildPerlPackage rec {
     pname = "HTML-FormatText-WithLinks-AndTables";
     version = "0.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DALEEVANS/HTML-FormatText-WithLinks-AndTables-0.07.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DALEEVANS/HTML-FormatText-WithLinks-AndTables-${version}.tar.gz";
       hash = "sha256-gJ7i8RcFcGszxUMStce+5nSDjyvqrtr4y5RecCquObY=";
     };
     propagatedBuildInputs = [ HTMLFormatTextWithLinks ];
@@ -16082,11 +16082,11 @@ with self;
     };
   };
 
-  HTMLFormFu = buildPerlPackage {
+  HTMLFormFu = buildPerlPackage rec {
     pname = "HTML-FormFu";
     version = "2.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CF/CFRANKS/HTML-FormFu-2.07.tar.gz";
+      url = "mirror://cpan/authors/id/C/CF/CFRANKS/HTML-FormFu-${version}.tar.gz";
       hash = "sha256-Ty8Bf3qHVPu26RIGyI7RPHVqFOO+oXgYjDuXdGNm6zI=";
     };
     buildInputs = [
@@ -16126,11 +16126,11 @@ with self;
     };
   };
 
-  HTMLFormFuMultiForm = buildPerlPackage {
+  HTMLFormFuMultiForm = buildPerlPackage rec {
     pname = "HTML-FormFu-MultiForm";
     version = "1.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NI/NIGELM/HTML-FormFu-MultiForm-1.03.tar.gz";
+      url = "mirror://cpan/authors/id/N/NI/NIGELM/HTML-FormFu-MultiForm-${version}.tar.gz";
       hash = "sha256-NvAM12u4luTaCd0rsOXYkGZ/cMePVCUa9NJYyCFJFZ8=";
     };
     propagatedBuildInputs = [
@@ -16148,11 +16148,11 @@ with self;
     };
   };
 
-  HTMLFormHandler = buildPerlPackage {
+  HTMLFormHandler = buildPerlPackage rec {
     pname = "HTML-FormHandler";
     version = "0.40068";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GS/GSHANK/HTML-FormHandler-0.40068.tar.gz";
+      url = "mirror://cpan/authors/id/G/GS/GSHANK/HTML-FormHandler-${version}.tar.gz";
       hash = "sha256-63t43aMSV1LMi8wDltOXf70o2jPS1ExQQq1tNdbN6Cc=";
     };
     # a single test is failing on perl 5.20
@@ -16187,11 +16187,11 @@ with self;
     };
   };
 
-  HTMLGumbo = buildPerlModule {
+  HTMLGumbo = buildPerlModule rec {
     pname = "HTML-Gumbo";
     version = "0.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RU/RUZ/HTML-Gumbo-0.18.tar.gz";
+      url = "mirror://cpan/authors/id/R/RU/RUZ/HTML-Gumbo-${version}.tar.gz";
       hash = "sha256-v1C2HCRlbMP8lYYC2AqcfQFyR6842Nv6Dp3sW3VCXV8=";
     };
     propagatedBuildInputs = [ AlienLibGumbo ];
@@ -16204,11 +16204,11 @@ with self;
     };
   };
 
-  HTMLMason = buildPerlPackage {
+  HTMLMason = buildPerlPackage rec {
     pname = "HTML-Mason";
     version = "1.60";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/HTML-Mason-1.60.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/HTML-Mason-${version}.tar.gz";
       hash = "sha256-qgu9WmtjxiyJVfjFXsCF43DXktZSZrbDtcXweIu8d+Y=";
     };
     buildInputs = [ TestDeep ];
@@ -16229,11 +16229,11 @@ with self;
     };
   };
 
-  HTMLMasonPSGIHandler = buildPerlPackage {
+  HTMLMasonPSGIHandler = buildPerlPackage rec {
     pname = "HTML-Mason-PSGIHandler";
     version = "0.53";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RU/RUZ/HTML-Mason-PSGIHandler-0.53.tar.gz";
+      url = "mirror://cpan/authors/id/R/RU/RUZ/HTML-Mason-PSGIHandler-${version}.tar.gz";
       hash = "sha256-6v18dlXfqCYd80RrkxooPTAwaHe4OsRnHEnP906n8As=";
     };
     buildInputs = [ Plack ];
@@ -16251,11 +16251,11 @@ with self;
     };
   };
 
-  HTMLParser = buildPerlPackage {
+  HTMLParser = buildPerlPackage rec {
     pname = "HTML-Parser";
     version = "3.81";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OA/OALDERS/HTML-Parser-3.81.tar.gz";
+      url = "mirror://cpan/authors/id/O/OA/OALDERS/HTML-Parser-${version}.tar.gz";
       hash = "sha256-wJEKXI+S+IF+3QbM/SJLocLr6MEPVR8DJYeh/IPWL/I=";
     };
     propagatedBuildInputs = [
@@ -16272,11 +16272,11 @@ with self;
     };
   };
 
-  HTMLTagCloud = buildPerlModule {
+  HTMLTagCloud = buildPerlModule rec {
     pname = "HTML-TagCloud";
     version = "0.38";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RO/ROBERTSD/HTML-TagCloud-0.38.tar.gz";
+      url = "mirror://cpan/authors/id/R/RO/ROBERTSD/HTML-TagCloud-${version}.tar.gz";
       hash = "sha256-SYCZRy3vhmtEi/YvQYLfrfWUcuE/JMuGZKZxynm2cBU=";
     };
     meta = {
@@ -16288,11 +16288,11 @@ with self;
     };
   };
 
-  HTMLQuoted = buildPerlPackage {
+  HTMLQuoted = buildPerlPackage rec {
     pname = "HTML-Quoted";
     version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TS/TSIBLEY/HTML-Quoted-0.04.tar.gz";
+      url = "mirror://cpan/authors/id/T/TS/TSIBLEY/HTML-Quoted-${version}.tar.gz";
       hash = "sha256-i0HzE/3BgS8C9vbDfVjyEshP3PeCf3/UsDCQfzncZQw=";
     };
     propagatedBuildInputs = [ HTMLParser ];
@@ -16305,11 +16305,11 @@ with self;
     };
   };
 
-  HTMLRewriteAttributes = buildPerlPackage {
+  HTMLRewriteAttributes = buildPerlPackage rec {
     pname = "HTML-RewriteAttributes";
-    version = "0.05";
+    version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BP/BPS/HTML-RewriteAttributes-0.06.tar.gz";
+      url = "mirror://cpan/authors/id/B/BP/BPS/HTML-RewriteAttributes-${version}.tar.gz";
       hash = "sha256-vGQgAmEUL5pffgeG3FqySmMwvBm9Hj6btLbXwxYhtyI=";
     };
     propagatedBuildInputs = [ HTMLParser ];
@@ -16322,11 +16322,11 @@ with self;
     };
   };
 
-  HTMLSelectorXPath = buildPerlPackage {
+  HTMLSelectorXPath = buildPerlPackage rec {
     pname = "HTML-Selector-XPath";
     version = "0.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CO/CORION/HTML-Selector-XPath-0.28.tar.gz";
+      url = "mirror://cpan/authors/id/C/CO/CORION/HTML-Selector-XPath-${version}.tar.gz";
       hash = "sha256-QycX8D7Szz1kETDP09ShU/Ca1PhW2gB4E3kv4LLljQ8=";
     };
     buildInputs = [ TestBase ];
@@ -16339,11 +16339,11 @@ with self;
     };
   };
 
-  HTMLScrubber = buildPerlPackage {
+  HTMLScrubber = buildPerlPackage rec {
     pname = "HTML-Scrubber";
     version = "0.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NI/NIGELM/HTML-Scrubber-0.19.tar.gz";
+      url = "mirror://cpan/authors/id/N/NI/NIGELM/HTML-Scrubber-${version}.tar.gz";
       hash = "sha256-rihVePhWX5FUxj5CNHBLV7aDX3ei+C/+ckiZ1FMmK7E=";
     };
     propagatedBuildInputs = [ HTMLParser ];
@@ -16360,11 +16360,11 @@ with self;
     };
   };
 
-  HTMLStripScripts = buildPerlPackage {
+  HTMLStripScripts = buildPerlPackage rec {
     pname = "HTML-StripScripts";
     version = "1.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DRTECH/HTML-StripScripts-1.06.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DRTECH/HTML-StripScripts-${version}.tar.gz";
       hash = "sha256-Iiv7fsH9+kZeMto9xKvtLtxzZLvhno48UTx9WFsBCa0=";
     };
     meta = {
@@ -16376,11 +16376,11 @@ with self;
     };
   };
 
-  HTMLStripScriptsParser = buildPerlPackage {
+  HTMLStripScriptsParser = buildPerlPackage rec {
     pname = "HTML-StripScripts-Parser";
     version = "1.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DRTECH/HTML-StripScripts-Parser-1.03.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DRTECH/HTML-StripScripts-Parser-${version}.tar.gz";
       hash = "sha256-R4waTkbrd/p7zpa6KIFo8LmMJ/JQ4A3GMSNlCBrtNAc=";
     };
     propagatedBuildInputs = [
@@ -16396,11 +16396,11 @@ with self;
     };
   };
 
-  HTMLTableExtract = buildPerlPackage {
+  HTMLTableExtract = buildPerlPackage rec {
     pname = "HTML-TableExtract";
     version = "2.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSISK/HTML-TableExtract-2.15.tar.gz";
+      url = "mirror://cpan/authors/id/M/MS/MSISK/HTML-TableExtract-${version}.tar.gz";
       hash = "sha256-hsWcnVjaPKF02l5i9aD7AvTaArGx4B355dFLtl5MPs8=";
     };
     preCheck = ''
@@ -16417,11 +16417,11 @@ with self;
     };
   };
 
-  HTMLTagset = buildPerlPackage {
+  HTMLTagset = buildPerlPackage rec {
     pname = "HTML-Tagset";
     version = "3.20";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PETDANCE/HTML-Tagset-3.20.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PETDANCE/HTML-Tagset-${version}.tar.gz";
       hash = "sha256-rbF9rJ42zQEfUkOIHJc5QX/RAvznYPjeTpvkxxMRCOI=";
     };
     meta = {
@@ -16433,11 +16433,11 @@ with self;
     };
   };
 
-  HTMLTemplate = buildPerlPackage {
+  HTMLTemplate = buildPerlPackage rec {
     pname = "HTML-Template";
     version = "2.97";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SA/SAMTREGAR/HTML-Template-2.97.tar.gz";
+      url = "mirror://cpan/authors/id/S/SA/SAMTREGAR/HTML-Template-${version}.tar.gz";
       hash = "sha256-ZUevYfOqhXk/hhYZCTjWd9eZX7O3IMFiWAQLyTXiEp8=";
     };
     propagatedBuildInputs = [ CGI ];
@@ -16451,11 +16451,11 @@ with self;
     };
   };
 
-  HTMLTidy = buildPerlPackage {
+  HTMLTidy = buildPerlPackage rec {
     pname = "HTML-Tidy";
     version = "1.60";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PETDANCE/HTML-Tidy-1.60.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PETDANCE/HTML-Tidy-${version}.tar.gz";
       hash = "sha256-vPv2XWh/jmcs9gyYIbzWXV6McqeCcrZ7sKwcaZoT18c=";
     };
 
@@ -16472,11 +16472,11 @@ with self;
     };
   };
 
-  HTMLTiny = buildPerlPackage {
+  HTMLTiny = buildPerlPackage rec {
     pname = "HTML-Tiny";
     version = "1.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AR/ARISTOTLE/HTML-Tiny-1.08.tar.gz";
+      url = "mirror://cpan/authors/id/A/AR/ARISTOTLE/HTML-Tiny-${version}.tar.gz";
       hash = "sha256-DwHfDJ/ICz2dooi6q/jApTdHRE964euWAOevxKPc/rU=";
     };
     meta = {
@@ -16488,11 +16488,11 @@ with self;
     };
   };
 
-  HTMLTokeParserSimple = buildPerlModule {
+  HTMLTokeParserSimple = buildPerlModule rec {
     pname = "HTML-TokeParser-Simple";
     version = "3.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OV/OVID/HTML-TokeParser-Simple-3.16.tar.gz";
+      url = "mirror://cpan/authors/id/O/OV/OVID/HTML-TokeParser-Simple-${version}.tar.gz";
       hash = "sha256-7RETXGg55uDq+WlS5qw1Oi8i67QKchZZZx5dLcwOSp0=";
     };
     propagatedBuildInputs = [
@@ -16508,11 +16508,11 @@ with self;
     };
   };
 
-  HTMLTree = buildPerlModule {
+  HTMLTree = buildPerlModule rec {
     pname = "HTML-Tree";
     version = "5.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KE/KENTNL/HTML-Tree-5.07.tar.gz";
+      url = "mirror://cpan/authors/id/K/KE/KENTNL/HTML-Tree-${version}.tar.gz";
       hash = "sha256-8DdNuEcxwgS4bB1bkJdf7w0wqGvZ3vkZND5VTjGp278=";
     };
     buildInputs = [ TestFatal ];
@@ -16527,11 +16527,11 @@ with self;
     };
   };
 
-  HTMLTreeBuilderXPath = buildPerlPackage {
+  HTMLTreeBuilderXPath = buildPerlPackage rec {
     pname = "HTML-TreeBuilder-XPath";
     version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIROD/HTML-TreeBuilder-XPath-0.14.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIROD/HTML-TreeBuilder-XPath-${version}.tar.gz";
       hash = "sha256-Jeu9skRKClma5eekV9deCe/N8yZqXFcAsUA8y3SIpPM=";
     };
     propagatedBuildInputs = [
@@ -16547,11 +16547,11 @@ with self;
     };
   };
 
-  HTMLWidget = buildPerlPackage {
+  HTMLWidget = buildPerlPackage rec {
     pname = "HTML-Widget";
     version = "1.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CF/CFRANKS/HTML-Widget-1.11.tar.gz";
+      url = "mirror://cpan/authors/id/C/CF/CFRANKS/HTML-Widget-${version}.tar.gz";
       hash = "sha256-vkLfQFWSXOalob818eB60SvEP2VJ91JJAuozMFoOggs=";
     };
     doCheck = false;
@@ -16574,11 +16574,11 @@ with self;
     };
   };
 
-  HTTPAcceptLanguage = buildPerlModule {
+  HTTPAcceptLanguage = buildPerlModule rec {
     pname = "HTTP-AcceptLanguage";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Y/YA/YAPPO/HTTP-AcceptLanguage-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/Y/YA/YAPPO/HTTP-AcceptLanguage-${version}.tar.gz";
       hash = "sha256-LmBfVk7J66tlVI/17sk/nF3qvv7XBzpyneCuKE5OQq8=";
     };
     buildInputs = [ ModuleBuildTiny ];
@@ -16592,11 +16592,11 @@ with self;
     };
   };
 
-  HTTPBody = buildPerlPackage {
+  HTTPBody = buildPerlPackage rec {
     pname = "HTTP-Body";
     version = "1.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GE/GETTY/HTTP-Body-1.23.tar.gz";
+      url = "mirror://cpan/authors/id/G/GE/GETTY/HTTP-Body-${version}.tar.gz";
       hash = "sha256-7OmB9BYWNaL7piFdAlcZXlOMTyNDhFMFAd/bahvY1jY=";
     };
     buildInputs = [ TestDeep ];
@@ -16610,11 +16610,11 @@ with self;
     };
   };
 
-  HTTPCookieJar = buildPerlPackage {
+  HTTPCookieJar = buildPerlPackage rec {
     pname = "HTTP-CookieJar";
     version = "0.014";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/HTTP-CookieJar-0.014.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/HTTP-CookieJar-${version}.tar.gz";
       hash = "sha256-cJTqXJH1NtJjuF6Dq06alj4RxECM4I7K5VP6nAzEfnM=";
     };
     propagatedBuildInputs = [ HTTPDate ];
@@ -16632,11 +16632,11 @@ with self;
     };
   };
 
-  HTTPCookies = buildPerlPackage {
+  HTTPCookies = buildPerlPackage rec {
     pname = "HTTP-Cookies";
     version = "6.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OA/OALDERS/HTTP-Cookies-6.10.tar.gz";
+      url = "mirror://cpan/authors/id/O/OA/OALDERS/HTTP-Cookies-${version}.tar.gz";
       hash = "sha256-4282Yzxc5rXkuHb/z3R4fMXv4HNt1/SHvdc8FPC9cAc=";
     };
     propagatedBuildInputs = [ HTTPMessage ];
@@ -16650,11 +16650,11 @@ with self;
     };
   };
 
-  HTTPDaemon = buildPerlPackage {
+  HTTPDaemon = buildPerlPackage rec {
     pname = "HTTP-Daemon";
     version = "6.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OA/OALDERS/HTTP-Daemon-6.16.tar.gz";
+      url = "mirror://cpan/authors/id/O/OA/OALDERS/HTTP-Daemon-${version}.tar.gz";
       hash = "sha256-s40JJyXm+k4MTcKkfhVwcEkbr6Db4Wx4o1joBqp+Fz0=";
     };
     buildInputs = [
@@ -16673,11 +16673,11 @@ with self;
     };
   };
 
-  HTTPDaemonSSL = buildPerlPackage {
+  HTTPDaemonSSL = buildPerlPackage rec {
     pname = "HTTP-Daemon-SSL";
     version = "1.05-01-5";
     src = fetchurl {
-      url = "https://salsa.debian.org/perl-team/modules/packages/libhttp-daemon-ssl-perl/-/archive/debian/1.05-01-5/libhttp-daemon-ssl-perl-debian-1.05-01-5.tar.gz";
+      url = "https://salsa.debian.org/perl-team/modules/packages/libhttp-daemon-ssl-perl/-/archive/debian/${version}/libhttp-daemon-ssl-perl-debian-${version}.tar.gz";
       hash = "sha256-2J4W3SAPgktQ8N+CTSm9fddaUlfzq074sj14fe5zHVc=";
     };
     patches = [
@@ -16685,22 +16685,22 @@ with self;
       # https://sources.debian.org/patches/libhttp-daemon-ssl-perl/1.05-01-5/
       (fetchpatch2 {
         name = "testmodule.diff";
-        url = "https://sources.debian.org/data/main/libh/libhttp-daemon-ssl-perl/1.05-01-5/debian/patches/testmodule.diff";
+        url = "https://sources.debian.org/data/main/libh/libhttp-daemon-ssl-perl/${version}/debian/patches/testmodule.diff";
         hash = "sha256-pVPtQLlMYr7Bm8QprJbCyfY+6SyZ/v7uuqvX3k/GnGs=";
       })
       (fetchpatch2 {
         name = "testpost.diff";
-        url = "https://sources.debian.org/data/main/libh/libhttp-daemon-ssl-perl/1.05-01-5/debian/patches/testpost.diff";
+        url = "https://sources.debian.org/data/main/libh/libhttp-daemon-ssl-perl/${version}/debian/patches/testpost.diff";
         hash = "sha256-clI4u2uYGPow8k3YjnjQFam5IK/xlW8SsJvJ/pwMm4o=";
       })
       (fetchpatch2 {
         name = "IO-Socket-SSL_2.078.patch";
-        url = "https://sources.debian.org/data/main/libh/libhttp-daemon-ssl-perl/1.05-01-5/debian/patches/IO-Socket-SSL_2.078.patch";
+        url = "https://sources.debian.org/data/main/libh/libhttp-daemon-ssl-perl/${version}/debian/patches/IO-Socket-SSL_2.078.patch";
         hash = "sha256-EoZPj7mlDm+KKAuXTdIhlyWAFjG9H8tqeZj42ZwV4no=";
       })
       (fetchpatch2 {
         name = "IO-Socket-SSL_2.079.patch";
-        url = "https://sources.debian.org/data/main/libh/libhttp-daemon-ssl-perl/1.05-01-5/debian/patches/IO-Socket-SSL_2.079.patch";
+        url = "https://sources.debian.org/data/main/libh/libhttp-daemon-ssl-perl/${version}/debian/patches/IO-Socket-SSL_2.079.patch";
         hash = "sha256-xT533707i+ZCn1/qDZJU/oW8j+Sk8WWbIPulddJPb1w=";
       })
     ];
@@ -16719,11 +16719,11 @@ with self;
     };
   };
 
-  HTTPDate = buildPerlPackage {
+  HTTPDate = buildPerlPackage rec {
     pname = "HTTP-Date";
     version = "6.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OA/OALDERS/HTTP-Date-6.06.tar.gz";
+      url = "mirror://cpan/authors/id/O/OA/OALDERS/HTTP-Date-${version}.tar.gz";
       hash = "sha256-e2hRkcasw+dz0fwCyV7h+frpT3d4MXX154wYHMktK1I=";
     };
     propagatedBuildInputs = [ TimeDate ];
@@ -16737,11 +16737,11 @@ with self;
     };
   };
 
-  HTTPEntityParser = buildPerlModule {
+  HTTPEntityParser = buildPerlModule rec {
     pname = "HTTP-Entity-Parser";
     version = "0.25";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KAZEBURO/HTTP-Entity-Parser-0.25.tar.gz";
+      url = "mirror://cpan/authors/id/K/KA/KAZEBURO/HTTP-Entity-Parser-${version}.tar.gz";
       hash = "sha256-OozQ2Muj0XzYwE7oLXNB36okfb3ZSknrlLU/aeSD7Do=";
     };
     propagatedBuildInputs = [
@@ -16765,11 +16765,11 @@ with self;
     };
   };
 
-  HTTPDAV = buildPerlPackage {
+  HTTPDAV = buildPerlPackage rec {
     pname = "HTTP-DAV";
     version = "0.49";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CO/COSIMO/HTTP-DAV-0.49.tar.gz";
+      url = "mirror://cpan/authors/id/C/CO/COSIMO/HTTP-DAV-${version}.tar.gz";
       hash = "sha256-MzOd+ewQbeN9hgnP0NPAg8z7sGwWxlG1s4UaVtF6lXw=";
     };
     propagatedBuildInputs = [ XMLDOM ];
@@ -16783,11 +16783,11 @@ with self;
     };
   };
 
-  HTTPHeadersActionPack = buildPerlPackage {
+  HTTPHeadersActionPack = buildPerlPackage rec {
     pname = "HTTP-Headers-ActionPack";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/HTTP-Headers-ActionPack-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/HTTP-Headers-ActionPack-${version}.tar.gz";
       hash = "sha256-x4ERq4V+SMaYJJA9S2zoKT/v/GtdZw21UKdn+FOsx9o=";
     };
     buildInputs = [
@@ -16810,11 +16810,11 @@ with self;
     };
   };
 
-  HTTPHeadersFast = buildPerlModule {
+  HTTPHeadersFast = buildPerlModule rec {
     pname = "HTTP-Headers-Fast";
     version = "0.22";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOKUHIROM/HTTP-Headers-Fast-0.22.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TOKUHIROM/HTTP-Headers-Fast-${version}.tar.gz";
       hash = "sha256-zEMdtoSW3YhNtLwMC3ESwfSk8dxoxPWjyqdXoedIG0g=";
     };
     buildInputs = [
@@ -16832,11 +16832,11 @@ with self;
     };
   };
 
-  HTTPLite = buildPerlPackage {
+  HTTPLite = buildPerlPackage rec {
     pname = "HTTP-Lite";
     version = "2.44";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/HTTP-Lite-2.44.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/HTTP-Lite-${version}.tar.gz";
       hash = "sha256-OOQ9eRHPwU46OPA4K2zHptVZMH0jsQnOc6x9JKmz53w=";
     };
     buildInputs = [ CGI ];
@@ -16849,11 +16849,11 @@ with self;
     };
   };
 
-  HTTPMessage = buildPerlPackage {
+  HTTPMessage = buildPerlPackage rec {
     pname = "HTTP-Message";
     version = "6.45";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OA/OALDERS/HTTP-Message-6.45.tar.gz";
+      url = "mirror://cpan/authors/id/O/OA/OALDERS/HTTP-Message-${version}.tar.gz";
       hash = "sha256-AcuEBmEqP3OIQtHpcxOuTYdIcNG41tZjMfFgAJQ9TL4=";
     };
     buildInputs = [
@@ -16878,11 +16878,11 @@ with self;
     };
   };
 
-  HTTPMultiPartParser = buildPerlPackage {
+  HTTPMultiPartParser = buildPerlPackage rec {
     pname = "HTTP-MultiPartParser";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHANSEN/HTTP-MultiPartParser-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/C/CH/CHANSEN/HTTP-MultiPartParser-${version}.tar.gz";
       hash = "sha256-Xt3aFZ9U0W+GjgMkQKwrAk5VqsSJMYcbYmJ/GhbQCxI=";
     };
     buildInputs = [ TestDeep ];
@@ -16895,11 +16895,11 @@ with self;
     };
   };
 
-  HTTPNegotiate = buildPerlPackage {
+  HTTPNegotiate = buildPerlPackage rec {
     pname = "HTTP-Negotiate";
     version = "6.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GA/GAAS/HTTP-Negotiate-6.01.tar.gz";
+      url = "mirror://cpan/authors/id/G/GA/GAAS/HTTP-Negotiate-${version}.tar.gz";
       hash = "sha256-HHKcHqYxAOh4QFzafWb5rf0+1PHWysrKDukVLfco4BY=";
     };
     propagatedBuildInputs = [ HTTPMessage ];
@@ -16912,11 +16912,11 @@ with self;
     };
   };
 
-  HTTPParserXS = buildPerlPackage {
+  HTTPParserXS = buildPerlPackage rec {
     pname = "HTTP-Parser-XS";
     version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KAZUHO/HTTP-Parser-XS-0.17.tar.gz";
+      url = "mirror://cpan/authors/id/K/KA/KAZUHO/HTTP-Parser-XS-${version}.tar.gz";
       hash = "sha256-eU5oM+MmsQ0kNp+c2/wWZxBe9lkej0HlYaPUGnAnqAk=";
     };
     meta = {
@@ -16928,11 +16928,11 @@ with self;
     };
   };
 
-  HTTPProxy = buildPerlPackage {
+  HTTPProxy = buildPerlPackage rec {
     pname = "HTTP-Proxy";
     version = "0.304";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOOK/HTTP-Proxy-0.304.tar.gz";
+      url = "mirror://cpan/authors/id/B/BO/BOOK/HTTP-Proxy-${version}.tar.gz";
       hash = "sha256-sFKQU07HNiXCGgVl/DUXCJDasWOEPZUzHCksI/UExp0=";
     };
     propagatedBuildInputs = [ LWP ];
@@ -16947,11 +16947,11 @@ with self;
     };
   };
 
-  HTTPRequestAsCGI = buildPerlPackage {
+  HTTPRequestAsCGI = buildPerlPackage rec {
     pname = "HTTP-Request-AsCGI";
     version = "1.2";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FL/FLORA/HTTP-Request-AsCGI-1.2.tar.gz";
+      url = "mirror://cpan/authors/id/F/FL/FLORA/HTTP-Request-AsCGI-${version}.tar.gz";
       hash = "sha256-lFv7B8bRr1J3P7eEW6YuOnQRGzXL0tXkPvgxnlWsvOo=";
     };
     propagatedBuildInputs = [
@@ -16967,11 +16967,11 @@ with self;
     };
   };
 
-  HTTPResponseEncoding = buildPerlPackage {
+  HTTPResponseEncoding = buildPerlPackage rec {
     pname = "HTTP-Response-Encoding";
     version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DANKOGAI/HTTP-Response-Encoding-0.06.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DANKOGAI/HTTP-Response-Encoding-${version}.tar.gz";
       hash = "sha256-EBZ7jiOKaCAEqw16zL6dduri21evB8WuLfqAgHSkqKo=";
     };
     propagatedBuildInputs = [ HTTPMessage ];
@@ -16985,11 +16985,11 @@ with self;
     };
   };
 
-  HTTPServerSimple = buildPerlPackage {
+  HTTPServerSimple = buildPerlPackage rec {
     pname = "HTTP-Server-Simple";
     version = "0.52";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BP/BPS/HTTP-Server-Simple-0.52.tar.gz";
+      url = "mirror://cpan/authors/id/B/BP/BPS/HTTP-Server-Simple-${version}.tar.gz";
       hash = "sha256-2JOfpPEr1rjAQ1N/0L+WsFWsNoa5zdn6dz3KauZ5y0w=";
     };
     doCheck = false;
@@ -17003,11 +17003,11 @@ with self;
     };
   };
 
-  HTTPServerSimpleAuthen = buildPerlPackage {
+  HTTPServerSimpleAuthen = buildPerlPackage rec {
     pname = "HTTP-Server-Simple-Authen";
     version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/HTTP-Server-Simple-Authen-0.04.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/HTTP-Server-Simple-Authen-${version}.tar.gz";
       hash = "sha256-Ld3Iq53ImGmAFR5LqDamu/CR9Fzxlb4XaOvbSpk+1Zs=";
     };
     propagatedBuildInputs = [
@@ -17023,11 +17023,11 @@ with self;
     };
   };
 
-  HTTPServerSimpleMason = buildPerlPackage {
+  HTTPServerSimpleMason = buildPerlPackage rec {
     pname = "HTTP-Server-Simple-Mason";
     version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JE/JESSE/HTTP-Server-Simple-Mason-0.14.tar.gz";
+      url = "mirror://cpan/authors/id/J/JE/JESSE/HTTP-Server-Simple-Mason-${version}.tar.gz";
       hash = "sha256-t6Sdjm5Vv/Cx8CeNlRaFRmsUMkO2+eWeBx9UcsoqAlo=";
     };
     propagatedBuildInputs = [
@@ -17044,11 +17044,11 @@ with self;
     };
   };
 
-  HTTPServerSimplePSGI = buildPerlPackage {
+  HTTPServerSimplePSGI = buildPerlPackage rec {
     pname = "HTTP-Server-Simple-PSGI";
     version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/HTTP-Server-Simple-PSGI-0.16.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/HTTP-Server-Simple-PSGI-${version}.tar.gz";
       hash = "sha256-X3zLhFMEO5cnhJKnVzKBFuEeA1LyhUooqcY05ukTHbo=";
     };
     propagatedBuildInputs = [ HTTPServerSimple ];
@@ -17062,11 +17062,11 @@ with self;
     };
   };
 
-  HTTPTinyCache = buildPerlPackage {
+  HTTPTinyCache = buildPerlPackage rec {
     pname = "HTTP-Tiny-Cache";
     version = "0.002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PERLANCAR/HTTP-Tiny-Cache-0.002.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PERLANCAR/HTTP-Tiny-Cache-${version}.tar.gz";
       hash = "sha256-c323zxncN4By2Rysdnh/sorNg8DRB85OTrS708kRhiE=";
     };
     propagatedBuildInputs = [
@@ -17084,11 +17084,11 @@ with self;
     };
   };
 
-  HTTPTinyish = buildPerlPackage {
+  HTTPTinyish = buildPerlPackage rec {
     pname = "HTTP-Tinyish";
     version = "0.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/HTTP-Tinyish-0.18.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/HTTP-Tinyish-${version}.tar.gz";
       hash = "sha256-gDgLjTPGv6lrsBBPpqQcJ9zE6cg6SN8frTkJf1/c/eU=";
     };
     propagatedBuildInputs = [
@@ -17105,11 +17105,11 @@ with self;
     };
   };
 
-  iCalParser = buildPerlPackage {
+  iCalParser = buildPerlPackage rec {
     pname = "iCal-Parser";
     version = "1.21";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RI/RIXED/iCal-Parser-1.21.tar.gz";
+      url = "mirror://cpan/authors/id/R/RI/RIXED/iCal-Parser-${version}.tar.gz";
       hash = "sha256-DXk5pkSo5nAX7HI509lgTzmGu5pP+Avmj+cpnr/SJww=";
     };
     propagatedBuildInputs = [
@@ -17146,11 +17146,11 @@ with self;
     };
   };
 
-  Imager = buildPerlPackage {
+  Imager = buildPerlPackage rec {
     pname = "Imager";
     version = "1.025";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TONYC/Imager-1.025.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TONYC/Imager-${version}.tar.gz";
       hash = "sha256-TwJ1y7HgEdfz/sYE3GtgwaxvAt78KYs9A31ur3vqcFg=";
     };
     buildInputs = [
@@ -17177,11 +17177,11 @@ with self;
     };
   };
 
-  ImagerQRCode = buildPerlPackage {
+  ImagerQRCode = buildPerlPackage rec {
     pname = "Imager-QRCode";
     version = "0.035";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KU/KURIHARA/Imager-QRCode-0.035.tar.gz";
+      url = "mirror://cpan/authors/id/K/KU/KURIHARA/Imager-QRCode-${version}.tar.gz";
       hash = "sha256-KoSN66Kes5QsRHCaaFPjGKyrDEaMv+27m6rlR2ADJRM=";
     };
     propagatedBuildInputs = [ Imager ];
@@ -17195,11 +17195,11 @@ with self;
     };
   };
 
-  ImageInfo = buildPerlPackage {
+  ImageInfo = buildPerlPackage rec {
     pname = "Image-Info";
     version = "1.44";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SR/SREZIC/Image-Info-1.44.tar.gz";
+      url = "mirror://cpan/authors/id/S/SR/SREZIC/Image-Info-${version}.tar.gz";
       hash = "sha256-y3/GXdHv/gHrR8HHmlLdFlT0KOOpfbHvI7EmzgFjbw0=";
     };
     propagatedBuildInputs = [ IOStringy ];
@@ -17212,12 +17212,12 @@ with self;
     };
   };
 
-  ImageSane = buildPerlPackage {
+  ImageSane = buildPerlPackage rec {
     pname = "Image-Sane";
     version = "5";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RA/RATCLIFFE/Image-Sane-5.tar.gz";
-      hash = "sha256-Ipqg6fBJ76dg88L25h2dU5r0PY92S1Cm4DBktHKaNf8=";
+      url = "mirror://cpan/authors/id/R/RA/RATCLIFFE/Image-Sane-${version}.tar.gz";
+      hash = "sha2${version}6-Ipqg6fBJ76dg88L2${version}h2dU${version}r0PY92S1Cm4DBktHKaNf8=";
     };
     buildInputs = [
       pkgs.sane-backends
@@ -17239,11 +17239,11 @@ with self;
     };
   };
 
-  ImageScale = buildPerlPackage {
+  ImageScale = buildPerlPackage rec {
     pname = "Image-Scale";
     version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AG/AGRUNDMA/Image-Scale-0.14.tar.gz";
+      url = "mirror://cpan/authors/id/A/AG/AGRUNDMA/Image-Scale-${version}.tar.gz";
       hash = "sha256-8JxfBmO4dzg2WsKBnhhrkJq+ue2F2DvBXudocslHzfg=";
     };
     buildInputs = [
@@ -17264,11 +17264,11 @@ with self;
     };
   };
 
-  ImageSize = buildPerlPackage {
+  ImageSize = buildPerlPackage rec {
     pname = "Image-Size";
     version = "3.300";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJRAY/Image-Size-3.300.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJRAY/Image-Size-${version}.tar.gz";
       hash = "sha256-U8mx+GUxzeBg7mNwnR/ac8q8DPLVgdKbIrAUeBufAms=";
     };
     buildInputs = [ ModuleBuild ];
@@ -17283,11 +17283,11 @@ with self;
     };
   };
 
-  ImageOCRTesseract = buildPerlPackage {
+  ImageOCRTesseract = buildPerlPackage rec {
     pname = "Image-OCR-Tesseract";
     version = "1.26";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEOCHARRE/Image-OCR-Tesseract-1.26.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEOCHARRE/Image-OCR-Tesseract-${version}.tar.gz";
       hash = "sha256-mNkEJmpwYvCcm0b3fE6UUp4f6ZM54/g/2h+SAT8AfOo=";
     };
     nativeBuildInputs = [
@@ -17325,11 +17325,11 @@ with self;
     };
   };
 
-  IMAPClient = buildPerlPackage {
+  IMAPClient = buildPerlPackage rec {
     pname = "IMAP-Client";
     version = "0.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CO/CONTEB/IMAP-Client-0.13.tar.gz";
+      url = "mirror://cpan/authors/id/C/CO/CONTEB/IMAP-Client-${version}.tar.gz";
       hash = "sha256-inovpVt1qFPEgBQXeDk62sKUts0gfN9UFA9nwS8kypU=";
     };
     doCheck = false; # nondeterministic
@@ -17342,11 +17342,11 @@ with self;
     };
   };
 
-  Importer = buildPerlPackage {
+  Importer = buildPerlPackage rec {
     pname = "Importer";
     version = "0.026";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EX/EXODIST/Importer-0.026.tar.gz";
+      url = "mirror://cpan/authors/id/E/EX/EXODIST/Importer-${version}.tar.gz";
       hash = "sha256-4I+oThPLmYt6iX/I7Jw0WfzBcWr/Jcw0Pjbvh1iRsO8=";
     };
     meta = {
@@ -17358,11 +17358,11 @@ with self;
     };
   };
 
-  ImportInto = buildPerlPackage {
+  ImportInto = buildPerlPackage rec {
     pname = "Import-Into";
     version = "1.002005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/Import-Into-1.002005.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Import-Into-${version}.tar.gz";
       hash = "sha256-vZ53o/tmK0C0OxjTKAzTUu35+tjZQoPlGBgcwc6fBWc=";
     };
     propagatedBuildInputs = [ ModuleRuntime ];
@@ -17375,11 +17375,11 @@ with self;
     };
   };
 
-  IO = buildPerlPackage {
+  IO = buildPerlPackage rec {
     pname = "IO";
     version = "1.51";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TODDR/IO-1.51.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TODDR/IO-${version}.tar.gz";
       hash = "sha256-VJPqVZmHKM0rfsuCNMWPtdXfJwmNDwet3KIkRNdhbOA=";
     };
     doCheck = false;
@@ -17392,11 +17392,11 @@ with self;
     };
   };
 
-  IOAIO = buildPerlPackage {
+  IOAIO = buildPerlPackage rec {
     pname = "IO-AIO";
     version = "4.73";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/IO-AIO-4.73.tar.gz";
+      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/IO-AIO-${version}.tar.gz";
       hash = "sha256-mltHx4Ak+rdmPR5a90ob6rRQ19Y7poV+MbP9gobkrFo=";
     };
     buildInputs = [ CanaryStability ];
@@ -17411,11 +17411,11 @@ with self;
     };
   };
 
-  IOAll = buildPerlPackage {
+  IOAll = buildPerlPackage rec {
     pname = "IO-All";
     version = "0.87";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FR/FREW/IO-All-0.87.tar.gz";
+      url = "mirror://cpan/authors/id/F/FR/FREW/IO-All-${version}.tar.gz";
       hash = "sha256-VOIdJQwCKRJ+MLd6NGHhAHeFTsJE8m+2cPG0Re1MTVs=";
     };
     meta = {
@@ -17428,11 +17428,11 @@ with self;
     };
   };
 
-  IOAsync = buildPerlModule {
+  IOAsync = buildPerlModule rec {
     pname = "IO-Async";
     version = "0.802";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/IO-Async-0.802.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/IO-Async-${version}.tar.gz";
       hash = "sha256-5YJzFXd2fEfqxDXvKQRmPUp1Cw5oAqSmGJo38Mswhzg";
     };
     preCheck = "rm t/50resolver.t"; # this test fails with "Temporary failure in name resolution" in sandbox
@@ -17456,11 +17456,11 @@ with self;
     };
   };
 
-  IOAsyncSSL = buildPerlModule {
+  IOAsyncSSL = buildPerlModule rec {
     pname = "IO-Async-SSL";
     version = "0.25";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/IO-Async-SSL-0.25.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/IO-Async-SSL-${version}.tar.gz";
       hash = "sha256-Te9IXbHv9OE5tLWRIgLA/WHDrtLOw1vVq4v3u9g/WnU=";
     };
     buildInputs = [ TestIdentity ];
@@ -17478,11 +17478,11 @@ with self;
     };
   };
 
-  IOCapture = buildPerlPackage {
+  IOCapture = buildPerlPackage rec {
     pname = "IO-Capture";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RE/REYNOLDS/IO-Capture-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/R/RE/REYNOLDS/IO-Capture-${version}.tar.gz";
       hash = "sha256-wsFaJUynT7jFfSXXtsvK/3ejtPtWlUI/H4C7Qjq//qk=";
     };
     meta = {
@@ -17494,11 +17494,11 @@ with self;
     };
   };
 
-  IOCaptureOutput = buildPerlPackage {
+  IOCaptureOutput = buildPerlPackage rec {
     pname = "IO-CaptureOutput";
     version = "1.1105";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/IO-CaptureOutput-1.1105.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/IO-CaptureOutput-${version}.tar.gz";
       hash = "sha256-rpkAn8oSc4APFp7LgvTtHMbHZ5XxVr7lwAkwBdVy9Ic=";
     };
     meta = {
@@ -17511,11 +17511,11 @@ with self;
     };
   };
 
-  IOCompress = buildPerlPackage {
+  IOCompress = buildPerlPackage rec {
     pname = "IO-Compress";
     version = "2.206";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PM/PMQS/IO-Compress-2.206.tar.gz";
+      url = "mirror://cpan/authors/id/P/PM/PMQS/IO-Compress-${version}.tar.gz";
       hash = "sha256-fTBiuaSU91fo0GFPIg2D8icxu9oa6198/w5yqD9DPTU=";
     };
     propagatedBuildInputs = [
@@ -17537,11 +17537,11 @@ with self;
 
   IOCompressBrotli = callPackage ../development/perl-modules/IOCompressBrotli { };
 
-  IODigest = buildPerlPackage {
+  IODigest = buildPerlPackage rec {
     pname = "IO-Digest";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CL/CLKAO/IO-Digest-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/C/CL/CLKAO/IO-Digest-${version}.tar.gz";
       hash = "sha256-j/z4Wn9iE+XpQUCtzCsXntAkmOrchDCUV+kE3sk/f5I=";
     };
     propagatedBuildInputs = [ PerlIOviadynamic ];
@@ -17554,11 +17554,11 @@ with self;
     };
   };
 
-  IOHTML = buildPerlPackage {
+  IOHTML = buildPerlPackage rec {
     pname = "IO-HTML";
     version = "1.004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CJ/CJM/IO-HTML-1.004.tar.gz";
+      url = "mirror://cpan/authors/id/C/CJ/CJM/IO-HTML-${version}.tar.gz";
       hash = "sha256-yHst9ZRju/LDlZZ3PftcA73g9+EFGvM5+WP1jBy9i/U=";
     };
     meta = {
@@ -17570,11 +17570,11 @@ with self;
     };
   };
 
-  IOHandleUtil = buildPerlModule {
+  IOHandleUtil = buildPerlModule rec {
     pname = "IO-Handle-Util";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/IO-Handle-Util-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/IO-Handle-Util-${version}.tar.gz";
       hash = "sha256-jblmqRPaxORkIwcCqiIr84r+ISGT5ja8DzzGUbrezO4=";
     };
     propagatedBuildInputs = [
@@ -17595,11 +17595,11 @@ with self;
     };
   };
 
-  IOInterface = buildPerlModule {
+  IOInterface = buildPerlModule rec {
     pname = "IO-Interface";
     version = "1.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LD/LDS/IO-Interface-1.09.tar.gz";
+      url = "mirror://cpan/authors/id/L/LD/LDS/IO-Interface-${version}.tar.gz";
       hash = "sha256-5j6BxS6x4OYOwtmD9VUtJJPhFxeZJclnV/I8S9n6cTo=";
     };
     nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ pkgs.ld-is-cc-hook ];
@@ -17612,11 +17612,11 @@ with self;
     };
   };
 
-  IOInteractive = buildPerlPackage {
+  IOInteractive = buildPerlPackage rec {
     pname = "IO-Interactive";
     version = "1.025";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/IO-Interactive-1.025.tar.gz";
+      url = "mirror://cpan/authors/id/B/BD/BDFOY/IO-Interactive-${version}.tar.gz";
       hash = "sha256-yh7G+6t6AnXdLpz2e3yw4ARYY/MVMyEMfcVEYxtqqqc=";
     };
     meta = {
@@ -17626,11 +17626,11 @@ with self;
     };
   };
 
-  IOInteractiveTiny = buildPerlPackage {
+  IOInteractiveTiny = buildPerlPackage rec {
     pname = "IO-Interactive-Tiny";
     version = "0.2";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DM/DMUEY/IO-Interactive-Tiny-0.2.tar.gz";
+      url = "mirror://cpan/authors/id/D/DM/DMUEY/IO-Interactive-Tiny-${version}.tar.gz";
       hash = "sha256-RcBpZQXH5DR4RfXNJRK3sbx4+85MvtK1gAgoP8lepfk=";
     };
     meta = {
@@ -17639,11 +17639,11 @@ with self;
     };
   };
 
-  IOLockedFile = buildPerlPackage {
+  IOLockedFile = buildPerlPackage rec {
     pname = "IO-LockedFile";
     version = "0.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RA/RANI/IO-LockedFile-0.23.tar.gz";
+      url = "mirror://cpan/authors/id/R/RA/RANI/IO-LockedFile-${version}.tar.gz";
       hash = "sha256-sdt+amvxvh4GFabstc6+eLAOKHsSfVhW0/FrNd1H+LU=";
     };
     meta = {
@@ -17655,11 +17655,11 @@ with self;
     };
   };
 
-  IOMultiplex = buildPerlPackage {
+  IOMultiplex = buildPerlPackage rec {
     pname = "IO-Multiplex";
     version = "1.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BB/BBB/IO-Multiplex-1.16.tar.gz";
+      url = "mirror://cpan/authors/id/B/BB/BBB/IO-Multiplex-${version}.tar.gz";
       hash = "sha256-dNIsRLWtLnGQ4nhuihfXS79M74m00RV7ozWYtaJyDa0=";
     };
     meta = {
@@ -17671,11 +17671,11 @@ with self;
     };
   };
 
-  IOPager = buildPerlPackage {
+  IOPager = buildPerlPackage rec {
     version = "2.10";
     pname = "IO-Pager";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JP/JPIERCE/IO-Pager-2.10.tgz";
+      url = "mirror://cpan/authors/id/J/JP/JPIERCE/IO-Pager-${version}.tgz";
       hash = "sha256-vLTYwtKAyANLglkcwLnrZ6AE+QzpqgWXn8YHEwessZU=";
     };
     propagatedBuildInputs = [
@@ -17693,11 +17693,11 @@ with self;
     };
   };
 
-  IOPrompt = buildPerlModule {
+  IOPrompt = buildPerlModule rec {
     pname = "IO-Prompt";
     version = "0.997004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCONWAY/IO-Prompt-0.997004.tar.gz";
+      url = "mirror://cpan/authors/id/D/DC/DCONWAY/IO-Prompt-${version}.tar.gz";
       hash = "sha256-8XuzBe5qyLWyA+bYJuuUDE8/bW9L/nGcOzoiX0b1hhU=";
     };
     propagatedBuildInputs = [
@@ -17714,11 +17714,11 @@ with self;
     };
   };
 
-  IOSessionData = buildPerlPackage {
+  IOSessionData = buildPerlPackage rec {
     pname = "IO-SessionData";
     version = "1.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PH/PHRED/IO-SessionData-1.03.tar.gz";
+      url = "mirror://cpan/authors/id/P/PH/PHRED/IO-SessionData-${version}.tar.gz";
       hash = "sha256-ZKRxKj7bs/0QIw2ylsKcjGbwZq37wMPfakglj+85Ld0=";
     };
     outputs = [
@@ -17734,11 +17734,11 @@ with self;
     };
   };
 
-  IOSocketINET6 = buildPerlModule {
+  IOSocketINET6 = buildPerlModule rec {
     pname = "IO-Socket-INET6";
     version = "2.73";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/IO-Socket-INET6-2.73.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/IO-Socket-INET6-${version}.tar.gz";
       hash = "sha256-ttp0aFMlPVtKxDGRtPaaRxlZXuE6fKZ2qAVM825tFrs=";
     };
     propagatedBuildInputs = [ Socket6 ];
@@ -17752,11 +17752,11 @@ with self;
     };
   };
 
-  IOSocketSSL = buildPerlPackage {
+  IOSocketSSL = buildPerlPackage rec {
     pname = "IO-Socket-SSL";
     version = "2.083";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SU/SULLR/IO-Socket-SSL-2.083.tar.gz";
+      url = "mirror://cpan/authors/id/S/SU/SULLR/IO-Socket-SSL-${version}.tar.gz";
       hash = "sha256-kE7yh2VECpfYqaDfWX+MPX88sKBT0bCCwQvtA7yAIGk=";
     };
     propagatedBuildInputs = [
@@ -17779,11 +17779,11 @@ with self;
     };
   };
 
-  IOSocketSocks = buildPerlPackage {
+  IOSocketSocks = buildPerlPackage rec {
     pname = "IO-Socket-Socks";
     version = "0.74";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OL/OLEG/IO-Socket-Socks-0.74.tar.gz";
+      url = "mirror://cpan/authors/id/O/OL/OLEG/IO-Socket-Socks-${version}.tar.gz";
       hash = "sha256-N/Bxos9LqPCQoil8ZIK3osUJ61Lc1s5dgDXU7ixoJLE=";
     };
     meta = {
@@ -17792,11 +17792,11 @@ with self;
     };
   };
 
-  IOSocketTimeout = buildPerlModule {
+  IOSocketTimeout = buildPerlModule rec {
     pname = "IO-Socket-Timeout";
     version = "0.32";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAMS/IO-Socket-Timeout-0.32.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAMS/IO-Socket-Timeout-${version}.tar.gz";
       hash = "sha256-7fkV1sxmvuQ1A6ptwrNzNm846v9wFYIYPa0Qy4rfKXI=";
     };
     buildInputs = [
@@ -17814,11 +17814,11 @@ with self;
     };
   };
 
-  IOString = buildPerlPackage {
+  IOString = buildPerlPackage rec {
     pname = "IO-String";
     version = "1.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GA/GAAS/IO-String-1.08.tar.gz";
+      url = "mirror://cpan/authors/id/G/GA/GAAS/IO-String-${version}.tar.gz";
       hash = "sha256-Kj9K2EQtkHB4DljvQ3ItGdHuIagDv3yCBod6EEgt5aA=";
     };
     meta = {
@@ -17830,11 +17830,11 @@ with self;
     };
   };
 
-  IOStringy = buildPerlPackage {
+  IOStringy = buildPerlPackage rec {
     pname = "IO-Stringy";
     version = "2.113";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CA/CAPOEIRAB/IO-Stringy-2.113.tar.gz";
+      url = "mirror://cpan/authors/id/C/CA/CAPOEIRAB/IO-Stringy-${version}.tar.gz";
       hash = "sha256-USIPyvn2amObadJR17B1e/QgL0+d69Rb3TQaaspi/k4=";
     };
     meta = {
@@ -17846,11 +17846,11 @@ with self;
     };
   };
 
-  IOStty = buildPerlModule {
+  IOStty = buildPerlModule rec {
     pname = "IO-Stty";
     version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TODDR/IO-Stty-0.04.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TODDR/IO-Stty-${version}.tar.gz";
       hash = "sha256-XJUJ8ahpPYKH+gE97wv4eqZM2ScThGHvjetVUDxmUcI=";
     };
     buildPhase = "make";
@@ -17866,11 +17866,11 @@ with self;
     };
   };
 
-  IOTee = buildPerlPackage {
+  IOTee = buildPerlPackage rec {
     pname = "IO-Tee";
     version = "0.66";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/IO-Tee-0.66.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/IO-Tee-${version}.tar.gz";
       hash = "sha256-LZznIGUW+cMIY6NnqhwrmzVwLjabCrqhX5n7LMCFUuA=";
     };
     meta = {
@@ -17882,11 +17882,11 @@ with self;
     };
   };
 
-  IOTieCombine = buildPerlPackage {
+  IOTieCombine = buildPerlPackage rec {
     pname = "IO-TieCombine";
     version = "1.005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/IO-TieCombine-1.005.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/IO-TieCombine-${version}.tar.gz";
       hash = "sha256-QC1NuDALPScWMvSZXgreMp2JKAp+R/K634s4r25Vaa8=";
     };
     meta = {
@@ -17921,11 +17921,11 @@ with self;
     };
   };
 
-  IPCConcurrencyLimit = buildPerlPackage {
+  IPCConcurrencyLimit = buildPerlPackage rec {
     pname = "IPC-ConcurrencyLimit";
     version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MATTK/IPC-ConcurrencyLimit-0.17.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MATTK/IPC-ConcurrencyLimit-${version}.tar.gz";
       hash = "sha256-Lk11vlLpD8YFg31ajp+yacCofdPTYfMBLA/5Sl+9z+8=";
     };
     buildInputs = [ ExtUtilsMakeMaker ];
@@ -17942,11 +17942,11 @@ with self;
     };
   };
 
-  IPCountry = buildPerlPackage {
+  IPCountry = buildPerlPackage rec {
     pname = "IP-Country";
     version = "2.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NW/NWETTERS/IP-Country-2.28.tar.gz";
+      url = "mirror://cpan/authors/id/N/NW/NWETTERS/IP-Country-${version}.tar.gz";
       hash = "sha256-iNuDOlqyLtBstT1vIFcl47U3GyVFlgU3OIhekfoQX3U=";
     };
     propagatedBuildInputs = [ GeographyCountries ];
@@ -17957,11 +17957,11 @@ with self;
     };
   };
 
-  GeographyCountries = buildPerlPackage {
+  GeographyCountries = buildPerlPackage rec {
     pname = "Geography-Countries";
     version = "2009041301";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AB/ABIGAIL/Geography-Countries-2009041301.tar.gz";
+      url = "mirror://cpan/authors/id/A/AB/ABIGAIL/Geography-Countries-${version}.tar.gz";
       hash = "sha256-SMQuQOgoG6fJgXQ6hUxI5t7y1R6wkl6myW4lx0SX8g8=";
     };
     meta = {
@@ -17970,11 +17970,11 @@ with self;
     };
   };
 
-  IPCRun = buildPerlPackage {
+  IPCRun = buildPerlPackage rec {
     pname = "IPC-Run";
     version = "20231003.0";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TODDR/IPC-Run-20231003.0.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TODDR/IPC-Run-${version}.tar.gz";
       hash = "sha256-6yW731kT0pF5fvG/6ZjxUTC0VdPtAqrN5oVvCyXk/lc=";
     };
     doCheck = false; # attempts a network connection to localhost
@@ -17989,11 +17989,11 @@ with self;
     };
   };
 
-  IPCRun3 = buildPerlPackage {
+  IPCRun3 = buildPerlPackage rec {
     pname = "IPC-Run3";
     version = "0.048";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/IPC-Run3-0.048.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/IPC-Run3-${version}.tar.gz";
       hash = "sha256-PYHDzBtc/2nMqTYeLG443wNSJRrntB4v8/68hQ5GNWU=";
     };
     meta = {
@@ -18006,11 +18006,11 @@ with self;
     };
   };
 
-  IPCShareable = buildPerlPackage {
+  IPCShareable = buildPerlPackage rec {
     pname = "IPC-Shareable";
     version = "1.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/ST/STEVEB/IPC-Shareable-1.13.tar.gz";
+      url = "mirror://cpan/authors/id/S/ST/STEVEB/IPC-Shareable-${version}.tar.gz";
       hash = "sha256-RW5mX3Kj+3ulqOcOMhz8nIJZ3vsxEbUZQK0IyrnADms=";
     };
     # remove t/04-key.t pulling in Mock::Sub, it'd get skipped anyways.
@@ -18033,11 +18033,11 @@ with self;
     };
   };
 
-  IPCShareLite = buildPerlPackage {
+  IPCShareLite = buildPerlPackage rec {
     pname = "IPC-ShareLite";
     version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AN/ANDYA/IPC-ShareLite-0.17.tar.gz";
+      url = "mirror://cpan/authors/id/A/AN/ANDYA/IPC-ShareLite-${version}.tar.gz";
       hash = "sha256-FNQGuR2pbWUh0NGoLSKjBidHZSJrhrClbn/93Plq578=";
     };
     meta = {
@@ -18049,11 +18049,11 @@ with self;
     };
   };
 
-  IPCSystemSimple = buildPerlPackage {
+  IPCSystemSimple = buildPerlPackage rec {
     pname = "IPC-System-Simple";
     version = "1.30";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JK/JKEENAN/IPC-System-Simple-1.30.tar.gz";
+      url = "mirror://cpan/authors/id/J/JK/JKEENAN/IPC-System-Simple-${version}.tar.gz";
       hash = "sha256-Iub1IitQXuUTBY/co1q3oeq4BTm5jlykqSOnCorpup4=";
     };
     meta = {
@@ -18066,11 +18066,11 @@ with self;
     };
   };
 
-  IPCSysV = buildPerlPackage {
+  IPCSysV = buildPerlPackage rec {
     pname = "IPC-SysV";
     version = "2.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MH/MHX/IPC-SysV-2.09.tar.gz";
+      url = "mirror://cpan/authors/id/M/MH/MHX/IPC-SysV-${version}.tar.gz";
       hash = "sha256-GJdUHHTVSP0QB+tsB/NBnTx1ddgFamK1ulJwohZtLb0=";
     };
     meta = {
@@ -18082,11 +18082,11 @@ with self;
     };
   };
 
-  IRCUtils = buildPerlPackage {
+  IRCUtils = buildPerlPackage rec {
     pname = "IRC-Utils";
     version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HI/HINRIK/IRC-Utils-0.12.tar.gz";
+      url = "mirror://cpan/authors/id/H/HI/HINRIK/IRC-Utils-${version}.tar.gz";
       hash = "sha256-x9YxHrbHnpg4M8nmtOjUJtB6mHTSD0vGQbMTuZybyKA=";
     };
     meta = {
@@ -18102,11 +18102,11 @@ with self;
 
   ImageExifTool = callPackage ../development/perl-modules/ImageExifTool { };
 
-  Inline = buildPerlPackage {
+  Inline = buildPerlPackage rec {
     pname = "Inline";
     version = "0.86";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IN/INGY/Inline-0.86.tar.gz";
+      url = "mirror://cpan/authors/id/I/IN/INGY/Inline-${version}.tar.gz";
       hash = "sha256-UQp94tARsNuAsIdOjA9zkAEJkQAK4TXP90dN8ebVHjo=";
     };
     buildInputs = [ TestWarn ];
@@ -18126,11 +18126,11 @@ with self;
     };
   };
 
-  InlineC = buildPerlPackage {
+  InlineC = buildPerlPackage rec {
     pname = "Inline-C";
     version = "0.82";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETJ/Inline-C-0.82.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETJ/Inline-C-${version}.tar.gz";
       hash = "sha256-EPvPHhWNHI134d2TTjeRZbEmpFwTZFrQvp3AfRUd0Mw=";
     };
     buildInputs = [
@@ -18158,12 +18158,12 @@ with self;
     };
   };
 
-  InlineJava = buildPerlPackage {
+  InlineJava = buildPerlPackage rec {
     pname = "Inline-Java";
     version = "0.67";
 
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETJ/Inline-Java-0.67.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETJ/Inline-Java-${version}.tar.gz";
       hash = "sha256-9YVLMcvOFjwz4mJN0jFODA2X4JRDcbcYjlkBuj9vpMk=";
     };
 
@@ -18190,11 +18190,11 @@ with self;
     };
   };
 
-  IteratorSimple = buildPerlPackage {
+  IteratorSimple = buildPerlPackage rec {
     pname = "Iterator-Simple";
     version = "0.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MICHAEL/Iterator-Simple-0.07.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MICHAEL/Iterator-Simple-${version}.tar.gz";
       hash = "sha256-y1dNBju0gcj7nLV4GkZFiWqg4e5xW6lHz3ZvH/Tp60Q=";
     };
     meta = {
@@ -18206,11 +18206,11 @@ with self;
     };
   };
 
-  IPCSignal = buildPerlPackage {
+  IPCSignal = buildPerlPackage rec {
     pname = "IPC-Signal";
     version = "1.00";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RO/ROSCH/IPC-Signal-1.00.tar.gz";
+      url = "mirror://cpan/authors/id/R/RO/ROSCH/IPC-Signal-${version}.tar.gz";
       hash = "sha256-fCH5yMLQwPDw9G533nw9h53VYmaN3wUlh1w4zvIHb9A=";
     };
     meta = {
@@ -18222,11 +18222,11 @@ with self;
     };
   };
 
-  JavaScriptMinifierXS = buildPerlPackage {
+  JavaScriptMinifierXS = buildPerlPackage rec {
     pname = "JavaScript-Minifier-XS";
     version = "0.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GT/GTERMARS/JavaScript-Minifier-XS-0.15.tar.gz";
+      url = "mirror://cpan/authors/id/G/GT/GTERMARS/JavaScript-Minifier-XS-${version}.tar.gz";
       hash = "sha256-XZsDT1jwtv9bZGR708WpzgWypw7e4zn7wxc67nR8wFA=";
     };
     buildInputs = [ TestDiagINC ];
@@ -18240,11 +18240,11 @@ with self;
     };
   };
 
-  JavaScriptValueEscape = buildPerlModule {
+  JavaScriptValueEscape = buildPerlModule rec {
     pname = "JavaScript-Value-Escape";
     version = "0.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KAZEBURO/JavaScript-Value-Escape-0.07.tar.gz";
+      url = "mirror://cpan/authors/id/K/KA/KAZEBURO/JavaScript-Value-Escape-${version}.tar.gz";
       hash = "sha256-msvaNwjt4R9r6uXxEvGIw6kCOk0myOzYmqgru2kxo9w=";
     };
     meta = {
@@ -18257,11 +18257,11 @@ with self;
     };
   };
 
-  JSON = buildPerlPackage {
+  JSON = buildPerlPackage rec {
     pname = "JSON";
     version = "4.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/JSON-4.10.tar.gz";
+      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/JSON-${version}.tar.gz";
       hash = "sha256-34tRQ9mn3pnEe1XxoXC9H2n3EZNcGGptwKtW3QV1jjU=";
     };
     # Force core provided JSON::PP backend when cross building since dynamic
@@ -18281,11 +18281,11 @@ with self;
     };
   };
 
-  JSONAny = buildPerlPackage {
+  JSONAny = buildPerlPackage rec {
     pname = "JSON-Any";
     version = "1.40";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/JSON-Any-1.40.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/JSON-Any-${version}.tar.gz";
       hash = "sha256-CDJWJVpICU/ZrBI54P6ooQojg6nNHvSxxyZO3htEAKs=";
     };
     buildInputs = [
@@ -18304,11 +18304,11 @@ with self;
     };
   };
 
-  JSONCreate = buildPerlPackage {
+  JSONCreate = buildPerlPackage rec {
     pname = "JSON-Create";
     version = "0.35";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BK/BKB/JSON-Create-0.35.tar.gz";
+      url = "mirror://cpan/authors/id/B/BK/BKB/JSON-Create-${version}.tar.gz";
       hash = "sha256-X67+DYM7gTJWiGUwjzI5082qG4oezJtWJNzx774QaD4=";
     };
     propagatedBuildInputs = [
@@ -18324,11 +18324,11 @@ with self;
     };
   };
 
-  JSONMaybeXS = buildPerlPackage {
+  JSONMaybeXS = buildPerlPackage rec {
     pname = "JSON-MaybeXS";
     version = "1.004005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/JSON-MaybeXS-1.004005.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/JSON-MaybeXS-${version}.tar.gz";
       hash = "sha256-9ba8GfV55mtymfh0i4rD4XGTbcTn/LcqiiV6m9SCozE=";
     };
     buildInputs = [ TestNeeds ];
@@ -18341,11 +18341,11 @@ with self;
     };
   };
 
-  JSONPP = buildPerlPackage {
+  JSONPP = buildPerlPackage rec {
     pname = "JSON-PP";
     version = "4.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/JSON-PP-4.16.tar.gz";
+      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/JSON-PP-${version}.tar.gz";
       hash = "sha256-i8LxYrr8QmRcSJkFrXJUDw08KEs2DJYpkJUYPDDMl4k=";
     };
     meta = {
@@ -18358,11 +18358,11 @@ with self;
     };
   };
 
-  JSONPPCompat5006 = buildPerlPackage {
+  JSONPPCompat5006 = buildPerlPackage rec {
     pname = "JSON-PP-Compat5006";
     version = "1.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MAKAMAKA/JSON-PP-Compat5006-1.09.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MAKAMAKA/JSON-PP-Compat5006-${version}.tar.gz";
       hash = "sha256-GXAw31JjX5u+Ja8QdC7qW9dJcUcxGMETEfyry2LjcWo=";
     };
     meta = {
@@ -18374,11 +18374,11 @@ with self;
     };
   };
 
-  JSONParse = buildPerlPackage {
+  JSONParse = buildPerlPackage rec {
     pname = "JSON-Parse";
     version = "0.62";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BK/BKB/JSON-Parse-0.62.tar.gz";
+      url = "mirror://cpan/authors/id/B/BK/BKB/JSON-Parse-${version}.tar.gz";
       hash = "sha256-YnMYD5OSSXQB3dbYIHBvWqhsG+iIkd1qq02Qa1z/Ztk=";
     };
     meta = {
@@ -18391,11 +18391,11 @@ with self;
     };
   };
 
-  JSONValidator = buildPerlPackage {
+  JSONValidator = buildPerlPackage rec {
     pname = "JSON-Validator";
     version = "5.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/JSON-Validator-5.14.tar.gz";
+      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/JSON-Validator-${version}.tar.gz";
       hash = "sha256-YISl1AdeQhqTj/su6XuFBPqjXoZtD3tbWBETr17ijhs=";
     };
     buildInputs = [ TestDeep ];
@@ -18411,11 +18411,11 @@ with self;
     };
   };
 
-  JSONWebToken = buildPerlModule {
+  JSONWebToken = buildPerlModule rec {
     pname = "JSON-WebToken";
     version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XA/XAICRON/JSON-WebToken-0.10.tar.gz";
+      url = "mirror://cpan/authors/id/X/XA/XAICRON/JSON-WebToken-${version}.tar.gz";
       hash = "sha256-d8GCqYUo8XFNgq/FSNWztNyT5nBpEou5uUE/JM8HJIs=";
     };
     buildInputs = [
@@ -18436,11 +18436,11 @@ with self;
     };
   };
 
-  JSONXS = buildPerlPackage {
+  JSONXS = buildPerlPackage rec {
     pname = "JSON-XS";
     version = "4.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/JSON-XS-4.03.tar.gz";
+      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/JSON-XS-${version}.tar.gz";
       hash = "sha256-UVU29F8voafojIgkUzdY0BIdJnq5y0U6G1iHyKVrkGg=";
     };
     patches = [ ../development/perl-modules/JSON-XS-CVE-2025-40928.patch ];
@@ -18456,11 +18456,11 @@ with self;
     };
   };
 
-  JSONXSVersionOneAndTwo = buildPerlPackage {
+  JSONXSVersionOneAndTwo = buildPerlPackage rec {
     pname = "JSON-XS-VersionOneAndTwo";
     version = "0.31";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LB/LBROCARD/JSON-XS-VersionOneAndTwo-0.31.tar.gz";
+      url = "mirror://cpan/authors/id/L/LB/LBROCARD/JSON-XS-VersionOneAndTwo-${version}.tar.gz";
       hash = "sha256-5gksTZYfrnd6z3/pn7PNbltxD+yFdlprkEF0gOTJSjQ=";
     };
     propagatedBuildInputs = [ JSONXS ];
@@ -18473,11 +18473,11 @@ with self;
     };
   };
 
-  Later = buildPerlPackage {
+  Later = buildPerlPackage rec {
     version = "0.21";
     pname = "Object-Realize-Later";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARKOV/Object-Realize-Later-0.21.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MARKOV/Object-Realize-Later-${version}.tar.gz";
       hash = "sha256-j3uWQMyONOqSvPbAEEmgPBReDrRuViJ14o3d06jW2Nk=";
     };
     meta = {
@@ -18586,11 +18586,11 @@ with self;
     };
   };
 
-  LEOCHARRECLI = buildPerlPackage {
+  LEOCHARRECLI = buildPerlPackage rec {
     pname = "LEOCHARRE-CLI";
     version = "1.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEOCHARRE/LEOCHARRE-CLI-1.19.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEOCHARRE/LEOCHARRE-CLI-${version}.tar.gz";
       hash = "sha256-N4NfEe41MmJBtNMDaK4bwZWlBBSzZi2z4TuGW9Uvzek=";
     };
     propagatedBuildInputs = [
@@ -18609,11 +18609,11 @@ with self;
     };
   };
 
-  LEOCHARREDebug = buildPerlPackage {
+  LEOCHARREDebug = buildPerlPackage rec {
     pname = "LEOCHARRE-Debug";
     version = "1.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEOCHARRE/LEOCHARRE-Debug-1.03.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEOCHARRE/LEOCHARRE-Debug-${version}.tar.gz";
       hash = "sha256-wWZao6vUV8yGJLjEGMb4vfWPs6aG+O7VFc9+k1FN8ZI=";
     };
     meta = {
@@ -18625,11 +18625,11 @@ with self;
     };
   };
 
-  LexicalSealRequireHints = buildPerlModule {
+  LexicalSealRequireHints = buildPerlModule rec {
     pname = "Lexical-SealRequireHints";
     version = "0.012";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Lexical-SealRequireHints-0.012.tar.gz";
+      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Lexical-SealRequireHints-${version}.tar.gz";
       hash = "sha256-wyvcOOBvjWyQdlu74xaMNYJH2n2uhbgLqEotoXY3V90=";
     };
     meta = {
@@ -18710,11 +18710,11 @@ with self;
     };
   };
 
-  libintl-perl = buildPerlPackage {
+  libintl-perl = buildPerlPackage rec {
     pname = "libintl-perl";
     version = "1.33";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GU/GUIDO/libintl-perl-1.33.tar.gz";
+      url = "mirror://cpan/authors/id/G/GU/GUIDO/libintl-perl-${version}.tar.gz";
       hash = "sha256-USbtqczQ7rENuC3e9jy8r329dx54zA+xEMw7WmuGeec=";
     };
     meta = {
@@ -18723,11 +18723,11 @@ with self;
     };
   };
 
-  libnet = buildPerlPackage {
+  libnet = buildPerlPackage rec {
     pname = "libnet";
     version = "3.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHAY/libnet-3.15.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHAY/libnet-${version}.tar.gz";
       hash = "sha256-px9NtYDhp2fWk2+qW6848fpheCQ0LaB4tWEoPob49KI=";
     };
     meta = {
@@ -18739,11 +18739,11 @@ with self;
     };
   };
 
-  librelative = buildPerlPackage {
+  librelative = buildPerlPackage rec {
     pname = "lib-relative";
     version = "1.002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DB/DBOOK/lib-relative-1.002.tar.gz";
+      url = "mirror://cpan/authors/id/D/DB/DBOOK/lib-relative-${version}.tar.gz";
       hash = "sha256-5EcCFRZ8QGkXYD54vk2TESz2kTzTQq64ALQS4BHIp4s=";
     };
     meta = {
@@ -18753,11 +18753,11 @@ with self;
     };
   };
 
-  libwwwperl = buildPerlPackage {
+  libwwwperl = buildPerlPackage rec {
     pname = "libwww-perl";
     version = "6.72";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OA/OALDERS/libwww-perl-6.72.tar.gz";
+      url = "mirror://cpan/authors/id/O/OA/OALDERS/libwww-perl-${version}.tar.gz";
       hash = "sha256-6bg1T9XiC+IHr+I93VhPzVm/gpmNwHfez2hLodrloF0=";
     };
     buildInputs = [
@@ -18791,11 +18791,11 @@ with self;
     };
   };
 
-  libxml_perl = buildPerlPackage {
+  libxml_perl = buildPerlPackage rec {
     pname = "libxml-perl";
     version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KM/KMACLEOD/libxml-perl-0.08.tar.gz";
+      url = "mirror://cpan/authors/id/K/KM/KMACLEOD/libxml-perl-${version}.tar.gz";
       hash = "sha256-RXEFm3tdSLfOUrATieldeYv1zyAgUjwVP/J7SYFTycs=";
     };
     propagatedBuildInputs = [ XMLParser ];
@@ -18808,11 +18808,11 @@ with self;
     };
   };
 
-  LinguaENFindNumber = buildPerlPackage {
+  LinguaENFindNumber = buildPerlPackage rec {
     pname = "Lingua-EN-FindNumber";
     version = "1.32";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/Lingua-EN-FindNumber-1.32.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/Lingua-EN-FindNumber-${version}.tar.gz";
       hash = "sha256-HRdtHIY/uYRL0Z0sKk5ooO1z2hWPckqJQFuQ236NvQQ=";
     };
     propagatedBuildInputs = [ LinguaENWords2Nums ];
@@ -18826,11 +18826,11 @@ with self;
     };
   };
 
-  LinguaENInflect = buildPerlPackage {
+  LinguaENInflect = buildPerlPackage rec {
     pname = "Lingua-EN-Inflect";
     version = "1.905";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCONWAY/Lingua-EN-Inflect-1.905.tar.gz";
+      url = "mirror://cpan/authors/id/D/DC/DCONWAY/Lingua-EN-Inflect-${version}.tar.gz";
       hash = "sha256-BcKew0guVyMTpg2iGBsLMMXbfPAfiudhatZ+G2YmMpY=";
     };
     meta = {
@@ -18842,11 +18842,11 @@ with self;
     };
   };
 
-  LinguaENInflectNumber = buildPerlPackage {
+  LinguaENInflectNumber = buildPerlPackage rec {
     pname = "Lingua-EN-Inflect-Number";
     version = "1.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/Lingua-EN-Inflect-Number-1.12.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/Lingua-EN-Inflect-Number-${version}.tar.gz";
       hash = "sha256-Zvszg4USdG9cWX6AJk/qZmQ/fyZXDsL5IFthNa1nrL8=";
     };
     propagatedBuildInputs = [ LinguaENInflect ];
@@ -18860,11 +18860,11 @@ with self;
     };
   };
 
-  LinguaENInflectPhrase = buildPerlPackage {
+  LinguaENInflectPhrase = buildPerlPackage rec {
     pname = "Lingua-EN-Inflect-Phrase";
     version = "0.20";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RK/RKITOVER/Lingua-EN-Inflect-Phrase-0.20.tar.gz";
+      url = "mirror://cpan/authors/id/R/RK/RKITOVER/Lingua-EN-Inflect-Phrase-${version}.tar.gz";
       hash = "sha256-VQWJEamfF1XePrRJqZ/765LYjAH/XcYFEaJGeQUN3qg=";
     };
     buildInputs = [ TestNoWarnings ];
@@ -18883,11 +18883,11 @@ with self;
     };
   };
 
-  LinguaENNumberIsOrdinal = buildPerlPackage {
+  LinguaENNumberIsOrdinal = buildPerlPackage rec {
     pname = "Lingua-EN-Number-IsOrdinal";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RK/RKITOVER/Lingua-EN-Number-IsOrdinal-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/R/RK/RKITOVER/Lingua-EN-Number-IsOrdinal-${version}.tar.gz";
       hash = "sha256-KNVpVADA9OK9IJeTy3T22iuSVzVqrLKUfGA0JeCWGNY=";
     };
     buildInputs = [
@@ -18905,11 +18905,11 @@ with self;
     };
   };
 
-  LinguaENTagger = buildPerlPackage {
+  LinguaENTagger = buildPerlPackage rec {
     pname = "Lingua-EN-Tagger";
     version = "0.31";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AC/ACOBURN/Lingua-EN-Tagger-0.31.tar.gz";
+      url = "mirror://cpan/authors/id/A/AC/ACOBURN/Lingua-EN-Tagger-${version}.tar.gz";
       hash = "sha256-lJ6Mh+SAj3uglrl5Ig/wgbvgO21XiQ0u7NS4Ouhy6ZM=";
     };
     propagatedBuildInputs = [
@@ -18923,11 +18923,11 @@ with self;
     };
   };
 
-  LinguaENWords2Nums = buildPerlPackage {
+  LinguaENWords2Nums = buildPerlPackage rec {
     pname = "Lingua-EN-Words2Nums";
     version = "0.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JO/JOEY/Lingua-EN-Words2Nums-0.18.tar.gz";
+      url = "mirror://cpan/authors/id/J/JO/JOEY/Lingua-EN-Words2Nums-${version}.tar.gz";
       hash = "sha256-aGVWeXzSpOqgZvGbvwOrJcBieCksnq0vGH39kDHqHYU=";
     };
     meta = {
@@ -18939,11 +18939,11 @@ with self;
     };
   };
 
-  LinguaPTStemmer = buildPerlPackage {
+  LinguaPTStemmer = buildPerlPackage rec {
     pname = "Lingua-PT-Stemmer";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/Lingua-PT-Stemmer-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/Lingua-PT-Stemmer-${version}.tar.gz";
       hash = "sha256-WW3wH4q3n//9RQ6Ug2pUQ3HYpMk6FffojqLxt5xGhJ0=";
     };
     meta = {
@@ -18956,11 +18956,11 @@ with self;
     };
   };
 
-  LinguaStem = buildPerlModule {
+  LinguaStem = buildPerlModule rec {
     pname = "Lingua-Stem";
     version = "2.31";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SN/SNOWHARE/Lingua-Stem-2.31.tar.gz";
+      url = "mirror://cpan/authors/id/S/SN/SNOWHARE/Lingua-Stem-${version}.tar.gz";
       hash = "sha256-qhqZMrZCflmCU+YajM0NBMxVn66dWNh3TCAncItjAmQ=";
     };
     doCheck = false;
@@ -18983,11 +18983,11 @@ with self;
     };
   };
 
-  LinguaStemFr = buildPerlPackage {
+  LinguaStemFr = buildPerlPackage rec {
     pname = "Lingua-Stem-Fr";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SD/SDP/Lingua-Stem-Fr-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/S/SD/SDP/Lingua-Stem-Fr-${version}.tar.gz";
       hash = "sha256-nU9ks6iJihhTQyGFJtWsaKSh+ObEQY1rqV1i9fnV2W8=";
     };
     meta = {
@@ -18999,11 +18999,11 @@ with self;
     };
   };
 
-  LinguaStemIt = buildPerlPackage {
+  LinguaStemIt = buildPerlPackage rec {
     pname = "Lingua-Stem-It";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AC/ACALPINI/Lingua-Stem-It-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/A/AC/ACALPINI/Lingua-Stem-It-${version}.tar.gz";
       hash = "sha256-OOZz+3T+ARWILlrbJnTesIH6tyHXKO4qgRQWPVDIB4g=";
     };
     meta = {
@@ -19015,11 +19015,11 @@ with self;
     };
   };
 
-  LinguaStemRu = buildPerlPackage {
+  LinguaStemRu = buildPerlPackage rec {
     pname = "Lingua-Stem-Ru";
     version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/Lingua-Stem-Ru-0.04.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/Lingua-Stem-Ru-${version}.tar.gz";
       hash = "sha256-EnDOt0dk/blYNwqAiDSvl26H9pqFRw+LxGJYeX6rUig=";
     };
     meta = {
@@ -19032,11 +19032,11 @@ with self;
     };
   };
 
-  LinguaStemSnowballDa = buildPerlPackage {
+  LinguaStemSnowballDa = buildPerlPackage rec {
     pname = "Lingua-Stem-Snowball-Da";
     version = "1.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CI/CINE/Lingua-Stem-Snowball-Da-1.01.tar.gz";
+      url = "mirror://cpan/authors/id/C/CI/CINE/Lingua-Stem-Snowball-Da-${version}.tar.gz";
       hash = "sha256-Ljm+TuAVx+xHwrBnhYAYp0BuONUSHWVcikaHSt+poFY=";
     };
     meta = {
@@ -19045,11 +19045,11 @@ with self;
     };
   };
 
-  LinguaTranslit = buildPerlPackage {
+  LinguaTranslit = buildPerlPackage rec {
     pname = "Lingua-Translit";
     version = "0.29";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AL/ALINKE/Lingua-Translit-0.29.tar.gz";
+      url = "mirror://cpan/authors/id/A/AL/ALINKE/Lingua-Translit-${version}.tar.gz";
       hash = "sha256-GtL6vAB52tcIt9nVVDfJ67GS5hC/lgryWUWFi5JZd1I=";
     };
     doCheck = false;
@@ -19063,11 +19063,11 @@ with self;
     };
   };
 
-  LinkEmbedder = buildPerlPackage {
+  LinkEmbedder = buildPerlPackage rec {
     pname = "LinkEmbedder";
     version = "1.20";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/LinkEmbedder-1.20.tar.gz";
+      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/LinkEmbedder-${version}.tar.gz";
       hash = "sha256-sd6LTiXHIplEOeesA0vorjeiCUijG/SF8iu0hvzI3KU=";
     };
     buildInputs = [ TestDeep ];
@@ -19080,11 +19080,11 @@ with self;
     };
   };
 
-  LinuxACL = buildPerlPackage {
+  LinuxACL = buildPerlPackage rec {
     pname = "Linux-ACL";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NA/NAZAROV/Linux-ACL-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/N/NA/NAZAROV/Linux-ACL-${version}.tar.gz";
       hash = "sha256-MSlAwfYPR8T8k/oKnSpiZCX6qDcEDIwvGtWO4J9i83E=";
     };
     buildInputs = [ pkgs.acl ];
@@ -19102,11 +19102,11 @@ with self;
     };
   };
 
-  LinuxDesktopFiles = buildPerlModule {
+  LinuxDesktopFiles = buildPerlModule rec {
     pname = "Linux-DesktopFiles";
     version = "0.25";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TR/TRIZEN/Linux-DesktopFiles-0.25.tar.gz";
+      url = "mirror://cpan/authors/id/T/TR/TRIZEN/Linux-DesktopFiles-${version}.tar.gz";
       hash = "sha256-YDd6dPupD6RlIA7hx0MNvd5p1FTYX57hAcA5gDoH5fU=";
     };
     meta = {
@@ -19116,11 +19116,11 @@ with self;
     };
   };
 
-  LinuxDistribution = buildPerlModule {
+  LinuxDistribution = buildPerlModule rec {
     pname = "Linux-Distribution";
     version = "0.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHORNY/Linux-Distribution-0.23.tar.gz";
+      url = "mirror://cpan/authors/id/C/CH/CHORNY/Linux-Distribution-${version}.tar.gz";
       hash = "sha256-YD4n2mB7PocqZp16ZtdZgvCWkVPqstSyDDQTR7Tr2l8=";
     };
     # The tests fail if the distro it's built on isn't in the supported list.
@@ -19136,11 +19136,11 @@ with self;
     };
   };
 
-  LinuxFD = buildPerlModule {
+  LinuxFD = buildPerlModule rec {
     pname = "Linux-FD";
     version = "0.014";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/Linux-FD-0.014.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/Linux-FD-${version}.tar.gz";
       hash = "sha256-eDHcJkxG2bh/dkNhdNdmFBRSQ2Mwg+CQqrTZo1LwQ60=";
     };
     buildInputs = [ TestException ];
@@ -19155,11 +19155,11 @@ with self;
     };
   };
 
-  LinuxInotify2 = buildPerlPackage {
+  LinuxInotify2 = buildPerlPackage rec {
     pname = "Linux-Inotify2";
     version = "2.3";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/Linux-Inotify2-2.3.tar.gz";
+      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/Linux-Inotify2-${version}.tar.gz";
       hash = "sha256-y5kVD5/6UdvDvl7pjY6RyYzf6uIuuI5xjyzzZ78nDRc=";
     };
     propagatedBuildInputs = [ commonsense ];
@@ -19174,11 +19174,11 @@ with self;
     };
   };
 
-  Linuxusermod = buildPerlPackage {
+  Linuxusermod = buildPerlPackage rec {
     pname = "Linux-usermod";
     version = "0.69";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/V/VI/VIDUL/Linux-usermod-0.69.tar.gz";
+      url = "mirror://cpan/authors/id/V/VI/VIDUL/Linux-usermod-${version}.tar.gz";
       hash = "sha256-l8oYajxBa/ae1i2gRvGmDYjYm45u0lAIsvlueH3unWA=";
     };
     meta = {
@@ -19191,11 +19191,11 @@ with self;
     };
   };
 
-  ListAllUtils = buildPerlPackage {
+  ListAllUtils = buildPerlPackage rec {
     pname = "List-AllUtils";
     version = "0.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/List-AllUtils-0.19.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/List-AllUtils-${version}.tar.gz";
       hash = "sha256-MKgUarIad4e4xW1YKc+afysVJ207P8oHM2rDjTAC/7w=";
     };
     propagatedBuildInputs = [
@@ -19209,11 +19209,11 @@ with self;
     };
   };
 
-  ListBinarySearch = buildPerlPackage {
+  ListBinarySearch = buildPerlPackage rec {
     pname = "List-BinarySearch";
     version = "0.25";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAVIDO/List-BinarySearch-0.25.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAVIDO/List-BinarySearch-${version}.tar.gz";
       hash = "sha256-yBEwcb1gQANe6KsBzxtyqRBXQZLx0XkQKud1qXPy6Co=";
     };
     meta = {
@@ -19225,11 +19225,11 @@ with self;
     };
   };
 
-  ListCompare = buildPerlPackage {
+  ListCompare = buildPerlPackage rec {
     pname = "List-Compare";
     version = "0.55";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JK/JKEENAN/List-Compare-0.55.tar.gz";
+      url = "mirror://cpan/authors/id/J/JK/JKEENAN/List-Compare-${version}.tar.gz";
       hash = "sha256-zHGUeYNledUrArwyjtgKmPZ53wQ6mbVxCrLBkWaeuDc=";
     };
     buildInputs = [ CaptureTiny ];
@@ -19243,11 +19243,11 @@ with self;
     };
   };
 
-  ListMoreUtils = buildPerlPackage {
+  ListMoreUtils = buildPerlPackage rec {
     pname = "List-MoreUtils";
     version = "0.430";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RE/REHSACK/List-MoreUtils-0.430.tar.gz";
+      url = "mirror://cpan/authors/id/R/RE/REHSACK/List-MoreUtils-${version}.tar.gz";
       hash = "sha256-Y7H3hCzULZtTjR404DMN5f8VWeTCc3NCUGQYJ29kZSc=";
     };
     propagatedBuildInputs = [
@@ -19264,11 +19264,11 @@ with self;
     };
   };
 
-  ListMoreUtilsXS = buildPerlPackage {
+  ListMoreUtilsXS = buildPerlPackage rec {
     pname = "List-MoreUtils-XS";
     version = "0.430";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RE/REHSACK/List-MoreUtils-XS-0.430.tar.gz";
+      url = "mirror://cpan/authors/id/R/RE/REHSACK/List-MoreUtils-XS-${version}.tar.gz";
       hash = "sha256-6M5G1XwXnuzYdYKT6UAP8wCq8g/v4KnRW5/iMCucskI=";
     };
     meta = {
@@ -19278,11 +19278,11 @@ with self;
     };
   };
 
-  ListSomeUtils = buildPerlPackage {
+  ListSomeUtils = buildPerlPackage rec {
     pname = "List-SomeUtils";
     version = "0.59";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/List-SomeUtils-0.59.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/List-SomeUtils-${version}.tar.gz";
       hash = "sha256-+rMDcuTGe/WkYGLaONHQyHVief6tqGbrQ5+ilXGi3Hs=";
     };
     buildInputs = [ TestLeakTrace ];
@@ -19297,11 +19297,11 @@ with self;
     };
   };
 
-  ListUtilsBy = buildPerlModule {
+  ListUtilsBy = buildPerlModule rec {
     pname = "List-UtilsBy";
     version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/List-UtilsBy-0.12.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/List-UtilsBy-${version}.tar.gz";
       hash = "sha256-//EoH9Rp/pgrGlgES+z9lw8xO/86JuHHsrP0wKXtceA=";
     };
     meta = {
@@ -19313,11 +19313,11 @@ with self;
     };
   };
 
-  LocaleCodes = buildPerlPackage {
+  LocaleCodes = buildPerlPackage rec {
     pname = "Locale-Codes";
     version = "3.76";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SB/SBECK/Locale-Codes-3.76.tar.gz";
+      url = "mirror://cpan/authors/id/S/SB/SBECK/Locale-Codes-${version}.tar.gz";
       hash = "sha256-Qo00GFUJ7fbaYoYoAJcohrsCwySTRU/L4Y+Zmk9DXzk=";
     };
     buildInputs = [ TestInter ];
@@ -19331,13 +19331,13 @@ with self;
     };
   };
 
-  LocaleGettext = buildPerlPackage {
+  LocaleGettext = buildPerlPackage rec {
     pname = "gettext";
     version = "1.07";
     strictDeps = true;
     buildInputs = [ pkgs.gettext ];
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PV/PVANDRY/gettext-1.07.tar.gz";
+      url = "mirror://cpan/authors/id/P/PV/PVANDRY/gettext-${version}.tar.gz";
       hash = "sha256-kJ1HlUaX58BCGPlykVt4e9EkTXXjvQFiC8Fn1bvEnBU=";
     };
     env.LANG = "C";
@@ -19350,11 +19350,11 @@ with self;
     };
   };
 
-  LocaleMaketextLexiconGetcontext = buildPerlPackage {
+  LocaleMaketextLexiconGetcontext = buildPerlPackage rec {
     pname = "Locale-Maketext-Lexicon-Getcontext";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SA/SAPER/Locale-Maketext-Lexicon-Getcontext-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/S/SA/SAPER/Locale-Maketext-Lexicon-Getcontext-${version}.tar.gz";
       hash = "sha256-dcsz35RypZYt5UCC9CxqdrJg/EBboQylMkb7H4LAkgg=";
     };
     propagatedBuildInputs = [ LocaleMaketextLexicon ];
@@ -19364,11 +19364,11 @@ with self;
     };
   };
 
-  LocaleMOFile = buildPerlPackage {
+  LocaleMOFile = buildPerlPackage rec {
     pname = "Locale-MO-File";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/ST/STEFFENW/Locale-MO-File-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/S/ST/STEFFENW/Locale-MO-File-${version}.tar.gz";
       hash = "sha256-lwNtw/Cds3BSrp2aUUSH6IS1bZDHbKEtbKtAXSNWSj8=";
     };
     propagatedBuildInputs = [
@@ -19393,11 +19393,11 @@ with self;
     };
   };
 
-  LocaleMaketextFuzzy = buildPerlPackage {
+  LocaleMaketextFuzzy = buildPerlPackage rec {
     pname = "Locale-Maketext-Fuzzy";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AU/AUDREYT/Locale-Maketext-Fuzzy-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/A/AU/AUDREYT/Locale-Maketext-Fuzzy-${version}.tar.gz";
       hash = "sha256-N4UXHOt4zHZxMZo6bYztmxkOCX382bKp68gEzRooL5Y=";
     };
     meta = {
@@ -19406,11 +19406,11 @@ with self;
     };
   };
 
-  LocaleMaketextLexicon = buildPerlPackage {
+  LocaleMaketextLexicon = buildPerlPackage rec {
     pname = "Locale-Maketext-Lexicon";
     version = "1.00";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DRTECH/Locale-Maketext-Lexicon-1.00.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DRTECH/Locale-Maketext-Lexicon-${version}.tar.gz";
       hash = "sha256-tz9rBKWNPw446/IRWkwVMvGk7vb6xcaipEnk4Uwd3Hw=";
     };
     meta = {
@@ -19421,11 +19421,11 @@ with self;
     };
   };
 
-  LocaleMsgfmt = buildPerlPackage {
+  LocaleMsgfmt = buildPerlPackage rec {
     pname = "Locale-Msgfmt";
     version = "0.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AZ/AZAWAWI/Locale-Msgfmt-0.15.tar.gz";
+      url = "mirror://cpan/authors/id/A/AZ/AZAWAWI/Locale-Msgfmt-${version}.tar.gz";
       hash = "sha256-wydoMcvuz1i+AggbzBgL00jao12iGnc3t7A4pZ9kOrQ=";
     };
     meta = {
@@ -19437,11 +19437,11 @@ with self;
     };
   };
 
-  LocalePO = buildPerlPackage {
+  LocalePO = buildPerlPackage rec {
     pname = "Locale-PO";
     version = "0.27";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CO/COSIMO/Locale-PO-0.27.tar.gz";
+      url = "mirror://cpan/authors/id/C/CO/COSIMO/Locale-PO-${version}.tar.gz";
       hash = "sha256-PJlKS2Pm5Og2xveak/UZIcq3fJDJdT/g+LVCkiDVFrk=";
     };
     propagatedBuildInputs = [ FileSlurp ];
@@ -19454,11 +19454,11 @@ with self;
     };
   };
 
-  LocaleTextDomainOO = buildPerlPackage {
+  LocaleTextDomainOO = buildPerlPackage rec {
     pname = "Locale-TextDomain-OO";
     version = "1.036";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/ST/STEFFENW/Locale-TextDomain-OO-1.036.tar.gz";
+      url = "mirror://cpan/authors/id/S/ST/STEFFENW/Locale-TextDomain-OO-${version}.tar.gz";
       hash = "sha256-tReD4aiWICE+oqg+RbrsOqhunL4en6W590+HSbBUDjg=";
     };
     propagatedBuildInputs = [
@@ -19489,11 +19489,11 @@ with self;
     };
   };
 
-  LocaleTextDomainOOUtil = buildPerlPackage {
+  LocaleTextDomainOOUtil = buildPerlPackage rec {
     pname = "Locale-TextDomain-OO-Util";
     version = "4.002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/ST/STEFFENW/Locale-TextDomain-OO-Util-4.002.tar.gz";
+      url = "mirror://cpan/authors/id/S/ST/STEFFENW/Locale-TextDomain-OO-Util-${version}.tar.gz";
       hash = "sha256-PF+gf2Xtd8Ap4g0kahBAQRSPGptH4332PzflHQK9RqA=";
     };
     propagatedBuildInputs = [ namespaceautoclean ];
@@ -19511,11 +19511,11 @@ with self;
     };
   };
 
-  LocaleUtilsPlaceholderBabelFish = buildPerlPackage {
+  LocaleUtilsPlaceholderBabelFish = buildPerlPackage rec {
     pname = "Locale-Utils-PlaceholderBabelFish";
     version = "0.006";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/ST/STEFFENW/Locale-Utils-PlaceholderBabelFish-0.006.tar.gz";
+      url = "mirror://cpan/authors/id/S/ST/STEFFENW/Locale-Utils-PlaceholderBabelFish-${version}.tar.gz";
       hash = "sha256-LhwAU5ljqeyr0se5te+QpWBna7A0giUXYin8jqS0pMw=";
     };
     propagatedBuildInputs = [
@@ -19538,11 +19538,11 @@ with self;
     };
   };
 
-  LocaleUtilsPlaceholderMaketext = buildPerlPackage {
+  LocaleUtilsPlaceholderMaketext = buildPerlPackage rec {
     pname = "Locale-Utils-PlaceholderMaketext";
     version = "1.005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/ST/STEFFENW/Locale-Utils-PlaceholderMaketext-1.005.tar.gz";
+      url = "mirror://cpan/authors/id/S/ST/STEFFENW/Locale-Utils-PlaceholderMaketext-${version}.tar.gz";
       hash = "sha256-UChgS9jzPY0yymkp+9DagP9L30KN6ARfs/Bbp9FdNOs=";
     };
     propagatedBuildInputs = [
@@ -19564,11 +19564,11 @@ with self;
     };
   };
 
-  LocaleUtilsPlaceholderNamed = buildPerlPackage {
+  LocaleUtilsPlaceholderNamed = buildPerlPackage rec {
     pname = "Locale-Utils-PlaceholderNamed";
     version = "1.004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/ST/STEFFENW/Locale-Utils-PlaceholderNamed-1.004.tar.gz";
+      url = "mirror://cpan/authors/id/S/ST/STEFFENW/Locale-Utils-PlaceholderNamed-${version}.tar.gz";
       hash = "sha256-b9eOojm1w1m6lCJ1N2b2OO5PkM0hdRpZs4YVXipFpr0=";
     };
     propagatedBuildInputs = [
@@ -19590,11 +19590,11 @@ with self;
     };
   };
 
-  locallib = buildPerlPackage {
+  locallib = buildPerlPackage rec {
     pname = "local-lib";
     version = "2.000029";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/local-lib-2.000029.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/local-lib-${version}.tar.gz";
       hash = "sha256-jfh6EMFMjpCcW0fFcB5LgYfVGeUlHofIBwmwK7M+/dc=";
     };
     propagatedBuildInputs = [ ModuleBuild ];
@@ -19607,11 +19607,11 @@ with self;
     };
   };
 
-  LockFileSimple = buildPerlPackage {
+  LockFileSimple = buildPerlPackage rec {
     pname = "LockFile-Simple";
     version = "0.208";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SC/SCHWIGON/lockfile-simple/LockFile-Simple-0.208.tar.gz";
+      url = "mirror://cpan/authors/id/S/SC/SCHWIGON/lockfile-simple/LockFile-Simple-${version}.tar.gz";
       hash = "sha256-Rcd4lrKloKRfYgKm+BP0N/+LKD+EocYNDE83MIAq86I=";
     };
     meta = {
@@ -19623,11 +19623,11 @@ with self;
     };
   };
 
-  LogAny = buildPerlPackage {
+  LogAny = buildPerlPackage rec {
     pname = "Log-Any";
     version = "1.717";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PR/PREACTION/Log-Any-1.717.tar.gz";
+      url = "mirror://cpan/authors/id/P/PR/PREACTION/Log-Any-${version}.tar.gz";
       hash = "sha256-VmSdoPOQAjDJ49KSUssKdIBvst3r0igFrNc2iVmmW8o=";
     };
     # Syslog test fails.
@@ -19642,11 +19642,11 @@ with self;
     };
   };
 
-  LogAnyAdapterLog4perl = buildPerlPackage {
+  LogAnyAdapterLog4perl = buildPerlPackage rec {
     pname = "Log-Any-Adapter-Log4perl";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PR/PREACTION/Log-Any-Adapter-Log4perl-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/P/PR/PREACTION/Log-Any-Adapter-Log4perl-${version}.tar.gz";
       hash = "sha256-EZfT5BIhS+IIgAz3v1BXsf6hVCRTmip5J8/kb3FuwaU=";
     };
     propagatedBuildInputs = [
@@ -19663,11 +19663,11 @@ with self;
     };
   };
 
-  LogAnyAdapterTAP = buildPerlPackage {
+  LogAnyAdapterTAP = buildPerlPackage rec {
     pname = "Log-Any-Adapter-TAP";
     version = "0.003003";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NERDVANA/Log-Any-Adapter-TAP-0.003003.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NERDVANA/Log-Any-Adapter-TAP-${version}.tar.gz";
       hash = "sha256-Ex8GibK0KxsxRJcUxu2o+BHdlqfIZ0jx4DsjnP0BIcA=";
     };
     propagatedBuildInputs = [
@@ -19684,11 +19684,11 @@ with self;
     };
   };
 
-  LogContextual = buildPerlPackage {
+  LogContextual = buildPerlPackage rec {
     pname = "Log-Contextual";
     version = "0.008001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FR/FREW/Log-Contextual-0.008001.tar.gz";
+      url = "mirror://cpan/authors/id/F/FR/FREW/Log-Contextual-${version}.tar.gz";
       hash = "sha256-uTy8+7h5bVHINuOwAkPNpWMICMFSwU7uXyDKCclFGZM=";
     };
     buildInputs = [ TestFatal ];
@@ -19707,11 +19707,11 @@ with self;
     };
   };
 
-  LogDispatch = buildPerlPackage {
+  LogDispatch = buildPerlPackage rec {
     pname = "Log-Dispatch";
     version = "2.71";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Log-Dispatch-2.71.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Log-Dispatch-${version}.tar.gz";
       hash = "sha256-nWDZZIw1zidUcx603rfwWAns4b1jO3TXR5Wu2exzJXA=";
     };
     propagatedBuildInputs = [
@@ -19732,11 +19732,11 @@ with self;
     };
   };
 
-  LogDispatchFileRotate = buildPerlPackage {
+  LogDispatchFileRotate = buildPerlPackage rec {
     pname = "Log-Dispatch-FileRotate";
     version = "1.38";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSCHOUT/Log-Dispatch-FileRotate-1.38.tar.gz";
+      url = "mirror://cpan/authors/id/M/MS/MSCHOUT/Log-Dispatch-FileRotate-${version}.tar.gz";
       hash = "sha256-tV1s7ePwoGQmSI+/pVT0VhMgsBTBAjiTztKVCOW85Ow=";
     };
     propagatedBuildInputs = [
@@ -19757,11 +19757,11 @@ with self;
     };
   };
 
-  LogfileRotate = buildPerlPackage {
+  LogfileRotate = buildPerlPackage rec {
     pname = "Logfile-Rotate";
     version = "1.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PA/PAULG/Logfile-Rotate-1.04.tar.gz";
+      url = "mirror://cpan/authors/id/P/PA/PAULG/Logfile-Rotate-${version}.tar.gz";
       hash = "sha256-gQ+LfM2GV9Ox71PNR1glR4Rc67WCArBVObNAhjjK2j4=";
     };
     meta = {
@@ -19775,11 +19775,11 @@ with self;
     };
   };
 
-  Logger = buildPerlPackage {
+  Logger = buildPerlPackage rec {
     pname = "Log-ger";
     version = "0.040";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PERLANCAR/Log-ger-0.040.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PERLANCAR/Log-ger-${version}.tar.gz";
       hash = "sha256-6JEdM4ePoWmeQ+jQpU7V1WEEA4Z/9cM5+TQQPRfsZLA=";
     };
     meta = {
@@ -19793,11 +19793,11 @@ with self;
     };
   };
 
-  LogHandler = buildPerlModule {
+  LogHandler = buildPerlModule rec {
     pname = "Log-Handler";
     version = "0.90";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BL/BLOONIX/Log-Handler-0.90.tar.gz";
+      url = "mirror://cpan/authors/id/B/BL/BLOONIX/Log-Handler-${version}.tar.gz";
       hash = "sha256-OlyA5xKEVHcPg6yrjL0+cOXsPVmmHcMnkqF48LMb900=";
     };
     propagatedBuildInputs = [ ParamsValidate ];
@@ -19810,11 +19810,11 @@ with self;
     };
   };
 
-  LogMessage = buildPerlPackage {
+  LogMessage = buildPerlPackage rec {
     pname = "Log-Message";
     version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BI/BINGOS/Log-Message-0.08.tar.gz";
+      url = "mirror://cpan/authors/id/B/BI/BINGOS/Log-Message-${version}.tar.gz";
       hash = "sha256-vWl91iqvJtEY6fCggTQp3rHFRORQFVmHm2H8vf6Z/kY=";
     };
     meta = {
@@ -19826,11 +19826,11 @@ with self;
     };
   };
 
-  LogMessageSimple = buildPerlPackage {
+  LogMessageSimple = buildPerlPackage rec {
     pname = "Log-Message-Simple";
     version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BI/BINGOS/Log-Message-Simple-0.10.tar.gz";
+      url = "mirror://cpan/authors/id/B/BI/BINGOS/Log-Message-Simple-${version}.tar.gz";
       hash = "sha256-qhLRpMCsJguU1Ej6Af66JCqKhctsv9xmQy47W0aK3ZY=";
     };
     propagatedBuildInputs = [ LogMessage ];
@@ -19843,11 +19843,11 @@ with self;
     };
   };
 
-  LogTrace = buildPerlPackage {
+  LogTrace = buildPerlPackage rec {
     pname = "Log-Trace";
     version = "1.070";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BB/BBC/Log-Trace-1.070.tar.gz";
+      url = "mirror://cpan/authors/id/B/BB/BBC/Log-Trace-${version}.tar.gz";
       hash = "sha256-nsuCWO8wwvJN7/SRckDQ/nMkLaWyGSQC95gVsJLtNuM=";
     };
     meta = {
@@ -19856,11 +19856,11 @@ with self;
     };
   };
 
-  MCE = buildPerlPackage {
+  MCE = buildPerlPackage rec {
     pname = "MCE";
     version = "1.901";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARIOROY/MCE-1.901.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MARIOROY/MCE-${version}.tar.gz";
       hash = "sha256-3RRrHpmFPjPBzbtowgJK7nQGeseDlNUbgdH6so9Q0TU=";
     };
     meta = {
@@ -19873,11 +19873,11 @@ with self;
     };
   };
 
-  MCEShared = buildPerlPackage {
+  MCEShared = buildPerlPackage rec {
     pname = "MCE-Shared";
     version = "1.893";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARIOROY/MCE-Shared-1.893.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MARIOROY/MCE-Shared-${version}.tar.gz";
       hash = "sha256-+kxIet+w2zyPK2qidNM9j4J/ojTGMbs689lPpKPJRi8=";
     };
     propagatedBuildInputs = [ MCE ];
@@ -19891,11 +19891,11 @@ with self;
     };
   };
 
-  LogLog4perl = buildPerlPackage {
+  LogLog4perl = buildPerlPackage rec {
     pname = "Log-Log4perl";
     version = "1.57";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETJ/Log-Log4perl-1.57.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETJ/Log-Log4perl-${version}.tar.gz";
       hash = "sha256-D4/Ldjio89tMeX35T9vFYBN0kULy+Uy8lbQ8n8oJahM=";
     };
     meta = {
@@ -19909,11 +19909,11 @@ with self;
     };
   };
 
-  LogDispatchArray = buildPerlPackage {
+  LogDispatchArray = buildPerlPackage rec {
     pname = "Log-Dispatch-Array";
     version = "1.005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Log-Dispatch-Array-1.005.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Log-Dispatch-Array-${version}.tar.gz";
       hash = "sha256-MRZAt6ln+N18m7QaInBzVlY21w30/MHUT+2KgiOzR8o=";
     };
     buildInputs = [ TestDeep ];
@@ -19928,11 +19928,11 @@ with self;
     };
   };
 
-  LogDispatchouli = buildPerlPackage {
+  LogDispatchouli = buildPerlPackage rec {
     pname = "Log-Dispatchouli";
     version = "3.007";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Log-Dispatchouli-3.007.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Log-Dispatchouli-${version}.tar.gz";
       hash = "sha256-mIEYlllSukmo+nkaZTaIDIkBf0651ywXRe1n0VwNJyw=";
     };
     buildInputs = [
@@ -19954,11 +19954,11 @@ with self;
     };
   };
 
-  LogJournald = buildPerlModule {
+  LogJournald = buildPerlModule rec {
     pname = "Log-Journald";
     version = "0.30";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LK/LKUNDRAK/Log-Journald-0.30.tar.gz";
+      url = "mirror://cpan/authors/id/L/LK/LKUNDRAK/Log-Journald-${version}.tar.gz";
       hash = "sha256-VZks+aHh+4M/QoMAUlv6fPftRrg+xBT4KgkXibN9CKM=";
     };
     nativeBuildInputs = [ pkgs.pkg-config ];
@@ -19976,11 +19976,11 @@ with self;
     };
   };
 
-  LogLogLite = buildPerlPackage {
+  LogLogLite = buildPerlPackage rec {
     pname = "Log-LogLite";
     version = "0.82";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RA/RANI/Log-LogLite-0.82.tar.gz";
+      url = "mirror://cpan/authors/id/R/RA/RANI/Log-LogLite-${version}.tar.gz";
       hash = "sha256-BQn7i8VDrJZ1pI6xplpjUoYIxsP99ioZ4XBzUA5RGms=";
     };
     propagatedBuildInputs = [ IOLockedFile ];
@@ -19993,11 +19993,11 @@ with self;
     };
   };
 
-  LongJump = buildPerlPackage {
+  LongJump = buildPerlPackage rec {
     pname = "Long-Jump";
     version = "0.000001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EX/EXODIST/Long-Jump-0.000001.tar.gz";
+      url = "mirror://cpan/authors/id/E/EX/EXODIST/Long-Jump-${version}.tar.gz";
       hash = "sha256-1dZFbYaZK1Wdj2b8kJYPkZKSzTgDwTQD+qxXV2LHevQ=";
     };
     buildInputs = [ Test2Suite ];
@@ -20010,11 +20010,11 @@ with self;
     };
   };
 
-  LWP = buildPerlPackage {
+  LWP = buildPerlPackage rec {
     pname = "libwww-perl";
     version = "6.72";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OA/OALDERS/libwww-perl-6.72.tar.gz";
+      url = "mirror://cpan/authors/id/O/OA/OALDERS/libwww-perl-${version}.tar.gz";
       hash = "sha256-6bg1T9XiC+IHr+I93VhPzVm/gpmNwHfez2hLodrloF0=";
     };
     propagatedBuildInputs = [
@@ -20050,11 +20050,11 @@ with self;
     };
   };
 
-  LWPAuthenOAuth = buildPerlPackage {
+  LWPAuthenOAuth = buildPerlPackage rec {
     pname = "LWP-Authen-OAuth";
     version = "1.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TI/TIMBRODY/LWP-Authen-OAuth-1.02.tar.gz";
+      url = "mirror://cpan/authors/id/T/TI/TIMBRODY/LWP-Authen-OAuth-${version}.tar.gz";
       hash = "sha256-544L196AAs+0dgBzJY1VXvVbLCfAepSz2KIWahf9lrw=";
     };
     propagatedBuildInputs = [ LWP ];
@@ -20067,11 +20067,11 @@ with self;
     };
   };
 
-  LWPMediaTypes = buildPerlPackage {
+  LWPMediaTypes = buildPerlPackage rec {
     pname = "LWP-MediaTypes";
     version = "6.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OA/OALDERS/LWP-MediaTypes-6.04.tar.gz";
+      url = "mirror://cpan/authors/id/O/OA/OALDERS/LWP-MediaTypes-${version}.tar.gz";
       hash = "sha256-jxvKEtqxahwqfAOknF5YzOQab+yVGfCq37qNrZl5Gdk=";
     };
     buildInputs = [ TestFatal ];
@@ -20085,11 +20085,11 @@ with self;
     };
   };
 
-  LWPProtocolConnect = buildPerlPackage {
+  LWPProtocolConnect = buildPerlPackage rec {
     pname = "LWP-Protocol-connect";
     version = "6.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BE/BENNING/LWP-Protocol-connect-6.09.tar.gz";
+      url = "mirror://cpan/authors/id/B/BE/BENNING/LWP-Protocol-connect-${version}.tar.gz";
       hash = "sha256-nyUjlHdeI6pCwxdmEeWTBjirUo1RkBELRzGqWwvzWhU=";
     };
     buildInputs = [ TestException ];
@@ -20103,11 +20103,11 @@ with self;
     };
   };
 
-  LWPProtocolHttps = buildPerlPackage {
+  LWPProtocolHttps = buildPerlPackage rec {
     pname = "LWP-Protocol-https";
     version = "6.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OA/OALDERS/LWP-Protocol-https-6.11.tar.gz";
+      url = "mirror://cpan/authors/id/O/OA/OALDERS/LWP-Protocol-https-${version}.tar.gz";
       hash = "sha256-ATLdvwNmFWXKhQUPKlCU+5Jjy7w8yxpNnEGsm7CDuRc=";
     };
     patches = [ ../development/perl-modules/lwp-protocol-https-cert-file.patch ];
@@ -20132,11 +20132,11 @@ with self;
     };
   };
 
-  LWPProtocolhttp10 = buildPerlPackage {
+  LWPProtocolhttp10 = buildPerlPackage rec {
     pname = "LWP-Protocol-http10";
     version = "6.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GA/GAAS/LWP-Protocol-http10-6.03.tar.gz";
+      url = "mirror://cpan/authors/id/G/GA/GAAS/LWP-Protocol-http10-${version}.tar.gz";
       hash = "sha256-8/+pEfnVkYHxcXkQ6iZiCQXCmLdNww99TlE57jAguNM=";
     };
     propagatedBuildInputs = [ LWP ];
@@ -20149,11 +20149,11 @@ with self;
     };
   };
 
-  LWPUserAgentCached = buildPerlPackage {
+  LWPUserAgentCached = buildPerlPackage rec {
     pname = "LWP-UserAgent-Cached";
     version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OL/OLEG/LWP-UserAgent-Cached-0.08.tar.gz";
+      url = "mirror://cpan/authors/id/O/OL/OLEG/LWP-UserAgent-Cached-${version}.tar.gz";
       hash = "sha256-Pc5atMeAQWVs54Vk92Az5b0ew4b1TS57MHQK5I7nh8M=";
     };
     propagatedBuildInputs = [ LWP ];
@@ -20166,11 +20166,11 @@ with self;
     };
   };
 
-  LWPUserAgentDNSHosts = buildPerlModule {
+  LWPUserAgentDNSHosts = buildPerlModule rec {
     pname = "LWP-UserAgent-DNS-Hosts";
     version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MASAKI/LWP-UserAgent-DNS-Hosts-0.14.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MASAKI/LWP-UserAgent-DNS-Hosts-${version}.tar.gz";
       hash = "sha256-mWl5RD8Ib/yLNmvbukSGWR2T+SF7wgSz5dZrlHIghx8=";
     };
     propagatedBuildInputs = [
@@ -20194,11 +20194,11 @@ with self;
     };
   };
 
-  LWPUserAgentDetermined = buildPerlPackage {
+  LWPUserAgentDetermined = buildPerlPackage rec {
     pname = "LWP-UserAgent-Determined";
     version = "1.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AL/ALEXMV/LWP-UserAgent-Determined-1.07.tar.gz";
+      url = "mirror://cpan/authors/id/A/AL/ALEXMV/LWP-UserAgent-Determined-${version}.tar.gz";
       hash = "sha256-BtjVDozTaSoRy0+0Si+E5UdqmPDi5qSg386fZ+Vd21M=";
     };
     propagatedBuildInputs = [ LWP ];
@@ -20211,11 +20211,11 @@ with self;
     };
   };
 
-  LWPUserAgentMockable = buildPerlModule {
+  LWPUserAgentMockable = buildPerlModule rec {
     pname = "LWP-UserAgent-Mockable";
     version = "1.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MJ/MJEMMESON/LWP-UserAgent-Mockable-1.18.tar.gz";
+      url = "mirror://cpan/authors/id/M/MJ/MJEMMESON/LWP-UserAgent-Mockable-${version}.tar.gz";
       hash = "sha256-JYZPUOOlIZ+J00oYQlmFSUWussXtSBjzbw8wIShUQyQ=";
     };
     propagatedBuildInputs = [
@@ -20240,11 +20240,11 @@ with self;
     };
   };
 
-  LWPxParanoidAgent = buildPerlPackage {
+  LWPxParanoidAgent = buildPerlPackage rec {
     pname = "LWPx-ParanoidAgent";
     version = "1.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SA/SAXJAZMAN/lwp/LWPx-ParanoidAgent-1.12.tar.gz";
+      url = "mirror://cpan/authors/id/S/SA/SAXJAZMAN/lwp/LWPx-ParanoidAgent-${version}.tar.gz";
       hash = "sha256-zAQa7bdOGDzfkcvryhx71tdk/e5o+9yE8r4IveTg0D0=";
     };
     doCheck = false; # 3 tests fail, probably because they try to connect to the network
@@ -20263,11 +20263,11 @@ with self;
 
   maatkit = callPackage ../development/perl-modules/maatkit { };
 
-  MacPasteboard = buildPerlPackage {
+  MacPasteboard = buildPerlPackage rec {
     pname = "Mac-Pasteboard";
     version = "0.103";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/W/WY/WYANT/Mac-Pasteboard-0.103.tar.gz";
+      url = "mirror://cpan/authors/id/W/WY/WYANT/Mac-Pasteboard-${version}.tar.gz";
       hash = "sha256-L16N0tsNZEVVhITKbULYOcWpfuiqGyUOaU1n1bf2Y0w=";
     };
     meta = {
@@ -20281,11 +20281,11 @@ with self;
     };
   };
 
-  MacPropertyList = buildPerlPackage {
+  MacPropertyList = buildPerlPackage rec {
     pname = "Mac-PropertyList";
     version = "1.504";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/Mac-PropertyList-1.504.tar.gz";
+      url = "mirror://cpan/authors/id/B/BD/BDFOY/Mac-PropertyList-${version}.tar.gz";
       hash = "sha256-aIl96Yw2j76c22iF1H3qADxG7Ho3MmNSPvZkVwc7eq4=";
     };
     propagatedBuildInputs = [ XMLEntities ];
@@ -20296,11 +20296,11 @@ with self;
     };
   };
 
-  MacSysProfile = buildPerlPackage {
+  MacSysProfile = buildPerlPackage rec {
     pname = "Mac-SysProfile";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DM/DMUEY/Mac-SysProfile-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/D/DM/DMUEY/Mac-SysProfile-${version}.tar.gz";
       hash = "sha256-QDOXa3dbOcwqaTtyoC1l71p7oDveTU2w3/RuEmx9n2w=";
     };
     propagatedBuildInputs = [ MacPropertyList ];
@@ -20314,11 +20314,11 @@ with self;
     };
   };
 
-  MailAuthenticationResults = buildPerlPackage {
+  MailAuthenticationResults = buildPerlPackage rec {
     pname = "Mail-AuthenticationResults";
     version = "2.20230112";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MB/MBRADSHAW/Mail-AuthenticationResults-2.20230112.tar.gz";
+      url = "mirror://cpan/authors/id/M/MB/MBRADSHAW/Mail-AuthenticationResults-${version}.tar.gz";
       hash = "sha256-wtFEyuAiX4vJ0PX60cPxOdJ89TT85+rHB2T79m/SI0E=";
     };
     buildInputs = [ TestException ];
@@ -20335,11 +20335,11 @@ with self;
     };
   };
 
-  MailDMARC = buildPerlPackage {
+  MailDMARC = buildPerlPackage rec {
     pname = "Mail-DMARC";
     version = "1.20230215";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MB/MBRADSHAW/Mail-DMARC-1.20230215.tar.gz";
+      url = "mirror://cpan/authors/id/M/MB/MBRADSHAW/Mail-DMARC-${version}.tar.gz";
       hash = "sha256-V9z1R1nLkkSOVukUE0D2E0QnTFjZ3WWqkKqczw5+uQM=";
     };
     buildInputs = [
@@ -20387,11 +20387,11 @@ with self;
     };
   };
 
-  MailMaildir = buildPerlPackage {
+  MailMaildir = buildPerlPackage rec {
     version = "1.0.0";
     pname = "Mail-Maildir";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZE/ZEROALTI/Mail-Maildir-100/Mail-Maildir-1.0.0.tar.bz2";
+      url = "mirror://cpan/authors/id/Z/ZE/ZEROALTI/Mail-Maildir-100/Mail-Maildir-${version}.tar.bz2";
       hash = "sha256-RF6s2ixmN5ApbXGbypzHKYVUX6GgkBRhdnFgo6/DM88=";
     };
     meta = {
@@ -20403,11 +20403,11 @@ with self;
     };
   };
 
-  MailBox = buildPerlPackage {
+  MailBox = buildPerlPackage rec {
     version = "3.010";
     pname = "Mail-Box";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARKOV/Mail-Box-3.010.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MARKOV/Mail-Box-${version}.tar.gz";
       hash = "sha256-rhlPolDFRcm5FT4/tRA8qyn3nPKs1On9dc7FMiAalWQ=";
     };
 
@@ -20428,11 +20428,11 @@ with self;
     };
   };
 
-  MailMboxMessageParser = buildPerlPackage {
+  MailMboxMessageParser = buildPerlPackage rec {
     pname = "Mail-Mbox-MessageParser";
     version = "1.5111";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCOPPIT/Mail-Mbox-MessageParser-1.5111.tar.gz";
+      url = "mirror://cpan/authors/id/D/DC/DCOPPIT/Mail-Mbox-MessageParser-${version}.tar.gz";
       hash = "sha256-VyPAqpzBC6ue0eO/2dXJX3FZ5xwaR1QU6xrx3uOkYjc=";
     };
     buildInputs = [
@@ -20453,11 +20453,11 @@ with self;
     };
   };
 
-  MailMessage = buildPerlPackage {
+  MailMessage = buildPerlPackage rec {
     pname = "Mail-Message";
     version = "3.013";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARKOV/Mail-Message-3.013.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MARKOV/Mail-Message-${version}.tar.gz";
       hash = "sha256-yK1YiNsBWkUOti7Cqj6mbcLdwRtwpdtsjKGn+fgg6B8=";
     };
     propagatedBuildInputs = [
@@ -20477,11 +20477,11 @@ with self;
     };
   };
 
-  MailDKIM = buildPerlPackage {
+  MailDKIM = buildPerlPackage rec {
     pname = "Mail-DKIM";
     version = "1.20230911";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MB/MBRADSHAW/Mail-DKIM-1.20230911.tar.gz";
+      url = "mirror://cpan/authors/id/M/MB/MBRADSHAW/Mail-DKIM-${version}.tar.gz";
       hash = "sha256-kecxcoK3JM+9LJtuZjDvFDKISLb8UgPv1w3sL7hyaMo=";
     };
     propagatedBuildInputs = [
@@ -20506,11 +20506,11 @@ with self;
     };
   };
 
-  MailIMAPClient = buildPerlPackage {
+  MailIMAPClient = buildPerlPackage rec {
     pname = "Mail-IMAPClient";
     version = "3.43";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLOBBES/Mail-IMAPClient-3.43.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLOBBES/Mail-IMAPClient-${version}.tar.gz";
       hash = "sha256-CTyX+sFbR6j+TSk27y3zd6v3fMirdAktISi7lF0ftG8=";
     };
     propagatedBuildInputs = [ ParseRecDescent ];
@@ -20523,11 +20523,11 @@ with self;
     };
   };
 
-  MailPOP3Client = buildPerlPackage {
+  MailPOP3Client = buildPerlPackage rec {
     pname = "Mail-POP3Client";
     version = "2.21";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SD/SDOWD/Mail-POP3Client-2.21.tar.gz";
+      url = "mirror://cpan/authors/id/S/SD/SDOWD/Mail-POP3Client-${version}.tar.gz";
       hash = "sha256-sW7yFJtuNXOHPx5ZDk1RNmxZlLi1MV3xaSXRe4niSQE=";
     };
     meta = {
@@ -20539,11 +20539,11 @@ with self;
     };
   };
 
-  MailRFC822Address = buildPerlPackage {
+  MailRFC822Address = buildPerlPackage rec {
     pname = "Mail-RFC822-Address";
     version = "0.3";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PD/PDWARREN/Mail-RFC822-Address-0.3.tar.gz";
+      url = "mirror://cpan/authors/id/P/PD/PDWARREN/Mail-RFC822-Address-${version}.tar.gz";
       hash = "sha256-NR70EE7LZ17K5pAIJD+ugkPRp+U8aB7rdZ57eBaEyKc=";
     };
     meta = {
@@ -20552,11 +20552,11 @@ with self;
     };
   };
 
-  MailSender = buildPerlPackage {
+  MailSender = buildPerlPackage rec {
     pname = "Mail-Sender";
     version = "0.903";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CA/CAPOEIRAB/Mail-Sender-0.903.tar.gz";
+      url = "mirror://cpan/authors/id/C/CA/CAPOEIRAB/Mail-Sender-${version}.tar.gz";
       hash = "sha256-RBPrSfUgqDGBUYEcywWo1UKXOq2iCqUDrTL5/8mKOb8=";
     };
     meta = {
@@ -20569,11 +20569,11 @@ with self;
     };
   };
 
-  MailSendmail = buildPerlPackage {
+  MailSendmail = buildPerlPackage rec {
     pname = "Mail-Sendmail";
     version = "0.80";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/Mail-Sendmail-0.80.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/Mail-Sendmail-${version}.tar.gz";
       hash = "sha256-W4qYy1zDnYBEGjiqsBCIXd+A5vzY5uAxQ5LLI+fCaOQ=";
     };
     # The test suite simply loads the module and attempts to send an email to
@@ -20597,11 +20597,11 @@ with self;
     };
   };
 
-  MailSPF = buildPerlPackage {
+  MailSPF = buildPerlPackage rec {
     pname = "Mail-SPF";
     version = "2.9.0";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JM/JMEHNLE/mail-spf/Mail-SPF-v2.9.0.tar.gz";
+      url = "mirror://cpan/authors/id/J/JM/JMEHNLE/mail-spf/Mail-SPF-v${version}.tar.gz";
       hash = "sha256-YctZFfHHrMepMf/Bv8EpG9+sVV4qRusjkbmV6p7LYWI=";
     };
     # remove this patch patches = [ ../development/perl-modules/Mail-SPF.patch ];
@@ -20627,11 +20627,11 @@ with self;
     };
   };
 
-  MailTools = buildPerlPackage {
+  MailTools = buildPerlPackage rec {
     pname = "MailTools";
     version = "2.21";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARKOV/MailTools-2.21.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MARKOV/MailTools-${version}.tar.gz";
       hash = "sha256-Stm9aCa28DonJzMkZrG30piQyNmaMrSzsKjZJu4aRMs=";
     };
     propagatedBuildInputs = [ TimeDate ];
@@ -20645,11 +20645,11 @@ with self;
     };
   };
 
-  MailTransport = buildPerlPackage {
+  MailTransport = buildPerlPackage rec {
     pname = "Mail-Transport";
     version = "3.005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARKOV/Mail-Transport-3.005.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MARKOV/Mail-Transport-${version}.tar.gz";
       hash = "sha256-0Ny5P3BcEoXYCONN59htvijR7WaqKn3oMPZlH8NRlqM=";
     };
     propagatedBuildInputs = [ MailMessage ];
@@ -20663,11 +20663,11 @@ with self;
     };
   };
 
-  MathBase85 = buildPerlPackage {
+  MathBase85 = buildPerlPackage rec {
     pname = "Math-Base85";
     version = "0.5";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PT/PTC/Math-Base85-0.5.tar.gz";
+      url = "mirror://cpan/authors/id/P/PT/PTC/Math-Base85-${version}.tar.gz";
       hash = "sha256-CwX3+2UKh5ezktjqkPLnK/uNCFBcmi4LlV39RacqNOU=";
     };
     meta = {
@@ -20679,11 +20679,11 @@ with self;
     };
   };
 
-  MathBaseConvert = buildPerlPackage {
+  MathBaseConvert = buildPerlPackage rec {
     pname = "Math-Base-Convert";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIKER/Math-Base-Convert-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIKER/Math-Base-Convert-${version}.tar.gz";
       hash = "sha256-jAlxNV8kyTt553rVSkVwCQoaWY/Lm4b1wX66QvOLQOA=";
     };
     meta = {
@@ -20695,11 +20695,11 @@ with self;
     };
   };
 
-  MathLibm = buildPerlPackage {
+  MathLibm = buildPerlPackage rec {
     pname = "Math-Libm";
     version = "1.00";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DS/DSLEWART/Math-Libm-1.00.tar.gz";
+      url = "mirror://cpan/authors/id/D/DS/DSLEWART/Math-Libm-${version}.tar.gz";
       hash = "sha256-v9MJ8oOsjLm/AK+MfDoQvyWr/WQoYcICLvr/CkpSwnY=";
     };
     meta = {
@@ -20711,11 +20711,11 @@ with self;
     };
   };
 
-  MathCalcParser = buildPerlPackage {
+  MathCalcParser = buildPerlPackage rec {
     pname = "Math-Calc-Parser";
     version = "1.005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DB/DBOOK/Math-Calc-Parser-1.005.tar.gz";
+      url = "mirror://cpan/authors/id/D/DB/DBOOK/Math-Calc-Parser-${version}.tar.gz";
       hash = "sha256-r8PrSWqzo6MBs0N68H4ZfrdDwGCQ8BAdrPggMC8rf3U=";
     };
     buildInputs = [ TestNeeds ];
@@ -20728,11 +20728,11 @@ with self;
     };
   };
 
-  MathCalcUnits = buildPerlPackage {
+  MathCalcUnits = buildPerlPackage rec {
     pname = "Math-Calc-Units";
     version = "1.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SF/SFINK/Math-Calc-Units-1.07.tar.gz";
+      url = "mirror://cpan/authors/id/S/SF/SFINK/Math-Calc-Units-${version}.tar.gz";
       hash = "sha256-YePP2ye7O+4nvrlxJN2TB2DhA57cHreBbC9WJ3Zfj48=";
     };
     meta = {
@@ -20745,11 +20745,11 @@ with self;
     };
   };
 
-  MathBigInt = buildPerlPackage {
+  MathBigInt = buildPerlPackage rec {
     pname = "Math-BigInt";
     version = "1.999842";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PJ/PJACKLAM/Math-BigInt-1.999842.tar.gz";
+      url = "mirror://cpan/authors/id/P/PJ/PJACKLAM/Math-BigInt-${version}.tar.gz";
       hash = "sha256-VGAcUMaZPn7hPYw6wzRs8VpNgGMUnNu+husB5WEORnU=";
     };
     meta = {
@@ -20761,11 +20761,11 @@ with self;
     };
   };
 
-  MathBigIntGMP = buildPerlPackage {
+  MathBigIntGMP = buildPerlPackage rec {
     pname = "Math-BigInt-GMP";
     version = "1.6013";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PJ/PJACKLAM/Math-BigInt-GMP-1.6013.tar.gz";
+      url = "mirror://cpan/authors/id/P/PJ/PJACKLAM/Math-BigInt-GMP-${version}.tar.gz";
       hash = "sha256-yxqS4CJn1AUV+OA6TiEvZv0wfJdMu9MT4j3jL98Q9rU=";
     };
     buildInputs = [ pkgs.gmp ];
@@ -20782,11 +20782,11 @@ with self;
     };
   };
 
-  MathBigIntLite = buildPerlPackage {
+  MathBigIntLite = buildPerlPackage rec {
     pname = "Math-BigInt-Lite";
     version = "0.29";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PJ/PJACKLAM/Math-BigInt-Lite-0.29.tar.gz";
+      url = "mirror://cpan/authors/id/P/PJ/PJACKLAM/Math-BigInt-Lite-${version}.tar.gz";
       hash = "sha256-R4YN/KYxl4txxKqZkaGynk7LrzYbW7nrOVl1t//Nd/U=";
     };
     propagatedBuildInputs = [ MathBigInt ];
@@ -20799,11 +20799,11 @@ with self;
     };
   };
 
-  MathClipper = buildPerlModule {
+  MathClipper = buildPerlModule rec {
     pname = "Math-Clipper";
     version = "1.29";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHELDRAKE/Math-Clipper-1.29.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHELDRAKE/Math-Clipper-${version}.tar.gz";
       hash = "sha256-UyfE8TOGbenXmzGGV/Zp7LSZhgVQs5aGmNRyiHr4dZM=";
     };
     nativeBuildInputs = [ pkgs.ld-is-cc-hook ];
@@ -20823,11 +20823,11 @@ with self;
     };
   };
 
-  MathConvexHullMonotoneChain = buildPerlPackage {
+  MathConvexHullMonotoneChain = buildPerlPackage rec {
     pname = "Math-ConvexHull-MonotoneChain";
     version = "0.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SM/SMUELLER/Math-ConvexHull-MonotoneChain-0.01.tar.gz";
+      url = "mirror://cpan/authors/id/S/SM/SMUELLER/Math-ConvexHull-MonotoneChain-${version}.tar.gz";
       hash = "sha256-KIvEWQgmMkVUj5FIKrEkiGjdne5Ef5yibK15YT47lPU=";
     };
     meta = {
@@ -20839,11 +20839,11 @@ with self;
     };
   };
 
-  MathFibonacci = buildPerlPackage {
+  MathFibonacci = buildPerlPackage rec {
     pname = "Math-Fibonacci";
     version = "1.5";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/V/VI/VIPUL/Math-Fibonacci-1.5.tar.gz";
+      url = "mirror://cpan/authors/id/V/VI/VIPUL/Math-Fibonacci-${version}.tar.gz";
       hash = "sha256-cKgobpRVjfmdyS9S2D4eIKe494UrzDod59njOCYLmbo=";
     };
     meta = {
@@ -20852,11 +20852,11 @@ with self;
     };
   };
 
-  MathGMP = buildPerlPackage {
+  MathGMP = buildPerlPackage rec {
     pname = "Math-GMP";
     version = "2.25";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Math-GMP-2.25.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Math-GMP-${version}.tar.gz";
       hash = "sha256-OCtx5Udi9jnppCqbBpNBUZh7pX0Ru3DTXjvsiNUEUM4=";
     };
     buildInputs = [
@@ -20871,11 +20871,11 @@ with self;
     };
   };
 
-  MathGMPz = buildPerlPackage {
+  MathGMPz = buildPerlPackage rec {
     pname = "Math-GMPz";
     version = "0.59";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SI/SISYPHUS/Math-GMPz-0.59.tar.gz";
+      url = "mirror://cpan/authors/id/S/SI/SISYPHUS/Math-GMPz-${version}.tar.gz";
       hash = "sha256-mmrN45G0Ff5f7HwUyCTVUf/j+W81rycYRWuJ3jpkEaQ=";
     };
     buildInputs = [
@@ -20894,11 +20894,11 @@ with self;
     };
   };
 
-  MathGeometryVoronoi = buildPerlPackage {
+  MathGeometryVoronoi = buildPerlPackage rec {
     pname = "Math-Geometry-Voronoi";
     version = "1.3";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SA/SAMTREGAR/Math-Geometry-Voronoi-1.3.tar.gz";
+      url = "mirror://cpan/authors/id/S/SA/SAMTREGAR/Math-Geometry-Voronoi-${version}.tar.gz";
       hash = "sha256-cgdeTpiDzuUURrqVESZMjDKgFagPSlZIo/azgsU0QCw=";
     };
     propagatedBuildInputs = [
@@ -20914,11 +20914,11 @@ with self;
     };
   };
 
-  MathInt128 = buildPerlPackage {
+  MathInt128 = buildPerlPackage rec {
     pname = "Math-Int128";
     version = "0.22";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SA/SALVA/Math-Int128-0.22.tar.gz";
+      url = "mirror://cpan/authors/id/S/SA/SALVA/Math-Int128-${version}.tar.gz";
       hash = "sha256-pjDKQBdThmlV8Rc4SKtbSsStXKatkIfxHN+R3ehRGbw=";
     };
     propagatedBuildInputs = [ MathInt64 ];
@@ -20933,11 +20933,11 @@ with self;
     };
   };
 
-  MathInt64 = buildPerlPackage {
+  MathInt64 = buildPerlPackage rec {
     pname = "Math-Int64";
     version = "0.54";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SA/SALVA/Math-Int64-0.54.tar.gz";
+      url = "mirror://cpan/authors/id/S/SA/SALVA/Math-Int64-${version}.tar.gz";
       hash = "sha256-3PxR5phDfqa5zv4CdiFcVs22p/hePiSitrQYnxlg01E=";
     };
     meta = {
@@ -20983,11 +20983,11 @@ with self;
     };
   };
 
-  MathPlanePath = buildPerlPackage {
+  MathPlanePath = buildPerlPackage rec {
     pname = "Math-PlanePath";
     version = "129";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KR/KRYDE/Math-PlanePath-129.tar.gz";
+      url = "mirror://cpan/authors/id/K/KR/KRYDE/Math-PlanePath-${version}.tar.gz";
       hash = "sha256-jaFdDk1Qd7bF0gN2WyiFv3KOUJ4y3pJkYFwIYhN+OX4=";
     };
     propagatedBuildInputs = [
@@ -21005,11 +21005,11 @@ with self;
     };
   };
 
-  MathPrimeUtil = buildPerlPackage {
+  MathPrimeUtil = buildPerlPackage rec {
     pname = "Math-Prime-Util";
     version = "0.73";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DANAJ/Math-Prime-Util-0.73.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DANAJ/Math-Prime-Util-${version}.tar.gz";
       hash = "sha256-Svpt2M25dJm9TsppJYYYEsKdn1oPGsJ62dLZybVgKJQ=";
     };
     propagatedBuildInputs = [ MathPrimeUtilGMP ];
@@ -21025,11 +21025,11 @@ with self;
     };
   };
 
-  MathPrimeUtilGMP = buildPerlPackage {
+  MathPrimeUtilGMP = buildPerlPackage rec {
     pname = "Math-Prime-Util-GMP";
     version = "0.52";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DANAJ/Math-Prime-Util-GMP-0.52.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DANAJ/Math-Prime-Util-GMP-${version}.tar.gz";
       hash = "sha256-JpfH/Vx+Nf3sf1DtVqZ76Aei8iZXWJ5jfa01knRAA74=";
     };
     buildInputs = [ pkgs.gmp ];
@@ -21046,11 +21046,11 @@ with self;
     };
   };
 
-  MathProvablePrime = buildPerlPackage {
+  MathProvablePrime = buildPerlPackage rec {
     pname = "Math-ProvablePrime";
     version = "0.51";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FE/FELIPE/Math-ProvablePrime-0.51.tar.gz";
+      url = "mirror://cpan/authors/id/F/FE/FELIPE/Math-ProvablePrime-${version}.tar.gz";
       hash = "sha256-D7YWRJ+weorR6KgJxwghthjlPcD/3ayWVnYY3jPEbBE=";
     };
     buildInputs = [
@@ -21071,11 +21071,11 @@ with self;
     };
   };
 
-  MathRandom = buildPerlPackage {
+  MathRandom = buildPerlPackage rec {
     pname = "Math-Random";
     version = "0.72";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GR/GROMMEL/Math-Random-0.72.tar.gz";
+      url = "mirror://cpan/authors/id/G/GR/GROMMEL/Math-Random-${version}.tar.gz";
       hash = "sha256-vgUiMogR2W3lBdnrrD0JY1kCb6jVw497uZmnjsW8JUw=";
     };
     meta = {
@@ -21088,11 +21088,11 @@ with self;
     };
   };
 
-  MathRandomISAAC = buildPerlPackage {
+  MathRandomISAAC = buildPerlPackage rec {
     pname = "Math-Random-ISAAC";
     version = "1.004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JA/JAWNSY/Math-Random-ISAAC-1.004.tar.gz";
+      url = "mirror://cpan/authors/id/J/JA/JAWNSY/Math-Random-ISAAC-${version}.tar.gz";
       hash = "sha256-J3PwL78gfpdF52oDffCL9ajMmH7SPFcEDOf3sVYfK3w=";
     };
     buildInputs = [ TestNoWarnings ];
@@ -21108,11 +21108,11 @@ with self;
     };
   };
 
-  MathRandomMTAuto = buildPerlPackage {
+  MathRandomMTAuto = buildPerlPackage rec {
     pname = "Math-Random-MT-Auto";
     version = "6.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JD/JDHEDDEN/Math-Random-MT-Auto-6.23.tar.gz";
+      url = "mirror://cpan/authors/id/J/JD/JDHEDDEN/Math-Random-MT-Auto-${version}.tar.gz";
       hash = "sha256-WLy1rTFilk/1oMTS3LqgICwshdnEcElvO3qZh1d3YxM=";
     };
     propagatedBuildInputs = [ ObjectInsideOut ];
@@ -21122,11 +21122,11 @@ with self;
     };
   };
 
-  MathRandomSecure = buildPerlPackage {
+  MathRandomSecure = buildPerlPackage rec {
     pname = "Math-Random-Secure";
     version = "0.080001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FR/FREW/Math-Random-Secure-0.080001.tar.gz";
+      url = "mirror://cpan/authors/id/F/FR/FREW/Math-Random-Secure-${version}.tar.gz";
       hash = "sha256-v6Sk6BfspyIGfB/z2hKrWrgNbFfapeXnq5NQyixx6zU=";
     };
     buildInputs = [
@@ -21145,11 +21145,11 @@ with self;
     };
   };
 
-  MathRound = buildPerlPackage {
+  MathRound = buildPerlPackage rec {
     pname = "Math-Round";
     version = "0.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GR/GROMMEL/Math-Round-0.07.tar.gz";
+      url = "mirror://cpan/authors/id/G/GR/GROMMEL/Math-Round-${version}.tar.gz";
       hash = "sha256-c6cymoblSlwppEA4LlgDCVtY8zEp5hod8Ak7SCTekyc=";
     };
     meta = {
@@ -21161,11 +21161,11 @@ with self;
     };
   };
 
-  MathVecStat = buildPerlPackage {
+  MathVecStat = buildPerlPackage rec {
     pname = "Math-VecStat";
     version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AS/ASPINELLI/Math-VecStat-0.08.tar.gz";
+      url = "mirror://cpan/authors/id/A/AS/ASPINELLI/Math-VecStat-${version}.tar.gz";
       hash = "sha256-QJqODksQJcjoD2KPZal3iqd6soUWFAbKSmwJexNlbQ0=";
     };
     meta = {
@@ -21177,11 +21177,11 @@ with self;
     };
   };
 
-  MaxMindDBCommon = buildPerlPackage {
+  MaxMindDBCommon = buildPerlPackage rec {
     pname = "MaxMind-DB-Common";
     version = "0.040001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MAXMIND/MaxMind-DB-Common-0.040001.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MAXMIND/MaxMind-DB-Common-${version}.tar.gz";
       hash = "sha256-a8bfS9NjANB6pKX4GYrmaUyn4xPAOBCciNvDqZeyG9c=";
     };
     propagatedBuildInputs = [
@@ -21197,11 +21197,11 @@ with self;
     };
   };
 
-  MaxMindDBReader = buildPerlPackage {
+  MaxMindDBReader = buildPerlPackage rec {
     pname = "MaxMind-DB-Reader";
     version = "1.000014";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MAXMIND/MaxMind-DB-Reader-1.000014.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MAXMIND/MaxMind-DB-Reader-${version}.tar.gz";
       hash = "sha256-OCAHj5yWf5qIch6kDKBeSZnBxTAb68HRGQYPntXOOak=";
     };
     propagatedBuildInputs = [
@@ -21224,11 +21224,11 @@ with self;
     };
   };
 
-  MaxMindDBReaderXS = buildPerlModule {
+  MaxMindDBReaderXS = buildPerlModule rec {
     pname = "MaxMind-DB-Reader-XS";
     version = "1.000009";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MAXMIND/MaxMind-DB-Reader-XS-1.000009.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MAXMIND/MaxMind-DB-Reader-XS-${version}.tar.gz";
       hash = "sha256-qm+4f+0Z1UnymxNd55l+6SsSJ9Ymyw6JBgCpHK3DBTo=";
     };
     propagatedBuildInputs = [
@@ -21250,11 +21250,11 @@ with self;
     };
   };
 
-  MaxMindDBWriter = buildPerlModule {
+  MaxMindDBWriter = buildPerlModule rec {
     pname = "MaxMind-DB-Writer";
     version = "0.300003";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MAXMIND/MaxMind-DB-Writer-0.300003.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MAXMIND/MaxMind-DB-Writer-${version}.tar.gz";
       hash = "sha256-ulP1upZfekd/ZxZNl7R1oMESCIcv7fI4mIVQ2SvN6z4=";
     };
     propagatedBuildInputs = [
@@ -21287,11 +21287,11 @@ with self;
     };
   };
 
-  Memoize = buildPerlPackage {
+  Memoize = buildPerlPackage rec {
     pname = "Memoize";
     version = "1.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AR/ARISTOTLE/Memoize-1.16.tar.gz";
+      url = "mirror://cpan/authors/id/A/AR/ARISTOTLE/Memoize-${version}.tar.gz";
       hash = "sha256-CRlSvPSS7O41ueW41ykgxYAjRB15IIwduHg3xcV4B74=";
     };
     meta = {
@@ -21303,11 +21303,11 @@ with self;
     };
   };
 
-  MemoizeExpireLRU = buildPerlPackage {
+  MemoizeExpireLRU = buildPerlPackage rec {
     pname = "Memoize-ExpireLRU";
     version = "0.56";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/Memoize-ExpireLRU-0.56.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/Memoize-ExpireLRU-${version}.tar.gz";
       hash = "sha256-7oNjAcu6uaJLBfxlft+pS3/YV42YNuVmoZHQpbAc1/Y=";
     };
     meta = {
@@ -21320,11 +21320,11 @@ with self;
     };
   };
 
-  MemoryProcess = buildPerlPackage {
+  MemoryProcess = buildPerlPackage rec {
     pname = "Memory-Process";
     version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SK/SKIM/Memory-Process-0.06.tar.gz";
+      url = "mirror://cpan/authors/id/S/SK/SKIM/Memory-Process-${version}.tar.gz";
       hash = "sha256-NYFEiP/SnJdiFiXqOz1wCvv6YO0FW9dZ1OWNnI/UTk4=";
     };
     buildInputs = [
@@ -21343,11 +21343,11 @@ with self;
     };
   };
 
-  MemoryUsage = buildPerlPackage {
+  MemoryUsage = buildPerlPackage rec {
     pname = "Memory-Usage";
     version = "0.201";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DO/DONEILL/Memory-Usage-0.201.tar.gz";
+      url = "mirror://cpan/authors/id/D/DO/DONEILL/Memory-Usage-${version}.tar.gz";
       hash = "sha256-jyr60h5Ap0joHIwPPkDKcYwU3bn7LYgL+9KK6RPOU0k=";
     };
     meta = {
@@ -21359,11 +21359,11 @@ with self;
     };
   };
 
-  Menlo = buildPerlPackage {
+  Menlo = buildPerlPackage rec {
     pname = "Menlo";
     version = "1.9019";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Menlo-1.9019.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Menlo-${version}.tar.gz";
       hash = "sha256-O1c/aOezo2qHyGC+JYWZMw+sJItRiFTftWV6xIPcpWU=";
     };
     propagatedBuildInputs = [
@@ -21390,11 +21390,11 @@ with self;
     };
   };
 
-  MenloLegacy = buildPerlPackage {
+  MenloLegacy = buildPerlPackage rec {
     pname = "Menlo-Legacy";
     version = "1.9022";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Menlo-Legacy-1.9022.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Menlo-Legacy-${version}.tar.gz";
       hash = "sha256-pqysP+4xioBLQ53lSsvHwn8LRM/a2FUbvJzUWYarwgE=";
     };
     propagatedBuildInputs = [ Menlo ];
@@ -21408,11 +21408,11 @@ with self;
     };
   };
 
-  meta = buildPerlModule {
+  meta = buildPerlModule rec {
     pname = "meta";
     version = "0.012";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/meta-0.012.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/meta-${version}.tar.gz";
       hash = "sha256-Fx0J0wn4APVTTQE4tXMDmpYfEDtDaKhBC3dogzFuuFk=";
     };
     buildInputs = [ Test2Suite ];
@@ -21425,11 +21425,11 @@ with self;
     };
   };
 
-  MetaBuilder = buildPerlModule {
+  MetaBuilder = buildPerlModule rec {
     pname = "Meta-Builder";
     version = "0.004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EX/EXODIST/Meta-Builder-0.004.tar.gz";
+      url = "mirror://cpan/authors/id/E/EX/EXODIST/Meta-Builder-${version}.tar.gz";
       hash = "sha256-rLSZqnIG652yHrhTV6dFIb/jva5KZBbVCnx1uTnPVv4=";
     };
     buildInputs = [
@@ -21445,11 +21445,11 @@ with self;
     };
   };
 
-  MetaCPANClient = buildPerlPackage {
+  MetaCPANClient = buildPerlPackage rec {
     pname = "MetaCPAN-Client";
     version = "2.030000";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MICKEY/MetaCPAN-Client-2.030000.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MICKEY/MetaCPAN-Client-${version}.tar.gz";
       hash = "sha256-2bdlxSN3VPFyYmljgqc4XZCy0BmGl5gXhisWZLBt068=";
     };
 
@@ -21485,11 +21485,11 @@ with self;
     };
   };
 
-  MethodSignaturesSimple = buildPerlPackage {
+  MethodSignaturesSimple = buildPerlPackage rec {
     pname = "Method-Signatures-Simple";
     version = "1.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RH/RHESA/Method-Signatures-Simple-1.07.tar.gz";
+      url = "mirror://cpan/authors/id/R/RH/RHESA/Method-Signatures-Simple-${version}.tar.gz";
       hash = "sha256-yM19Rxl3zIh2BEGSq9mKga/d/yomu5oQu+NY76Nx2tw=";
     };
     propagatedBuildInputs = [ DevelDeclare ];
@@ -21502,11 +21502,11 @@ with self;
     };
   };
 
-  MetricsAny = buildPerlModule {
+  MetricsAny = buildPerlModule rec {
     pname = "Metrics-Any";
     version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Metrics-Any-0.10.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Metrics-Any-${version}.tar.gz";
       hash = "sha256-qQ6t+civJKUWu5obZwYfZBhT+QuP7p/8JNK7lyDouZs=";
     };
     buildInputs = [ Test2Suite ];
@@ -21520,12 +21520,12 @@ with self;
   };
 
   # TODO: use CPAN version
-  MHonArc = buildPerlPackage {
+  MHonArc = buildPerlPackage rec {
     pname = "MHonArc";
     version = "2.6.24";
 
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LD/LDIDRY/MHonArc-2.6.24.tar.gz";
+      url = "mirror://cpan/authors/id/L/LD/LDIDRY/MHonArc-${version}.tar.gz";
       hash = "sha256-RX3HN07lnLdaBynlHO8vLFK0gYD3Odj9lW6hmIKBXzM=";
     };
 
@@ -21544,11 +21544,11 @@ with self;
     };
   };
 
-  MIMECharset = buildPerlPackage {
+  MIMECharset = buildPerlPackage rec {
     pname = "MIME-Charset";
     version = "1.013.1";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEZUMI/MIME-Charset-1.013.1.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEZUMI/MIME-Charset-${version}.tar.gz";
       hash = "sha256-G7em4MDSUfI9bmC/hMmt78W3TuxYR1v+5NORB+YIcPA=";
     };
     meta = {
@@ -21560,11 +21560,11 @@ with self;
     };
   };
 
-  mimeConstruct = buildPerlPackage {
+  mimeConstruct = buildPerlPackage rec {
     pname = "mime-construct";
     version = "1.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RO/ROSCH/mime-construct-1.11.tar.gz";
+      url = "mirror://cpan/authors/id/R/RO/ROSCH/mime-construct-${version}.tar.gz";
       hash = "sha256-TNe7YbUdQRktFJjBBRqmpMzXWusJtx0uxwanCEpKkwM=";
     };
     outputs = [ "out" ];
@@ -21580,11 +21580,11 @@ with self;
     '';
   };
 
-  MIMEEncWords = buildPerlPackage {
+  MIMEEncWords = buildPerlPackage rec {
     pname = "MIME-EncWords";
     version = "1.014.3";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEZUMI/MIME-EncWords-1.014.3.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEZUMI/MIME-EncWords-${version}.tar.gz";
       hash = "sha256-6a+1SGEdTn5sULfwa70rG7KAjjeoEN7vtTfGevVIUjg=";
     };
     propagatedBuildInputs = [ MIMECharset ];
@@ -21599,11 +21599,11 @@ with self;
     };
   };
 
-  MIMELite = buildPerlPackage {
+  MIMELite = buildPerlPackage rec {
     pname = "MIME-Lite";
     version = "3.033";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/MIME-Lite-3.033.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/MIME-Lite-${version}.tar.gz";
       hash = "sha256-eKJ58dLiQlUcNH75ehP8Z1dmYCy4TCqAxWlAD082i6s=";
     };
     propagatedBuildInputs = [ EmailDateFormat ];
@@ -21616,11 +21616,11 @@ with self;
     };
   };
 
-  MIMELiteHTML = buildPerlPackage {
+  MIMELiteHTML = buildPerlPackage rec {
     pname = "MIME-Lite-HTML";
     version = "1.24";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AL/ALIAN/MIME-Lite-HTML-1.24.tar.gz";
+      url = "mirror://cpan/authors/id/A/AL/ALIAN/MIME-Lite-HTML-${version}.tar.gz";
       hash = "sha256-22A8y/ZlO80oz6gk1y5RHq0Bn8ivufGFTshy2y082No=";
     };
     doCheck = false;
@@ -21637,11 +21637,11 @@ with self;
     };
   };
 
-  MIMETools = buildPerlPackage {
+  MIMETools = buildPerlPackage rec {
     pname = "MIME-tools";
     version = "5.509";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DS/DSKOLL/MIME-tools-5.509.tar.gz";
+      url = "mirror://cpan/authors/id/D/DS/DSKOLL/MIME-tools-${version}.tar.gz";
       hash = "sha256-ZFefDJI9gdmiGUWG5Hw0dVGeJkbktcECqJIHWfrPaXM=";
     };
     propagatedBuildInputs = [ MailTools ];
@@ -21655,11 +21655,11 @@ with self;
     };
   };
 
-  MIMETypes = buildPerlPackage {
+  MIMETypes = buildPerlPackage rec {
     pname = "MIME-Types";
     version = "2.24";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARKOV/MIME-Types-2.24.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MARKOV/MIME-Types-${version}.tar.gz";
       hash = "sha256-Yp42HyKyIL5QwtpzVOI8BFF1dwmgPCWiLzFg7blMtl8=";
     };
     meta = {
@@ -21672,11 +21672,11 @@ with self;
     };
   };
 
-  Minion = buildPerlPackage {
+  Minion = buildPerlPackage rec {
     pname = "Minion";
     version = "10.31";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SR/SRI/Minion-10.31.tar.gz";
+      url = "mirror://cpan/authors/id/S/SR/SRI/Minion-${version}.tar.gz";
       hash = "sha256-MGj5kDPmnfCBRbWEqR7iJPTpfcYkLhAiIegiCj8oUDs=";
     };
     propagatedBuildInputs = [
@@ -21691,11 +21691,11 @@ with self;
     };
   };
 
-  MinionBackendRedis = buildPerlModule {
+  MinionBackendRedis = buildPerlModule rec {
     pname = "Minion-Backend-Redis";
     version = "0.003";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DF/DFUG/Minion-Backend-Redis-0.003.tar.gz";
+      url = "mirror://cpan/authors/id/D/DF/DFUG/Minion-Backend-Redis-${version}.tar.gz";
       hash = "sha256-zXZRIQbfHKmQF75fObSmXgSCawzZQxe3GsAWGzXzI6A=";
     };
     buildInputs = [ ModuleBuildTiny ];
@@ -21713,11 +21713,11 @@ with self;
     };
   };
 
-  MinionBackendSQLite = buildPerlModule {
+  MinionBackendSQLite = buildPerlModule rec {
     pname = "Minion-Backend-SQLite";
     version = "5.0.7";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DB/DBOOK/Minion-Backend-SQLite-v5.0.7.tar.gz";
+      url = "mirror://cpan/authors/id/D/DB/DBOOK/Minion-Backend-SQLite-v${version}.tar.gz";
       hash = "sha256-zd49IrGv+n32seErKlLp88G2gci1k6G+TeO+aOTaXHI=";
     };
     buildInputs = [ ModuleBuildTiny ];
@@ -21733,11 +21733,11 @@ with self;
     };
   };
 
-  MinionBackendmysql = buildPerlPackage {
+  MinionBackendmysql = buildPerlPackage rec {
     pname = "Minion-Backend-mysql";
     version = "1.003";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PR/PREACTION/Minion-Backend-mysql-1.003.tar.gz";
+      url = "mirror://cpan/authors/id/P/PR/PREACTION/Minion-Backend-mysql-${version}.tar.gz";
       hash = "sha256-aaJcJAyw5NTvTxqjKgTt+Nolt+jTqCDP1kVhWZ7aRUI=";
     };
     buildInputs = [ Testmysqld ];
@@ -21756,11 +21756,11 @@ with self;
     };
   };
 
-  MixinLinewise = buildPerlPackage {
+  MixinLinewise = buildPerlPackage rec {
     pname = "Mixin-Linewise";
     version = "0.111";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Mixin-Linewise-0.111.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Mixin-Linewise-${version}.tar.gz";
       hash = "sha256-0o6IUWzptSlcMWMdzM3A/I8qt9ilzIdrsbIBMQh7Ads=";
     };
     propagatedBuildInputs = [
@@ -21777,11 +21777,11 @@ with self;
     };
   };
 
-  MLDBM = buildPerlModule {
+  MLDBM = buildPerlModule rec {
     pname = "MLDBM";
     version = "2.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHORNY/MLDBM-2.05.tar.gz";
+      url = "mirror://cpan/authors/id/C/CH/CHORNY/MLDBM-${version}.tar.gz";
       hash = "sha256-WGiA7QwggBq79nNHR+E+AgPt7+zm68TyDdtQWfAqF6I=";
     };
     meta = {
@@ -21795,11 +21795,11 @@ with self;
 
   MNI-Perllib = callPackage ../development/perl-modules/MNI { };
 
-  Mo = buildPerlPackage {
+  Mo = buildPerlPackage rec {
     pname = "Mo";
     version = "0.40";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TI/TINITA/Mo-0.40.tar.gz";
+      url = "mirror://cpan/authors/id/T/TI/TINITA/Mo-${version}.tar.gz";
       hash = "sha256-kdJBUjkfjCeX7jUDkTja6m3j7gO98+G4ck+lx1VAzrk=";
     };
     meta = {
@@ -21813,11 +21813,11 @@ with self;
     };
   };
 
-  MockConfig = buildPerlPackage {
+  MockConfig = buildPerlPackage rec {
     pname = "Mock-Config";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RU/RURBAN/Mock-Config-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/R/RU/RURBAN/Mock-Config-${version}.tar.gz";
       hash = "sha256-pbg0V1fKTyuTNfW+FOk+u7UChlIzp1W/U7xxVt7sABs=";
     };
     meta = {
@@ -21829,12 +21829,12 @@ with self;
     };
   };
 
-  ModernPerl = buildPerlPackage {
+  ModernPerl = buildPerlPackage rec {
     pname = "Modern-Perl";
     version = "1.20230106";
 
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHROMATIC/Modern-Perl-1.20230106.tar.gz";
+      url = "mirror://cpan/authors/id/C/CH/CHROMATIC/Modern-Perl-${version}.tar.gz";
       hash = "sha256-BFncq4DOgrY0Yf2B7pTgbpplFdmPP7wxmDjdHmAoUfc=";
     };
     meta = {
@@ -21847,11 +21847,11 @@ with self;
     };
   };
 
-  Modulecpmfile = buildPerlModule {
+  Modulecpmfile = buildPerlModule rec {
     pname = "Module-cpmfile";
     version = "0.006";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SK/SKAJI/Module-cpmfile-0.006.tar.gz";
+      url = "mirror://cpan/authors/id/S/SK/SKAJI/Module-cpmfile-${version}.tar.gz";
       hash = "sha256-G8l24pN3JIlsn26unl3KmB4n+YQwuS3icO41FP0ArA8=";
     };
     buildInputs = [
@@ -21870,11 +21870,11 @@ with self;
     };
   };
 
-  ModuleBuild = buildPerlPackage {
+  ModuleBuild = buildPerlPackage rec {
     pname = "Module-Build";
     version = "0.4234";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/Module-Build-0.4234.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/Module-Build-${version}.tar.gz";
       hash = "sha256-Zq6sYSdBi+XkcerTdEZIx2a9AUgoJcW2ZlJnXyvIao8=";
     };
     postConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
@@ -21901,11 +21901,11 @@ with self;
     };
   };
 
-  ModuleBuildDeprecated = buildPerlModule {
+  ModuleBuildDeprecated = buildPerlModule rec {
     pname = "Module-Build-Deprecated";
     version = "0.4210";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/Module-Build-Deprecated-0.4210.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/Module-Build-Deprecated-${version}.tar.gz";
       hash = "sha256-vgiTE/wjjuIYNHOsqMhrVfs89EeXMSy+m4ktY2JiFwM=";
     };
     doCheck = false;
@@ -21918,11 +21918,11 @@ with self;
     };
   };
 
-  ModuleBuildPluggable = buildPerlModule {
+  ModuleBuildPluggable = buildPerlModule rec {
     pname = "Module-Build-Pluggable";
     version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOKUHIROM/Module-Build-Pluggable-0.10.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TOKUHIROM/Module-Build-Pluggable-${version}.tar.gz";
       hash = "sha256-5bsqyxF3ksmEYogSrLD+w3bLlwyu6O3ldTXgTXYrDkA=";
     };
     propagatedBuildInputs = [
@@ -21941,11 +21941,11 @@ with self;
     };
   };
 
-  ModuleBuildPluggableCPANfile = buildPerlModule {
+  ModuleBuildPluggableCPANfile = buildPerlModule rec {
     pname = "Module-Build-Pluggable-CPANfile";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KAZEBURO/Module-Build-Pluggable-CPANfile-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/K/KA/KAZEBURO/Module-Build-Pluggable-CPANfile-${version}.tar.gz";
       hash = "sha256-SuxsuiQMtueAFkBrajqHVjTMKuwI/8XxVy2hzcQOHnw=";
     };
     buildInputs = [
@@ -21967,11 +21967,11 @@ with self;
     };
   };
 
-  ModuleBuildPluggablePPPort = buildPerlModule {
+  ModuleBuildPluggablePPPort = buildPerlModule rec {
     pname = "Module-Build-Pluggable-PPPort";
     version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOKUHIROM/Module-Build-Pluggable-PPPort-0.04.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TOKUHIROM/Module-Build-Pluggable-PPPort-${version}.tar.gz";
       hash = "sha256-RAhLo9iBXzQ705FYWsXYM5pIB85cDdhMmNuPMQtkwOo=";
     };
     buildInputs = [
@@ -21988,11 +21988,11 @@ with self;
     };
   };
 
-  ModuleBuildTiny = buildPerlModule {
+  ModuleBuildTiny = buildPerlModule rec {
     pname = "Module-Build-Tiny";
     version = "0.047";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/Module-Build-Tiny-0.047.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/Module-Build-Tiny-${version}.tar.gz";
       hash = "sha256-cSYOlCG5PDPdGz59DPFfdZwMp8dT+oQCeew75w+PjJ0=";
     };
     buildInputs = [ FileShareDir ];
@@ -22009,11 +22009,11 @@ with self;
     };
   };
 
-  ModuleBuildWithXSpp = buildPerlModule {
+  ModuleBuildWithXSpp = buildPerlModule rec {
     pname = "Module-Build-WithXSpp";
     version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SM/SMUELLER/Module-Build-WithXSpp-0.14.tar.gz";
+      url = "mirror://cpan/authors/id/S/SM/SMUELLER/Module-Build-WithXSpp-${version}.tar.gz";
       hash = "sha256-U7PIyP29UPw9rT0Z2iDxtkFO9wZluTEXEMgClp50aTQ=";
     };
     propagatedBuildInputs = [
@@ -22029,11 +22029,11 @@ with self;
     };
   };
 
-  ModuleBuildXSUtil = buildPerlModule {
+  ModuleBuildXSUtil = buildPerlModule rec {
     pname = "Module-Build-XSUtil";
     version = "0.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HI/HIDEAKIO/Module-Build-XSUtil-0.19.tar.gz";
+      url = "mirror://cpan/authors/id/H/HI/HIDEAKIO/Module-Build-XSUtil-${version}.tar.gz";
       hash = "sha256-kGOzw0bt60IoB//kn/sjA4xPkA1Kd7hFzktT2XvylAA=";
     };
     buildInputs = [
@@ -22052,11 +22052,11 @@ with self;
     };
   };
 
-  ModuleCompile = buildPerlPackage {
+  ModuleCompile = buildPerlPackage rec {
     pname = "Module-Compile";
     version = "0.38";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IN/INGY/Module-Compile-0.38.tar.gz";
+      url = "mirror://cpan/authors/id/I/IN/INGY/Module-Compile-${version}.tar.gz";
       hash = "sha256-gJDPu2ESNDfu/sPjvthgBdH3xaUp+2/aLr68ZWS5qhA=";
     };
     propagatedBuildInputs = [
@@ -22073,11 +22073,11 @@ with self;
     };
   };
 
-  ModuleCPANTSAnalyse = buildPerlPackage {
+  ModuleCPANTSAnalyse = buildPerlPackage rec {
     pname = "Module-CPANTS-Analyse";
     version = "1.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/Module-CPANTS-Analyse-1.02.tar.gz";
+      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/Module-CPANTS-Analyse-${version}.tar.gz";
       hash = "sha256-nhFzm5zQi6LXWllzfx+yl/RYA/KJBjxcdZv8eP1Rbns=";
     };
     propagatedBuildInputs = [
@@ -22105,11 +22105,11 @@ with self;
     };
   };
 
-  ModuleCPANfile = buildPerlPackage {
+  ModuleCPANfile = buildPerlPackage rec {
     pname = "Module-CPANfile";
     version = "1.1004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Module-CPANfile-1.1004.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Module-CPANfile-${version}.tar.gz";
       hash = "sha256-iO++LppkLc6qGGQw/t/PmZqvDgb2zO0opxS45WtRSSE=";
     };
     buildInputs = [ Filepushd ];
@@ -22123,11 +22123,11 @@ with self;
     };
   };
 
-  ModuleExtractUse = buildPerlModule {
+  ModuleExtractUse = buildPerlModule rec {
     pname = "Module-ExtractUse";
     version = "0.345";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DO/DOMM/Module-ExtractUse-0.345.tar.gz";
+      url = "mirror://cpan/authors/id/D/DO/DOMM/Module-ExtractUse-${version}.tar.gz";
       hash = "sha256-juJOh0KrnaeSKL4Yfdoxm01fUKkaHs+H1JQhO1uzDdE=";
     };
     propagatedBuildInputs = [
@@ -22151,11 +22151,11 @@ with self;
     };
   };
 
-  ModuleExtractVERSION = buildPerlPackage {
+  ModuleExtractVERSION = buildPerlPackage rec {
     pname = "Module-Extract-VERSION";
     version = "1.116";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/Module-Extract-VERSION-1.116.tar.gz";
+      url = "mirror://cpan/authors/id/B/BD/BDFOY/Module-Extract-VERSION-${version}.tar.gz";
       hash = "sha256-QZA6BoUXgoU0X12oVdkluUVO5xCpeV48TDJ7ri9Vdpg=";
     };
     meta = {
@@ -22165,11 +22165,11 @@ with self;
     };
   };
 
-  ModuleFind = buildPerlPackage {
+  ModuleFind = buildPerlPackage rec {
     pname = "Module-Find";
     version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CR/CRENZ/Module-Find-0.16.tar.gz";
+      url = "mirror://cpan/authors/id/C/CR/CRENZ/Module-Find-${version}.tar.gz";
       hash = "sha256-S8qqN2kVAUco1PUzqYxbWdZlBRzTzbr8lg5aZv0TEJI=";
     };
     meta = {
@@ -22181,11 +22181,11 @@ with self;
     };
   };
 
-  ModuleImplementation = buildPerlPackage {
+  ModuleImplementation = buildPerlPackage rec {
     pname = "Module-Implementation";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Module-Implementation-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Module-Implementation-${version}.tar.gz";
       hash = "sha256-wV8aEvDCEwye//PC4a/liHsIzNAzvRMhhtHn1Qh/1m0=";
     };
     buildInputs = [
@@ -22203,11 +22203,11 @@ with self;
     };
   };
 
-  ModuleInfo = buildPerlPackage {
+  ModuleInfo = buildPerlPackage rec {
     pname = "Module-Info";
     version = "0.37";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/Module-Info-0.37.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/Module-Info-${version}.tar.gz";
       hash = "sha256-jqgCUpeQsZwfNzoeR9g4FmT5xMH3ao2LvG221zEcJEg=";
     };
     buildInputs = [
@@ -22225,11 +22225,11 @@ with self;
     };
   };
 
-  ModuleInstall = buildPerlPackage {
+  ModuleInstall = buildPerlPackage rec {
     pname = "Module-Install";
     version = "1.21";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Module-Install-1.21.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Module-Install-${version}.tar.gz";
       hash = "sha256-+/kQB/MFZfOSDhBgVf0NQoeYHV59rYs1MjzktzPxWns=";
     };
     propagatedBuildInputs = [
@@ -22247,11 +22247,11 @@ with self;
     };
   };
 
-  ModuleInstallAuthorRequires = buildPerlPackage {
+  ModuleInstallAuthorRequires = buildPerlPackage rec {
     pname = "Module-Install-AuthorRequires";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FL/FLORA/Module-Install-AuthorRequires-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/F/FL/FLORA/Module-Install-AuthorRequires-${version}.tar.gz";
       hash = "sha256-zGMhU310XSqDqChvhe8zRnRZOcw7NBAgRb7IVg6PTOw=";
     };
     propagatedBuildInputs = [ ModuleInstall ];
@@ -22264,11 +22264,11 @@ with self;
     };
   };
 
-  ModuleInstallAuthorTests = buildPerlPackage {
+  ModuleInstallAuthorTests = buildPerlPackage rec {
     pname = "Module-Install-AuthorTests";
     version = "0.002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Module-Install-AuthorTests-0.002.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Module-Install-AuthorTests-${version}.tar.gz";
       hash = "sha256-QCVyLeY1ft9TwoUBsA59qSzS+fxhG6B1N2Gg4d/zLYg=";
     };
     propagatedBuildInputs = [ ModuleInstall ];
@@ -22281,11 +22281,11 @@ with self;
     };
   };
 
-  ModuleInstallGithubMeta = buildPerlPackage {
+  ModuleInstallGithubMeta = buildPerlPackage rec {
     pname = "Module-Install-GithubMeta";
     version = "0.30";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BI/BINGOS/Module-Install-GithubMeta-0.30.tar.gz";
+      url = "mirror://cpan/authors/id/B/BI/BINGOS/Module-Install-GithubMeta-${version}.tar.gz";
       hash = "sha256-Lq1EyXPHSNctnxmeQcRNwYAf6a4GsPrcWUR2k6PJgoE=";
     };
     buildInputs = [ CaptureTiny ];
@@ -22301,11 +22301,11 @@ with self;
     };
   };
 
-  ModuleInstallReadmeFromPod = buildPerlPackage {
+  ModuleInstallReadmeFromPod = buildPerlPackage rec {
     pname = "Module-Install-ReadmeFromPod";
     version = "0.30";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BI/BINGOS/Module-Install-ReadmeFromPod-0.30.tar.gz";
+      url = "mirror://cpan/authors/id/B/BI/BINGOS/Module-Install-ReadmeFromPod-${version}.tar.gz";
       hash = "sha256-efbfVTZhn6/72mlr3SXMrRfEab8y5RzT5hM2bUlAAWk=";
     };
     buildInputs = [ TestInDistDir ];
@@ -22326,11 +22326,11 @@ with self;
     };
   };
 
-  ModuleInstallReadmeMarkdownFromPod = buildPerlPackage {
+  ModuleInstallReadmeMarkdownFromPod = buildPerlPackage rec {
     pname = "Module-Install-ReadmeMarkdownFromPod";
     version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MATTN/Module-Install-ReadmeMarkdownFromPod-0.04.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MATTN/Module-Install-ReadmeMarkdownFromPod-${version}.tar.gz";
       hash = "sha256-MAsuJE+DuaVKlfhATBzTrwY1tPrpdMplOQ7kKOxmhZE=";
     };
     buildInputs = [ URI ];
@@ -22349,11 +22349,11 @@ with self;
     };
   };
 
-  ModuleInstallRepository = buildPerlPackage {
+  ModuleInstallRepository = buildPerlPackage rec {
     pname = "Module-Install-Repository";
     version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Module-Install-Repository-0.06.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Module-Install-Repository-${version}.tar.gz";
       hash = "sha256-AOJZDQkznMzL2qMo0SrY7HfoMaOMmtZjcF5Z7LsYcis=";
     };
     buildInputs = [ PathClass ];
@@ -22367,11 +22367,11 @@ with self;
     };
   };
 
-  ModuleInstallXSUtil = buildPerlPackage {
+  ModuleInstallXSUtil = buildPerlPackage rec {
     pname = "Module-Install-XSUtil";
     version = "0.45";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GF/GFUJI/Module-Install-XSUtil-0.45.tar.gz";
+      url = "mirror://cpan/authors/id/G/GF/GFUJI/Module-Install-XSUtil-${version}.tar.gz";
       hash = "sha256-/nHlMyC+4TGXdJoLF2CaomP3H/RuXiwTDpR0Lqar31Y=";
     };
     buildInputs = [ BHooksOPAnnotation ];
@@ -22385,11 +22385,11 @@ with self;
     };
   };
 
-  ModuleManifest = buildPerlPackage {
+  ModuleManifest = buildPerlPackage rec {
     pname = "Module-Manifest";
     version = "1.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Module-Manifest-1.09.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Module-Manifest-${version}.tar.gz";
       hash = "sha256-o5X4D/FeoOZv1sRThEtnh+1Kh1o82N+ffikoAlC9U5s=";
     };
     buildInputs = [
@@ -22407,11 +22407,11 @@ with self;
     };
   };
 
-  ModulePath = buildPerlPackage {
+  ModulePath = buildPerlPackage rec {
     pname = "Module-Path";
     version = "0.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/Module-Path-0.19.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/Module-Path-${version}.tar.gz";
       hash = "sha256-szF5zk3XPfzefUaAiAS5/7sR2wJF/kVafQAXR1Yv6so=";
     };
     buildInputs = [ DevelFindPerl ];
@@ -22426,11 +22426,11 @@ with self;
     };
   };
 
-  ModulePluggable = buildPerlPackage {
+  ModulePluggable = buildPerlPackage rec {
     pname = "Module-Pluggable";
     version = "5.2";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SI/SIMONW/Module-Pluggable-5.2.tar.gz";
+      url = "mirror://cpan/authors/id/S/SI/SIMONW/Module-Pluggable-${version}.tar.gz";
       hash = "sha256-s/KtReT9ELP7kNkS142LeVqylUgNtW3GToa5+nXFpt8=";
     };
     patches = [
@@ -22447,11 +22447,11 @@ with self;
     };
   };
 
-  ModulePluggableFast = buildPerlPackage {
+  ModulePluggableFast = buildPerlPackage rec {
     pname = "Module-Pluggable-Fast";
     version = "0.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MR/MRAMBERG/Module-Pluggable-Fast-0.19.tar.gz";
+      url = "mirror://cpan/authors/id/M/MR/MRAMBERG/Module-Pluggable-Fast-${version}.tar.gz";
       hash = "sha256-CMhXcFjxmTLKG2Zre5EmoYtVajmwi+b7ObBqRTkqB18=";
     };
     propagatedBuildInputs = [ UNIVERSALrequire ];
@@ -22464,11 +22464,11 @@ with self;
     };
   };
 
-  ModuleRefresh = buildPerlPackage {
+  ModuleRefresh = buildPerlPackage rec {
     pname = "Module-Refresh";
     version = "0.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BP/BPS/Module-Refresh-0.18.tar.gz";
+      url = "mirror://cpan/authors/id/B/BP/BPS/Module-Refresh-${version}.tar.gz";
       hash = "sha256-4JTaqQmv32SJqeKzJzP2haLBy1zIh2BhB1SGEJsN71k=";
     };
     buildInputs = [ PathClass ];
@@ -22481,11 +22481,11 @@ with self;
     };
   };
 
-  ModuleRuntime = buildPerlModule {
+  ModuleRuntime = buildPerlModule rec {
     pname = "Module-Runtime";
     version = "0.016";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Module-Runtime-0.016.tar.gz";
+      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Module-Runtime-${version}.tar.gz";
       hash = "sha256-aDAuxkaDNUfUEL4o4JZ223UAb0qlihHzvbRP/pnw8CQ=";
     };
     meta = {
@@ -22497,11 +22497,11 @@ with self;
     };
   };
 
-  ModuleRuntimeConflicts = buildPerlPackage {
+  ModuleRuntimeConflicts = buildPerlPackage rec {
     pname = "Module-Runtime-Conflicts";
     version = "0.003";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Module-Runtime-Conflicts-0.003.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Module-Runtime-Conflicts-${version}.tar.gz";
       hash = "sha256-cHzcdQOMcP6Rd5uIisBQ8ShWXTlnupZoDhscfMlzOHU=";
     };
     propagatedBuildInputs = [ DistCheckConflicts ];
@@ -22515,11 +22515,11 @@ with self;
     };
   };
 
-  ModuleScanDeps = buildPerlPackage {
+  ModuleScanDeps = buildPerlPackage rec {
     pname = "Module-ScanDeps";
     version = "1.37";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RS/RSCHUPP/Module-ScanDeps-1.37.tar.gz";
+      url = "mirror://cpan/authors/id/R/RS/RSCHUPP/Module-ScanDeps-${version}.tar.gz";
       hash = "sha256-H14RnK3hRmw5xx5bw1qNT05nJjXbA9eaWg3PCMTitaM=";
     };
     buildInputs = [
@@ -22537,11 +22537,11 @@ with self;
     };
   };
 
-  ModuleSignature = buildPerlPackage {
+  ModuleSignature = buildPerlPackage rec {
     pname = "Module-Signature";
     version = "0.87";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AU/AUDREYT/Module-Signature-0.87.tar.gz";
+      url = "mirror://cpan/authors/id/A/AU/AUDREYT/Module-Signature-${version}.tar.gz";
       hash = "sha256-IU6AVcUP7DcalXQ1IP4mlAAE52FpBjsrROyQoNRdaYI=";
     };
     buildInputs = [ IPCRun ];
@@ -22552,11 +22552,11 @@ with self;
     };
   };
 
-  ModuleUtil = buildPerlModule {
+  ModuleUtil = buildPerlModule rec {
     pname = "Module-Util";
     version = "1.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MATTLAW/Module-Util-1.09.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MATTLAW/Module-Util-${version}.tar.gz";
       hash = "sha256-bPvLakUGREbsiqDuGn3dxCC1RGkwM0QYeu+E0sfz4sY=";
     };
     meta = {
@@ -22569,11 +22569,11 @@ with self;
     };
   };
 
-  ModuleVersions = buildPerlPackage {
+  ModuleVersions = buildPerlPackage rec {
     pname = "Module-Versions";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TH/THW/Module-Versions-0.02.zip";
+      url = "mirror://cpan/authors/id/T/TH/THW/Module-Versions-${version}.zip";
       hash = "sha256-DTimWxenrFGI1zh8/+f6oSY4Rw3JNxYevz2kh7fR+Dw=";
     };
     buildInputs = [ pkgs.unzip ];
@@ -22586,11 +22586,11 @@ with self;
     };
   };
 
-  ModuleVersionsReport = buildPerlPackage {
+  ModuleVersionsReport = buildPerlPackage rec {
     pname = "Module-Versions-Report";
     version = "1.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JE/JESSE/Module-Versions-Report-1.06.tar.gz";
+      url = "mirror://cpan/authors/id/J/JE/JESSE/Module-Versions-Report-${version}.tar.gz";
       hash = "sha256-oyYdDYSxdnjYxP1V6w+JL1FE2BylPqmjjXXRoArZeWo=";
     };
     meta = {
@@ -22602,11 +22602,11 @@ with self;
     };
   };
 
-  MojoDOM58 = buildPerlPackage {
+  MojoDOM58 = buildPerlPackage rec {
     pname = "Mojo-DOM58";
     version = "3.001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DB/DBOOK/Mojo-DOM58-3.001.tar.gz";
+      url = "mirror://cpan/authors/id/D/DB/DBOOK/Mojo-DOM58-${version}.tar.gz";
       hash = "sha256-GLJtVB5TFEFa3d8xQ2nZQMi6BrESNMpQb9vmzyJPV5Y=";
     };
     meta = {
@@ -22616,11 +22616,11 @@ with self;
     };
   };
 
-  mod_perl2 = buildPerlPackage {
+  mod_perl2 = buildPerlPackage rec {
     pname = "mod_perl";
     version = "2.0.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHAY/mod_perl-2.0.13.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHAY/mod_perl-${version}.tar.gz";
       hash = "sha256-reO+McRHuESIaf7N/KziWNbVh7jGx3PF8ic19w2C1to=";
     };
 
@@ -22635,11 +22635,11 @@ with self;
     };
   };
 
-  Mojolicious = buildPerlPackage {
+  Mojolicious = buildPerlPackage rec {
     pname = "Mojolicious";
     version = "9.39";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SR/SRI/Mojolicious-9.39.tar.gz";
+      url = "mirror://cpan/authors/id/S/SR/SRI/Mojolicious-${version}.tar.gz";
       hash = "sha256-EwpJDXfXYTn3NM4biU1Fm64DgF+x89/dWPxE/oKvPP0=";
     };
     meta = {
@@ -22655,11 +22655,11 @@ with self;
     };
   };
 
-  MojoliciousPluginAssetPack = buildPerlPackage {
+  MojoliciousPluginAssetPack = buildPerlPackage rec {
     pname = "Mojolicious-Plugin-AssetPack";
     version = "2.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SR/SRI/Mojolicious-Plugin-AssetPack-2.14.tar.gz";
+      url = "mirror://cpan/authors/id/S/SR/SRI/Mojolicious-Plugin-AssetPack-${version}.tar.gz";
       hash = "sha256-jwWMyIw1mb6/ZjeK7GS91uvNkMljGL3m1ov6551j6qM=";
     };
     propagatedBuildInputs = [
@@ -22675,11 +22675,11 @@ with self;
     };
   };
 
-  MojoliciousPluginGravatar = buildPerlPackage {
+  MojoliciousPluginGravatar = buildPerlPackage rec {
     pname = "Mojolicious-Plugin-Gravatar";
     version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KO/KOORCHIK/Mojolicious-Plugin-Gravatar-0.04.tar.gz";
+      url = "mirror://cpan/authors/id/K/KO/KOORCHIK/Mojolicious-Plugin-Gravatar-${version}.tar.gz";
       hash = "sha256-pJ+XDGxw+ZMLMEp1IWPLlfHZmHEvecsTZAgy5Le2dd0=";
     };
     propagatedBuildInputs = [ Mojolicious ];
@@ -22693,11 +22693,11 @@ with self;
     };
   };
 
-  MojoliciousPluginI18N = buildPerlModule {
+  MojoliciousPluginI18N = buildPerlModule rec {
     pname = "Mojolicious-Plugin-I18N";
     version = "1.6";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHARIFULN/Mojolicious-Plugin-I18N-1.6.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHARIFULN/Mojolicious-Plugin-I18N-${version}.tar.gz";
       hash = "sha256-Mvte+AN9lUt+zr71wbKyS0IKvYKXAjEvStQnlPUrUU0=";
     };
     propagatedBuildInputs = [ Mojolicious ];
@@ -22711,11 +22711,11 @@ with self;
     };
   };
 
-  MojoliciousPluginMail = buildPerlModule {
+  MojoliciousPluginMail = buildPerlModule rec {
     pname = "Mojolicious-Plugin-Mail";
     version = "1.5";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHARIFULN/Mojolicious-Plugin-Mail-1.5.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHARIFULN/Mojolicious-Plugin-Mail-${version}.tar.gz";
       hash = "sha256-VvDTQevDp6zzkZ9a3UPpghbqEoWqDYfn+wDAK7Dv8UY=";
     };
     propagatedBuildInputs = [
@@ -22734,11 +22734,11 @@ with self;
     };
   };
 
-  MojoliciousPluginOpenAPI = buildPerlPackage {
+  MojoliciousPluginOpenAPI = buildPerlPackage rec {
     pname = "Mojolicious-Plugin-OpenAPI";
     version = "5.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/Mojolicious-Plugin-OpenAPI-5.09.tar.gz";
+      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/Mojolicious-Plugin-OpenAPI-${version}.tar.gz";
       hash = "sha256-BIJdfOIe20G80Ujrz6Gu+Ek258QOhKOdvyeGcdSaMQY=";
     };
     propagatedBuildInputs = [
@@ -22753,11 +22753,11 @@ with self;
     };
   };
 
-  MojoliciousPluginRenderFile = buildPerlPackage {
+  MojoliciousPluginRenderFile = buildPerlPackage rec {
     pname = "Mojolicious-Plugin-RenderFile";
     version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KO/KOORCHIK/Mojolicious-Plugin-RenderFile-0.12.tar.gz";
+      url = "mirror://cpan/authors/id/K/KO/KOORCHIK/Mojolicious-Plugin-RenderFile-${version}.tar.gz";
       hash = "sha256-AT5CoswGvHBBuxPJ3ziK8kAQ5peTqN8PCrHSQKphFz8=";
     };
     propagatedBuildInputs = [ Mojolicious ];
@@ -22772,11 +22772,11 @@ with self;
     };
   };
 
-  MojoliciousPluginStatus = buildPerlPackage {
+  MojoliciousPluginStatus = buildPerlPackage rec {
     pname = "Mojolicious-Plugin-Status";
     version = "1.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SR/SRI/Mojolicious-Plugin-Status-1.17.tar.gz";
+      url = "mirror://cpan/authors/id/S/SR/SRI/Mojolicious-Plugin-Status-${version}.tar.gz";
       hash = "sha256-TCsfr+PhkSYby0TiDo75rz+YjR25akrgsG7tQSArh7Q=";
     };
     propagatedBuildInputs = [
@@ -22794,11 +22794,11 @@ with self;
     };
   };
 
-  MojoliciousPluginSyslog = buildPerlPackage {
+  MojoliciousPluginSyslog = buildPerlPackage rec {
     pname = "Mojolicious-Plugin-Syslog";
     version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/Mojolicious-Plugin-Syslog-0.06.tar.gz";
+      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/Mojolicious-Plugin-Syslog-${version}.tar.gz";
       hash = "sha256-IuxL9TYwDseyAYuoV3C9g2ZFDBAwVDZ9srFp9Mh3QRM=";
     };
     propagatedBuildInputs = [ Mojolicious ];
@@ -22810,11 +22810,11 @@ with self;
     };
   };
 
-  MojoliciousPluginTemplateToolkit = buildPerlModule {
+  MojoliciousPluginTemplateToolkit = buildPerlModule rec {
     pname = "Mojolicious-Plugin-TemplateToolkit";
     version = "0.006";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DB/DBOOK/Mojolicious-Plugin-TemplateToolkit-0.006.tar.gz";
+      url = "mirror://cpan/authors/id/D/DB/DBOOK/Mojolicious-Plugin-TemplateToolkit-${version}.tar.gz";
       hash = "sha256-dBoFAmtTArtrKc+I3KICC3rv0iNHgWELpZNaqPCXNKY=";
     };
     buildInputs = [ ModuleBuildTiny ];
@@ -22831,11 +22831,11 @@ with self;
     };
   };
 
-  MojoliciousPluginTextExceptions = buildPerlPackage {
+  MojoliciousPluginTextExceptions = buildPerlPackage rec {
     pname = "Mojolicious-Plugin-TextExceptions";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MR/MRAMBERG/Mojolicious-Plugin-TextExceptions-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/M/MR/MRAMBERG/Mojolicious-Plugin-TextExceptions-${version}.tar.gz";
       hash = "sha256-Oht0BcV4TO5mHP8bARpzlRBN1IS7kbnnWT+ralOb+HQ=";
     };
     propagatedBuildInputs = [ Mojolicious ];
@@ -22847,11 +22847,11 @@ with self;
     };
   };
 
-  MojoliciousPluginWebpack = buildPerlPackage {
+  MojoliciousPluginWebpack = buildPerlPackage rec {
     pname = "Mojolicious-Plugin-Webpack";
     version = "1.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/Mojolicious-Plugin-Webpack-1.02.tar.gz";
+      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/Mojolicious-Plugin-Webpack-${version}.tar.gz";
       hash = "sha256-REzqioOZquelrWt8iQ/yFgk8WM6uaxyKBl77cBC3zn0=";
     };
     propagatedBuildInputs = [
@@ -22866,11 +22866,11 @@ with self;
     };
   };
 
-  MojoRedis = buildPerlPackage {
+  MojoRedis = buildPerlPackage rec {
     pname = "Mojo-Redis";
     version = "3.29";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/Mojo-Redis-3.29.tar.gz";
+      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/Mojo-Redis-${version}.tar.gz";
       hash = "sha256-oDMZpF0uYTpsfS1ZrAD9SwtHiGVi5ish3pG0r4llgII=";
     };
     propagatedBuildInputs = [
@@ -22885,11 +22885,11 @@ with self;
     };
   };
 
-  MojoSAML = buildPerlModule {
+  MojoSAML = buildPerlModule rec {
     pname = "Mojo-SAML";
     version = "0.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JB/JBERGER/Mojo-SAML-0.07.tar.gz";
+      url = "mirror://cpan/authors/id/J/JB/JBERGER/Mojo-SAML-${version}.tar.gz";
       hash = "sha256-csJMrNtvHXp14uqgBDfHFKv1eafSENSqTT8g8e/0cQ0=";
     };
     buildInputs = [ ModuleBuildTiny ];
@@ -22910,11 +22910,11 @@ with self;
     };
   };
 
-  MojoSQLite = buildPerlModule {
+  MojoSQLite = buildPerlModule rec {
     pname = "Mojo-SQLite";
     version = "3.009";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DB/DBOOK/Mojo-SQLite-3.009.tar.gz";
+      url = "mirror://cpan/authors/id/D/DB/DBOOK/Mojo-SQLite-${version}.tar.gz";
       hash = "sha256-Vzmprz/A/BYrOAMt9hCgcANSY7++C+wWrsUvDd3Xtkc=";
     };
     buildInputs = [ ModuleBuildTiny ];
@@ -22933,11 +22933,11 @@ with self;
     };
   };
 
-  Mojomysql = buildPerlPackage {
+  Mojomysql = buildPerlPackage rec {
     pname = "Mojo-mysql";
     version = "1.26";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/Mojo-mysql-1.26.tar.gz";
+      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/Mojo-mysql-${version}.tar.gz";
       hash = "sha256-H9LjBlr4Je9N2x2W9g9MVc9NCCD77L0wrHGdTeJx5rw=";
     };
     propagatedBuildInputs = [
@@ -22954,11 +22954,11 @@ with self;
     };
   };
 
-  MojoIOLoopDelay = buildPerlModule {
+  MojoIOLoopDelay = buildPerlModule rec {
     pname = "Mojo-IOLoop-Delay";
     version = "8.76";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JB/JBERGER/Mojo-IOLoop-Delay-8.76.tar.gz";
+      url = "mirror://cpan/authors/id/J/JB/JBERGER/Mojo-IOLoop-Delay-${version}.tar.gz";
       hash = "sha256-jsvAYUg3IdkgRZQya+zpXM2/vbbRihc8gt1xgXLQqe0=";
     };
     buildInputs = [ ModuleBuildTiny ];
@@ -22970,11 +22970,11 @@ with self;
     };
   };
 
-  MojoIOLoopForkCall = buildPerlModule {
+  MojoIOLoopForkCall = buildPerlModule rec {
     pname = "Mojo-IOLoop-ForkCall";
     version = "0.21";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JB/JBERGER/Mojo-IOLoop-ForkCall-0.21.tar.gz";
+      url = "mirror://cpan/authors/id/J/JB/JBERGER/Mojo-IOLoop-ForkCall-${version}.tar.gz";
       hash = "sha256-8dpdh4RxvdhvAcQjhQgAgE9ttCtUU8IW8Jslt5RYS3g=";
     };
     propagatedBuildInputs = [
@@ -22997,11 +22997,11 @@ with self;
     };
   };
 
-  MojoJWT = buildPerlModule {
+  MojoJWT = buildPerlModule rec {
     pname = "Mojo-JWT";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JB/JBERGER/Mojo-JWT-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/J/JB/JBERGER/Mojo-JWT-${version}.tar.gz";
       hash = "sha256-wE4DmD4MbyvORdCOoucph5yWee+mNLDmjLa4t7SoWIY=";
     };
     buildInputs = [ ModuleBuildTiny ];
@@ -23017,11 +23017,11 @@ with self;
     };
   };
 
-  MojoPg = buildPerlPackage {
+  MojoPg = buildPerlPackage rec {
     pname = "Mojo-Pg";
     version = "4.27";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SR/SRI/Mojo-Pg-4.27.tar.gz";
+      url = "mirror://cpan/authors/id/S/SR/SRI/Mojo-Pg-${version}.tar.gz";
       hash = "sha256-oyLI3wDj5WVf300LernXmSiTIOKfZP6ZrHrxJEhO+dg=";
     };
     propagatedBuildInputs = [
@@ -23038,11 +23038,11 @@ with self;
     };
   };
 
-  MojoUserAgentCached = buildPerlPackage {
+  MojoUserAgentCached = buildPerlPackage rec {
     pname = "Mojo-UserAgent-Cached";
     version = "1.25";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NI/NICOMEN/Mojo-UserAgent-Cached-1.25.tar.gz";
+      url = "mirror://cpan/authors/id/N/NI/NICOMEN/Mojo-UserAgent-Cached-${version}.tar.gz";
       hash = "sha256-lZmikTjq/ZKPWF7jDvFm0j/x3FKkBn50hyxR4W3shko=";
     };
     buildInputs = [ ModuleInstall ];
@@ -23067,11 +23067,11 @@ with self;
     };
   };
 
-  MonitoringPlugin = buildPerlPackage {
+  MonitoringPlugin = buildPerlPackage rec {
     pname = "Monitoring-Plugin";
     version = "0.40";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NI/NIERLEIN/Monitoring-Plugin-0.40.tar.gz";
+      url = "mirror://cpan/authors/id/N/NI/NIERLEIN/Monitoring-Plugin-${version}.tar.gz";
       hash = "sha256-+LprfifSuwpPmjKVWiRC1OQo0cSLgMixIUL/YRvnI28=";
     };
     propagatedBuildInputs = [
@@ -23092,11 +23092,11 @@ with self;
     };
   };
 
-  IOPipely = buildPerlPackage {
+  IOPipely = buildPerlPackage rec {
     pname = "IO-Pipely";
     version = "0.006";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RC/RCAPUTO/IO-Pipely-0.006.tar.gz";
+      url = "mirror://cpan/authors/id/R/RC/RCAPUTO/IO-Pipely-${version}.tar.gz";
       hash = "sha256-Dj/NhBoyfvtUn6AbIIPcNpXnLqDGMwPlbtUWG/gQQTs=";
     };
     meta = {
@@ -23109,11 +23109,11 @@ with self;
     };
   };
 
-  Moo = buildPerlPackage {
+  Moo = buildPerlPackage rec {
     pname = "Moo";
     version = "2.005005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/Moo-2.005005.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Moo-${version}.tar.gz";
       hash = "sha256-+1opUmSfrtBzc/Igt4AEqcaro4dzkTN0DBdw6bH0sQg=";
     };
     buildInputs = [ TestFatal ];
@@ -23132,11 +23132,11 @@ with self;
     };
   };
 
-  Moose = buildPerlPackage {
+  Moose = buildPerlPackage rec {
     pname = "Moose";
     version = "2.2206";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Moose-2.2206.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Moose-${version}.tar.gz";
       hash = "sha256-Z5csTivDn72jhRgXevDme7vrVIVi5OxLdZoaelg+UFs=";
     };
     buildInputs = [
@@ -23174,11 +23174,11 @@ with self;
     };
   };
 
-  MooXHandlesVia = buildPerlPackage {
+  MooXHandlesVia = buildPerlPackage rec {
     pname = "MooX-HandlesVia";
     version = "0.001009";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOBYINK/MooX-HandlesVia-0.001009.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TOBYINK/MooX-HandlesVia-${version}.tar.gz";
       hash = "sha256-cWNT44iU7Lfo5MF7yVSD219ZACsDVBtUpywn8qjzbBI=";
     };
     buildInputs = [
@@ -23199,11 +23199,11 @@ with self;
     };
   };
 
-  MooXLocalePassthrough = buildPerlPackage {
+  MooXLocalePassthrough = buildPerlPackage rec {
     pname = "MooX-Locale-Passthrough";
     version = "0.001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RE/REHSACK/MooX-Locale-Passthrough-0.001.tar.gz";
+      url = "mirror://cpan/authors/id/R/RE/REHSACK/MooX-Locale-Passthrough-${version}.tar.gz";
       hash = "sha256-egWCflKrWh3eLqXHEpJ7HljI0lFmTZZmJ6353TDsBRI=";
     };
     propagatedBuildInputs = [ Moo ];
@@ -23217,11 +23217,11 @@ with self;
     };
   };
 
-  MooXLocaleTextDomainOO = buildPerlPackage {
+  MooXLocaleTextDomainOO = buildPerlPackage rec {
     pname = "MooX-Locale-TextDomain-OO";
     version = "0.001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RE/REHSACK/MooX-Locale-TextDomain-OO-0.001.tar.gz";
+      url = "mirror://cpan/authors/id/R/RE/REHSACK/MooX-Locale-TextDomain-OO-${version}.tar.gz";
       hash = "sha256-W45Sz/3YSpXTaMoQuUNUG5lqk+DQY5b0/hkzVojkFz0=";
     };
     propagatedBuildInputs = [
@@ -23238,11 +23238,11 @@ with self;
     };
   };
 
-  MooXOptions = buildPerlPackage {
+  MooXOptions = buildPerlPackage rec {
     pname = "MooX-Options";
     version = "4.103";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RE/REHSACK/MooX-Options-4.103.tar.gz";
+      url = "mirror://cpan/authors/id/R/RE/REHSACK/MooX-Options-${version}.tar.gz";
       hash = "sha256-TfnVdPjybbAivwbBvaRwgolFEJjC4VYzNd840jsHMm0=";
     };
     propagatedBuildInputs = [
@@ -23271,11 +23271,11 @@ with self;
     };
   };
 
-  MooXSingleton = buildPerlModule {
+  MooXSingleton = buildPerlModule rec {
     pname = "MooX-Singleton";
     version = "1.20";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AJ/AJGB/MooX-Singleton-1.20.tar.gz";
+      url = "mirror://cpan/authors/id/A/AJ/AJGB/MooX-Singleton-${version}.tar.gz";
       hash = "sha256-99dib//emPhewSwe4msB8Tmk3d0vRT6lbDQd8ZTjIQ4=";
     };
     propagatedBuildInputs = [ RoleTiny ];
@@ -23290,11 +23290,11 @@ with self;
     };
   };
 
-  MooXStrictConstructor = buildPerlPackage {
+  MooXStrictConstructor = buildPerlPackage rec {
     pname = "MooX-StrictConstructor";
     version = "0.011";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HARTZELL/MooX-StrictConstructor-0.011.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HARTZELL/MooX-StrictConstructor-${version}.tar.gz";
       hash = "sha256-2jgvgi/8TiKgOqQZpCVydJmdNtiaThI27PT892vGU+I=";
     };
     propagatedBuildInputs = [
@@ -23312,11 +23312,11 @@ with self;
     };
   };
 
-  MooXTypesMooseLike = buildPerlPackage {
+  MooXTypesMooseLike = buildPerlPackage rec {
     pname = "MooX-Types-MooseLike";
     version = "0.29";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MATEU/MooX-Types-MooseLike-0.29.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MATEU/MooX-Types-MooseLike-${version}.tar.gz";
       hash = "sha256-HTeAqpvqQwr75lqox25xjxBFzniKrdpBFvWdO3p60rQ=";
     };
     propagatedBuildInputs = [ ModuleRuntime ];
@@ -23333,11 +23333,11 @@ with self;
     };
   };
 
-  MooXTypesMooseLikeNumeric = buildPerlPackage {
+  MooXTypesMooseLikeNumeric = buildPerlPackage rec {
     pname = "MooX-Types-MooseLike-Numeric";
     version = "1.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MATEU/MooX-Types-MooseLike-Numeric-1.03.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MATEU/MooX-Types-MooseLike-Numeric-${version}.tar.gz";
       hash = "sha256-Fq3rYXuWPQEBeZIsLk6HYt93x1Iy4XMgtFmGjElwxEs=";
     };
     buildInputs = [
@@ -23354,11 +23354,11 @@ with self;
     };
   };
 
-  MooXTypeTiny = buildPerlPackage {
+  MooXTypeTiny = buildPerlPackage rec {
     pname = "MooX-TypeTiny";
     version = "0.002003";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/MooX-TypeTiny-0.002003.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/MooX-TypeTiny-${version}.tar.gz";
       hash = "sha256-2B4m/2+NsQJh8Ah/ltxUNn3LSanz3o1TI4+DTs4ZYks=";
     };
     buildInputs = [ TestFatal ];
@@ -23376,11 +23376,11 @@ with self;
     };
   };
 
-  MooseAutobox = buildPerlModule {
+  MooseAutobox = buildPerlModule rec {
     pname = "Moose-Autobox";
     version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Moose-Autobox-0.16.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Moose-Autobox-${version}.tar.gz";
       hash = "sha256-kkAdpM9ITrcYjsGWtoGG76eCoQK0UeoVbNi4dy5ocFU=";
     };
     buildInputs = [
@@ -23404,11 +23404,11 @@ with self;
     };
   };
 
-  MooseXABC = buildPerlPackage {
+  MooseXABC = buildPerlPackage rec {
     pname = "MooseX-ABC";
     version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DO/DOY/MooseX-ABC-0.06.tar.gz";
+      url = "mirror://cpan/authors/id/D/DO/DOY/MooseX-ABC-${version}.tar.gz";
       hash = "sha256-Tr7suUbkVSssRyH1u/I+9huTJlELVzlr9ZkLEW8Dfuo=";
     };
     buildInputs = [ TestFatal ];
@@ -23423,11 +23423,11 @@ with self;
     };
   };
 
-  MooseXAliases = buildPerlPackage {
+  MooseXAliases = buildPerlPackage rec {
     pname = "MooseX-Aliases";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DO/DOY/MooseX-Aliases-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/D/DO/DOY/MooseX-Aliases-${version}.tar.gz";
       hash = "sha256-xIUPlyQmw0R6ru2Ny0Az6ERgylFwWtPqeLY6+Rn+B0g=";
     };
     buildInputs = [ TestFatal ];
@@ -23441,11 +23441,11 @@ with self;
     };
   };
 
-  MooseXAppCmd = buildPerlModule {
+  MooseXAppCmd = buildPerlModule rec {
     pname = "MooseX-App-Cmd";
     version = "0.34";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-App-Cmd-0.34.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-App-Cmd-${version}.tar.gz";
       hash = "sha256-9eLy7xKcOI8qPjb1PeWYBErxtyLofXEFKdBcwl0jesI=";
     };
     buildInputs = [
@@ -23469,11 +23469,11 @@ with self;
     };
   };
 
-  MooseXStorageFormatJSONpm = buildPerlPackage {
+  MooseXStorageFormatJSONpm = buildPerlPackage rec {
     pname = "MooseX-Storage-Format-JSONpm";
     version = "0.093094";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/MooseX-Storage-Format-JSONpm-0.093094.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/MooseX-Storage-Format-JSONpm-${version}.tar.gz";
       hash = "sha256-9sgItyC99HI4VaZ4sblQLHSSABXFq8YL2uasYNFGxYQ=";
     };
     buildInputs = [
@@ -23499,11 +23499,11 @@ with self;
     };
   };
 
-  MooX = buildPerlPackage {
+  MooX = buildPerlPackage rec {
     pname = "MooX";
     version = "0.101";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GE/GETTY/MooX-0.101.tar.gz";
+      url = "mirror://cpan/authors/id/G/GE/GETTY/MooX-${version}.tar.gz";
       hash = "sha256-L/kaZW54quCspCKTgp16flrLm/IrBAFjWyq2yHDeMtU=";
     };
     propagatedBuildInputs = [
@@ -23521,11 +23521,11 @@ with self;
     };
   };
 
-  MooXAliases = buildPerlPackage {
+  MooXAliases = buildPerlPackage rec {
     pname = "MooX-Aliases";
     version = "0.001006";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/MooX-Aliases-0.001006.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/MooX-Aliases-${version}.tar.gz";
       hash = "sha256-AWAxJ4ysYSY9AZUt/lv7XztGtLhCsv/6nyybiKrGOGc=";
     };
     propagatedBuildInputs = [
@@ -23542,11 +23542,11 @@ with self;
     };
   };
 
-  MooXCmd = buildPerlPackage {
+  MooXCmd = buildPerlPackage rec {
     pname = "MooX-Cmd";
     version = "0.017";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RE/REHSACK/MooX-Cmd-0.017.tar.gz";
+      url = "mirror://cpan/authors/id/R/RE/REHSACK/MooX-Cmd-${version}.tar.gz";
       hash = "sha256-lD/yjaqAiXMnx8X+xacQDPqsktrw+fl8OOOnfQCucPU=";
     };
     propagatedBuildInputs = [
@@ -23568,11 +23568,11 @@ with self;
     };
   };
 
-  MooXlate = buildPerlPackage {
+  MooXlate = buildPerlPackage rec {
     pname = "MooX-late";
     version = "0.100";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOBYINK/MooX-late-0.100.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TOBYINK/MooX-late-${version}.tar.gz";
       hash = "sha256-KuWx49pavA5ABieOy8+o+nwiTqVSmmpoisuyKcCeal8=";
     };
     buildInputs = [
@@ -23593,11 +23593,11 @@ with self;
     };
   };
 
-  MouseXSimpleConfig = buildPerlPackage {
+  MouseXSimpleConfig = buildPerlPackage rec {
     pname = "MouseX-SimpleConfig";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MJ/MJGARDNER/MouseX-SimpleConfig-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/M/MJ/MJGARDNER/MouseX-SimpleConfig-${version}.tar.gz";
       hash = "sha256-JX84QJHTPTQDc6YVOUcDnGmNxEnR75iTNWRPw9LaAGk=";
     };
     propagatedBuildInputs = [
@@ -23613,11 +23613,11 @@ with self;
     };
   };
 
-  TestArchiveLibarchive = buildPerlPackage {
+  TestArchiveLibarchive = buildPerlPackage rec {
     pname = "Test-Archive-Libarchive";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Test-Archive-Libarchive-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Test-Archive-Libarchive-${version}.tar.gz";
       hash = "sha256-KxkYZx4F2i2dIiwQx9kXWFpiQYb+r7j4SQhZnDRwJ1E=";
     };
     propagatedBuildInputs = [
@@ -23635,11 +23635,11 @@ with self;
     };
   };
 
-  TestPostgreSQL = buildPerlModule {
+  TestPostgreSQL = buildPerlModule rec {
     pname = "Test-PostgreSQL";
     version = "1.29";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TJ/TJC/Test-PostgreSQL-1.29.tar.gz";
+      url = "mirror://cpan/authors/id/T/TJ/TJC/Test-PostgreSQL-${version}.tar.gz";
       hash = "sha256-GKz35YnKTMqc3kdgm1NsnYI8hWLRqlIQwWjl6xuOT54=";
     };
     buildInputs = [
@@ -23667,11 +23667,11 @@ with self;
     };
   };
 
-  TestUseAllModules = buildPerlPackage {
+  TestUseAllModules = buildPerlPackage rec {
     pname = "Test-UseAllModules";
     version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/Test-UseAllModules-0.17.tar.gz";
+      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/Test-UseAllModules-${version}.tar.gz";
       hash = "sha256-px8v6LlquL/Cdgqh0xNeoEmlsg3LEFRXt2mhGVx6JQk=";
     };
     meta = {
@@ -23683,11 +23683,11 @@ with self;
     };
   };
 
-  TestValgrind = buildPerlPackage {
+  TestValgrind = buildPerlPackage rec {
     pname = "Test-Valgrind";
     version = "1.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/V/VP/VPIT/Test-Valgrind-1.19.tar.gz";
+      url = "mirror://cpan/authors/id/V/VP/VPIT/Test-Valgrind-${version}.tar.gz";
       hash = "sha256-GDinoV/ueo8Gnk5rRhxeFpBYthW437Q3hLPV2hpggRs=";
     };
     propagatedBuildInputs = [
@@ -23706,11 +23706,11 @@ with self;
     };
   };
 
-  MouseXTypesPathClass = buildPerlPackage {
+  MouseXTypesPathClass = buildPerlPackage rec {
     pname = "MouseX-Types-Path-Class";
     version = "0.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MASAKI/MouseX-Types-Path-Class-0.07.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MASAKI/MouseX-Types-Path-Class-${version}.tar.gz";
       hash = "sha256-Io1LTz8O2VRyeGkdC3xf5T2Qh0pp33CaSXA8avh8Cd4=";
     };
     buildInputs = [ TestUseAllModules ];
@@ -23727,11 +23727,11 @@ with self;
     };
   };
 
-  MouseXTypes = buildPerlPackage {
+  MouseXTypes = buildPerlPackage rec {
     pname = "MouseX-Types";
     version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GF/GFUJI/MouseX-Types-0.06.tar.gz";
+      url = "mirror://cpan/authors/id/G/GF/GFUJI/MouseX-Types-${version}.tar.gz";
       hash = "sha256-dyiEQf2t0Vvu7JoIE+zorsFULx2M6q7BR1Wz8xb7z4s=";
     };
     buildInputs = [ TestException ];
@@ -23745,11 +23745,11 @@ with self;
     };
   };
 
-  MouseXConfigFromFile = buildPerlPackage {
+  MouseXConfigFromFile = buildPerlPackage rec {
     pname = "MouseX-ConfigFromFile";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MASAKI/MouseX-ConfigFromFile-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MASAKI/MouseX-ConfigFromFile-${version}.tar.gz";
       hash = "sha256-khsxyxP8H5gqYC+OI4Fbet0joiQlfkN5Dih1BM6HlTQ=";
     };
     buildInputs = [ TestUseAllModules ];
@@ -23763,11 +23763,11 @@ with self;
     };
   };
 
-  MouseXGetopt = buildPerlModule {
+  MouseXGetopt = buildPerlModule rec {
     pname = "MouseX-Getopt";
     version = "0.38";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GF/GFUJI/MouseX-Getopt-0.38.tar.gz";
+      url = "mirror://cpan/authors/id/G/GF/GFUJI/MouseX-Getopt-${version}.tar.gz";
       hash = "sha256-3j6o70Ut2VAeqMTtqHRLciRgJgKwRpJgft19YrefA48=";
     };
     buildInputs = [
@@ -23795,11 +23795,11 @@ with self;
     };
   };
 
-  MooseXAttributeChained = buildPerlModule {
+  MooseXAttributeChained = buildPerlModule rec {
     pname = "MooseX-Attribute-Chained";
     version = "1.0.3";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOMHUKINS/MooseX-Attribute-Chained-1.0.3.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TOMHUKINS/MooseX-Attribute-Chained-${version}.tar.gz";
       hash = "sha256-5+OKp8O3i1c06dQ892gy/OAHZ+alPV3Xmhci2GdtXk4=";
     };
     propagatedBuildInputs = [ Moose ];
@@ -23812,11 +23812,11 @@ with self;
     };
   };
 
-  MooseXAttributeHelpers = buildPerlModule {
+  MooseXAttributeHelpers = buildPerlModule rec {
     pname = "MooseX-AttributeHelpers";
     version = "0.25";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-AttributeHelpers-0.25.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-AttributeHelpers-${version}.tar.gz";
       hash = "sha256-sMgZ7IOZmyWLJI+CBZ+ll1oM7jZUI6u+4O+spUAcXsY=";
     };
     buildInputs = [
@@ -23834,11 +23834,11 @@ with self;
     };
   };
 
-  MooseXClone = buildPerlModule {
+  MooseXClone = buildPerlModule rec {
     pname = "MooseX-Clone";
     version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Clone-0.06.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Clone-${version}.tar.gz";
       hash = "sha256-y9eCXbnnSwU/UkVEoBTwZv3OKQMW67Vo+HZ5GBs5jac=";
     };
     propagatedBuildInputs = [
@@ -23856,11 +23856,11 @@ with self;
     };
   };
 
-  MooseXConfigFromFile = buildPerlModule {
+  MooseXConfigFromFile = buildPerlModule rec {
     pname = "MooseX-ConfigFromFile";
     version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-ConfigFromFile-0.14.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-ConfigFromFile-${version}.tar.gz";
       hash = "sha256-mtNDzZ+G1xS+m1S5xopEPYrMZQG2rWsV6coBMLLpbwg=";
     };
     buildInputs = [
@@ -23881,11 +23881,11 @@ with self;
     };
   };
 
-  MooseXDaemonize = buildPerlModule {
+  MooseXDaemonize = buildPerlModule rec {
     pname = "MooseX-Daemonize";
     version = "0.22";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Daemonize-0.22.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Daemonize-${version}.tar.gz";
       hash = "sha256-in+5mdypuAKoUTahAUGy0zeKPs3gUnwd9z1V7bKOWbM=";
     };
     buildInputs = [
@@ -23907,11 +23907,11 @@ with self;
     };
   };
 
-  MooseXEmulateClassAccessorFast = buildPerlPackage {
+  MooseXEmulateClassAccessorFast = buildPerlPackage rec {
     pname = "MooseX-Emulate-Class-Accessor-Fast";
     version = "0.009032";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/MooseX-Emulate-Class-Accessor-Fast-0.009032.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/MooseX-Emulate-Class-Accessor-Fast-${version}.tar.gz";
       hash = "sha256-gu637x8NJUGK5AbqJpErJBQo1LKrlRDV6d6z9ywYeZQ=";
     };
     buildInputs = [ TestException ];
@@ -23928,11 +23928,11 @@ with self;
     };
   };
 
-  MooseXGetopt = buildPerlModule {
+  MooseXGetopt = buildPerlModule rec {
     pname = "MooseX-Getopt";
     version = "0.76";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Getopt-0.76.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Getopt-${version}.tar.gz";
       hash = "sha256-/4cxvSsd+DNH37av6coVwE0uzYsojleT0JXq+Va2sCg=";
     };
     buildInputs = [
@@ -23959,11 +23959,11 @@ with self;
     };
   };
 
-  MooseXHasOptions = buildPerlPackage {
+  MooseXHasOptions = buildPerlPackage rec {
     pname = "MooseX-Has-Options";
     version = "0.003";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PS/PSHANGOV/MooseX-Has-Options-0.003.tar.gz";
+      url = "mirror://cpan/authors/id/P/PS/PSHANGOV/MooseX-Has-Options-${version}.tar.gz";
       hash = "sha256-B8Ic+O1QCycgIP+NoZ8ZRyi7QU4AEqLwzFTvLvYiKmg=";
     };
     buildInputs = [
@@ -23990,11 +23990,11 @@ with self;
     };
   };
 
-  MooseXHasSugar = buildPerlPackage {
+  MooseXHasSugar = buildPerlPackage rec {
     pname = "MooseX-Has-Sugar";
     version = "1.000006";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KE/KENTNL/MooseX-Has-Sugar-1.000006.tar.gz";
+      url = "mirror://cpan/authors/id/K/KE/KENTNL/MooseX-Has-Sugar-${version}.tar.gz";
       hash = "sha256-7+7T3bOo6hj0FtSF88KwQnFF0mfmM2jGUdSI6qjCjQk=";
     };
     buildInputs = [
@@ -24012,11 +24012,11 @@ with self;
     };
   };
 
-  MooseXLazyRequire = buildPerlModule {
+  MooseXLazyRequire = buildPerlModule rec {
     pname = "MooseX-LazyRequire";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-LazyRequire-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-LazyRequire-${version}.tar.gz";
       hash = "sha256-72IMHgGdr5zz8jqUPSWpTJHpOrMSvNY74ul0DsC5Qog=";
     };
     buildInputs = [
@@ -24038,11 +24038,11 @@ with self;
     };
   };
 
-  MooseXMarkAsMethods = buildPerlPackage {
+  MooseXMarkAsMethods = buildPerlPackage rec {
     pname = "MooseX-MarkAsMethods";
     version = "0.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RS/RSRCHBOY/MooseX-MarkAsMethods-0.15.tar.gz";
+      url = "mirror://cpan/authors/id/R/RS/RSRCHBOY/MooseX-MarkAsMethods-${version}.tar.gz";
       hash = "sha256-yezBM3bQ/326SBl3M3wz6nTl0makKLavMVUqKRnvfvg=";
     };
     propagatedBuildInputs = [
@@ -24056,11 +24056,11 @@ with self;
     };
   };
 
-  MooseXMethodAttributes = buildPerlPackage {
+  MooseXMethodAttributes = buildPerlPackage rec {
     pname = "MooseX-MethodAttributes";
     version = "0.32";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-MethodAttributes-0.32.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-MethodAttributes-${version}.tar.gz";
       hash = "sha256-yzOIZXS30t05xCwNzccHrNsK7H273pohwEImYDaMGXs=";
     };
     buildInputs = [
@@ -24082,11 +24082,11 @@ with self;
     };
   };
 
-  MooseXNonMoose = buildPerlPackage {
+  MooseXNonMoose = buildPerlPackage rec {
     pname = "MooseX-NonMoose";
     version = "0.26";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DO/DOY/MooseX-NonMoose-0.26.tar.gz";
+      url = "mirror://cpan/authors/id/D/DO/DOY/MooseX-NonMoose-${version}.tar.gz";
       hash = "sha256-y75S7PFgOCMfvX8sxrzhZqNWnIyzlq6A7EUXwuCNqn0=";
     };
     buildInputs = [ TestFatal ];
@@ -24104,11 +24104,11 @@ with self;
     };
   };
 
-  MooseXOneArgNew = buildPerlPackage {
+  MooseXOneArgNew = buildPerlPackage rec {
     pname = "MooseX-OneArgNew";
     version = "0.007";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/MooseX-OneArgNew-0.007.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/MooseX-OneArgNew-${version}.tar.gz";
       hash = "sha256-hCgkNfEWnPCddRP6k4fiCReRY1zzWgeLUAuCmu6gYTg=";
     };
     propagatedBuildInputs = [ MooseXRoleParameterized ];
@@ -24122,11 +24122,11 @@ with self;
     };
   };
 
-  MooseXRelatedClassRoles = buildPerlPackage {
+  MooseXRelatedClassRoles = buildPerlPackage rec {
     pname = "MooseX-RelatedClassRoles";
     version = "0.004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HD/HDP/MooseX-RelatedClassRoles-0.004.tar.gz";
+      url = "mirror://cpan/authors/id/H/HD/HDP/MooseX-RelatedClassRoles-${version}.tar.gz";
       hash = "sha256-MNt6I33SYCIhb/+5cLmFKFNHEws2kjxxGqCVaty0fp8=";
     };
     propagatedBuildInputs = [ MooseXRoleParameterized ];
@@ -24139,11 +24139,11 @@ with self;
     };
   };
 
-  MooseXParamsValidate = buildPerlPackage {
+  MooseXParamsValidate = buildPerlPackage rec {
     pname = "MooseX-Params-Validate";
     version = "0.21";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/MooseX-Params-Validate-0.21.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/MooseX-Params-Validate-${version}.tar.gz";
       hash = "sha256-iClURqupmcu4+ZjX+5onAdZhc5SlHW1yTHdObZ/xOdk=";
     };
     buildInputs = [ TestFatal ];
@@ -24161,11 +24161,11 @@ with self;
     };
   };
 
-  MooseXRoleParameterized = buildPerlModule {
+  MooseXRoleParameterized = buildPerlModule rec {
     pname = "MooseX-Role-Parameterized";
     version = "1.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Role-Parameterized-1.11.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Role-Parameterized-${version}.tar.gz";
       hash = "sha256-HP52bF1/Dsq1f3M9zKQwoqKs1rmVdXFBuUCt42kr7J4=";
     };
     buildInputs = [
@@ -24188,11 +24188,11 @@ with self;
     };
   };
 
-  MooseXRoleWithOverloading = buildPerlPackage {
+  MooseXRoleWithOverloading = buildPerlPackage rec {
     pname = "MooseX-Role-WithOverloading";
     version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Role-WithOverloading-0.17.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Role-WithOverloading-${version}.tar.gz";
       hash = "sha256-krCV1z8SIPnC7S06qlugcutaot4gm3xFXaWocBuYaGU=";
     };
     propagatedBuildInputs = [
@@ -24210,11 +24210,11 @@ with self;
     };
   };
 
-  MooseXRunnable = buildPerlModule {
+  MooseXRunnable = buildPerlModule rec {
     pname = "MooseX-Runnable";
     version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Runnable-0.10.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Runnable-${version}.tar.gz";
       hash = "sha256-QNj9G1UkrpZZZaHxRNegoMhQWUxSRAKyMZsk1cSvEZk=";
     };
     buildInputs = [
@@ -24237,11 +24237,11 @@ with self;
     };
   };
 
-  MooseXSemiAffordanceAccessor = buildPerlPackage {
+  MooseXSemiAffordanceAccessor = buildPerlPackage rec {
     pname = "MooseX-SemiAffordanceAccessor";
     version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/MooseX-SemiAffordanceAccessor-0.10.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/MooseX-SemiAffordanceAccessor-${version}.tar.gz";
       hash = "sha256-pbhXdrzd7RaAJ6H/ZktBxfZYhnIc3VQ+OvnVN1misdU=";
     };
     propagatedBuildInputs = [ Moose ];
@@ -24251,11 +24251,11 @@ with self;
     };
   };
 
-  MooseXSetOnce = buildPerlPackage {
+  MooseXSetOnce = buildPerlPackage rec {
     pname = "MooseX-SetOnce";
     version = "0.200002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/MooseX-SetOnce-0.200002.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/MooseX-SetOnce-${version}.tar.gz";
       hash = "sha256-y+0Gt/zTU/DZm/gKh8HAtYEWBpcjGzrZpgjaIxuitlk=";
     };
     buildInputs = [ TestFatal ];
@@ -24269,11 +24269,11 @@ with self;
     };
   };
 
-  MooseXSingleton = buildPerlModule {
+  MooseXSingleton = buildPerlModule rec {
     pname = "MooseX-Singleton";
     version = "0.30";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Singleton-0.30.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Singleton-${version}.tar.gz";
       hash = "sha256-ZYSy8xsdPrbdfiMShzjnP2wBWxUhOLCoFX09DVnQZUE=";
     };
     buildInputs = [
@@ -24292,11 +24292,11 @@ with self;
     };
   };
 
-  MooseXStorage = buildPerlPackage {
+  MooseXStorage = buildPerlPackage rec {
     pname = "MooseX-Storage";
     version = "0.53";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Storage-0.53.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Storage-${version}.tar.gz";
       hash = "sha256-hwS/5QX2azQPYuhcn/MZwZ6WcLJtSwEskfThA7HarOA=";
     };
     buildInputs = [
@@ -24337,11 +24337,11 @@ with self;
     };
   };
 
-  MooseXStrictConstructor = buildPerlPackage {
+  MooseXStrictConstructor = buildPerlPackage rec {
     pname = "MooseX-StrictConstructor";
     version = "0.21";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/MooseX-StrictConstructor-0.21.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/MooseX-StrictConstructor-${version}.tar.gz";
       hash = "sha256-xypa6Vg3Bszexx1AHcswVAE6dTa3UN8UNmE9hY6ikg0=";
     };
     buildInputs = [
@@ -24360,11 +24360,11 @@ with self;
     };
   };
 
-  MooseXTraits = buildPerlModule {
+  MooseXTraits = buildPerlModule rec {
     pname = "MooseX-Traits";
     version = "0.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Traits-0.13.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Traits-${version}.tar.gz";
       hash = "sha256-dK/gxPr047l8V/KJQ3yqYL7Mo0zVgh9IndTMnaT74po=";
     };
     buildInputs = [
@@ -24387,11 +24387,11 @@ with self;
     };
   };
 
-  MooseXTraitsPluggable = buildPerlPackage {
+  MooseXTraitsPluggable = buildPerlPackage rec {
     pname = "MooseX-Traits-Pluggable";
     version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RK/RKITOVER/MooseX-Traits-Pluggable-0.12.tar.gz";
+      url = "mirror://cpan/authors/id/R/RK/RKITOVER/MooseX-Traits-Pluggable-${version}.tar.gz";
       hash = "sha256-q5a3lQ7L8puDb9/uu+Cqwiylc+cYO+fLfW0S3yKrWMo=";
     };
     buildInputs = [ TestException ];
@@ -24409,11 +24409,11 @@ with self;
     };
   };
 
-  MooseXTypes = buildPerlModule {
+  MooseXTypes = buildPerlModule rec {
     pname = "MooseX-Types";
     version = "0.50";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-0.50.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-${version}.tar.gz";
       hash = "sha256-nNh7NJLL8L6dLfkxeyrfn8MGY3cOaZBmVL6j9BsXywg=";
     };
     buildInputs = [
@@ -24437,11 +24437,11 @@ with self;
     };
   };
 
-  MooseXTypesCommon = buildPerlModule {
+  MooseXTypesCommon = buildPerlModule rec {
     pname = "MooseX-Types-Common";
     version = "0.001014";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-Common-0.001014.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-Common-${version}.tar.gz";
       hash = "sha256-75Nxi20vJA1QtcOssadLTCoZGGllFHAAGoK+HzXQ7w8=";
     };
     buildInputs = [
@@ -24460,11 +24460,11 @@ with self;
     };
   };
 
-  MooseXTypesDateTime = buildPerlModule {
+  MooseXTypesDateTime = buildPerlModule rec {
     pname = "MooseX-Types-DateTime";
     version = "0.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-DateTime-0.13.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-DateTime-${version}.tar.gz";
       hash = "sha256-uJ+iZjb2oX6qOGi0UUNARytou9whYaHXmiKhv1sdOcY=";
     };
     buildInputs = [
@@ -24485,11 +24485,11 @@ with self;
     };
   };
 
-  MooseXTypesDateTimeMoreCoercions = buildPerlModule {
+  MooseXTypesDateTimeMoreCoercions = buildPerlModule rec {
     pname = "MooseX-Types-DateTime-MoreCoercions";
     version = "0.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-DateTime-MoreCoercions-0.15.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-DateTime-MoreCoercions-${version}.tar.gz";
       hash = "sha256-Ibs6WXcZiI7bbOqhMkGNXPkuy5KlDM43uUJZpV4ON5Y=";
     };
     buildInputs = [
@@ -24511,11 +24511,11 @@ with self;
     };
   };
 
-  MooseXTypesLoadableClass = buildPerlModule {
+  MooseXTypesLoadableClass = buildPerlModule rec {
     pname = "MooseX-Types-LoadableClass";
     version = "0.015";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-LoadableClass-0.015.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-LoadableClass-${version}.tar.gz";
       hash = "sha256-4DfTd4JT3PkpRkNXFbraDmRJwKKAj6P/MqllBk1aO/Q=";
     };
     buildInputs = [
@@ -24533,11 +24533,11 @@ with self;
     };
   };
 
-  MooseXTypesPathClass = buildPerlModule {
+  MooseXTypesPathClass = buildPerlModule rec {
     pname = "MooseX-Types-Path-Class";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-Path-Class-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-Path-Class-${version}.tar.gz";
       hash = "sha256-54S6tTaYrpWnCahmMwYUX/7FVmjfbPMWFTM1I/vn734=";
     };
     propagatedBuildInputs = [
@@ -24557,11 +24557,11 @@ with self;
     };
   };
 
-  MooseXTypesPathTiny = buildPerlModule {
+  MooseXTypesPathTiny = buildPerlModule rec {
     pname = "MooseX-Types-Path-Tiny";
     version = "0.012";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-Path-Tiny-0.012.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-Path-Tiny-${version}.tar.gz";
       hash = "sha256-Ge7eAt1lTnD3PjTNevAGN2UXO8rv7v8b2+ITGOz9kVg=";
     };
     buildInputs = [
@@ -24581,11 +24581,11 @@ with self;
     };
   };
 
-  MooseXTypesPerl = buildPerlPackage {
+  MooseXTypesPerl = buildPerlPackage rec {
     pname = "MooseX-Types-Perl";
     version = "0.101344";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/MooseX-Types-Perl-0.101344.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/MooseX-Types-Perl-${version}.tar.gz";
       hash = "sha256-h2RDVPdPplI1yyv8pEJ3kwp+q+UazF+B+2MVMKg1XiQ=";
     };
     propagatedBuildInputs = [ MooseXTypes ];
@@ -24599,11 +24599,11 @@ with self;
     };
   };
 
-  MooseXTypesStringlike = buildPerlPackage {
+  MooseXTypesStringlike = buildPerlPackage rec {
     pname = "MooseX-Types-Stringlike";
     version = "0.003";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/MooseX-Types-Stringlike-0.003.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/MooseX-Types-Stringlike-${version}.tar.gz";
       hash = "sha256-LuNJ7FxSmm80f0L/ZA5HskVWS5PMowXfY8eCH1tVzxk=";
     };
     propagatedBuildInputs = [ MooseXTypes ];
@@ -24614,11 +24614,11 @@ with self;
     };
   };
 
-  MooseXTypesStructured = buildPerlModule {
+  MooseXTypesStructured = buildPerlModule rec {
     pname = "MooseX-Types-Structured";
     version = "0.36";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-Structured-0.36.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-Structured-${version}.tar.gz";
       hash = "sha256-Q822UvljhyPjV3yw+LVGhiAkTJY252WYEeW0qAFgPVc=";
     };
     buildInputs = [
@@ -24642,11 +24642,11 @@ with self;
     };
   };
 
-  MooseXTypesURI = buildPerlModule {
+  MooseXTypesURI = buildPerlModule rec {
     pname = "MooseX-Types-URI";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-URI-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-URI-${version}.tar.gz";
       hash = "sha256-Jxd1Ta25EIbhHSH+oGy6qaEuYBtB0VRDFQ7dfZUI7+g=";
     };
     buildInputs = [
@@ -24670,11 +24670,11 @@ with self;
     };
   };
 
-  MP3CutGapless = buildPerlPackage {
+  MP3CutGapless = buildPerlPackage rec {
     pname = "MP3-Cut-Gapless";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AG/AGRUNDMA/MP3-Cut-Gapless-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/A/AG/AGRUNDMA/MP3-Cut-Gapless-${version}.tar.gz";
       hash = "sha256-PoS3OdHx4902FvhR3GV14WXTKEZ/AySGB5UOWVH+pPM=";
     };
     propagatedBuildInputs = [ AudioCuefileParser ];
@@ -24684,11 +24684,11 @@ with self;
     };
   };
 
-  MP3Info = buildPerlPackage {
+  MP3Info = buildPerlPackage rec {
     pname = "MP3-Info";
     version = "1.26";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JM/JMERELO/MP3-Info-1.26.tar.gz";
+      url = "mirror://cpan/authors/id/J/JM/JMERELO/MP3-Info-${version}.tar.gz";
       hash = "sha256-V2I0BzJCHyUCp3DWoSblhPLNljNR0rwle9J4w5vOi+c=";
     };
     meta = {
@@ -24700,11 +24700,11 @@ with self;
     };
   };
 
-  MP3Tag = buildPerlPackage {
+  MP3Tag = buildPerlPackage rec {
     pname = "MP3-Tag";
     version = "1.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IL/ILYAZ/modules/MP3-Tag-1.16.zip";
+      url = "mirror://cpan/authors/id/I/IL/ILYAZ/modules/MP3-Tag-${version}.zip";
       hash = "sha256-UDhQk6owAFa8Jiu2pACpbiGVl3wcXh6/FaXgdak3e4Y=";
     };
     buildInputs = [ pkgs.unzip ];
@@ -24722,11 +24722,11 @@ with self;
     };
   };
 
-  MockMonkeyPatch = buildPerlModule {
+  MockMonkeyPatch = buildPerlModule rec {
     pname = "Mock-MonkeyPatch";
     version = "1.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JB/JBERGER/Mock-MonkeyPatch-1.02.tar.gz";
+      url = "mirror://cpan/authors/id/J/JB/JBERGER/Mock-MonkeyPatch-${version}.tar.gz";
       hash = "sha256-xbaUTKVP6DVXN2cwYO1OnvhyNyZXfXluHK5eVr8bAYE=";
     };
     buildInputs = [ ModuleBuildTiny ];
@@ -24739,11 +24739,11 @@ with self;
     };
   };
 
-  Mouse = buildPerlModule {
+  Mouse = buildPerlModule rec {
     pname = "Mouse";
     version = "2.5.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SK/SKAJI/Mouse-v2.5.11.tar.gz";
+      url = "mirror://cpan/authors/id/S/SK/SKAJI/Mouse-v${version}.tar.gz";
       hash = "sha256-4qDQkwGQwhpES5YHk6ouNp7yih3QuPNIKXlfhqGRWVY=";
     };
     buildInputs = [
@@ -24766,11 +24766,11 @@ with self;
     };
   };
 
-  MouseXNativeTraits = buildPerlPackage {
+  MouseXNativeTraits = buildPerlPackage rec {
     pname = "MouseX-NativeTraits";
     version = "1.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GF/GFUJI/MouseX-NativeTraits-1.09.tar.gz";
+      url = "mirror://cpan/authors/id/G/GF/GFUJI/MouseX-NativeTraits-${version}.tar.gz";
       hash = "sha256-+KW/WihwLfsTyAk75cQcq5xfwcXSR6uR4i591ydky14=";
     };
     buildInputs = [
@@ -24787,11 +24787,11 @@ with self;
     };
   };
 
-  MozillaCA = buildPerlPackage {
+  MozillaCA = buildPerlPackage rec {
     pname = "Mozilla-CA";
     version = "20230821";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LW/LWP/Mozilla-CA-20230821.tar.gz";
+      url = "mirror://cpan/authors/id/L/LW/LWP/Mozilla-CA-${version}.tar.gz";
       hash = "sha256-MuHQBFKZAEBFucTRbC2q5FOiFiCIc97qJED3EmCnzaE=";
     };
 
@@ -24808,11 +24808,11 @@ with self;
 
   MozillaLdap = callPackage ../development/perl-modules/Mozilla-LDAP { };
 
-  MROCompat = buildPerlPackage {
+  MROCompat = buildPerlPackage rec {
     pname = "MRO-Compat";
     version = "0.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/MRO-Compat-0.15.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/MRO-Compat-${version}.tar.gz";
       hash = "sha256-DUU1+I5Dur2Eq2BIZiFfxNBDmL1Nt7IYUtSjGxwV72E=";
     };
     meta = {
@@ -24847,11 +24847,11 @@ with self;
     };
   };
 
-  MusicBrainzDiscID = buildPerlPackage {
+  MusicBrainzDiscID = buildPerlPackage rec {
     pname = "MusicBrainz-DiscID";
     version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NJ/NJH/MusicBrainz-DiscID-0.06.tar.gz";
+      url = "mirror://cpan/authors/id/N/NJ/NJH/MusicBrainz-DiscID-${version}.tar.gz";
       hash = "sha256-ugtu0JiX/1Y7pZhy7pNxW+83FXUVsZt8bW8obmVI7Ks=";
     };
     # Makefile.PL in this package uses which to find pkg-config -- make it use envvar instead
@@ -24871,11 +24871,11 @@ with self;
     };
   };
 
-  MusicBrainz = buildPerlModule {
+  MusicBrainz = buildPerlModule rec {
     pname = "WebService-MusicBrainz";
     version = "1.0.6";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BF/BFAIST/WebService-MusicBrainz-1.0.6.tar.gz";
+      url = "mirror://cpan/authors/id/B/BF/BFAIST/WebService-MusicBrainz-${version}.tar.gz";
       hash = "sha256-XpH1ZZZ3w5CJv28lO0Eoe7zTVh9qJaB5Zc6DsmKIUuE=";
     };
     propagatedBuildInputs = [ Mojolicious ];
@@ -24889,11 +24889,11 @@ with self;
     };
   };
 
-  MustacheSimple = buildPerlPackage {
+  MustacheSimple = buildPerlPackage rec {
     pname = "Mustache-Simple";
     version = "1.3.6";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CM/CMS/Mustache-Simple-v1.3.6.tar.gz";
+      url = "mirror://cpan/authors/id/C/CM/CMS/Mustache-Simple-v${version}.tar.gz";
       hash = "sha256-UdtdUf9LJaZw2L+r45ArbUVDTs94spvB//Ga9uc4MAM=";
     };
     propagatedBuildInputs = [ YAMLLibYAML ];
@@ -24906,11 +24906,11 @@ with self;
     };
   };
 
-  MySQLDiff = buildPerlPackage {
+  MySQLDiff = buildPerlPackage rec {
     pname = "MySQL-Diff";
     version = "0.60";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ES/ESTRABD/MySQL-Diff-0.60.tar.gz";
+      url = "mirror://cpan/authors/id/E/ES/ESTRABD/MySQL-Diff-${version}.tar.gz";
       hash = "sha256-XXCApL1XFP+e9Taqd0p62zxvDnYCFcpsOdijVFNE+VY=";
     };
     propagatedBuildInputs = [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -141,11 +141,11 @@ with self;
     };
   };
 
-  ActionCircuitBreaker = buildPerlPackage {
+  ActionCircuitBreaker = buildPerlPackage rec {
     pname = "Action-CircuitBreaker";
     version = "0.1";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HANGY/Action-CircuitBreaker-0.1.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HANGY/Action-CircuitBreaker-${version}.tar.gz";
       hash = "sha256-P49dcm+uU3qzNuAKaBmuSoWW5MXyQ+dypTbvLrbmBrE=";
     };
     buildInputs = [
@@ -163,11 +163,11 @@ with self;
     };
   };
 
-  ActionRetry = buildPerlPackage {
+  ActionRetry = buildPerlPackage rec {
     pname = "Action-Retry";
     version = "0.24";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAMS/Action-Retry-0.24.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAMS/Action-Retry-${version}.tar.gz";
       hash = "sha256-o3WXQsW+8tGXWrc9NUmdgRMySRmySTYTAlXP8H0ClPc=";
     };
     propagatedBuildInputs = [
@@ -184,11 +184,11 @@ with self;
     };
   };
 
-  AlgorithmAnnotate = buildPerlPackage {
+  AlgorithmAnnotate = buildPerlPackage rec {
     pname = "Algorithm-Annotate";
     version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CL/CLKAO/Algorithm-Annotate-0.10.tar.gz";
+      url = "mirror://cpan/authors/id/C/CL/CLKAO/Algorithm-Annotate-${version}.tar.gz";
       hash = "sha256-ybF2RkOTPrGjNWkGzDctSDqZQWIHox3z5Y7piS2ZIvk=";
     };
     propagatedBuildInputs = [ AlgorithmDiff ];
@@ -201,11 +201,11 @@ with self;
     };
   };
 
-  AlgorithmBackoff = buildPerlPackage {
+  AlgorithmBackoff = buildPerlPackage rec {
     pname = "Algorithm-Backoff";
     version = "0.009";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PERLANCAR/Algorithm-Backoff-0.009.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PERLANCAR/Algorithm-Backoff-${version}.tar.gz";
       sha256 = "9f0ffcdf1e65a88022d6412f46ad977ede5a7b64be663009d13948fe8c9d180b";
     };
     buildInputs = [
@@ -222,11 +222,11 @@ with self;
     };
   };
 
-  AlgorithmC3 = buildPerlPackage {
+  AlgorithmC3 = buildPerlPackage rec {
     pname = "Algorithm-C3";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/Algorithm-C3-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Algorithm-C3-${version}.tar.gz";
       hash = "sha256-qvSEZ3Zd7qbkgFS8fUPkbk1Ay82hZVLGKdN74Jgokwk=";
     };
     meta = {
@@ -238,11 +238,11 @@ with self;
     };
   };
 
-  AlgorithmCheckDigits = buildPerlModule {
+  AlgorithmCheckDigits = buildPerlModule rec {
     pname = "Algorithm-CheckDigits";
     version = "1.3.6";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MAMAWE/Algorithm-CheckDigits-v1.3.6.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MAMAWE/Algorithm-CheckDigits-v${version}.tar.gz";
       hash = "sha256-DySHqP0fMbGcUbJlCELyJkwed9liSHoTtSG74GbEtLw=";
     };
     buildInputs = [ ProbePerl ];
@@ -256,11 +256,11 @@ with self;
     };
   };
 
-  AlgorithmDiff = buildPerlPackage {
+  AlgorithmDiff = buildPerlPackage rec {
     pname = "Algorithm-Diff";
     version = "1.1903";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TY/TYEMQ/Algorithm-Diff-1.1903.tar.gz";
+      url = "mirror://cpan/authors/id/T/TY/TYEMQ/Algorithm-Diff-${version}.tar.gz";
       hash = "sha256-MOhKxLMdQLZik/exIhMxxaUFYaOdWA2FAE2cH/+ZF1E=";
     };
     buildInputs = [ pkgs.unzip ];
@@ -273,11 +273,11 @@ with self;
     };
   };
 
-  AlgorithmLCSS = buildPerlPackage {
+  AlgorithmLCSS = buildPerlPackage rec {
     pname = "Algorithm-LCSS";
     version = "0.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JF/JFREEMAN/Algorithm-LCSS-0.01.tar.gz";
+      url = "mirror://cpan/authors/id/J/JF/JFREEMAN/Algorithm-LCSS-${version}.tar.gz";
       hash = "sha256-cXzvzHhCoXGrVXbyLrcuVm7fBhzq+H3Mvn8ggfVgH3g=";
     };
     propagatedBuildInputs = [ AlgorithmDiff ];
@@ -291,11 +291,11 @@ with self;
     };
   };
 
-  AlgorithmMerge = buildPerlPackage {
+  AlgorithmMerge = buildPerlPackage rec {
     pname = "Algorithm-Merge";
     version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JS/JSMITH/Algorithm-Merge-0.08.tar.gz";
+      url = "mirror://cpan/authors/id/J/JS/JSMITH/Algorithm-Merge-${version}.tar.gz";
       hash = "sha256-nAaIJYodxLg5iAU7n5qY53KM25tppQCNy9JR0PgIFs8=";
     };
     propagatedBuildInputs = [ AlgorithmDiff ];
@@ -308,11 +308,11 @@ with self;
     };
   };
 
-  AlienBaseModuleBuild = buildPerlModule {
+  AlienBaseModuleBuild = buildPerlModule rec {
     pname = "Alien-Base-ModuleBuild";
     version = "1.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Alien-Base-ModuleBuild-1.17.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Alien-Base-ModuleBuild-${version}.tar.gz";
       hash = "sha256-/nJwrHNa3ehk5GjiHGQqRxuoi6Ja0w2pRXiDITLyufQ=";
     };
     buildInputs = [ Test2Suite ];
@@ -337,11 +337,11 @@ with self;
     };
   };
 
-  AlienBuild = buildPerlPackage {
+  AlienBuild = buildPerlPackage rec {
     pname = "Alien-Build";
     version = "2.80";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Alien-Build-2.80.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Alien-Build-${version}.tar.gz";
       hash = "sha256-2e3JNrBnBbtcte5aLqi89hEaPogVkU8XfhXjwP7TAfM=";
     };
 
@@ -370,11 +370,11 @@ with self;
     };
   };
 
-  AlienBuildPluginDownloadGitLab = buildPerlPackage {
+  AlienBuildPluginDownloadGitLab = buildPerlPackage rec {
     pname = "Alien-Build-Plugin-Download-GitLab";
     version = "0.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Alien-Build-Plugin-Download-GitLab-0.01.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Alien-Build-Plugin-Download-GitLab-${version}.tar.gz";
       hash = "sha256-wfCJyOoVKniZCdSKg9v88mJvdz2vMEMchiJYKyarqQI=";
     };
     buildInputs = [ Test2Suite ];
@@ -393,11 +393,11 @@ with self;
     };
   };
 
-  AlienFFI = buildPerlPackage {
+  AlienFFI = buildPerlPackage rec {
     pname = "Alien-FFI";
     version = "0.27";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Alien-FFI-0.27.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Alien-FFI-${version}.tar.gz";
       hash = "sha256-Kbsgg/P5gqOfSFIkP09qEZFpZvIObneGTpkmnRHotl4=";
     };
     patches = [ ../development/perl-modules/Alien-FFI-dont-download.patch ];
@@ -422,11 +422,11 @@ with self;
     };
   };
 
-  AlienGMP = buildPerlPackage {
+  AlienGMP = buildPerlPackage rec {
     pname = "Alien-GMP";
     version = "1.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Alien-GMP-1.16.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Alien-GMP-${version}.tar.gz";
       hash = "sha256-CQzUjuU1v2LxeIlWF6hReDrhGqTGAGof1NhKQy8RPaU=";
     };
     propagatedBuildInputs = [ AlienBuild ];
@@ -448,11 +448,11 @@ with self;
     };
   };
 
-  AlienLibGumbo = buildPerlModule {
+  AlienLibGumbo = buildPerlModule rec {
     pname = "Alien-LibGumbo";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RU/RUZ/Alien-LibGumbo-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/R/RU/RUZ/Alien-LibGumbo-${version}.tar.gz";
       hash = "sha256-D76RarEfaA5cKM0ayAA3IyPioOBq/8bIs2J5/GTXZRc=";
     };
     # Fix linker detection broken by exported LD (see nixpkgs#9f2a89f)
@@ -475,11 +475,11 @@ with self;
     };
   };
 
-  AlienLibxml2 = buildPerlPackage {
+  AlienLibxml2 = buildPerlPackage rec {
     pname = "Alien-Libxml2";
     version = "0.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Alien-Libxml2-0.19.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Alien-Libxml2-${version}.tar.gz";
       hash = "sha256-9KZ0CZu9V0fAw7derYQfOyRJNdnvQro1NoAkvWERdMk=";
     };
     strictDeps = true;
@@ -503,11 +503,11 @@ with self;
     };
   };
 
-  aliased = buildPerlModule {
+  aliased = buildPerlModule rec {
     pname = "aliased";
     version = "0.34";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/aliased-0.34.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/aliased-${version}.tar.gz";
       hash = "sha256-w1BSRQfNgn+rhk5dTCzDULG6uqEvqVrsDKAIQ/zH3us=";
     };
     buildInputs = [ ModuleBuildTiny ];
@@ -520,11 +520,11 @@ with self;
     };
   };
 
-  asa = buildPerlPackage {
+  asa = buildPerlPackage rec {
     pname = "asa";
     version = "1.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/asa-1.04.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/asa-${version}.tar.gz";
       hash = "sha256-5YM7dOczuu4Z0e9eBLEmPBz/nBdGmVrXL8QJGPRAZ14=";
     };
     meta = {
@@ -537,11 +537,11 @@ with self;
     };
   };
 
-  AlienSDL = buildPerlModule {
+  AlienSDL = buildPerlModule rec {
     pname = "Alien-SDL";
     version = "1.446";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FR/FROGGS/Alien-SDL-1.446.tar.gz";
+      url = "mirror://cpan/authors/id/F/FR/FROGGS/Alien-SDL-${version}.tar.gz";
       hash = "sha256-yaosncPGPYl3PH1yA/KkbRuSTQxy2fgBrxR6Pci8USo=";
     };
     patches = [ ../development/perl-modules/alien-sdl.patch ];
@@ -570,11 +570,11 @@ with self;
     };
   };
 
-  AlienTidyp = buildPerlModule {
+  AlienTidyp = buildPerlModule rec {
     pname = "Alien-Tidyp";
     version = "1.4.7";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KM/KMX/Alien-Tidyp-v1.4.7.tar.gz";
+      url = "mirror://cpan/authors/id/K/KM/KMX/Alien-Tidyp-v${version}.tar.gz";
       hash = "sha256-uWTL2nH79sDqaaTztBUEwUXygWga/hmewrSUQC6/SmU=";
     };
 
@@ -590,11 +590,11 @@ with self;
     };
   };
 
-  AlienWxWidgets = buildPerlModule {
+  AlienWxWidgets = buildPerlModule rec {
     pname = "Alien-wxWidgets";
     version = "0.69";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MD/MDOOTSON/Alien-wxWidgets-0.69.tar.gz";
+      url = "mirror://cpan/authors/id/M/MD/MDOOTSON/Alien-wxWidgets-${version}.tar.gz";
       hash = "sha256-UyJOS7vv/0z3tj7ZpiljiTuf/Ull1w2WcQNI+Gdt4kk=";
     };
     postPatch = ''
@@ -617,11 +617,11 @@ with self;
     };
   };
 
-  Alienm4 = buildPerlPackage {
+  Alienm4 = buildPerlPackage rec {
     pname = "Alien-m4";
     version = "0.21";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Alien-m4-0.21.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Alien-m4-${version}.tar.gz";
       hash = "sha256-qypAXIA5RP0BxR+h6fK+/VhxqwPxdE3sKlZonyFI02E=";
     };
     propagatedBuildInputs = [ AlienBuild ];
@@ -645,11 +645,11 @@ with self;
     };
   };
 
-  Alienpatch = buildPerlPackage {
+  Alienpatch = buildPerlPackage rec {
     pname = "Alien-patch";
     version = "0.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Alien-patch-0.15.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Alien-patch-${version}.tar.gz";
       hash = "sha256-/tZyJbLZamZpL30vQ+DTRykhRSnbHWsTsNykYgquANA=";
     };
     propagatedBuildInputs = [ AlienBuild ];
@@ -671,11 +671,11 @@ with self;
     };
   };
 
-  AltCryptRSABigInt = buildPerlPackage {
+  AltCryptRSABigInt = buildPerlPackage rec {
     pname = "Alt-Crypt-RSA-BigInt";
     version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DANAJ/Alt-Crypt-RSA-BigInt-0.06.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DANAJ/Alt-Crypt-RSA-BigInt-${version}.tar.gz";
       hash = "sha256-dvQ0yrNpmc3wmBE0W7Oda3y+1+CFsCM4Mox/RuCLOPM=";
     };
     propagatedBuildInputs = [
@@ -699,11 +699,11 @@ with self;
     };
   };
 
-  AnyEvent = buildPerlPackage {
+  AnyEvent = buildPerlPackage rec {
     pname = "AnyEvent";
     version = "7.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/AnyEvent-7.17.tar.gz";
+      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/AnyEvent-${version}.tar.gz";
       hash = "sha256-UL7qaJwJj+Sq64OAbEC5/n+UbVdprPmfhJ8JkJGkuYU=";
     };
     buildInputs = [ CanaryStability ];
@@ -716,11 +716,11 @@ with self;
     };
   };
 
-  AnyEventAIO = buildPerlPackage {
+  AnyEventAIO = buildPerlPackage rec {
     pname = "AnyEvent-AIO";
     version = "1.1";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/AnyEvent-AIO-1.1.tar.gz";
+      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/AnyEvent-AIO-${version}.tar.gz";
       hash = "sha256-axBbjGQVYWMfUz7DQj6AZ6PX1YBDv4Xw9eCdcGkFcGs=";
     };
     propagatedBuildInputs = [
@@ -757,11 +757,11 @@ with self;
     };
   };
 
-  AnyEventCacheDNS = buildPerlModule {
+  AnyEventCacheDNS = buildPerlModule rec {
     pname = "AnyEvent-CacheDNS";
     version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PO/POTYL/AnyEvent-CacheDNS-0.08.tar.gz";
+      url = "mirror://cpan/authors/id/P/PO/POTYL/AnyEvent-CacheDNS-${version}.tar.gz";
       hash = "sha256-QcH68YO2GAa1WInO6hI3dQwfYbnOJzX98z3AVTZxLa4=";
     };
     propagatedBuildInputs = [ AnyEvent ];
@@ -776,11 +776,11 @@ with self;
     };
   };
 
-  AnyEventFastPing = buildPerlPackage {
+  AnyEventFastPing = buildPerlPackage rec {
     pname = "AnyEvent-FastPing";
     version = "2.1";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/AnyEvent-FastPing-2.1.tar.gz";
+      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/AnyEvent-FastPing-${version}.tar.gz";
       hash = "sha256-5ZIbj3rTXJg6ACWuAKSPyVyQwX/uw+WFmBhwSwxScCw=";
     };
     propagatedBuildInputs = [
@@ -797,11 +797,11 @@ with self;
     };
   };
 
-  AnyEventHTTP = buildPerlPackage {
+  AnyEventHTTP = buildPerlPackage rec {
     pname = "AnyEvent-HTTP";
     version = "2.25";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/AnyEvent-HTTP-2.25.tar.gz";
+      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/AnyEvent-HTTP-${version}.tar.gz";
       hash = "sha256-XPpTQWEkF29vTNMrAOqMp5otXfUSWGg5ic0E/obiUBM=";
     };
     propagatedBuildInputs = [
@@ -817,11 +817,11 @@ with self;
     };
   };
 
-  AnyEventI3 = buildPerlPackage {
+  AnyEventI3 = buildPerlPackage rec {
     pname = "AnyEvent-I3";
     version = "0.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSTPLBG/AnyEvent-I3-0.19.tar.gz";
+      url = "mirror://cpan/authors/id/M/MS/MSTPLBG/AnyEvent-I3-${version}.tar.gz";
       hash = "sha256-G807YNs9VWAUjeeRNT6K8RciZPWoXncZe5/8BB2sSDo=";
     };
     propagatedBuildInputs = [
@@ -858,11 +858,11 @@ with self;
     };
   };
 
-  AnyEventRabbitMQ = buildPerlPackage {
+  AnyEventRabbitMQ = buildPerlPackage rec {
     pname = "AnyEvent-RabbitMQ";
     version = "1.22";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DL/DLAMBLEY/AnyEvent-RabbitMQ-1.22.tar.gz";
+      url = "mirror://cpan/authors/id/D/DL/DLAMBLEY/AnyEvent-RabbitMQ-${version}.tar.gz";
       hash = "sha256-mMUqH+cAcQ8+W8VaOLJd5iXpsug0HSeNz54bPz0ZrO4=";
     };
     buildInputs = [
@@ -887,11 +887,11 @@ with self;
     };
   };
 
-  AnyMoose = buildPerlPackage {
+  AnyMoose = buildPerlPackage rec {
     pname = "Any-Moose";
     version = "0.27";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Any-Moose-0.27.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Any-Moose-${version}.tar.gz";
       hash = "sha256-qKY+N/qALoJYvpmYORbN5FElgdyAYt5Q5z1mr24thTU=";
     };
     propagatedBuildInputs = [
@@ -907,11 +907,11 @@ with self;
     };
   };
 
-  AnyURIEscape = buildPerlPackage {
+  AnyURIEscape = buildPerlPackage rec {
     pname = "Any-URI-Escape";
     version = "0.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PH/PHRED/Any-URI-Escape-0.01.tar.gz";
+      url = "mirror://cpan/authors/id/P/PH/PHRED/Any-URI-Escape-${version}.tar.gz";
       hash = "sha256-44E87J8Qj6XAvmbgjBmGv7pNJCFRsPn07F4MXhcQjEw=";
     };
     propagatedBuildInputs = [ URI ];
@@ -924,11 +924,11 @@ with self;
     };
   };
 
-  URIEscapeXS = buildPerlPackage {
+  URIEscapeXS = buildPerlPackage rec {
     pname = "URI-Escape-XS";
     version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DANKOGAI/URI-Escape-XS-0.14.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DANKOGAI/URI-Escape-XS-${version}.tar.gz";
       hash = "sha256-w5rFDGwrgxrkvwhpLmyl1KP5xX3E1/nEywZj4shsJ1k=";
     };
     meta = {
@@ -940,11 +940,11 @@ with self;
     };
   };
 
-  ApacheAuthCookie = buildPerlPackage {
+  ApacheAuthCookie = buildPerlPackage rec {
     pname = "Apache-AuthCookie";
     version = "3.31";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSCHOUT/Apache-AuthCookie-3.31.tar.gz";
+      url = "mirror://cpan/authors/id/M/MS/MSCHOUT/Apache-AuthCookie-${version}.tar.gz";
       hash = "sha256-ByhnLrmLzWZSWWenXXxNYXwLTEEWIBOsmkzv5G99/3w=";
     };
     buildInputs = [ ApacheTest ];
@@ -969,11 +969,11 @@ with self;
     };
   };
 
-  ApacheDB = buildPerlPackage {
+  ApacheDB = buildPerlPackage rec {
     pname = "Apache-DB";
     version = "0.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LZ/LZE/Apache-DB-0.18.tar.gz";
+      url = "mirror://cpan/authors/id/L/LZ/LZE/Apache-DB-${version}.tar.gz";
       hash = "sha256-ZSf08VmCcL6ge+x4e3G98OwrVyVIvnQ4z3TyuaYAv+0=";
     };
     meta = {
@@ -986,11 +986,11 @@ with self;
     };
   };
 
-  ApacheLogFormatCompiler = buildPerlModule {
+  ApacheLogFormatCompiler = buildPerlModule rec {
     pname = "Apache-LogFormat-Compiler";
     version = "0.36";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KAZEBURO/Apache-LogFormat-Compiler-0.36.tar.gz";
+      url = "mirror://cpan/authors/id/K/KA/KAZEBURO/Apache-LogFormat-Compiler-${version}.tar.gz";
       hash = "sha256-lFCVA+506oIBg9BwwRYw7lvA/YwSy3T66VPtYuShrBc=";
     };
     buildInputs = [
@@ -1014,11 +1014,11 @@ with self;
     };
   };
 
-  ApacheSession = buildPerlModule {
+  ApacheSession = buildPerlModule rec {
     pname = "Apache-Session";
     version = "1.94";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHORNY/Apache-Session-1.94.tar.gz";
+      url = "mirror://cpan/authors/id/C/CH/CHORNY/Apache-Session-${version}.tar.gz";
       hash = "sha256-/mm3aJmv6QuK5bgt4qqnV1rakIk39EhbgKrvMXVj6Z8=";
     };
     buildInputs = [
@@ -1034,11 +1034,11 @@ with self;
     };
   };
 
-  ApacheTest = buildPerlPackage {
+  ApacheTest = buildPerlPackage rec {
     pname = "Apache-Test";
     version = "1.43";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHAY/Apache-Test-1.43.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHAY/Apache-Test-${version}.tar.gz";
       hash = "sha256-qZmfAqeBpYkhi1ibGHnBHEladFrwlXXly7It/LZWgKw=";
     };
     doCheck = false;
@@ -1048,11 +1048,11 @@ with self;
     };
   };
 
-  AppCLI = buildPerlPackage {
+  AppCLI = buildPerlPackage rec {
     pname = "App-CLI";
     version = "0.52";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PT/PTC/App-CLI-0.52.tar.gz";
+      url = "mirror://cpan/authors/id/P/PT/PTC/App-CLI-${version}.tar.gz";
       hash = "sha256-Ur1D9VWRPML/1kBfmVHSqr1Gr2PXAdm140amMycJ8M4=";
     };
     propagatedBuildInputs = [
@@ -1072,11 +1072,11 @@ with self;
     };
   };
 
-  AppClusterSSH = buildPerlModule {
+  AppClusterSSH = buildPerlModule rec {
     pname = "App-ClusterSSH";
     version = "4.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DU/DUNCS/App-ClusterSSH-4.16.tar.gz";
+      url = "mirror://cpan/authors/id/D/DU/DUNCS/App-ClusterSSH-${version}.tar.gz";
       hash = "sha256-G3y4q2BoViRK34vZrE0nUHwuQWh7OvGiJs4dsvP9VXg=";
     };
     propagatedBuildInputs = [
@@ -1113,11 +1113,11 @@ with self;
     };
   };
 
-  AppCmd = buildPerlPackage {
+  AppCmd = buildPerlPackage rec {
     pname = "App-Cmd";
     version = "0.336";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/App-Cmd-0.336.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/App-Cmd-${version}.tar.gz";
       hash = "sha256-35ZrV9WauxluADBIheW/EXypWBgq4/Tu3xchjqKDjoE=";
     };
     buildInputs = [ TestFatal ];
@@ -1139,11 +1139,11 @@ with self;
     };
   };
 
-  AppConfig = buildPerlPackage {
+  AppConfig = buildPerlPackage rec {
     pname = "AppConfig";
     version = "1.71";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/AppConfig-1.71.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/AppConfig-${version}.tar.gz";
       hash = "sha256-EXcCcCXssJ7mTZ+fJVYVwE214U91NsNEr2MgMuuIew8=";
     };
     buildInputs = [ TestPod ];
@@ -1156,11 +1156,11 @@ with self;
     };
   };
 
-  AppFatPacker = buildPerlPackage {
+  AppFatPacker = buildPerlPackage rec {
     pname = "App-FatPacker";
     version = "0.010008";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSTROUT/App-FatPacker-0.010008.tar.gz";
+      url = "mirror://cpan/authors/id/M/MS/MSTROUT/App-FatPacker-${version}.tar.gz";
       hash = "sha256-Ep2zbchFZhpYIoaBDP4tUhbrLOCCutQK4fzc4PRd7M8=";
     };
     meta = {
@@ -1173,11 +1173,11 @@ with self;
     };
   };
 
-  AppFatPackerSimple = buildPerlModule {
+  AppFatPackerSimple = buildPerlModule rec {
     pname = "App-FatPacker-Simple";
     version = "0.20";
     src = pkgs.fetchurl {
-      url = "mirror://cpan/authors/id/S/SK/SKAJI/App-FatPacker-Simple-0.20.tar.gz";
+      url = "mirror://cpan/authors/id/S/SK/SKAJI/App-FatPacker-Simple-${version}.tar.gz";
       sha256 = "sha256-nkSy/gno2PxT5aA3UWCRK0Dnn9fIdcCOtQvoGUZocSo=";
     };
     buildInputs = [
@@ -1198,11 +1198,11 @@ with self;
     };
   };
 
-  Appcpanminus = buildPerlPackage {
+  Appcpanminus = buildPerlPackage rec {
     pname = "App-cpanminus";
     version = "1.7047";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7047.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/App-cpanminus-${version}.tar.gz";
       hash = "sha256-lj5jxuGocl/y9iTpCGOWrhUNtR3QozfDeB0JqZSvBaU=";
     };
     # CVE-2024-45321: Use TLS endpoints for downloads and metadata
@@ -1226,11 +1226,11 @@ with self;
     };
   };
 
-  Appcpm = buildPerlModule {
+  Appcpm = buildPerlModule rec {
     pname = "App-cpm";
     version = "0.997018";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SK/SKAJI/App-cpm-0.997018.tar.gz";
+      url = "mirror://cpan/authors/id/S/SK/SKAJI/App-cpm-${version}.tar.gz";
       hash = "sha256-ePvZawR9A4O2p/iJWxk/CziworVQuS8YwH91Lql8Tv0=";
     };
     buildInputs = [ ModuleBuildTiny ];
@@ -1263,11 +1263,11 @@ with self;
     };
   };
 
-  Applify = buildPerlPackage {
+  Applify = buildPerlPackage rec {
     pname = "Applify";
     version = "0.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/Applify-0.23.tar.gz";
+      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/Applify-${version}.tar.gz";
       hash = "sha256-fI3Z55e9DsJgDTAOzUnul4EZgxxlay0L3q7OoENIoRI=";
     };
     meta = {
@@ -1278,11 +1278,11 @@ with self;
     };
   };
 
-  AppMusicChordPro = buildPerlPackage {
+  AppMusicChordPro = buildPerlPackage rec {
     pname = "App-Music-ChordPro";
     version = "6.050.7";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JV/JV/App-Music-ChordPro-6.050.7.tar.gz";
+      url = "mirror://cpan/authors/id/J/JV/JV/App-Music-ChordPro-${version}.tar.gz";
       hash = "sha256-tpNsqhoWOPIwprK3ou5tb9oXKih3HEQjm/2c5F9rOoQ=";
     };
     buildInputs = [ ObjectPad ];
@@ -1319,11 +1319,11 @@ with self;
     };
   };
 
-  AppPackager = buildPerlPackage {
+  AppPackager = buildPerlPackage rec {
     pname = "App-Packager";
     version = "1.440";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JV/JV/App-Packager-1.440.tar.gz";
+      url = "mirror://cpan/authors/id/J/JV/JV/App-Packager-${version}.tar.gz";
       hash = "sha256-VoFBa+b9eJe+mEg8TqKOsN3gzGWzwg5o1HswRN7PKHo=";
     };
     meta = {
@@ -1357,11 +1357,11 @@ with self;
     };
   };
 
-  Appperlbrew = buildPerlModule {
+  Appperlbrew = buildPerlModule rec {
     pname = "App-perlbrew";
     version = "1.00";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GU/GUGOD/App-perlbrew-1.00.tar.gz";
+      url = "mirror://cpan/authors/id/G/GU/GUGOD/App-perlbrew-${version}.tar.gz";
       hash = "sha256-PKNFnK6f/VHef2i95CEtBx1hOLZEUo9izJDHikhSyss=";
     };
     buildInputs = [
@@ -1393,12 +1393,12 @@ with self;
     };
   };
 
-  AppXMLDocBookBuilder = buildPerlPackage {
+  AppXMLDocBookBuilder = buildPerlPackage rec {
     pname = "docmake";
     version = "0.1101";
 
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/App-XML-DocBook-Builder-0.1101.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/App-XML-DocBook-Builder-${version}.tar.gz";
       hash = "sha256-oa8C24OsbeaNdLIssSz/KH3MNFr0WuQJ67govyhxmqQ=";
     };
 
@@ -1415,11 +1415,11 @@ with self;
     };
   };
 
-  ArchiveAnyLite = buildPerlPackage {
+  ArchiveAnyLite = buildPerlPackage rec {
     pname = "Archive-Any-Lite";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/Archive-Any-Lite-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/Archive-Any-Lite-${version}.tar.gz";
       hash = "sha256-FcGIJTmTpLZuVZnweJsTJvCmbAkr2/rJMTcG1BwoUXA=";
     };
     propagatedBuildInputs = [ ArchiveZip ];
@@ -1436,11 +1436,11 @@ with self;
     };
   };
 
-  AppSqitch = buildPerlModule {
+  AppSqitch = buildPerlModule rec {
     version = "1.5.2";
     pname = "App-Sqitch";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DW/DWHEELER/App-Sqitch-v1.5.2.tar.gz";
+      url = "mirror://cpan/authors/id/D/DW/DWHEELER/App-Sqitch-v${version}.tar.gz";
       hash = "sha256-horqXNSz6uDPrKiXK546ag+PmYiEjVNazstJVbAovNE=";
     };
     buildInputs = [
@@ -1487,11 +1487,11 @@ with self;
     };
   };
 
-  AppSt = buildPerlPackage {
+  AppSt = buildPerlPackage rec {
     pname = "App-St";
     version = "1.1.4";
     src = fetchurl {
-      url = "https://github.com/nferraz/st/archive/v1.1.4.tar.gz";
+      url = "https://github.com/nferraz/st/archive/v${version}.tar.gz";
       hash = "sha256-wCoW9n5MNXaQpUODGYQxSf1wDCIxKPn/6+yrKEnFi7g=";
     };
     postInstall = ''
@@ -1506,11 +1506,11 @@ with self;
     };
   };
 
-  AttributeParamsValidate = buildPerlPackage {
+  AttributeParamsValidate = buildPerlPackage rec {
     pname = "Attribute-Params-Validate";
     version = "1.21";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Attribute-Params-Validate-1.21.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Attribute-Params-Validate-${version}.tar.gz";
       hash = "sha256-WGuTnO/9s3GIt8Rh3RqPnzVpUYTIcDsFw19tUIyAkPU=";
     };
     buildInputs = [ TestFatal ];
@@ -1523,11 +1523,11 @@ with self;
     };
   };
 
-  ArchiveLibarchive = buildPerlPackage {
+  ArchiveLibarchive = buildPerlPackage rec {
     pname = "Archive-Libarchive";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Archive-Libarchive-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Archive-Libarchive-${version}.tar.gz";
       hash = "sha256-avdG7P9/GjUwzmtaWNCtR0MaaZjUWduw8VYqEiPn3v8=";
     };
     patches = [ ../development/perl-modules/ArchiveLibarchive-set-findlib-path.patch ];
@@ -1562,11 +1562,11 @@ with self;
     };
   };
 
-  ArchiveLibarchiveExtract = buildPerlPackage {
+  ArchiveLibarchiveExtract = buildPerlPackage rec {
     pname = "Archive-Libarchive-Extract";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Archive-Libarchive-Extract-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Archive-Libarchive-Extract-${version}.tar.gz";
       hash = "sha256-yXfAR0hnIX6zJvte5pA04e9spBQUkWHjEpAblf0SwIE=";
     };
     buildInputs = [
@@ -1590,11 +1590,11 @@ with self;
     };
   };
 
-  ArchiveLibarchivePeek = buildPerlPackage {
+  ArchiveLibarchivePeek = buildPerlPackage rec {
     pname = "Archive-Libarchive-Peek";
     version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Archive-Libarchive-Peek-0.04.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Archive-Libarchive-Peek-${version}.tar.gz";
       hash = "sha256-DYhJ4xG2RsozWz6gGodTtAIkK5XOgAo7zNXHCC4nJPo=";
     };
     buildInputs = [
@@ -1618,11 +1618,11 @@ with self;
     };
   };
 
-  ArrayCompare = buildPerlModule {
+  ArrayCompare = buildPerlModule rec {
     pname = "Array-Compare";
     version = "3.0.8";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAVECROSS/Array-Compare-v3.0.8.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAVECROSS/Array-Compare-v${version}.tar.gz";
       hash = "sha256-MEc7XpEBU4QNJDHqlGO55W5SPN56PFBhadaaK5dC2DQ=";
     };
 
@@ -1640,11 +1640,11 @@ with self;
     };
   };
 
-  ArrayDiff = buildPerlPackage {
+  ArrayDiff = buildPerlPackage rec {
     pname = "Array-Diff";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/Array-Diff-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/Array-Diff-${version}.tar.gz";
       hash = "sha256-gAY5Lphh50FTfCu8kRbI5CuWLy4H6NZBov9qEcZEUHc=";
     };
     propagatedBuildInputs = [
@@ -1661,11 +1661,11 @@ with self;
     };
   };
 
-  ArrayFIFO = buildPerlPackage {
+  ArrayFIFO = buildPerlPackage rec {
     pname = "Array-FIFO";
     version = "0.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DB/DBURKE/Array-FIFO-0.13.tar.gz";
+      url = "mirror://cpan/authors/id/D/DB/DBURKE/Array-FIFO-${version}.tar.gz";
       hash = "sha256-virrX1qa8alvADNQilacqTrRmtFdx8a5mObXvHQMZvc=";
     };
     buildInputs = [
@@ -1684,11 +1684,11 @@ with self;
     };
   };
 
-  ArrayRefElem = buildPerlPackage {
+  ArrayRefElem = buildPerlPackage rec {
     pname = "Array-RefElem";
     version = "1.00";
     src = fetchurl {
-      url = "mirror://cpan/authors/id//G/GA/GAAS/Array-RefElem-1.00.tar.gz";
+      url = "mirror://cpan/authors/id//G/GA/GAAS/Array-RefElem-${version}.tar.gz";
       hash = "sha256-U7iAo67AQ+TjcM4SaCtHVt5F3XQtq1cpT+IaFUU87+M=";
     };
     meta = {
@@ -1700,11 +1700,11 @@ with self;
     };
   };
 
-  ArrayUtils = buildPerlPackage {
+  ArrayUtils = buildPerlPackage rec {
     pname = "ArrayUtils";
     version = "0.5";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZM/ZMIJ/Array/Array-Utils-0.5.tar.gz";
+      url = "mirror://cpan/authors/id/Z/ZM/ZMIJ/Array/Array-Utils-${version}.tar.gz";
       hash = "sha256-id0bf82bQ3lJKjp3SW45/mzTebdz/QOmsWDdJu3mN3A=";
     };
     meta = {
@@ -1717,11 +1717,11 @@ with self;
     };
   };
 
-  AsyncPing = buildPerlPackage {
+  AsyncPing = buildPerlPackage rec {
     pname = "AsyncPing";
     version = "2016.1207";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XI/XINFWANG/AsyncPing-2016.1207.tar.gz";
+      url = "mirror://cpan/authors/id/X/XI/XINFWANG/AsyncPing-${version}.tar.gz";
       hash = "sha256-b76a/sF6d3B2+K2JksjSMAr2WpUDRD0dT/nD+NKZyVo=";
     };
     meta = {
@@ -1730,11 +1730,11 @@ with self;
     };
   };
 
-  AsyncUtil = buildPerlPackage {
+  AsyncUtil = buildPerlPackage rec {
     pname = "Async-Util";
     version = "0.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/W/WH/WHITNEY/Async-Util-0.01.tar.gz";
+      url = "mirror://cpan/authors/id/W/WH/WHITNEY/Async-Util-${version}.tar.gz";
       hash = "sha256-jzKxHKvFD2Xjh79W8mWBV6IsNah5Nmbhtfis/hMQkQY=";
     };
     buildInputs = [
@@ -1750,11 +1750,11 @@ with self;
     };
   };
 
-  ArchiveCpio = buildPerlPackage {
+  ArchiveCpio = buildPerlPackage rec {
     pname = "Archive-Cpio";
     version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PI/PIXEL/Archive-Cpio-0.10.tar.gz";
+      url = "mirror://cpan/authors/id/P/PI/PIXEL/Archive-Cpio-${version}.tar.gz";
       hash = "sha256-JG+zFml2TngzayGRE0Ei4HxE8tgtxPN9VSqyj4ZovtM=";
     };
     meta = {
@@ -1767,11 +1767,11 @@ with self;
     };
   };
 
-  ArchiveExtract = buildPerlPackage {
+  ArchiveExtract = buildPerlPackage rec {
     pname = "Archive-Extract";
     version = "0.88";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BI/BINGOS/Archive-Extract-0.88.tar.gz";
+      url = "mirror://cpan/authors/id/B/BI/BINGOS/Archive-Extract-${version}.tar.gz";
       hash = "sha256-z/zxNc0GIih9OwIVT31nFklUSfyu0DlmYhlI4l6l90I=";
     };
     meta = {
@@ -1783,11 +1783,11 @@ with self;
     };
   };
 
-  ArchiveTar = buildPerlPackage {
+  ArchiveTar = buildPerlPackage rec {
     pname = "Archive-Tar";
     version = "3.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BI/BINGOS/Archive-Tar-3.02.tar.gz";
+      url = "mirror://cpan/authors/id/B/BI/BINGOS/Archive-Tar-${version}.tar.gz";
       hash = "sha256-gWM8h/c3hGGD01wPTJ1ALalHqEa0iBswzObZ6+PInRk=";
     };
     meta = {
@@ -1800,11 +1800,11 @@ with self;
     };
   };
 
-  ArchiveTarWrapper = buildPerlPackage {
+  ArchiveTarWrapper = buildPerlPackage rec {
     pname = "Archive-Tar-Wrapper";
     version = "0.38";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AR/ARFREITAS/Archive-Tar-Wrapper-0.38.tar.gz";
+      url = "mirror://cpan/authors/id/A/AR/ARFREITAS/Archive-Tar-Wrapper-${version}.tar.gz";
       hash = "sha256-GfPQ2qi5XP+2jHBDUN0GdKI+HS8U0DKQO36WCe23s3o=";
     };
     propagatedBuildInputs = [
@@ -1818,11 +1818,11 @@ with self;
     };
   };
 
-  ArchiveZip = buildPerlPackage {
+  ArchiveZip = buildPerlPackage rec {
     pname = "Archive-Zip";
     version = "1.68";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PH/PHRED/Archive-Zip-1.68.tar.gz";
+      url = "mirror://cpan/authors/id/P/PH/PHRED/Archive-Zip-${version}.tar.gz";
       hash = "sha256-mE4YXXhbr2EpxudfjrREEXRawAv2Ei+xyOgio4YexlA=";
     };
     buildInputs = [ TestMockModule ];
@@ -1836,11 +1836,11 @@ with self;
     };
   };
 
-  AstroFITSHeader = buildPerlModule {
+  AstroFITSHeader = buildPerlModule rec {
     pname = "Astro-FITS-Header";
     version = "3.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GS/GSB/Astro-FITS-Header-3.09.tar.gz";
+      url = "mirror://cpan/authors/id/G/GS/GSB/Astro-FITS-Header-${version}.tar.gz";
       hash = "sha256-cq1oveWku+zv8VFtZ3A/4tACFDlwQpo81pplFlLVaYY=";
     };
     meta = {
@@ -1850,11 +1850,11 @@ with self;
     };
   };
 
-  AudioCuefileParser = buildPerlPackage {
+  AudioCuefileParser = buildPerlPackage rec {
     pname = "Audio-Cuefile-Parser";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MATTK/Audio-Cuefile-Parser-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MATTK/Audio-Cuefile-Parser-${version}.tar.gz";
       hash = "sha256-ulbQcMhz2WxoatmoH99P6JuETkPrSd/gAL+c70PFtmk=";
     };
     meta = {
@@ -1865,11 +1865,11 @@ with self;
     };
   };
 
-  AudioFLACHeader = buildPerlPackage {
+  AudioFLACHeader = buildPerlPackage rec {
     pname = "Audio-FLAC-Header";
     version = "2.4";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DANIEL/Audio-FLAC-Header-2.4.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DANIEL/Audio-FLAC-Header-${version}.tar.gz";
       hash = "sha256-+6WRHWwi2BUGVlzZoUOOhgVCD/eYbPA9GhLQBqQHBUM=";
     };
     meta = {
@@ -1881,11 +1881,11 @@ with self;
     };
   };
 
-  AudioScan = buildPerlPackage {
+  AudioScan = buildPerlPackage rec {
     pname = "Audio-Scan";
     version = "1.11";
     src = fetchurl {
-      url = "https://github.com/Logitech/slimserver-vendor/raw/public/9.1/CPAN/Audio-Scan-1.11.tar.gz";
+      url = "https://github.com/Logitech/slimserver-vendor/raw/public/9.1/CPAN/Audio-Scan-${version}.tar.gz";
       hash = "sha256-G+0qaqP2c1w/UKuOmRawq/qKZjsWvZUzTAl5C6H6bUI=";
     };
     buildInputs = [
@@ -1901,11 +1901,11 @@ with self;
     };
   };
 
-  AuthenDecHpwd = buildPerlModule {
+  AuthenDecHpwd = buildPerlModule rec {
     pname = "Authen-DecHpwd";
     version = "2.007";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Authen-DecHpwd-2.007.tar.gz";
+      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Authen-DecHpwd-${version}.tar.gz";
       hash = "sha256-9DqTuwK0H3Mn2S+eljtpUF9nNQpS6PUHlvmK/E+z8Xc=";
     };
     propagatedBuildInputs = [
@@ -1919,11 +1919,11 @@ with self;
     };
   };
 
-  AuthenHtpasswd = buildPerlPackage {
+  AuthenHtpasswd = buildPerlPackage rec {
     pname = "Authen-Htpasswd";
     version = "0.171";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSTROUT/Authen-Htpasswd-0.171.tar.gz";
+      url = "mirror://cpan/authors/id/M/MS/MSTROUT/Authen-Htpasswd-${version}.tar.gz";
       hash = "sha256-tfr0fj+UikUoEGzLiMxxBIz+WY5bAmpEQ2i8fjk0gGc=";
     };
     propagatedBuildInputs = [
@@ -1945,11 +1945,11 @@ with self;
     };
   };
 
-  AuthenKrb5 = buildPerlModule {
+  AuthenKrb5 = buildPerlModule rec {
     pname = "Authen-Krb5";
     version = "1.906";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OD/ODENBACH/Authen-Krb5-1.906.tar.gz";
+      url = "mirror://cpan/authors/id/O/OD/ODENBACH/Authen-Krb5-${version}.tar.gz";
       hash = "sha256-LcCSjvsTtfMF3zRSCI5j+StnrOqH+9RwMI9GD3kSboQ=";
     };
     propagatedBuildInputs = [ pkgs.libkrb5 ];
@@ -1967,11 +1967,11 @@ with self;
     };
   };
 
-  AuthenKrb5Admin = buildPerlPackage {
+  AuthenKrb5Admin = buildPerlPackage rec {
     pname = "Authen-Krb5-Admin";
     version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SJ/SJQUINNEY/Authen-Krb5-Admin-0.17.tar.gz";
+      url = "mirror://cpan/authors/id/S/SJ/SJQUINNEY/Authen-Krb5-Admin-${version}.tar.gz";
       hash = "sha256-XdScrNmD79YajD8aVlcbtzeF6xVZCLXXvsl+7XjfDFQ=";
     };
     propagatedBuildInputs = [
@@ -1998,11 +1998,11 @@ with self;
     };
   };
 
-  AuthenModAuthPubTkt = buildPerlPackage {
+  AuthenModAuthPubTkt = buildPerlPackage rec {
     pname = "Authen-ModAuthPubTkt";
     version = "0.1.1";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AG/AGORDON/Authen-ModAuthPubTkt-0.1.1.tar.gz";
+      url = "mirror://cpan/authors/id/A/AG/AGORDON/Authen-ModAuthPubTkt-${version}.tar.gz";
       hash = "sha256-eZbhpCxRIWADzPA8S1JQKGtMVWhCV5cYUfXs6RYdx90=";
     };
     propagatedBuildInputs = [
@@ -2025,11 +2025,11 @@ with self;
     };
   };
 
-  AuthenOATH = buildPerlPackage {
+  AuthenOATH = buildPerlPackage rec {
     pname = "Authen-OATH";
     version = "2.0.1";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OA/OALDERS/Authen-OATH-2.0.1.tar.gz";
+      url = "mirror://cpan/authors/id/O/OA/OALDERS/Authen-OATH-${version}.tar.gz";
       hash = "sha256-GoE9vcBcP72d0528/YXiz7C6PQ9lLPaybsg6uBRt3Hc=";
     };
     buildInputs = [ TestNeeds ];
@@ -2049,11 +2049,11 @@ with self;
     };
   };
 
-  AuthenPassphrase = buildPerlModule {
+  AuthenPassphrase = buildPerlModule rec {
     pname = "Authen-Passphrase";
     version = "0.008";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Authen-Passphrase-0.008.tar.gz";
+      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Authen-Passphrase-${version}.tar.gz";
       hash = "sha256-VdtFIGF9hZ2IwO5Ull2oFbcibXkrjNyN6/kgc1WeBGM=";
     };
     propagatedBuildInputs = [
@@ -2076,11 +2076,11 @@ with self;
     };
   };
 
-  AuthenRadius = buildPerlPackage {
+  AuthenRadius = buildPerlPackage rec {
     pname = "Authen-Radius";
     version = "0.32";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PO/PORTAONE/Authen-Radius-0.32.tar.gz";
+      url = "mirror://cpan/authors/id/P/PO/PORTAONE/Authen-Radius-${version}.tar.gz";
       hash = "sha256-eyCPmDfIOhhCZyVIklNlh+7Qvd5J577euj1ypmUjF0A=";
     };
     buildInputs = [ TestNoWarnings ];
@@ -2094,11 +2094,11 @@ with self;
     };
   };
 
-  AuthenSASL = buildPerlPackage {
+  AuthenSASL = buildPerlPackage rec {
     pname = "Authen-SASL";
     version = "2.1900";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EH/EHUELS/Authen-SASL-2.1900.tar.gz";
+      url = "mirror://cpan/authors/id/E/EH/EHUELS/Authen-SASL-${version}.tar.gz";
       hash = "sha256-vjUzpokbLmdxULR5waDUvxHIu+6+0+e466NAU+k5I7A=";
     };
     propagatedBuildInputs = [
@@ -2114,11 +2114,11 @@ with self;
     };
   };
 
-  AuthenSASLSASLprep = buildPerlModule {
+  AuthenSASLSASLprep = buildPerlModule rec {
     pname = "Authen-SASL-SASLprep";
     version = "1.100";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CF/CFAERBER/Authen-SASL-SASLprep-1.100.tar.gz";
+      url = "mirror://cpan/authors/id/C/CF/CFAERBER/Authen-SASL-SASLprep-${version}.tar.gz";
       hash = "sha256-pMzMNLs/U6zwunjJ/GGvjRVtEJ0cEEh7pZiKVQd9H3A=";
     };
     buildInputs = [ TestNoWarnings ];
@@ -2133,11 +2133,11 @@ with self;
     };
   };
 
-  AuthenSCRAM = buildPerlPackage {
+  AuthenSCRAM = buildPerlPackage rec {
     pname = "Authen-SCRAM";
     version = "0.011";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Authen-SCRAM-0.011.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Authen-SCRAM-${version}.tar.gz";
       hash = "sha256-RRCMI5pzc9AJQdzw0XGs0D58FqY85vfZVo/wUrF89ag=";
     };
     buildInputs = [
@@ -2160,11 +2160,11 @@ with self;
     };
   };
 
-  AuthenSimple = buildPerlPackage {
+  AuthenSimple = buildPerlPackage rec {
     pname = "Authen-Simple";
     version = "0.5";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHANSEN/Authen-Simple-0.5.tar.gz";
+      url = "mirror://cpan/authors/id/C/CH/CHANSEN/Authen-Simple-${version}.tar.gz";
       hash = "sha256-As3atH+L8aHL1Mm/jSWPbQURFJnDP4MV5yRIEvcmE6o=";
     };
     # Our C crypt() doesn't support this weak "crypt" algorithm anymore.
@@ -2196,11 +2196,11 @@ with self;
     };
   };
 
-  AuthenSimplePasswd = buildPerlModule {
+  AuthenSimplePasswd = buildPerlModule rec {
     pname = "Authen-Simple-Passwd";
     version = "0.6";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHANSEN/Authen-Simple-Passwd-0.6.tar.gz";
+      url = "mirror://cpan/authors/id/C/CH/CHANSEN/Authen-Simple-Passwd-${version}.tar.gz";
       hash = "sha256-z1W8NiWe3w/Wr5rSusgbMdxbVqFixmBZDsuWnHwWdLI=";
     };
     # Our C crypt() doesn't support this weak "crypt" algorithm anymore.
@@ -2217,11 +2217,11 @@ with self;
     };
   };
 
-  autobox = buildPerlPackage {
+  autobox = buildPerlPackage rec {
     pname = "autobox";
     version = "3.0.1";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHOCOLATE/autobox-v3.0.1.tar.gz";
+      url = "mirror://cpan/authors/id/C/CH/CHOCOLATE/autobox-v${version}.tar.gz";
       hash = "sha256-wwO3/M+qH/TUxCmrPxXlyip3VU74yfw7jGK6hZ6HTJg=";
     };
     propagatedBuildInputs = [ ScopeGuard ];
@@ -2235,11 +2235,11 @@ with self;
     };
   };
 
-  Autodia = buildPerlPackage {
+  Autodia = buildPerlPackage rec {
     pname = "Autodia";
     version = "2.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TE/TEEJAY/Autodia-2.14.tar.gz";
+      url = "mirror://cpan/authors/id/T/TE/TEEJAY/Autodia-${version}.tar.gz";
       hash = "sha256-rIElyIq+Odn+Aco6zBOgCinzM2pLt+9gRH5ri4Iv9CI=";
     };
     propagatedBuildInputs = [
@@ -2267,11 +2267,11 @@ with self;
     };
   };
 
-  AWSSignature4 = buildPerlModule {
+  AWSSignature4 = buildPerlModule rec {
     pname = "AWS-Signature4";
     version = "1.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LD/LDS/AWS-Signature4-1.02.tar.gz";
+      url = "mirror://cpan/authors/id/L/LD/LDS/AWS-Signature4-${version}.tar.gz";
       hash = "sha256-ILvBbLNFT+XozzT+YfGpH+JsPxfkSf9mX8u7kqtEPr0=";
     };
     propagatedBuildInputs = [
@@ -2288,11 +2288,11 @@ with self;
     };
   };
 
-  autovivification = buildPerlPackage {
+  autovivification = buildPerlPackage rec {
     pname = "autovivification";
     version = "0.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/V/VP/VPIT/autovivification-0.18.tar.gz";
+      url = "mirror://cpan/authors/id/V/VP/VPIT/autovivification-${version}.tar.gz";
       hash = "sha256-LZmXVoUkKYDQqZBPY5FEwFnW7OFYme/eSst0LTJT8QU=";
     };
     meta = {
@@ -2327,11 +2327,11 @@ with self;
     };
   };
 
-  BC = buildPerlPackage {
+  BC = buildPerlPackage rec {
     pname = "B-C";
     version = "1.57";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RU/RURBAN/B-C-1.57.tar.gz";
+      url = "mirror://cpan/authors/id/R/RU/RURBAN/B-C-${version}.tar.gz";
       hash = "sha256-BFKmEdNDrfnZX86ra6a2YXbjrX/MzlKAkiwOQx9RSf8=";
     };
     propagatedBuildInputs = [
@@ -2354,11 +2354,11 @@ with self;
     };
   };
 
-  BCOW = buildPerlPackage {
+  BCOW = buildPerlPackage rec {
     pname = "B-COW";
     version = "0.007";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AT/ATOOMIC/B-COW-0.007.tar.gz";
+      url = "mirror://cpan/authors/id/A/AT/ATOOMIC/B-COW-${version}.tar.gz";
       hash = "sha256-EpDa8ifosJiJoxzxguKRBvHPnxpOm/d1L53pLtEVi0Q=";
     };
     meta = {
@@ -2370,11 +2370,11 @@ with self;
     };
   };
 
-  BFlags = buildPerlPackage {
+  BFlags = buildPerlPackage rec {
     pname = "B-Flags";
     version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RU/RURBAN/B-Flags-0.17.tar.gz";
+      url = "mirror://cpan/authors/id/R/RU/RURBAN/B-Flags-${version}.tar.gz";
       hash = "sha256-wduX0BMVvtEJtMSJWM0yGVz8nvXTt3B+tHhAwdV8ELI=";
     };
     meta = {
@@ -2386,11 +2386,11 @@ with self;
     };
   };
 
-  BeanstalkClient = buildPerlPackage {
+  BeanstalkClient = buildPerlPackage rec {
     pname = "Beanstalk-Client";
     version = "1.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GB/GBARR/Beanstalk-Client-1.07.tar.gz";
+      url = "mirror://cpan/authors/id/G/GB/GBARR/Beanstalk-Client-${version}.tar.gz";
       hash = "sha256-MYirESfyyrqX32XIT2nbDscMZOXXDylvmiZ0+nnBEsw=";
     };
     propagatedBuildInputs = [
@@ -2406,12 +2406,12 @@ with self;
     };
   };
 
-  BerkeleyDB = buildPerlPackage {
+  BerkeleyDB = buildPerlPackage rec {
     pname = "BerkeleyDB";
     version = "0.65";
 
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PM/PMQS/BerkeleyDB-0.65.tar.gz";
+      url = "mirror://cpan/authors/id/P/PM/PMQS/BerkeleyDB-${version}.tar.gz";
       hash = "sha256-QQqonnIylB1JEGyeBI1jN0dVQ+wdIz6nzbcly1uWNQQ=";
     };
 
@@ -2448,11 +2448,11 @@ with self;
     };
   };
 
-  BHooksEndOfScope = buildPerlPackage {
+  BHooksEndOfScope = buildPerlPackage rec {
     pname = "B-Hooks-EndOfScope";
     version = "0.26";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/B-Hooks-EndOfScope-0.26.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/B-Hooks-EndOfScope-${version}.tar.gz";
       hash = "sha256-Od8vjAB6dUZyB1+VuQeXuuvpetptlEsZemNScJyzBnE=";
     };
     propagatedBuildInputs = [
@@ -2469,11 +2469,11 @@ with self;
     };
   };
 
-  BHooksOPAnnotation = buildPerlPackage {
+  BHooksOPAnnotation = buildPerlPackage rec {
     pname = "B-Hooks-OP-Annotation";
     version = "0.44";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHOCOLATE/B-Hooks-OP-Annotation-0.44.tar.gz";
+      url = "mirror://cpan/authors/id/C/CH/CHOCOLATE/B-Hooks-OP-Annotation-${version}.tar.gz";
       hash = "sha256-bib5k2f06pRBac9uBc9NBngyCCQkyo7O/Mt7WmMhexY=";
     };
     propagatedBuildInputs = [ ExtUtilsDepends ];
@@ -2486,11 +2486,11 @@ with self;
     };
   };
 
-  BHooksOPCheck = buildPerlPackage {
+  BHooksOPCheck = buildPerlPackage rec {
     pname = "B-Hooks-OP-Check";
     version = "0.22";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/B-Hooks-OP-Check-0.22.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/B-Hooks-OP-Check-${version}.tar.gz";
       hash = "sha256-x7XRvvWe+Qh/9n6zFo0mJL6UrlRkRp4lmtEb+4rYzc0=";
     };
     buildInputs = [ ExtUtilsDepends ];
@@ -2506,11 +2506,11 @@ with self;
 
   BioExtAlign = callPackage ../development/perl-modules/Bio-Ext-Align { };
 
-  BioDBHTS = buildPerlModule {
+  BioDBHTS = buildPerlModule rec {
     pname = "Bio-DB-HTS";
     version = "3.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AV/AVULLO/Bio-DB-HTS-3.01.tar.gz";
+      url = "mirror://cpan/authors/id/A/AV/AVULLO/Bio-DB-HTS-${version}.tar.gz";
       sha256 = "12a6bc1f579513cac8b9167cce4e363655cc8eba26b7d9fe1170dfe95e044f42";
     };
 
@@ -2534,11 +2534,11 @@ with self;
 
   BioBigFile = callPackage ../development/perl-modules/Bio-BigFile { };
 
-  BioPerl = buildPerlPackage {
+  BioPerl = buildPerlPackage rec {
     pname = "BioPerl";
     version = "1.7.8";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CJ/CJFIELDS/BioPerl-1.7.8.tar.gz";
+      url = "mirror://cpan/authors/id/C/CJ/CJFIELDS/BioPerl-${version}.tar.gz";
       hash = "sha256-xJCjvncV6m5DBe/ZcQ5e2rgtq8Vf14a2UFtVCjDXFzg=";
     };
     buildInputs = [
@@ -2585,11 +2585,11 @@ with self;
     };
   };
 
-  BitVector = buildPerlPackage {
+  BitVector = buildPerlPackage rec {
     pname = "Bit-Vector";
     version = "7.4";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/ST/STBEY/Bit-Vector-7.4.tar.gz";
+      url = "mirror://cpan/authors/id/S/ST/STBEY/Bit-Vector-${version}.tar.gz";
       hash = "sha256-PG2qZx/s+8Nfkqk4W1Y9ZfUN/Gvci0gF+e9GwNA1qSY=";
     };
     patches = [
@@ -2612,11 +2612,11 @@ with self;
     };
   };
 
-  BKeywords = buildPerlPackage {
+  BKeywords = buildPerlPackage rec {
     pname = "B-Keywords";
     version = "1.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RU/RURBAN/B-Keywords-1.28.tar.gz";
+      url = "mirror://cpan/authors/id/R/RU/RURBAN/B-Keywords-${version}.tar.gz";
       hash = "sha256-nn62dpWSlIfGGq8trouvndoa2HYCu1oJTxB0SxJ2Xj4=";
     };
     meta = {
@@ -2628,11 +2628,11 @@ with self;
     };
   };
 
-  boolean = buildPerlPackage {
+  boolean = buildPerlPackage rec {
     pname = "boolean";
     version = "0.46";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IN/INGY/boolean-0.46.tar.gz";
+      url = "mirror://cpan/authors/id/I/IN/INGY/boolean-${version}.tar.gz";
       hash = "sha256-lcCICFw+g79oD+bOFtgmTsJjEEkPfRaA5BbqehGPFWo=";
     };
     meta = {
@@ -2645,11 +2645,11 @@ with self;
     };
   };
 
-  BoostGeometryUtils = buildPerlModule {
+  BoostGeometryUtils = buildPerlModule rec {
     pname = "Boost-Geometry-Utils";
     version = "0.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AA/AAR/Boost-Geometry-Utils-0.15.tar.gz";
+      url = "mirror://cpan/authors/id/A/AA/AAR/Boost-Geometry-Utils-${version}.tar.gz";
       hash = "sha256-AFTdP1c70/b0e3PugdHoRYQvugSq21KICqUnAcaH0co=";
     };
     patches = [
@@ -2699,11 +2699,11 @@ with self;
     };
   };
 
-  BotTraining = buildPerlPackage {
+  BotTraining = buildPerlPackage rec {
     pname = "Bot-Training";
     version = "0.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AV/AVAR/Bot-Training-0.07.tar.gz";
+      url = "mirror://cpan/authors/id/A/AV/AVAR/Bot-Training-${version}.tar.gz";
       hash = "sha256-7ma7+BTw3D0egGgOBQ+tELHgGP7Xkp9lPtQOCIsqopU=";
     };
     buildInputs = [ FileSlurp ];
@@ -2726,11 +2726,11 @@ with self;
     };
   };
 
-  BotTrainingMegaHAL = buildPerlPackage {
+  BotTrainingMegaHAL = buildPerlPackage rec {
     pname = "Bot-Training-MegaHAL";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AV/AVAR/Bot-Training-MegaHAL-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/A/AV/AVAR/Bot-Training-MegaHAL-${version}.tar.gz";
       hash = "sha256-lWByr/BPIW5cO4GWlltdgNTUdpXXfsqr1W5Z1l8iv2A=";
     };
     buildInputs = [ FileShareDirInstall ];
@@ -2745,11 +2745,11 @@ with self;
     };
   };
 
-  BotTrainingStarCraft = buildPerlPackage {
+  BotTrainingStarCraft = buildPerlPackage rec {
     pname = "Bot-Training-StarCraft";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AV/AVAR/Bot-Training-StarCraft-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/A/AV/AVAR/Bot-Training-StarCraft-${version}.tar.gz";
       hash = "sha256-58640Bxi5zLdib/l9Ng+eBwc2RJULRd8Iudht8hhTV4=";
     };
     buildInputs = [ FileShareDirInstall ];
@@ -2764,11 +2764,11 @@ with self;
     };
   };
 
-  BSDResource = buildPerlPackage {
+  BSDResource = buildPerlPackage rec {
     pname = "BSD-Resource";
     version = "1.2911";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JH/JHI/BSD-Resource-1.2911.tar.gz";
+      url = "mirror://cpan/authors/id/J/JH/JHI/BSD-Resource-${version}.tar.gz";
       hash = "sha256-nRz7oGPMGPckJ6IkUfeQiDa3MxrIeF2+B1U8WwQ6DD0=";
     };
     meta = {
@@ -2781,11 +2781,11 @@ with self;
     };
   };
 
-  BUtils = buildPerlPackage {
+  BUtils = buildPerlPackage rec {
     pname = "B-Utils";
     version = "0.27";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/B-Utils-0.27.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/B-Utils-${version}.tar.gz";
       hash = "sha256-+X9T9qMFAQmqQU/usYTK0QGBLUF2DpUrXYSZP2aF/+o=";
     };
     propagatedBuildInputs = [ TaskWeaken ];
@@ -2804,11 +2804,11 @@ with self;
     };
   };
 
-  BusinessHours = buildPerlPackage {
+  BusinessHours = buildPerlPackage rec {
     pname = "Business-Hours";
     version = "0.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BP/BPS/Business-Hours-0.13.tar.gz";
+      url = "mirror://cpan/authors/id/B/BP/BPS/Business-Hours-${version}.tar.gz";
       hash = "sha256-qAf+P/u4T/pTlnEazOdXZPOknyQjZGc1DHHIp3pcPsI=";
     };
     propagatedBuildInputs = [ SetIntSpan ];
@@ -2821,11 +2821,11 @@ with self;
     };
   };
 
-  BusinessISBN = buildPerlPackage {
+  BusinessISBN = buildPerlPackage rec {
     pname = "Business-ISBN";
     version = "3.008";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/Business-ISBN-3.008.tar.gz";
+      url = "mirror://cpan/authors/id/B/BD/BDFOY/Business-ISBN-${version}.tar.gz";
       hash = "sha256-GcSh1NmaDddpWpAZKxNASg4+7r7fy+l6AgLjayOMDmk=";
     };
     propagatedBuildInputs = [ BusinessISBNData ];
@@ -2836,11 +2836,11 @@ with self;
     };
   };
 
-  BusinessISBNData = buildPerlPackage {
+  BusinessISBNData = buildPerlPackage rec {
     pname = "Business-ISBN-Data";
     version = "20231006.001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/Business-ISBN-Data-20231006.001.tar.gz";
+      url = "mirror://cpan/authors/id/B/BD/BDFOY/Business-ISBN-Data-${version}.tar.gz";
       hash = "sha256-KhazbjIzXOjI337m8ig2LzSuc8T8wSNQCVCiyMd/F0g=";
     };
     meta = {
@@ -2850,11 +2850,11 @@ with self;
     };
   };
 
-  BusinessISMN = buildPerlPackage {
+  BusinessISMN = buildPerlPackage rec {
     pname = "Business-ISMN";
     version = "1.203";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/Business-ISMN-1.203.tar.gz";
+      url = "mirror://cpan/authors/id/B/BD/BDFOY/Business-ISMN-${version}.tar.gz";
       hash = "sha256-T1Ou2rLmh9Th9yhW6vwiFZOQYhEj2q955FBqiX4pPog=";
     };
     propagatedBuildInputs = [ TieCycle ];
@@ -2865,11 +2865,11 @@ with self;
     };
   };
 
-  BusinessISSN = buildPerlPackage {
+  BusinessISSN = buildPerlPackage rec {
     pname = "Business-ISSN";
     version = "1.005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/Business-ISSN-1.005.tar.gz";
+      url = "mirror://cpan/authors/id/B/BD/BDFOY/Business-ISSN-${version}.tar.gz";
       hash = "sha256-OwmwJn8KZmD7krb1DEx3lu9qJjtirTu+qgcYmgx8ObM=";
     };
     meta = {
@@ -2879,11 +2879,11 @@ with self;
     };
   };
 
-  BytesRandomSecure = buildPerlPackage {
+  BytesRandomSecure = buildPerlPackage rec {
     pname = "Bytes-Random-Secure";
     version = "0.29";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAVIDO/Bytes-Random-Secure-0.29.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAVIDO/Bytes-Random-Secure-${version}.tar.gz";
       hash = "sha256-U7vTOeahHvygfGGaYVx8GIpouyvoSaHLfvw91Nmuha4=";
     };
     propagatedBuildInputs = [
@@ -2900,11 +2900,11 @@ with self;
     };
   };
 
-  BytesRandomSecureTiny = buildPerlPackage {
+  BytesRandomSecureTiny = buildPerlPackage rec {
     pname = "Bytes-Random-Secure-Tiny";
     version = "1.011";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAVIDO/Bytes-Random-Secure-Tiny-1.011.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAVIDO/Bytes-Random-Secure-Tiny-${version}.tar.gz";
       hash = "sha256-A9lntfgoRpCRN9WrmYSsVwrBCkQB4MYC89IgjEZayYI=";
     };
     meta = {
@@ -2917,11 +2917,11 @@ with self;
     };
   };
 
-  CacheCache = buildPerlPackage {
+  CacheCache = buildPerlPackage rec {
     pname = "Cache-Cache";
     version = "1.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Cache-Cache-1.08.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Cache-Cache-${version}.tar.gz";
       hash = "sha256-0sf9Xbpd0BC32JI1FokLtsz2tfGIzLafNcsP1sAx0eg=";
     };
     propagatedBuildInputs = [
@@ -2939,11 +2939,11 @@ with self;
     };
   };
 
-  CacheFastMmap = buildPerlPackage {
+  CacheFastMmap = buildPerlPackage rec {
     pname = "Cache-FastMmap";
     version = "1.60";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RO/ROBM/Cache-FastMmap-1.60.tar.gz";
+      url = "mirror://cpan/authors/id/R/RO/ROBM/Cache-FastMmap-${version}.tar.gz";
       hash = "sha256-my07Cu8JXSxZs1akSClQ0MOiLoTm5puXu5bcwe3GQv8=";
     };
     buildInputs = [ TestDeep ];
@@ -2956,11 +2956,11 @@ with self;
     };
   };
 
-  CacheKyotoTycoon = buildPerlModule {
+  CacheKyotoTycoon = buildPerlModule rec {
     pname = "Cache-KyotoTycoon";
     version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOKUHIROM/Cache-KyotoTycoon-0.16.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TOKUHIROM/Cache-KyotoTycoon-${version}.tar.gz";
       hash = "sha256-zLBII1iUxItpegDleMtFC05evBQYpVSnz6hjJwezlHw=";
     };
     propagatedBuildInputs = [
@@ -2983,11 +2983,11 @@ with self;
     };
   };
 
-  CacheMemcached = buildPerlPackage {
+  CacheMemcached = buildPerlPackage rec {
     pname = "Cache-Memcached";
     version = "1.30";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DO/DORMANDO/Cache-Memcached-1.30.tar.gz";
+      url = "mirror://cpan/authors/id/D/DO/DORMANDO/Cache-Memcached-${version}.tar.gz";
       hash = "sha256-MbPFHsDqrwMALizI49fVy+YZGc/a2mHACOuYU6ysQqk=";
     };
     propagatedBuildInputs = [ StringCRC32 ];
@@ -3000,11 +3000,11 @@ with self;
     };
   };
 
-  CacheMemcachedFast = buildPerlPackage {
+  CacheMemcachedFast = buildPerlPackage rec {
     pname = "Cache-Memcached-Fast";
     version = "0.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RA/RAZ/Cache-Memcached-Fast-0.28.tar.gz";
+      url = "mirror://cpan/authors/id/R/RA/RAZ/Cache-Memcached-Fast-${version}.tar.gz";
       hash = "sha256-fEJMJTtl/2LPFXe7QYgCGSoYgF6jH6/Ap65YnkRsidI=";
     };
     buildInputs = [ Test2Suite ];
@@ -3017,11 +3017,11 @@ with self;
     };
   };
 
-  CacheMemory = buildPerlModule {
+  CacheMemory = buildPerlModule rec {
     pname = "Cache";
     version = "2.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Cache-2.11.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Cache-${version}.tar.gz";
       hash = "sha256-4dLYlneYEWarxbtuXsxkcfAB8T61bVvpVE2AR9wIpZI=";
     };
     propagatedBuildInputs = [
@@ -3041,11 +3041,11 @@ with self;
     };
   };
 
-  CacheSimpleTimedExpiry = buildPerlPackage {
+  CacheSimpleTimedExpiry = buildPerlPackage rec {
     pname = "Cache-Simple-TimedExpiry";
     version = "0.27";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JE/JESSE/Cache-Simple-TimedExpiry-0.27.tar.gz";
+      url = "mirror://cpan/authors/id/J/JE/JESSE/Cache-Simple-TimedExpiry-${version}.tar.gz";
       hash = "sha256-Tni35N0jG1VxpIzQ7htjlT9eNHkMnQIOFZWnx9Crvkk=";
     };
     meta = {
@@ -3057,11 +3057,11 @@ with self;
     };
   };
 
-  Cairo = buildPerlPackage {
+  Cairo = buildPerlPackage rec {
     pname = "Cairo";
     version = "1.109";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XA/XAOC/Cairo-1.109.tar.gz";
+      url = "mirror://cpan/authors/id/X/XA/XAOC/Cairo-${version}.tar.gz";
       hash = "sha256-ghlzbkAcIxHaX1FXdd5D/YfmOEtQTaNqGS8rIXZDB38=";
     };
     nativeBuildInputs = [
@@ -3079,11 +3079,11 @@ with self;
     };
   };
 
-  CairoGObject = buildPerlPackage {
+  CairoGObject = buildPerlPackage rec {
     pname = "Cairo-GObject";
     version = "1.005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XA/XAOC/Cairo-GObject-1.005.tar.gz";
+      url = "mirror://cpan/authors/id/X/XA/XAOC/Cairo-GObject-${version}.tar.gz";
       hash = "sha256-jYlkRNceHQvKPSTjHl2CvQ2VQqrtkdH7fqs2e85nXFA=";
     };
     nativeBuildInputs = [
@@ -3101,11 +3101,11 @@ with self;
     };
   };
 
-  CallContext = buildPerlPackage {
+  CallContext = buildPerlPackage rec {
     pname = "Call-Context";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FE/FELIPE/Call-Context-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/F/FE/FELIPE/Call-Context-${version}.tar.gz";
       hash = "sha256-Dua/RrxydVrbemsI550S4gfeX3gJcHs8NTtYyy8LWiY=";
     };
     meta = {
@@ -3118,11 +3118,11 @@ with self;
     };
   };
 
-  cam_pdf = buildPerlModule {
+  cam_pdf = buildPerlModule rec {
     pname = "CAM-PDF";
     version = "1.60";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CD/CDOLAN/CAM-PDF-1.60.tar.gz";
+      url = "mirror://cpan/authors/id/C/CD/CDOLAN/CAM-PDF-${version}.tar.gz";
       hash = "sha256-52r8fzimJJJKd8XJiMNsnjiL+ncW51zTl/744bQuu4k=";
     };
     propagatedBuildInputs = [
@@ -3138,11 +3138,11 @@ with self;
     };
   };
 
-  capitalization = buildPerlPackage {
+  capitalization = buildPerlPackage rec {
     pname = "capitalization";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/capitalization-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/capitalization-${version}.tar.gz";
       hash = "sha256-8TUW1XKUH2ihwj8uDkn1vwmyL5B+uSkrcrr/5ie77jw=";
     };
     propagatedBuildInputs = [ DevelSymdump ];
@@ -3155,11 +3155,11 @@ with self;
     };
   };
 
-  CanaryStability = buildPerlPackage {
+  CanaryStability = buildPerlPackage rec {
     pname = "Canary-Stability";
     version = "2013";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/Canary-Stability-2013.tar.gz";
+      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/Canary-Stability-${version}.tar.gz";
       hash = "sha256-pckcYs+V/Lho9g6rXIMpCPaQUiEBP+orzj/1cEbXtuo=";
     };
     meta = {
@@ -3168,11 +3168,11 @@ with self;
     };
   };
 
-  CaptchaReCAPTCHA = buildPerlPackage {
+  CaptchaReCAPTCHA = buildPerlPackage rec {
     pname = "Captcha-reCaptcha";
     version = "0.99";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SU/SUNNYP/Captcha-reCaptcha-0.99.tar.gz";
+      url = "mirror://cpan/authors/id/S/SU/SUNNYP/Captcha-reCaptcha-${version}.tar.gz";
       hash = "sha256-uJI1dmARZu3j9/Ly/1X/bjw7znDmnzZaUe076MykQ5I=";
     };
     propagatedBuildInputs = [
@@ -3188,11 +3188,11 @@ with self;
     };
   };
 
-  CaptureTiny = buildPerlPackage {
+  CaptureTiny = buildPerlPackage rec {
     pname = "Capture-Tiny";
     version = "0.48";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Capture-Tiny-0.48.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Capture-Tiny-${version}.tar.gz";
       hash = "sha256-bCMRPoe605MwjJCiBwE+UF9lknRzZjjYx5usnGfMPhk=";
     };
     meta = {
@@ -3202,11 +3202,11 @@ with self;
     };
   };
 
-  CarpAlways = buildPerlPackage {
+  CarpAlways = buildPerlPackage rec {
     pname = "Carp-Always";
     version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FE/FERREIRA/Carp-Always-0.16.tar.gz";
+      url = "mirror://cpan/authors/id/F/FE/FERREIRA/Carp-Always-${version}.tar.gz";
       hash = "sha256-mKoRSSFxwBb7CCdYGrH6XtAbHpnGNXSJ3fOoJzFYZvE=";
     };
     buildInputs = [ TestBase ];
@@ -3219,11 +3219,11 @@ with self;
     };
   };
 
-  CarpAssert = buildPerlPackage {
+  CarpAssert = buildPerlPackage rec {
     pname = "Carp-Assert";
     version = "0.22";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Y/YV/YVES/Carp-Assert-0.22.tar.gz";
+      url = "mirror://cpan/authors/id/Y/YV/YVES/Carp-Assert-${version}.tar.gz";
       hash = "sha256-gH6pfGvtdqwuSWnvun2uSP7+ufKHl/ESZxs6yKSTVfc=";
     };
     meta = {
@@ -3235,11 +3235,11 @@ with self;
     };
   };
 
-  CarpAssertMore = buildPerlPackage {
+  CarpAssertMore = buildPerlPackage rec {
     pname = "Carp-Assert-More";
     version = "2.3.0";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PETDANCE/Carp-Assert-More-2.3.0.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PETDANCE/Carp-Assert-More-${version}.tar.gz";
       hash = "sha256-/2nqCb2maiAPygiK3ZHFww5lcqt7ujF6f58zxRKzzqc=";
     };
     propagatedBuildInputs = [ CarpAssert ];
@@ -3250,11 +3250,11 @@ with self;
     };
   };
 
-  CarpClan = buildPerlPackage {
+  CarpClan = buildPerlPackage rec {
     pname = "Carp-Clan";
     version = "6.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Carp-Clan-6.08.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Carp-Clan-${version}.tar.gz";
       hash = "sha256-x1+S40QizFplqwXRVYQrcBRSQ06a77ZJ1uIonEfvZwg=";
     };
     meta = {
@@ -3267,11 +3267,11 @@ with self;
     };
   };
 
-  Carton = buildPerlPackage {
+  Carton = buildPerlPackage rec {
     pname = "Carton";
     version = "1.0.35";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Carton-v1.0.35.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Carton-v${version}.tar.gz";
       hash = "sha256-nEVYypfNCLaf37UrKMPdwgQ+9S8GJ7kOU9BaQIc0QXU=";
     };
     propagatedBuildInputs = [
@@ -3290,11 +3290,11 @@ with self;
     };
   };
 
-  CatalystActionRenderView = buildPerlPackage {
+  CatalystActionRenderView = buildPerlPackage rec {
     pname = "Catalyst-Action-RenderView";
     version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOBTFISH/Catalyst-Action-RenderView-0.16.tar.gz";
+      url = "mirror://cpan/authors/id/B/BO/BOBTFISH/Catalyst-Action-RenderView-${version}.tar.gz";
       hash = "sha256-hWUgOVCgV9Q+zWTpWTcV1WXC+9iwLJH0PFOyERrNOUg=";
     };
     propagatedBuildInputs = [
@@ -3311,11 +3311,11 @@ with self;
     };
   };
 
-  CatalystActionREST = buildPerlPackage {
+  CatalystActionREST = buildPerlPackage rec {
     pname = "Catalyst-Action-REST";
     version = "1.21";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JJ/JJNAPIORK/Catalyst-Action-REST-1.21.tar.gz";
+      url = "mirror://cpan/authors/id/J/JJ/JJNAPIORK/Catalyst-Action-REST-${version}.tar.gz";
       hash = "sha256-zPgbulIA06CtaQH5I68XOj1EFmGK6gimk4uq/970yyA=";
     };
     buildInputs = [ TestRequires ];
@@ -3332,11 +3332,11 @@ with self;
     };
   };
 
-  CatalystAuthenticationCredentialHTTP = buildPerlModule {
+  CatalystAuthenticationCredentialHTTP = buildPerlModule rec {
     pname = "Catalyst-Authentication-Credential-HTTP";
     version = "1.018";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Catalyst-Authentication-Credential-HTTP-1.018.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Catalyst-Authentication-Credential-HTTP-${version}.tar.gz";
       hash = "sha256-b6GBbe5kSw216gzBXF5xHcLO0gg2JavOcJZSHx1lpSk=";
     };
     patches = [
@@ -3369,11 +3369,11 @@ with self;
     };
   };
 
-  CatalystAuthenticationStoreHtpasswd = buildPerlModule {
+  CatalystAuthenticationStoreHtpasswd = buildPerlModule rec {
     pname = "Catalyst-Authentication-Store-Htpasswd";
     version = "1.006";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Catalyst-Authentication-Store-Htpasswd-1.006.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Catalyst-Authentication-Store-Htpasswd-${version}.tar.gz";
       hash = "sha256-x/2FYnXo3hjAAWHXNJTsZr0N3QoZ27dMQtVXHJ7ggE8=";
     };
     buildInputs = [
@@ -3398,11 +3398,11 @@ with self;
     };
   };
 
-  CatalystAuthenticationStoreDBIxClass = buildPerlPackage {
+  CatalystAuthenticationStoreDBIxClass = buildPerlPackage rec {
     pname = "Catalyst-Authentication-Store-DBIx-Class";
     version = "0.1506";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IL/ILMARI/Catalyst-Authentication-Store-DBIx-Class-0.1506.tar.gz";
+      url = "mirror://cpan/authors/id/I/IL/ILMARI/Catalyst-Authentication-Store-DBIx-Class-${version}.tar.gz";
       hash = "sha256-fFefJZUoXmTD3LVUAzSqmgAkQ+HUyMg6tEk7kMxRskQ=";
     };
     propagatedBuildInputs = [
@@ -3419,11 +3419,11 @@ with self;
     };
   };
 
-  CatalystAuthenticationStoreLDAP = buildPerlPackage {
+  CatalystAuthenticationStoreLDAP = buildPerlPackage rec {
     pname = "Catalyst-Authentication-Store-LDAP";
     version = "1.017";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IL/ILMARI/Catalyst-Authentication-Store-LDAP-1.017.tar.gz";
+      url = "mirror://cpan/authors/id/I/IL/ILMARI/Catalyst-Authentication-Store-LDAP-${version}.tar.gz";
       hash = "sha256-keW4vd/XOGYqNh6/6nPYQrO6Me1wne2xqE7DRB3O7sU=";
     };
     propagatedBuildInputs = [
@@ -3446,11 +3446,11 @@ with self;
     };
   };
 
-  CatalystComponentInstancePerContext = buildPerlPackage {
+  CatalystComponentInstancePerContext = buildPerlPackage rec {
     pname = "Catalyst-Component-InstancePerContext";
     version = "0.001001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GR/GRODITI/Catalyst-Component-InstancePerContext-0.001001.tar.gz";
+      url = "mirror://cpan/authors/id/G/GR/GRODITI/Catalyst-Component-InstancePerContext-${version}.tar.gz";
       hash = "sha256-f2P5MOHmE/FZVcnm1zhzZ1xQwKO8KmGgNHMzYe0m0nE=";
     };
     propagatedBuildInputs = [ CatalystRuntime ];
@@ -3463,11 +3463,11 @@ with self;
     };
   };
 
-  CatalystControllerHTMLFormFu = buildPerlPackage {
+  CatalystControllerHTMLFormFu = buildPerlPackage rec {
     pname = "Catalyst-Controller-HTML-FormFu";
     version = "2.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NI/NIGELM/Catalyst-Controller-HTML-FormFu-2.04.tar.gz";
+      url = "mirror://cpan/authors/id/N/NI/NIGELM/Catalyst-Controller-HTML-FormFu-${version}.tar.gz";
       hash = "sha256-8T+5s7OwCzXwarwxYURhyNc0b74H+1accejVhuXrXdw=";
     };
     buildInputs = [
@@ -3509,11 +3509,11 @@ with self;
     };
   };
 
-  CatalystControllerPOD = buildPerlModule {
+  CatalystControllerPOD = buildPerlModule rec {
     pname = "Catalyst-Controller-POD";
     version = "1.0.0";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PERLER/Catalyst-Controller-POD-1.0.0.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PERLER/Catalyst-Controller-POD-${version}.tar.gz";
       hash = "sha256-7ipLs+14uqFGQzVAjyhDRba6DvZXate/vXtlbHiKOfk=";
     };
     buildInputs = [
@@ -3538,11 +3538,11 @@ with self;
     };
   };
 
-  CatalystDevel = buildPerlPackage {
+  CatalystDevel = buildPerlPackage rec {
     pname = "Catalyst-Devel";
     version = "1.42";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/Catalyst-Devel-1.42.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Catalyst-Devel-${version}.tar.gz";
       hash = "sha256-fsbwtsq1uMCX5Hdp/HOk1MAVpYxB/bQPwk3z7nfEir0=";
     };
     buildInputs = [
@@ -3569,11 +3569,11 @@ with self;
     };
   };
 
-  CatalystDispatchTypeRegex = buildPerlModule {
+  CatalystDispatchTypeRegex = buildPerlModule rec {
     pname = "Catalyst-DispatchType-Regex";
     version = "5.90035";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MG/MGRIMES/Catalyst-DispatchType-Regex-5.90035.tar.gz";
+      url = "mirror://cpan/authors/id/M/MG/MGRIMES/Catalyst-DispatchType-Regex-${version}.tar.gz";
       hash = "sha256-AC3Pnv7HxYiSoYP5CAFTnQzxPsOvzPjTrRkhfCsNWBo=";
     };
     propagatedBuildInputs = [ CatalystRuntime ];
@@ -3586,11 +3586,11 @@ with self;
     };
   };
 
-  CatalystManual = buildPerlPackage {
+  CatalystManual = buildPerlPackage rec {
     pname = "Catalyst-Manual";
     version = "5.9011";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/Catalyst-Manual-5.9011.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Catalyst-Manual-${version}.tar.gz";
       hash = "sha256-s54zllkDwAWD4BgOPdUopUkg9SB83wUmBcoTgoz6wTw=";
     };
     meta = {
@@ -3602,11 +3602,11 @@ with self;
     };
   };
 
-  CatalystModelDBICSchema = buildPerlPackage {
+  CatalystModelDBICSchema = buildPerlPackage rec {
     pname = "Catalyst-Model-DBIC-Schema";
     version = "0.66";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/Catalyst-Model-DBIC-Schema-0.66.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Catalyst-Model-DBIC-Schema-${version}.tar.gz";
       hash = "sha256-GST0wA6PD/HF0a+hbv5PhW8cXnT+VW7Cxfj1v2OtA0g=";
     };
     buildInputs = [
@@ -3632,11 +3632,11 @@ with self;
     };
   };
 
-  CatalystRuntime = buildPerlPackage {
+  CatalystRuntime = buildPerlPackage rec {
     pname = "Catalyst-Runtime";
     version = "5.90131";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JJ/JJNAPIORK/Catalyst-Runtime-5.90131.tar.gz";
+      url = "mirror://cpan/authors/id/J/JJ/JJNAPIORK/Catalyst-Runtime-${version}.tar.gz";
       hash = "sha256-nWQe+s8PmTXm7LmPWjtHbJYbH4Gb0vjyOmR9HYZ+GEk=";
     };
     buildInputs = [
@@ -3679,11 +3679,11 @@ with self;
     };
   };
 
-  CatalystPluginAccessLog = buildPerlPackage {
+  CatalystPluginAccessLog = buildPerlPackage rec {
     pname = "Catalyst-Plugin-AccessLog";
     version = "1.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AR/ARODLAND/Catalyst-Plugin-AccessLog-1.10.tar.gz";
+      url = "mirror://cpan/authors/id/A/AR/ARODLAND/Catalyst-Plugin-AccessLog-${version}.tar.gz";
       hash = "sha256-hz245OcqmU4+F661PSuDfm1SS0uLDzU58mITXIjMISA=";
     };
     propagatedBuildInputs = [
@@ -3700,11 +3700,11 @@ with self;
     };
   };
 
-  CatalystPluginAuthentication = buildPerlPackage {
+  CatalystPluginAuthentication = buildPerlPackage rec {
     pname = "Catalyst-Plugin-Authentication";
     version = "0.10023";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOBTFISH/Catalyst-Plugin-Authentication-0.10023.tar.gz";
+      url = "mirror://cpan/authors/id/B/BO/BOBTFISH/Catalyst-Plugin-Authentication-${version}.tar.gz";
       hash = "sha256-NgOaq9rLB+Zoek16i/rHj+nQ+7BM2o1tlm1sHjJZ0Gw=";
     };
     buildInputs = [ TestException ];
@@ -3718,11 +3718,11 @@ with self;
     };
   };
 
-  CatalystPluginAuthorizationACL = buildPerlPackage {
+  CatalystPluginAuthorizationACL = buildPerlPackage rec {
     pname = "Catalyst-Plugin-Authorization-ACL";
     version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RK/RKITOVER/Catalyst-Plugin-Authorization-ACL-0.16.tar.gz";
+      url = "mirror://cpan/authors/id/R/RK/RKITOVER/Catalyst-Plugin-Authorization-ACL-${version}.tar.gz";
       hash = "sha256-KjfmU0gu/SyTuGxqg4lB4FbF+U3YbA8LiT1RkzMSg3w=";
     };
     propagatedBuildInputs = [
@@ -3745,11 +3745,11 @@ with self;
     };
   };
 
-  CatalystPluginAuthorizationRoles = buildPerlPackage {
+  CatalystPluginAuthorizationRoles = buildPerlPackage rec {
     pname = "Catalyst-Plugin-Authorization-Roles";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOBTFISH/Catalyst-Plugin-Authorization-Roles-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/B/BO/BOBTFISH/Catalyst-Plugin-Authorization-Roles-${version}.tar.gz";
       hash = "sha256-7kBE5eKg2UxOxRL61V7gyN4UTh47h4Ugf5YCXPmkA1E=";
     };
     buildInputs = [ TestException ];
@@ -3767,11 +3767,11 @@ with self;
     };
   };
 
-  CatalystPluginCache = buildPerlPackage {
+  CatalystPluginCache = buildPerlPackage rec {
     pname = "Catalyst-Plugin-Cache";
     version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOBTFISH/Catalyst-Plugin-Cache-0.12.tar.gz";
+      url = "mirror://cpan/authors/id/B/BO/BOBTFISH/Catalyst-Plugin-Cache-${version}.tar.gz";
       hash = "sha256-KV/tRJyTJLBleP1GjjOR4E+/ZK0kN2oARAjRvG9UQ+A=";
     };
     buildInputs = [
@@ -3789,11 +3789,11 @@ with self;
     };
   };
 
-  CatalystPluginCacheHTTP = buildPerlPackage {
+  CatalystPluginCacheHTTP = buildPerlPackage rec {
     pname = "Catalyst-Plugin-Cache-HTTP";
     version = "0.001000";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GR/GRAF/Catalyst-Plugin-Cache-HTTP-0.001000.tar.gz";
+      url = "mirror://cpan/authors/id/G/GR/GRAF/Catalyst-Plugin-Cache-HTTP-${version}.tar.gz";
       hash = "sha256-aq2nDrKfYd90xTj5KaEHD92TIMW278lNJkwzghe8sWw=";
     };
     buildInputs = [
@@ -3816,11 +3816,11 @@ with self;
     };
   };
 
-  CatalystPluginCaptcha = buildPerlPackage {
+  CatalystPluginCaptcha = buildPerlPackage rec {
     pname = "Catalyst-Plugin-Captcha";
     version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DI/DIEGOK/Catalyst-Plugin-Captcha-0.04.tar.gz";
+      url = "mirror://cpan/authors/id/D/DI/DIEGOK/Catalyst-Plugin-Captcha-${version}.tar.gz";
       hash = "sha256-Sj1ccgBiTT567ULQWnBnSSdGg+t7rSYN6Sx1W/aQnlI=";
     };
     propagatedBuildInputs = [
@@ -3836,11 +3836,11 @@ with self;
     };
   };
 
-  CatalystPluginConfigLoader = buildPerlPackage {
+  CatalystPluginConfigLoader = buildPerlPackage rec {
     pname = "Catalyst-Plugin-ConfigLoader";
     version = "0.35";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/Catalyst-Plugin-ConfigLoader-0.35.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Catalyst-Plugin-ConfigLoader-${version}.tar.gz";
       hash = "sha256-nippim8tBG4NxeV1EpKc1CPIB9Sja6Pynp5a3NcaGXE=";
     };
     propagatedBuildInputs = [
@@ -3857,11 +3857,11 @@ with self;
     };
   };
 
-  CatalystPluginFormValidator = buildPerlPackage {
+  CatalystPluginFormValidator = buildPerlPackage rec {
     pname = "Catalyst-Plugin-FormValidator";
     version = "0.094";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DH/DHOSS/Catalyst-Plugin-FormValidator-0.094.tar.gz";
+      url = "mirror://cpan/authors/id/D/DH/DHOSS/Catalyst-Plugin-FormValidator-${version}.tar.gz";
       hash = "sha256-WDTxG/XJ9LXTNtZcfOZjm3bOe/56KHXrBI1+ocgs4Fo=";
     };
     propagatedBuildInputs = [
@@ -3877,11 +3877,11 @@ with self;
     };
   };
 
-  CatalystPluginFormValidatorSimple = buildPerlPackage {
+  CatalystPluginFormValidatorSimple = buildPerlPackage rec {
     pname = "Catalyst-Plugin-FormValidator-Simple";
     version = "0.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DH/DHOSS/Catalyst-Plugin-FormValidator-Simple-0.15.tar.gz";
+      url = "mirror://cpan/authors/id/D/DH/DHOSS/Catalyst-Plugin-FormValidator-Simple-${version}.tar.gz";
       hash = "sha256-SGxqDo9BD9AXJ59IBKueNbpGMh0zoKlyH+Hgijkd56A=";
     };
     propagatedBuildInputs = [
@@ -3897,11 +3897,11 @@ with self;
     };
   };
 
-  CatalystPluginLogHandler = buildPerlModule {
+  CatalystPluginLogHandler = buildPerlModule rec {
     pname = "Catalyst-Plugin-Log-Handler";
     version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEPE/Catalyst-Plugin-Log-Handler-0.08.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEPE/Catalyst-Plugin-Log-Handler-${version}.tar.gz";
       hash = "sha256-DbPDpXtO49eJulEpiQ4oWJE/7wDYGFvcnF1/3jHgQ+8=";
     };
     propagatedBuildInputs = [
@@ -3918,11 +3918,11 @@ with self;
     };
   };
 
-  CatalystPluginPrometheusTiny = buildPerlPackage {
+  CatalystPluginPrometheusTiny = buildPerlPackage rec {
     pname = "Catalyst-Plugin-PrometheusTiny";
     version = "0.006";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SY/SYSPETE/Catalyst-Plugin-PrometheusTiny-0.006.tar.gz";
+      url = "mirror://cpan/authors/id/S/SY/SYSPETE/Catalyst-Plugin-PrometheusTiny-${version}.tar.gz";
       hash = "sha256-Kzm5l7q/+rNTquMsol8smbdljlBEew23H7gKFsS2osE=";
     };
     buildInputs = [
@@ -3947,11 +3947,11 @@ with self;
     };
   };
 
-  CatalystPluginSession = buildPerlPackage {
+  CatalystPluginSession = buildPerlPackage rec {
     pname = "Catalyst-Plugin-Session";
     version = "0.44";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/Catalyst-Plugin-Session-0.44.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Catalyst-Plugin-Session-${version}.tar.gz";
       hash = "sha256-CSyNgOA1D5Jdx2XycsDuKPmSMAsU9bhphBIgTmyFfEI=";
     };
     buildInputs = [
@@ -3973,11 +3973,11 @@ with self;
     };
   };
 
-  CatalystPluginSessionDynamicExpiry = buildPerlPackage {
+  CatalystPluginSessionDynamicExpiry = buildPerlPackage rec {
     pname = "Catalyst-Plugin-Session-DynamicExpiry";
     version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOBTFISH/Catalyst-Plugin-Session-DynamicExpiry-0.04.tar.gz";
+      url = "mirror://cpan/authors/id/B/BO/BOBTFISH/Catalyst-Plugin-Session-DynamicExpiry-${version}.tar.gz";
       hash = "sha256-dwfFZzTNsVEvcz3EAPrfb0xTyyF7WCB4V4JNrWeAoHk=";
     };
     propagatedBuildInputs = [ CatalystPluginSession ];
@@ -3990,11 +3990,11 @@ with self;
     };
   };
 
-  CatalystPluginSessionStateCookie = buildPerlPackage {
+  CatalystPluginSessionStateCookie = buildPerlPackage rec {
     pname = "Catalyst-Plugin-Session-State-Cookie";
     version = "0.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/Catalyst-Plugin-Session-State-Cookie-0.18.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Catalyst-Plugin-Session-State-Cookie-${version}.tar.gz";
       hash = "sha256-6bHHsrlsGU+Hpfd+FElxcHfHD/xnpL/CnwJsnuLge+o=";
     };
     propagatedBuildInputs = [ CatalystPluginSession ];
@@ -4007,11 +4007,11 @@ with self;
     };
   };
 
-  CatalystPluginSessionStoreFastMmap = buildPerlPackage {
+  CatalystPluginSessionStoreFastMmap = buildPerlPackage rec {
     pname = "Catalyst-Plugin-Session-Store-FastMmap";
     version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOBTFISH/Catalyst-Plugin-Session-Store-FastMmap-0.16.tar.gz";
+      url = "mirror://cpan/authors/id/B/BO/BOBTFISH/Catalyst-Plugin-Session-Store-FastMmap-${version}.tar.gz";
       hash = "sha256-uut/17+QW+dGMciHYP2KKYDO6pVieZM5lYFkPvY3cnQ=";
     };
     propagatedBuildInputs = [
@@ -4027,11 +4027,11 @@ with self;
     };
   };
 
-  CatalystPluginSessionStoreFile = buildPerlPackage {
+  CatalystPluginSessionStoreFile = buildPerlPackage rec {
     pname = "Catalyst-Plugin-Session-Store-File";
     version = "0.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FL/FLORA/Catalyst-Plugin-Session-Store-File-0.18.tar.gz";
+      url = "mirror://cpan/authors/id/F/FL/FLORA/Catalyst-Plugin-Session-Store-File-${version}.tar.gz";
       hash = "sha256-VHOOPOdvi+i2aUcJLSiXPHPXnR7hm12SsFdVL4/wm08=";
     };
     propagatedBuildInputs = [
@@ -4048,11 +4048,11 @@ with self;
     };
   };
 
-  CatalystPluginSmartURI = buildPerlPackage {
+  CatalystPluginSmartURI = buildPerlPackage rec {
     pname = "Catalyst-Plugin-SmartURI";
     version = "0.041";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RK/RKITOVER/Catalyst-Plugin-SmartURI-0.041.tar.gz";
+      url = "mirror://cpan/authors/id/R/RK/RKITOVER/Catalyst-Plugin-SmartURI-${version}.tar.gz";
       hash = "sha256-y4ghhphUUSA9kj19+QIKoELajcGUltgj4WU1twUfX1c=";
     };
     propagatedBuildInputs = [
@@ -4074,11 +4074,11 @@ with self;
     };
   };
 
-  CatalystPluginStackTrace = buildPerlPackage {
+  CatalystPluginStackTrace = buildPerlPackage rec {
     pname = "Catalyst-Plugin-StackTrace";
     version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOBTFISH/Catalyst-Plugin-StackTrace-0.12.tar.gz";
+      url = "mirror://cpan/authors/id/B/BO/BOBTFISH/Catalyst-Plugin-StackTrace-${version}.tar.gz";
       hash = "sha256-Mp2s0LoJ0Qp2CHqxdvldtro9smotD+M+7i9eRs7XU6w=";
     };
     propagatedBuildInputs = [ CatalystRuntime ];
@@ -4091,11 +4091,11 @@ with self;
     };
   };
 
-  CatalystPluginStaticSimple = buildPerlPackage {
+  CatalystPluginStaticSimple = buildPerlPackage rec {
     pname = "Catalyst-Plugin-Static-Simple";
     version = "0.37";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IL/ILMARI/Catalyst-Plugin-Static-Simple-0.37.tar.gz";
+      url = "mirror://cpan/authors/id/I/IL/ILMARI/Catalyst-Plugin-Static-Simple-${version}.tar.gz";
       hash = "sha256-Wk2Fo1iM1Og/GwAlgUEufXG31X9mBW5dh6Nvk9icnnw=";
     };
     patches = [ ../development/perl-modules/catalyst-plugin-static-simple-etag.patch ];
@@ -4113,11 +4113,11 @@ with self;
     };
   };
 
-  CatalystPluginStatusMessage = buildPerlPackage {
+  CatalystPluginStatusMessage = buildPerlPackage rec {
     pname = "Catalyst-Plugin-StatusMessage";
     version = "1.002000";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HK/HKCLARK/Catalyst-Plugin-StatusMessage-1.002000.tar.gz";
+      url = "mirror://cpan/authors/id/H/HK/HKCLARK/Catalyst-Plugin-StatusMessage-${version}.tar.gz";
       hash = "sha256-ZJyJSrFvn0itqPnMWZp+y7iJGrN2H/b9UQUgxt5AfB8=";
     };
     propagatedBuildInputs = [
@@ -4133,11 +4133,11 @@ with self;
     };
   };
 
-  CatalystViewCSV = buildPerlPackage {
+  CatalystViewCSV = buildPerlPackage rec {
     pname = "Catalyst-View-CSV";
     version = "1.8";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JM/JMREIN/Catalyst-View-CSV-1.8.tar.gz";
+      url = "mirror://cpan/authors/id/J/JM/JMREIN/Catalyst-View-CSV-${version}.tar.gz";
       hash = "sha256-vKcEaDzDXEevuJrDjHFRAu2+gIF57gcz0qDrMRojbN8=";
     };
     buildInputs = [
@@ -4163,11 +4163,11 @@ with self;
     };
   };
 
-  CatalystViewDownload = buildPerlPackage {
+  CatalystViewDownload = buildPerlPackage rec {
     pname = "Catalyst-View-Download";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GA/GAUDEON/Catalyst-View-Download-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/G/GA/GAUDEON/Catalyst-View-Download-${version}.tar.gz";
       hash = "sha256-es+PXyRex/bzU/SHKdE3sSrxrPos8fvWXHA5HpM3+OE=";
     };
     buildInputs = [
@@ -4187,11 +4187,11 @@ with self;
     };
   };
 
-  CatalystViewJSON = buildPerlPackage {
+  CatalystViewJSON = buildPerlPackage rec {
     pname = "Catalyst-View-JSON";
     version = "0.37";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/Catalyst-View-JSON-0.37.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Catalyst-View-JSON-${version}.tar.gz";
       hash = "sha256-xdo/bop3scmYVd431YgCwLGU4pp9hsYO04Mc/dWfnew=";
     };
     propagatedBuildInputs = [ CatalystRuntime ];
@@ -4204,11 +4204,11 @@ with self;
     };
   };
 
-  CatalystViewTT = buildPerlPackage {
+  CatalystViewTT = buildPerlPackage rec {
     pname = "Catalyst-View-TT";
     version = "0.46";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JJ/JJNAPIORK/Catalyst-View-TT-0.46.tar.gz";
+      url = "mirror://cpan/authors/id/J/JJ/JJNAPIORK/Catalyst-View-TT-${version}.tar.gz";
       hash = "sha256-7aRFfbv4GkJBtzWl1GnZcn2KMJHSSvGuPJog8CTeUcw=";
     };
     propagatedBuildInputs = [
@@ -4225,11 +4225,11 @@ with self;
     };
   };
 
-  CatalystXComponentTraits = buildPerlPackage {
+  CatalystXComponentTraits = buildPerlPackage rec {
     pname = "CatalystX-Component-Traits";
     version = "0.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RK/RKITOVER/CatalystX-Component-Traits-0.19.tar.gz";
+      url = "mirror://cpan/authors/id/R/RK/RKITOVER/CatalystX-Component-Traits-${version}.tar.gz";
       hash = "sha256-CElE6cnQ37ENSrNFPhwSX97jkSm0bRfAI0w8U1FkBEc=";
     };
     propagatedBuildInputs = [
@@ -4245,11 +4245,11 @@ with self;
     };
   };
 
-  CatalystXRoleApplicator = buildPerlPackage {
+  CatalystXRoleApplicator = buildPerlPackage rec {
     pname = "CatalystX-RoleApplicator";
     version = "0.005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HD/HDP/CatalystX-RoleApplicator-0.005.tar.gz";
+      url = "mirror://cpan/authors/id/H/HD/HDP/CatalystX-RoleApplicator-${version}.tar.gz";
       hash = "sha256-4o5HZ3aJva31VE4cQaKsV1WZNm+EDXO70LA8ZPtVim8=";
     };
     propagatedBuildInputs = [
@@ -4265,11 +4265,11 @@ with self;
     };
   };
 
-  CatalystTraitForRequestProxyBase = buildPerlPackage {
+  CatalystTraitForRequestProxyBase = buildPerlPackage rec {
     pname = "Catalyst-TraitFor-Request-ProxyBase";
     version = "0.000005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOBTFISH/Catalyst-TraitFor-Request-ProxyBase-0.000005.tar.gz";
+      url = "mirror://cpan/authors/id/B/BO/BOBTFISH/Catalyst-TraitFor-Request-ProxyBase-${version}.tar.gz";
       hash = "sha256-p78Pqn4Syl32Jdn1/HEPEb/Ra6U4WDfkjUKz0obJcQo=";
     };
     buildInputs = [
@@ -4291,11 +4291,11 @@ with self;
     };
   };
 
-  CatalystXScriptServerStarman = buildPerlPackage {
+  CatalystXScriptServerStarman = buildPerlPackage rec {
     pname = "CatalystX-Script-Server-Starman";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AB/ABRAXXA/CatalystX-Script-Server-Starman-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/A/AB/ABRAXXA/CatalystX-Script-Server-Starman-${version}.tar.gz";
       hash = "sha256-5jpH80y0P3+87GdYyaVCiAGOOIAjZTYYkLKjTfCKWyI=";
     };
     patches = [
@@ -4318,11 +4318,11 @@ with self;
     };
   };
 
-  CDB_File = buildPerlPackage {
+  CDB_File = buildPerlPackage rec {
     pname = "CDB_File";
     version = "1.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TODDR/CDB_File-1.05.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TODDR/CDB_File-${version}.tar.gz";
       hash = "sha256-hWSEnVY5AV3iNiTlc8riU265CUMrZNkAmKHgtFKp60s=";
     };
     buildInputs = [
@@ -4340,11 +4340,11 @@ with self;
     };
   };
 
-  Catmandu = buildPerlModule {
+  Catmandu = buildPerlModule rec {
     pname = "Catmandu";
     version = "1.2020";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HO/HOCHSTEN/Catmandu-1.2020.tar.gz";
+      url = "mirror://cpan/authors/id/H/HO/HOCHSTEN/Catmandu-${version}.tar.gz";
       hash = "sha256-1jIbR+NkGvkb7vZjNhWZVk88wzwAc5isa7opuO5A4cU=";
     };
     propagatedBuildInputs = [
@@ -4394,11 +4394,11 @@ with self;
     };
   };
 
-  CDDB_get = buildPerlPackage {
+  CDDB_get = buildPerlPackage rec {
     pname = "CDDB_get";
     version = "2.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FO/FONKIE/CDDB_get-2.28.tar.gz";
+      url = "mirror://cpan/authors/id/F/FO/FONKIE/CDDB_get-${version}.tar.gz";
       hash = "sha256-vcy6H6jkwc8xicXlo1KaZpOmSKpSgrWXU4x6rdzm2ck=";
     };
     meta = {
@@ -4409,11 +4409,11 @@ with self;
     };
   };
 
-  CDDBFile = buildPerlPackage {
+  CDDBFile = buildPerlPackage rec {
     pname = "CDDB-File";
     version = "1.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TM/TMTM/CDDB-File-1.05.tar.gz";
+      url = "mirror://cpan/authors/id/T/TM/TMTM/CDDB-File-${version}.tar.gz";
       hash = "sha256-6+ZCnEFcFOc8bK/g1OLc3o4WnYFScfHhUjwmThrsx8k=";
     };
     meta = {
@@ -4422,11 +4422,11 @@ with self;
     };
   };
 
-  CGI = buildPerlPackage {
+  CGI = buildPerlPackage rec {
     pname = "CGI";
     version = "4.59";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEEJO/CGI-4.59.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEEJO/CGI-${version}.tar.gz";
       hash = "sha256-be5LibiLEOd8lvPAjRm1hq74M7F6Ql1hiq19KMJi+Rw=";
     };
     buildInputs = [
@@ -4447,11 +4447,11 @@ with self;
     };
   };
 
-  CGICompile = buildPerlModule {
+  CGICompile = buildPerlModule rec {
     pname = "CGI-Compile";
     version = "0.26";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RK/RKITOVER/CGI-Compile-0.26.tar.gz";
+      url = "mirror://cpan/authors/id/R/RK/RKITOVER/CGI-Compile-${version}.tar.gz";
       hash = "sha256-TzhcEMLJd+tgPzjNFT4OA2jfA3H9vSP1qm7nL0/GXcg=";
     };
     propagatedBuildInputs = [
@@ -4479,11 +4479,11 @@ with self;
     };
   };
 
-  CGICookieXS = buildPerlPackage {
+  CGICookieXS = buildPerlPackage rec {
     pname = "CGI-Cookie-XS";
     version = "0.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AG/AGENT/CGI-Cookie-XS-0.18.tar.gz";
+      url = "mirror://cpan/authors/id/A/AG/AGENT/CGI-Cookie-XS-${version}.tar.gz";
       hash = "sha256-RpnLSr2XIBSvO+ubCmlbQluH2ibLK0vbJgIHCqrdPcY=";
     };
     meta = {
@@ -4495,11 +4495,11 @@ with self;
     };
   };
 
-  CGIEmulatePSGI = buildPerlPackage {
+  CGIEmulatePSGI = buildPerlPackage rec {
     pname = "CGI-Emulate-PSGI";
     version = "0.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOKUHIROM/CGI-Emulate-PSGI-0.23.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TOKUHIROM/CGI-Emulate-PSGI-${version}.tar.gz";
       hash = "sha256-3VtsNT8I+6EA2uCZBChPf3P4Mo0x9qZ7LBNvrXKNFYs=";
     };
     buildInputs = [ TestRequires ];
@@ -4514,11 +4514,11 @@ with self;
     };
   };
 
-  CGIExpand = buildPerlPackage {
+  CGIExpand = buildPerlPackage rec {
     pname = "CGI-Expand";
     version = "2.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOWMANBS/CGI-Expand-2.05.tar.gz";
+      url = "mirror://cpan/authors/id/B/BO/BOWMANBS/CGI-Expand-${version}.tar.gz";
       hash = "sha256-boLRGOPEwMLa/NpYde3l6N2//+C336pkjkUeA5pFpKk=";
     };
     buildInputs = [ TestException ];
@@ -4531,11 +4531,11 @@ with self;
     };
   };
 
-  CGIFast = buildPerlPackage {
+  CGIFast = buildPerlPackage rec {
     pname = "CGI-Fast";
     version = "2.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEEJO/CGI-Fast-2.16.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEEJO/CGI-Fast-${version}.tar.gz";
       hash = "sha256-AiPX+RuAA3ud/183NgZAtx9dyNvZiaBZPV0i8/c8s9Q=";
     };
     propagatedBuildInputs = [
@@ -4553,11 +4553,11 @@ with self;
     };
   };
 
-  CGIFormBuilder = buildPerlPackage {
+  CGIFormBuilder = buildPerlPackage rec {
     pname = "CGI-FormBuilder";
     version = "3.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BI/BIGPRESH/CGI-FormBuilder-3.10.tar.gz";
+      url = "mirror://cpan/authors/id/B/BI/BIGPRESH/CGI-FormBuilder-${version}.tar.gz";
       hash = "sha256-rsmb4MDwZ6fnJpxTeOWubI1905s2i08SwNhGOxPucZg=";
     };
 
@@ -4571,11 +4571,11 @@ with self;
     };
   };
 
-  CGIMinimal = buildPerlModule {
+  CGIMinimal = buildPerlModule rec {
     pname = "CGI-Minimal";
     version = "1.30";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SN/SNOWHARE/CGI-Minimal-1.30.tar.gz";
+      url = "mirror://cpan/authors/id/S/SN/SNOWHARE/CGI-Minimal-${version}.tar.gz";
       hash = "sha256-uU1QghsCYR2m7lQjGTFFB4xNuygvKxYqSw1YCUmXvEc=";
     };
     meta = {
@@ -4585,11 +4585,11 @@ with self;
     };
   };
 
-  CGIPSGI = buildPerlPackage {
+  CGIPSGI = buildPerlPackage rec {
     pname = "CGI-PSGI";
     version = "0.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/CGI-PSGI-0.15.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/CGI-PSGI-${version}.tar.gz";
       hash = "sha256-xQ3LEL+EhqmEO67QMq2J2Hn/L0HJkzQt6tYvlHpZjZE=";
     };
     propagatedBuildInputs = [ CGI ];
@@ -4602,11 +4602,11 @@ with self;
     };
   };
 
-  CGISession = buildPerlModule {
+  CGISession = buildPerlModule rec {
     pname = "CGI-Session";
     version = "4.48";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARKSTOS/CGI-Session-4.48.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MARKSTOS/CGI-Session-${version}.tar.gz";
       hash = "sha256-RnVkYcJM52ZrgQjduW26thJpnfMBLIDvEQFmGf4VVPc=";
     };
     propagatedBuildInputs = [ CGI ];
@@ -4616,11 +4616,11 @@ with self;
     };
   };
 
-  CGISimple = buildPerlPackage {
+  CGISimple = buildPerlPackage rec {
     pname = "CGI-Simple";
     version = "1.282";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MANWAR/CGI-Simple-1.282.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MANWAR/CGI-Simple-${version}.tar.gz";
       hash = "sha256-xX8PPjLN2AYSZFFVwbgptMy+TO1lXegzq5MAWYnCfy8=";
     };
     buildInputs = [
@@ -4636,11 +4636,11 @@ with self;
     };
   };
 
-  CGIStruct = buildPerlPackage {
+  CGIStruct = buildPerlPackage rec {
     pname = "CGI-Struct";
     version = "1.21";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FU/FULLERMD/CGI-Struct-1.21.tar.gz";
+      url = "mirror://cpan/authors/id/F/FU/FULLERMD/CGI-Struct-${version}.tar.gz";
       hash = "sha256-0T2Np/3NbZBgVOR2D8KKcYrskb088GeliSf7fLHAnWw=";
     };
     buildInputs = [ TestDeep ];
@@ -4650,11 +4650,11 @@ with self;
     };
   };
 
-  CHI = buildPerlPackage {
+  CHI = buildPerlPackage rec {
     pname = "CHI";
     version = "0.61";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AS/ASB/CHI-0.61.tar.gz";
+      url = "mirror://cpan/authors/id/A/AS/ASB/CHI-${version}.tar.gz";
       hash = "sha256-WDVFyeUxK7QZOrFt6fVf+PS0p97RKM7o3SywIdRni1s=";
     };
     preConfigure = ''
@@ -4693,11 +4693,11 @@ with self;
     };
   };
 
-  Chart = buildPerlPackage {
+  Chart = buildPerlPackage rec {
     pname = "Chart";
     version = "2.403.9";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LI/LICHTKIND/Chart-v2.403.9.tar.gz";
+      url = "mirror://cpan/authors/id/L/LI/LICHTKIND/Chart-v${version}.tar.gz";
       hash = "sha256-V8aCi7TIpyFw/rZ9wfFIq/Gcqzgnd54wh3tGEe1n86s=";
     };
     buildInputs = [ TestWarn ];
@@ -4714,11 +4714,11 @@ with self;
     };
   };
 
-  ChipcardPCSC = buildPerlPackage {
+  ChipcardPCSC = buildPerlPackage rec {
     pname = "Chipcard-PCSC";
     version = "1.4.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/W/WH/WHOM/Chipcard-PCSC-v1.4.16.tar.gz";
+      url = "mirror://cpan/authors/id/W/WH/WHOM/Chipcard-PCSC-v${version}.tar.gz";
       hash = "sha256-O14p1jRDXxQm7Nzfebo1G04mWPNsPCK+N7HTHjbKj6k=";
     };
     buildInputs = [ pkgs.pcsclite ];
@@ -4748,11 +4748,11 @@ with self;
     };
   };
 
-  CiscoIPPhone = buildPerlPackage {
+  CiscoIPPhone = buildPerlPackage rec {
     pname = "Cisco-IPPhone";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MR/MRPALMER/Cisco-IPPhone-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/M/MR/MRPALMER/Cisco-IPPhone-${version}.tar.gz";
       hash = "sha256-sDyiY/j0Gm7FRcU5MhOjFG02vUUzWt6Zr1HdQqtu4W0=";
     };
     meta = {
@@ -4761,11 +4761,11 @@ with self;
     };
   };
 
-  CLASS = buildPerlPackage {
+  CLASS = buildPerlPackage rec {
     pname = "CLASS";
     version = "1.1.8";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JD/JDEGUEST/CLASS-v1.1.8.tar.gz";
+      url = "mirror://cpan/authors/id/J/JD/JDEGUEST/CLASS-v${version}.tar.gz";
       hash = "sha256-IZAaUmXL29iRJ36X/Gs0X3nby/B3RFePX/iGaltddgM=";
     };
     meta = {
@@ -4779,11 +4779,11 @@ with self;
     };
   };
 
-  ClassAccessor = buildPerlPackage {
+  ClassAccessor = buildPerlPackage rec {
     pname = "Class-Accessor";
     version = "0.51";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KASEI/Class-Accessor-0.51.tar.gz";
+      url = "mirror://cpan/authors/id/K/KA/KASEI/Class-Accessor-${version}.tar.gz";
       hash = "sha256-vxKj5d5aLG6KRHs2T09aBQv3RiTFbjFQIq55kv8vQRw=";
     };
     meta = {
@@ -4795,11 +4795,11 @@ with self;
     };
   };
 
-  ClassAccessorChained = buildPerlModule {
+  ClassAccessorChained = buildPerlModule rec {
     pname = "Class-Accessor-Chained";
     version = "0.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RC/RCLAMP/Class-Accessor-Chained-0.01.tar.gz";
+      url = "mirror://cpan/authors/id/R/RC/RCLAMP/Class-Accessor-Chained-${version}.tar.gz";
       hash = "sha256-pb9J04BPg60lobFvMn0U1MvuInATIQSyhwUDHbzMNNI=";
     };
     propagatedBuildInputs = [ ClassAccessor ];
@@ -4812,11 +4812,11 @@ with self;
     };
   };
 
-  ClassAccessorGrouped = buildPerlPackage {
+  ClassAccessorGrouped = buildPerlPackage rec {
     pname = "Class-Accessor-Grouped";
     version = "0.10014";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/Class-Accessor-Grouped-0.10014.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Class-Accessor-Grouped-${version}.tar.gz";
       hash = "sha256-NdWwPvwJ9n86MVXJYkEmw+FiyOPKmP+CbbNYUzpExLs=";
     };
     buildInputs = [ TestException ];
@@ -4831,11 +4831,11 @@ with self;
     };
   };
 
-  ClassAccessorLite = buildPerlPackage {
+  ClassAccessorLite = buildPerlPackage rec {
     pname = "Class-Accessor-Lite";
     version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KAZUHO/Class-Accessor-Lite-0.08.tar.gz";
+      url = "mirror://cpan/authors/id/K/KA/KAZUHO/Class-Accessor-Lite-${version}.tar.gz";
       hash = "sha256-dbO47I7+aHZ3tj8KEO75ZuAfYHNcVmVs51y7RMq6M1o=";
     };
     meta = {
@@ -4847,11 +4847,11 @@ with self;
     };
   };
 
-  ClassAutouse = buildPerlPackage {
+  ClassAutouse = buildPerlPackage rec {
     pname = "Class-Autouse";
     version = "2.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AD/ADAMK/Class-Autouse-2.01.tar.gz";
+      url = "mirror://cpan/authors/id/A/AD/ADAMK/Class-Autouse-${version}.tar.gz";
       hash = "sha256-wFsyNsBXGdgZwg2w/ettCVR0fkPXpzgpTu1/vPNuzxs=";
     };
     meta = {
@@ -4863,11 +4863,11 @@ with self;
     };
   };
 
-  ClassBase = buildPerlPackage {
+  ClassBase = buildPerlPackage rec {
     pname = "Class-Base";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Y/YA/YANICK/Class-Base-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/Y/YA/YANICK/Class-Base-${version}.tar.gz";
       hash = "sha256-4aW93lJQWAJmSpEIpRXJ6OUCy3IppJ3pT0CBsbKu7YQ=";
     };
     propagatedBuildInputs = [ Clone ];
@@ -4880,11 +4880,11 @@ with self;
     };
   };
 
-  ClassC3 = buildPerlPackage {
+  ClassC3 = buildPerlPackage rec {
     pname = "Class-C3";
     version = "0.35";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/Class-C3-0.35.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Class-C3-${version}.tar.gz";
       hash = "sha256-hAU88aaPzIwSBWwvEgrfBPf2jjvjT0QI6V0Cb+5n4z4=";
     };
     propagatedBuildInputs = [ AlgorithmC3 ];
@@ -4898,11 +4898,11 @@ with self;
     };
   };
 
-  ClassC3AdoptNEXT = buildPerlModule {
+  ClassC3AdoptNEXT = buildPerlModule rec {
     pname = "Class-C3-Adopt-NEXT";
     version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Class-C3-Adopt-NEXT-0.14.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Class-C3-Adopt-NEXT-${version}.tar.gz";
       hash = "sha256-hWdiJarbduhmamq+LgZZ1A60WBrWOFsXDupOHWvzS/c=";
     };
     buildInputs = [
@@ -4920,11 +4920,11 @@ with self;
     };
   };
 
-  ClassC3Componentised = buildPerlPackage {
+  ClassC3Componentised = buildPerlPackage rec {
     pname = "Class-C3-Componentised";
     version = "1.001002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/Class-C3-Componentised-1.001002.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Class-C3-Componentised-${version}.tar.gz";
       hash = "sha256-MFGxRtwe/q6hqaLp5rF3MICZW4mKtYPxVWWNX8gLlpM=";
     };
     buildInputs = [ TestException ];
@@ -4942,11 +4942,11 @@ with self;
     };
   };
 
-  ClassClassgenclassgen = buildPerlPackage {
+  ClassClassgenclassgen = buildPerlPackage rec {
     pname = "Class-Classgen-classgen";
     version = "3.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSCHLUE/Class-Classgen-classgen-3.03.tar.gz";
+      url = "mirror://cpan/authors/id/M/MS/MSCHLUE/Class-Classgen-classgen-${version}.tar.gz";
       hash = "sha256-m2XUG5kVOJkugWsyzE+ptKSguz6cEOfuvv+CZY27yPY=";
     };
     meta = {
@@ -4959,11 +4959,11 @@ with self;
     };
   };
 
-  ClassContainer = buildPerlModule {
+  ClassContainer = buildPerlModule rec {
     pname = "Class-Container";
     version = "0.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KW/KWILLIAMS/Class-Container-0.13.tar.gz";
+      url = "mirror://cpan/authors/id/K/KW/KWILLIAMS/Class-Container-${version}.tar.gz";
       hash = "sha256-9dSVsd+4JtXAxF0DtNDmtgR8uwbNv2vhX9TckCrutws=";
     };
     propagatedBuildInputs = [ ParamsValidate ];
@@ -4976,11 +4976,11 @@ with self;
     };
   };
 
-  ClassDataAccessor = buildPerlPackage {
+  ClassDataAccessor = buildPerlPackage rec {
     pname = "Class-Data-Accessor";
     version = "0.04004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CL/CLACO/Class-Data-Accessor-0.04004.tar.gz";
+      url = "mirror://cpan/authors/id/C/CL/CLACO/Class-Data-Accessor-${version}.tar.gz";
       hash = "sha256-wSLW4t9hNs6b6h5tK3dsueaeAAhezplTAYFMevOo6BQ=";
     };
     meta = {
@@ -4992,11 +4992,11 @@ with self;
     };
   };
 
-  ClassDataInheritable = buildPerlPackage {
+  ClassDataInheritable = buildPerlPackage rec {
     pname = "Class-Data-Inheritable";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RS/RSHERER/Class-Data-Inheritable-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/R/RS/RSHERER/Class-Data-Inheritable-${version}.tar.gz";
       hash = "sha256-RAiNbpBxLhh7ilsFDKWxxw7+K6oyrhI+m9j1nynwbk0=";
     };
     meta = {
@@ -5008,11 +5008,11 @@ with self;
     };
   };
 
-  ClassEHierarchy = buildPerlPackage {
+  ClassEHierarchy = buildPerlPackage rec {
     pname = "Class-EHierarchy";
     version = "2.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CO/CORLISS/Class-EHierarchy/Class-EHierarchy-2.01.tar.gz";
+      url = "mirror://cpan/authors/id/C/CO/CORLISS/Class-EHierarchy/Class-EHierarchy-${version}.tar.gz";
       hash = "sha256-Y3q3a+s4MqmwcbmZobFb8F0pffamYsyxqABPKYcwg4I=";
     };
     meta = {
@@ -5024,11 +5024,11 @@ with self;
     };
   };
 
-  ClassFactory = buildPerlPackage {
+  ClassFactory = buildPerlPackage rec {
     pname = "Class-Factory";
     version = "1.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PH/PHRED/Class-Factory-1.06.tar.gz";
+      url = "mirror://cpan/authors/id/P/PH/PHRED/Class-Factory-${version}.tar.gz";
       hash = "sha256-w3otJp65NfNqI+ETSArglG+nwSoSeBOWoSJsjkNfMPU=";
     };
     meta = {
@@ -5040,11 +5040,11 @@ with self;
     };
   };
 
-  ClassFactoryUtil = buildPerlModule {
+  ClassFactoryUtil = buildPerlModule rec {
     pname = "Class-Factory-Util";
     version = "1.7";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Class-Factory-Util-1.7.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Class-Factory-Util-${version}.tar.gz";
       hash = "sha256-bFFrRFtE+HNj+zoUhDHTHp7LXm8h+2SByJskBrZpLiY=";
     };
     meta = {
@@ -5056,11 +5056,11 @@ with self;
     };
   };
 
-  ClassGomor = buildPerlModule {
+  ClassGomor = buildPerlModule rec {
     pname = "Class-Gomor";
     version = "1.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GO/GOMOR/Class-Gomor-1.03.tar.gz";
+      url = "mirror://cpan/authors/id/G/GO/GOMOR/Class-Gomor-${version}.tar.gz";
       hash = "sha256-R9s86pzp/6mL+cdFV/0yz3AHkatTcCDJWKwwtKn/IAs=";
     };
     meta = {
@@ -5069,11 +5069,11 @@ with self;
     };
   };
 
-  ClassInspector = buildPerlPackage {
+  ClassInspector = buildPerlPackage rec {
     pname = "Class-Inspector";
     version = "1.36";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Class-Inspector-1.36.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Class-Inspector-${version}.tar.gz";
       hash = "sha256-zCldI6RyaHwkSJ1YIm6tI7n9wliOUi8LXwdHdBcAaU4=";
     };
     meta = {
@@ -5086,11 +5086,11 @@ with self;
     };
   };
 
-  ClassISA = buildPerlPackage {
+  ClassISA = buildPerlPackage rec {
     pname = "Class-ISA";
     version = "0.36";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SM/SMUELLER/Class-ISA-0.36.tar.gz";
+      url = "mirror://cpan/authors/id/S/SM/SMUELLER/Class-ISA-${version}.tar.gz";
       hash = "sha256-iBbzTpo46EmhDfdWAw3M+f4GGhlsEaw/qv1xE8kpuWQ=";
     };
     meta = {
@@ -5102,11 +5102,11 @@ with self;
     };
   };
 
-  ClassIterator = buildPerlPackage {
+  ClassIterator = buildPerlPackage rec {
     pname = "Class-Iterator";
     version = "0.3";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TE/TEXMEC/Class-Iterator-0.3.tar.gz";
+      url = "mirror://cpan/authors/id/T/TE/TEXMEC/Class-Iterator-${version}.tar.gz";
       hash = "sha256-2xuofKkQfxYf6cHp5+JnwAJt78Jv4+c7ytirj/wY750=";
     };
     meta = {
@@ -5118,11 +5118,11 @@ with self;
     };
   };
 
-  ClassLoader = buildPerlPackage {
+  ClassLoader = buildPerlPackage rec {
     pname = "Class-Loader";
     version = "2.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/V/VI/VIPUL/Class-Loader-2.03.tar.gz";
+      url = "mirror://cpan/authors/id/V/VI/VIPUL/Class-Loader-${version}.tar.gz";
       hash = "sha256-T+8gdurWBCNFT/H06ChZqam5lCtfuO7gyYucY8nyuOc=";
     };
     meta = {
@@ -5134,11 +5134,11 @@ with self;
     };
   };
 
-  ClassMakeMethods = buildPerlPackage {
+  ClassMakeMethods = buildPerlPackage rec {
     pname = "Class-MakeMethods";
     version = "1.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EV/EVO/Class-MakeMethods-1.01.tar.gz";
+      url = "mirror://cpan/authors/id/E/EV/EVO/Class-MakeMethods-${version}.tar.gz";
       hash = "sha256-rKx0LnnQ7Ip75Nj7gTqF6kTUfRnAFwzdswZEYCtYLGY=";
     };
     preConfigure = ''
@@ -5154,11 +5154,11 @@ with self;
     };
   };
 
-  ClassMember = buildPerlPackage {
+  ClassMember = buildPerlPackage rec {
     pname = "Class-Member";
     version = "1.6";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OP/OPI/Class-Member-1.6.tar.gz";
+      url = "mirror://cpan/authors/id/O/OP/OPI/Class-Member-${version}.tar.gz";
       hash = "sha256-p1KK8in6OhIF3NJakd59dKxvp9lSgbmTtV6Lb0+HuZE=";
     };
     meta = {
@@ -5170,11 +5170,11 @@ with self;
     };
   };
 
-  ClassMethodMaker = buildPerlPackage {
+  ClassMethodMaker = buildPerlPackage rec {
     pname = "Class-MethodMaker";
     version = "2.24";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SC/SCHWIGON/class-methodmaker/Class-MethodMaker-2.24.tar.gz";
+      url = "mirror://cpan/authors/id/S/SC/SCHWIGON/class-methodmaker/Class-MethodMaker-${version}.tar.gz";
       hash = "sha256-Xu9YzLJ+vQG83lsUvMVTtTR6Bpnlw+khx3gMNSaJAyg=";
     };
     # Remove unnecessary, non-autoconf, configure script.
@@ -5188,11 +5188,11 @@ with self;
     };
   };
 
-  ClassMethodModifiers = buildPerlPackage {
+  ClassMethodModifiers = buildPerlPackage rec {
     pname = "Class-Method-Modifiers";
     version = "2.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Class-Method-Modifiers-2.15.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Class-Method-Modifiers-${version}.tar.gz";
       hash = "sha256-Zc2Fv+R10GbpGG96jMY2BwmFswsOuxzehoHPBiwuFfw=";
     };
     buildInputs = [
@@ -5209,11 +5209,11 @@ with self;
     };
   };
 
-  ClassMix = buildPerlModule {
+  ClassMix = buildPerlModule rec {
     pname = "Class-Mix";
     version = "0.006";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Class-Mix-0.006.tar.gz";
+      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Class-Mix-${version}.tar.gz";
       hash = "sha256-h0f2Q4k5FPjESXnxcW0MHsikE5R5ZVVEeUToYPH/fAs=";
     };
     propagatedBuildInputs = [ ParamsClassify ];
@@ -5226,11 +5226,11 @@ with self;
     };
   };
 
-  ClassRefresh = buildPerlPackage {
+  ClassRefresh = buildPerlPackage rec {
     pname = "Class-Refresh";
     version = "0.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DO/DOY/Class-Refresh-0.07.tar.gz";
+      url = "mirror://cpan/authors/id/D/DO/DOY/Class-Refresh-${version}.tar.gz";
       hash = "sha256-47ADU1XLs1oq7j8iNojVeJRqenxXCs05iyjN2x/UvrM=";
     };
     buildInputs = [
@@ -5253,11 +5253,11 @@ with self;
     };
   };
 
-  ClassReturnValue = buildPerlPackage {
+  ClassReturnValue = buildPerlPackage rec {
     pname = "Class-ReturnValue";
     version = "0.55";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JE/JESSE/Class-ReturnValue-0.55.tar.gz";
+      url = "mirror://cpan/authors/id/J/JE/JESSE/Class-ReturnValue-${version}.tar.gz";
       hash = "sha256-7Tg2iF149zTM16mFUOxCKmFt98MTEMG3sfZFn1+w5L0=";
     };
     propagatedBuildInputs = [ DevelStackTrace ];
@@ -5271,11 +5271,11 @@ with self;
     };
   };
 
-  ClassSingleton = buildPerlPackage {
+  ClassSingleton = buildPerlPackage rec {
     pname = "Class-Singleton";
     version = "1.6";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHAY/Class-Singleton-1.6.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHAY/Class-Singleton-${version}.tar.gz";
       hash = "sha256-J7oT8NlRKSkWa72MnvldkNYw/IDwyaG3RYiRBV6SgqQ=";
     };
     meta = {
@@ -5287,11 +5287,11 @@ with self;
     };
   };
 
-  ClassThrowable = buildPerlPackage {
+  ClassThrowable = buildPerlPackage rec {
     pname = "Class-Throwable";
     version = "0.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KM/KMX/Class-Throwable-0.13.tar.gz";
+      url = "mirror://cpan/authors/id/K/KM/KMX/Class-Throwable-${version}.tar.gz";
       hash = "sha256-3JoR4Nq1bcIg3qjJT+PEfbXn3Xwe0E3IF4qlu3v7vM4=";
     };
     preCheck = ''
@@ -5309,11 +5309,11 @@ with self;
     };
   };
 
-  ClassTiny = buildPerlPackage {
+  ClassTiny = buildPerlPackage rec {
     pname = "Class-Tiny";
     version = "1.008";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Class-Tiny-1.008.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Class-Tiny-${version}.tar.gz";
       hash = "sha256-7gWKY5Evofy5pySY9WykIaIFbcf59LZ4N0RtZCGBVhU=";
     };
     meta = {
@@ -5323,11 +5323,11 @@ with self;
     };
   };
 
-  ClassLoad = buildPerlPackage {
+  ClassLoad = buildPerlPackage rec {
     pname = "Class-Load";
     version = "0.25";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Class-Load-0.25.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Class-Load-${version}.tar.gz";
       hash = "sha256-Kkj6d5tSl+VhVjgOizJjfGxY3stPSn88c1BSPhEnX48=";
     };
     buildInputs = [
@@ -5348,11 +5348,11 @@ with self;
     };
   };
 
-  ClassLoadXS = buildPerlPackage {
+  ClassLoadXS = buildPerlPackage rec {
     pname = "Class-Load-XS";
     version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Class-Load-XS-0.10.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Class-Load-XS-${version}.tar.gz";
       hash = "sha256-W8Is9Tbr/SVkxb2vQvDYpM7j0ZMPyLRLfUpCA4YirdE=";
     };
     buildInputs = [
@@ -5367,11 +5367,11 @@ with self;
     };
   };
 
-  ClassObservable = buildPerlPackage {
+  ClassObservable = buildPerlPackage rec {
     pname = "Class-Observable";
     version = "2.004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AR/ARISTOTLE/Class-Observable-2.004.tar.gz";
+      url = "mirror://cpan/authors/id/A/AR/ARISTOTLE/Class-Observable-${version}.tar.gz";
       hash = "sha256-bfMun+XwCIkfxO+k5PReqhQE0wIgRZyPyKUB8KfPLmk=";
     };
     propagatedBuildInputs = [ ClassISA ];
@@ -5384,11 +5384,11 @@ with self;
     };
   };
 
-  ClassStd = buildPerlModule {
+  ClassStd = buildPerlModule rec {
     pname = "Class-Std";
     version = "0.013";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHORNY/Class-Std-0.013.tar.gz";
+      url = "mirror://cpan/authors/id/C/CH/CHORNY/Class-Std-${version}.tar.gz";
       hash = "sha256-vNbYL2yK8P4Gn87X3RZaR5WwtukjUcfU5aGrmhT8NcY=";
     };
     meta = {
@@ -5400,11 +5400,11 @@ with self;
     };
   };
 
-  ClassStdFast = buildPerlModule {
+  ClassStdFast = buildPerlModule rec {
     pname = "Class-Std-Fast";
     version = "0.0.8";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AC/ACID/Class-Std-Fast-v0.0.8.tar.gz";
+      url = "mirror://cpan/authors/id/A/AC/ACID/Class-Std-Fast-v${version}.tar.gz";
       hash = "sha256-G9Q3Y8ajcxgwl6MOeH9dZxOw2ydRHFLVMyZrWdLPp4A=";
     };
     propagatedBuildInputs = [ ClassStd ];
@@ -5421,11 +5421,11 @@ with self;
     };
   };
 
-  ClassUnload = buildPerlPackage {
+  ClassUnload = buildPerlPackage rec {
     pname = "Class-Unload";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IL/ILMARI/Class-Unload-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/I/IL/ILMARI/Class-Unload-${version}.tar.gz";
       hash = "sha256-UuKXR6fk0uGiicDh3oEHY08QyEJs18nTHsrIOD5KCl8=";
     };
     propagatedBuildInputs = [ ClassInspector ];
@@ -5439,11 +5439,11 @@ with self;
     };
   };
 
-  ClassVirtual = buildPerlPackage {
+  ClassVirtual = buildPerlPackage rec {
     pname = "Class-Virtual";
     version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSCHWERN/Class-Virtual-0.08.tar.gz";
+      url = "mirror://cpan/authors/id/M/MS/MSCHWERN/Class-Virtual-${version}.tar.gz";
       hash = "sha256-xkmbQtO05cZIil6C+8KGmObJhgFlBy3d+mdJNVqc+7I=";
     };
     propagatedBuildInputs = [
@@ -5461,11 +5461,11 @@ with self;
     };
   };
 
-  ClassXSAccessor = buildPerlPackage {
+  ClassXSAccessor = buildPerlPackage rec {
     pname = "Class-XSAccessor";
     version = "1.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SM/SMUELLER/Class-XSAccessor-1.19.tar.gz";
+      url = "mirror://cpan/authors/id/S/SM/SMUELLER/Class-XSAccessor-${version}.tar.gz";
       hash = "sha256-mcVrOV8SOa8ZkB8v7rEl2ey041Gg2A2qlSkhGkcApvI=";
     };
     meta = {
@@ -5477,11 +5477,11 @@ with self;
     };
   };
 
-  CLDRNumber = buildPerlModule {
+  CLDRNumber = buildPerlModule rec {
     pname = "CLDR-Number";
     version = "0.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PA/PATCH/CLDR-Number-0.19.tar.gz";
+      url = "mirror://cpan/authors/id/P/PA/PATCH/CLDR-Number-${version}.tar.gz";
       hash = "sha256-xnFkiOZf53n/eag/DyA2rZRGPv49DzSca5kRKXW9hfw=";
     };
     buildInputs = [
@@ -5506,11 +5506,11 @@ with self;
     };
   };
 
-  CLIHelpers = buildPerlPackage {
+  CLIHelpers = buildPerlPackage rec {
     pname = "CLI-Helpers";
     version = "2.0";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BL/BLHOTSKY/CLI-Helpers-2.0.tar.gz";
+      url = "mirror://cpan/authors/id/B/BL/BLHOTSKY/CLI-Helpers-${version}.tar.gz";
       hash = "sha256-yhpPFnTzsfMmjyekfJiAszgmrenxI34sEUXnAqfIePY=";
     };
     buildInputs = [
@@ -5531,11 +5531,11 @@ with self;
     };
   };
 
-  Clipboard = buildPerlModule {
+  Clipboard = buildPerlModule rec {
     pname = "Clipboard";
     version = "0.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Clipboard-0.28.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Clipboard-${version}.tar.gz";
       hash = "sha256-no15AVGUJjNXwloPXQlIAP/0O9v5+GAew7DtXrCWbSY=";
     };
     propagatedBuildInputs = [ CGI ];
@@ -5554,11 +5554,11 @@ with self;
     };
   };
 
-  Clone = buildPerlPackage {
+  Clone = buildPerlPackage rec {
     pname = "Clone";
     version = "0.46";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GA/GARU/Clone-0.46.tar.gz";
+      url = "mirror://cpan/authors/id/G/GA/GARU/Clone-${version}.tar.gz";
       hash = "sha256-qt7tXkyL1rvfaMDdAGbLUT4Wq55bQ4LcSgqv1ViQaXs=";
     };
     buildInputs = [ BCOW ];
@@ -5571,11 +5571,11 @@ with self;
     };
   };
 
-  CloneChoose = buildPerlPackage {
+  CloneChoose = buildPerlPackage rec {
     pname = "Clone-Choose";
     version = "0.010";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HE/HERMES/Clone-Choose-0.010.tar.gz";
+      url = "mirror://cpan/authors/id/H/HE/HERMES/Clone-Choose-${version}.tar.gz";
       hash = "sha256-ViNIH1jO6O25bNICqtDfViLUJ+X3SLJThR39YuUSNjI=";
     };
     buildInputs = [
@@ -5593,11 +5593,11 @@ with self;
     };
   };
 
-  ClonePP = buildPerlPackage {
+  ClonePP = buildPerlPackage rec {
     pname = "Clone-PP";
     version = "1.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/Clone-PP-1.08.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/Clone-PP-${version}.tar.gz";
       hash = "sha256-VyAwlKXYV0tqAJUejyOZtmb050+VEdnJ+1tFPV0R9Xg=";
     };
     meta = {
@@ -5609,11 +5609,11 @@ with self;
     };
   };
 
-  CodeTidyAll = buildPerlPackage {
+  CodeTidyAll = buildPerlPackage rec {
     pname = "Code-TidyAll";
     version = "0.84";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Code-TidyAll-0.84.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Code-TidyAll-${version}.tar.gz";
       hash = "sha256-s8AU4e3X9EBHkJjkHkeHNhBy9QE6ZqX4j5a05Tyisfc=";
     };
     propagatedBuildInputs = [
@@ -5656,11 +5656,11 @@ with self;
     };
   };
 
-  CodeTidyAllPluginPerlAlignMooseAttributes = buildPerlPackage {
+  CodeTidyAllPluginPerlAlignMooseAttributes = buildPerlPackage rec {
     pname = "Code-TidyAll-Plugin-Perl-AlignMooseAttributes";
     version = "0.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JS/JSWARTZ/Code-TidyAll-Plugin-Perl-AlignMooseAttributes-0.01.tar.gz";
+      url = "mirror://cpan/authors/id/J/JS/JSWARTZ/Code-TidyAll-Plugin-Perl-AlignMooseAttributes-${version}.tar.gz";
       hash = "sha256-jR3inlbwczFoXqONGDr87f8hCOccSp2zb0GeUN0sHOU=";
     };
     propagatedBuildInputs = [
@@ -5676,11 +5676,11 @@ with self;
     };
   };
 
-  ColorLibrary = buildPerlPackage {
+  ColorLibrary = buildPerlPackage rec {
     pname = "Color-Library";
     version = "0.021";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RO/ROKR/Color-Library-0.021.tar.gz";
+      url = "mirror://cpan/authors/id/R/RO/ROKR/Color-Library-${version}.tar.gz";
       hash = "sha256-WMv34zPTpKQCl6vENBKzIdpEnGgWAg5PpmJasHn8kKU=";
     };
     buildInputs = [
@@ -5704,11 +5704,11 @@ with self;
     };
   };
 
-  CommandRunner = buildPerlModule {
+  CommandRunner = buildPerlModule rec {
     pname = "Command-Runner";
     version = "0.200";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SK/SKAJI/Command-Runner-0.200.tar.gz";
+      url = "mirror://cpan/authors/id/S/SK/SKAJI/Command-Runner-${version}.tar.gz";
       hash = "sha256-WtJtBhEb/s1TyPW7XeqUvyAl9seOlfbYAS5M+oninyY=";
     };
     buildInputs = [ ModuleBuildTiny ];
@@ -5728,11 +5728,11 @@ with self;
     };
   };
 
-  commonsense = buildPerlPackage {
+  commonsense = buildPerlPackage rec {
     pname = "common-sense";
     version = "3.75";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/common-sense-3.75.tar.gz";
+      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/common-sense-${version}.tar.gz";
       hash = "sha256-qGocTKTzAG10eQZEJaCfpbZonlcmH8uZT+Z9Bhy6Dn4=";
     };
     meta = {
@@ -5744,11 +5744,11 @@ with self;
     };
   };
 
-  CompilerLexer = buildPerlModule {
+  CompilerLexer = buildPerlModule rec {
     pname = "Compiler-Lexer";
     version = "0.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GO/GOCCY/Compiler-Lexer-0.23.tar.gz";
+      url = "mirror://cpan/authors/id/G/GO/GOCCY/Compiler-Lexer-${version}.tar.gz";
       hash = "sha256-YDHOSv67+k9JKidJSb57gjIxTpECOCjEOOR5gf8Kmds=";
     };
     nativeBuildInputs = [ pkgs.ld-is-cc-hook ];
@@ -5767,11 +5767,11 @@ with self;
     };
   };
 
-  CompressBzip2 = buildPerlPackage {
+  CompressBzip2 = buildPerlPackage rec {
     pname = "Compress-Bzip2";
     version = "2.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RU/RURBAN/Compress-Bzip2-2.28.tar.gz";
+      url = "mirror://cpan/authors/id/R/RU/RURBAN/Compress-Bzip2-${version}.tar.gz";
       hash = "sha256-hZ+DXD9cmYgQ2LKm+eKC/5nWy2bM+lXK5+Ztr7A1EW4=";
     };
     meta = {
@@ -5799,11 +5799,11 @@ with self;
     };
   };
 
-  CompressRawBzip2 = buildPerlPackage {
+  CompressRawBzip2 = buildPerlPackage rec {
     pname = "Compress-Raw-Bzip2";
     version = "2.206";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PM/PMQS/Compress-Raw-Bzip2-2.206.tar.gz";
+      url = "mirror://cpan/authors/id/P/PM/PMQS/Compress-Raw-Bzip2-${version}.tar.gz";
       hash = "sha256-ISuB2xwK6CLRmShhmmA70QjLXVxHAPxn3HyxaeDMZSU=";
     };
 
@@ -5822,11 +5822,11 @@ with self;
     };
   };
 
-  CompressRawLzma = buildPerlPackage {
+  CompressRawLzma = buildPerlPackage rec {
     pname = "Compress-Raw-Lzma";
     version = "2.206";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PM/PMQS/Compress-Raw-Lzma-2.206.tar.gz";
+      url = "mirror://cpan/authors/id/P/PM/PMQS/Compress-Raw-Lzma-${version}.tar.gz";
       hash = "sha256-4BpwQLhL3GdZLRPuwMeIWQ4faW0dTwfHCXvXKk+IbrQ=";
     };
     preConfigure = ''
@@ -5845,12 +5845,12 @@ with self;
     };
   };
 
-  CompressRawZlib = buildPerlPackage {
+  CompressRawZlib = buildPerlPackage rec {
     pname = "Compress-Raw-Zlib";
     version = "2.206";
 
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PM/PMQS/Compress-Raw-Zlib-2.206.tar.gz";
+      url = "mirror://cpan/authors/id/P/PM/PMQS/Compress-Raw-Zlib-${version}.tar.gz";
       hash = "sha256-Rnhaajg6HIQ4lbf58l1ddZ58MFFZ+dHgSjYE63THc3Q=";
     };
 
@@ -5877,11 +5877,11 @@ with self;
     };
   };
 
-  CompressUnLZMA = buildPerlPackage {
+  CompressUnLZMA = buildPerlPackage rec {
     pname = "Compress-unLZMA";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FE/FERREIRA/Compress-unLZMA-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/F/FE/FERREIRA/Compress-unLZMA-${version}.tar.gz";
       hash = "sha256-TegBoo2S1ekJR0Zc60jU45/WQJOF6cIw5MBIKdllF7g=";
     };
     meta = {
@@ -5894,11 +5894,11 @@ with self;
     };
   };
 
-  ConfigAny = buildPerlPackage {
+  ConfigAny = buildPerlPackage rec {
     pname = "Config-Any";
     version = "0.33";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/Config-Any-0.33.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Config-Any-${version}.tar.gz";
       hash = "sha256-wGaOtfLNNVvyBVfwTcGKJUdLegvPp5Vi4xZdmjx4kzM=";
     };
     propagatedBuildInputs = [ ModulePluggable ];
@@ -5911,11 +5911,11 @@ with self;
     };
   };
 
-  ConfigAutoConf = buildPerlPackage {
+  ConfigAutoConf = buildPerlPackage rec {
     pname = "Config-AutoConf";
     version = "0.320";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AM/AMBS/Config-AutoConf-0.320.tar.gz";
+      url = "mirror://cpan/authors/id/A/AM/AMBS/Config-AutoConf-${version}.tar.gz";
       hash = "sha256-u1epWO9J0/cWInba4Up71a9D/R2FEyMa811mVFlFQCM=";
     };
     propagatedBuildInputs = [ CaptureTiny ];
@@ -5929,11 +5929,11 @@ with self;
     };
   };
 
-  ConfigGeneral = buildPerlPackage {
+  ConfigGeneral = buildPerlPackage rec {
     pname = "Config-General";
     version = "2.65";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TL/TLINDEN/Config-General-2.65.tar.gz";
+      url = "mirror://cpan/authors/id/T/TL/TLINDEN/Config-General-${version}.tar.gz";
       hash = "sha256-TW1XVL46nzCQaDbwzBDlVMiDLhTnoTQe+xWwXXBvxY8=";
     };
     meta = {
@@ -5942,11 +5942,11 @@ with self;
     };
   };
 
-  ConfigGitLike = buildPerlPackage {
+  ConfigGitLike = buildPerlPackage rec {
     pname = "Config-GitLike";
     version = "1.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AL/ALEXMV/Config-GitLike-1.18.tar.gz";
+      url = "mirror://cpan/authors/id/A/AL/ALEXMV/Config-GitLike-${version}.tar.gz";
       hash = "sha256-9650QPOtq1uf+apXIW2E/UpoEAm5WE4y2kL4u3HjMsU=";
     };
     buildInputs = [ TestException ];
@@ -5963,11 +5963,11 @@ with self;
     };
   };
 
-  ConfigGrammar = buildPerlPackage {
+  ConfigGrammar = buildPerlPackage rec {
     pname = "Config-Grammar";
     version = "1.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DS/DSCHWEI/Config-Grammar-1.13.tar.gz";
+      url = "mirror://cpan/authors/id/D/DS/DSCHWEI/Config-Grammar-${version}.tar.gz";
       hash = "sha256-qLOjosnIxDuS3EAb8nCdZRTxW0Z/1PcsSNNWM1dx1uM=";
     };
     meta = {
@@ -5980,11 +5980,11 @@ with self;
     };
   };
 
-  ConfigINI = buildPerlPackage {
+  ConfigINI = buildPerlPackage rec {
     pname = "Config-INI";
     version = "0.029";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Config-INI-0.029.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Config-INI-${version}.tar.gz";
       hash = "sha256-C755enMCEGRKkH2QzUqisjrVgMsnvTk5O/xqfvn9/eo=";
     };
     propagatedBuildInputs = [ MixinLinewise ];
@@ -5998,11 +5998,11 @@ with self;
     };
   };
 
-  ConfigIdentity = buildPerlPackage {
+  ConfigIdentity = buildPerlPackage rec {
     pname = "Config-Identity";
     version = "0.0019";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Config-Identity-0.0019.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Config-Identity-${version}.tar.gz";
       hash = "sha256-KVIL2zdlnmQUkbDGlmFCmhqJtqLkdcL5tOvyfkXoEqg=";
     };
     propagatedBuildInputs = [
@@ -6020,11 +6020,11 @@ with self;
     };
   };
 
-  ConfigIniFiles = buildPerlPackage {
+  ConfigIniFiles = buildPerlPackage rec {
     pname = "Config-IniFiles";
     version = "3.000003";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Config-IniFiles-3.000003.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Config-IniFiles-${version}.tar.gz";
       hash = "sha256-PEV7ZdmOX/QL25z4FLDVmD6wxT+4aWvaO6A1rSrNaAI=";
     };
     propagatedBuildInputs = [ IOStringy ];
@@ -6042,11 +6042,11 @@ with self;
     };
   };
 
-  ConfigMerge = buildPerlPackage {
+  ConfigMerge = buildPerlPackage rec {
     pname = "Config-Merge";
     version = "1.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DRTECH/Config-Merge-1.04.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DRTECH/Config-Merge-${version}.tar.gz";
       hash = "sha256-qTJHe0OuX7BKFvBxqJHae9IIbBDGgFkvKIj6nZlyzM8=";
     };
     buildInputs = [ YAML ];
@@ -6060,11 +6060,11 @@ with self;
     };
   };
 
-  ConfigOnion = buildPerlPackage {
+  ConfigOnion = buildPerlPackage rec {
     pname = "Config-Onion";
     version = "1.007";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DS/DSHEROH/Config-Onion-1.007.tar.gz";
+      url = "mirror://cpan/authors/id/D/DS/DSHEROH/Config-Onion-${version}.tar.gz";
       hash = "sha256-Mn/d9o4TiyRp5aK643xzP4fKhMr2Hhz6qUm+PZUNqK8=";
     };
     propagatedBuildInputs = [
@@ -6085,11 +6085,11 @@ with self;
     };
   };
 
-  ConfigMVP = buildPerlPackage {
+  ConfigMVP = buildPerlPackage rec {
     pname = "Config-MVP";
     version = "2.200013";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Config-MVP-2.200013.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Config-MVP-${version}.tar.gz";
       hash = "sha256-AY0WFiPuOmf4YNnmgOIuYbeermAY8OfDtSX8k09bfUU=";
     };
     buildInputs = [ TestFatal ];
@@ -6111,11 +6111,11 @@ with self;
     };
   };
 
-  ConfigMVPReaderINI = buildPerlPackage {
+  ConfigMVPReaderINI = buildPerlPackage rec {
     pname = "Config-MVP-Reader-INI";
     version = "2.101465";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Config-MVP-Reader-INI-2.101465.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Config-MVP-Reader-INI-${version}.tar.gz";
       hash = "sha256-E8eqJ8HfmM0zraOZ5Z/zj6v6nWVRPkKvAvcsLT9jYkc=";
     };
     propagatedBuildInputs = [
@@ -6132,11 +6132,11 @@ with self;
     };
   };
 
-  ConfigProperties = buildPerlPackage {
+  ConfigProperties = buildPerlPackage rec {
     pname = "Config-Properties";
     version = "1.80";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SA/SALVA/Config-Properties-1.80.tar.gz";
+      url = "mirror://cpan/authors/id/S/SA/SALVA/Config-Properties-${version}.tar.gz";
       hash = "sha256-XQQ5W+fhTpcKA+qVL7dimuME2XwDH5DMHCm9Cmpi/EA=";
     };
     meta = {
@@ -6148,11 +6148,11 @@ with self;
     };
   };
 
-  ConfigSimple = buildPerlPackage {
+  ConfigSimple = buildPerlPackage rec {
     pname = "Config-Simple";
     version = "4.58";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHERZODR/Config-Simple-4.58.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHERZODR/Config-Simple-${version}.tar.gz";
       hash = "sha256-3ZmVcG8Pk4ShXM/+EWw7biL0K6LljY8k7QPEoOOG7bQ=";
     };
     meta = {
@@ -6164,11 +6164,11 @@ with self;
     };
   };
 
-  ConfigStd = buildPerlModule {
+  ConfigStd = buildPerlModule rec {
     pname = "Config-Std";
     version = "0.903";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BR/BRICKER/Config-Std-0.903.tar.gz";
+      url = "mirror://cpan/authors/id/B/BR/BRICKER/Config-Std-${version}.tar.gz";
       hash = "sha256-t3Cf9mO9J50mSrnC9R6elYhHmjNnqMTPwYZZwqEUgP4=";
     };
     propagatedBuildInputs = [ ClassStd ];
@@ -6181,11 +6181,11 @@ with self;
     };
   };
 
-  ConfigTiny = buildPerlPackage {
+  ConfigTiny = buildPerlPackage rec {
     pname = "Config-Tiny";
     version = "2.29";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RS/RSAVAGE/Config-Tiny-2.29.tgz";
+      url = "mirror://cpan/authors/id/R/RS/RSAVAGE/Config-Tiny-${version}.tgz";
       hash = "sha256-PeebDqA6jWqT6dkSj+hF+1ViIrFGmaT28NXKBXrjMzs=";
     };
     buildInputs = [ TestPod ];
@@ -6198,11 +6198,11 @@ with self;
     };
   };
 
-  ConfigVersioned = buildPerlPackage {
+  ConfigVersioned = buildPerlPackage rec {
     pname = "Config-Versioned";
     version = "1.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MR/MRSCOTTY/Config-Versioned-1.01.tar.gz";
+      url = "mirror://cpan/authors/id/M/MR/MRSCOTTY/Config-Versioned-${version}.tar.gz";
       hash = "sha256-vJpK43OL2J+GoHvKZzYnyjySupaXN81tvHq3rRfNI0g=";
     };
     propagatedBuildInputs = [
@@ -6220,11 +6220,11 @@ with self;
     };
   };
 
-  Connector = buildPerlModule {
+  Connector = buildPerlModule rec {
     pname = "Connector";
     version = "1.53";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MR/MRSCOTTY/Connector-1.53.tar.gz";
+      url = "mirror://cpan/authors/id/M/MR/MRSCOTTY/Connector-${version}.tar.gz";
       hash = "sha256-1D50VEcZ/7lKDgZFhqetRXVbKTZPGJHZ4ncEFqsSTPo=";
     };
     buildInputs = [
@@ -6265,11 +6265,11 @@ with self;
     };
   };
 
-  ConstFast = buildPerlModule {
+  ConstFast = buildPerlModule rec {
     pname = "Const-Fast";
     version = "0.014";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/Const-Fast-0.014.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/Const-Fast-${version}.tar.gz";
       hash = "sha256-+AWVOgjFeEahak2F17dmOYr698NsFGX8sd6gnl+jlNs=";
     };
     propagatedBuildInputs = [ SubExporterProgressive ];
@@ -6286,11 +6286,11 @@ with self;
     };
   };
 
-  ConvertASCIIArmour = buildPerlPackage {
+  ConvertASCIIArmour = buildPerlPackage rec {
     pname = "Convert-ASCII-Armour";
     version = "1.4";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/V/VI/VIPUL/Convert-ASCII-Armour-1.4.tar.gz";
+      url = "mirror://cpan/authors/id/V/VI/VIPUL/Convert-ASCII-Armour-${version}.tar.gz";
       hash = "sha256-l+istusqKpGvfWzw0t/2+kKq+Tn8fW0cYFek8N9SyQQ=";
     };
     meta = {
@@ -6303,11 +6303,11 @@ with self;
     };
   };
 
-  ConvertASN1 = buildPerlPackage {
+  ConvertASN1 = buildPerlPackage rec {
     pname = "Convert-ASN1";
     version = "0.34";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TI/TIMLEGGE/Convert-ASN1-0.34.tar.gz";
+      url = "mirror://cpan/authors/id/T/TI/TIMLEGGE/Convert-ASN1-${version}.tar.gz";
       hash = "sha256-pijXydOQVo+3Y1mXX6A/YmzlfxDcF5gOjjWH13E+Tuc=";
     };
     meta = {
@@ -6319,11 +6319,11 @@ with self;
     };
   };
 
-  ConvertBase32 = buildPerlPackage {
+  ConvertBase32 = buildPerlPackage rec {
     pname = "Convert-Base32";
     version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IK/IKEGAMI/Convert-Base32-0.06.tar.gz";
+      url = "mirror://cpan/authors/id/I/IK/IKEGAMI/Convert-Base32-${version}.tar.gz";
       hash = "sha256-S6gsFnxB9FWqgoRzhyfkyUouvLHEznl/b9oHJFpkIRU=";
     };
     buildInputs = [ TestException ];
@@ -6337,11 +6337,11 @@ with self;
     };
   };
 
-  ConvertBencode = buildPerlPackage {
+  ConvertBencode = buildPerlPackage rec {
     pname = "Convert-Bencode";
     version = "1.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OR/ORCLEV/Convert-Bencode-1.03.tar.gz";
+      url = "mirror://cpan/authors/id/O/OR/ORCLEV/Convert-Bencode-${version}.tar.gz";
       hash = "sha256-Jp89+GVpJZbeIU/kK5Lc+H1qa8It237Sq8f0i4LkXmw=";
     };
     meta = {
@@ -6353,11 +6353,11 @@ with self;
     };
   };
 
-  ConvertColor = buildPerlModule {
+  ConvertColor = buildPerlModule rec {
     pname = "Convert-Color";
     version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Convert-Color-0.17.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Convert-Color-${version}.tar.gz";
       hash = "sha256-5/jDN8VSXqoDd3xXaD6hGvm5j/HQURojSvH4CkMiTsc=";
     };
     buildInputs = [ Test2Suite ];
@@ -6374,11 +6374,11 @@ with self;
     };
   };
 
-  ConvertUU = buildPerlPackage {
+  ConvertUU = buildPerlPackage rec {
     pname = "Convert-UU";
     version = "0.5201";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AN/ANDK/Convert-UU-0.5201.tar.gz";
+      url = "mirror://cpan/authors/id/A/AN/ANDK/Convert-UU-${version}.tar.gz";
       hash = "sha256-kjKc4cMrWVLEjhIj2wGMjFjOr+8Dv6D9SBfNicNVo70=";
     };
     meta = {
@@ -6390,11 +6390,11 @@ with self;
     };
   };
 
-  constantboolean = buildPerlModule {
+  constantboolean = buildPerlModule rec {
     pname = "constant-boolean";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DE/DEXTER/constant-boolean-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/D/DE/DEXTER/constant-boolean-${version}.tar.gz";
       hash = "sha256-zSxZ1YBhzhpJdaMTFg33GG9i7qJlW4XVIOXiTp7rD+k=";
     };
     propagatedBuildInputs = [ SymbolUtil ];
@@ -6407,11 +6407,11 @@ with self;
     };
   };
 
-  curry = buildPerlPackage {
+  curry = buildPerlPackage rec {
     pname = "curry";
     version = "2.000001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSTROUT/curry-2.000001.tar.gz";
+      url = "mirror://cpan/authors/id/M/MS/MSTROUT/curry-${version}.tar.gz";
       hash = "sha256-yY/iBQ+t7KOYGdboDVROkSGE/oRsvnNTnGhpT7G1HAg=";
     };
     meta = {
@@ -6423,12 +6423,12 @@ with self;
     };
   };
 
-  constant-defer = buildPerlPackage {
+  constant-defer = buildPerlPackage rec {
     pname = "constant-defer";
     version = "6";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KR/KRYDE/constant-defer-6.tar.gz";
-      hash = "sha256-eyEmMZjKImhu//OumHokC+Qj3SFgr96yn+cW0DKYb/o=";
+      url = "mirror://cpan/authors/id/K/KR/KRYDE/constant-defer-${version}.tar.gz";
+      hash = "sha25${version}-eyEmMZjKImhu//OumHokC+Qj3SFgr9${version}yn+cW0DKYb/o=";
     };
     meta = {
       description = "Constant subs with deferred value calculation";
@@ -6436,11 +6436,11 @@ with self;
     };
   };
 
-  ContextPreserve = buildPerlPackage {
+  ContextPreserve = buildPerlPackage rec {
     pname = "Context-Preserve";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Context-Preserve-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Context-Preserve-${version}.tar.gz";
       hash = "sha256-CZFKTCx725nKtoDBg8v0kuyY1uI/vMSH/MSuEFZ9/R8=";
     };
     buildInputs = [
@@ -6455,11 +6455,11 @@ with self;
     };
   };
 
-  CookieBaker = buildPerlModule {
+  CookieBaker = buildPerlModule rec {
     pname = "Cookie-Baker";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KAZEBURO/Cookie-Baker-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/K/KA/KAZEBURO/Cookie-Baker-${version}.tar.gz";
       hash = "sha256-WSdfR04HwKo2EePmhLiU59uRMzPYIUQgvmPxLsGM16s=";
     };
     buildInputs = [
@@ -6477,11 +6477,11 @@ with self;
     };
   };
 
-  CookieXS = buildPerlPackage {
+  CookieXS = buildPerlPackage rec {
     pname = "Cookie-XS";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AG/AGENT/Cookie-XS-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/A/AG/AGENT/Cookie-XS-${version}.tar.gz";
       hash = "sha256-o7lxB4CiJC5w750G5R+Rt/PqCq5o9Tx25CxYLCzLJpg=";
     };
     propagatedBuildInputs = [ CGICookieXS ];
@@ -6494,11 +6494,11 @@ with self;
     };
   };
 
-  Coro = buildPerlPackage {
+  Coro = buildPerlPackage rec {
     pname = "Coro";
     version = "6.57";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/Coro-6.57.tar.gz";
+      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/Coro-${version}.tar.gz";
       hash = "sha256-GSjkgDNUDhHr9VBpht0QGveNJCHSEPllmSI7FdUXFMY=";
     };
     patches = [
@@ -6506,7 +6506,7 @@ with self;
       # https://rt.cpan.org/Public/Bug/Display.html?id=158609
       (fetchpatch {
         name = "perl-coro-c23.patch";
-        url = "https://src.fedoraproject.org/rpms/perl-Coro/raw/7099f289e10ec5d4d5dbbabe6267257588417693/f/Coro-6.57-c23.patch";
+        url = "https://src.fedoraproject.org/rpms/perl-Coro/raw/7099f289e10ec5d4d5dbbabe6267257588417693/f/Coro-${version}-c23.patch";
         hash = "sha256-BnVE+E8taPfmAN+bsKK3AvesVrwi52GWUMa6TFJw3KY=";
       })
     ];
@@ -6552,11 +6552,11 @@ with self;
     };
   };
 
-  Corona = buildPerlPackage {
+  Corona = buildPerlPackage rec {
     pname = "Corona";
     version = "0.1004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Corona-0.1004.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Corona-${version}.tar.gz";
       hash = "sha256-//XRnoPeem0mWfNGgpgmsWUrtmZlS4eDsRmlNFS9rzw=";
     };
     propagatedBuildInputs = [
@@ -6577,11 +6577,11 @@ with self;
     };
   };
 
-  CPAN = buildPerlPackage {
+  CPAN = buildPerlPackage rec {
     pname = "CPAN";
     version = "2.36";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AN/ANDK/CPAN-2.36.tar.gz";
+      url = "mirror://cpan/authors/id/A/AN/ANDK/CPAN-${version}.tar.gz";
       hash = "sha256-HXKl60DliOPBDx88hckC6HGxaDdH1ncjOvd3yCv8kJ4=";
     };
     propagatedBuildInputs = [
@@ -6612,11 +6612,11 @@ with self;
     };
   };
 
-  CPANAudit = buildPerlPackage {
+  CPANAudit = buildPerlPackage rec {
     pname = "CPAN-Audit";
     version = "20230826.001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/CPAN-Audit-20230826.001.tar.gz";
+      url = "mirror://cpan/authors/id/B/BD/BDFOY/CPAN-Audit-${version}.tar.gz";
       hash = "sha256-DXU7O9fdpXweIKycWScKcKTNkfttfN4mJEPoVUy2Geo=";
     };
     buildInputs = [
@@ -6642,11 +6642,11 @@ with self;
     };
   };
 
-  CPANMini = buildPerlPackage {
+  CPANMini = buildPerlPackage rec {
     pname = "CPAN-Mini";
     version = "1.111017";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/CPAN-Mini-1.111017.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/CPAN-Mini-${version}.tar.gz";
       hash = "sha256-8gQpO+JqyEGsyHBEoYjbD1kegIgTFseiiK7A7s4wYVU=";
     };
     propagatedBuildInputs = [
@@ -6666,11 +6666,11 @@ with self;
     };
   };
 
-  CpanelJSONXS = buildPerlPackage {
+  CpanelJSONXS = buildPerlPackage rec {
     pname = "Cpanel-JSON-XS";
     version = "4.37";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RU/RURBAN/Cpanel-JSON-XS-4.37.tar.gz";
+      url = "mirror://cpan/authors/id/R/RU/RURBAN/Cpanel-JSON-XS-${version}.tar.gz";
       hash = "sha256-wkFhWg4X/3Raqoa79Gam4pzSQFFeZfBqegUBe2GebUs=";
     };
     patches = [ ../development/perl-modules/Cpanel-JSON-XS-CVE-2025-40929.patch ];
@@ -6684,11 +6684,11 @@ with self;
     };
   };
 
-  CPAN02PackagesSearch = buildPerlModule {
+  CPAN02PackagesSearch = buildPerlModule rec {
     pname = "CPAN-02Packages-Search";
     version = "0.100";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SK/SKAJI/CPAN-02Packages-Search-0.100.tar.gz";
+      url = "mirror://cpan/authors/id/S/SK/SKAJI/CPAN-02Packages-Search-${version}.tar.gz";
       hash = "sha256-prabrHmiUwA0RrKD76bzrv+mCdDBxStCCYeCEtpw+as=";
     };
     buildInputs = [ ModuleBuildTiny ];
@@ -6703,11 +6703,11 @@ with self;
     };
   };
 
-  CPANChanges = buildPerlPackage {
+  CPANChanges = buildPerlPackage rec {
     pname = "CPAN-Changes";
     version = "0.400002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/CPAN-Changes-0.400002.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/CPAN-Changes-${version}.tar.gz";
       hash = "sha256-Ae7eqQ0HRoy1jkpQv6O7HU7tqQc1lq3REY/DWRU6vo0=";
     };
     meta = {
@@ -6720,11 +6720,11 @@ with self;
     };
   };
 
-  CPANChecksums = buildPerlPackage {
+  CPANChecksums = buildPerlPackage rec {
     pname = "CPAN-Checksums";
     version = "2.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AN/ANDK/CPAN-Checksums-2.14.tar.gz";
+      url = "mirror://cpan/authors/id/A/AN/ANDK/CPAN-Checksums-${version}.tar.gz";
       hash = "sha256-QIBxbF2n4DtQTjzA6h/V757WkV9vtzdWTp4T01Wonjk=";
     };
     propagatedBuildInputs = [
@@ -6741,11 +6741,11 @@ with self;
     };
   };
 
-  CPANCommonIndex = buildPerlPackage {
+  CPANCommonIndex = buildPerlPackage rec {
     pname = "CPAN-Common-Index";
     version = "0.010";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/CPAN-Common-Index-0.010.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/CPAN-Common-Index-${version}.tar.gz";
       hash = "sha256-xD3bsi/UKwYRj+Y1f1NwD7139TG6PEJ/qvvzA8v06vA=";
     };
     buildInputs = [
@@ -6766,11 +6766,11 @@ with self;
     };
   };
 
-  CPANDistnameInfo = buildPerlPackage {
+  CPANDistnameInfo = buildPerlPackage rec {
     pname = "CPAN-DistnameInfo";
     version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GB/GBARR/CPAN-DistnameInfo-0.12.tar.gz";
+      url = "mirror://cpan/authors/id/G/GB/GBARR/CPAN-DistnameInfo-${version}.tar.gz";
       hash = "sha256-LyT76ffurLwmnTX8YWGDIvwXvkme4M2QGPNwk0qfJDU=";
     };
     meta = {
@@ -6782,11 +6782,11 @@ with self;
     };
   };
 
-  CPANMetaCheck = buildPerlPackage {
+  CPANMetaCheck = buildPerlPackage rec {
     pname = "CPAN-Meta-Check";
     version = "0.018";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/CPAN-Meta-Check-0.018.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/CPAN-Meta-Check-${version}.tar.gz";
       hash = "sha256-9hnS316g/ZHIz4PrVKzMteQ9nm7Bo/cns9CsFdDPN4o=";
     };
     buildInputs = [ TestDeep ];
@@ -6799,11 +6799,11 @@ with self;
     };
   };
 
-  CPANPerlReleases = buildPerlPackage {
+  CPANPerlReleases = buildPerlPackage rec {
     pname = "CPAN-Perl-Releases";
     version = "5.20230920";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BI/BINGOS/CPAN-Perl-Releases-5.20230920.tar.gz";
+      url = "mirror://cpan/authors/id/B/BI/BINGOS/CPAN-Perl-Releases-${version}.tar.gz";
       hash = "sha256-MbyTiJR2uOx1iRjdmSSmKYPgh7BsjN6Sb7mnp+h60cA=";
     };
     meta = {
@@ -6816,11 +6816,11 @@ with self;
     };
   };
 
-  CPANPLUS = buildPerlPackage {
+  CPANPLUS = buildPerlPackage rec {
     pname = "CPANPLUS";
     version = "0.9914";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BI/BINGOS/CPANPLUS-0.9914.tar.gz";
+      url = "mirror://cpan/authors/id/B/BI/BINGOS/CPANPLUS-${version}.tar.gz";
       hash = "sha256-dsPl2mI6SvYP5krexEj7H44Mrp9nmKNraIZZdAROm2c=";
     };
     propagatedBuildInputs = [
@@ -6841,11 +6841,11 @@ with self;
     };
   };
 
-  CPANUploader = buildPerlPackage {
+  CPANUploader = buildPerlPackage rec {
     pname = "CPAN-Uploader";
     version = "0.103018";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/CPAN-Uploader-0.103018.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/CPAN-Uploader-${version}.tar.gz";
       hash = "sha256-xP/k7enbebOW47/F583w4umCHh8eCH9SO8+nTJ/J4kg=";
     };
     propagatedBuildInputs = [
@@ -6865,11 +6865,11 @@ with self;
     };
   };
 
-  CryptArgon2 = buildPerlModule {
+  CryptArgon2 = buildPerlModule rec {
     pname = "Crypt-Argon2";
     version = "0.019";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/Crypt-Argon2-0.019.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/Crypt-Argon2-${version}.tar.gz";
       hash = "sha256-+Fm+6NL2tAf11EZFwiOu4hL+AFkd/YLlBlrhvnio5Dg=";
     };
     nativeBuildInputs = [ pkgs.ld-is-cc-hook ];
@@ -6879,11 +6879,11 @@ with self;
     };
   };
 
-  CryptBcrypt = buildPerlPackage {
+  CryptBcrypt = buildPerlPackage rec {
     pname = "Crypt-Bcrypt";
     version = "0.011";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/Crypt-Bcrypt-0.011.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/Crypt-Bcrypt-${version}.tar.gz";
       hash = "sha256-Z/ymiwUm5zTi2VvGsyutAcMZ5Yer9j5M80Itpmu+o6A=";
     };
     meta = {
@@ -6895,11 +6895,11 @@ with self;
     };
   };
 
-  CryptBlowfish = buildPerlPackage {
+  CryptBlowfish = buildPerlPackage rec {
     pname = "Crypt-Blowfish";
     version = "2.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DP/DPARIS/Crypt-Blowfish-2.14.tar.gz";
+      url = "mirror://cpan/authors/id/D/DP/DPARIS/Crypt-Blowfish-${version}.tar.gz";
       hash = "sha256-RrNDH/tr9bnLNZ95Vl1IQH5lKtKwT99cpipp5xl6Z7E=";
     };
     meta = {
@@ -6908,11 +6908,11 @@ with self;
     };
   };
 
-  CryptCAST5_PP = buildPerlPackage {
+  CryptCAST5_PP = buildPerlPackage rec {
     pname = "Crypt-CAST5_PP";
     version = "1.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOBMATH/Crypt-CAST5_PP-1.04.tar.gz";
+      url = "mirror://cpan/authors/id/B/BO/BOBMATH/Crypt-CAST5_PP-${version}.tar.gz";
       hash = "sha256-y6mKgEA/uJihTJKPI39EgWtISGQYQM4lFzY8LAcbUyc=";
     };
     meta = {
@@ -6925,11 +6925,11 @@ with self;
     };
   };
 
-  CryptCBC = buildPerlPackage {
+  CryptCBC = buildPerlPackage rec {
     pname = "Crypt-CBC";
     version = "2.33";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LD/LDS/Crypt-CBC-2.33.tar.gz";
+      url = "mirror://cpan/authors/id/L/LD/LDS/Crypt-CBC-${version}.tar.gz";
       hash = "sha256-anDeIbbMfysQAGfo4Yjblm6agAG122+pdufLWylK5kU=";
     };
     meta = {
@@ -6941,11 +6941,11 @@ with self;
     };
   };
 
-  CryptCurve25519 = buildPerlPackage {
+  CryptCurve25519 = buildPerlPackage rec {
     pname = "Crypt-Curve25519";
     version = "0.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KARASIK/Crypt-Curve25519-0.07.tar.gz";
+      url = "mirror://cpan/authors/id/K/KA/KARASIK/Crypt-Curve25519-${version}.tar.gz";
       hash = "sha256-Z6mIcTclIdb34R/dYnyq21wdVAFCag6c9CFnpDxbSx0=";
     };
     meta = {
@@ -6958,11 +6958,11 @@ with self;
     };
   };
 
-  CryptDES = buildPerlPackage {
+  CryptDES = buildPerlPackage rec {
     pname = "Crypt-DES";
     version = "2.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DP/DPARIS/Crypt-DES-2.07.tar.gz";
+      url = "mirror://cpan/authors/id/D/DP/DPARIS/Crypt-DES-${version}.tar.gz";
       hash = "sha256-LbHrtYN7TLIAUcDuW3M7RFPjE33wqSMGA0yGdiHt1+c=";
     };
     patches = [
@@ -6976,11 +6976,11 @@ with self;
     };
   };
 
-  CryptDES_EDE3 = buildPerlPackage {
+  CryptDES_EDE3 = buildPerlPackage rec {
     pname = "Crypt-DES_EDE3";
     version = "0.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BT/BTROTT/Crypt-DES_EDE3-0.01.tar.gz";
+      url = "mirror://cpan/authors/id/B/BT/BTROTT/Crypt-DES_EDE3-${version}.tar.gz";
       hash = "sha256-nLLgS2JenMCDPNSZ92/RJVZYPs7KeCqXWKVeP5aXSNY=";
     };
     propagatedBuildInputs = [ CryptDES ];
@@ -6994,11 +6994,11 @@ with self;
     };
   };
 
-  CryptDH = buildPerlPackage {
+  CryptDH = buildPerlPackage rec {
     pname = "Crypt-DH";
     version = "0.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MITHALDU/Crypt-DH-0.07.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MITHALDU/Crypt-DH-${version}.tar.gz";
       hash = "sha256-yIzzQjsB5nguiYbX/lMEQ2q4SwklxEmMb9+hfvmjf18=";
     };
     propagatedBuildInputs = [ MathBigIntGMP ];
@@ -7011,11 +7011,11 @@ with self;
     };
   };
 
-  CryptDHGMP = buildPerlPackage {
+  CryptDHGMP = buildPerlPackage rec {
     pname = "Crypt-DH-GMP";
     version = "0.00012";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DM/DMAKI/Crypt-DH-GMP-0.00012.tar.gz";
+      url = "mirror://cpan/authors/id/D/DM/DMAKI/Crypt-DH-GMP-${version}.tar.gz";
       hash = "sha256-UeekeuWUz1X2bAdi9mkhVIbn2LNGC9rf55NQzPJtrzg=";
     };
     buildInputs = [
@@ -7034,11 +7034,11 @@ with self;
     };
   };
 
-  CryptDSA = buildPerlPackage {
+  CryptDSA = buildPerlPackage rec {
     pname = "Crypt-DSA";
     version = "1.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AD/ADAMK/Crypt-DSA-1.17.tar.gz";
+      url = "mirror://cpan/authors/id/A/AD/ADAMK/Crypt-DSA-${version}.tar.gz";
       hash = "sha256-0bhYX2v3RvduXcXaNkHTJe1la8Ll80S1RRS1XDEAmgM=";
     };
     propagatedBuildInputs = [
@@ -7056,11 +7056,11 @@ with self;
     };
   };
 
-  CryptECB = buildPerlPackage {
+  CryptECB = buildPerlPackage rec {
     pname = "Crypt-ECB";
     version = "2.22";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AP/APPEL/Crypt-ECB-2.22.tar.gz";
+      url = "mirror://cpan/authors/id/A/AP/APPEL/Crypt-ECB-${version}.tar.gz";
       hash = "sha256-9a9i6QjNMaNLK4ExNaBxgBb9AD/6ACH/vdhMUBWCZ6o=";
     };
     meta = {
@@ -7072,11 +7072,11 @@ with self;
     };
   };
 
-  CryptEksblowfish = buildPerlModule {
+  CryptEksblowfish = buildPerlModule rec {
     pname = "Crypt-Eksblowfish";
     version = "0.009";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Crypt-Eksblowfish-0.009.tar.gz";
+      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Crypt-Eksblowfish-${version}.tar.gz";
       hash = "sha256-PMcSbVhBEHI3qb4txcf7wWfPPEtM40Z4qESLhQdXAUw=";
     };
     propagatedBuildInputs = [ ClassMix ];
@@ -7089,11 +7089,11 @@ with self;
     };
   };
 
-  CryptFormat = buildPerlPackage {
+  CryptFormat = buildPerlPackage rec {
     pname = "Crypt-Format";
     version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FE/FELIPE/Crypt-Format-0.12.tar.gz";
+      url = "mirror://cpan/authors/id/F/FE/FELIPE/Crypt-Format-${version}.tar.gz";
       hash = "sha256-p1cdS+9XeOGln0O2XPLVaAtJ+nu78z89IfRSL0Pmp9o=";
     };
     buildInputs = [
@@ -7110,11 +7110,11 @@ with self;
     };
   };
 
-  CryptHSXKPasswd = buildPerlPackage {
+  CryptHSXKPasswd = buildPerlPackage rec {
     pname = "Crypt-HSXKPasswd";
     version = "3.6";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BA/BARTB/Crypt-HSXKPasswd-v3.6.tar.gz";
+      url = "mirror://cpan/authors/id/B/BA/BARTB/Crypt-HSXKPasswd-v${version}.tar.gz";
       hash = "sha256-lZ3MX58BG/ALha0i31ZrerK/XqHTYrDeD7WuKfvEWLM=";
     };
     propagatedBuildInputs = [
@@ -7144,11 +7144,11 @@ with self;
     doCheck = false;
   };
 
-  CryptIDEA = buildPerlPackage {
+  CryptIDEA = buildPerlPackage rec {
     pname = "Crypt-IDEA";
     version = "1.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DP/DPARIS/Crypt-IDEA-1.10.tar.gz";
+      url = "mirror://cpan/authors/id/D/DP/DPARIS/Crypt-IDEA-${version}.tar.gz";
       hash = "sha256-M714wRkkoPwf8+7d6UB4y79rbKnt4EbSsvVh6emnIBk=";
     };
     meta = {
@@ -7157,11 +7157,11 @@ with self;
     };
   };
 
-  CryptJWT = buildPerlPackage {
+  CryptJWT = buildPerlPackage rec {
     pname = "Crypt-JWT";
     version = "0.035";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIK/Crypt-JWT-0.035.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIK/Crypt-JWT-${version}.tar.gz";
       hash = "sha256-XPvVX63DrtNtZ0/AU6zoZ7XT4aTOiiDPu3wmef3wlkE=";
     };
     propagatedBuildInputs = [
@@ -7177,11 +7177,11 @@ with self;
     };
   };
 
-  CryptPassphrase = buildPerlPackage {
+  CryptPassphrase = buildPerlPackage rec {
     pname = "Crypt-Passphrase";
     version = "0.016";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/Crypt-Passphrase-0.016.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/Crypt-Passphrase-${version}.tar.gz";
       hash = "sha256-TOtPi1SsM/PYHJq0euTPoejDbzhJ76ghcDycMH46T8c=";
     };
     propagatedBuildInputs = [ CryptURandom ];
@@ -7194,11 +7194,11 @@ with self;
     };
   };
 
-  CryptPassphraseArgon2 = buildPerlPackage {
+  CryptPassphraseArgon2 = buildPerlPackage rec {
     pname = "Crypt-Passphrase-Argon2";
     version = "0.009";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/Crypt-Passphrase-Argon2-0.009.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/Crypt-Passphrase-Argon2-${version}.tar.gz";
       hash = "sha256-M39AVZY6EG2bt7tcJvwPSHCGYJ2XKHVgucpEwEPCF1I=";
     };
     propagatedBuildInputs = with perlPackages; [
@@ -7214,11 +7214,11 @@ with self;
     };
   };
 
-  CryptPassphraseBcrypt = buildPerlPackage {
+  CryptPassphraseBcrypt = buildPerlPackage rec {
     pname = "Crypt-Passphrase-Bcrypt";
     version = "0.007";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/Crypt-Passphrase-Bcrypt-0.007.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/Crypt-Passphrase-Bcrypt-${version}.tar.gz";
       hash = "sha256-/k1NHTm9TxODQaJZUFzhE3EnCnZ8nndH90H7dGH9sA8=";
     };
     propagatedBuildInputs = [
@@ -7235,11 +7235,11 @@ with self;
     };
   };
 
-  CryptPasswdMD5 = buildPerlPackage {
+  CryptPasswdMD5 = buildPerlPackage rec {
     pname = "Crypt-PasswdMD5";
     version = "1.42";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RS/RSAVAGE/Crypt-PasswdMD5-1.42.tgz";
+      url = "mirror://cpan/authors/id/R/RS/RSAVAGE/Crypt-PasswdMD5-${version}.tgz";
       hash = "sha256-/Tlubn9E7rkj6TyZOUC49nqa7Vb8dKrK8Dj8QFPvO1k=";
     };
     meta = {
@@ -7251,11 +7251,11 @@ with self;
     };
   };
 
-  CryptPKCS10 = buildPerlModule {
+  CryptPKCS10 = buildPerlModule rec {
     pname = "Crypt-PKCS10";
     version = "2.005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MR/MRSCOTTY/Crypt-PKCS10-2.005.tar.gz";
+      url = "mirror://cpan/authors/id/M/MR/MRSCOTTY/Crypt-PKCS10-${version}.tar.gz";
       hash = "sha256-LdEv0JHCPjp8NKZqw1rDq/kHQCOUtVV0mO3kj8QUU6c=";
     };
     buildInputs = [
@@ -7271,11 +7271,11 @@ with self;
     };
   };
 
-  CryptRandomSeed = buildPerlPackage {
+  CryptRandomSeed = buildPerlPackage rec {
     pname = "Crypt-Random-Seed";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DANAJ/Crypt-Random-Seed-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DANAJ/Crypt-Random-Seed-${version}.tar.gz";
       hash = "sha256-WT2lS1IsCcwmu8wOTknByOaIpv0zsHJq+AHXIqXI0PE=";
     };
     propagatedBuildInputs = [ CryptRandomTESHA2 ];
@@ -7290,11 +7290,11 @@ with self;
     };
   };
 
-  CryptRandom = buildPerlPackage {
+  CryptRandom = buildPerlPackage rec {
     pname = "Crypt-Random";
     version = "1.57";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TI/TIMLEGGE/Crypt-Random-1.57.tar.gz";
+      url = "mirror://cpan/authors/id/T/TI/TIMLEGGE/Crypt-Random-${version}.tar.gz";
       hash = "sha256-lQRnbAzgQRA636cCP4yGHECAYckCljQUwe27LYhydRU=";
     };
     propagatedBuildInputs = [
@@ -7313,11 +7313,11 @@ with self;
     };
   };
 
-  CryptRandomSource = buildPerlModule {
+  CryptRandomSource = buildPerlModule rec {
     pname = "Crypt-Random-Source";
     version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Crypt-Random-Source-0.14.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Crypt-Random-Source-${version}.tar.gz";
       hash = "sha256-7E7OJp+a0ZWMbimOzuLlpDReNX86T/ssdIEWr4du7eY=";
     };
     buildInputs = [
@@ -7342,11 +7342,11 @@ with self;
     };
   };
 
-  CryptRandomTESHA2 = buildPerlPackage {
+  CryptRandomTESHA2 = buildPerlPackage rec {
     pname = "Crypt-Random-TESHA2";
     version = "0.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DANAJ/Crypt-Random-TESHA2-0.01.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DANAJ/Crypt-Random-TESHA2-${version}.tar.gz";
       hash = "sha256-oJErQsUr4XPaUo1VJ+QNlnMkvASseNn8LdyR/xb+ljM=";
     };
     meta = {
@@ -7359,11 +7359,11 @@ with self;
     };
   };
 
-  CryptRC4 = buildPerlPackage {
+  CryptRC4 = buildPerlPackage rec {
     pname = "Crypt-RC4";
     version = "2.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SI/SIFUKURT/Crypt-RC4-2.02.tar.gz";
+      url = "mirror://cpan/authors/id/S/SI/SIFUKURT/Crypt-RC4-${version}.tar.gz";
       hash = "sha256-XsRCXGvCIgeIljC+c1DZlobmKkTGE2lgEQIDzVlK4Oo=";
     };
     meta = {
@@ -7375,11 +7375,11 @@ with self;
     };
   };
 
-  CryptRandPasswd = buildPerlPackage {
+  CryptRandPasswd = buildPerlPackage rec {
     pname = "Crypt-RandPasswd";
     version = "0.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JA/JANITOR/Crypt-RandPasswd-0.07.tar.gz";
+      url = "mirror://cpan/authors/id/J/JA/JANITOR/Crypt-RandPasswd-${version}.tar.gz";
       hash = "sha256-bd26Sdx+DwBRr6oKvhbxN4OiRM0eu1+B2qEay2KKSWE=";
     };
     meta = {
@@ -7391,11 +7391,11 @@ with self;
     };
   };
 
-  CryptRIPEMD160 = buildPerlPackage {
+  CryptRIPEMD160 = buildPerlPackage rec {
     pname = "Crypt-RIPEMD160";
     version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TODDR/Crypt-RIPEMD160-0.08.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TODDR/Crypt-RIPEMD160-${version}.tar.gz";
       hash = "sha256-NNHIdgf2yd76s3QbdtMbzPu21NIBr4Dg9gg8N4EwsjI=";
     };
     meta = {
@@ -7409,11 +7409,11 @@ with self;
     };
   };
 
-  CryptMySQL = buildPerlModule {
+  CryptMySQL = buildPerlModule rec {
     pname = "Crypt-MySQL";
     version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IK/IKEBE/Crypt-MySQL-0.04.tar.gz";
+      url = "mirror://cpan/authors/id/I/IK/IKEBE/Crypt-MySQL-${version}.tar.gz";
       hash = "sha256-k+vfqu/P6atoPwEhyF8kR12Bl/C87EYBghnkERQ03eM=";
     };
     propagatedBuildInputs = [ DigestSHA1 ];
@@ -7426,11 +7426,11 @@ with self;
     };
   };
 
-  CryptRijndael = buildPerlPackage {
+  CryptRijndael = buildPerlPackage rec {
     pname = "Crypt-Rijndael";
     version = "1.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/Crypt-Rijndael-1.16.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/Crypt-Rijndael-${version}.tar.gz";
       hash = "sha256-ZUAIXjgEuCpvB1LBEiz3jK3SIZkBNt1v1MCX0FbITUA=";
     };
     meta = {
@@ -7439,11 +7439,11 @@ with self;
     };
   };
 
-  CryptUnixCryptXS = buildPerlPackage {
+  CryptUnixCryptXS = buildPerlPackage rec {
     pname = "Crypt-UnixCrypt_XS";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BORISZ/Crypt-UnixCrypt_XS-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/B/BO/BORISZ/Crypt-UnixCrypt_XS-${version}.tar.gz";
       hash = "sha256-Yus0EsLJG9TcK4pNnuJtW94usRkycDtu6sR3Pk0fT6o=";
     };
     meta = {
@@ -7455,11 +7455,11 @@ with self;
     };
   };
 
-  CryptURandom = buildPerlPackage {
+  CryptURandom = buildPerlPackage rec {
     pname = "Crypt-URandom";
     version = "0.55";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DD/DDICK/Crypt-URandom-0.55.tar.gz";
+      url = "mirror://cpan/authors/id/D/DD/DDICK/Crypt-URandom-${version}.tar.gz";
       hash = "sha256-759EFBBzwTVz6FsUj/mpCJxFglt9ZgjYMuQmOJnTotQ=";
     };
     meta = {
@@ -7472,11 +7472,11 @@ with self;
     };
   };
 
-  CryptScryptKDF = buildPerlModule {
+  CryptScryptKDF = buildPerlModule rec {
     pname = "Crypt-ScryptKDF";
     version = "0.010";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIK/Crypt-ScryptKDF-0.010.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIK/Crypt-ScryptKDF-${version}.tar.gz";
       hash = "sha256-fRbulczj61TBdGc6cpn0wIb7o6yF+EfQ4TT+7V93YBc=";
     };
     propagatedBuildInputs = [ CryptOpenSSLRandom ];
@@ -7491,11 +7491,11 @@ with self;
     };
   };
 
-  CryptSmbHash = buildPerlPackage {
+  CryptSmbHash = buildPerlPackage rec {
     pname = "Crypt-SmbHash";
     version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BJ/BJKUIT/Crypt-SmbHash-0.12.tar.gz";
+      url = "mirror://cpan/authors/id/B/BJ/BJKUIT/Crypt-SmbHash-${version}.tar.gz";
       hash = "sha256-aMSsfqv6lX3PiUwsI7zsCW+H6M8G3t/Lv3AuVTHbsTc=";
     };
     meta = {
@@ -7504,11 +7504,11 @@ with self;
     };
   };
 
-  CryptSodium = buildPerlPackage {
+  CryptSodium = buildPerlPackage rec {
     pname = "Crypt-Sodium";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MG/MGREGORO/Crypt-Sodium-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/M/MG/MGREGORO/Crypt-Sodium-${version}.tar.gz";
       hash = "sha256-kHxzoQVs6gV9qYGa6kipKreG5qqq858c3ZZHsj8RbHg=";
     };
     env.NIX_CFLAGS_COMPILE = "-I${pkgs.libsodium.dev}/include";
@@ -7524,11 +7524,11 @@ with self;
     };
   };
 
-  CryptSysRandom = buildPerlPackage {
+  CryptSysRandom = buildPerlPackage rec {
     pname = "Crypt-SysRandom";
     version = "0.007";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/Crypt-SysRandom-0.007.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/Crypt-SysRandom-${version}.tar.gz";
       hash = "sha256-pdSemPyjxSZsea6YmoXsoik0sFiAPuSz5usI78pO70Y=";
     };
     meta = {
@@ -7540,11 +7540,11 @@ with self;
     };
   };
 
-  CryptTwofish = buildPerlPackage {
+  CryptTwofish = buildPerlPackage rec {
     pname = "Crypt-Twofish";
     version = "2.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AM/AMS/Crypt-Twofish-2.18.tar.gz";
+      url = "mirror://cpan/authors/id/A/AM/AMS/Crypt-Twofish-${version}.tar.gz";
       hash = "sha256-WIFVXWGHlyojgqoNTbLXTJcLBndMYhtspSNzkjbS1QE=";
     };
     meta = {
@@ -7557,11 +7557,11 @@ with self;
     };
   };
 
-  CryptOpenPGP = buildPerlPackage {
+  CryptOpenPGP = buildPerlPackage rec {
     pname = "Crypt-OpenPGP";
     version = "1.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SR/SROMANOV/Crypt-OpenPGP-1.12.tar.gz";
+      url = "mirror://cpan/authors/id/S/SR/SROMANOV/Crypt-OpenPGP-${version}.tar.gz";
       hash = "sha256-6Kf/Kpk7dqaa1t/9vlV1W+Vni4Tm7ElNzZq5Zvdm9Q4=";
     };
     patches = [
@@ -7596,11 +7596,11 @@ with self;
     };
   };
 
-  CryptOpenSSLAES = buildPerlPackage {
+  CryptOpenSSLAES = buildPerlPackage rec {
     pname = "Crypt-OpenSSL-AES";
     version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TI/TIMLEGGE/Crypt-OpenSSL-AES-0.17.tar.gz";
+      url = "mirror://cpan/authors/id/T/TI/TIMLEGGE/Crypt-OpenSSL-AES-${version}.tar.gz";
       hash = "sha256-7+GBsYxtIqc/LlNWOQ6Fdyes5UY2JeIhHdhgIyvtO7c=";
     };
     buildInputs = [
@@ -7622,11 +7622,11 @@ with self;
     };
   };
 
-  CryptOpenSSLBignum = buildPerlPackage {
+  CryptOpenSSLBignum = buildPerlPackage rec {
     pname = "Crypt-OpenSSL-Bignum";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KM/KMX/Crypt-OpenSSL-Bignum-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/K/KM/KMX/Crypt-OpenSSL-Bignum-${version}.tar.gz";
       hash = "sha256-I05y+4OW1FUn5v1F5DdZxcPzogjPjynmoiFhqZb9Qtw=";
     };
     env.NIX_CFLAGS_COMPILE = "-I${pkgs.openssl.dev}/include";
@@ -7640,11 +7640,11 @@ with self;
     };
   };
 
-  CryptOpenSSLGuess = buildPerlPackage {
+  CryptOpenSSLGuess = buildPerlPackage rec {
     pname = "Crypt-OpenSSL-Guess";
     version = "0.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AK/AKIYM/Crypt-OpenSSL-Guess-0.15.tar.gz";
+      url = "mirror://cpan/authors/id/A/AK/AKIYM/Crypt-OpenSSL-Guess-${version}.tar.gz";
       hash = "sha256-HFAzOBgZ/bTJCH3SkbkOxw54ENMdV+remziOzP1wOG0=";
     };
     meta = {
@@ -7657,11 +7657,11 @@ with self;
     };
   };
 
-  CryptOpenSSLRandom = buildPerlPackage {
+  CryptOpenSSLRandom = buildPerlPackage rec {
     pname = "Crypt-OpenSSL-Random";
     version = "0.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RU/RURBAN/Crypt-OpenSSL-Random-0.15.tar.gz";
+      url = "mirror://cpan/authors/id/R/RU/RURBAN/Crypt-OpenSSL-Random-${version}.tar.gz";
       hash = "sha256-8IdvqhujER45uGqnMMYDIR7/KQXkYMcqV7YejPR1zvQ=";
     };
     env.NIX_CFLAGS_COMPILE = "-I${pkgs.openssl.dev}/include";
@@ -7677,11 +7677,11 @@ with self;
     };
   };
 
-  CryptOpenSSLRSA = buildPerlPackage {
+  CryptOpenSSLRSA = buildPerlPackage rec {
     pname = "Crypt-OpenSSL-RSA";
     version = "0.35";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TODDR/Crypt-OpenSSL-RSA-0.35.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TODDR/Crypt-OpenSSL-RSA-${version}.tar.gz";
       hash = "sha256-XuvVWsBxY0yGSo549c+vuq9Dz4TAQyOgm3Hddr8CXMI=";
     };
     propagatedBuildInputs = [ CryptOpenSSLRandom ];
@@ -7698,11 +7698,11 @@ with self;
     };
   };
 
-  CryptOpenSSLX509 = buildPerlPackage {
+  CryptOpenSSLX509 = buildPerlPackage rec {
     pname = "Crypt-OpenSSL-X509";
     version = "1.915";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JO/JONASBN/Crypt-OpenSSL-X509-1.915.tar.gz";
+      url = "mirror://cpan/authors/id/J/JO/JONASBN/Crypt-OpenSSL-X509-${version}.tar.gz";
       hash = "sha256-xNvBbE/CloV4I3v8MkWH/9eSSacQFQJlLbnjjUSJUX8=";
     };
     env.NIX_CFLAGS_COMPILE = "-I${pkgs.openssl.dev}/include";
@@ -7721,11 +7721,11 @@ with self;
     };
   };
 
-  CryptPBKDF2 = buildPerlPackage {
+  CryptPBKDF2 = buildPerlPackage rec {
     pname = "Crypt-PBKDF2";
     version = "0.161520";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AR/ARODLAND/Crypt-PBKDF2-0.161520.tar.gz";
+      url = "mirror://cpan/authors/id/A/AR/ARODLAND/Crypt-PBKDF2-${version}.tar.gz";
       hash = "sha256-l9+nmjCaCG4YSk5hBH+KEP+z2wUQJefSIqJfGRMLpBc=";
     };
     buildInputs = [ TestFatal ];
@@ -7748,11 +7748,11 @@ with self;
     };
   };
 
-  CryptPerl = buildPerlPackage {
+  CryptPerl = buildPerlPackage rec {
     pname = "Crypt-Perl";
     version = "0.38";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FE/FELIPE/Crypt-Perl-0.38.tar.gz";
+      url = "mirror://cpan/authors/id/F/FE/FELIPE/Crypt-Perl-${version}.tar.gz";
       hash = "sha256-eJdUj7AeFqIK5JDt3UZX+Br3sZKEFLkvbbQsY10ax+A=";
     };
     nativeCheckInputs = [
@@ -7789,11 +7789,11 @@ with self;
     };
   };
 
-  CryptEd25519 = buildPerlPackage {
+  CryptEd25519 = buildPerlPackage rec {
     pname = "Crypt-Ed25519";
     version = "1.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/Crypt-Ed25519-1.05.tar.gz";
+      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/Crypt-Ed25519-${version}.tar.gz";
       hash = "sha256-sdEaWU/rUeQG2BsUfcDRClV8z0yrgcDbP4mBAmd9JKg=";
     };
 
@@ -7807,11 +7807,11 @@ with self;
     };
   };
 
-  CryptSSLeay = buildPerlPackage {
+  CryptSSLeay = buildPerlPackage rec {
     pname = "Crypt-SSLeay";
     version = "0.73_06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NA/NANIS/Crypt-SSLeay-0.73_06.tar.gz";
+      url = "mirror://cpan/authors/id/N/NA/NANIS/Crypt-SSLeay-${version}.tar.gz";
       hash = "sha256-+OzKRch+uRMlmSsT8FlPgI5vG8TDuafxQbmoODhNJSw=";
     };
 
@@ -7830,11 +7830,11 @@ with self;
     };
   };
 
-  CSSDOM = buildPerlPackage {
+  CSSDOM = buildPerlPackage rec {
     pname = "CSS-DOM";
     version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SP/SPROUT/CSS-DOM-0.17.tar.gz";
+      url = "mirror://cpan/authors/id/S/SP/SPROUT/CSS-DOM-${version}.tar.gz";
       hash = "sha256-Zbl46/PDmF5V7jK7baHp+upJSoXTAFxjuux+lphZ8CY=";
     };
 
@@ -7854,11 +7854,11 @@ with self;
     };
   };
 
-  CSSMinifier = buildPerlPackage {
+  CSSMinifier = buildPerlPackage rec {
     pname = "CSS-Minifier";
     version = "0.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PM/PMICHAUX/CSS-Minifier-0.01.tar.gz";
+      url = "mirror://cpan/authors/id/P/PM/PMICHAUX/CSS-Minifier-${version}.tar.gz";
       hash = "sha256-0Kk0m46LfoOrcM+IVM+7Qv8pwfbHyCmPIlfdIaoMf+8=";
     };
     meta = {
@@ -7867,11 +7867,11 @@ with self;
     };
   };
 
-  CSSMinifierXS = buildPerlPackage {
+  CSSMinifierXS = buildPerlPackage rec {
     pname = "CSS-Minifier-XS";
     version = "0.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GT/GTERMARS/CSS-Minifier-XS-0.13.tar.gz";
+      url = "mirror://cpan/authors/id/G/GT/GTERMARS/CSS-Minifier-XS-${version}.tar.gz";
       hash = "sha256-xBnjCM3IKvHCXWuNB7L/JjR6Yit6Y+wghWq+jbQFH4I=";
     };
     buildInputs = [ TestDiagINC ];
@@ -7885,11 +7885,11 @@ with self;
     };
   };
 
-  CSSSquish = buildPerlPackage {
+  CSSSquish = buildPerlPackage rec {
     pname = "CSS-Squish";
     version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TS/TSIBLEY/CSS-Squish-0.10.tar.gz";
+      url = "mirror://cpan/authors/id/T/TS/TSIBLEY/CSS-Squish-${version}.tar.gz";
       hash = "sha256-ZfwNaazR+jPZpMOwnM4PvXN9dHsfzE6dh+vZEFDLy04=";
     };
     buildInputs = [ TestLongString ];
@@ -7903,11 +7903,11 @@ with self;
     };
   };
 
-  Curses = buildPerlPackage {
+  Curses = buildPerlPackage rec {
     pname = "Curses";
     version = "1.44";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GI/GIRAFFED/Curses-1.44.tar.gz";
+      url = "mirror://cpan/authors/id/G/GI/GIRAFFED/Curses-${version}.tar.gz";
       hash = "sha256-ou+4x8iG1pL/xNshNhx2gJoGXliOQ/rQ1n5E751CvTA=";
     };
     preConfigure = ''
@@ -7922,11 +7922,11 @@ with self;
     };
   };
 
-  CursesUI = buildPerlPackage {
+  CursesUI = buildPerlPackage rec {
     pname = "Curses-UI";
     version = "0.9609";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MD/MDXI/Curses-UI-0.9609.tar.gz";
+      url = "mirror://cpan/authors/id/M/MD/MDXI/Curses-UI-${version}.tar.gz";
       hash = "sha256-CrgnpRO24UQDGE+wZajqHS69oSLSF4y/RceB8xEkDq8=";
     };
     propagatedBuildInputs = [
@@ -7942,11 +7942,11 @@ with self;
     };
   };
 
-  CursesUIGrid = buildPerlPackage {
+  CursesUIGrid = buildPerlPackage rec {
     pname = "Curses-UI-Grid";
     version = "0.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AD/ADRIANWIT/Curses-UI-Grid-0.15.tar.gz";
+      url = "mirror://cpan/authors/id/A/AD/ADRIANWIT/Curses-UI-Grid-${version}.tar.gz";
       hash = "sha256-CCDKSp+5SbqPr5evV0AYuu/7aU6YDFCHu2UiqnC52+w=";
     };
     propagatedBuildInputs = [
@@ -7963,11 +7963,11 @@ with self;
     };
   };
 
-  CryptX = buildPerlPackage {
+  CryptX = buildPerlPackage rec {
     pname = "CryptX";
     version = "0.088";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIK/CryptX-0.088.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIK/CryptX-${version}.tar.gz";
       hash = "sha256-kUn4t0JjRWbpgbmUn7fZs/Qa7zbvBOziG1HPNRU8SUA=";
     };
     meta = {
@@ -7979,11 +7979,11 @@ with self;
     };
   };
 
-  CryptX509 = buildPerlPackage {
+  CryptX509 = buildPerlPackage rec {
     pname = "Crypt-X509";
     version = "0.55";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MR/MRSCOTTY/Crypt-X509-0.55.tar.gz";
+      url = "mirror://cpan/authors/id/M/MR/MRSCOTTY/Crypt-X509-${version}.tar.gz";
       hash = "sha256-FHlrEdFfdq10ROeKYZtw/92RMIaN0LANhYV5yTA4Icc=";
     };
     propagatedBuildInputs = [ ConvertASN1 ];
@@ -7996,11 +7996,11 @@ with self;
     };
   };
 
-  CwdGuard = buildPerlModule {
+  CwdGuard = buildPerlModule rec {
     pname = "Cwd-Guard";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KAZEBURO/Cwd-Guard-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/K/KA/KAZEBURO/Cwd-Guard-${version}.tar.gz";
       hash = "sha256-evx8orlQLkQCQZOK2Xo+fr1VAYDr1hQuHbOUGGsmjnc=";
     };
     buildInputs = [ TestRequires ];
@@ -8013,11 +8013,11 @@ with self;
     };
   };
 
-  DataClone = buildPerlPackage {
+  DataClone = buildPerlPackage rec {
     pname = "Data-Clone";
     version = "0.004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GF/GFUJI/Data-Clone-0.004.tar.gz";
+      url = "mirror://cpan/authors/id/G/GF/GFUJI/Data-Clone-${version}.tar.gz";
       hash = "sha256-L+XheYgqa5Jt/vChCLSiyHof+waJK88vuI5Mj0uEODw=";
     };
     buildInputs = [ TestRequires ];
@@ -8033,11 +8033,11 @@ with self;
     };
   };
 
-  DataCompactReadonly = buildPerlPackage {
+  DataCompactReadonly = buildPerlPackage rec {
     pname = "Data-CompactReadonly";
     version = "0.1.0";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/Data-CompactReadonly-0.1.0.tar.gz";
+      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/Data-CompactReadonly-${version}.tar.gz";
       hash = "sha256-fVYJCEz1E7p6d4u1lSNHDoNXdn1ZHL1CxYTgPfO+xug=";
     };
     propagatedBuildInputs = [
@@ -8057,11 +8057,11 @@ with self;
     };
   };
 
-  DataCompare = buildPerlPackage {
+  DataCompare = buildPerlPackage rec {
     pname = "Data-Compare";
     version = "1.29";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/Data-Compare-1.29.tar.gz";
+      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/Data-Compare-${version}.tar.gz";
       hash = "sha256-U8nbO5MmPIiqo8QHLYGere0CTXo2s4wMN3N9KI1a+ow=";
     };
     propagatedBuildInputs = [
@@ -8077,11 +8077,11 @@ with self;
     };
   };
 
-  DataDump = buildPerlPackage {
+  DataDump = buildPerlPackage rec {
     pname = "Data-Dump";
     version = "1.25";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GA/GARU/Data-Dump-1.25.tar.gz";
+      url = "mirror://cpan/authors/id/G/GA/GARU/Data-Dump-${version}.tar.gz";
       hash = "sha256-pKpuDdvznVrUm93+D4nZ2oZOO8APYnEl0bxYBHL1P70=";
     };
     meta = {
@@ -8093,11 +8093,11 @@ with self;
     };
   };
 
-  DataDumperAutoEncode = buildPerlModule {
+  DataDumperAutoEncode = buildPerlModule rec {
     pname = "Data-Dumper-AutoEncode";
     version = "1.00";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BA/BAYASHI/Data-Dumper-AutoEncode-1.00.tar.gz";
+      url = "mirror://cpan/authors/id/B/BA/BAYASHI/Data-Dumper-AutoEncode-${version}.tar.gz";
       hash = "sha256-LZoCYq1EPTIdxInvbfp7Pu0RonCKddOX03G7JYXl7KE=";
     };
     buildInputs = [
@@ -8112,11 +8112,11 @@ with self;
     };
   };
 
-  DataDumperConcise = buildPerlPackage {
+  DataDumperConcise = buildPerlPackage rec {
     pname = "Data-Dumper-Concise";
     version = "2.023";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Data-Dumper-Concise-2.023.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Data-Dumper-Concise-${version}.tar.gz";
       hash = "sha256-psIvETyvMRN1kN7xtwKKfnGO+s4yKCctBnLCXgNdWFM=";
     };
     meta = {
@@ -8128,11 +8128,11 @@ with self;
     };
   };
 
-  DataEntropy = buildPerlPackage {
+  DataEntropy = buildPerlPackage rec {
     pname = "Data-Entropy";
     version = "0.008";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RR/RRWO/Data-Entropy-0.008.tar.gz";
+      url = "mirror://cpan/authors/id/R/RR/RRWO/Data-Entropy-${version}.tar.gz";
       hash = "sha256-GKUrE4boLGuM2zhKOYYdYCIKRCp5DgdwEL5y3YU7Z7M=";
     };
     propagatedBuildInputs = [
@@ -8151,11 +8151,11 @@ with self;
     };
   };
 
-  DataFloat = buildPerlModule {
+  DataFloat = buildPerlModule rec {
     pname = "Data-Float";
     version = "0.013";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Data-Float-0.013.tar.gz";
+      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Data-Float-${version}.tar.gz";
       hash = "sha256-4rFSPYWJMLi729GW8II19eZ4uEkZuodxLiYxO5wnUYo=";
     };
     meta = {
@@ -8167,11 +8167,11 @@ with self;
     };
   };
 
-  DataFormValidator = buildPerlPackage {
+  DataFormValidator = buildPerlPackage rec {
     pname = "Data-FormValidator";
     version = "4.88";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DF/DFARRELL/Data-FormValidator-4.88.tar.gz";
+      url = "mirror://cpan/authors/id/D/DF/DFARRELL/Data-FormValidator-${version}.tar.gz";
       hash = "sha256-waU5+RySy82KjYNZfsmnZD/NjM9alOFTgsN2UokXAGY=";
     };
     propagatedBuildInputs = [
@@ -8192,11 +8192,11 @@ with self;
     };
   };
 
-  DataGUID = buildPerlPackage {
+  DataGUID = buildPerlPackage rec {
     pname = "Data-GUID";
     version = "0.051";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Data-GUID-0.051.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Data-GUID-${version}.tar.gz";
       hash = "sha256-aOp3xz/KiROC8gbhJEkJRQG2+/Llf1SQLVBkInz9ji4=";
     };
     propagatedBuildInputs = [
@@ -8213,11 +8213,11 @@ with self;
     };
   };
 
-  DataHexDump = buildPerlPackage {
+  DataHexDump = buildPerlPackage rec {
     pname = "Data-HexDump";
     version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/Data-HexDump-0.04.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/Data-HexDump-${version}.tar.gz";
       hash = "sha256-vDb0BEOKw2rSuSlVOSJ9Nvmc0WI/HjR693xZTEDMvPg=";
     };
     meta = {
@@ -8232,11 +8232,11 @@ with self;
     };
   };
 
-  DataHexdumper = buildPerlPackage {
+  DataHexdumper = buildPerlPackage rec {
     pname = "Data-Hexdumper";
     version = "3.0001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/Data-Hexdumper-3.0001.tar.gz";
+      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/Data-Hexdumper-${version}.tar.gz";
       hash = "sha256-+SQ8vor/7VBF/k31BXJqenKJRx4wxRrAZbPtbODRpgQ=";
     };
     meta = {
@@ -8248,11 +8248,11 @@ with self;
     };
   };
 
-  DataHierarchy = buildPerlPackage {
+  DataHierarchy = buildPerlPackage rec {
     pname = "Data-Hierarchy";
     version = "0.34";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CL/CLKAO/Data-Hierarchy-0.34.tar.gz";
+      url = "mirror://cpan/authors/id/C/CL/CLKAO/Data-Hierarchy-${version}.tar.gz";
       hash = "sha256-s6jmK1Pin3HdWYmu75n7+vH0tuJyoGgAOBNg1Z6f2e0=";
     };
     buildInputs = [ TestException ];
@@ -8265,11 +8265,11 @@ with self;
     };
   };
 
-  DataICal = buildPerlPackage {
+  DataICal = buildPerlPackage rec {
     pname = "Data-ICal";
     version = "0.24";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BP/BPS/Data-ICal-0.24.tar.gz";
+      url = "mirror://cpan/authors/id/B/BP/BPS/Data-ICal-${version}.tar.gz";
       hash = "sha256-czHHyEiGxTM3wNuCNhXg5xNKjxPv0oTlwgcm1bzVLf8=";
     };
     buildInputs = [
@@ -8290,11 +8290,11 @@ with self;
     };
   };
 
-  DataIEEE754 = buildPerlPackage {
+  DataIEEE754 = buildPerlPackage rec {
     pname = "Data-IEEE754";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MAXMIND/Data-IEEE754-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MAXMIND/Data-IEEE754-${version}.tar.gz";
       hash = "sha256-xvSrE0ZygjQTtQ8HR5saGwUfTO5C3Tzn6xWD1mkbZx0=";
     };
     buildInputs = [ TestBits ];
@@ -8305,11 +8305,11 @@ with self;
     };
   };
 
-  DataInteger = buildPerlModule {
+  DataInteger = buildPerlModule rec {
     pname = "Data-Integer";
     version = "0.006";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Data-Integer-0.006.tar.gz";
+      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Data-Integer-${version}.tar.gz";
       hash = "sha256-Y7d+3jtjnONRUlA0hjYpr5iavL/0qwOxT8Tq1GH/o1Q=";
     };
     meta = {
@@ -8321,11 +8321,11 @@ with self;
     };
   };
 
-  DataMessagePack = buildPerlModule {
+  DataMessagePack = buildPerlModule rec {
     pname = "Data-MessagePack";
     version = "1.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SY/SYOHEX/Data-MessagePack-1.02.tar.gz";
+      url = "mirror://cpan/authors/id/S/SY/SYOHEX/Data-MessagePack-${version}.tar.gz";
       hash = "sha256-wz20R5CqjSVBR4guI3jf/pcK1gMxNQveBi0XlTSCsbc=";
     };
     buildInputs = [
@@ -8343,11 +8343,11 @@ with self;
     };
   };
 
-  DataOptList = buildPerlPackage {
+  DataOptList = buildPerlPackage rec {
     pname = "Data-OptList";
     version = "0.114";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Data-OptList-0.114.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Data-OptList-${version}.tar.gz";
       hash = "sha256-n9EJO5F6Ift5rhYH21PRE7TgrY/grndssHen5QBE/fM=";
     };
     propagatedBuildInputs = [
@@ -8364,11 +8364,11 @@ with self;
     };
   };
 
-  DataPage = buildPerlPackage {
+  DataPage = buildPerlPackage rec {
     pname = "Data-Page";
     version = "2.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Data-Page-2.03.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Data-Page-${version}.tar.gz";
       hash = "sha256-LvpSFn0ferNZAs8yrgJ3amI3BdeRnUEYmBKHsETOPYs=";
     };
     propagatedBuildInputs = [ ClassAccessorChained ];
@@ -8382,11 +8382,11 @@ with self;
     };
   };
 
-  DataPagePageset = buildPerlModule {
+  DataPagePageset = buildPerlModule rec {
     pname = "Data-Page-Pageset";
     version = "1.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHUNZI/Data-Page-Pageset-1.02.tar.gz";
+      url = "mirror://cpan/authors/id/C/CH/CHUNZI/Data-Page-Pageset-${version}.tar.gz";
       hash = "sha256-zqwbtVQ+I9qyUZUTxibj/+ZaF3uOHtnlagMNRVHUUZA=";
     };
     buildInputs = [
@@ -8403,11 +8403,11 @@ with self;
     };
   };
 
-  DataPassword = buildPerlPackage {
+  DataPassword = buildPerlPackage rec {
     pname = "Data-Password";
     version = "1.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RA/RAZINF/Data-Password-1.12.tar.gz";
+      url = "mirror://cpan/authors/id/R/RA/RAZINF/Data-Password-${version}.tar.gz";
       hash = "sha256-gwzegXQf84Q4VBLhb6ulV0WlSnzAGd0j1+1PBdVRqWE=";
     };
     meta = {
@@ -8419,11 +8419,11 @@ with self;
     };
   };
 
-  DataPerl = buildPerlPackage {
+  DataPerl = buildPerlPackage rec {
     pname = "Data-Perl";
     version = "0.002011";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOBYINK/Data-Perl-0.002011.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TOBYINK/Data-Perl-${version}.tar.gz";
       hash = "sha256-jTTb4xTPotmb2arlRrvelMOLsFt0sHyJveFnOm9sVfQ=";
     };
     buildInputs = [
@@ -8448,11 +8448,11 @@ with self;
     };
   };
 
-  DataPrinter = buildPerlPackage {
+  DataPrinter = buildPerlPackage rec {
     pname = "Data-Printer";
     version = "1.001001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GA/GARU/Data-Printer-1.001001.tar.gz";
+      url = "mirror://cpan/authors/id/G/GA/GARU/Data-Printer-${version}.tar.gz";
       hash = "sha256-q64DMVUU0rcxxkYrjwZ2SN2ZChA1SyFgbHeM/ZHUe4A=";
     };
     propagatedBuildInputs = [
@@ -8470,11 +8470,11 @@ with self;
     };
   };
 
-  DataRandom = buildPerlPackage {
+  DataRandom = buildPerlPackage rec {
     pname = "Data-Random";
     version = "0.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BA/BAREFOOT/Data-Random-0.13.tar.gz";
+      url = "mirror://cpan/authors/id/B/BA/BAREFOOT/Data-Random-${version}.tar.gz";
       hash = "sha256-61kBhKjbKKfknqsJ4l+GUMM/H2aLakcoKd50pTJWv8A=";
     };
     buildInputs = [
@@ -8490,11 +8490,11 @@ with self;
     };
   };
 
-  DataSection = buildPerlPackage {
+  DataSection = buildPerlPackage rec {
     pname = "Data-Section";
     version = "0.200008";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Data-Section-0.200008.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Data-Section-${version}.tar.gz";
       hash = "sha256-g6zHpV091+026deNNQrzE4xpz6F4pEdlgicS/0M7mQ4=";
     };
     propagatedBuildInputs = [
@@ -8512,11 +8512,11 @@ with self;
     };
   };
 
-  DataSectionSimple = buildPerlPackage {
+  DataSectionSimple = buildPerlPackage rec {
     pname = "Data-Section-Simple";
     version = "0.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Data-Section-Simple-0.07.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Data-Section-Simple-${version}.tar.gz";
       hash = "sha256-CzA1/9uQmqH33ta2CPqdiUQhyCwJfVHnFxFw1nV5qcs=";
     };
     buildInputs = [ TestRequires ];
@@ -8530,11 +8530,11 @@ with self;
     };
   };
 
-  DataSerializer = buildPerlModule {
+  DataSerializer = buildPerlModule rec {
     pname = "Data-Serializer";
     version = "0.65";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEELY/Data-Serializer-0.65.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEELY/Data-Serializer-${version}.tar.gz";
       hash = "sha256-EhVaUgADPYCl8HVzd19JPxcAcs97KK48otFStZGXHxE=";
     };
     meta = {
@@ -8547,11 +8547,11 @@ with self;
     };
   };
 
-  DataSExpression = buildPerlPackage {
+  DataSExpression = buildPerlPackage rec {
     pname = "Data-SExpression";
     version = "0.41";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NELHAGE/Data-SExpression-0.41.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NELHAGE/Data-SExpression-${version}.tar.gz";
       hash = "sha256-gWJCakKFoJQ4X9+vbQnO0QbVr1dVP5U6yx1Whn3QFJs=";
     };
     buildInputs = [ TestDeep ];
@@ -8565,11 +8565,11 @@ with self;
     };
   };
 
-  DataSpreadPagination = buildPerlPackage {
+  DataSpreadPagination = buildPerlPackage rec {
     pname = "Data-SpreadPagination";
     version = "0.1.2";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KN/KNEW/Data-SpreadPagination-0.1.2.tar.gz";
+      url = "mirror://cpan/authors/id/K/KN/KNEW/Data-SpreadPagination-${version}.tar.gz";
       hash = "sha256-dOv9hHEyw4zJ6DXhToLEPxgJqVy8mLuE0ffOLk70h+M=";
     };
     propagatedBuildInputs = [
@@ -8585,11 +8585,11 @@ with self;
     };
   };
 
-  DataStag = buildPerlPackage {
+  DataStag = buildPerlPackage rec {
     pname = "Data-Stag";
     version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CM/CMUNGALL/Data-Stag-0.14.tar.gz";
+      url = "mirror://cpan/authors/id/C/CM/CMUNGALL/Data-Stag-${version}.tar.gz";
       hash = "sha256-SrEiUI0vuG0XGhX0AG5c+JbV+s+mUhnAskOomQYljlk=";
     };
     propagatedBuildInputs = [ IOString ];
@@ -8602,11 +8602,11 @@ with self;
     };
   };
 
-  DataStreamBulk = buildPerlPackage {
+  DataStreamBulk = buildPerlPackage rec {
     pname = "Data-Stream-Bulk";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DO/DOY/Data-Stream-Bulk-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/D/DO/DOY/Data-Stream-Bulk-${version}.tar.gz";
       hash = "sha256-BuCEMqa5dwVgbJJXCbmRKa2SZRbkd9WORGHks9nzCRc=";
     };
     buildInputs = [ TestRequires ];
@@ -8625,11 +8625,11 @@ with self;
     };
   };
 
-  DataStructureUtil = buildPerlPackage {
+  DataStructureUtil = buildPerlPackage rec {
     pname = "Data-Structure-Util";
     version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AN/ANDYA/Data-Structure-Util-0.16.tar.gz";
+      url = "mirror://cpan/authors/id/A/AN/ANDYA/Data-Structure-Util-${version}.tar.gz";
       hash = "sha256-nNQqE+ZcsV86diluuaE02iIBaOx0fFaNMxpQrnot28Y=";
     };
     buildInputs = [ TestPod ];
@@ -8642,11 +8642,11 @@ with self;
     };
   };
 
-  DataTaxi = buildPerlPackage {
+  DataTaxi = buildPerlPackage rec {
     pname = "Data-Taxi";
     version = "0.96";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIKO/Data-Taxi-0.96.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIKO/Data-Taxi-${version}.tar.gz";
       hash = "sha256-q8s2EPygbZodmRaraYB0OmHYWvVfn9N2vqZxKommnHg=";
     };
     buildInputs = [ DebugShowStuff ];
@@ -8659,11 +8659,11 @@ with self;
     };
   };
 
-  DataULID = buildPerlPackage {
+  DataULID = buildPerlPackage rec {
     pname = "Data-ULID";
     version = "1.2.1";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BA/BALDUR/Data-ULID-1.2.1.tar.gz";
+      url = "mirror://cpan/authors/id/B/BA/BALDUR/Data-ULID-${version}.tar.gz";
       hash = "sha256-SbThGyY0inXfNONGF0UuMZ/XpygasJQgYvFieeqKHSc=";
     };
     propagatedBuildInputs = [ CryptX ];
@@ -8678,11 +8678,11 @@ with self;
     };
   };
 
-  DataUniqid = buildPerlPackage {
+  DataUniqid = buildPerlPackage rec {
     pname = "Data-Uniqid";
     version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MW/MWX/Data-Uniqid-0.12.tar.gz";
+      url = "mirror://cpan/authors/id/M/MW/MWX/Data-Uniqid-${version}.tar.gz";
       hash = "sha256-tpGbpJuf6Yv98+isyue5t/eNyeceu9C3/vekXZkyTMs=";
     };
     meta = {
@@ -8694,11 +8694,11 @@ with self;
     };
   };
 
-  DataUtil = buildPerlModule {
+  DataUtil = buildPerlModule rec {
     pname = "Data-Util";
     version = "0.67";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SY/SYOHEX/Data-Util-0.67.tar.gz";
+      url = "mirror://cpan/authors/id/S/SY/SYOHEX/Data-Util-${version}.tar.gz";
       hash = "sha256-tVypHHafgTN8xrCrIMMmg4eOWyZj8cwljFEamZpd/dM=";
     };
     buildInputs = [
@@ -8717,11 +8717,11 @@ with self;
     };
   };
 
-  DataURIEncode = buildPerlPackage {
+  DataURIEncode = buildPerlPackage rec {
     pname = "Data-URIEncode";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RH/RHANDOM/Data-URIEncode-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/R/RH/RHANDOM/Data-URIEncode-${version}.tar.gz";
       hash = "sha256-Ucnvv4QjhTYW6qJIQeTRmWstsANpAGF/sdvHbHWh82A=";
     };
     meta = {
@@ -8733,11 +8733,11 @@ with self;
     };
   };
 
-  DataUUID = buildPerlPackage {
+  DataUUID = buildPerlPackage rec {
     pname = "Data-UUID";
     version = "1.226";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Data-UUID-1.226.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Data-UUID-${version}.tar.gz";
       hash = "sha256-CT1X/6DUEalLr6+uSVaX2yb1ydAncZj+P3zyviKZZFM=";
     };
     patches = [
@@ -8749,11 +8749,11 @@ with self;
     };
   };
 
-  DataUUIDMT = buildPerlPackage {
+  DataUUIDMT = buildPerlPackage rec {
     pname = "Data-UUID-MT";
     version = "1.001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Data-UUID-MT-1.001.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Data-UUID-MT-${version}.tar.gz";
       hash = "sha256-MExLmBKDEfhLf1KccBi6hJx102Q6qA6jgrSwgFfEZy0=";
     };
     buildInputs = [ ListAllUtils ];
@@ -8765,11 +8765,11 @@ with self;
     };
   };
 
-  DataValidateDomain = buildPerlPackage {
+  DataValidateDomain = buildPerlPackage rec {
     pname = "Data-Validate-Domain";
     version = "0.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Data-Validate-Domain-0.15.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Data-Validate-Domain-${version}.tar.gz";
       hash = "sha256-PJ95GHsNPHGt0fj1WbgN8VmTAKbSA+CxYcvhjhdqqzY=";
     };
     buildInputs = [ Test2Suite ];
@@ -8784,11 +8784,11 @@ with self;
     };
   };
 
-  DataValidateIP = buildPerlPackage {
+  DataValidateIP = buildPerlPackage rec {
     pname = "Data-Validate-IP";
     version = "0.31";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Data-Validate-IP-0.31.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Data-Validate-IP-${version}.tar.gz";
       hash = "sha256-c0r/hrb5ytQOHE2oHyj68Y4IAsdqVm2V5WE9QxgYL8E=";
     };
     buildInputs = [ TestRequires ];
@@ -8803,11 +8803,11 @@ with self;
     };
   };
 
-  DataValidateURI = buildPerlPackage {
+  DataValidateURI = buildPerlPackage rec {
     pname = "Data-Validate-URI";
     version = "0.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SO/SONNEN/Data-Validate-URI-0.07.tar.gz";
+      url = "mirror://cpan/authors/id/S/SO/SONNEN/Data-Validate-URI-${version}.tar.gz";
       hash = "sha256-8GQY0qRgORPRts5SsWfdE+eH4TvyvjJaBl331Aj3nGA=";
     };
     propagatedBuildInputs = [
@@ -8823,11 +8823,11 @@ with self;
     };
   };
 
-  DataVisitor = buildPerlPackage {
+  DataVisitor = buildPerlPackage rec {
     pname = "Data-Visitor";
     version = "0.32";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Data-Visitor-0.32.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Data-Visitor-${version}.tar.gz";
       hash = "sha256-sZQpDyV8xidaA5N0ERVUxmahZQ5MAa15nB4KJ39HkX0=";
     };
     buildInputs = [ TestNeeds ];
@@ -8845,11 +8845,11 @@ with self;
     };
   };
 
-  DateCalc = buildPerlPackage {
+  DateCalc = buildPerlPackage rec {
     pname = "Date-Calc";
     version = "6.4";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/ST/STBEY/Date-Calc-6.4.tar.gz";
+      url = "mirror://cpan/authors/id/S/ST/STBEY/Date-Calc-${version}.tar.gz";
       hash = "sha256-fOE3sueXt8CQHzrfGgWhk0M1bNHwRnaqHFap9iT4Wa0=";
     };
     propagatedBuildInputs = [ BitVector ];
@@ -8863,11 +8863,11 @@ with self;
     };
   };
 
-  DateExtract = buildPerlPackage {
+  DateExtract = buildPerlPackage rec {
     pname = "Date-Extract";
     version = "0.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Date-Extract-0.07.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Date-Extract-${version}.tar.gz";
       hash = "sha256-+geIBK3k7uwd4UcuDguwR65i5MjU1QIHAbnlBXfFuPQ=";
     };
     buildInputs = [ TestMockTimeHiRes ];
@@ -8884,11 +8884,11 @@ with self;
     };
   };
 
-  DateManip = buildPerlPackage {
+  DateManip = buildPerlPackage rec {
     pname = "Date-Manip";
     version = "6.98";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SB/SBECK/Date-Manip-6.98.tar.gz";
+      url = "mirror://cpan/authors/id/S/SB/SBECK/Date-Manip-${version}.tar.gz";
       hash = "sha256-rP2KYFGbpM0YHIpnqD1/ApxtmrTosCEtxH5B1iEP2kk=";
     };
     # for some reason, parsing /etc/localtime does not work anymore - make sure that the fallback "/bin/date +%Z" will work
@@ -8907,11 +8907,11 @@ with self;
     };
   };
 
-  DateRange = buildPerlPackage {
+  DateRange = buildPerlPackage rec {
     pname = "Date-Range";
     version = "1.41";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TM/TMTM/Date-Range-1.41.tar.gz";
+      url = "mirror://cpan/authors/id/T/TM/TMTM/Date-Range-${version}.tar.gz";
       hash = "sha256-v5iXSSsQHAUDh50Up+fr6QJUQ4NgGufGmpXedcvZSLk=";
     };
     propagatedBuildInputs = [ DateSimple ];
@@ -8921,11 +8921,11 @@ with self;
     };
   };
 
-  DateSimple = buildPerlPackage {
+  DateSimple = buildPerlPackage rec {
     pname = "Date-Simple";
     version = "3.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IZ/IZUT/Date-Simple-3.03.tar.gz";
+      url = "mirror://cpan/authors/id/I/IZ/IZUT/Date-Simple-${version}.tar.gz";
       hash = "sha256-KaGSYxTOFoGjEtYVXClZDHcd2s+Rt0hYc85EnvIJ3QQ=";
     };
     meta = {
@@ -8937,11 +8937,11 @@ with self;
     };
   };
 
-  DateTime = buildPerlPackage {
+  DateTime = buildPerlPackage rec {
     pname = "DateTime";
     version = "1.59";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/DateTime-1.59.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/DateTime-${version}.tar.gz";
       hash = "sha256-3j6aY84VRwtNtK2tS6asjsKX2IwMbGs1SwgYg7CmdpU=";
     };
     buildInputs = [
@@ -8961,11 +8961,11 @@ with self;
     };
   };
 
-  DateTimeCalendarJulian = buildPerlPackage {
+  DateTimeCalendarJulian = buildPerlPackage rec {
     pname = "DateTime-Calendar-Julian";
     version = "0.107";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/W/WY/WYANT/DateTime-Calendar-Julian-0.107.tar.gz";
+      url = "mirror://cpan/authors/id/W/WY/WYANT/DateTime-Calendar-Julian-${version}.tar.gz";
       hash = "sha256-/LK0JIRLsTvK1GsceqI5taCbqyVW9TvR8n+tkMJg0z0=";
     };
     propagatedBuildInputs = [ DateTime ];
@@ -8978,11 +8978,11 @@ with self;
     };
   };
 
-  DateTimeEventICal = buildPerlPackage {
+  DateTimeEventICal = buildPerlPackage rec {
     pname = "DateTime-Event-ICal";
     version = "0.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FG/FGLOCK/DateTime-Event-ICal-0.13.tar.gz";
+      url = "mirror://cpan/authors/id/F/FG/FGLOCK/DateTime-Event-ICal-${version}.tar.gz";
       hash = "sha256-U9pDhO9c8w7ofcATH0tu7iEhzA66NHFioyi5vPr0deo=";
     };
     propagatedBuildInputs = [ DateTimeEventRecurrence ];
@@ -8995,11 +8995,11 @@ with self;
     };
   };
 
-  DateTimeEventRecurrence = buildPerlPackage {
+  DateTimeEventRecurrence = buildPerlPackage rec {
     pname = "DateTime-Event-Recurrence";
     version = "0.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FG/FGLOCK/DateTime-Event-Recurrence-0.19.tar.gz";
+      url = "mirror://cpan/authors/id/F/FG/FGLOCK/DateTime-Event-Recurrence-${version}.tar.gz";
       hash = "sha256-+UCHiaRhEHdmyhojK7PsHnAu7HyoFnQB6m7D9LbQtaU=";
     };
     propagatedBuildInputs = [ DateTimeSet ];
@@ -9012,11 +9012,11 @@ with self;
     };
   };
 
-  DateTimeFormatBuilder = buildPerlPackage {
+  DateTimeFormatBuilder = buildPerlPackage rec {
     pname = "DateTime-Format-Builder";
     version = "0.83";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/DateTime-Format-Builder-0.83.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/DateTime-Format-Builder-${version}.tar.gz";
       hash = "sha256-Yf+yPYWzyheGstoyiembV+BiX+DknbAqbcDLYsaJ4vI=";
     };
     propagatedBuildInputs = [
@@ -9030,11 +9030,11 @@ with self;
     };
   };
 
-  DateTimeFormatDateParse = buildPerlModule {
+  DateTimeFormatDateParse = buildPerlModule rec {
     pname = "DateTime-Format-DateParse";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JH/JHOBLITT/DateTime-Format-DateParse-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/J/JH/JHOBLITT/DateTime-Format-DateParse-${version}.tar.gz";
       hash = "sha256-9uykyL5mzpmS7hUJMvj88HgJ/T0WZMryALil/Tp+Xrw=";
     };
     propagatedBuildInputs = [
@@ -9050,11 +9050,11 @@ with self;
     };
   };
 
-  DateTimeFormatFlexible = buildPerlPackage {
+  DateTimeFormatFlexible = buildPerlPackage rec {
     pname = "DateTime-Format-Flexible";
     version = "0.34";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TH/THINC/DateTime-Format-Flexible-0.34.tar.gz";
+      url = "mirror://cpan/authors/id/T/TH/THINC/DateTime-Format-Flexible-${version}.tar.gz";
       hash = "sha256-g2rvXSXm/4gnMIpDv/dBkeXSAiDao9ISAFC8w0FI/PE=";
     };
     propagatedBuildInputs = [
@@ -9076,11 +9076,11 @@ with self;
     };
   };
 
-  DateTimeFormatHTTP = buildPerlModule {
+  DateTimeFormatHTTP = buildPerlModule rec {
     pname = "DateTime-Format-HTTP";
     version = "0.42";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CK/CKRAS/DateTime-Format-HTTP-0.42.tar.gz";
+      url = "mirror://cpan/authors/id/C/CK/CKRAS/DateTime-Format-HTTP-${version}.tar.gz";
       hash = "sha256-0E52nfRZaN/S0b3GR6Mlxod2FAaXYnhubxN/H17D2EA=";
     };
     propagatedBuildInputs = [
@@ -9096,11 +9096,11 @@ with self;
     };
   };
 
-  DateTimeFormatICal = buildPerlModule {
+  DateTimeFormatICal = buildPerlModule rec {
     pname = "DateTime-Format-ICal";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/DateTime-Format-ICal-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/DateTime-Format-ICal-${version}.tar.gz";
       hash = "sha256-iwn2U59enA3w5hNQMWme1O+e74Fl/ICu/uzIF++ZfDM=";
     };
     propagatedBuildInputs = [ DateTimeEventICal ];
@@ -9113,11 +9113,11 @@ with self;
     };
   };
 
-  DateTimeFormatISO8601 = buildPerlPackage {
+  DateTimeFormatISO8601 = buildPerlPackage rec {
     pname = "DateTime-Format-ISO8601";
     version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/DateTime-Format-ISO8601-0.16.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/DateTime-Format-ISO8601-${version}.tar.gz";
       hash = "sha256-WChH9uApBlM0oAVk8gzXwo9OXNTsIVE9D2klMe07VuE=";
     };
     propagatedBuildInputs = [ DateTimeFormatBuilder ];
@@ -9132,11 +9132,11 @@ with self;
     };
   };
 
-  DateTimeFormatMail = buildPerlPackage {
+  DateTimeFormatMail = buildPerlPackage rec {
     pname = "DateTime-Format-Mail";
     version = "0.403";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOOK/DateTime-Format-Mail-0.403.tar.gz";
+      url = "mirror://cpan/authors/id/B/BO/BOOK/DateTime-Format-Mail-${version}.tar.gz";
       hash = "sha256-jfjjXER3OI/1x86LPotq5O0wIJx6UFHUFze9FNdV/LA=";
     };
     propagatedBuildInputs = [
@@ -9152,11 +9152,11 @@ with self;
     };
   };
 
-  DateTimeFormatNatural = buildPerlModule {
+  DateTimeFormatNatural = buildPerlModule rec {
     pname = "DateTime-Format-Natural";
     version = "1.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SC/SCHUBIGER/DateTime-Format-Natural-1.18.tar.gz";
+      url = "mirror://cpan/authors/id/S/SC/SCHUBIGER/DateTime-Format-Natural-${version}.tar.gz";
       hash = "sha256-2TRqRhUDVFnYvO4PrD1OuuoDj09DsoT2nt9z9u1XUf4=";
     };
     buildInputs = [
@@ -9182,11 +9182,11 @@ with self;
     };
   };
 
-  DateTimeFormatMySQL = buildPerlModule {
+  DateTimeFormatMySQL = buildPerlModule rec {
     pname = "DateTime-Format-MySQL";
     version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XM/XMIKEW/DateTime-Format-MySQL-0.08.tar.gz";
+      url = "mirror://cpan/authors/id/X/XM/XMIKEW/DateTime-Format-MySQL-${version}.tar.gz";
       hash = "sha256-Gctw6YWEZV41TS1qjnHMXKkC3dw6xEQWcS+RY9Eiueg=";
     };
     propagatedBuildInputs = [ DateTimeFormatBuilder ];
@@ -9199,11 +9199,11 @@ with self;
     };
   };
 
-  DateTimeFormatPg = buildPerlModule {
+  DateTimeFormatPg = buildPerlModule rec {
     pname = "DateTime-Format-Pg";
     version = "0.16014";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DM/DMAKI/DateTime-Format-Pg-0.16014.tar.gz";
+      url = "mirror://cpan/authors/id/D/DM/DMAKI/DateTime-Format-Pg-${version}.tar.gz";
       hash = "sha256-OLuWZlJNw4TDNm9jQsuWVsULrA+XFqPUTxz1Usy+Drk=";
     };
     propagatedBuildInputs = [ DateTimeFormatBuilder ];
@@ -9218,11 +9218,11 @@ with self;
     };
   };
 
-  DateTimeFormatStrptime = buildPerlPackage {
+  DateTimeFormatStrptime = buildPerlPackage rec {
     pname = "DateTime-Format-Strptime";
     version = "1.79";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/DateTime-Format-Strptime-1.79.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/DateTime-Format-Strptime-${version}.tar.gz";
       hash = "sha256-cB5GgCyG7U2IaVwabay76QszkL7reU84fnx5IwADdXk=";
     };
     buildInputs = [
@@ -9237,11 +9237,11 @@ with self;
     };
   };
 
-  DateTimeFormatSQLite = buildPerlPackage {
+  DateTimeFormatSQLite = buildPerlPackage rec {
     pname = "DateTime-Format-SQLite";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CF/CFAERBER/DateTime-Format-SQLite-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/C/CF/CFAERBER/DateTime-Format-SQLite-${version}.tar.gz";
       hash = "sha256-zB9OCuHTmw1MPd3M/XQjx3xnpwlQxLXsq/jKVTqylLQ=";
     };
     propagatedBuildInputs = [ DateTimeFormatBuilder ];
@@ -9254,11 +9254,11 @@ with self;
     };
   };
 
-  DateTimeFormatW3CDTF = buildPerlPackage {
+  DateTimeFormatW3CDTF = buildPerlPackage rec {
     pname = "DateTime-Format-W3CDTF";
     version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GW/GWILLIAMS/DateTime-Format-W3CDTF-0.08.tar.gz";
+      url = "mirror://cpan/authors/id/G/GW/GWILLIAMS/DateTime-Format-W3CDTF-${version}.tar.gz";
       hash = "sha256-3MIAoHOiHLpIEipdrgtqh135PT+MiunURtzdm++qQTo=";
     };
     propagatedBuildInputs = [ DateTime ];
@@ -9272,11 +9272,11 @@ with self;
     };
   };
 
-  DateTimeHiRes = buildPerlPackage {
+  DateTimeHiRes = buildPerlPackage rec {
     pname = "DateTime-HiRes";
     version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/DateTime-HiRes-0.04.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/DateTime-HiRes-${version}.tar.gz";
       hash = "sha256-HCMVkzLDD566VLdeZpK+TeqAUiQ+r/MCbJyQuLZLw5U=";
     };
     propagatedBuildInputs = [ DateTime ];
@@ -9290,11 +9290,11 @@ with self;
     };
   };
 
-  DateTimeLocale = buildPerlPackage {
+  DateTimeLocale = buildPerlPackage rec {
     pname = "DateTime-Locale";
     version = "1.39";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/DateTime-Locale-1.39.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/DateTime-Locale-${version}.tar.gz";
       hash = "sha256-EMFFpsfa9xGIZOl0grSun5T5O5QUIS7uiqMLFqgTUQA=";
     };
     buildInputs = [
@@ -9337,11 +9337,11 @@ with self;
     };
   };
 
-  DateTimeSet = buildPerlModule {
+  DateTimeSet = buildPerlModule rec {
     pname = "DateTime-Set";
     version = "0.3900";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FG/FGLOCK/DateTime-Set-0.3900.tar.gz";
+      url = "mirror://cpan/authors/id/F/FG/FGLOCK/DateTime-Set-${version}.tar.gz";
       hash = "sha256-lPQcOSSq/eTvf6a1jgWV1AONisX/1iuhEbE8X028CUY=";
     };
     propagatedBuildInputs = [
@@ -9358,11 +9358,11 @@ with self;
     };
   };
 
-  DateTimeTimeZone = buildPerlPackage {
+  DateTimeTimeZone = buildPerlPackage rec {
     pname = "DateTime-TimeZone";
     version = "2.60";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/DateTime-TimeZone-2.60.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/DateTime-TimeZone-${version}.tar.gz";
       hash = "sha256-8EYNN5MjkFtXm+1E4UEjejN9wl3Sa2qwxgrCuAYpMj0=";
     };
     buildInputs = [
@@ -9385,11 +9385,11 @@ with self;
     };
   };
 
-  DateTimeXEasy = buildPerlPackage {
+  DateTimeXEasy = buildPerlPackage rec {
     pname = "DateTimeX-Easy";
     version = "0.091";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JJ/JJNAPIORK/DateTimeX-Easy-0.091.tar.gz";
+      url = "mirror://cpan/authors/id/J/JJ/JJNAPIORK/DateTimeX-Easy-${version}.tar.gz";
       hash = "sha256-pfjbvntpZdUD4VJYIBXaKk+B46WGA9/t1Oc9H92s/II=";
     };
     buildInputs = [ TestMost ];
@@ -9409,11 +9409,11 @@ with self;
     };
   };
 
-  DebugShowStuff = buildPerlModule {
+  DebugShowStuff = buildPerlModule rec {
     pname = "Debug-ShowStuff";
     version = "1.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIKO/Debug-ShowStuff-1.16.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIKO/Debug-ShowStuff-${version}.tar.gz";
       hash = "sha256-pN1dLNfbjqbkhhsZPgJLQYeisO0rmdWHBi37EaXNLLc=";
     };
     propagatedBuildInputs = [
@@ -9455,11 +9455,11 @@ with self;
     };
   };
 
-  DevelCaller = buildPerlPackage {
+  DevelCaller = buildPerlPackage rec {
     pname = "Devel-Caller";
     version = "2.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RC/RCLAMP/Devel-Caller-2.07.tar.gz";
+      url = "mirror://cpan/authors/id/R/RC/RCLAMP/Devel-Caller-${version}.tar.gz";
       hash = "sha256-tnmisYA0sLcg3oLDcIckw2SxCmyhZMvGfNw68oPzUD8=";
     };
     propagatedBuildInputs = [ PadWalker ];
@@ -9472,11 +9472,11 @@ with self;
     };
   };
 
-  DevelCheckBin = buildPerlPackage {
+  DevelCheckBin = buildPerlPackage rec {
     pname = "Devel-CheckBin";
     version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOKUHIROM/Devel-CheckBin-0.04.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TOKUHIROM/Devel-CheckBin-${version}.tar.gz";
       hash = "sha256-FX89tZwp7R1JEzpGnO53LIha1O5k6GkqkbPr/b4v4+Q=";
     };
     meta = {
@@ -9489,11 +9489,11 @@ with self;
     };
   };
 
-  DevelCheckCompiler = buildPerlModule {
+  DevelCheckCompiler = buildPerlModule rec {
     pname = "Devel-CheckCompiler";
     version = "0.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SY/SYOHEX/Devel-CheckCompiler-0.07.tar.gz";
+      url = "mirror://cpan/authors/id/S/SY/SYOHEX/Devel-CheckCompiler-${version}.tar.gz";
       hash = "sha256-dot2l7S41NNyx1B7ZendJqpCI/cQAYO7tNOvRtQ4abU=";
     };
     buildInputs = [ ModuleBuildTiny ];
@@ -9507,11 +9507,11 @@ with self;
     };
   };
 
-  DevelChecklib = buildPerlPackage {
+  DevelChecklib = buildPerlPackage rec {
     pname = "Devel-CheckLib";
     version = "1.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MATTN/Devel-CheckLib-1.16.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MATTN/Devel-CheckLib-${version}.tar.gz";
       hash = "sha256-hp04wljmRtzvZ2YJ8N18qQ8IX1bPb9cAGwGaXVuDH8o=";
     };
     buildInputs = [
@@ -9527,11 +9527,11 @@ with self;
     };
   };
 
-  DevelCheckOS = buildPerlPackage {
+  DevelCheckOS = buildPerlPackage rec {
     pname = "Devel-CheckOS";
     version = "1.96";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/Devel-CheckOS-1.96.tar.gz";
+      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/Devel-CheckOS-${version}.tar.gz";
       hash = "sha256-+GB5BfT1reSI9+9Et8HnyFI/ure5HS3IMLMa6cqBPfU=";
     };
     buildInputs = [ TestWarnings ];
@@ -9545,11 +9545,11 @@ with self;
     };
   };
 
-  DevelCover = buildPerlPackage {
+  DevelCover = buildPerlPackage rec {
     pname = "Devel-Cover";
     version = "1.44";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PJ/PJCJ/Devel-Cover-1.44.tar.gz";
+      url = "mirror://cpan/authors/id/P/PJ/PJCJ/Devel-Cover-${version}.tar.gz";
       hash = "sha256-9AwVQ5kuXWWm94AD1GLVms15rm0w04BHscadmZ0rH9g=";
     };
     propagatedBuildInputs = [ HTMLParser ];
@@ -9564,11 +9564,11 @@ with self;
     };
   };
 
-  DevelDeprecationsEnvironmental = buildPerlPackage {
+  DevelDeprecationsEnvironmental = buildPerlPackage rec {
     pname = "Devel-Deprecations-Environmental";
     version = "1.101";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/Devel-Deprecations-Environmental-1.101.tar.gz";
+      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/Devel-Deprecations-Environmental-${version}.tar.gz";
       hash = "sha256-S+SC08PcOtHvR0P6s4DOuQG3QVZQeVOoNITfadolpqY=";
     };
     propagatedBuildInputs = [
@@ -9587,11 +9587,11 @@ with self;
     };
   };
 
-  DevelLeak = buildPerlPackage {
+  DevelLeak = buildPerlPackage rec {
     pname = "Devel-Leak";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NI/NI-S/Devel-Leak-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/N/NI/NI-S/Devel-Leak-${version}.tar.gz";
       hash = "sha256-b0LDTxHitOPqLg5rlBaoimha3UR5EMr02R3SwXgXclI=";
     };
     meta = {
@@ -9604,11 +9604,11 @@ with self;
     };
   };
 
-  DevelPatchPerl = buildPerlPackage {
+  DevelPatchPerl = buildPerlPackage rec {
     pname = "Devel-PatchPerl";
     version = "2.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BI/BINGOS/Devel-PatchPerl-2.08.tar.gz";
+      url = "mirror://cpan/authors/id/B/BI/BINGOS/Devel-PatchPerl-${version}.tar.gz";
       hash = "sha256-acbpcBYmD0COnX5Ej5QrNqbUnfWvBzQPHWXX4jAWdBk=";
     };
     propagatedBuildInputs = [
@@ -9626,11 +9626,11 @@ with self;
     };
   };
 
-  DevelRefcount = buildPerlModule {
+  DevelRefcount = buildPerlModule rec {
     pname = "Devel-Refcount";
     version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Devel-Refcount-0.10.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Devel-Refcount-${version}.tar.gz";
       hash = "sha256-tlTUaWPRqIFCa6FZlPKPUuuDmw0TW/I5tNG/OLHKyko=";
     };
     buildInputs = [ TestFatal ];
@@ -9643,11 +9643,11 @@ with self;
     };
   };
 
-  DevelPPPort = buildPerlPackage {
+  DevelPPPort = buildPerlPackage rec {
     pname = "Devel-PPPort";
     version = "3.68";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AT/ATOOMIC/Devel-PPPort-3.68.tar.gz";
+      url = "mirror://cpan/authors/id/A/AT/ATOOMIC/Devel-PPPort-${version}.tar.gz";
       hash = "sha256-UpDVu4TN6enmEROiDGe11HJn645loRmookjMlqrAuts=";
     };
     meta = {
@@ -9659,11 +9659,11 @@ with self;
     };
   };
 
-  DevelTrace = buildPerlPackage {
+  DevelTrace = buildPerlPackage rec {
     pname = "Devel-Trace";
     version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MJ/MJD/Devel-Trace-0.12.tar.gz";
+      url = "mirror://cpan/authors/id/M/MJ/MJD/Devel-Trace-${version}.tar.gz";
       hash = "sha256-9QHK93b/fphvduAlRNbOI0yJdwFzKD8x333MV4AKOGg=";
     };
     meta = {
@@ -9672,11 +9672,11 @@ with self;
     };
   };
 
-  DeviceMAC = buildPerlPackage {
+  DeviceMAC = buildPerlPackage rec {
     pname = "Device-MAC";
     version = "1.00";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JA/JASONK/Device-MAC-1.00.tar.gz";
+      url = "mirror://cpan/authors/id/J/JA/JASONK/Device-MAC-${version}.tar.gz";
       hash = "sha256-xCGCqahImjFMv+bhyEUvMrO2Jqpsif7h2JJebftk+tU=";
     };
     buildInputs = [
@@ -9700,15 +9700,15 @@ with self;
     };
   };
 
-  DeviceOUI = buildPerlPackage {
+  DeviceOUI = buildPerlPackage rec {
     pname = "Device-OUI";
     version = "1.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JA/JASONK/Device-OUI-1.04.tar.gz";
+      url = "mirror://cpan/authors/id/J/JA/JASONK/Device-OUI-${version}.tar.gz";
       hash = "sha256-SzZ+YbH63ed/tvtynzzVrNHUbnEhjZb0Bry6ONQ7S+8=";
     };
     buildInputs = [ TestException ];
-    patches = [ ../development/perl-modules/Device-OUI-1.04-hash.patch ];
+    patches = [ ../development/perl-modules/Device-OUI-${version}-hash.patch ];
     propagatedBuildInputs = [
       ClassAccessorGrouped
       LWP
@@ -9724,11 +9724,11 @@ with self;
     };
   };
 
-  DBDCSV = buildPerlPackage {
+  DBDCSV = buildPerlPackage rec {
     pname = "DBD-CSV";
     version = "0.60";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HM/HMBRAND/DBD-CSV-0.60.tgz";
+      url = "mirror://cpan/authors/id/H/HM/HMBRAND/DBD-CSV-${version}.tgz";
       hash = "sha256-AYuDow95mXm8jDwwRMixyAAc32C9w+dGhIgYGVJUtOc=";
     };
     propagatedBuildInputs = [
@@ -9745,11 +9745,11 @@ with self;
     };
   };
 
-  DBDMock = buildPerlModule {
+  DBDMock = buildPerlModule rec {
     pname = "DBD-Mock";
     version = "1.59";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JL/JLCOOPER/DBD-Mock-1.59.tar.gz";
+      url = "mirror://cpan/authors/id/J/JL/JLCOOPER/DBD-Mock-${version}.tar.gz";
       hash = "sha256-ClqllTq2XPeQaB5sBFLjGK1X2ArCf1dfhJGMYDqkdAY=";
     };
     propagatedBuildInputs = [ DBI ];
@@ -9766,12 +9766,12 @@ with self;
     };
   };
 
-  DBDSQLite = buildPerlPackage {
+  DBDSQLite = buildPerlPackage rec {
     pname = "DBD-SQLite";
     version = "1.74";
 
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/DBD-SQLite-1.74.tar.gz";
+      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/DBD-SQLite-${version}.tar.gz";
       hash = "sha256-iZSZfYS5/rRUd5X3h0bGYfty48tqJdvdeJtzH1aIpN0=";
     };
 
@@ -9812,11 +9812,11 @@ with self;
     };
   };
 
-  DBDMariaDB = buildPerlPackage {
+  DBDMariaDB = buildPerlPackage rec {
     pname = "DBD-MariaDB";
     version = "1.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PA/PALI/DBD-MariaDB-1.23.tar.gz";
+      url = "mirror://cpan/authors/id/P/PA/PALI/DBD-MariaDB-${version}.tar.gz";
       hash = "sha256-DQx2xmDd1VVw5I8+L96o9iGmmsDtSBkOjPyvy16bhZ0=";
     };
     nativeBuildInputs = [ pkgs.mariadb-connector-c ];
@@ -9840,12 +9840,12 @@ with self;
     };
   };
 
-  DBDmysql = buildPerlPackage {
+  DBDmysql = buildPerlPackage rec {
     pname = "DBD-mysql";
     version = "5.010";
 
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DV/DVEEDEN/DBD-mysql-5.010.tar.gz";
+      url = "mirror://cpan/authors/id/D/DV/DVEEDEN/DBD-mysql-${version}.tar.gz";
       hash = "sha256-LKL/Odk+idT3RG5fD68DgF6RZ+6bigS6fLJG4stG7uc=";
     };
 
@@ -9877,12 +9877,12 @@ with self;
     };
   };
 
-  DBDOracle = buildPerlPackage {
+  DBDOracle = buildPerlPackage rec {
     pname = "DBD-Oracle";
     version = "1.83";
 
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZA/ZARQUON/DBD-Oracle-1.83.tar.gz";
+      url = "mirror://cpan/authors/id/Z/ZA/ZARQUON/DBD-Oracle-${version}.tar.gz";
       hash = "sha256-Uf6cFYlV/aDKkXqAaGPwvFEGi1M/u8dCOzzErVle0VM=";
     };
 
@@ -9906,12 +9906,12 @@ with self;
     };
   };
 
-  DBDPg = buildPerlPackage {
+  DBDPg = buildPerlPackage rec {
     pname = "DBD-Pg";
     version = "3.17.0";
 
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TU/TURNSTEP/DBD-Pg-3.17.0.tar.gz";
+      url = "mirror://cpan/authors/id/T/TU/TURNSTEP/DBD-Pg-${version}.tar.gz";
       hash = "sha256-jZANTA50nzchh1KmZh+w01V6sfzMjeo4TLWHw4LeIZs=";
     };
 
@@ -9944,12 +9944,12 @@ with self;
     };
   };
 
-  DBDsybase = buildPerlPackage {
+  DBDsybase = buildPerlPackage rec {
     pname = "DBD-Sybase";
     version = "1.23";
 
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/ME/MEWP/DBD-Sybase-1.23.tar.gz";
+      url = "mirror://cpan/authors/id/M/ME/MEWP/DBD-Sybase-${version}.tar.gz";
       hash = "sha256-B1e6aqyaKaLcOFmV1myPQSqIlo/SNsDYu0ZZAo5OmWU=";
     };
 
@@ -9969,12 +9969,12 @@ with self;
     };
   };
 
-  DBFile = buildPerlPackage {
+  DBFile = buildPerlPackage rec {
     pname = "DB_File";
     version = "1.859";
 
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PM/PMQS/DB_File-1.859.tar.gz";
+      url = "mirror://cpan/authors/id/P/PM/PMQS/DB_File-${version}.tar.gz";
       hash = "sha256-VnTg0s0LBgxNElNnDqAixk2EKlUlf5647bGcD1PiVlw=";
     };
 
@@ -9995,12 +9995,12 @@ with self;
     };
   };
 
-  DBI = buildPerlPackage {
+  DBI = buildPerlPackage rec {
     pname = "DBI";
     version = "1.644";
 
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HM/HMBRAND/DBI-1.644.tar.gz";
+      url = "mirror://cpan/authors/id/H/HM/HMBRAND/DBI-${version}.tar.gz";
       hash = "sha256-Ipe5neCeZwhmQLWQaZ4OmC+0adpjqT/ijcFHgtt6U8g=";
     };
 
@@ -10057,11 +10057,11 @@ with self;
     };
   };
 
-  DBICxTestDatabase = buildPerlPackage {
+  DBICxTestDatabase = buildPerlPackage rec {
     pname = "DBICx-TestDatabase";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JR/JROCKWAY/DBICx-TestDatabase-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/J/JR/JROCKWAY/DBICx-TestDatabase-${version}.tar.gz";
       hash = "sha256-jjvCUwsBIWGIw6plrNvS9ZxOYx864IXfxDmr2J+PCs8=";
     };
     buildInputs = [
@@ -10082,11 +10082,11 @@ with self;
     };
   };
 
-  DBIxClass = buildPerlPackage {
+  DBIxClass = buildPerlPackage rec {
     pname = "DBIx-Class";
     version = "0.082843";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RI/RIBASUSHI/DBIx-Class-0.082843.tar.gz";
+      url = "mirror://cpan/authors/id/R/RI/RIBASUSHI/DBIx-Class-${version}.tar.gz";
       hash = "sha256-NB4Lbssp2MSRdKbAnXxtvzhym6QBXuf9cDYKT/7h8lE=";
     };
     buildInputs = [
@@ -10122,11 +10122,11 @@ with self;
     };
   };
 
-  DBIxClassCandy = buildPerlPackage {
+  DBIxClassCandy = buildPerlPackage rec {
     pname = "DBIx-Class-Candy";
     version = "0.005003";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FR/FREW/DBIx-Class-Candy-0.005003.tar.gz";
+      url = "mirror://cpan/authors/id/F/FR/FREW/DBIx-Class-Candy-${version}.tar.gz";
       hash = "sha256-uKIpp7FfVZCV1FYc+CIEYBKFQbp/w1Re01hpkj1GVlw=";
     };
     buildInputs = [
@@ -10148,11 +10148,11 @@ with self;
     };
   };
 
-  DBIxClassCursorCached = buildPerlPackage {
+  DBIxClassCursorCached = buildPerlPackage rec {
     pname = "DBIx-Class-Cursor-Cached";
     version = "1.001004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AR/ARCANEZ/DBIx-Class-Cursor-Cached-1.001004.tar.gz";
+      url = "mirror://cpan/authors/id/A/AR/ARCANEZ/DBIx-Class-Cursor-Cached-${version}.tar.gz";
       hash = "sha256-NwhSMqEjClqodUOZ+1mw+PzV9Zeh4uNIxSJ0YaGSYiU=";
     };
     buildInputs = [
@@ -10172,11 +10172,11 @@ with self;
     };
   };
 
-  DBIxClassDynamicDefault = buildPerlPackage {
+  DBIxClassDynamicDefault = buildPerlPackage rec {
     pname = "DBIx-Class-DynamicDefault";
     version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSTROUT/DBIx-Class-DynamicDefault-0.04.tar.gz";
+      url = "mirror://cpan/authors/id/M/MS/MSTROUT/DBIx-Class-DynamicDefault-${version}.tar.gz";
       hash = "sha256-Io9RqyJGQlhLTcY9tt4mZ8W/riqJSpN2shChBIBqWvs=";
     };
     buildInputs = [ DBICxTestDatabase ];
@@ -10192,11 +10192,11 @@ with self;
     };
   };
 
-  DBIxClassHTMLWidget = buildPerlPackage {
+  DBIxClassHTMLWidget = buildPerlPackage rec {
     pname = "DBIx-Class-HTMLWidget";
     version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AN/ANDREMAR/DBIx-Class-HTMLWidget-0.16.tar.gz";
+      url = "mirror://cpan/authors/id/A/AN/ANDREMAR/DBIx-Class-HTMLWidget-${version}.tar.gz";
       hash = "sha256-QUJ1YyFu31qTllCQrg4chaldN6gdcg8CwTYM+n208Bc=";
     };
     propagatedBuildInputs = [
@@ -10212,11 +10212,11 @@ with self;
     };
   };
 
-  DBIxClassHelpers = buildPerlPackage {
+  DBIxClassHelpers = buildPerlPackage rec {
     pname = "DBIx-Class-Helpers";
     version = "2.036000";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FR/FREW/DBIx-Class-Helpers-2.036000.tar.gz";
+      url = "mirror://cpan/authors/id/F/FR/FREW/DBIx-Class-Helpers-${version}.tar.gz";
       hash = "sha256-t7i0iRqYPANO8LRfQRJASgpAVQxOIX2ut6IsoWhh79s=";
     };
     buildInputs = [
@@ -10248,11 +10248,11 @@ with self;
     };
   };
 
-  DBIxClassInflateColumnSerializer = buildPerlPackage {
+  DBIxClassInflateColumnSerializer = buildPerlPackage rec {
     pname = "DBIx-Class-InflateColumn-Serializer";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MR/MRUIZ/DBIx-Class-InflateColumn-Serializer-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/M/MR/MRUIZ/DBIx-Class-InflateColumn-Serializer-${version}.tar.gz";
       hash = "sha256-YmK0hx22psRaDL583o8biQsiwpGt1OzEDKruq1o6b1A=";
     };
     buildInputs = [
@@ -10275,11 +10275,11 @@ with self;
     };
   };
 
-  DBIxClassIntrospectableM2M = buildPerlPackage {
+  DBIxClassIntrospectableM2M = buildPerlPackage rec {
     pname = "DBIx-Class-IntrospectableM2M";
     version = "0.001002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IL/ILMARI/DBIx-Class-IntrospectableM2M-0.001002.tar.gz";
+      url = "mirror://cpan/authors/id/I/IL/ILMARI/DBIx-Class-IntrospectableM2M-${version}.tar.gz";
       hash = "sha256-xrqvtCQWk/2zSynr2QaZOt02S/Mar6RGLz4GIgTMh/A=";
     };
     propagatedBuildInputs = [ DBIxClass ];
@@ -10292,11 +10292,11 @@ with self;
     };
   };
 
-  DBIxClassSchemaLoader = buildPerlPackage {
+  DBIxClassSchemaLoader = buildPerlPackage rec {
     pname = "DBIx-Class-Schema-Loader";
     version = "0.07051";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/V/VE/VEESH/DBIx-Class-Schema-Loader-0.07051.tar.gz";
+      url = "mirror://cpan/authors/id/V/VE/VEESH/DBIx-Class-Schema-Loader-${version}.tar.gz";
       hash = "sha256-GgieUISlJ2j0J0vCGB3LrhTcxXnk2YD89WnGeBsGCSw=";
     };
     buildInputs = [
@@ -10325,11 +10325,11 @@ with self;
     };
   };
 
-  DBIxConnector = buildPerlPackage {
+  DBIxConnector = buildPerlPackage rec {
     pname = "DBIx-Connector";
     version = "0.59";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AR/ARISTOTLE/DBIx-Connector-0.59.tar.gz";
+      url = "mirror://cpan/authors/id/A/AR/ARISTOTLE/DBIx-Connector-${version}.tar.gz";
       hash = "sha256-eCmU8T9JVVhAU4SU+EBrC/JVj1M8zahsjSuV4jAQh/Q=";
     };
     buildInputs = [ TestMockModule ];
@@ -10343,11 +10343,11 @@ with self;
     };
   };
 
-  DBIxDBSchema = buildPerlPackage {
+  DBIxDBSchema = buildPerlPackage rec {
     pname = "DBIx-DBSchema";
     version = "0.47";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IV/IVAN/DBIx-DBSchema-0.47.tar.gz";
+      url = "mirror://cpan/authors/id/I/IV/IVAN/DBIx-DBSchema-${version}.tar.gz";
       hash = "sha256-7u4hDcFKjWPrAawtZsZ6HcJ5+Sib6WphckyJUXkcUhI=";
     };
     propagatedBuildInputs = [ DBI ];
@@ -10360,11 +10360,11 @@ with self;
     };
   };
 
-  DBIxSearchBuilder = buildPerlPackage {
+  DBIxSearchBuilder = buildPerlPackage rec {
     pname = "DBIx-SearchBuilder";
     version = "1.82";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BP/BPS/DBIx-SearchBuilder-1.82.tar.gz";
+      url = "mirror://cpan/authors/id/B/BP/BPS/DBIx-SearchBuilder-${version}.tar.gz";
       hash = "sha256-3IDX5PRVdt4/2Ui2slD+3FAM/QCrzTC2qLLXeJV2uPE=";
     };
     buildInputs = [ DBDSQLite ];
@@ -10386,11 +10386,11 @@ with self;
     };
   };
 
-  DBIxSimple = buildPerlPackage {
+  DBIxSimple = buildPerlPackage rec {
     pname = "DBIx-Simple";
     version = "1.37";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JU/JUERD/DBIx-Simple-1.37.tar.gz";
+      url = "mirror://cpan/authors/id/J/JU/JUERD/DBIx-Simple-${version}.tar.gz";
       hash = "sha256-RtMRqizgiQdAHFYRllhCbbsETFpA3nPZp7eb9QOQyuM=";
     };
     propagatedBuildInputs = [ DBI ];
@@ -10403,11 +10403,11 @@ with self;
     };
   };
 
-  DBMDeep = buildPerlPackage {
+  DBMDeep = buildPerlPackage rec {
     pname = "DBM-Deep";
     version = "2.0017";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/DBM-Deep-2.0017.tar.gz";
+      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/DBM-Deep-${version}.tar.gz";
       hash = "sha256-1yNFIFdVO72UXWMhXr/gqnepLsbg+jOw2spXrhuKTSQ=";
     };
     buildInputs = [
@@ -10427,11 +10427,11 @@ with self;
     };
   };
 
-  DataBinary = buildPerlPackage {
+  DataBinary = buildPerlPackage rec {
     pname = "Data-Binary";
     version = "0.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SN/SNKWATT/Data-Binary-0.01.tar.gz";
+      url = "mirror://cpan/authors/id/S/SN/SNKWATT/Data-Binary-${version}.tar.gz";
       hash = "sha256-SCGi3hCscQj03LKEpxuHaYGwyx6mxe1q+xd78ufLjXM=";
     };
     meta = {
@@ -10440,11 +10440,11 @@ with self;
     };
   };
 
-  DataBuffer = buildPerlPackage {
+  DataBuffer = buildPerlPackage rec {
     pname = "Data-Buffer";
     version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BT/BTROTT/Data-Buffer-0.04.tar.gz";
+      url = "mirror://cpan/authors/id/B/BT/BTROTT/Data-Buffer-${version}.tar.gz";
       hash = "sha256-Kz0Jt7zzifwRYgeyg77iUONI1EycY0YL7mfvq03SG7Q=";
     };
     meta = {
@@ -10457,11 +10457,11 @@ with self;
     };
   };
 
-  DBIxIntrospector = buildPerlPackage {
+  DBIxIntrospector = buildPerlPackage rec {
     pname = "DBIx-Introspector";
     version = "0.001005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FR/FREW/DBIx-Introspector-0.001005.tar.gz";
+      url = "mirror://cpan/authors/id/F/FR/FREW/DBIx-Introspector-${version}.tar.gz";
       hash = "sha256-lqlNLMaQwfqP00ET47CEvypGmjI6l4AoWu+S3cOB5jo=";
     };
 
@@ -10483,11 +10483,11 @@ with self;
     };
   };
 
-  DevelCamelcadedb = buildPerlPackage {
+  DevelCamelcadedb = buildPerlPackage rec {
     pname = "Devel-Camelcadedb";
     version = "2023.1";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HU/HURRICUP/Devel-Camelcadedb-v2023.1.tar.gz";
+      url = "mirror://cpan/authors/id/H/HU/HURRICUP/Devel-Camelcadedb-v${version}.tar.gz";
       hash = "sha256-z/jSTllF45RN6/ITmVprFVuR5YE0aRVrE9Ws819qXZ8=";
     };
     propagatedBuildInputs = [
@@ -10501,11 +10501,11 @@ with self;
     };
   };
 
-  DevelCycle = buildPerlPackage {
+  DevelCycle = buildPerlPackage rec {
     pname = "Devel-Cycle";
     version = "1.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LD/LDS/Devel-Cycle-1.12.tar.gz";
+      url = "mirror://cpan/authors/id/L/LD/LDS/Devel-Cycle-${version}.tar.gz";
       hash = "sha256-/TNlxNiYsrK927eKRtUHoYzKhJCikBmVR9q38ec5C8I=";
     };
     meta = {
@@ -10517,11 +10517,11 @@ with self;
     };
   };
 
-  DevelDeclare = buildPerlPackage {
+  DevelDeclare = buildPerlPackage rec {
     pname = "Devel-Declare";
     version = "0.006022";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Devel-Declare-0.006022.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Devel-Declare-${version}.tar.gz";
       hash = "sha256-cvKco1ZGpZO+mDEf/dtyAzrh6KnYJUxiqiSL1iYOWW4=";
     };
     buildInputs = [
@@ -10542,11 +10542,11 @@ with self;
     };
   };
 
-  DevelFindPerl = buildPerlPackage {
+  DevelFindPerl = buildPerlPackage rec {
     pname = "Devel-FindPerl";
     version = "0.016";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/Devel-FindPerl-0.016.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/Devel-FindPerl-${version}.tar.gz";
       hash = "sha256-Q6K/L3h6PxuIEXkGMWKyqj58sET25eduxkZq6QqGETg=";
     };
     meta = {
@@ -10558,11 +10558,11 @@ with self;
     };
   };
 
-  DevelGlobalDestruction = buildPerlPackage {
+  DevelGlobalDestruction = buildPerlPackage rec {
     pname = "Devel-GlobalDestruction";
     version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/Devel-GlobalDestruction-0.14.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Devel-GlobalDestruction-${version}.tar.gz";
       hash = "sha256-NLil8pmRMRRo/mkTytq6df1dKws+47tB/ltT76uRVKs=";
     };
     propagatedBuildInputs = [ SubExporterProgressive ];
@@ -10576,11 +10576,11 @@ with self;
     };
   };
 
-  DevelGlobalPhase = buildPerlPackage {
+  DevelGlobalPhase = buildPerlPackage rec {
     pname = "Devel-GlobalPhase";
     version = "0.003003";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/Devel-GlobalPhase-0.003003.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Devel-GlobalPhase-${version}.tar.gz";
       hash = "sha256-jaMCL3ynHf2/SqYGmJRNcgCsMUn0c32KnJG/Q4f/MvU=";
     };
     meta = {
@@ -10592,11 +10592,11 @@ with self;
     };
   };
 
-  DevelHide = buildPerlPackage {
+  DevelHide = buildPerlPackage rec {
     pname = "Devel-Hide";
     version = "0.0015";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/Devel-Hide-0.0015.tar.gz";
+      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/Devel-Hide-${version}.tar.gz";
       hash = "sha256-/I2+t/fXWnjtSWseDgXPyZxorKs6LpLP8VXKXw+l31g=";
     };
     meta = {
@@ -10608,11 +10608,11 @@ with self;
     };
   };
 
-  DevelNYTProf = buildPerlPackage {
+  DevelNYTProf = buildPerlPackage rec {
     pname = "Devel-NYTProf";
     version = "6.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JK/JKEENAN/Devel-NYTProf-6.12.tar.gz";
+      url = "mirror://cpan/authors/id/J/JK/JKEENAN/Devel-NYTProf-${version}.tar.gz";
       hash = "sha256-qDtZheTalr24X1McFqtvPUkHGnM80JSqMPqF+2pLAsQ=";
     };
     propagatedBuildInputs = [
@@ -10633,11 +10633,11 @@ with self;
     };
   };
 
-  DevelOverloadInfo = buildPerlPackage {
+  DevelOverloadInfo = buildPerlPackage rec {
     pname = "Devel-OverloadInfo";
     version = "0.007";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IL/ILMARI/Devel-OverloadInfo-0.007.tar.gz";
+      url = "mirror://cpan/authors/id/I/IL/ILMARI/Devel-OverloadInfo-${version}.tar.gz";
       hash = "sha256-IaGEFjuQ+R8G/8f13guWg1ZUaum0AKnXXFc8lYwkYiI=";
     };
     propagatedBuildInputs = [
@@ -10655,11 +10655,11 @@ with self;
     };
   };
 
-  DevelOverrideGlobalRequire = buildPerlPackage {
+  DevelOverrideGlobalRequire = buildPerlPackage rec {
     pname = "Devel-OverrideGlobalRequire";
     version = "0.001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Devel-OverrideGlobalRequire-0.001.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Devel-OverrideGlobalRequire-${version}.tar.gz";
       hash = "sha256-B5GJLeOuKSr0qU44LyHbHuiCEIdQMYUebqgsNBB4Xvk=";
     };
     meta = {
@@ -10672,11 +10672,11 @@ with self;
     };
   };
 
-  DevelPartialDump = buildPerlPackage {
+  DevelPartialDump = buildPerlPackage rec {
     pname = "Devel-PartialDump";
     version = "0.20";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Devel-PartialDump-0.20.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Devel-PartialDump-${version}.tar.gz";
       hash = "sha256-rvD/PqWalpGWfCiFEY/2ZxVghJVwicQ4j0nbZG/T2Qc=";
     };
     propagatedBuildInputs = [
@@ -10696,11 +10696,11 @@ with self;
     };
   };
 
-  DevelStackTrace = buildPerlPackage {
+  DevelStackTrace = buildPerlPackage rec {
     pname = "Devel-StackTrace";
     version = "2.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Devel-StackTrace-2.04.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Devel-StackTrace-${version}.tar.gz";
       hash = "sha256-zTwD7VR9PULGH6WBTJgpYTk5LnlxwJLgmkMfLJ9daFU=";
     };
     meta = {
@@ -10710,11 +10710,11 @@ with self;
     };
   };
 
-  DevelSize = buildPerlPackage {
+  DevelSize = buildPerlPackage rec {
     pname = "Devel-Size";
     version = "0.85";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NW/NWCLARK/Devel-Size-0.85.tar.gz";
+      url = "mirror://cpan/authors/id/N/NW/NWCLARK/Devel-Size-${version}.tar.gz";
       hash = "sha256-KS+YsT7dGqSlROOlzx2fLXAZ91xzZNLo+oo16lRR5z4=";
     };
     meta = {
@@ -10726,11 +10726,11 @@ with self;
     };
   };
 
-  DevelStackTraceAsHTML = buildPerlPackage {
+  DevelStackTraceAsHTML = buildPerlPackage rec {
     pname = "Devel-StackTrace-AsHTML";
     version = "0.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Devel-StackTrace-AsHTML-0.15.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Devel-StackTrace-AsHTML-${version}.tar.gz";
       hash = "sha256-YoPb4hl+LyAAnMS0SZl3Qhac3ZUb/ETLxuYsKpYtMUc=";
     };
     propagatedBuildInputs = [ DevelStackTrace ];
@@ -10744,11 +10744,11 @@ with self;
     };
   };
 
-  DevelSymdump = buildPerlPackage {
+  DevelSymdump = buildPerlPackage rec {
     pname = "Devel-Symdump";
     version = "2.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AN/ANDK/Devel-Symdump-2.18.tar.gz";
+      url = "mirror://cpan/authors/id/A/AN/ANDK/Devel-Symdump-${version}.tar.gz";
       hash = "sha256-gm+BoQf1WSolFnZu1DvrR+EMyD7cnqSAkLAqNgQHdsA=";
     };
     meta = {
@@ -10760,11 +10760,11 @@ with self;
     };
   };
 
-  DigestCRC = buildPerlPackage {
+  DigestCRC = buildPerlPackage rec {
     pname = "Digest-CRC";
     version = "0.24";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OL/OLIMAUL/Digest-CRC-0.24.tar.gz";
+      url = "mirror://cpan/authors/id/O/OL/OLIMAUL/Digest-CRC-${version}.tar.gz";
       hash = "sha256-ugIqBbGtvsc3EsRvIz2Eif4Tobn8QKH8zu2bUvkN78E=";
     };
     meta = {
@@ -10773,11 +10773,11 @@ with self;
     };
   };
 
-  DigestHMAC = buildPerlPackage {
+  DigestHMAC = buildPerlPackage rec {
     pname = "Digest-HMAC";
     version = "1.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AR/ARODLAND/Digest-HMAC-1.05.tar.gz";
+      url = "mirror://cpan/authors/id/A/AR/ARODLAND/Digest-HMAC-${version}.tar.gz";
       hash = "sha256-IVy1nLphB0XPstSz+O91bVkOV+OteYapkuh8SWn83Ho=";
     };
     meta = {
@@ -10790,11 +10790,11 @@ with self;
     };
   };
 
-  DigestJHash = buildPerlPackage {
+  DigestJHash = buildPerlPackage rec {
     pname = "Digest-JHash";
     version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Digest-JHash-0.10.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Digest-JHash-${version}.tar.gz";
       hash = "sha256-x0bPCoYaAECQJjzVTXco0MdZWgz5DLv9hAmzlu47AGM=";
     };
     meta = {
@@ -10803,11 +10803,11 @@ with self;
     };
   };
 
-  DigestMD2 = buildPerlPackage {
+  DigestMD2 = buildPerlPackage rec {
     pname = "Digest-MD2";
     version = "2.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GA/GAAS/Digest-MD2-2.04.tar.gz";
+      url = "mirror://cpan/authors/id/G/GA/GAAS/Digest-MD2-${version}.tar.gz";
       hash = "sha256-0Kq/SDTCCsQRvqQnxKMItZpfyqMnZ571KUwdaKtx7tM=";
     };
     meta = {
@@ -10820,11 +10820,11 @@ with self;
     };
   };
 
-  DigestMD4 = buildPerlPackage {
+  DigestMD4 = buildPerlPackage rec {
     pname = "Digest-MD4";
     version = "1.9";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIKEM/DigestMD4/Digest-MD4-1.9.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIKEM/DigestMD4/Digest-MD4-${version}.tar.gz";
       hash = "sha256-ZlEQu6MkcPOY8xHNZGL9iXXXyDZ1/2dLwvbHtysMqqY=";
     };
     meta = {
@@ -10836,11 +10836,11 @@ with self;
     };
   };
 
-  DigestMD5File = buildPerlPackage {
+  DigestMD5File = buildPerlPackage rec {
     pname = "Digest-MD5-File";
     version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DM/DMUEY/Digest-MD5-File-0.08.tar.gz";
+      url = "mirror://cpan/authors/id/D/DM/DMUEY/Digest-MD5-File-${version}.tar.gz";
       hash = "sha256-rbQ6VOMmJ7T35XyWQObrBtC7edjqVM0L157TVoj7Ehg=";
     };
     propagatedBuildInputs = [ LWP ];
@@ -10853,11 +10853,11 @@ with self;
     };
   };
 
-  DigestPerlMD5 = buildPerlPackage {
+  DigestPerlMD5 = buildPerlPackage rec {
     pname = "Digest-Perl-MD5";
     version = "1.9";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DE/DELTA/Digest-Perl-MD5-1.9.tar.gz";
+      url = "mirror://cpan/authors/id/D/DE/DELTA/Digest-Perl-MD5-${version}.tar.gz";
       hash = "sha256-cQDLoXEPRfsOkH2LGnvYyu81xkrNMdfyJa/1r/7s2bE=";
     };
     meta = {
@@ -10869,11 +10869,11 @@ with self;
     };
   };
 
-  DigestSHA1 = buildPerlPackage {
+  DigestSHA1 = buildPerlPackage rec {
     pname = "Digest-SHA1";
     version = "2.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GA/GAAS/Digest-SHA1-2.13.tar.gz";
+      url = "mirror://cpan/authors/id/G/GA/GAAS/Digest-SHA1-${version}.tar.gz";
       hash = "sha256-aMHawhh0IfDrer9xRSoG8ZAYG4/Eso7e31uQKW+5Q8w=";
     };
     meta = {
@@ -10885,11 +10885,11 @@ with self;
     };
   };
 
-  DigestSHA3 = buildPerlPackage {
+  DigestSHA3 = buildPerlPackage rec {
     pname = "Digest-SHA3";
     version = "1.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSHELOR/Digest-SHA3-1.05.tar.gz";
+      url = "mirror://cpan/authors/id/M/MS/MSHELOR/Digest-SHA3-${version}.tar.gz";
       hash = "sha256-rfG5B5sreBdV5XBId6FDCl8SmX6oIgX9KWbJzEZahSI=";
     };
     meta = {
@@ -10904,11 +10904,11 @@ with self;
     };
   };
 
-  DigestSRI = buildPerlPackage {
+  DigestSRI = buildPerlPackage rec {
     pname = "Digest-SRI";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAUKEX/Digest-SRI-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/H/HA/HAUKEX/Digest-SRI-${version}.tar.gz";
       hash = "sha256-VITN/m68OYwkZfeBx3w++1OKOULNSyDWiBjG//kHT8c=";
     };
     meta = {
@@ -10918,11 +10918,11 @@ with self;
     };
   };
 
-  DirManifest = buildPerlModule {
+  DirManifest = buildPerlModule rec {
     pname = "Dir-Manifest";
     version = "0.6.1";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Dir-Manifest-0.6.1.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Dir-Manifest-${version}.tar.gz";
       hash = "sha256-hP9yJoc9XoZW7Hc0TAg4wVOp8BW0a2Dh/oeYuykn5QU=";
     };
     propagatedBuildInputs = [
@@ -10936,11 +10936,11 @@ with self;
     };
   };
 
-  DirSelf = buildPerlPackage {
+  DirSelf = buildPerlPackage rec {
     pname = "Dir-Self";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MAUKE/Dir-Self-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MAUKE/Dir-Self-${version}.tar.gz";
       hash = "sha256-4lGlGrx9m6PnCPc8KqII4J1HoMUo1iVHEPp4zI1ohbU=";
     };
     meta = {
@@ -10953,11 +10953,11 @@ with self;
     };
   };
 
-  DispatchClass = buildPerlPackage {
+  DispatchClass = buildPerlPackage rec {
     pname = "Dispatch-Class";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MAUKE/Dispatch-Class-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MAUKE/Dispatch-Class-${version}.tar.gz";
       hash = "sha256-1020Oxr56L1G/8Fb/k3x5dgQxCzoWC6TdRDcKiyhZYI=";
     };
     propagatedBuildInputs = [ ExporterTiny ];
@@ -10970,11 +10970,11 @@ with self;
     };
   };
 
-  DistCheckConflicts = buildPerlPackage {
+  DistCheckConflicts = buildPerlPackage rec {
     pname = "Dist-CheckConflicts";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DO/DOY/Dist-CheckConflicts-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/D/DO/DOY/Dist-CheckConflicts-${version}.tar.gz";
       hash = "sha256-6oRLlobJTWZtnURDIddkSQss3i+YXEFltMLHdmXK7cQ=";
     };
     buildInputs = [ TestFatal ];
@@ -10989,11 +10989,11 @@ with self;
     };
   };
 
-  DistributionMetadata = buildPerlModule {
+  DistributionMetadata = buildPerlModule rec {
     pname = "Distribution-Metadata";
     version = "0.10";
     src = pkgs.fetchurl {
-      url = "mirror://cpan/authors/id/S/SK/SKAJI/Distribution-Metadata-0.10.tar.gz";
+      url = "mirror://cpan/authors/id/S/SK/SKAJI/Distribution-Metadata-${version}.tar.gz";
       sha256 = "sha256-uynMfh26OQphJnYfB9BwQ27fqinrjpBwMCOwXzET6nE=";
     };
     buildInputs = [
@@ -11012,11 +11012,11 @@ with self;
     };
   };
 
-  DistZilla = buildPerlPackage {
+  DistZilla = buildPerlPackage rec {
     pname = "Dist-Zilla";
     version = "6.030";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Dist-Zilla-6.030.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Dist-Zilla-${version}.tar.gz";
       hash = "sha256-xAa75oCelO23DKlDJMMBQz1sij375wsC3xLh3/LzsTA=";
     };
     buildInputs = [
@@ -11058,11 +11058,11 @@ with self;
     };
   };
 
-  DistZillaPluginBundleTestingMania = buildPerlModule {
+  DistZillaPluginBundleTestingMania = buildPerlModule rec {
     pname = "Dist-Zilla-PluginBundle-TestingMania";
     version = "0.25";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DO/DOHERTY/Dist-Zilla-PluginBundle-TestingMania-0.25.tar.gz";
+      url = "mirror://cpan/authors/id/D/DO/DOHERTY/Dist-Zilla-PluginBundle-TestingMania-${version}.tar.gz";
       hash = "sha256-XguywA8UD9ZNy9EvpdPJ4kS5NWgor0ZRmLYjBGnUWRw=";
     };
     buildInputs = [
@@ -11100,11 +11100,11 @@ with self;
     };
   };
 
-  DistZillaPluginCheckChangeLog = buildPerlPackage {
+  DistZillaPluginCheckChangeLog = buildPerlPackage rec {
     pname = "Dist-Zilla-Plugin-CheckChangeLog";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FA/FAYLAND/Dist-Zilla-Plugin-CheckChangeLog-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/F/FA/FAYLAND/Dist-Zilla-Plugin-CheckChangeLog-${version}.tar.gz";
       hash = "sha256-sLNNbXC1bxlE0DxfDcO49vJEdMgW0HtlehFsaSwuBSo=";
     };
     propagatedBuildInputs = [ DistZilla ];
@@ -11127,11 +11127,11 @@ with self;
     };
   };
 
-  DistZillaPluginMojibakeTests = buildPerlPackage {
+  DistZillaPluginMojibakeTests = buildPerlPackage rec {
     pname = "Dist-Zilla-Plugin-MojibakeTests";
     version = "0.8";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SY/SYP/Dist-Zilla-Plugin-MojibakeTests-0.8.tar.gz";
+      url = "mirror://cpan/authors/id/S/SY/SYP/Dist-Zilla-Plugin-MojibakeTests-${version}.tar.gz";
       hash = "sha256-8f/1R+okqPekg0Bqcu1sQFjXRtna6WNyVQLdugJas4A=";
     };
     propagatedBuildInputs = [ DistZilla ];
@@ -11146,11 +11146,11 @@ with self;
     };
   };
 
-  DistZillaPluginPodWeaver = buildPerlPackage {
+  DistZillaPluginPodWeaver = buildPerlPackage rec {
     pname = "Dist-Zilla-Plugin-PodWeaver";
     version = "4.010";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Dist-Zilla-Plugin-PodWeaver-4.010.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Dist-Zilla-Plugin-PodWeaver-${version}.tar.gz";
       hash = "sha256-Zm1S1UXUjSpn8VN63HTPOMdkofmVHQtiNiP2IGDLYj4=";
     };
     propagatedBuildInputs = [
@@ -11168,11 +11168,11 @@ with self;
     };
   };
 
-  DistZillaPluginReadmeAnyFromPod = buildPerlPackage {
+  DistZillaPluginReadmeAnyFromPod = buildPerlPackage rec {
     pname = "Dist-Zilla-Plugin-ReadmeAnyFromPod";
     version = "0.163250";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RT/RTHOMPSON/Dist-Zilla-Plugin-ReadmeAnyFromPod-0.163250.tar.gz";
+      url = "mirror://cpan/authors/id/R/RT/RTHOMPSON/Dist-Zilla-Plugin-ReadmeAnyFromPod-${version}.tar.gz";
       hash = "sha256-1E8nmZIveLKnlh7YkSPhG913q/6FuiBA2CuArXLtE7w=";
     };
     buildInputs = [
@@ -11200,11 +11200,11 @@ with self;
     };
   };
 
-  DistZillaPluginReadmeMarkdownFromPod = buildPerlPackage {
+  DistZillaPluginReadmeMarkdownFromPod = buildPerlPackage rec {
     pname = "Dist-Zilla-Plugin-ReadmeMarkdownFromPod";
     version = "0.141140";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RT/RTHOMPSON/Dist-Zilla-Plugin-ReadmeMarkdownFromPod-0.141140.tar.gz";
+      url = "mirror://cpan/authors/id/R/RT/RTHOMPSON/Dist-Zilla-Plugin-ReadmeMarkdownFromPod-${version}.tar.gz";
       hash = "sha256-nKrXs2bqWRGa1zzdmdzdU/h3pRW9AWT8KLM5wBc5qAE=";
     };
     buildInputs = [
@@ -11225,11 +11225,11 @@ with self;
     };
   };
 
-  DistZillaPluginTestCPANChanges = buildPerlPackage {
+  DistZillaPluginTestCPANChanges = buildPerlPackage rec {
     pname = "Dist-Zilla-Plugin-Test-CPAN-Changes";
     version = "0.012";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DO/DOHERTY/Dist-Zilla-Plugin-Test-CPAN-Changes-0.012.tar.gz";
+      url = "mirror://cpan/authors/id/D/DO/DOHERTY/Dist-Zilla-Plugin-Test-CPAN-Changes-${version}.tar.gz";
       hash = "sha256-IVs6XDxYyLqw6icTBEG72uxzfuzADwZwk39gi9v2SAY=";
     };
     buildInputs = [
@@ -11247,11 +11247,11 @@ with self;
     };
   };
 
-  DistZillaPluginTestCPANMetaJSON = buildPerlModule {
+  DistZillaPluginTestCPANMetaJSON = buildPerlModule rec {
     pname = "Dist-Zilla-Plugin-Test-CPAN-Meta-JSON";
     version = "0.004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DO/DOHERTY/Dist-Zilla-Plugin-Test-CPAN-Meta-JSON-0.004.tar.gz";
+      url = "mirror://cpan/authors/id/D/DO/DOHERTY/Dist-Zilla-Plugin-Test-CPAN-Meta-JSON-${version}.tar.gz";
       hash = "sha256-Clc+HVZAN05u5NVtT7lKPGfU511Ss93q5wz6ZFDhryI=";
     };
     buildInputs = [
@@ -11267,11 +11267,11 @@ with self;
     };
   };
 
-  DistZillaPluginTestCompile = buildPerlModule {
+  DistZillaPluginTestCompile = buildPerlModule rec {
     pname = "Dist-Zilla-Plugin-Test-Compile";
     version = "2.058";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Dist-Zilla-Plugin-Test-Compile-2.058.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Dist-Zilla-Plugin-Test-Compile-${version}.tar.gz";
       hash = "sha256-0M+T5SXxAuyg9/OWcSTS5Z0KIS9zjOVMHd2R3aJo2Io=";
     };
     buildInputs = [
@@ -11292,11 +11292,11 @@ with self;
     };
   };
 
-  DistZillaPluginTestDistManifest = buildPerlModule {
+  DistZillaPluginTestDistManifest = buildPerlModule rec {
     pname = "Dist-Zilla-Plugin-Test-DistManifest";
     version = "2.000006";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Dist-Zilla-Plugin-Test-DistManifest-2.000006.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Dist-Zilla-Plugin-Test-DistManifest-${version}.tar.gz";
       hash = "sha256-Wj2kW/yYzjhf7X3BZTp4kGEfC57xVsABOueFdPiWYH0=";
     };
     buildInputs = [
@@ -11316,11 +11316,11 @@ with self;
     };
   };
 
-  DistZillaPluginTestEOL = buildPerlModule {
+  DistZillaPluginTestEOL = buildPerlModule rec {
     pname = "Dist-Zilla-Plugin-Test-EOL";
     version = "0.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Dist-Zilla-Plugin-Test-EOL-0.19.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Dist-Zilla-Plugin-Test-EOL-${version}.tar.gz";
       hash = "sha256-orlZx6AszDLt1D7lhgmHVhPv1Ty8u9YDmeF/FUZ6Qzg=";
     };
     buildInputs = [
@@ -11340,11 +11340,11 @@ with self;
     };
   };
 
-  DistZillaPluginTestKwalitee = buildPerlModule {
+  DistZillaPluginTestKwalitee = buildPerlModule rec {
     pname = "Dist-Zilla-Plugin-Test-Kwalitee";
     version = "2.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Dist-Zilla-Plugin-Test-Kwalitee-2.12.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Dist-Zilla-Plugin-Test-Kwalitee-${version}.tar.gz";
       hash = "sha256-vdvPzHXo6y0tnIYRVS8AzcGwUfDwB5hiO4aS/1Awry8=";
     };
     buildInputs = [
@@ -11363,11 +11363,11 @@ with self;
     };
   };
 
-  DistZillaPluginTestMinimumVersion = buildPerlModule {
+  DistZillaPluginTestMinimumVersion = buildPerlModule rec {
     pname = "Dist-Zilla-Plugin-Test-MinimumVersion";
     version = "2.000010";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Dist-Zilla-Plugin-Test-MinimumVersion-2.000010.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Dist-Zilla-Plugin-Test-MinimumVersion-${version}.tar.gz";
       hash = "sha256-uLcfS2S2ifS2R6OofWqqrkWmiJLTXja6qXb2BXNjcPs=";
     };
     buildInputs = [
@@ -11386,11 +11386,11 @@ with self;
     };
   };
 
-  DistZillaPluginTestNoTabs = buildPerlModule {
+  DistZillaPluginTestNoTabs = buildPerlModule rec {
     pname = "Dist-Zilla-Plugin-Test-NoTabs";
     version = "0.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Dist-Zilla-Plugin-Test-NoTabs-0.15.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Dist-Zilla-Plugin-Test-NoTabs-${version}.tar.gz";
       hash = "sha256-G2EMQpFpKbtwFDw2t55XF1JbDp3njj1GCal4ZCtk0KQ=";
     };
     propagatedBuildInputs = [ DistZilla ];
@@ -11410,11 +11410,11 @@ with self;
     };
   };
 
-  DistZillaPluginTestPerlCritic = buildPerlModule {
+  DistZillaPluginTestPerlCritic = buildPerlModule rec {
     pname = "Dist-Zilla-Plugin-Test-Perl-Critic";
     version = "3.001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Dist-Zilla-Plugin-Test-Perl-Critic-3.001.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Dist-Zilla-Plugin-Test-Perl-Critic-${version}.tar.gz";
       hash = "sha256-klC1nV3Brkxok7p4O9PwUTGxT/npGvtFVTFPVSaKOCU=";
     };
     buildInputs = [
@@ -11432,11 +11432,11 @@ with self;
     };
   };
 
-  DistZillaPluginTestPodLinkCheck = buildPerlPackage {
+  DistZillaPluginTestPodLinkCheck = buildPerlPackage rec {
     pname = "Dist-Zilla-Plugin-Test-Pod-LinkCheck";
     version = "1.004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RW/RWSTAUNER/Dist-Zilla-Plugin-Test-Pod-LinkCheck-1.004.tar.gz";
+      url = "mirror://cpan/authors/id/R/RW/RWSTAUNER/Dist-Zilla-Plugin-Test-Pod-LinkCheck-${version}.tar.gz";
       hash = "sha256-Ml0jbaCUA4jSqobsXBMmUWtK1Fre+Oek+Du5HV7hVJA=";
     };
     # buildInputs = [ TestPodLinkCheck ];
@@ -11452,11 +11452,11 @@ with self;
     };
   };
 
-  DistZillaPluginTestPortability = buildPerlModule {
+  DistZillaPluginTestPortability = buildPerlModule rec {
     pname = "Dist-Zilla-Plugin-Test-Portability";
     version = "2.001001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Dist-Zilla-Plugin-Test-Portability-2.001001.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Dist-Zilla-Plugin-Test-Portability-${version}.tar.gz";
       hash = "sha256-07kxVx4VoidI6BJwmq/aclEKdMAA/AaiyrWHVYEACyA=";
     };
     buildInputs = [
@@ -11476,11 +11476,11 @@ with self;
     };
   };
 
-  DistZillaPluginTestSynopsis = buildPerlPackage {
+  DistZillaPluginTestSynopsis = buildPerlPackage rec {
     pname = "Dist-Zilla-Plugin-Test-Synopsis";
     version = "2.000007";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DO/DOHERTY/Dist-Zilla-Plugin-Test-Synopsis-2.000007.tar.gz";
+      url = "mirror://cpan/authors/id/D/DO/DOHERTY/Dist-Zilla-Plugin-Test-Synopsis-${version}.tar.gz";
       hash = "sha256-59XiUwzYpbtarfPhZpplOqqW4yyte9a5yrprQlzqtWM=";
     };
     buildInputs = [
@@ -11498,11 +11498,11 @@ with self;
     };
   };
 
-  DistZillaPluginTestUnusedVars = buildPerlModule {
+  DistZillaPluginTestUnusedVars = buildPerlModule rec {
     pname = "Dist-Zilla-Plugin-Test-UnusedVars";
     version = "2.001001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Dist-Zilla-Plugin-Test-UnusedVars-2.001001.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Dist-Zilla-Plugin-Test-UnusedVars-${version}.tar.gz";
       hash = "sha256-df7W0NzCv0B/8nrJ4W7yFTRnFEuYbPovmPhpuqWNdkc=";
     };
     buildInputs = [
@@ -11522,11 +11522,11 @@ with self;
     };
   };
 
-  DistZillaPluginTestVersion = buildPerlPackage {
+  DistZillaPluginTestVersion = buildPerlPackage rec {
     pname = "Dist-Zilla-Plugin-Test-Version";
     version = "1.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Dist-Zilla-Plugin-Test-Version-1.09.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Dist-Zilla-Plugin-Test-Version-${version}.tar.gz";
       hash = "sha256-ckBQhzG8G/bfrXcB7GVFChjvkkWlIasm69ass5qevhc=";
     };
     buildInputs = [
@@ -11544,11 +11544,11 @@ with self;
     };
   };
 
-  DistZillaRoleFileWatcher = buildPerlModule {
+  DistZillaRoleFileWatcher = buildPerlModule rec {
     pname = "Dist-Zilla-Role-FileWatcher";
     version = "0.006";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Dist-Zilla-Role-FileWatcher-0.006.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Dist-Zilla-Role-FileWatcher-${version}.tar.gz";
       hash = "sha256-/jpEuVhtrxJ3/Lu69yFrAs4j77vWlPDfEbf3U0S+TpY=";
     };
     propagatedBuildInputs = [
@@ -11570,11 +11570,11 @@ with self;
     };
   };
 
-  Dotenv = buildPerlPackage {
+  Dotenv = buildPerlPackage rec {
     pname = "Dotenv";
     version = "0.002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOOK/Dotenv-0.002.tar.gz";
+      url = "mirror://cpan/authors/id/B/BO/BOOK/Dotenv-${version}.tar.gz";
       hash = "sha256-BMenzEURYX16cMTKQQ0QcH3EliSM2tICQK4kIiMhJFQ=";
     };
     buildInputs = [
@@ -11592,11 +11592,11 @@ with self;
     };
   };
 
-  Dumbbench = buildPerlPackage {
+  Dumbbench = buildPerlPackage rec {
     pname = "Dumbbench";
     version = "0.503";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/Dumbbench-0.503.tar.gz";
+      url = "mirror://cpan/authors/id/B/BD/BDFOY/Dumbbench-${version}.tar.gz";
       hash = "sha256-0BYBmoGDE+cERk8oDPZB72Dodx0HeRtZuZ4XoeyAH6k=";
     };
     propagatedBuildInputs = [
@@ -11617,11 +11617,11 @@ with self;
     };
   };
 
-  EmailAbstract = buildPerlPackage {
+  EmailAbstract = buildPerlPackage rec {
     pname = "Email-Abstract";
     version = "3.010";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-Abstract-3.010.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-Abstract-${version}.tar.gz";
       hash = "sha256-jBL2i1l0yvyZ10lCq+/IWXGTA1qv0nYxKOaqr8pLftY=";
     };
     propagatedBuildInputs = [
@@ -11639,11 +11639,11 @@ with self;
     };
   };
 
-  EmailAddress = buildPerlPackage {
+  EmailAddress = buildPerlPackage rec {
     pname = "Email-Address";
     version = "1.913";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-Address-1.913.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-Address-${version}.tar.gz";
       hash = "sha256-avtUH232tTXM92QtNhrhjXqVo/k6zhvFNz9kwkEMpa8=";
     };
     meta = {
@@ -11656,11 +11656,11 @@ with self;
     };
   };
 
-  EmailAddressList = buildPerlPackage {
+  EmailAddressList = buildPerlPackage rec {
     pname = "Email-Address-List";
     version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BP/BPS/Email-Address-List-0.06.tar.gz";
+      url = "mirror://cpan/authors/id/B/BP/BPS/Email-Address-List-${version}.tar.gz";
       hash = "sha256-MFuUx3gBHO5w2fIVFNkumF+p3Mu4TGR5jwwfCyTrhw4=";
     };
     buildInputs = [ JSON ];
@@ -11674,11 +11674,11 @@ with self;
     };
   };
 
-  EmailAddressXS = buildPerlPackage {
+  EmailAddressXS = buildPerlPackage rec {
     pname = "Email-Address-XS";
     version = "1.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PA/PALI/Email-Address-XS-1.05.tar.gz";
+      url = "mirror://cpan/authors/id/P/PA/PALI/Email-Address-XS-${version}.tar.gz";
       hash = "sha256-FRC38Q1nIBA3zVDSLJ1rJu7KVe3tpM20a7yiflmk6hY=";
     };
     meta = {
@@ -11690,11 +11690,11 @@ with self;
     };
   };
 
-  EmailDateFormat = buildPerlPackage {
+  EmailDateFormat = buildPerlPackage rec {
     pname = "Email-Date-Format";
     version = "1.008";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-Date-Format-1.008.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-Date-Format-${version}.tar.gz";
       hash = "sha256-Qyt8g/+IdJrxKAA/UlfFc67BpGNBjbkO0ihDy7wli08=";
     };
     meta = {
@@ -11707,11 +11707,11 @@ with self;
     };
   };
 
-  EmailReply = buildPerlPackage {
+  EmailReply = buildPerlPackage rec {
     pname = "Email-Reply";
     version = "1.204";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-Reply-1.204.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-Reply-${version}.tar.gz";
       hash = "sha256-uk/YCsUBfW0TLgNYx4aw7NHHrcvu5cGfs9opZHkaVvA=";
     };
     propagatedBuildInputs = [
@@ -11729,11 +11729,11 @@ with self;
     };
   };
 
-  EmailMessageID = buildPerlPackage {
+  EmailMessageID = buildPerlPackage rec {
     pname = "Email-MessageID";
     version = "1.408";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-MessageID-1.408.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-MessageID-${version}.tar.gz";
       hash = "sha256-Hz1bT/Cxx7OemsfDGPs3rc0LrJVWA2VGSU0U8G3FZDw=";
     };
     meta = {
@@ -11746,11 +11746,11 @@ with self;
     };
   };
 
-  EmailMIME = buildPerlPackage {
+  EmailMIME = buildPerlPackage rec {
     pname = "Email-MIME";
     version = "1.953";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-MIME-1.953.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-MIME-${version}.tar.gz";
       hash = "sha256-mPsGeFBpmiJLq8NI8c7+MNdExg2okC56XOnYt+c99zU=";
     };
     propagatedBuildInputs = [
@@ -11772,7 +11772,7 @@ with self;
     };
   };
 
-  EmailMIMEAttachmentStripper = buildPerlPackage {
+  EmailMIMEAttachmentStripper = buildPerlPackage rec {
     pname = "Email-MIME-Attachment-Stripper";
     version = "1.317";
     buildInputs = [ CaptureTiny ];
@@ -11782,7 +11782,7 @@ with self;
     ];
 
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-MIME-Attachment-Stripper-1.317.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-MIME-Attachment-Stripper-${version}.tar.gz";
       hash = "sha256-3LmLCdw+j3V+w4gqQjRUgQi7LRLjz635WibO84Gp54k=";
     };
     meta = {
@@ -11795,11 +11795,11 @@ with self;
     };
   };
 
-  EmailMIMEContentType = buildPerlPackage {
+  EmailMIMEContentType = buildPerlPackage rec {
     pname = "Email-MIME-ContentType";
     version = "1.028";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-MIME-ContentType-1.028.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-MIME-ContentType-${version}.tar.gz";
       hash = "sha256-55UCRkM/ftbD5P1N8iJ+DyNBE3w8qxmJAY/DcPWBRcQ=";
     };
     propagatedBuildInputs = [ TextUnidecode ];
@@ -11813,11 +11813,11 @@ with self;
     };
   };
 
-  EmailMIMEEncodings = buildPerlPackage {
+  EmailMIMEEncodings = buildPerlPackage rec {
     pname = "Email-MIME-Encodings";
     version = "1.317";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-MIME-Encodings-1.317.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-MIME-Encodings-${version}.tar.gz";
       hash = "sha256-SppBZxqdFQTE2iQb5BmpUD+jSGJiUm7bgeyp4uvqC68=";
     };
     buildInputs = [ CaptureTiny ];
@@ -11831,11 +11831,11 @@ with self;
     };
   };
 
-  EmailSend = buildPerlPackage {
+  EmailSend = buildPerlPackage rec {
     pname = "Email-Send";
     version = "2.201";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-Send-2.201.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-Send-${version}.tar.gz";
       hash = "sha256-S77JM1WNfMm4FSutht0xPeJ3ohqJtOqD2E5hWH6V28Y=";
     };
     propagatedBuildInputs = [
@@ -11857,11 +11857,11 @@ with self;
     };
   };
 
-  EmailOutlookMessage = buildPerlModule {
+  EmailOutlookMessage = buildPerlModule rec {
     pname = "Email-Outlook-Message";
     version = "0.921";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MV/MVZ/Email-Outlook-Message-0.921.tar.gz";
+      url = "mirror://cpan/authors/id/M/MV/MVZ/Email-Outlook-Message-${version}.tar.gz";
       hash = "sha256-+0q+6hTNpRweYLwhHPlSG7uq50uEEYym1Y8KciNoA4g=";
     };
     propagatedBuildInputs = [
@@ -11884,11 +11884,11 @@ with self;
     };
   };
 
-  EmailSender = buildPerlPackage {
+  EmailSender = buildPerlPackage rec {
     pname = "Email-Sender";
     version = "2.600";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-Sender-2.600.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-Sender-${version}.tar.gz";
       hash = "sha256-7MZ10DDXnZpPsGRWfqiFxmsXw4Yjea0w+CBaKBzY7ik=";
     };
     buildInputs = [ CaptureTiny ];
@@ -11916,11 +11916,11 @@ with self;
     };
   };
 
-  EmailSimple = buildPerlPackage {
+  EmailSimple = buildPerlPackage rec {
     pname = "Email-Simple";
     version = "2.218";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-Simple-2.218.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-Simple-${version}.tar.gz";
       hash = "sha256-Lc4daP3pnVPbnKQ+IRtpsWm6Lvrs+HpVyzOpM2BHyW0=";
     };
     propagatedBuildInputs = [ EmailDateFormat ];
@@ -11934,11 +11934,11 @@ with self;
     };
   };
 
-  EmailStuffer = buildPerlPackage {
+  EmailStuffer = buildPerlPackage rec {
     pname = "Email-Stuffer";
     version = "0.020";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-Stuffer-0.020.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-Stuffer-${version}.tar.gz";
       hash = "sha256-Ch77fy3t05BSsSb3GMotO1hFpBI6OTkv2d+gx25gV8c=";
     };
     buildInputs = [
@@ -11962,11 +11962,11 @@ with self;
     };
   };
 
-  EmailValid = buildPerlPackage {
+  EmailValid = buildPerlPackage rec {
     pname = "Email-Valid";
     version = "1.203";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-Valid-1.203.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Email-Valid-${version}.tar.gz";
       hash = "sha256-ICG/ux4sJ55evYRoDllvlzRNQphQsjIme3b0kDdSK5M=";
     };
     propagatedBuildInputs = [
@@ -11985,11 +11985,11 @@ with self;
     };
   };
 
-  EmailValidLoose = buildPerlPackage {
+  EmailValidLoose = buildPerlPackage rec {
     pname = "Email-Valid-Loose";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Email-Valid-Loose-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Email-Valid-Loose-${version}.tar.gz";
       hash = "sha256-5xjnbt3uJAJRyZnhOcjL5vLMgBktpa+HXL0S+oq5Olk=";
     };
     propagatedBuildInputs = [ EmailValid ];
@@ -12002,11 +12002,11 @@ with self;
     };
   };
 
-  Encode = buildPerlPackage {
+  Encode = buildPerlPackage rec {
     pname = "Encode";
     version = "3.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DANKOGAI/Encode-3.19.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DANKOGAI/Encode-${version}.tar.gz";
       hash = "sha256-kWP4SO72nk1MyIODl/CGH9nqft4AERfb2WlPjZUFLvU=";
     };
     meta = {
@@ -12019,11 +12019,11 @@ with self;
     };
   };
 
-  EncodeBase32GMP = buildPerlPackage {
+  EncodeBase32GMP = buildPerlPackage rec {
     pname = "Encode-Base32-GMP";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JW/JWANG/Encode-Base32-GMP-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/J/JW/JWANG/Encode-Base32-GMP-${version}.tar.gz";
       hash = "sha256-RUIG+n2C5V4DJ0aYcyNBtgcVDwDo4q7FjzUyagMIMtw=";
     };
     buildInputs = [ TestBase ];
@@ -12036,11 +12036,11 @@ with self;
     };
   };
 
-  EncodeDetect = buildPerlModule {
+  EncodeDetect = buildPerlModule rec {
     pname = "Encode-Detect";
     version = "1.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JG/JGMYERS/Encode-Detect-1.01.tar.gz";
+      url = "mirror://cpan/authors/id/J/JG/JGMYERS/Encode-Detect-${version}.tar.gz";
       hash = "sha256-g02JOqfbbOPxWK+9DkMtbtFaJ24JQNsKdL4T/ZxLu/E=";
     };
     nativeBuildInputs = [ pkgs.ld-is-cc-hook ];
@@ -12054,11 +12054,11 @@ with self;
     };
   };
 
-  EncodeEUCJPASCII = buildPerlPackage {
+  EncodeEUCJPASCII = buildPerlPackage rec {
     pname = "Encode-EUCJPASCII";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEZUMI/Encode-EUCJPASCII-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEZUMI/Encode-EUCJPASCII-${version}.tar.gz";
       hash = "sha256-+ZjTTVX9nILPkQeGoESNHt+mC/aOLCMGckymfGKd6GE=";
     };
     outputs = [ "out" ];
@@ -12071,11 +12071,11 @@ with self;
     };
   };
 
-  EncodeHanExtra = buildPerlPackage {
+  EncodeHanExtra = buildPerlPackage rec {
     pname = "Encode-HanExtra";
     version = "0.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AU/AUDREYT/Encode-HanExtra-0.23.tar.gz";
+      url = "mirror://cpan/authors/id/A/AU/AUDREYT/Encode-HanExtra-${version}.tar.gz";
       hash = "sha256-H9SwbK2nCFgAOvFT+UyGOzuV8uPQO6GNBFGoHVHbRDo=";
     };
     meta = {
@@ -12084,11 +12084,11 @@ with self;
     };
   };
 
-  EncodeIMAPUTF7 = buildPerlPackage {
+  EncodeIMAPUTF7 = buildPerlPackage rec {
     pname = "Encode-IMAPUTF7";
     version = "1.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PM/PMAKHOLM/Encode-IMAPUTF7-1.05.tar.gz";
+      url = "mirror://cpan/authors/id/P/PM/PMAKHOLM/Encode-IMAPUTF7-${version}.tar.gz";
       hash = "sha256-RwMF3cN0g8/o08FtE3cKKAEfYAv1V6y4w+B3OZl8N+E=";
     };
     nativeCheckInputs = [ TestNoWarnings ];
@@ -12104,11 +12104,11 @@ with self;
     ];
   };
 
-  EncodeJIS2K = buildPerlPackage {
+  EncodeJIS2K = buildPerlPackage rec {
     pname = "Encode-JIS2K";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DANKOGAI/Encode-JIS2K-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DANKOGAI/Encode-JIS2K-${version}.tar.gz";
       hash = "sha256-HshNcts53rTa1vypWs/MIQM/RaJNNHwg+aGmlolsNcw=";
     };
     outputs = [ "out" ];
@@ -12121,11 +12121,11 @@ with self;
     };
   };
 
-  EncodeLocale = buildPerlPackage {
+  EncodeLocale = buildPerlPackage rec {
     pname = "Encode-Locale";
     version = "1.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GA/GAAS/Encode-Locale-1.05.tar.gz";
+      url = "mirror://cpan/authors/id/G/GA/GAAS/Encode-Locale-${version}.tar.gz";
       hash = "sha256-F2+gJ3H1QqTvsdvCpMko6PQ5G/QHhHO9YEDY8RrbDsE=";
     };
     preCheck =
@@ -12146,11 +12146,11 @@ with self;
     };
   };
 
-  EncodeNewlines = buildPerlPackage {
+  EncodeNewlines = buildPerlPackage rec {
     pname = "Encode-Newlines";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/Encode-Newlines-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/Encode-Newlines-${version}.tar.gz";
       hash = "sha256-NLMfysjI/cghubNDSoLXEzIT73TM/yVf4UioavloN74=";
     };
     meta = {
@@ -12163,11 +12163,11 @@ with self;
     };
   };
 
-  EncodePunycode = buildPerlPackage {
+  EncodePunycode = buildPerlPackage rec {
     pname = "Encode-Punycode";
     version = "1.002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CF/CFAERBER/Encode-Punycode-1.002.tar.gz";
+      url = "mirror://cpan/authors/id/C/CF/CFAERBER/Encode-Punycode-${version}.tar.gz";
       hash = "sha256-yjrO7NuAtdRaoQ4c3o/sTpC0+MkYnHUE3YZY8HH3cZQ=";
     };
     buildInputs = [ TestNoWarnings ];
@@ -12182,11 +12182,11 @@ with self;
     };
   };
 
-  enum = buildPerlPackage {
+  enum = buildPerlPackage rec {
     pname = "enum";
     version = "1.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/enum-1.12.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/enum-${version}.tar.gz";
       hash = "sha256-aaeokc04iO2LAsXpmh9In5KmLsNRwLx4lP1719FEfqk=";
     };
     meta = {
@@ -12199,11 +12199,11 @@ with self;
     };
   };
 
-  Env = buildPerlPackage {
+  Env = buildPerlPackage rec {
     pname = "Env";
     version = "1.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FL/FLORA/Env-1.04.tar.gz";
+      url = "mirror://cpan/authors/id/F/FL/FLORA/Env-${version}.tar.gz";
       hash = "sha256-2Uo9QS3yRq/cMaIZnL2K6RUWej9GhPe3AUzhIAJR67A=";
     };
     meta = {
@@ -12216,11 +12216,11 @@ with self;
     };
   };
 
-  EnvPath = buildPerlPackage {
+  EnvPath = buildPerlPackage rec {
     pname = "Env-Path";
     version = "0.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DS/DSB/Env-Path-0.19.tar.gz";
+      url = "mirror://cpan/authors/id/D/DS/DSB/Env-Path-${version}.tar.gz";
       hash = "sha256-JEvwk3mIMqfYQdnuW0sOa0iZlu72NUHlBQkao0qQFeI=";
     };
     meta = {
@@ -12233,11 +12233,11 @@ with self;
     };
   };
 
-  EnvSanctify = buildPerlPackage {
+  EnvSanctify = buildPerlPackage rec {
     pname = "Env-Sanctify";
     version = "1.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BI/BINGOS/Env-Sanctify-1.12.tar.gz";
+      url = "mirror://cpan/authors/id/B/BI/BINGOS/Env-Sanctify-${version}.tar.gz";
       hash = "sha256-IOO1ZhwmVHSmnyiZR46ye5RkklWGu2tvtmYSnlgoMl8=";
     };
     meta = {
@@ -12250,11 +12250,11 @@ with self;
     };
   };
 
-  ENVUtil = buildPerlPackage {
+  ENVUtil = buildPerlPackage rec {
     pname = "ENV-Util";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GA/GARU/ENV-Util-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/G/GA/GARU/ENV-Util-${version}.tar.gz";
       hash = "sha256-B1574ehSxD6wiGYvr978FS9O9WyEPB4F2QDaGQb3P60=";
     };
     meta = {
@@ -12266,11 +12266,11 @@ with self;
     };
   };
 
-  Error = buildPerlModule {
+  Error = buildPerlModule rec {
     pname = "Error";
     version = "0.17030";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Error-0.17030.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Error-${version}.tar.gz";
       hash = "sha256-NNOCJ2wPsNazg1W5TJajCxLYNNVmLrU/CI7iXj5xKSQ=";
     };
     meta = {
@@ -12282,17 +12282,17 @@ with self;
     };
   };
 
-  EV = buildPerlPackage {
+  EV = buildPerlPackage rec {
     pname = "EV";
     version = "4.34";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/EV-4.34.tar.gz";
+      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/EV-${version}.tar.gz";
       hash = "sha256-EhFoPc57Z3H0q3EMwVNxK913umFXoTKU0LtzSR/QZWA=";
     };
     patches = [
       (fetchpatch {
-        name = "EV-4.34-perl-5.42.patch";
-        url = "https://free.nchc.org.tw/gentoo-portage/dev-perl/EV/files/EV-4.34-perl-5.42.patch";
+        name = "EV-${version}-perl-5.42.patch";
+        url = "https://free.nchc.org.tw/gentoo-portage/dev-perl/EV/files/EV-${version}-perl-5.42.patch";
         hash = "sha256-GiQ89pk3EZ3b6oxB7jDTY5C62qqKsZUjJ4Ag2JVwGFw=";
       })
     ];
@@ -12304,11 +12304,11 @@ with self;
     };
   };
 
-  EvalClosure = buildPerlPackage {
+  EvalClosure = buildPerlPackage rec {
     pname = "Eval-Closure";
     version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DO/DOY/Eval-Closure-0.14.tar.gz";
+      url = "mirror://cpan/authors/id/D/DO/DOY/Eval-Closure-${version}.tar.gz";
       hash = "sha256-6glE8vXsmNiVvvbVA+bko3b+pjg6a8ZMdnDUb/IhjK0=";
     };
     buildInputs = [
@@ -12341,11 +12341,11 @@ with self;
     };
   };
 
-  ExcelWriterXLSX = buildPerlPackage {
+  ExcelWriterXLSX = buildPerlPackage rec {
     pname = "Excel-Writer-XLSX";
     version = "1.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JM/JMCNAMARA/Excel-Writer-XLSX-1.11.tar.gz";
+      url = "mirror://cpan/authors/id/J/JM/JMCNAMARA/Excel-Writer-XLSX-${version}.tar.gz";
       hash = "sha256-yzMA0jEZxpiGTvC3PBmnLLpxi/wG7QBzWaUxP5YcwqA=";
     };
     propagatedBuildInputs = [ ArchiveZip ];
@@ -12360,11 +12360,11 @@ with self;
     };
   };
 
-  ExceptionBase = buildPerlModule {
+  ExceptionBase = buildPerlModule rec {
     pname = "Exception-Base";
     version = "0.2501";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DE/DEXTER/Exception-Base-0.2501.tar.gz";
+      url = "mirror://cpan/authors/id/D/DE/DEXTER/Exception-Base-${version}.tar.gz";
       hash = "sha256-VyPdePSsC00mKgXqRq9mPqANgJay6cCkNRXCEHYOHnU=";
     };
     buildInputs = [ TestUnitLite ];
@@ -12380,11 +12380,11 @@ with self;
     };
   };
 
-  ExceptionClass = buildPerlPackage {
+  ExceptionClass = buildPerlPackage rec {
     pname = "Exception-Class";
     version = "1.45";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Exception-Class-1.45.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Exception-Class-${version}.tar.gz";
       hash = "sha256-VIKnfvAnyh+fOeH0jFWDVulUk2/I+73ubIEcUScBskk=";
     };
     propagatedBuildInputs = [
@@ -12400,11 +12400,11 @@ with self;
     };
   };
 
-  ExceptionDied = buildPerlModule {
+  ExceptionDied = buildPerlModule rec {
     pname = "Exception-Died";
     version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DE/DEXTER/Exception-Died-0.06.tar.gz";
+      url = "mirror://cpan/authors/id/D/DE/DEXTER/Exception-Died-${version}.tar.gz";
       hash = "sha256-NcRAvCr9TVfiQaDbG05o2dUpXfLbjXidObX0UQWXirU=";
     };
     buildInputs = [
@@ -12424,11 +12424,11 @@ with self;
     };
   };
 
-  ExceptionWarning = buildPerlModule {
+  ExceptionWarning = buildPerlModule rec {
     pname = "Exception-Warning";
     version = "0.0401";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DE/DEXTER/Exception-Warning-0.0401.tar.gz";
+      url = "mirror://cpan/authors/id/D/DE/DEXTER/Exception-Warning-${version}.tar.gz";
       hash = "sha256-ezacps61se3ytdX4cOl0x8k+kwNnw5o5AL/2CZce06g=";
     };
     buildInputs = [
@@ -12445,11 +12445,11 @@ with self;
     };
   };
 
-  ExporterDeclare = buildPerlModule {
+  ExporterDeclare = buildPerlModule rec {
     pname = "Exporter-Declare";
     version = "0.114";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EX/EXODIST/Exporter-Declare-0.114.tar.gz";
+      url = "mirror://cpan/authors/id/E/EX/EXODIST/Exporter-Declare-${version}.tar.gz";
       hash = "sha256-S9cNbKdvb2un5MYY1KyTuFk6WPEjPMvhixD18gTx1OQ=";
     };
     buildInputs = [
@@ -12470,11 +12470,11 @@ with self;
     };
   };
 
-  ExporterLite = buildPerlPackage {
+  ExporterLite = buildPerlPackage rec {
     pname = "Exporter-Lite";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/Exporter-Lite-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/Exporter-Lite-${version}.tar.gz";
       hash = "sha256-edixT9UBOSLGPoUPFb9RBZ8lAkBFNetmkO8jYSwqGY0=";
     };
     meta = {
@@ -12486,11 +12486,11 @@ with self;
     };
   };
 
-  ExporterTiny = buildPerlPackage {
+  ExporterTiny = buildPerlPackage rec {
     pname = "Exporter-Tiny";
     version = "1.006002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOBYINK/Exporter-Tiny-1.006002.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TOBYINK/Exporter-Tiny-${version}.tar.gz";
       hash = "sha256-byleLL/7HbwVvbna3DQWccHgzSvfLTErF1Jic8MiY40=";
     };
     meta = {
@@ -12503,11 +12503,11 @@ with self;
     };
   };
 
-  Expect = buildPerlPackage {
+  Expect = buildPerlPackage rec {
     pname = "Expect";
     version = "1.35";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JA/JACOBY/Expect-1.35.tar.gz";
+      url = "mirror://cpan/authors/id/J/JA/JACOBY/Expect-${version}.tar.gz";
       hash = "sha256-CdknYUId7NSVhTEDN5FlqZ779FLHIPMCd2As8jZ5/QY=";
     };
     propagatedBuildInputs = [ IOTty ];
@@ -12520,11 +12520,11 @@ with self;
     };
   };
 
-  ExpectSimple = buildPerlPackage {
+  ExpectSimple = buildPerlPackage rec {
     pname = "Expect-Simple";
     version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DJ/DJERIUS/Expect-Simple-0.04.tar.gz";
+      url = "mirror://cpan/authors/id/D/DJ/DJERIUS/Expect-Simple-${version}.tar.gz";
       hash = "sha256-r4O5IYXmQmlZE/8Tjv6Bl1LoCFd1mZber8qrJwCtXbU=";
     };
     propagatedBuildInputs = [ Expect ];
@@ -12537,11 +12537,11 @@ with self;
     };
   };
 
-  ExtUtilsCChecker = buildPerlModule {
+  ExtUtilsCChecker = buildPerlModule rec {
     pname = "ExtUtils-CChecker";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/ExtUtils-CChecker-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/ExtUtils-CChecker-${version}.tar.gz";
       hash = "sha256-EXc2Z343/GEfW3Y3TX+VLhlw64Dh9q1RUNUW565TG/U=";
     };
     buildInputs = [ TestFatal ];
@@ -12554,11 +12554,11 @@ with self;
     };
   };
 
-  ExtUtilsConfig = buildPerlPackage {
+  ExtUtilsConfig = buildPerlPackage rec {
     pname = "ExtUtils-Config";
     version = "0.008";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/ExtUtils-Config-0.008.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/ExtUtils-Config-${version}.tar.gz";
       hash = "sha256-rlEE9jRlDc6KebftE/tZ1no5whOmd2z9qj7nSeYvGow=";
     };
     meta = {
@@ -12570,11 +12570,11 @@ with self;
     };
   };
 
-  ExtUtilsConstant = buildPerlPackage {
+  ExtUtilsConstant = buildPerlPackage rec {
     pname = "ExtUtils-Constant";
     version = "0.25";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NW/NWCLARK/ExtUtils-Constant-0.25.tar.gz";
+      url = "mirror://cpan/authors/id/N/NW/NWCLARK/ExtUtils-Constant-${version}.tar.gz";
       hash = "sha256-aTPQ6WO2IoHvdWEGjmrsrIxKwrR2srugmrC5D7rJ11c=";
     };
     patches = [
@@ -12589,11 +12589,11 @@ with self;
     };
   };
 
-  ExtUtilsCppGuess = buildPerlPackage {
+  ExtUtilsCppGuess = buildPerlPackage rec {
     pname = "ExtUtils-CppGuess";
     version = "0.26";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETJ/ExtUtils-CppGuess-0.26.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETJ/ExtUtils-CppGuess-${version}.tar.gz";
       hash = "sha256-yLNiuGAXKkB2rO4AQ49SuGRk8sUAcCz891J4Ef+aaD4=";
     };
     doCheck = !stdenv.hostPlatform.isDarwin;
@@ -12609,11 +12609,11 @@ with self;
     };
   };
 
-  ExtUtilsDepends = buildPerlPackage {
+  ExtUtilsDepends = buildPerlPackage rec {
     pname = "ExtUtils-Depends";
     version = "0.8001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XA/XAOC/ExtUtils-Depends-0.8001.tar.gz";
+      url = "mirror://cpan/authors/id/X/XA/XAOC/ExtUtils-Depends-${version}.tar.gz";
       hash = "sha256-ZzxDh+eJbBohYJnB+7P6qndj1/X5WhpWpgoqKQbBMcU=";
     };
     meta = {
@@ -12627,11 +12627,11 @@ with self;
     };
   };
 
-  ExtUtilsF77 = buildPerlPackage {
+  ExtUtilsF77 = buildPerlPackage rec {
     pname = "ExtUtils-F77";
     version = "1.26";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETJ/ExtUtils-F77-1.26.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETJ/ExtUtils-F77-${version}.tar.gz";
       hash = "sha256-q90dPuxMpPyuXxUrQLyqhi48gG4H5KqRI3V/aqSLndY=";
     };
     buildInputs = [ pkgs.gfortran ];
@@ -12645,11 +12645,11 @@ with self;
     };
   };
 
-  ExtUtilsHelpers = buildPerlPackage {
+  ExtUtilsHelpers = buildPerlPackage rec {
     pname = "ExtUtils-Helpers";
     version = "0.026";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/ExtUtils-Helpers-0.026.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/ExtUtils-Helpers-${version}.tar.gz";
       hash = "sha256-3pAbZ5CkVXz07JCBSeA1eDsSW/EV65ZA/rG8HCTDNBY=";
     };
     meta = {
@@ -12661,11 +12661,11 @@ with self;
     };
   };
 
-  ExtUtilsH2PM = buildPerlPackage {
+  ExtUtilsH2PM = buildPerlPackage rec {
     pname = "ExtUtils-H2PM";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/ExtUtils-H2PM-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/ExtUtils-H2PM-${version}.tar.gz";
       hash = "sha256-RrSuyafSxXSSVtCdz3ukwtAM3dQRAUgkme2Ix2bp6No=";
     };
     buildInputs = [ ModuleBuild ];
@@ -12678,11 +12678,11 @@ with self;
     };
   };
 
-  ExtUtilsInstall = buildPerlPackage {
+  ExtUtilsInstall = buildPerlPackage rec {
     pname = "ExtUtils-Install";
     version = "2.22";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BI/BINGOS/ExtUtils-Install-2.22.tar.gz";
+      url = "mirror://cpan/authors/id/B/BI/BINGOS/ExtUtils-Install-${version}.tar.gz";
       hash = "sha256-M3Jbr77Tgp1hPkxlHC4a0SBnDH0qxc8F+DdX/Jddb/I=";
     };
     meta = {
@@ -12695,11 +12695,11 @@ with self;
     };
   };
 
-  ExtUtilsInstallPaths = buildPerlPackage {
+  ExtUtilsInstallPaths = buildPerlPackage rec {
     pname = "ExtUtils-InstallPaths";
     version = "0.012";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/ExtUtils-InstallPaths-0.012.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/ExtUtils-InstallPaths-${version}.tar.gz";
       hash = "sha256-hHNeMDe6sf3/o8JQhWetQSp4XJFZnbPBJZOlCh3UNO0=";
     };
     propagatedBuildInputs = [ ExtUtilsConfig ];
@@ -12712,11 +12712,11 @@ with self;
     };
   };
 
-  ExtUtilsLibBuilder = buildPerlModule {
+  ExtUtilsLibBuilder = buildPerlModule rec {
     pname = "ExtUtils-LibBuilder";
     version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AM/AMBS/ExtUtils-LibBuilder-0.08.tar.gz";
+      url = "mirror://cpan/authors/id/A/AM/AMBS/ExtUtils-LibBuilder-${version}.tar.gz";
       hash = "sha256-xRFx4G3lMDnwvKHZemRx7DeUH/Weij0csXDr3SVztdI=";
     };
     meta = {
@@ -12728,11 +12728,11 @@ with self;
     };
   };
 
-  ExtUtilsMakeMaker = buildPerlPackage {
+  ExtUtilsMakeMaker = buildPerlPackage rec {
     pname = "ExtUtils-MakeMaker";
     version = "7.70";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BI/BINGOS/ExtUtils-MakeMaker-7.70.tar.gz";
+      url = "mirror://cpan/authors/id/B/BI/BINGOS/ExtUtils-MakeMaker-${version}.tar.gz";
       hash = "sha256-8Qi9RkINLwDSQoJfhlsPaIUQhJJJJPkiYdaExJ4+enQ=";
     };
     meta = {
@@ -12746,11 +12746,11 @@ with self;
     };
   };
 
-  ExtUtilsMakeMakerCPANfile = buildPerlPackage {
+  ExtUtilsMakeMakerCPANfile = buildPerlPackage rec {
     pname = "ExtUtils-MakeMaker-CPANfile";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/ExtUtils-MakeMaker-CPANfile-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/ExtUtils-MakeMaker-CPANfile-${version}.tar.gz";
       hash = "sha256-LAd2B9SwoQhWkHTf926BaGWQYq2jpq94swzKDUD44nU=";
     };
     propagatedBuildInputs = [ ModuleCPANfile ];
@@ -12763,11 +12763,11 @@ with self;
     };
   };
 
-  ExtUtilsPkgConfig = buildPerlPackage {
+  ExtUtilsPkgConfig = buildPerlPackage rec {
     pname = "ExtUtils-PkgConfig";
     version = "1.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XA/XAOC/ExtUtils-PkgConfig-1.16.tar.gz";
+      url = "mirror://cpan/authors/id/X/XA/XAOC/ExtUtils-PkgConfig-${version}.tar.gz";
       hash = "sha256-u+rO2ZXX2NEM/FGjpaZtpBzrK8BP7cq1DhDmMA6AHG4=";
     };
     nativeBuildInputs = [ buildPackages.pkg-config ];
@@ -12802,11 +12802,11 @@ with self;
   #   5.16.
   #
   # [1] https://metacpan.org/pod/release/SMUELLER/ExtUtils-Typemap-1.00/lib/ExtUtils/Typemap.pm:
-  ExtUtilsTypemap = buildPerlPackage {
+  ExtUtilsTypemap = buildPerlPackage rec {
     pname = "ExtUtils-Typemap";
     version = "1.00";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SM/SMUELLER/ExtUtils-Typemap-1.00.tar.gz";
+      url = "mirror://cpan/authors/id/S/SM/SMUELLER/ExtUtils-Typemap-${version}.tar.gz";
       hash = "sha256-sbAVdy27BouToPb/oC9dlIIjZeYBisXtK8U8pmkHH8c=";
     };
     meta = {
@@ -12818,11 +12818,11 @@ with self;
     };
   };
 
-  ExtUtilsTypemapsDefault = buildPerlModule {
+  ExtUtilsTypemapsDefault = buildPerlModule rec {
     pname = "ExtUtils-Typemaps-Default";
     version = "1.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SM/SMUELLER/ExtUtils-Typemaps-Default-1.05.tar.gz";
+      url = "mirror://cpan/authors/id/S/SM/SMUELLER/ExtUtils-Typemaps-Default-${version}.tar.gz";
       hash = "sha256-Pfr1g36/3AB4lb/KhMPC521Ymn0zZADo37MkPYGCFd4=";
     };
     meta = {
@@ -12834,11 +12834,11 @@ with self;
     };
   };
 
-  ExtUtilsXSBuilder = buildPerlPackage {
+  ExtUtilsXSBuilder = buildPerlPackage rec {
     pname = "ExtUtils-XSBuilder";
     version = "0.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GR/GRICHTER/ExtUtils-XSBuilder-0.28.tar.gz";
+      url = "mirror://cpan/authors/id/G/GR/GRICHTER/ExtUtils-XSBuilder-${version}.tar.gz";
       hash = "sha256-jM7ThuPVRMXsLes67QVbcuvPwuqabIB9qHxCRScv6Ao=";
     };
     propagatedBuildInputs = [
@@ -12854,11 +12854,11 @@ with self;
     };
   };
 
-  ExtUtilsXSpp = buildPerlModule {
+  ExtUtilsXSpp = buildPerlModule rec {
     pname = "ExtUtils-XSpp";
     version = "0.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SM/SMUELLER/ExtUtils-XSpp-0.18.tar.gz";
+      url = "mirror://cpan/authors/id/S/SM/SMUELLER/ExtUtils-XSpp-${version}.tar.gz";
       hash = "sha256-kXatZGcp470nz3q/EUvt00JL/xumEYXPx9VPOpIjqP8=";
     };
     buildInputs = [
@@ -12875,11 +12875,11 @@ with self;
     };
   };
 
-  FatalException = buildPerlModule {
+  FatalException = buildPerlModule rec {
     pname = "Fatal-Exception";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DE/DEXTER/Fatal-Exception-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/D/DE/DEXTER/Fatal-Exception-${version}.tar.gz";
       hash = "sha256-KAldIT+zKknJwjKmhEg375Rdua1unmHkULTfTQjj7k8=";
     };
     buildInputs = [
@@ -12897,11 +12897,11 @@ with self;
     };
   };
 
-  FCGI = buildPerlPackage {
+  FCGI = buildPerlPackage rec {
     pname = "FCGI";
     version = "0.82";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/FCGI-0.82.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/FCGI-${version}.tar.gz";
       hash = "sha256-TH1g4m2iwH8Fik40UCHpJQUnOzPJVCIVl34IRhHwns8=";
     };
     buildInputs = [ FCGIClient ];
@@ -12914,11 +12914,11 @@ with self;
     };
   };
 
-  FCGIClient = buildPerlModule {
+  FCGIClient = buildPerlModule rec {
     pname = "FCGI-Client";
     version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOKUHIROM/FCGI-Client-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TOKUHIROM/FCGI-Client-${version}.tar.gz";
       hash = "sha256-1TfLCc5aqz9Eemu0QV5GzAbv4BYRzVYom1WCvbRiIeg=";
     };
     propagatedBuildInputs = [
@@ -12936,11 +12936,11 @@ with self;
     };
   };
 
-  FCGIProcManager = buildPerlPackage {
+  FCGIProcManager = buildPerlPackage rec {
     pname = "FCGI-ProcManager";
     version = "0.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AR/ARODLAND/FCGI-ProcManager-0.28.tar.gz";
+      url = "mirror://cpan/authors/id/A/AR/ARODLAND/FCGI-ProcManager-${version}.tar.gz";
       hash = "sha256-4clYwEJCehdeBR4ACPICXo7IBhPTx3UFl7+OUpsEQg4=";
     };
     meta = {
@@ -12949,11 +12949,11 @@ with self;
     };
   };
 
-  FFIC = buildPerlPackage {
+  FFIC = buildPerlPackage rec {
     pname = "FFI-C";
     version = "0.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/FFI-C-0.15.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/FFI-C-${version}.tar.gz";
       hash = "sha256-63BgfmZzvMsY3yf0zuRZ+23EGODak+aSzcNVX+QNL04=";
     };
     buildInputs = [
@@ -12980,11 +12980,11 @@ with self;
     };
   };
 
-  FFICheckLib = buildPerlPackage {
+  FFICheckLib = buildPerlPackage rec {
     pname = "FFI-CheckLib";
     version = "0.31";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/FFI-CheckLib-0.31.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/FFI-CheckLib-${version}.tar.gz";
       hash = "sha256-BNiF/Dd9RIluXqHE7DEPl5uwTy8YZYp+ek1Qn36Au4A=";
     };
     buildInputs = [ Test2Suite ];
@@ -12999,11 +12999,11 @@ with self;
     };
   };
 
-  FeatureCompatTry = buildPerlModule {
+  FeatureCompatTry = buildPerlModule rec {
     pname = "Feature-Compat-Try";
     version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Feature-Compat-Try-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Feature-Compat-Try-${version}.tar.gz";
       hash = "sha256-WaHHFzysMNsTHF8T+jhA9xhYju+bV5NS/+FWtVBxbXw=";
     };
     buildInputs = [ Test2Suite ];
@@ -13017,11 +13017,11 @@ with self;
     };
   };
 
-  FFICStat = buildPerlPackage {
+  FFICStat = buildPerlPackage rec {
     pname = "FFI-C-Stat";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/FFI-C-Stat-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/FFI-C-Stat-${version}.tar.gz";
       hash = "sha256-YOjveCyLs0cFXJ49ov1BTzX2EP5P77eNBzncyiQoQx4=";
     };
     buildInputs = [
@@ -13045,11 +13045,11 @@ with self;
     };
   };
 
-  FFIPlatypus = buildPerlPackage {
+  FFIPlatypus = buildPerlPackage rec {
     pname = "FFI-Platypus";
     version = "2.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/FFI-Platypus-2.10.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/FFI-Platypus-${version}.tar.gz";
       hash = "sha256-ZxFcAjF7I9EZtu4aXm1fJvr4mFlD61PPiGLFcZ54+28=";
     };
     buildInputs = [
@@ -13071,11 +13071,11 @@ with self;
     };
   };
 
-  FFIPlatypusTypePtrObject = buildPerlPackage {
+  FFIPlatypusTypePtrObject = buildPerlPackage rec {
     pname = "FFI-Platypus-Type-PtrObject";
     version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/FFI-Platypus-Type-PtrObject-0.03.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/FFI-Platypus-Type-PtrObject-${version}.tar.gz";
       hash = "sha256-4elJB++QtANgqabAPSlaEwR9T2ybVqyvHfK1TRcwf3Q=";
     };
     buildInputs = [
@@ -13097,11 +13097,11 @@ with self;
     };
   };
 
-  FFIPlatypusTypeEnum = buildPerlPackage {
+  FFIPlatypusTypeEnum = buildPerlPackage rec {
     pname = "FFI-Platypus-Type-Enum";
     version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/FFI-Platypus-Type-Enum-0.06.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/FFI-Platypus-Type-Enum-${version}.tar.gz";
       hash = "sha256-yVSmBPfWkpYk+pQT2NDh2DtL2XfQVifKznPtU6lcd98=";
     };
     buildInputs = [
@@ -13120,11 +13120,11 @@ with self;
     };
   };
 
-  FennecLite = buildPerlModule {
+  FennecLite = buildPerlModule rec {
     pname = "Fennec-Lite";
     version = "0.004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EX/EXODIST/Fennec-Lite-0.004.tar.gz";
+      url = "mirror://cpan/authors/id/E/EX/EXODIST/Fennec-Lite-${version}.tar.gz";
       hash = "sha256-3OKOOTJ2LC/5KqUtkEBcBuiY6By3sWTMrolmrnfx3Ks=";
     };
     meta = {
@@ -13137,11 +13137,11 @@ with self;
     };
   };
 
-  FileChangeNotify = buildPerlPackage {
+  FileChangeNotify = buildPerlPackage rec {
     pname = "File-ChangeNotify";
     version = "0.31";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/File-ChangeNotify-0.31.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/File-ChangeNotify-${version}.tar.gz";
       hash = "sha256-GSvbHOdiZsamlKjpYtA5463uuCm2rB4j9QV/K1Bjkr0=";
     };
     buildInputs = [
@@ -13161,11 +13161,11 @@ with self;
     };
   };
 
-  Filechdir = buildPerlPackage {
+  Filechdir = buildPerlPackage rec {
     pname = "File-chdir";
     version = "0.1011";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/File-chdir-0.1011.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/File-chdir-${version}.tar.gz";
       hash = "sha256-Mev5Et9I1daB3vdLmIDXix86ykNRoO0f41cLjgOvbHk=";
     };
     meta = {
@@ -13177,11 +13177,11 @@ with self;
     };
   };
 
-  FileBaseDir = buildPerlPackage {
+  FileBaseDir = buildPerlPackage rec {
     version = "0.09";
     pname = "File-BaseDir";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/File-BaseDir-0.09.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/File-BaseDir-${version}.tar.gz";
       hash = "sha256-bab3KBVirI8R7xo69q7bUcQRgrYPHxIs7QB579kpZ9k=";
     };
     propagatedBuildInputs = [ IPCSystemSimple ];
@@ -13195,11 +13195,11 @@ with self;
     };
   };
 
-  FileBOM = buildPerlModule {
+  FileBOM = buildPerlModule rec {
     pname = "File-BOM";
     version = "0.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MATTLAW/File-BOM-0.18.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MATTLAW/File-BOM-${version}.tar.gz";
       hash = "sha256-KO3EP8sRjhG8RYya6InVbTiMHZvCmZewCx3/2Fc4I6M=";
     };
     buildInputs = [ TestException ];
@@ -13213,11 +13213,11 @@ with self;
     };
   };
 
-  FileCheckTree = buildPerlPackage {
+  FileCheckTree = buildPerlPackage rec {
     pname = "File-CheckTree";
     version = "4.42";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/File-CheckTree-4.42.tar.gz";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/File-CheckTree-${version}.tar.gz";
       hash = "sha256-ZvtBf4/4peW36iVgYVbnDiBIYcWfqMODGSW03T8VX4o=";
     };
     meta = {
@@ -13230,11 +13230,11 @@ with self;
     };
   };
 
-  Filechmod = buildPerlPackage {
+  Filechmod = buildPerlPackage rec {
     pname = "File-chmod";
     version = "0.42";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XE/XENO/File-chmod-0.42.tar.gz";
+      url = "mirror://cpan/authors/id/X/XE/XENO/File-chmod-${version}.tar.gz";
       hash = "sha256-bK+v/2i8hCFRaLVe3g0ZHctX+aMgG1HWHtsoWKJAd5U=";
     };
     meta = {
@@ -13247,11 +13247,11 @@ with self;
     };
   };
 
-  FilechmodRecursive = buildPerlPackage {
+  FilechmodRecursive = buildPerlPackage rec {
     pname = "File-chmod-Recursive";
     version = "1.0.3";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MITHUN/File-chmod-Recursive-v1.0.3.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MITHUN/File-chmod-Recursive-v${version}.tar.gz";
       hash = "sha256-k0jKXFuI3q3MSDuTme98Lg/CUE+QWNtl88PFPEETmqc=";
     };
     propagatedBuildInputs = [ Filechmod ];
@@ -13265,11 +13265,11 @@ with self;
     };
   };
 
-  FileCopyRecursive = buildPerlPackage {
+  FileCopyRecursive = buildPerlPackage rec {
     pname = "File-Copy-Recursive";
     version = "0.45";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DM/DMUEY/File-Copy-Recursive-0.45.tar.gz";
+      url = "mirror://cpan/authors/id/D/DM/DMUEY/File-Copy-Recursive-${version}.tar.gz";
       hash = "sha256-05cc94qDReOAQrIIu3s5y2lQgDhq9in0oE/9ZUnfEVc=";
     };
     buildInputs = [
@@ -13288,11 +13288,11 @@ with self;
     };
   };
 
-  FileCopyRecursiveReduced = buildPerlPackage {
+  FileCopyRecursiveReduced = buildPerlPackage rec {
     pname = "File-Copy-Recursive-Reduced";
     version = "0.007";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JK/JKEENAN/File-Copy-Recursive-Reduced-0.007.tar.gz";
+      url = "mirror://cpan/authors/id/J/JK/JKEENAN/File-Copy-Recursive-Reduced-${version}.tar.gz";
       hash = "sha256-07WFIuaYA6kUN+KcCZ63Bug3Px7vBRik3DZp3T383Cc=";
     };
     buildInputs = [
@@ -13309,11 +13309,11 @@ with self;
     };
   };
 
-  FileCountLines = buildPerlPackage {
+  FileCountLines = buildPerlPackage rec {
     pname = "File-CountLines";
     version = "0.0.3";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MO/MORITZ/File-CountLines-v0.0.3.tar.gz";
+      url = "mirror://cpan/authors/id/M/MO/MORITZ/File-CountLines-v${version}.tar.gz";
       hash = "sha256-z9l8znyWE+TladR4dKK1cE8b6eztLwc5yHByVpQ4KmI=";
     };
     meta = {
@@ -13325,11 +13325,11 @@ with self;
     };
   };
 
-  FileDesktopEntry = buildPerlPackage {
+  FileDesktopEntry = buildPerlPackage rec {
     version = "0.22";
     pname = "File-DesktopEntry";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MICHIELB/File-DesktopEntry-0.22.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MICHIELB/File-DesktopEntry-${version}.tar.gz";
       hash = "sha256-FpwB49ri9il2e+wanxzb1uxtcT0VAeCyeG5N0SNWNbg=";
     };
     propagatedBuildInputs = [
@@ -13345,11 +13345,11 @@ with self;
     };
   };
 
-  FileDirList = buildPerlPackage {
+  FileDirList = buildPerlPackage rec {
     version = "0.05";
     pname = "File-DirList";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TP/TPABA/File-DirList/File-DirList-0.05.tar.gz";
+      url = "mirror://cpan/authors/id/T/TP/TPABA/File-DirList/File-DirList-${version}.tar.gz";
       sha256 = "sha256-mTt9dmLlV5hEih7azLmr0oHSvSO+fquZ9Wm44pYtO8M=";
     };
     preCheck = ''
@@ -13364,11 +13364,11 @@ with self;
     };
   };
 
-  FileFindIterator = buildPerlPackage {
+  FileFindIterator = buildPerlPackage rec {
     pname = "File-Find-Iterator";
     version = "0.4";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TE/TEXMEC/File-Find-Iterator-0.4.tar.gz";
+      url = "mirror://cpan/authors/id/T/TE/TEXMEC/File-Find-Iterator-${version}.tar.gz";
       hash = "sha256-orh6uXVqLlu2dK29OZN2Y+0gwoxxa/WhCVo8pE1Uqyw=";
     };
     propagatedBuildInputs = [ ClassIterator ];
@@ -13381,11 +13381,11 @@ with self;
     };
   };
 
-  FileFindObject = buildPerlModule {
+  FileFindObject = buildPerlModule rec {
     pname = "File-Find-Object";
     version = "0.3.8";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/File-Find-Object-0.3.8.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/File-Find-Object-${version}.tar.gz";
       hash = "sha256-TlJRRt6GTt+8kJsIRGKe7O0AY7YdQYuXLu8D+ES7NRQ=";
     };
     buildInputs = [
@@ -13400,11 +13400,11 @@ with self;
     };
   };
 
-  FileFindObjectRule = buildPerlModule {
+  FileFindObjectRule = buildPerlModule rec {
     pname = "File-Find-Object-Rule";
     version = "0.0313";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/File-Find-Object-Rule-0.0313.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/File-Find-Object-Rule-${version}.tar.gz";
       hash = "sha256-gZQPKZ1khySPvzDY8ft99sajSz35RApWIbE1yONPz/I=";
     };
     buildInputs = [ FileTreeCreate ];
@@ -13429,11 +13429,11 @@ with self;
     };
   };
 
-  FileFindRule = buildPerlPackage {
+  FileFindRule = buildPerlPackage rec {
     pname = "File-Find-Rule";
     version = "0.34";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RC/RCLAMP/File-Find-Rule-0.34.tar.gz";
+      url = "mirror://cpan/authors/id/R/RC/RCLAMP/File-Find-Rule-${version}.tar.gz";
       hash = "sha256-fm8WzDPrHyn/Jb7lHVE/S4qElHu/oY7bLTzECi1kyv4=";
     };
     patches = [
@@ -13453,11 +13453,11 @@ with self;
     };
   };
 
-  FileFindRulePerl = buildPerlPackage {
+  FileFindRulePerl = buildPerlPackage rec {
     pname = "File-Find-Rule-Perl";
     version = "1.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/File-Find-Rule-Perl-1.16.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/File-Find-Rule-Perl-${version}.tar.gz";
       hash = "sha256-rhiGBQ2cohIjwHPihwq9yA3DDj9VKJoRw32jggqDIf8=";
     };
     propagatedBuildInputs = [
@@ -13474,11 +13474,11 @@ with self;
     };
   };
 
-  FileFinder = buildPerlPackage {
+  FileFinder = buildPerlPackage rec {
     pname = "File-Finder";
     version = "0.53";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/ME/MERLYN/File-Finder-0.53.tar.gz";
+      url = "mirror://cpan/authors/id/M/ME/MERLYN/File-Finder-${version}.tar.gz";
       hash = "sha256-LsvBmsZ6nmNchyqAeo0+qv9bq8BU8VoZHUfN/F8XanQ=";
     };
     propagatedBuildInputs = [ TextGlob ];
@@ -13491,11 +13491,11 @@ with self;
     };
   };
 
-  FileFnMatch = buildPerlPackage {
+  FileFnMatch = buildPerlPackage rec {
     pname = "File-FnMatch";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MJ/MJP/File-FnMatch-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/M/MJ/MJP/File-FnMatch-${version}.tar.gz";
       hash = "sha256-liRUuOhr6osTK/ivNXV9DGqPXVmQFb1qXWjLeuep6RY=";
     };
     meta = {
@@ -13511,11 +13511,11 @@ with self;
     };
   };
 
-  FileFcntlLock = buildPerlPackage {
+  FileFcntlLock = buildPerlPackage rec {
     pname = "File-FcntlLock";
     version = "0.22";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JT/JTT/File-FcntlLock-0.22.tar.gz";
+      url = "mirror://cpan/authors/id/J/JT/JTT/File-FcntlLock-${version}.tar.gz";
       hash = "sha256-mpq7Lv/5Orc3QaEo0/cA5SUnNUbBXQTnxRxwSrCdvN8=";
     };
     meta = {
@@ -13525,11 +13525,11 @@ with self;
     };
   };
 
-  FileGrep = buildPerlPackage {
+  FileGrep = buildPerlPackage rec {
     pname = "File-Grep";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MN/MNEYLON/File-Grep-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/M/MN/MNEYLON/File-Grep-${version}.tar.gz";
       hash = "sha256-Ri4VJ062J4UhQH6jAtnupyUs1EyrI4KHH33oM9X4VjI=";
     };
     meta = {
@@ -13545,11 +13545,11 @@ with self;
     };
   };
 
-  FileHandleUnget = buildPerlPackage {
+  FileHandleUnget = buildPerlPackage rec {
     pname = "FileHandle-Unget";
     version = "0.1634";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCOPPIT/FileHandle-Unget-0.1634.tar.gz";
+      url = "mirror://cpan/authors/id/D/DC/DCOPPIT/FileHandle-Unget-${version}.tar.gz";
       hash = "sha256-OA80rTzl6exmHUxGi7M5IjHBYjF9QXLfN4FGtCqrF4U=";
     };
     buildInputs = [
@@ -13566,11 +13566,11 @@ with self;
     };
   };
 
-  FileHomeDir = buildPerlPackage {
+  FileHomeDir = buildPerlPackage rec {
     pname = "File-HomeDir";
     version = "1.006";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RE/REHSACK/File-HomeDir-1.006.tar.gz";
+      url = "mirror://cpan/authors/id/R/RE/REHSACK/File-HomeDir-${version}.tar.gz";
       hash = "sha256-WTc3xi3w9tq11BIuC0R2QXlFu2Jiwz7twAlmXvFUiFI=";
     };
     propagatedBuildInputs = [ FileWhich ];
@@ -13586,11 +13586,11 @@ with self;
     };
   };
 
-  FileKDBX = buildPerlPackage {
+  FileKDBX = buildPerlPackage rec {
     pname = "File-KDBX";
     version = "0.906";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CC/CCM/File-KDBX-0.906.tar.gz";
+      url = "mirror://cpan/authors/id/C/CC/CCM/File-KDBX-${version}.tar.gz";
       hash = "sha256-tHt/kzOrtJHqrsY0WhTn+TlW0UOUTBS4Fkp/0bIkvW8=";
     };
     propagatedBuildInputs = [
@@ -13619,11 +13619,11 @@ with self;
     };
   };
 
-  FileKeePass = buildPerlPackage {
+  FileKeePass = buildPerlPackage rec {
     pname = "File-KeePass";
     version = "2.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RH/RHANDOM/File-KeePass-2.03.tar.gz";
+      url = "mirror://cpan/authors/id/R/RH/RHANDOM/File-KeePass-${version}.tar.gz";
       hash = "sha256-wwxogCelL/T1jNadbY7zVHKnzxBtTOlOtzp5a6fH/6c=";
     };
     propagatedBuildInputs = [ CryptRijndael ];
@@ -13636,11 +13636,11 @@ with self;
     };
   };
 
-  Filelchown = buildPerlModule {
+  Filelchown = buildPerlModule rec {
     pname = "File-lchown";
     version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/File-lchown-0.02.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/File-lchown-${version}.tar.gz";
       hash = "sha256-oC+/KFQGqKTZOZKE8DLy1VxWl1FUwuFnS9EJg3uAluw=";
     };
     buildInputs = [ ExtUtilsCChecker ];
@@ -13653,11 +13653,11 @@ with self;
     };
   };
 
-  FileLibMagic = buildPerlPackage {
+  FileLibMagic = buildPerlPackage rec {
     pname = "File-LibMagic";
     version = "1.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/File-LibMagic-1.23.tar.gz";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/File-LibMagic-${version}.tar.gz";
       hash = "sha256-Uuax3Hyy2HpM30OboUXguejPKMwmpIo8+Zd8g0Y5Z+4=";
     };
     buildInputs = [
@@ -13680,11 +13680,11 @@ with self;
     };
   };
 
-  FileListing = buildPerlPackage {
+  FileListing = buildPerlPackage rec {
     pname = "File-Listing";
     version = "6.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/File-Listing-6.16.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/File-Listing-${version}.tar.gz";
       hash = "sha256-GJs6E/wKG6QSudnsWQHp5eREzHRrnwFW1DmTcNM2VcY=";
     };
     propagatedBuildInputs = [ HTTPDate ];
@@ -13697,11 +13697,11 @@ with self;
     };
   };
 
-  FileLoadLines = buildPerlPackage {
+  FileLoadLines = buildPerlPackage rec {
     pname = "File-LoadLines";
     version = "1.046";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JV/JV/File-LoadLines-1.046.tar.gz";
+      url = "mirror://cpan/authors/id/J/JV/JV/File-LoadLines-${version}.tar.gz";
       hash = "sha256-ebmx0HqFLHJaR/YEa3V9HXDKOvrWP6J6CHCHQ23XK8I=";
     };
     buildInputs = [ TestException ];
@@ -13714,11 +13714,11 @@ with self;
     };
   };
 
-  FileMimeInfo = buildPerlPackage {
+  FileMimeInfo = buildPerlPackage rec {
     pname = "File-MimeInfo";
     version = "0.33";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MICHIELB/File-MimeInfo-0.33.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MICHIELB/File-MimeInfo-${version}.tar.gz";
       hash = "sha256-9r6ms4kGITJeycJ5KvruiOlIoK4dEIcvpyxxELPhscQ=";
     };
     doCheck = false; # Failed test 'desktop file is the right one'
@@ -13736,11 +13736,11 @@ with self;
     };
   };
 
-  FileMMagic = buildPerlPackage {
+  FileMMagic = buildPerlPackage rec {
     pname = "File-MMagic";
     version = "1.30";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KN/KNOK/File-MMagic-1.30.tar.gz";
+      url = "mirror://cpan/authors/id/K/KN/KNOK/File-MMagic-${version}.tar.gz";
       hash = "sha256-zwwbHrKXBcAtl8KRNkgAnAvkLOk+wks2xpa/LU9evX4=";
     };
     meta = {
@@ -13749,11 +13749,11 @@ with self;
     };
   };
 
-  FileMap = buildPerlModule {
+  FileMap = buildPerlModule rec {
     pname = "File-Map";
     version = "0.71";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/File-Map-0.71.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/File-Map-${version}.tar.gz";
       hash = "sha256-yOJpM4BOhw1KupJiO3iGrIs8dgyY+/zTvcSyMFxGR1k=";
     };
     propagatedBuildInputs = [
@@ -13773,11 +13773,11 @@ with self;
     };
   };
 
-  FileModified = buildPerlPackage {
+  FileModified = buildPerlPackage rec {
     pname = "File-Modified";
     version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/File-Modified-0.10.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/File-Modified-${version}.tar.gz";
       hash = "sha256-a1CxqrbsaZigF/ZAPCc1s7weHPRhh70TTX623z/EUUQ=";
     };
     meta = {
@@ -13790,11 +13790,11 @@ with self;
     };
   };
 
-  FileNext = buildPerlPackage {
+  FileNext = buildPerlPackage rec {
     pname = "File-Next";
     version = "1.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PETDANCE/File-Next-1.18.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PETDANCE/File-Next-${version}.tar.gz";
       hash = "sha256-+QDLOVBetuFoqcpRoQtz8bveGRS5I6CezXLZwC5uwu8=";
     };
     meta = {
@@ -13803,11 +13803,11 @@ with self;
     };
   };
 
-  FileNFSLock = buildPerlPackage {
+  FileNFSLock = buildPerlPackage rec {
     pname = "File-NFSLock";
     version = "1.29";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BB/BBB/File-NFSLock-1.29.tar.gz";
+      url = "mirror://cpan/authors/id/B/BB/BBB/File-NFSLock-${version}.tar.gz";
       hash = "sha256-YdQVmbSBFk7fm4vsq77y0j9iKpcn9sGDZekrV4LU+jc=";
     };
     meta = {
@@ -13819,11 +13819,11 @@ with self;
     };
   };
 
-  FilePath = buildPerlPackage {
+  FilePath = buildPerlPackage rec {
     pname = "File-Path";
     version = "2.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JK/JKEENAN/File-Path-2.18.tar.gz";
+      url = "mirror://cpan/authors/id/J/JK/JKEENAN/File-Path-${version}.tar.gz";
       hash = "sha256-mA8KF+2zU99G6c17NX+fWSnN4PgMRf16Bs9+DovWrd0=";
     };
     meta = {
@@ -13835,17 +13835,17 @@ with self;
     };
   };
 
-  FilePid = buildPerlPackage {
+  FilePid = buildPerlPackage rec {
     pname = "File-Pid";
     version = "1.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CW/CWEST/File-Pid-1.01.tar.gz";
+      url = "mirror://cpan/authors/id/C/CW/CWEST/File-Pid-${version}.tar.gz";
       hash = "sha256-uv7uj9yW6wYwagxYu9tyCbbeRfhQ51/caxbbV24F5CI=";
     };
     patches = [
       (fetchpatch {
         name = "missing-pidfile.patch";
-        url = "https://sources.debian.org/data/main/libf/libfile-pid-perl/1.01-2/debian/patches/missing-pidfile.patch";
+        url = "https://sources.debian.org/data/main/libf/libfile-pid-perl/${version}-2/debian/patches/missing-pidfile.patch";
         hash = "sha256-VBsIYyCnjcZLYQ2Uq2MKPK3kF2wiMKvnq0m727DoavM=";
       })
     ];
@@ -13863,11 +13863,11 @@ with self;
     };
   };
 
-  Filepushd = buildPerlPackage {
+  Filepushd = buildPerlPackage rec {
     pname = "File-pushd";
     version = "1.016";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/File-pushd-1.016.tar.gz";
+      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/File-pushd-${version}.tar.gz";
       hash = "sha256-1zp/CUQpg7CYJg3z33qDKl9mB3OjE8onP6i1ZmX5fNw=";
     };
     meta = {
@@ -13877,11 +13877,11 @@ with self;
     };
   };
 
-  FileReadBackwards = buildPerlPackage {
+  FileReadBackwards = buildPerlPackage rec {
     pname = "File-ReadBackwards";
     version = "1.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/File-ReadBackwards-1.06.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/File-ReadBackwards-${version}.tar.gz";
       hash = "sha256-MrKgVJOJqviIde8D1+u//y1ZeeyoW3yBL2tLsQ0QL2I=";
     };
     meta = {
@@ -13894,11 +13894,11 @@ with self;
     };
   };
 
-  FileRemove = buildPerlModule {
+  FileRemove = buildPerlModule rec {
     pname = "File-Remove";
     version = "1.61";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/File-Remove-1.61.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/File-Remove-${version}.tar.gz";
       hash = "sha256-/YV/WFkI/FA0YbnkizyFlOZTV2a8FL6xfJC6WNXcSXU=";
     };
     meta = {
@@ -13910,11 +13910,11 @@ with self;
     };
   };
 
-  FileShare = buildPerlPackage {
+  FileShare = buildPerlPackage rec {
     pname = "File-Share";
     version = "0.27";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IN/INGY/File-Share-0.27.tar.gz";
+      url = "mirror://cpan/authors/id/I/IN/INGY/File-Share-${version}.tar.gz";
       hash = "sha256-1uj0tV69OOC7ReRDkuP6J9wf3harxdH/U+FX4ZpXVb4=";
     };
     propagatedBuildInputs = [
@@ -13931,11 +13931,11 @@ with self;
     };
   };
 
-  FileShareDir = buildPerlPackage {
+  FileShareDir = buildPerlPackage rec {
     pname = "File-ShareDir";
     version = "1.118";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RE/REHSACK/File-ShareDir-1.118.tar.gz";
+      url = "mirror://cpan/authors/id/R/RE/REHSACK/File-ShareDir-${version}.tar.gz";
       hash = "sha256-O7KiC6Nd+VjcCk8jBvwF2QPYuMTePIvu/OF3OdKByVg=";
     };
     # Fix dynamic loading not available when cross compiling
@@ -13955,11 +13955,11 @@ with self;
     };
   };
 
-  FileShareDirDist = buildPerlPackage {
+  FileShareDirDist = buildPerlPackage rec {
     pname = "File-ShareDir-Dist";
     version = "0.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/File-ShareDir-Dist-0.07.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/File-ShareDir-Dist-${version}.tar.gz";
       hash = "sha256-jX/l0O4iNR9B75Wtwi29VsMf+iqbLBmEMA6S/36f6G0=";
     };
     meta = {
@@ -13973,11 +13973,11 @@ with self;
     };
   };
 
-  FileShareDirInstall = buildPerlPackage {
+  FileShareDirInstall = buildPerlPackage rec {
     pname = "File-ShareDir-Install";
     version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/File-ShareDir-Install-0.14.tar.gz";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/File-ShareDir-Install-${version}.tar.gz";
       hash = "sha256-j5UzsZjy1KmlKIy8fSJPdnmtBaeoVzdFWZeJQovFrqA=";
     };
     meta = {
@@ -13990,12 +13990,12 @@ with self;
     };
   };
 
-  FileShouldUpdate = buildPerlModule {
+  FileShouldUpdate = buildPerlModule rec {
     pname = "File-ShouldUpdate";
     version = "0.2.1";
 
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/File-ShouldUpdate-0.2.1.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/File-ShouldUpdate-${version}.tar.gz";
       hash = "sha256-r1k1mNBvHCG63TrnQb8LRQbOJl7ImVDGCj8+cQbes+I=";
     };
 
@@ -14010,11 +14010,11 @@ with self;
     };
   };
 
-  FilesysDf = buildPerlPackage {
+  FilesysDf = buildPerlPackage rec {
     pname = "Filesys-Df";
     version = "0.92";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IG/IGUTHRIE/Filesys-Df-0.92.tar.gz";
+      url = "mirror://cpan/authors/id/I/IG/IGUTHRIE/Filesys-Df-${version}.tar.gz";
       hash = "sha256-/onLtCfg4F8c2Xwt1tOGasayG8eoVzTt4Vm9w1R5VSo=";
     };
     meta = {
@@ -14026,11 +14026,11 @@ with self;
     };
   };
 
-  FilesysNotifySimple = buildPerlPackage {
+  FilesysNotifySimple = buildPerlPackage rec {
     pname = "Filesys-Notify-Simple";
     version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Filesys-Notify-Simple-0.14.tar.gz";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Filesys-Notify-Simple-${version}.tar.gz";
       hash = "sha256-H9pxLUul4YaBWe019vjvv66dQ11jdvVgbVM7ywgFVaQ=";
     };
     buildInputs = [ TestSharedFork ];
@@ -14044,11 +14044,11 @@ with self;
     };
   };
 
-  FilesysDiskUsage = buildPerlPackage {
+  FilesysDiskUsage = buildPerlPackage rec {
     pname = "Filesys-DiskUsage";
     version = "0.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MANWAR/Filesys-DiskUsage-0.13.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MANWAR/Filesys-DiskUsage-${version}.tar.gz";
       hash = "sha256-/T5SxvYkEnGigTSNHUPEQVTC9hoyVD20aqnhVpLRtxM=";
     };
     buildInputs = [ TestWarn ];
@@ -14062,11 +14062,11 @@ with self;
     };
   };
 
-  FileSlurp = buildPerlPackage {
+  FileSlurp = buildPerlPackage rec {
     pname = "File-Slurp";
     version = "9999.32";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CA/CAPOEIRAB/File-Slurp-9999.32.tar.gz";
+      url = "mirror://cpan/authors/id/C/CA/CAPOEIRAB/File-Slurp-${version}.tar.gz";
       hash = "sha256-TDwhmSqdQr46ed10o8g9J9OAVyadZVCaL1VeoPsrxbA=";
     };
     meta = {
@@ -14078,11 +14078,11 @@ with self;
     };
   };
 
-  FileSlurper = buildPerlPackage {
+  FileSlurper = buildPerlPackage rec {
     pname = "File-Slurper";
     version = "0.014";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/File-Slurper-0.014.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/File-Slurper-${version}.tar.gz";
       hash = "sha256-1aNkhzOYiMPNdY5kgWDuHXDrQVPKy6/1eEbbzvs0Sww=";
     };
     buildInputs = [ TestWarnings ];
@@ -14095,11 +14095,11 @@ with self;
     };
   };
 
-  FileSlurpTiny = buildPerlPackage {
+  FileSlurpTiny = buildPerlPackage rec {
     pname = "File-Slurp-Tiny";
     version = "0.004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/File-Slurp-Tiny-0.004.tar.gz";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/File-Slurp-Tiny-${version}.tar.gz";
       hash = "sha256-RSmVvuq/DpI+Zf3GJ6cl27EsnhDADYAYwW0QumJ1fx4=";
     };
     meta = {
@@ -14111,11 +14111,11 @@ with self;
     };
   };
 
-  FileTail = buildPerlPackage {
+  FileTail = buildPerlPackage rec {
     pname = "File-Tail";
     version = "1.3";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MG/MGRABNAR/File-Tail-1.3.tar.gz";
+      url = "mirror://cpan/authors/id/M/MG/MGRABNAR/File-Tail-${version}.tar.gz";
       hash = "sha256-JtCfgYNuQ+rkACjVKD/lYg/m/mJ4vz6462AMSOw0r8c=";
     };
     meta = {
@@ -14131,11 +14131,11 @@ with self;
     };
   };
 
-  FileTouch = buildPerlPackage {
+  FileTouch = buildPerlPackage rec {
     pname = "File-Touch";
     version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/File-Touch-0.12.tar.gz";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/File-Touch-${version}.tar.gz";
       hash = "sha256-KgTcQk30jpjFRVbGBFyrAmpJ43N6qUohz0l3YbDy5Zw=";
     };
     meta = {
@@ -14152,11 +14152,11 @@ with self;
     };
   };
 
-  FileTreeCreate = buildPerlModule {
+  FileTreeCreate = buildPerlModule rec {
     pname = "File-TreeCreate";
     version = "0.0.1";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/File-TreeCreate-0.0.1.tar.gz";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/File-TreeCreate-${version}.tar.gz";
       hash = "sha256-V2hvEIQ76Br/rRha5BMXkLoMSvNtIQTW+2kSZSgFUmc=";
     };
     meta = {
@@ -14166,11 +14166,11 @@ with self;
     };
   };
 
-  FileType = buildPerlModule {
+  FileType = buildPerlModule rec {
     pname = "File-Type";
     version = "0.22";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PM/PMISON/File-Type-0.22.tar.gz";
+      url = "mirror://cpan/authors/id/P/PM/PMISON/File-Type-${version}.tar.gz";
       hash = "sha256-01zZX+9X/U39iDH2LDTilNfEuGH8kJ4Ct2Bxc51S00E=";
     };
     meta = {
@@ -14182,11 +14182,11 @@ with self;
     };
   };
 
-  FileUtil = buildPerlModule {
+  FileUtil = buildPerlModule rec {
     pname = "File-Util";
     version = "4.201720";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOMMY/File-Util-4.201720.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TOMMY/File-Util-${version}.tar.gz";
       hash = "sha256-1EkQIYUNXFy9cCx+R0SFgHmEHS+pPxwtCd3Jp4Y2CN8=";
     };
     buildInputs = [ TestNoWarnings ];
@@ -14200,11 +14200,11 @@ with self;
     };
   };
 
-  FileUtilTempdir = buildPerlPackage {
+  FileUtilTempdir = buildPerlPackage rec {
     pname = "File-Util-Tempdir";
     version = "0.034";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PERLANCAR/File-Util-Tempdir-0.034.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PERLANCAR/File-Util-Tempdir-${version}.tar.gz";
       hash = "sha256-0R3izl5vrT8GFLymR0ykScNa7TUSXVsyJ+ZpvBdv3Bw=";
     };
     buildInputs = [
@@ -14222,11 +14222,11 @@ with self;
     };
   };
 
-  FileWhich = buildPerlPackage {
+  FileWhich = buildPerlPackage rec {
     pname = "File-Which";
     version = "1.27";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/File-Which-1.27.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/File-Which-${version}.tar.gz";
       hash = "sha256-MgHxpg4/FkhAguYEXIloQiYfw0Xen7LmIP0qLHrzqTo=";
     };
     meta = {
@@ -14239,11 +14239,11 @@ with self;
     };
   };
 
-  FileXDG = buildPerlPackage {
+  FileXDG = buildPerlPackage rec {
     pname = "File-XDG";
     version = "1.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/File-XDG-1.03.tar.gz";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/File-XDG-${version}.tar.gz";
       hash = "sha256-iL18FFjLdjvs7W570MEZcqFWseOSMphPinqL5CBr984=";
     };
     preCheck = "rm t/file_xdg.t"; # Tries to write to $HOME
@@ -14262,11 +14262,11 @@ with self;
     };
   };
 
-  FileZglob = buildPerlPackage {
+  FileZglob = buildPerlPackage rec {
     pname = "File-Zglob";
     version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOKUHIROM/File-Zglob-0.11.tar.gz";
+      url = "mirror://cpan/authors/id/T/TO/TOKUHIROM/File-Zglob-${version}.tar.gz";
       hash = "sha256-HLHt3iCsCU7wA3lLr+8sdiQWnPhALHNn2bdGD2wOZps=";
     };
     meta = {
@@ -14278,11 +14278,11 @@ with self;
     };
   };
 
-  Filter = buildPerlPackage {
+  Filter = buildPerlPackage rec {
     pname = "Filter";
     version = "1.64";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RU/RURBAN/Filter-1.64.tar.gz";
+      url = "mirror://cpan/authors/id/R/RU/RURBAN/Filter-${version}.tar.gz";
       hash = "sha256-E+f7fh0yZZjjZgEDzxl0vun2kKxbQ7M58sAi8rX87yw=";
     };
     meta = {
@@ -14345,11 +14345,11 @@ with self;
     };
   };
 
-  FindLib = buildPerlPackage {
+  FindLib = buildPerlPackage rec {
     pname = "Find-Lib";
     version = "1.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Y/YA/YANNK/Find-Lib-1.04.tar.gz";
+      url = "mirror://cpan/authors/id/Y/YA/YANNK/Find-Lib-${version}.tar.gz";
       hash = "sha256-HXOSHjBh4bBG/kJo4tBf/VpMV2Jmbi5HI/g6rMFG6FE=";
     };
     meta = {
@@ -14361,11 +14361,11 @@ with self;
     };
   };
 
-  FontAFM = buildPerlPackage {
+  FontAFM = buildPerlPackage rec {
     pname = "Font-AFM";
     version = "1.20";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GA/GAAS/Font-AFM-1.20.tar.gz";
+      url = "mirror://cpan/authors/id/G/GA/GAAS/Font-AFM-${version}.tar.gz";
       hash = "sha256-MmcRZtoyWWoPa6rNDBIzglpgrK8lgF15yBo/GNYIi8E=";
     };
     meta = {
@@ -14377,11 +14377,11 @@ with self;
     };
   };
 
-  FontTTF = buildPerlPackage {
+  FontTTF = buildPerlPackage rec {
     pname = "Font-TTF";
     version = "1.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BH/BHALLISSY/Font-TTF-1.06.tar.gz";
+      url = "mirror://cpan/authors/id/B/BH/BHALLISSY/Font-TTF-${version}.tar.gz";
       hash = "sha256-S2l9REJZdZ6gLSxELJv/5f/hTJIUCEoB90NpOpRMwpM=";
     };
     buildInputs = [ IOString ];
@@ -14391,11 +14391,11 @@ with self;
     };
   };
 
-  ForksSuper = buildPerlPackage {
+  ForksSuper = buildPerlPackage rec {
     pname = "Forks-Super";
     version = "0.97";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MO/MOB/Forks-Super-0.97.tar.gz";
+      url = "mirror://cpan/authors/id/M/MO/MOB/Forks-Super-${version}.tar.gz";
       hash = "sha256-M9tDV+Es1vQPKlijq5b+tP/9JedC29SL75B9skLQKk4=";
     };
     doCheck = false;
@@ -14409,11 +14409,11 @@ with self;
     };
   };
 
-  FormValidatorSimple = buildPerlPackage {
+  FormValidatorSimple = buildPerlPackage rec {
     pname = "FormValidator-Simple";
     version = "0.29";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LY/LYOKATO/FormValidator-Simple-0.29.tar.gz";
+      url = "mirror://cpan/authors/id/L/LY/LYOKATO/FormValidator-Simple-${version}.tar.gz";
       hash = "sha256-/Dpj3FS5YtdFhgcBdq2vW+hp8JtWG7MPX9Mu9TF5JmY=";
     };
     propagatedBuildInputs = [
@@ -14437,11 +14437,11 @@ with self;
     };
   };
 
-  FreezeThaw = buildPerlPackage {
+  FreezeThaw = buildPerlPackage rec {
     pname = "FreezeThaw";
     version = "0.5001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IL/ILYAZ/modules/FreezeThaw-0.5001.tar.gz";
+      url = "mirror://cpan/authors/id/I/IL/ILYAZ/modules/FreezeThaw-${version}.tar.gz";
       hash = "sha256-PF4IMpEG+c7jq0RLgTMcWTX4MIShUdiFBeekZdpUD0E=";
     };
     doCheck = false;
@@ -14454,11 +14454,11 @@ with self;
     };
   };
 
-  FunctionParameters = buildPerlPackage {
+  FunctionParameters = buildPerlPackage rec {
     pname = "Function-Parameters";
     version = "2.002004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MAUKE/Function-Parameters-2.002004.tar.gz";
+      url = "mirror://cpan/authors/id/M/MA/MAUKE/Function-Parameters-${version}.tar.gz";
       hash = "sha256-KKvqWODAnOMnmaCMvXr3DaHimXd8KZEZQpygaacYg+g=";
     };
     buildInputs = [
@@ -14478,11 +14478,11 @@ with self;
     };
   };
 
-  Furl = buildPerlModule {
+  Furl = buildPerlModule rec {
     pname = "Furl";
     version = "3.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SY/SYOHEX/Furl-3.14.tar.gz";
+      url = "mirror://cpan/authors/id/S/SY/SYOHEX/Furl-${version}.tar.gz";
       hash = "sha256-Nd29iIDXHxniAkM+F2H9EXc4XmML9QaFvEi2t6y4V7k=";
     };
     propagatedBuildInputs = [
@@ -14513,11 +14513,11 @@ with self;
     };
   };
 
-  Future = buildPerlModule {
+  Future = buildPerlModule rec {
     pname = "Future";
     version = "0.50";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Future-0.50.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Future-${version}.tar.gz";
       hash = "sha256-wDXj2eaaOvFEszrINN7p5lrTYPKlHbnxWNw0Ls3dX0Q=";
     };
     buildInputs = [ Test2Suite ];
@@ -14530,11 +14530,11 @@ with self;
     };
   };
 
-  FutureAsyncAwait = buildPerlModule {
+  FutureAsyncAwait = buildPerlModule rec {
     pname = "Future-AsyncAwait";
     version = "0.70";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Future-AsyncAwait-0.70.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Future-AsyncAwait-${version}.tar.gz";
       hash = "sha256-hCiZBJyXf7IyaoCWkmRB5XvsqRK7K0kY1c4JDfTUprc=";
     };
     buildInputs = [ Test2Suite ];
@@ -14552,11 +14552,11 @@ with self;
     };
   };
 
-  FutureIO = buildPerlModule {
+  FutureIO = buildPerlModule rec {
     pname = "Future-IO";
     version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Future-IO-0.14.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Future-IO-${version}.tar.gz";
       hash = "sha256-a1j++vwwlMJwHwp7mMsUCwmItRaKfV3069Hu6OhyBgo=";
     };
     buildInputs = [ TestFutureIOImpl ];
@@ -14574,11 +14574,11 @@ with self;
     };
   };
 
-  FutureQueue = buildPerlModule {
+  FutureQueue = buildPerlModule rec {
     pname = "Future-Queue";
     version = "0.51";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Future-Queue-0.51.tar.gz";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Future-Queue-${version}.tar.gz";
       hash = "sha256-HVAcOpot3/x8YPlvpmlp1AyykuCSBM9t7NHCuLUAPNY=";
     };
     buildInputs = [ Test2Suite ];


### PR DESCRIPTION
switch from hardcoded version to ${version} interpolation and matched drifting version to the newer version in the version string.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
