### PR TITLE
gh-cherry-pick -> ghcherry: 1.5.0 -> 1.6.0

### DIFF
--- a/pkgs/by-name/gh/ghcherry/package.nix
+++ b/pkgs/by-name/gh/ghcherry/package.nix
@@ -4,15 +4,16 @@
   fetchFromGitHub,
 }:
 python3Packages.buildPythonApplication (finalAttrs: {
-  pname = "gh-cherry-pick";
-  version = "1.5.0";
+  pname = "ghcherry";
+  version = "1.6.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "PerchunPak";
-    repo = "gh-cherry-pick";
+    repo = "ghcherry";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-a2vhQ9upJYc+t4Juq+eukNc7dzq6MafNxDUULPZs9sQ=";
+    hash = "sha256-yUsYf0v5IZh4yxkG+nu8cG4L/WcJTFDefc//l4v36sY=";
   };
 
   build-system = with python3Packages; [
@@ -39,13 +40,13 @@ python3Packages.buildPythonApplication (finalAttrs: {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "gh_cherry_pick" ];
+  pythonImportsCheck = [ "ghcherry" ];
 
   meta = {
     description = "Cherry-pick commits across GitHub repositories using only the GitHub API";
-    homepage = "https://github.com/PerchunPak/gh-cherry-pick";
-    license = lib.licenses.mit;
+    homepage = "https://github.com/PerchunPak/ghcherry";
+    license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.PerchunPak ];
-    mainProgram = "gh-cherry-pick";
+    mainProgram = "ghcherry";
   };
 })

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -838,6 +838,7 @@ mapAliases {
   gfortran12 = throw "gfortran12 has been removed from Nixpkgs, as it is unmaintained and obsolete"; # Added 2025-08-08
   gg = throw "'gg' has been renamed to/replaced by 'go-graft'"; # Converted to throw 2025-10-27
   ggobi = throw "'ggobi' has been removed from Nixpkgs, as it is unmaintained and broken"; # Added 2025-05-18
+  gh-cherry-pick = warnAlias "'gh-cherry-pick' has been renamed to 'ghcherry'" ghcherry; # Added 2026-05-17
   gh-copilot = throw "'gh-copilot' has been removed since it has been deprecated and archived upstream. Consider using 'github-copilot-cli' instead"; # Added 2026-01-20
   gImageReader = gimagereader; # Added 2026-02-08
   gImageReader-qt = gimagereader-qt; # Added 2026-02-08


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Upstream provides an alias with deprecation, so this is not a breaking change
https://github.com/PerchunPak/ghcherry/releases/tag/v1.6.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
