### PR TITLE
treewide: fix typos in all markdown files

### DIFF
--- a/doc/languages-frameworks/android.section.md
+++ b/doc/languages-frameworks/android.section.md
@@ -308,7 +308,7 @@ Ensure that your buildToolsVersion and ndkVersion match what is declared in andr
 If you are using cmake, make sure its declared version is correct too.
 
 Otherwise, you may get cryptic errors from aapt2 and the Android Gradle plugin warning
-that it cannot install the build tools because the SDK directory is not writeable.
+that it cannot install the build tools because the SDK directory is not writable.
 
 ```gradle
 android {

--- a/doc/languages-frameworks/emscripten.section.md
+++ b/doc/languages-frameworks/emscripten.section.md
@@ -205,7 +205,7 @@ pkgs.buildEmscriptenPackage {
 
 ## Debugging {#declarative-debugging}
 
-Use `nix-shell -I nixpkgs=/some/dir/nixpkgs -A emscriptenPackages.libz` and from there you can go trough the individual steps. This makes it easy to build a good `unit test` or list the files of the project.
+Use `nix-shell -I nixpkgs=/some/dir/nixpkgs -A emscriptenPackages.libz` and from there you can go through the individual steps. This makes it easy to build a good `unit test` or list the files of the project.
 
 1. `nix-shell -I nixpkgs=/some/dir/nixpkgs -A emscriptenPackages.libz`
 2. `cd /tmp/`

--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -115,7 +115,7 @@
 
 - `nodePackages.browserify` has been removed, as it was unmaintained within nixpkgs.
 
-- `command-not-found` package will be enabled by default if the source of nixpkgs contains the file `programs.sqlite`. This is the case if a nixpkgs tarball from https://channels.nixos.org is used. This usage will also make the database of `command-no-found` stateless.
+- `command-not-found` package will be enabled by default if the source of nixpkgs contains the file `programs.sqlite`. This is the case if a nixpkgs tarball from https://channels.nixos.org is used. This usage will also make the database of `command-not-found` stateless.
 
 - `nodePackages.sass` has been removed, as it was unmaintained within nixpkgs.
 
@@ -130,7 +130,7 @@
 
 - Keycloak has been updated to 26.6.X, bringing a lot new features like federated client authentication, JWT authorization grants, workflows and the ability to do
   zero-downtime patch releases. Read more about [all the exciting new capabilities in keycloak 26.6 here](https://github.com/keycloak/keycloak/releases/tag/26.6.0)
-  and [consult the migration guide to 26.6](https://www.keycloak.org/docs/latest/upgrading/index.html#migrating-to-26-6-0) to find out wether this is a breaking
+  and [consult the migration guide to 26.6](https://www.keycloak.org/docs/latest/upgrading/index.html#migrating-to-26-6-0) to find out whether this is a breaking
   change for your keycloak instance.
 
 - `elegant-sddm` has been updated to be Qt6 compatible. Themes for SDDM are slightly different so read the [wiki](https://wiki.nixos.org/wiki/SDDM_Themes) for more.
@@ -392,7 +392,7 @@ gnuradioMinimal.override {
 
 - The `nodejs_latest` alias now points to `nodejs_25` instead of `nodejs_24`.
 
-- `nodejs-slim` no longer exposes a `corepack` executable, it has been moved to an ad-hoc output; to restore the previous behavior, `nodejs-slim.corepack` must be explicitely included.
+- `nodejs-slim` no longer exposes a `corepack` executable, it has been moved to an ad-hoc output; to restore the previous behavior, `nodejs-slim.corepack` must be explicitly included.
 
 - `nodejs` is now a simple wrapper for `nodejs-slim`+`nodejs-slim.npm`+`nodejs-slim.corepack`, meaning it is no longer possible to reference or override its attributes or outputs (e.g. `nodejs.libv8` must be replaced with `nodejs-slim.libv8`, `nodejs.nativeBuildInputs` with `nodejs-slim.nativeBuildInputs`, etc.).
 

--- a/nixos/doc/manual/configuration/renaming-interfaces.section.md
+++ b/nixos/doc/manual/configuration/renaming-interfaces.section.md
@@ -22,7 +22,7 @@ to `false`.
 In case there are multiple interfaces of the same type, it's better to
 assign custom names based on the device hardware address. For example,
 we assign the name `wan` to the interface with MAC address
-`52:54:00:12:01:01` using a netword link unit:
+`52:54:00:12:01:01` using a network link unit:
 
 ```nix
 {

--- a/nixos/doc/manual/release-notes/rl-2105.section.md
+++ b/nixos/doc/manual/release-notes/rl-2105.section.md
@@ -389,7 +389,7 @@ When upgrading from a previous release, please be aware of the following incompa
 
   Additionally, `platform.kernelArch` moved to the top level as `linuxArch` to match the other `*Arch` variables.
 
-  The `platform` grouping of these things never meant anything, and was just a historial/implementation artifact that was overdue removal.
+  The `platform` grouping of these things never meant anything, and was just a historical/implementation artifact that was overdue removal.
 
 - `services.restic` now uses a dedicated cache directory for every backup defined in `services.restic.backups`. The old global cache directory, `/root/.cache/restic`, is now unused and can be removed to free up disk space.
 

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -196,7 +196,7 @@ In addition to numerous new and upgraded packages, this release has the followin
       # Provide languages as ISO 639-2 codes
       # separated by a plus (+) sign.
       # https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes
-      PAPERLESS_OCR_LANGUAGE = "deu+eng+jpn"; # German & English & Japanse
+      PAPERLESS_OCR_LANGUAGE = "deu+eng+jpn"; # German & English & Japanese
     };
   }
   ```
@@ -436,7 +436,7 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - `retroArchCores` has been removed. This means that using `nixpkgs.config.retroarch` to customize RetroArch cores is not supported anymore. Instead, use package overrides, for example: `retroarch.override { cores = with libretro; [ citra snes9x ]; };`. Also, `retroarchFull` derivation is available for those who want to have all RetroArch cores available.
 
-- The Linux kernel for security reasons now restricts access to BPF syscalls via `BPF_UNPRIV_DEFAULT_OFF=y`. Unprivileged access can be reenabled via the `kernel.unprivileged_bpf_disabled` sysctl knob.
+- The Linux kernel for security reasons now restricts access to BPF syscalls via `BPF_UNPRIV_DEFAULT_OFF=y`. Unprivileged access can be re-enabled via the `kernel.unprivileged_bpf_disabled` sysctl knob.
 
 - `/usr` will always be included in the initial ramdisk. See the `fileSystems.<name>.neededForBoot` option.
   If any files exist under `/usr` (which is not typical for NixOS), they will be included in the initial ramdisk, increasing its size to a possibly problematic extent.

--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -293,7 +293,7 @@ Make sure to also check the many updates in the [Nixpkgs library](#sec-release-2
 
 - `odoo` defaults to v16 now, updated from v15.
 
-- `varnish` was upgraded from v7.2.x to v7.4.x. Refer to upgrade guides vor
+- `varnish` was upgraded from v7.2.x to v7.4.x. Refer to upgrade guides for
   [v7.3](https://varnish-cache.org/docs/7.3/whats-new/upgrading-7.3.html) and
   [v7.4](https://varnish-cache.org/docs/7.4/whats-new/upgrading-7.4.html). The
   current LTS version is still offered as `varnish60`.
@@ -692,7 +692,7 @@ Make sure to also check the many updates in the [Nixpkgs library](#sec-release-2
   NixOS configuration.
 
 - GNOME, Pantheon, Cinnamon modules no longer force Qt applications to use
-  Adwaita style. This implemantion  was buggy and is no longer maintained
+  Adwaita style. This implementation  was buggy and is no longer maintained
   upstream. Specifically, Cinnamon defaults to the gtk2 style instead now,
   following the default in Linux Mint). If you still want Adwaita used, you may
   add the following options to your configuration. Please be aware, that it
@@ -799,7 +799,7 @@ Make sure to also check the many updates in the [Nixpkgs library](#sec-release-2
     directly. Please upgrade to `nextcloud26` (or earlier) first. Nextcloud
     prohibits skipping major versions while upgrading. You may upgrade by
     declaring [`services.nextcloud.package =
