### PR TITLE
solana-cli: 3.0.12 -> 4.0.0

### DIFF
--- a/pkgs/by-name/so/solana-cli/package.nix
+++ b/pkgs/by-name/so/solana-cli/package.nix
@@ -1,6 +1,7 @@
 {
   stdenv,
   fetchFromGitHub,
+  fetchCrate,
   lib,
   rustPlatform,
   udev,
@@ -14,50 +15,34 @@
   libclang,
   rocksdb,
   # Taken from https://github.com/anza-xyz/agave/blob/master/scripts/cargo-install-all.sh#L84
+  # https://github.com/anza-xyz/agave/blob/master/scripts/agave-build-lists.sh
   solanaPkgs ? [
-    "cargo-build-sbf"
-    "cargo-test-sbf"
-    "solana"
-    "solana-bench-tps"
-    "solana-faucet"
-    "solana-gossip"
+    # AGAVE_BINS_END_USER
     "agave-install"
+    "solana"
     "solana-keygen"
-    "agave-ledger-tool"
-    "solana-dos"
-    "solana-net-shaper"
-    "agave-validator"
+    # AGAVE_BINS_DEV
     "solana-test-validator"
-    "agave-watchtower"
-  ]
-  ++ [
-    # XXX: Ensure `solana-genesis` is built LAST!
-    # See https://github.com/solana-labs/solana/issues/5826
+    # AGAVE_BINS_VAL_OP
     "solana-genesis"
+    "agave-validator"
+    "agave-watchtower"
+    "solana-gossip"
+    "solana-faucet"
   ],
 }:
 let
