### PR TITLE
devin-cli: init at 2026.5.6-8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19514,6 +19514,11 @@
     githubId = 10180857;
     name = "Anmol Sethi";
   };
+  nhshah15 = {
+    github = "nhshah15";
+    githubId = 31825306;
+    name = "Neil Shah";
+  };
   ni5arga = {
     email = "hello@ni5arga.com";
     github = "ni5arga";

--- a/pkgs/by-name/de/devin-cli/package.nix
+++ b/pkgs/by-name/de/devin-cli/package.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  installShellFiles,
+  versionCheckHook,
+}:
+
+let
+  version = "2026.5.6-8";
+
+  throwSystem = throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}";
+
+  srcs = {
+    x86_64-linux = fetchurl {
+      url = "https://static.devin.ai/cli/${version}/devin-${version}-x86_64-unknown-linux.tar.gz";
+      hash = "sha256-kBHRIUiMwbFIGRCkNIOSST6fwEULs8yJu3cwHq2eyac=";
+    };
+
+    aarch64-linux = fetchurl {
+      url = "https://static.devin.ai/cli/${version}/devin-${version}-aarch64-unknown-linux.tar.gz";
+      hash = "sha256-3Kg90ec9Fdne/+OhfFV24JCoDWzwilrej3vRM52XRqI=";
+    };
+
+    aarch64-darwin = fetchurl {
+      url = "https://static.devin.ai/cli/${version}/devin-${version}-aarch64-apple-darwin.tar.gz";
+      hash = "sha256-nUb8yotP9cUrWeDw5kb+ZLZ5Ug2l7QTO6eQnYNaD9o4=";
+    };
+
+    x86_64-darwin = fetchurl {
+      url = "https://static.devin.ai/cli/${version}/devin-${version}-x86_64-apple-darwin.tar.gz";
+      hash = "sha256-CN03ZsVb1gyvFqAcVnjpT4VHB/mxnAQ2PhG8PwRZSrw=";
+    };
+  };
+
+  src = srcs.${stdenvNoCC.hostPlatform.system} or throwSystem;
+in
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "devin-cli";
+  inherit version;
+
+  outputs = [
+    "out"
+    "man"
+    "doc"
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  inherit src;
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  dontConfigure = true;
+  dontStrip = true;
+  dontBuild = true;
+
+  doCheck = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    installBin ./bin/devin
+    installManPage ./share/man/man1/*.1
+
+    mkdir -p $out/share/doc
+
+    mv ./share/devin/docs/* $out/share/doc
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Cognition's Devin Agent CLI";
+    homepage = "https://devin.ai/";
+    license = lib.licenses.unfree;
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+    maintainers = with lib.maintainers; [ ethancedwards8 ];
+    mainProgram = "devin";
+  };
+})

--- a/pkgs/by-name/de/devin-cli/package.nix
+++ b/pkgs/by-name/de/devin-cli/package.nix
@@ -84,7 +84,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://devin.ai/";
     license = lib.licenses.unfree;
     sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
-    maintainers = with lib.maintainers; [ ethancedwards8 ];
+    maintainers = with lib.maintainers; [
+      ethancedwards8
+      nhshah15
+    ];
     mainProgram = "devin";
   };
 })

--- a/pkgs/by-name/de/devin-cli/update.sh
+++ b/pkgs/by-name/de/devin-cli/update.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash nix-update common-updater-scripts nix jq
+
+set -euo pipefail
+
+currentVersion=$(nix-instantiate --eval -E "with import ./. {}; devin-cli.version or (lib.getVersion devin-cli)" | tr -d '"')
+latestVersion=$(curl https://static.devin.ai/cli/current/manifest.json | jq '.version' | tr -d '"')
+
+if [[ "$currentVersion" == "$latestVersion" ]]; then
+    echo "package is up-to-date: $currentVersion"
+    exit 0
+fi
+
+update-source-version devin-cli $latestVersion || true
+
+for system in \
+    x86_64-linux \
+    aarch64-linux \
+    x86_64-darwin \
+    aarch64-darwin; do
+    hash=$(nix --extra-experimental-features nix-command hash convert --to sri --hash-algo sha256 $(nix-prefetch-url $(nix-instantiate --eval -E "with import ./. {}; devin-cli.src.url" --system "$system" | tr -d '"')))
+    update-source-version devin-cli $latestVersion $hash --system=$system --ignore-same-version
+done


### PR DESCRIPTION
Homepage: https://devin.ai


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
