### PR TITLE
surelog: fix tcmalloc segfaulting on darwin

### DIFF
--- a/pkgs/by-name/su/surelog/package.nix
+++ b/pkgs/by-name/su/surelog/package.nix
@@ -43,12 +43,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     libuuid
-    gperftools
     uhdm
     capnproto
     antlr4.runtime.cpp
     nlohmann_json
-  ];
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ gperftools ];
 
   cmakeFlags = [
     "-DSURELOG_USE_HOST_CAPNP=On"
@@ -57,7 +57,8 @@ stdenv.mkDerivation (finalAttrs: {
     "-DSURELOG_USE_HOST_ANTLR=On"
     "-DSURELOG_USE_HOST_JSON=On"
     "-DANTLR_JAR_LOCATION=${antlr4.jarLocation}"
-  ];
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ "-DSURELOG_WITH_TCMALLOC=Off" ];
 
   doCheck = true;
   checkPhase = ''


### PR DESCRIPTION
On Darwin, the precompilation of ASTs with the compiled surelog was causing segfaulting due to tcmalloc. I disabled tcmalloc for compilation of surelog and removed gperftools, which should be unnecessary now.

https://github.com/NixOS/nixpkgs/issues/516381

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
