### PR TITLE
feedr: 0.7.0 -> 0.8.0

### DIFF
--- a/pkgs/by-name/fe/feedr/package.nix
+++ b/pkgs/by-name/fe/feedr/package.nix
@@ -12,16 +12,18 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "feedr";
-  version = "0.7.0";
+  version = "0.8.0";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "bahdotsh";
     repo = "feedr";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-5s4QgkUX27WNrTyzyYDQjf4VjKD0Kdkicjf7hlO9OKE=";
+    hash = "sha256-x8FypbvuAzARc/Jy9kSfSVSSVUsTTdLJU9ihNWpUbak=";
   };
 
-  cargoHash = "sha256-3xSvqj2kW0lOFUzkAbBJThJx6u7f1tSk1qgFdm2tVfg=";
+  cargoHash = "sha256-bUZnaAKlbNCOoMYufBZSHu2QLtxsrur3Cdmpd5y4Sw8=";
 
   nativeBuildInputs = [
     pkg-config
@@ -41,6 +43,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
     # event loop thread panicked
     "--skip=test_problematic_feeds"
     "--skip=test_reddit_style_atom_feeds"
+    "--skip=test_extract_article_rejects_non_http_scheme"
+    # bind 127.0.0.1: Os { code: 1, kind: PermissionDenied, message: "Operation not permitted" }
+    "--skip=test_extract_article_rejects_non_html_content_type"
+    "--skip=test_extract_article_follows_safe_redirect_to_public_target"
+    "--skip=test_extract_article_does_not_send_authorization_header"
+    "--skip=test_extract_article_rejects_oversized_content_length"
+    "--skip=test_extract_article_rejects_redirect_into_private_ip_via_safe_client"
   ];
 
   doInstallCheck = true;


### PR DESCRIPTION
Diff: https://github.com/bahdotsh/feedr/compare/v0.7.0...v0.8.0

Changelog: https://github.com/bahdotsh/feedr/releases/tag/v0.8.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
