### PR TITLE
mediathekview: set lib.platforms.linux

### DIFF
--- a/pkgs/by-name/me/mediathekview/package.nix
+++ b/pkgs/by-name/me/mediathekview/package.nix
@@ -67,6 +67,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     mainProgram = "mediathek";
     maintainers = with lib.maintainers; [ makefu ];
-    platforms = lib.platforms.all;
+    platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
The build is failing on Darwin and the src fetchurl is hardcoded to fetch a linux tarball.

This commit sets: `platforms = lib.platforms.linux` to prevent those build failures.

## Things done

I've verified the following error occurs when trying to build on `aarch64-darwin`:
```
error: Refusing to evaluate package 'mediathekview-14.4.2' in /Users/sean/github/nixos/nixpkgs/pkgs/by-name/me/mediathekview/package.nix:64 because it is not available on the requested hostPlatform:
 hostPlatform.system = "aarch64-darwin"
````



- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
