### PR TITLE
whisper-dictate: init at 0.2.23

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15168,6 +15168,12 @@
     githubId = 182024;
     name = "Lars Rasmusson";
   };
+  larswa = {
+    email = "lars@factus.dk";
+    github = "Larswa";
+    githubId = 1431240;
+    name = "Lars W. Andersen";
+  };
   lasandell = {
     email = "lasandell@gmail.com";
     github = "lasandell";

--- a/pkgs/by-name/wh/whisper-dictate/package.nix
+++ b/pkgs/by-name/wh/whisper-dictate/package.nix
@@ -1,35 +1,45 @@
-{ lib
-, python3
-, makeWrapper
-, stdenv
-, fetchFromGitHub
+{
+  lib,
+  python3,
+  makeWrapper,
+  stdenv,
+  fetchFromGitHub,
 }:
 
 let
-  pythonEnv = python3.withPackages (ps: with ps; [
-    faster-whisper
-    requests
-    numpy
-    sounddevice
-    pynput
-    pyperclip
-  ] ++ lib.optionals stdenv.isLinux [
-    evdev
-    scipy
-  ]);
+  pythonEnv = python3.withPackages (
+    ps:
+    with ps;
+    [
+      faster-whisper
+      requests
+      numpy
+      sounddevice
+      pynput
+      pyperclip
+    ]
+    ++ lib.optionals stdenv.isLinux [
+      evdev
+      scipy
+    ]
+  );
 
-in stdenv.mkDerivation (finalAttrs: {
-  pname   = "whisper-dictate";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "whisper-dictate";
   version = "0.2.23";
 
   src = fetchFromGitHub {
     owner = "FactusConsulting";
-    repo  = "whisper-dictate";
-    rev   = "v${finalAttrs.version}";
-    hash  = "sha256-Y93fRQNO+VCc+GXltV672r0zdFuOJkN2zRpslSx7Q/4=";
+    repo = "whisper-dictate";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-Y93fRQNO+VCc+GXltV672r0zdFuOJkN2zRpslSx7Q/4=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   dontBuild = true;
 
@@ -46,17 +56,17 @@ in stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description  = "Local push-to-talk dictation using Whisper STT";
+    description = "Local push-to-talk dictation using Whisper STT";
     longDescription = ''
       App-agnostic push-to-talk dictation. Hold a key, speak quietly but clearly,
       release — the transcribed text is injected into whatever window has focus.
       Whisper runs fully locally on your own machine; nothing leaves the box.
     '';
-    homepage     = "https://github.com/FactusConsulting/whisper-dictate";
-    changelog    = "https://github.com/FactusConsulting/whisper-dictate/releases/tag/v${finalAttrs.version}";
-    license      = lib.licenses.mit;
-    maintainers  = with lib.maintainers; [ ];
-    platforms    = lib.platforms.unix;
-    mainProgram  = "whisper-dictate";
+    homepage = "https://github.com/FactusConsulting/whisper-dictate";
+    changelog = "https://github.com/FactusConsulting/whisper-dictate/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+    platforms = lib.platforms.unix;
+    mainProgram = "whisper-dictate";
   };
 })

--- a/pkgs/by-name/wh/whisper-dictate/package.nix
+++ b/pkgs/by-name/wh/whisper-dictate/package.nix
@@ -1,0 +1,62 @@
+{ lib
+, python3
+, makeWrapper
+, stdenv
+, fetchFromGitHub
+}:
+
+let
+  pythonEnv = python3.withPackages (ps: with ps; [
+    faster-whisper
+    requests
+    numpy
+    sounddevice
+    pynput
+    pyperclip
+  ] ++ lib.optionals stdenv.isLinux [
+    evdev
+    scipy
+  ]);
+
+in stdenv.mkDerivation (finalAttrs: {
+  pname   = "whisper-dictate";
+  version = "0.2.23";
+
+  src = fetchFromGitHub {
+    owner = "FactusConsulting";
+    repo  = "whisper-dictate";
+    rev   = "v${finalAttrs.version}";
+    hash  = "sha256-Y93fRQNO+VCc+GXltV672r0zdFuOJkN2zRpslSx7Q/4=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 voice_pi.py $out/lib/whisper-dictate/voice_pi.py
+
+    makeWrapper ${pythonEnv}/bin/python3 $out/bin/whisper-dictate \
+      --add-flags "$out/lib/whisper-dictate/voice_pi.py" \
+      --set VOICEPI_SKIP_SYSCHECK 1
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description  = "Local push-to-talk dictation using Whisper STT";
+    longDescription = ''
+      App-agnostic push-to-talk dictation. Hold a key, speak quietly but clearly,
+      release — the transcribed text is injected into whatever window has focus.
+      Whisper runs fully locally on your own machine; nothing leaves the box.
+    '';
+    homepage     = "https://github.com/FactusConsulting/whisper-dictate";
+    changelog    = "https://github.com/FactusConsulting/whisper-dictate/releases/tag/v${finalAttrs.version}";
+    license      = lib.licenses.mit;
+    maintainers  = with lib.maintainers; [ ];
+    platforms    = lib.platforms.unix;
+    mainProgram  = "whisper-dictate";
+  };
+})

--- a/pkgs/by-name/wh/whisper-dictate/package.nix
+++ b/pkgs/by-name/wh/whisper-dictate/package.nix
@@ -65,8 +65,8 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/FactusConsulting/whisper-dictate";
     changelog = "https://github.com/FactusConsulting/whisper-dictate/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ];
-    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ larswa ];
+    platforms = lib.platforms.linux;
     mainProgram = "whisper-dictate";
   };
 })


### PR DESCRIPTION
## Description

Add [whisper-dictate](https://github.com/FactusConsulting/whisper-dictate) v0.2.23 — an app-agnostic, push-to-talk voice dictation tool that runs Whisper STT fully locally.

Hold a configurable key, speak, release — the transcribed text is injected into whatever window has focus via `pynput`/`evdev`. Nothing is sent off-device.

## Package details

| Field | Value |
|---|---|
| pname | `whisper-dictate` |
| version | `0.2.23` |
| license | MIT |
| platforms | `lib.platforms.unix` |
| mainProgram | `whisper-dictate` |

The package is a single Python script (`voice_pi.py`) wrapped with `makeWrapper` around a `python3.withPackages` environment. Linux-specific extras (`evdev`, `scipy`) are included via `lib.optionals stdenv.isLinux`.

## Checklist

- [x] `package.nix` placed at `pkgs/by-name/wh/whisper-dictate/package.nix`
- [x] `fetchFromGitHub` with tagged release
- [x] `meta` block: `description`, `longDescription`, `homepage`, `changelog`, `license`, `platforms`, `mainProgram`
- [x] Uses `makeWrapper` + `python3.withPackages` pattern
- [x] Platform-conditional dependencies via `lib.optionals stdenv.isLinux`