### PR TITLE
nixos/music-assistant: Add squeezelite/slimproto firewall ports

### DIFF
--- a/nixos/modules/services/audio/music-assistant.nix
+++ b/nixos/modules/services/audio/music-assistant.nix
@@ -83,7 +83,18 @@ in
         lib.optional cfg.enable 8097 # Music Assistant stream port
         ++ lib.optional (lib.elem "airplay" cfg.providers) 7000
         ++ lib.optional (lib.elem "sendspin" cfg.providers) 8927
-        ++ lib.optional (lib.elem "snapcast" cfg.providers) 1780;
+        ++ lib.optional (lib.elem "snapcast" cfg.providers) 1780
+        ++ lib.optionals (lib.elem "squeezelite" cfg.providers) [
+          # https://lyrion.org/reference/slimproto-protocol/
+          3483 # Slimproto control
+          # https://lyrion.org/reference/cli/using-the-cli/
+          9000 # Slimproto JSON-RPC
+          9090 # Slimproto CLI
+        ];
+      allowedUDPPorts = lib.optionals (lib.elem "squeezelite" cfg.providers) [
+        # https://lyrion.org/reference/slimproto-protocol/
+        3483 # Slimproto discovery
+      ];
       # The information published by Apple 1 seem to not apply to libraop.
       # The closest we could find that represents the port range being used as observed by tcpdump is the ephemeral port range.
       # 1: https://support.apple.com/en-us/103229#:~:text=49152%E2%80%93-,65535,-TCP%2C%20UDP


### PR DESCRIPTION
Add squeezelite/slimproto firewall ports. Port Documentation:

- https://lyrion.org/reference/slimproto-protocol/
- https://lyrion.org/reference/cli/using-the-cli/

Tested locally with a fresh Music-Assistant install using unstable (2.8.7) and two PiCorePlayers (v10.0.0, Squeezelite v2.0.0-1476-pCP).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
