### PR TITLE
blesh: 0.4.0-devel3 -> 0.4.0-devel3-unstable-2026-03-10

### DIFF
--- a/pkgs/by-name/bl/blesh/package.nix
+++ b/pkgs/by-name/bl/blesh/package.nix
@@ -7,13 +7,14 @@
   glibcLocales,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation {
   pname = "blesh";
-  version = "0.4.0-devel3";
+  version = "0.4.0-devel3-unstable-2026-03-10";
 
   src = fetchzip {
-    url = "https://github.com/akinomyoga/ble.sh/releases/download/v${version}/ble-${version}.tar.xz";
-    sha256 = "sha256-kGLp8RaInYSrJEi3h5kWEOMAbZV/gEPFUjOLgBuMhCI=";
+    url = "https://github.com/akinomyoga/ble.sh/releases/download/nightly/ble-nightly-20260310%2Bb99cadb.tar.xz";
+    name = "ble-nightly-20260310+b99cadb.tar.xz";
+    sha256 = "sha256-rJnSEY7J4wfy8dnL9Bg59u0epPe0HL1J7piPbkNyes0=";
   };
 
   dontBuild = true;


### PR DESCRIPTION
Bumps blesh to a recent upstream nightly snapshot.

The current `v0.4.0-devel3` (2023-04) is broken with bash 5.3: after
`ble-attach`, every keystroke produces
`_ble_decode_hook: command not found` and the shell becomes unusable
(only `C-d` works). Fixed upstream in
[`48c7bbe`](https://github.com/akinomyoga/ble.sh/commit/48c7bbe)
("global: work around function names with slashes in Bash 5.3 POSIX
mode", 2024-06-05).

ble.sh has not had a tagged release since 2023-04. The upstream
maintainer explicitly recommends nightly in
[akinomyoga/ble.sh#566](https://github.com/akinomyoga/ble.sh/issues/566):

> I actually recommend that users clone the GitHub repository and build
> `ble.sh` locally, or users use the night build version.

In the same thread, the maintainer also notes that "the Nixpkgs package
needs to be updated, but it would take even longer time because of the
lack of man power in Nixpkgs," which this PR is directly addressing.

A new tagged release has been "coming soon" for over a year without
materializing: the maintainer estimated ~one month in April 2025, had
~30 commits left to review in July 2025, and the issue is still open as
of May 2026 with no release. Meanwhile other Nix users have resorted to
ad-hoc overlays to escape the broken state — for example,
[a comment from 2026-05-14](https://github.com/akinomyoga/ble.sh/issues/566#issuecomment-4452112975)
shows a `blesh.overrideAttrs` snippet pinning a nightly snapshot.

I'm adding myself as a maintainer and intend to keep the package up to
date. After this PR lands, I plan to open a follow-up that switches
`src` to `fetchFromGitHub` and wires
`passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch=master" ]; };`,
so future bumps can be automated and the ongoing maintenance burden
stays low. This PR is kept
minimal so the bug-fix and the structural refactor can be reviewed
independently.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
