### PR TITLE
nixos/reframe: add to module-list.nix, switch to freeformType

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1366,6 +1366,7 @@
   ./services/networking/rdnssd.nix
   ./services/networking/realm.nix
   ./services/networking/redsocks.nix
+  ./services/networking/reframe.nix
   ./services/networking/resilio.nix
   ./services/networking/robustirc-bridge.nix
   ./services/networking/rosenpass.nix

--- a/nixos/modules/services/networking/reframe.nix
+++ b/nixos/modules/services/networking/reframe.nix
@@ -6,160 +6,47 @@
 }:
 let
   cfg = config.services.reframe;
-  iniFmt = pkgs.formats.ini { };
+  settingsFormat = pkgs.formats.ini { };
 in
 {
   options.services.reframe = {
     enable = lib.mkEnableOption "DRM/KMS based remote desktop for Linux that supports Wayland/NVIDIA/headless/login…";
     package = lib.mkPackageOption pkgs "reframe" { };
     configs = lib.mkOption {
-      type = lib.types.attrsOf (
-        lib.types.submodule {
-          options = {
+      type = lib.types.submodule {
+        freeformType = settingsFormat.type;
+      };
+      default = { };
+
+      description = "Configurations for ReFrame";
+      example = ''
+        {
+          main = {
             reframe = {
-              card = lib.mkOption {
-                type = lib.types.str;
-                default = "";
-                description = "Select monitor via DRM card. All available cards and connectors can be found in `/sys/class/drm/`.";
-                example = "card0";
-              };
-              connector = lib.mkOption {
-                type = lib.types.str;
-                default = "";
-                description = "Select monitor via connector. All available cards and connectors can be found in `/sys/class/drm/`.";
-                example = "eDP-1";
-              };
-              rotation = lib.mkOption {
-                type = lib.types.enum [
-                  0
-                  90
-                  180
-                  270
-                ];
-                default = 0;
-                description = ''
-                  This is the angle you rotate the monitor, not the angle of display content relative to the monitor!
-                  Valid angles are clockwise `0`, `90`, `180`, `270`.
-                '';
-              };
-              desktop-width = lib.mkOption {
-                type = lib.types.int;
-                default = 0;
-                description = ''
-                  If you have more than 1 monitor, set those values to the logical size of the whole virtual desktop.
-                  You can get those value by finding the pointer position of the right most and bottom most border of your monitors.
-                '';
-              };
-              desktop-height = lib.mkOption {
-                type = lib.types.int;
-                default = 0;
-                description = ''
-                  If you have more than 1 monitor, set those values to the logical size of the whole virtual desktop.
-                  You can get those value by finding the pointer position of the right most and bottom most border of your monitors.
-                '';
-              };
-              monitor-x = lib.mkOption {
-                type = lib.types.int;
-                default = 0;
-                description = ''
-                  If you have more than 1 monitor, set those values to the logical position of the top left corner of your selected monitor.
-                '';
-              };
-              monitor-y = lib.mkOption {
-                type = lib.types.int;
-                default = 0;
-                description = ''
-                  If you have more than 1 monitor, set those values to the logical position of the top left corner of your selected monitor.
-                '';
-              };
-              default-width = lib.mkOption {
-                type = lib.types.int;
-                default = 0;
-                description = ''
-                  If your client does not support resizing, use those to force a size. Empty or `0` means monitor size.
-                '';
-              };
-              default-height = lib.mkOption {
-                type = lib.types.int;
-                default = 0;
-                description = ''
-                  If your client does not support resizing, use those to force a size. Empty or `0` means monitor size.
-                '';
-              };
-              resize = lib.mkOption {
-                type = lib.types.bool;
-                default = true;
-                description = ''
-                  Set to `false` to prohibit client resizing.
-                '';
-              };
-              cursor = lib.mkOption {
-                type = lib.types.bool;
-                default = true;
-                description = ''
-                  Set to `false` to ignore DRM cursor plane.
-                '';
-              };
-              wakeup = lib.mkOption {
-                type = lib.types.bool;
-                default = true;
-                description = ''
-                  Set to `false` if you already disabled automatic screen blank.
-                '';
-              };
-              damage = lib.mkOption {
-                type = lib.types.enum [
-                  ""
-                  "cpu"
-                  "gpu"
-                ];
-                default = "cpu";
-                description = ''
-                  Set to `gpu` to use GPU damage region detection, which may be more efficiency but may cause artifacts depending on GPU vendors.
-                  Set to `cpu` to use CPU damage region detection if you get bugs with `gpu`.
-                  Empty to disable damage region detection, which may require higher network bandwidth.
-                '';
-              };
-              fps = lib.mkOption {
-                type = lib.types.int;
-                default = 30;
-              };
+              card = "card0";
+              connector = "eDP-1";
+              rotation = 0;
+              desktop-width = 1920;
+              desktop-height = 1080;
+              monitor-x = 0;
+              monitor-y = 0;
+              default-width = 1920;
+              default-height = 1080;
+              resize = true;
+              cursor = true;
+              wakeup = true;
+              damage = "cpu";
+              fps = 30;
             };
             vnc = {
-              ip = lib.mkOption {
-                type = lib.types.str;
-                default = "";
-                description = ''
-                  Empty means accept all incoming connections.
-                '';
-              };
-              port = lib.mkOption {
-                type = lib.types.port;
-                default = 5933;
-              };
-              password = lib.mkOption {
-                type = lib.types.str;
-                default = "";
-                description = ''
-                  Empty means no password.
-                '';
-              };
-              type = lib.mkOption {
-                type = lib.types.enum [
-                  "libvncserver"
-                  "neatvnc"
-                ];
-                default = "libvncserver";
-                description = ''
-                  Set to `neatvnc` to prefer neatvnc, which provides more efficient encoding methods but maybe more unstable.
-                '';
-              };
+              ip = "0.0.0.0";
+              port = 5933;
+              password = "password";
+              type = "libvncserver";
             };
           };
         }
-      );
-      default = { };
-      description = "Configurations for ReFrame";
+      '';
     };
   };
 
@@ -179,7 +66,7 @@ in
         mode = "0644";
         user = "root";
         group = "root";
-        source = iniFmt.generate "${name}.conf" value;
+        source = settingsFormat.generate "${name}.conf" value;
       }
     ) cfg.configs;
     systemd.services = lib.mapAttrs' (


### PR DESCRIPTION
## Things done

Someday I'll get this module right.... It's not obviously mentioned in docs that this is needed, just one mention that does not explicitly say you need to add your module to it.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
