### PR TITLE
bite: 0.3 -> 0.43

### DIFF
--- a/pkgs/by-name/bi/bite/package.nix
+++ b/pkgs/by-name/bi/bite/package.nix
@@ -21,16 +21,18 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "bite";
-  version = "0.3";
+  version = "0.43";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "WINSDK";
     repo = "bite";
-    rev = "V${finalAttrs.version}";
-    hash = "sha256-gio4J+V8achSuR2vQa2dnvOR/u4Zbb5z0UE0xP0gGCU=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-akwkTV1bZJ3GcEtObyF+qN5IkBRoXdztUSOghjQy7A0=";
   };
 
-  cargoHash = "sha256-ESGX1hnDnU2taKQXre4AQRzQxTC7W+0cEIoQPPC9Lfs=";
+  cargoHash = "sha256-OlxUHYTbljWGWdiceBmW3J0oB4w0/5izgNnwCafV6xY=";
 
   nativeBuildInputs = [
     pkg-config
@@ -90,7 +92,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "Disassembler focused on comprehensive rust support";
     homepage = "https://github.com/WINSDK/bite";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ vinnymeller ];
+    maintainers = with lib.maintainers; [
+      vinnymeller
+      kybe236
+    ];
     mainProgram = "bite";
   };
 })


### PR DESCRIPTION
Diff: https://github.com/WINSDK/bite/compare/V0.3...v0.43
Changelog: https://github.com/WINSDK/bite/releases/tag/v0.43

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
