### PR TITLE
kuma: 2.12.3 -> 2.13.6

### DIFF
--- a/pkgs/applications/networking/cluster/kuma/default.nix
+++ b/pkgs/applications/networking/cluster/kuma/default.nix
@@ -17,17 +17,21 @@
 
 buildGoModule rec {
   inherit pname;
-  version = "2.12.3";
+  version = "2.13.6";
   tags = lib.optionals enableGateway [ "gateway" ];
 
   src = fetchFromGitHub {
     owner = "kumahq";
     repo = "kuma";
-    tag = version;
-    hash = "sha256-C/q3fCcMMnqjXeoO/t/YOKHLq8HDNfF+x75nCcjwwvE=";
+    tag = "v${version}";
+    hash = "sha256-oA6yN369Ndkm4+B15RnFXPGRFVFhKwGRunMGHZ1DZKo=";
   };
 
-  vendorHash = "sha256-KgZYKopW+FOdwBIGxa2RLiEbefZ/1vAhcsWtcYhgdFs=";
+  vendorHash = "sha256-f8FBx4ODzJHk7CwRCZ7Ot/YUEGrLQVx/a22X1vWj3kQ=";
+
+  postPatch = ''
+    substituteInPlace go.mod --replace-fail "go 1.26.3" "go 1.26.2"
+  '';
 
   # no test files
   doCheck = false;
@@ -55,14 +59,14 @@ buildGoModule rec {
 
   ldflags =
     let
-      prefix = "github.com/kumahq/kuma/pkg/version";
+      prefix = "github.com/kumahq/kuma/v2/pkg/version";
     in
     [
       "-s"
       "-w"
       "-X ${prefix}.version=${version}"
-      "-X ${prefix}.gitTag=${version}"
-      "-X ${prefix}.gitCommit=${version}"
+      "-X ${prefix}.gitTag=v${version}"
+      "-X ${prefix}.gitCommit=v${version}"
       "-X ${prefix}.buildDate=${version}"
     ];
 


### PR DESCRIPTION
Update kuma to 2.13.6

Change tag format and patch go version (1.26.3 is not yet available)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/` (tried kumactl config changes).
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
