### PR TITLE
taskopen: 1.1.5 -> 2.0.3

### DIFF
--- a/pkgs/by-name/ta/taskopen/package.nix
+++ b/pkgs/by-name/ta/taskopen/package.nix
@@ -6,49 +6,36 @@
   which,
   perl,
   perlPackages,
+  buildNimPackage,
+  git,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+buildNimPackage (finalAttrs: {
   pname = "taskopen";
-  version = "1.1.5";
+  version = "2.0.3";
 
   src = fetchFromGitHub {
-    owner = "ValiValpas";
+    owner = "jschlatow";
     repo = "taskopen";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-/xf7Ph2KKiZ5lgLKk95nCgw/z9wIBmuWf3QGaNebgHg=";
+    sha256 = "sha256-0SAiSaN9V1JYnyJsWda6unqUlyXRL8y8JHXP4VNAFhM=";
   };
 
-  postPatch = ''
-    # We don't need a DESTDIR and an empty string results in an absolute path
-    # (due to the trailing slash) which breaks the build.
-    sed 's|$(DESTDIR)/||' -i Makefile
-  '';
-
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [
-    which
-  ]
-  ++ (with perlPackages; [
-    JSON
-    perl
-  ]);
+
+  buildPhase = ''
+    export HOME=$(pwd)
+  '';
 
   installPhase = ''
-    make PREFIX=$out
     make PREFIX=$out install
-  '';
-
-  postFixup = ''
-    wrapProgram $out/bin/taskopen \
-         --set PERL5LIB "$PERL5LIB"
   '';
 
   meta = {
     description = "Script for taking notes and open urls with taskwarrior";
     mainProgram = "taskopen";
     homepage = "https://github.com/ValiValpas/taskopen";
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.all;
     license = lib.licenses.gpl2Plus;
     maintainers = [ lib.maintainers.winpat ];
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Tag: https://github.com/jschlatow/taskopen/releases/tag/v2.0.3
Diff: https://github.com/jschlatow/taskopen/compare/v1.1.5...v2.0.3

This would supersede #297473, opened in 2024.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## `nixpkgs-review` result for [#521152](https://github.com/NixOS/nixpkgs/pull/521152)

Generated using [`nixpkgs-review-gha`](https://github.com/Defelo/nixpkgs-review-gha)

Command: `nixpkgs-review pr 521152`
Commit: [`37a8943f86ea93a1378acd7171da1766c1026528`](https://github.com/NixOS/nixpkgs/commit/37a8943f86ea93a1378acd7171da1766c1026528) ([subsequent changes](https://github.com/NixOS/nixpkgs/compare/37a8943f86ea93a1378acd7171da1766c1026528..pull/521152/head))
Merge: [`3c2f70965336bac3cae7b4533831006d0531fa5c`](https://github.com/NixOS/nixpkgs/commit/3c2f70965336bac3cae7b4533831006d0531fa5c)

Logs: https://github.com/cbrxyz/nixpkgs-review-gha/actions/runs/25980779491


---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>taskopen</li>
  </ul>
</details>

---
### `aarch64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>taskopen</li>
  </ul>
</details>

---
### `x86_64-darwin` (sandbox = relaxed)
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>taskopen</li>
  </ul>
</details>

---
### `aarch64-darwin` (sandbox = relaxed)
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>taskopen</li>
  </ul>
</details>