-  version = "3.0.12";
-  hash = "sha256-Zubu7cTSJrJFSuguCo3msdas/QshFpo1+T6DVQyqrhY=";
-in
-rustPlatform.buildRustPackage rec {
-  pname = "solana-cli";
-  inherit version;
+  version = "4.0.3";
 
   src = fetchFromGitHub {
     owner = "anza-xyz";
     repo = "agave";
     tag = "v${version}";
-    inherit hash;
+    hash = "sha256-lbkuywAuLeTIoe/5zbKmxCbnNcEx96BiX6ftNJHutZE=";
   };
 
-  cargoHash = "sha256-qnZbFkyzE2hdy/ynZQZmCs5kCeTUMci9f/pVKID/mRQ=";
-
-  strictDeps = true;
-  cargoBuildFlags = map (n: "--bin=${n}") solanaPkgs;
-
-  env = {
-    RUSTFLAGS = "-Amismatched_lifetime_syntaxes -Adead_code -Aunused_parens -Aunused_imports";
+  commonEnv = {
+    RUSTFLAGS = "-Amismatched_lifetime_syntaxes -Adead_code -Aunused_parens -Aunused_imports -Ainteger_to_ptr_transmutes -Aunused_unsafe";
     LIBCLANG_PATH = "${libclang.lib}/lib";
 
     # Used by build.rs in the rocksdb-sys crate. If we don't set these, it would
@@ -73,56 +58,117 @@ rustPlatform.buildRustPackage rec {
     OPENSSL_NO_VENDOR = 1;
   };
 
-  # Even tho the tests work, a shit ton of them try to connect to a local RPC
-  # or access internet in other ways, eventually failing due to Nix sandbox.
-  # Maybe we could restrict the check to the tests that don't require an RPC,
-  # but judging by the quantity of tests, that seems like a lengthty work and
-  # I'm not in the mood ((ΦωΦ))
-  doCheck = false;
-
-  nativeBuildInputs = [
-    installShellFiles
-    protobuf
-    pkg-config
-  ];
-  buildInputs = [
-    openssl
-    clang
-    libclang
-    rustPlatform.bindgenHook
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [ udev ];
-
-  doInstallCheck = true;
-
-  nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgram = "${placeholder "out"}/bin/solana";
-
-  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
-    installShellCompletion --cmd solana \
-      --bash <($out/bin/solana completion --shell bash) \
-      --fish <($out/bin/solana completion --shell fish)
-
-    mkdir -p $out/bin/platform-tools-sdk
-    cp -r ./platform-tools-sdk/sbf $out/bin/platform-tools-sdk
-
-    mkdir -p $out/bin/deps
-    find . -name libsolana_program.dylib -exec cp {} $out/bin/deps \;
-    find . -name libsolana_program.rlib -exec cp {} $out/bin/deps \;
-  '';
-
-  meta = {
-    description = "Web-Scale Blockchain for fast, secure, scalable, decentralized apps and marketplaces";
-    homepage = "https://solana.com";
-    license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [
-      netfox
-      happysalada
-      aikooo7
-      JacoMalan1
+  commonArgs = {
+    strictDeps = true;
+    # Even tho the tests work, a shit ton of them try to connect to a local RPC
+    # or access internet in other ways, eventually failing due to Nix sandbox.
+    # Maybe we could restrict the check to the tests that don't require an RPC,
+    # but judging by the quantity of tests, that seems like a lengthty work and
+    # I'm not in the mood ((ΦωΦ))
+    doCheck = false;
+    env = commonEnv;
+    nativeBuildInputs = [
+      protobuf
+      pkg-config
     ];
-    platforms = lib.platforms.unix;
+    buildInputs = [
+      openssl
+      clang
+      libclang
+      rustPlatform.bindgenHook
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ udev ];
   };
 
-  passthru.updateScript = nix-update-script { };
-}
+  spl-token = rustPlatform.buildRustPackage (
+    commonArgs
+    // {
+      pname = "spl-token";
+      version = "5.6.1";
+      src = fetchCrate {
+        pname = "spl-token-cli";
+        version = "5.6.1";
+        hash = "sha256-nlbnDTEAUBpY1oz5kqEBpvt0WFA9qmzmokBOftf1qVk=";
+      };
+      cargoHash = "sha256-fH5AgpMtnOKuB0jf5tiXDAeWBL+JcA7KJ8xjYGd1bek=";
+    }
+  );
+
+  # These are now independent crates.io packages (https://github.com/anza-xyz/agave/pull/10584).
+  # The version is independent from agave's version - 4.0.0 was published to crates.io
+  cargo-build-sbf = rustPlatform.buildRustPackage (
+    commonArgs
+    // {
+      pname = "cargo-build-sbf";
+      version = "4.1.0";
+      src = fetchCrate {
+        pname = "cargo-build-sbf";
+        version = "4.1.0";
+        hash = "sha256-tfmsjOixus0JhAQ7XjqYwzgqB4U9FxZL3u89kKu5TWI=";
+      };
+      cargoHash = "sha256-TCur1rDsfx4j4VtJIVhSBkXR6UyADJ3JXhdHFuT5h8U=";
+    }
+  );
+
+  cargo-test-sbf = rustPlatform.buildRustPackage (
+    commonArgs
+    // {
+      pname = "cargo-test-sbf";
+      version = "4.0.0";
+      src = fetchCrate {
+        pname = "cargo-test-sbf";
+        version = "4.0.0";
+        hash = "sha256-t0iTMCfwCC5tXZ8OH8i9FfpdWKf9NK/3DkoZXCJsvfk=";
+      };
+      cargoHash = "sha256-ZBTW3T9MdRaU/ziI46AHYbhLcHGO3R135ctt/+HuHOY=";
+    }
+  );
+in
+
+rustPlatform.buildRustPackage (
+  commonArgs
+  // {
+    pname = "solana-cli";
+    inherit version src;
+
+    cargoHash = "sha256-lQl8q0xMpXOmUirqL3Eyb4JcmYGSZK6pPMxQHOav9Zk=";
+
+    cargoBuildFlags = map (n: "--bin=${n}") solanaPkgs;
+
+    nativeBuildInputs = [ installShellFiles ] ++ commonArgs.nativeBuildInputs;
+
+    doInstallCheck = true;
+    nativeInstallCheckInputs = [ versionCheckHook ];
+    versionCheckProgram = "${placeholder "out"}/bin/solana";
+
+    postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      # installShellCompletion --cmd solana \
+      #   --bash <($out/bin/solana completion --shell bash) \
+      #   --fish <($out/bin/solana completion --shell fish)
+
+      cp ${cargo-build-sbf}/bin/cargo-build-sbf $out/bin/
+      cp ${cargo-test-sbf}/bin/cargo-test-sbf $out/bin/
+      cp ${spl-token}/bin/spl-token $out/bin/
+
+      # mkdir -p $out/bin/deps
+      # find . -name libsolana_program.dylib -exec cp {} $out/bin/deps \;
+      # find . -name libsolana_program.rlib -exec cp {} $out/bin/deps \;
+    '';
+
+    meta = {
+      description = "Web-Scale Blockchain for fast, secure, scalable, decentralized apps and marketplaces";
+      homepage = "https://solana.com";
+      changelog = "https://github.com/anza-xyz/agave/blob/${src.tag}/CHANGELOG.md";
+      license = lib.licenses.asl20;
+      maintainers = with lib.maintainers; [
+        netfox
+        happysalada
+        aikooo7
+        JacoMalan1
+      ];
+      platforms = lib.platforms.unix;
+    };
+
+    passthru.updateScript = nix-update-script { };
+  }
+)


### PR DESCRIPTION
.organised solanaPkgs according to agave-build-lists.sh
.removed solana-stake-accounts,solana-tokens,agave-install-init because they are deprecated and the functionality can be achieved by existing binaries
.removed solana-dos,solana-net-shaper because they are removed from upstream for this version
.commented out agave-ledger-tool,solana-bench-tps because they are moved to differet workspace
.moved solana-genesis to the agave-bins-val-op category because the issue was long resolved and now dcou bins are built separately so this wont cause issues
.installing cargo-build-sbf,cargo-test-sbf and spl-token-cli because in the new version they are decoupled from the upstream repo and downloaded from crates.io in the build process
.removed the platform-tools sdk related code in  postinstall because now it will be managed by cargo-build-sbf
.added myself as a maintainer


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
