### PR TITLE
ant: build from source

### DIFF
--- a/lib/licenses/licenses.nix
+++ b/lib/licenses/licenses.nix
@@ -204,8 +204,8 @@ lib.mapAttrs mkLicense (
     };
 
     bola11 = {
-      url = "https://blitiri.com.ar/p/bola/";
-      fullName = "Buena Onda License Agreement 1.1";
+      spdxId = "BOLA-1.1";
+      fullName = "Buena Onda License Agreement v1.1";
     };
 
     boost = {
@@ -326,8 +326,8 @@ lib.mapAttrs mkLicense (
     };
 
     capec = {
-      fullName = "Common Attack Pattern Enumeration and Classification";
-      url = "https://capec.mitre.org/about/termsofuse.html";
+      fullName = "Common Attack Pattern Enumeration and Classification License";
+      spdxId = "CAPEC-tou";
     };
 
     clArtistic = {
@@ -765,14 +765,7 @@ lib.mapAttrs mkLicense (
 
     hpndSellVariantSafetyClause = {
       fullName = "HPND - sell variant with safety critical systems clause";
-      url = "https://gitlab.freedesktop.org/xorg/driver/xf86-video-voodoo/-/blob/68a5b6d98ae34749cca889f4373b4043d00bfe6a/src/voodoo_dga.c#L12-33";
-      # TODO: if the license gets accepted to spdx then
-      #   add spdxId
-      # else
-      #   remove license
-      #   && replace reference with whatever this license is supposed to be then
-      # https://github.com/spdx/license-list-XML/issues/2922
-      # spdxId = "HPND-sell-variant-safety-clause";
+      spdxId = "HPND-sell-variant-critical-systems";
     };
 
     hpndDec = {
@@ -1262,8 +1255,8 @@ lib.mapAttrs mkLicense (
     };
 
     paratype = {
-      fullName = "ParaType Free Font Licensing Agreement";
-      url = "https://web.archive.org/web/20161209023955/http://www.paratype.ru/public/pt_openlicense_eng.asp";
+      spdxId = "ParaType-Free-Font-1.3";
+      fullName = "ParaType Free Font Licensing Agreement v1.3";
     };
 
     parity70 = {
@@ -1342,7 +1335,8 @@ lib.mapAttrs mkLicense (
     # Gentoo seems to treat it as a license:
     # https://gitweb.gentoo.org/repo/gentoo.git/tree/licenses/SGMLUG?id=7d999af4a47bf55e53e54713d98d145f935935c1
     sgmlug = {
-      fullName = "SGML UG SGML Parser Materials license";
+      spdxId = "SGMLUG-PM";
+      fullName = "SGMLUG Parser Materials License";
     };
 
     sissl11 = {
@@ -1439,11 +1433,8 @@ lib.mapAttrs mkLicense (
     };
 
     tekHvcLicense = {
+      spdxId = "TekHVC";
       fullName = "TekHVC License";
-      url = "https://gitlab.freedesktop.org/xorg/lib/libx11/-/blob/7f8305c779ac6948d7261764f5ffb8ae9aa975b1/COPYING#L138-171";
-      # TODO: add spdxId when it gets accepted to spdx
-      # https://tools.spdx.org/app/license_requests/458
-      # https://github.com/spdx/license-list-XML/issues/2757
     };
 
     torque11 = {
@@ -1464,8 +1455,8 @@ lib.mapAttrs mkLicense (
     };
 
     tost = {
+      spdxId = "Pixar";
       fullName = "Tomorrow Open Source Technology License 1.0";
-      url = "https://github.com/PixarAnimationStudios/OpenUSD/blob/release/LICENSE.txt";
     };
 
     ubdlException = {

--- a/pkgs/by-name/an/ant-bootstrap/package.nix
+++ b/pkgs/by-name/an/ant-bootstrap/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  jdk,
+  makeWrapper,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ant-bootstrap";
+  version = "1.10.15";
+
+  src = fetchurl {
+    url = "mirror://apache/ant/source/apache-ant-${finalAttrs.version}-src.tar.bz2";
+    hash = "sha256-WPU+khKoAFW/FOknicf1BCBqs1uLw5dfo7cocg2A79c=";
+  };
+
+  nativeBuildInputs = [
+    jdk
+    makeWrapper
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    sh bootstrap.sh
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/ant
+    cp -r bootstrap/* $out/share/ant/
+    rm -rf $out/share/ant/bin/*.bat
+
+    makeWrapper $out/share/ant/bin/ant $out/bin/ant \
+      --set ANT_HOME $out/share/ant \
+      --set JAVA_HOME ${jdk.home}
+    runHook postInstall
+  '';
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  meta = {
+    homepage = "https://ant.apache.org/";
+    description = "Java-based build tool (bootstrapped from source)";
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    license = lib.licenses.asl20;
+    teams = [ lib.teams.java ];
+    platforms = lib.platforms.all;
+    mainProgram = "ant";
+  };
+})

--- a/pkgs/by-name/an/ant/package.nix
+++ b/pkgs/by-name/an/ant/package.nix
@@ -5,22 +5,35 @@
   coreutils,
   makeWrapper,
   gitUpdater,
+  ant-bootstrap,
+  jdk,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "ant";
   version = "1.10.17";
 
-  nativeBuildInputs = [ makeWrapper ];
-
   src = fetchurl {
-    url = "mirror://apache/ant/binaries/apache-ant-${finalAttrs.version}-bin.tar.bz2";
-    hash = "sha256-UhD8nXfpa/X0Y5KH8pgm2oXlSlQuCkCUY7FkK8PKruc=";
+    url = "mirror://apache/ant/source/apache-ant-${finalAttrs.version}-src.tar.bz2";
+    hash = "sha256-WPU+khKoAFW/FOknicf1BCBqs1uLw5dfo7cocg2A79c=";
   };
 
+  nativeBuildInputs = [
+    makeWrapper
+    ant-bootstrap
+    jdk
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    ant dist -Djavadoc.notrequired=true
+    runHook postBuild
+  '';
+
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin $out/share/ant
-    mv * $out/share/ant/
+    # ant dist puts the distribution in apache-ant-${finalAttrs.version}/ directory
+    cp -r apache-ant-${finalAttrs.version}/* $out/share/ant/
 
     # Get rid of the manual (35 MiB).  Maybe we should put this in a
     # separate output.  Keep the antRun script since it's vanilla sh
@@ -77,6 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
     EOF
 
     chmod +x $out/bin/ant
+    runHook postInstall
   '';
 
   passthru = {
@@ -113,7 +127,10 @@ stdenv.mkDerivation (finalAttrs: {
       by an object that implements a particular Task interface.
     '';
 
-    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    sourceProvenance = with lib.sourceTypes; [
+      # Ant source comes with prebuilt JUnit jars
+      binaryBytecode
+    ];
     license = lib.licenses.asl20;
     teams = [ lib.teams.java ];
     platforms = lib.platforms.all;


### PR DESCRIPTION
Currently, `ant` relies on pre-compiled binaries. This PR implements building `ant` entirely from source and updating its`sourceProvenance`.

Building:
1. `ant-bootstrap`: minimal build. It bypasses `build.xml` and compiles core classes directly with `javac` using the upstream `bootstrap.sh` script.
2. `ant`: builds with `ant-bootstrap` in `nativeBuildInputs`. Runs `ant dist`.

Notes:
- `-Djavadoc.notrequired=true` is passed during the main build to prevent failures caused by stricter `DocLint` rules in more modern JDKs and to save build time. Also the manuals were already deleted in the `installPhase`  anyway.
- I'm a Nix noobie still, and this is a naive attempt, more so made for the sake of learning. There are probably mistakes in this implementation.
- These commits change the resulting hash of `ant`, meaning a lot of packages will rebuild. I don't know how to avoid this.
- Also if this implementation truly sucks, I won't take it the wrong way if you close the PR. I don't want to add work to people.

This should close #353512.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
