### PR TITLE
ci/github-script/check-target-branch: disable review for xanmod kernels

### DIFF
--- a/ci/github-script/check-target-branch.js
+++ b/ci/github-script/check-target-branch.js
@@ -105,7 +105,7 @@ async function checkTargetBranch({ github, context, core, dry }) {
   // These should go to staging-nixos instead of master,
   // but release-xx.xx (not staging-xx.xx) when backported
   let isExemptKernelUpdate = false
-  if (prInfo.changed_files === 1 && base.startsWith('release-')) {
+  if (prInfo.changed_files === 1) {
     const changedFiles = (
       await github.rest.pulls.listFiles({
         ...context.repo,
@@ -114,8 +114,11 @@ async function checkTargetBranch({ github, context, core, dry }) {
     ).data
     isExemptKernelUpdate =
       changedFiles.length === 1 &&
-      changedFiles[0].filename ===
-        'pkgs/os-specific/linux/kernel/kernels-org.json'
+      (changedFiles[0].filename ===
+        'pkgs/os-specific/linux/kernel/xanmod-kernels.nix' ||
+        (base.startsWith('release-') &&
+          changedFiles[0].filename ===
+            'pkgs/os-specific/linux/kernel/kernels-org.json'))
   }
 
   // https://github.com/NixOS/nixpkgs/pull/483194#issuecomment-3793393218


### PR DESCRIPTION
updates should go to master or release branches

e.g. https://github.com/NixOS/nixpkgs/pull/520739#pullrequestreview-4303332613, https://github.com/NixOS/nixpkgs/pull/520742#pullrequestreview-4303346935


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
