### PR TITLE
python3Packages.functions-framework: cleanup, skip failing tests on python>=3.14

### DIFF
--- a/pkgs/development/python-modules/cloudevents/default.nix
+++ b/pkgs/development/python-modules/cloudevents/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonAtLeast,
   setuptools,
   deprecation,
   flask,
@@ -39,7 +40,15 @@ buildPythonPackage (finalAttrs: {
     sanic-testing
   ];
 
-  disabledTestPaths = [ "samples/http-image-cloudevents/image_sample_test.py" ];
+  disabledTestPaths = [
+    "samples/http-image-cloudevents/image_sample_test.py"
+  ]
+  # pydantic v1 doesn't work on python 3.14
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    "cloudevents/tests/test_pydantic_cloudevent.py"
+    "cloudevents/tests/test_pydantic_conversions.py"
+    "cloudevents/tests/test_pydantic_events.py"
+  ];
 
   __darwinAllowLocalNetworking = true;
 

--- a/pkgs/development/python-modules/functions-framework/default.nix
+++ b/pkgs/development/python-modules/functions-framework/default.nix
@@ -1,27 +1,34 @@
 {
   lib,
   buildPythonPackage,
+  fetchFromGitHub,
+  pythonAtLeast,
+
+  # build-system
+  setuptools,
+
+  # dependencies
   click,
   cloudevents,
   deprecation,
-  docker,
-  fetchFromGitHub,
   flask,
   gunicorn,
-  httpx,
-  pretend,
-  pytest-asyncio,
-  pytestCheckHook,
-  requests,
-  setuptools,
   starlette,
   uvicorn,
   uvicorn-worker,
   watchdog,
   werkzeug,
+
+  # tests
+  docker,
+  httpx,
+  pretend,
+  pytest-asyncio,
+  pytestCheckHook,
+  requests,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "functions-framework";
   version = "3.10.1";
   pyproject = true;
@@ -29,7 +36,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "GoogleCloudPlatform";
     repo = "functions-framework-python";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-CEH0PokH3lhyJl7OPIpJkaKZxAUp1fYVia89DtGoJ7k=";
   };
 
@@ -62,6 +69,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "functions_framework" ];
 
+  disabledTestPaths = lib.optionals (pythonAtLeast "3.14") [
+    # _pickle.PicklingError: Can't pickle local object <function Flask.__init__.<locals>.<lambda> at 0x7ffff47e54e0>
+    "tests/test_timeouts.py"
+  ];
+
   disabledTests = [
     # Test requires a running Docker instance
     "test_cloud_run_http"
@@ -70,8 +82,8 @@ buildPythonPackage rec {
   meta = {
     description = "FaaS (Function as a service) framework for writing portable Python functions";
     homepage = "https://github.com/GoogleCloudPlatform/functions-framework-python";
-    changelog = "https://github.com/GoogleCloudPlatform/functions-framework-python/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/GoogleCloudPlatform/functions-framework-python/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
