### PR TITLE
blightmud: 5.3.1 -> 5.6.1

### DIFF
--- a/pkgs/by-name/bl/blightmud/package.nix
+++ b/pkgs/by-name/bl/blightmud/package.nix
@@ -11,16 +11,20 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "blightmud";
-  version = "5.3.1";
+  version = "5.6.1";
 
   src = fetchFromGitHub {
     owner = "blightmud";
     repo = "blightmud";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-9GUul5EoejcnCQqq1oX+seBtxttYIUhgcexaZk+7chk=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-fwWyQq6rb8qSR7aiQagOodkQRqanUJA2uH5I/Z1XfAA=";
   };
 
-  cargoHash = "sha256-7cMd7pNWGV5DOSCLRW5fP3L1VnDTEsZZjhVz1AQLEXM=";
+  cargoHash = "sha256-4JArgwNFjnGwyEnWdjZkUlahloQu+C8qF9QyYo8s1jQ=";
+
+  postPatch = ''
+    substituteInPlace Cargo.toml --replace-fail 'version = "0.0.0"' 'version = "${finalAttrs.version}"'
+  '';
 
   buildFeatures = lib.optional withTTS "tts";
 
@@ -38,6 +42,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   env = lib.optionalAttrs (!stdenv.cc.isClang) {
     NIX_CFLAGS_COMPILE = "-std=gnu17";
   };
+
+  __darwinAllowLocalNetworking = true;
 
   checkFlags =
     let
@@ -58,6 +64,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
         "test_tls_init_verify_err"
         "test_tls_init_no_verify"
         "test_tls_init_verify"
+        "test_exec"
+        "test_line_tags"
+        "test_lua_api"
+        "test_suggest"
+        "test_mccp2_decompression"
+        "test_mccp2_incremental"
+        "test_mccp2_negotiation"
       ];
     in
     builtins.map (x: "--skip=" + x) skipList;


### PR DESCRIPTION
Update to 5.6.1

Disable tests not working in sandbox and fix versionstring.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
