### PR TITLE
python3Packages.wasmtime: fix darwin shared library path

### DIFF
--- a/pkgs/development/python-modules/wasmtime/default.nix
+++ b/pkgs/development/python-modules/wasmtime/default.nix
@@ -78,8 +78,11 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Python WebAssembly runtime powered by Wasmtime";
     homepage = "https://github.com/bytecodealliance/wasmtime-py";
-    changelog = "https://github.com/bytecodealliance/wasmtime-py/releases/tag/{${finalAttrs.src.tag}}";
-    license = lib.licenses.asl20;
+    changelog = "https://github.com/bytecodealliance/wasmtime-py/releases/tag/${finalAttrs.src.tag}";
+    license = [
+      lib.licenses.asl20
+      lib.licenses.llvm-exception
+    ];
     maintainers = with lib.maintainers; [ fab ];
   };
 })

--- a/pkgs/development/python-modules/wasmtime/default.nix
+++ b/pkgs/development/python-modules/wasmtime/default.nix
@@ -10,8 +10,13 @@
   setuptools-git-versioning,
   setuptools,
   writableTmpDirAsHomeHook,
+  stdenvNoCC,
 }:
-
+let
+  inherit (stdenvNoCC) targetPlatform;
+  systemDir = "${targetPlatform.parsed.kernel.name}-${targetPlatform.parsed.cpu.name}";
+  libExt = targetPlatform.extensions.sharedLibrary;
+in
 buildPythonPackage (finalAttrs: {
   pname = "wasmtime";
   version = "44.0.0";
@@ -35,9 +40,8 @@ buildPythonPackage (finalAttrs: {
     sed -i '/^backend-path = \[/,/^\]/d' pyproject.toml
 
     # Use nixpkgs' wasmtime instead of downloading prebuilt C API artifacts.
-    mkdir -p wasmtime/linux-x86_64 wasmtime/linux-aarch64
-    ln -s ${lib.getLib pkgs.wasmtime}/lib/libwasmtime.so wasmtime/linux-x86_64/_libwasmtime.so
-    ln -s ${lib.getLib pkgs.wasmtime}/lib/libwasmtime.so wasmtime/linux-aarch64/_libwasmtime.so
+    mkdir -p wasmtime/${systemDir}
+    ln -s ${lib.getLib pkgs.wasmtime}/lib/libwasmtime${libExt} wasmtime/${systemDir}/_libwasmtime${libExt}
   '';
 
   build-system = [
@@ -49,10 +53,8 @@ buildPythonPackage (finalAttrs: {
 
   postInstall = ''
     # Ensure the installed module can find the shared library at runtime
-    mkdir -p "$out/${python.sitePackages}/wasmtime/linux-x86_64"
-    mkdir -p "$out/${python.sitePackages}/wasmtime/linux-aarch64"
-    ln -sf ${lib.getLib pkgs.wasmtime}/lib/libwasmtime.so "$out/${python.sitePackages}/wasmtime/linux-x86_64/_libwasmtime.so"
-    ln -sf ${lib.getLib pkgs.wasmtime}/lib/libwasmtime.so "$out/${python.sitePackages}/wasmtime/linux-aarch64/_libwasmtime.so"
+    mkdir -p "$out/${python.sitePackages}/wasmtime/${systemDir}"
+    ln -sf ${lib.getLib pkgs.wasmtime}/lib/libwasmtime${libExt} "$out/${python.sitePackages}/wasmtime/${systemDir}/_libwasmtime${libExt}"
   '';
 
   nativeCheckInputs = [


### PR DESCRIPTION
Fixes the build on darwin

alternative to #518181 I guess

ZHF: #516381

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
