### PR TITLE
unigine-superposition: remove dependency on mailspring

### DIFF
--- a/pkgs/by-name/un/unigine-superposition/package.nix
+++ b/pkgs/by-name/un/unigine-superposition/package.nix
@@ -14,7 +14,7 @@
   libglvnd,
   libxext,
   libxrandr,
-  mailspring,
+  openssl,
   libx11,
   libice,
   libxrender,
@@ -59,16 +59,17 @@ let
       libglvnd
       libxext
       libxrandr
-      mailspring
       libx11
       libice
       libxrender
+      openssl
     ];
 
     installPhase = ''
       bash $src --target $name --noexec
       mkdir -p $out/bin $out/lib/unigine/superposition/
       cp -r $name/* $out/lib/unigine/superposition/
+      ln -s ${lib.getLib openssl}/lib/libcrypto.so $out/lib/libcrypto.so.1.0.0
       echo "exec $out/lib/unigine/superposition/Superposition" >> $out/bin/superposition
       chmod +x $out/bin/superposition
        wrapProgram $out/lib/unigine/superposition/Superposition \
@@ -116,11 +117,11 @@ buildFHSEnv {
     libglvnd
     libxext
     libxrandr
-    mailspring
     libx11
     libice
     libxrender
     openal
+    openssl
   ];
   runScript = "superposition";
 


### PR DESCRIPTION
Noticed that `unigine-superposition` has a strange dependency on mailspring, through which it was getting `libcrypto`.
Replaced this dependency with the actual `openssl` library. 

Relates to #521117

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
