### PR TITLE
flare: 1.14 -> 1.15

### DIFF
--- a/pkgs/by-name/fl/flare/engine.nix
+++ b/pkgs/by-name/fl/flare/engine.nix
@@ -12,24 +12,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "flare-engine";
-  version = "1.14";
+  version = "1.15";
 
   src = fetchFromGitHub {
     owner = "flareteam";
     repo = "flare-engine";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-DIzfTqwZJ8NAPB/TWzvPjepHb7hIbIr+Kk+doXJmpLc=";
+    hash = "sha256-QwrSMkJE8dNIODlmdi1c6qgTULhJP9HEV8wI7k5vHAA=";
   };
 
   patches = [
     ./desktop.patch
-
-    # cmake-4 compatibility patch
-    (fetchpatch {
-      name = "cmake-4.patch";
-      url = "https://github.com/flareteam/flare-engine/commit/9500379f886484382bba2f893faf49865de9f2c0.patch";
-      hash = "sha256-nUn54ZBEvvFkIhzE/UBbsvF0rFC9JAeQACTAPtsc1VI=";
-    })
   ];
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/fl/flare/game.nix
+++ b/pkgs/by-name/fl/flare/game.nix
@@ -8,23 +8,16 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "flare-game";
-  version = "1.14";
+  version = "1.15";
 
   src = fetchFromGitHub {
     owner = "flareteam";
     repo = "flare-game";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-tINIwxyQn8eeJCHwRmAMo2TYRgrgJlGaUrnrgbmM3Jo=";
+    hash = "sha256-IsVfP8wmrublAqoVix7gOA4u8CRmXdyNzagnaXyFsxc=";
   };
 
-  patches = [
-    # cmake-4 compatibility patch
-    (fetchpatch {
-      name = "cmake-4.patch";
-      url = "https://github.com/flareteam/flare-game/commit/5b61dfd69f4ecbaca6439caa9ae41b3168e4d21a.patch";
-      hash = "sha256-5Um6LWAWQyialzO3KSebmLju0VOuz1S5dzavO9EWlLE=";
-    })
-  ];
+  patches = [ ];
 
   nativeBuildInputs = [ cmake ];
 

--- a/pkgs/by-name/fl/flare/package.nix
+++ b/pkgs/by-name/fl/flare/package.nix
@@ -7,7 +7,7 @@
 
 buildEnv {
   pname = "flare";
-  version = "1.14";
+  version = "1.15";
 
   paths = [
     (callPackage ./engine.nix { })


### PR DESCRIPTION
Update to 1.15

remove outdated patch preventing auto update.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