-    pkgs.nextcloud26;`](options.html#opt-services.nextcloud.package) inbetween.
+    pkgs.nextcloud26;`](options.html#opt-services.nextcloud.package) in between.
 
 - `postgresql_11` has been removed since it'll stop receiving fixes on November
   9th 2023.
@@ -1131,7 +1131,7 @@ Make sure to also check the many updates in the [Nixpkgs library](#sec-release-2
   network interface is irrelevant.
 
 - `services.outline` can be configured to use local filesystem storage now.
-  Previously ony S3 storage was possible. This may be set using
+  Previously only S3 storage was possible. This may be set using
   [services.outline.storage.storageType](#opt-services.outline.storage.storageType).
 
 - `pkgs.openvpn3` optionally supports systemd-resolved now. `programs.openvpn3`

--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -708,7 +708,7 @@ Use `services.pipewire.extraConfig` or `services.pipewire.configPackages` for Pi
   The port can be specified in [`services.nextcloud.config.dbhost`](#opt-services.nextcloud.config.dbhost).
 
 - `services.kavita` now uses the free-form option `services.kavita.settings` for the application settings file.
-  The options `services.kavita.ipAdresses` and `services.kavita.port` now exist at `services.kavita.settings.IpAddresses`
+  The options `services.kavita.ipAddresses` and `services.kavita.port` now exist at `services.kavita.settings.IpAddresses`
   and `services.kavita.settings.IpAddresses`. The file at `services.kavita.tokenKeyFile` now needs to contain a secret with
   512+ bits instead of 128+ bits.
 

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -283,7 +283,7 @@ Alongside many enhancements to NixOS modules and general system improvements, th
 
 - The `virtualisation.hypervGuest.videoMode` option has been removed. Standard tooling can now be used to configure display modes for Hyper-V VMs.
 
-- Nextcloud's default FPM pool settings have been increased according to upstream recommentations. It's advised
+- Nextcloud's default FPM pool settings have been increased according to upstream recommendations. It's advised
   to review the new defaults and description of
   [](#opt-services.nextcloud.poolSettings).
 

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -14,7 +14,7 @@
   - The `cryptsetup-askpass` program is not available; use `systemctl default` instead, which will prompt for passphrases as necessary. If you pipe password responses into SSH over stdin, use `ssh -o RequestTTY=force` to ensure `systemctl default` gets a TTY to prompt on.
   - Many kernel parameters have been replaced with native systemd versions; see [](#sec-boot-problems).
 
-- The system.nix file has been added has an alternative entry point to configuration.nix (and flake.nix) that allows to configure NixOS without using `nix-channel`.
+- The system.nix file has been added as an alternative entry point to configuration.nix (and flake.nix) that allows to configure NixOS without using `nix-channel`.
   This file must evaluate to a NixOS system derivation or an attribute set of such derivations, in which case the attribute to build has to be selected with the `--attr` option of `nixos-rebuild` or `nixos-install`.
   For example,
   ```nix
@@ -389,11 +389,11 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 - `security.acme` now defaults to a dynamic renewal duration, if
   [security.acme.defaults.validMinDays](#opt-security.acme.defaults.validMinDays)
-  remains unset. This accomodates certificates with different ACME profile:
+  remains unset. This accommodates certificates with different ACME profile:
     - For certificates with a total validity at or above 10 days renewal will happen
       after two thirds of the lifetime has passed (e.g. a certificate valid for 90
       days renews once the validity falls below 30 days)
-    - For shortlived certificates with a total validty below 10 days renewal
+    - For shortlived certificates with a total validity below 10 days renewal
       will happen after half of the total lifetime has passed
 
 - The module for the Dovecot IMAP server, *services.dovecot*, now uses RFC-42-style settings, exposing a structured interface to write the configuration file.

--- a/nixos/modules/security/acme/default.md
+++ b/nixos/modules/security/acme/default.md
@@ -379,7 +379,7 @@ systemctl start acme-example.com.service
 
 ## Ensuring dependencies for services that need to be reloaded when a certificate changes {#module-security-acme-reload-dependencies}
 
-Services that depend on ACME certificates and need to be reloaded can use one of two approaches to reload upon successfull certificate acquisition or renewal:
+Services that depend on ACME certificates and need to be reloaded can use one of two approaches to reload upon successful certificate acquisition or renewal:
 
 1. **Using the `security.acme.certs.<name>.reloadServices` option**: This will cause `systemctl try-reload-or-restart` to be run for the listed services.
 

--- a/nixos/modules/services/databases/postgresql.md
+++ b/nixos/modules/services/databases/postgresql.md
@@ -237,7 +237,7 @@ PostgreSQL's versioning policy is described [here](https://www.postgresql.org/su
 
 - Each major version is supported for 5 years.
 - Every three months there will be a new minor release, containing bug and security fixes.
-- For criticial/security fixes there could be more minor releases inbetween. This happens *very* infrequently.
+- For critical/security fixes there could be more minor releases in between. This happens *very* infrequently.
 - After five years, a final minor version is released. This usually happens in early November.
 - After that a version is considered end-of-life (EOL).
 - Around February each year is the first time an EOL-release will not have received regular updates anymore.

--- a/nixos/modules/services/misc/paisa.md
+++ b/nixos/modules/services/misc/paisa.md
@@ -9,7 +9,7 @@ built on top of the ledger plain-text-accounting tool.
 
 ## Usage {#module-services-paisa-usage}
 
-Paisa needs to have one of the following cli tools availabe in the PATH at
+Paisa needs to have one of the following cli tools available in the PATH at
 runtime:
 
 - ledger

--- a/nixos/modules/services/network-filesystems/samba.md
+++ b/nixos/modules/services/network-filesystems/samba.md
@@ -29,7 +29,7 @@ which is read-only and accessible without authentication:
       "public" = {
         "path" = "/public";
         "read only" = "yes";
-        "browseable" = "yes";
+        "browsable" = "yes";
         "guest ok" = "yes";
         "comment" = "Public samba share.";
       };

--- a/nixos/modules/services/networking/prosody.md
+++ b/nixos/modules/services/networking/prosody.md
@@ -56,7 +56,7 @@ certificate by leveraging the ACME
 [extraDomainNames](#opt-security.acme.certs._name_.extraDomainNames) module option.
 
 Provided the setup detailed in the previous section, you'll need the following acme configuration to generate
-a TLS certificate for the three endponits:
+a TLS certificate for the three endpoints:
 ```nix
 {
   security.acme = {

--- a/nixos/modules/services/web-apps/ente.md
+++ b/nixos/modules/services/web-apps/ente.md
@@ -117,10 +117,10 @@ with your admin user to modify the storage limit.
 
 ## iOS background sync {#module-services-ente-ios-background-sync}
 
-On iOS, background sync is achived via a silent notification sent by the server
+On iOS, background sync is achieved via a silent notification sent by the server
 every 30 minutes that allows the phone to sync for about 30 seconds, enough for
 all but the largest videos to be synced on background (if the app is brought to
-foreground though, sync will resume as normal). To achive this however, a
+foreground though, sync will resume as normal). To achieve this however, a
 Firebase account is needed. In the settings option, configure credentials-dir
 to point towards the directory where the JSON containing the Firebase
 credentials are stored.

--- a/pkgs/README.md
+++ b/pkgs/README.md
@@ -1210,7 +1210,7 @@ Security fixes are submitted in the same way as other changes and thus the same 
 
 If a security fix applies to both master and a stable release then, similar to regular changes, they are preferably delivered via master first and cherry-picked to the release branch.
 
-Critical security fixes may by-pass the staging branches and be delivered directly to release branches such as `master` and `release-*`.
+Critical security fixes may bypass the staging branches and be delivered directly to release branches such as `master` and `release-*`.
 
 ### Vulnerability Roundup
 

--- a/pkgs/by-name/tr/tracy/README.md
+++ b/pkgs/by-name/tr/tracy/README.md
@@ -14,7 +14,7 @@ with the most recent available "by name" as `tracy`.
 ## Version Retention Guidelines
 
 Older releases of Tracy are provided as a convenience, not a guarantee. Maintainers
-should balance relevance to nixpkgs, maintainance burden, and user need.
+should balance relevance to nixpkgs, maintenance burden, and user need.
 
 - Dependants in nixpkgs use `tracy` rather than a pinned version;
 - No more than three pinned versions of Tracy are maintained, assuming annual release
@@ -126,7 +126,7 @@ CPM `NAME`.
 
 Package is not available in nixpkgs or is incompatible.
 
-### Mechansim
+### Mechanism
 
 Uses the same mechanism as a nixpkg src, except the source is downloaded with a fetcher such as
 `fetchFromGithub`.


### PR DESCRIPTION
I ran
```sh
find -name '*.md' | xargs typos
find -name '*.md' | xargs codespell
```
and cherry-picked all non-false-positives.
Plus corrected few typos that I found using my own eyes :)

Note: `codespell` also complained a lot about the word`re-use` and its forms, but I am not good enough english speaker to confidently decide whether it is a hard misspelling or just another normal way of spelling that word.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
