### PR TITLE
av1an-unwrapped: 0.4.4 -> 0.5.2

### DIFF
--- a/pkgs/by-name/av/av1an-unwrapped/package.nix
+++ b/pkgs/by-name/av/av1an-unwrapped/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   ffmpeg_7,
   libaom,
   nasm,
@@ -16,26 +15,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "av1an-unwrapped";
-  version = "0.4.4";
+  version = "0.5.2";
 
   src = fetchFromGitHub {
     owner = "rust-av";
     repo = "Av1an";
-    tag = finalAttrs.version;
-    hash = "sha256-YF+j349777pE+evvXWTo42DQn1CE0jlfKBEXUFTfcb8=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JwYnDl9ZSSE+dD+ZAxuN7ywqFN314Ib/9Flh52kL3do=";
   };
 
-  cargoPatches = [
-    # TODO: Remove in next version
-    # Avoids https://github.com/shssoichiro/ffmpeg-the-third/issues/63
-    # https://github.com/master-of-zen/Av1an/pull/912
-    (fetchpatch {
-      url = "https://github.com/rust-av/Av1an/commit/e6b29a5a624434eb0dc95b7e8aa31ccf624ccb9d.patch";
-      hash = "sha256-nFE04hlTzApYafSzgl/XOUdchxEjKvxXy+SKr/d6+0Q=";
-    })
-  ];
-
-  cargoHash = "sha256-PcxnWkruFH4d2FqS+y3PmyA70kSe9BKtmTdCnfKnfpU=";
+  cargoHash = "sha256-mxWYXujwp7tYAj9bM/ZhqbyISMjvX+AYG07otcB67pg=";
 
   nativeBuildInputs = [
     nasm
@@ -49,9 +38,33 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   nativeCheckInputs = [
-    libaom
+    libaom.bin
     rav1e
     versionCheckHook
+  ];
+
+  # The encode_tests integration suite drives the full encode pipeline
+  # (external encoders, ffmpeg and vapoursynth source plugins at
+  # runtime) and only passes in upstream's prebuilt CI image, so limit
+  # the check phase to the unit tests.
+  cargoTestFlags = [
+    "--workspace"
+    "--lib"
+    "--bins"
+  ];
+
+  # libvapoursynth-script spins up an embedded Python and runs
+  # `import vapoursynth`; without this the VSScript API fails to
+  # initialize during unit tests that exercise the vapoursynth code path.
+  preCheck = ''
+    export PYTHONPATH=${vapoursynth}/${vapoursynth.python3.sitePackages}''${PYTHONPATH:+:$PYTHONPATH}
+  '';
+
+  # These unit tests load blank_1080p.mkv via core.lsmas.LWLibavSource,
+  # which needs the L-SMASH Works plugin.
+  checkFlags = [
+    "--skip=chunk::tests::apply_photon_noise_args_with_noise"
+    "--skip=scenes::tests::validate_zones_target_quality"
   ];
 
   passthru.updateScript = nix-update-script { };
@@ -67,7 +80,5 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ getchoo ];
     mainProgram = "av1an";
-    # symbol index out of range file '/private/tmp/nix-build-av1an-unwrapped-0.4.4.drv-0/rustcz0anL2/librav1e-ca440893f9248a14.rlib' for architecture x86_64
-    broken = stdenv.hostPlatform.system == "x86_64-darwin";
   };
 })

--- a/pkgs/by-name/av/av1an-unwrapped/package.nix
+++ b/pkgs/by-name/av/av1an-unwrapped/package.nix
@@ -11,6 +11,7 @@
   rav1e,
   rustPlatform,
   vapoursynth,
+  versionCheckHook,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -19,7 +20,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "rust-av";
-    repo = "av1an";
+    repo = "Av1an";
     tag = finalAttrs.version;
     hash = "sha256-YF+j349777pE+evvXWTo42DQn1CE0jlfKBEXUFTfcb8=";
   };
@@ -50,16 +51,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeCheckInputs = [
     libaom
     rav1e
+    versionCheckHook
   ];
 
-  passthru = {
-    updateScript = nix-update-script {
-      extraArgs = [
-        "--version-regex"
-        "'^(\\d*\\.\\d*\\.\\d*)$'"
-      ];
-    };
-  };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Cross-platform command-line encoding framework";


### PR DESCRIPTION
Fix build on darwin by updating the package.

Updated the nix update script according to the versioning change upstream + added `versionCheckHook`.

https://github.com/rust-av/Av1an/releases/tag/0.5
https://github.com/rust-av/Av1an/releases/tag/0.5.1
https://github.com/rust-av/Av1an/releases/tag/v0.5.2

#ZHFZurich

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
