### PR TITLE
maintainers: remove mbbx6spp

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17369,12 +17369,6 @@
     githubId = 613740;
     name = "Martin Baillie";
   };
-  mbbx6spp = {
-    email = "me@susanpotter.net";
-    github = "mbbx6spp";
-    githubId = 564;
-    name = "Susan Potter";
-  };
   mbe = {
     email = "brandonedens@gmail.com";
     github = "brandonedens";

--- a/nixos/tests/nginx.nix
+++ b/nixos/tests/nginx.nix
@@ -4,13 +4,11 @@
 #   2. whether the ETag header is properly generated whenever we're serving
 #      files in Nix store paths
 #   3. nginx doesn't restart on configuration changes (only reloads)
-{ pkgs, ... }:
+{ ... }:
 {
   name = "nginx";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [
-      mbbx6spp
-    ];
+  meta = {
+    maintainers = [ ];
   };
 
   nodes = {

--- a/pkgs/by-name/in/inform7/package.nix
+++ b/pkgs/by-name/in/inform7/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation {
     mainProgram = "i7";
     homepage = "http://inform7.com/";
     license = lib.licenses.artistic2;
-    maintainers = with lib.maintainers; [ mbbx6spp ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
     # never built on aarch64-darwin since first introduction in nixpkgs
     broken =

--- a/pkgs/development/compilers/purescript/purescript/default.nix
+++ b/pkgs/development/compilers/purescript/purescript/default.nix
@@ -85,7 +85,6 @@ stdenv.mkDerivation rec {
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     maintainers = with lib.maintainers; [
       justinwoo
-      mbbx6spp
       cdepillabout
     ];
     platforms = [

--- a/pkgs/os-specific/linux/ply/default.nix
+++ b/pkgs/os-specific/linux/ply/default.nix
@@ -65,7 +65,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = [ lib.licenses.gpl2Only ];
     maintainers = with lib.maintainers; [
       mic92
-      mbbx6spp
       snu
     ];
     platforms = lib.platforms.linux;


### PR DESCRIPTION
## Reasons

- Last commented in [January 2024](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Ambbx6spp)
- Hasn't created any PRs / Issues since [March 2021](https://github.com/NixOS/nixpkgs/issues?q=author%3Ambbx6spp)
- About 40 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Ambbx6spp%20-commenter%3Ambbx6spp%20-author%3Ambbx6spp%20-reviewed-by%3Ambbx6spp) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] inform7
- [ ] nixosTests.nginx