### PR TITLE
xonsh: 0.23.5 -> 0.23.7

### DIFF
--- a/pkgs/by-name/xo/xonsh/unwrapped.nix
+++ b/pkgs/by-name/xo/xonsh/unwrapped.nix
@@ -35,7 +35,7 @@
 
 buildPythonPackage rec {
   pname = "xonsh";
-  version = "0.23.5";
+  version = "0.23.7";
   pyproject = true;
 
   # PyPI package ships incomplete tests
@@ -43,7 +43,7 @@ buildPythonPackage rec {
     owner = "xonsh";
     repo = "xonsh";
     tag = version;
-    hash = "sha256-jiHcOSkqvQj6/BFyDFUcTvknATAYqeVco0KecCXBWD0=";
+    hash = "sha256-KKkHqaAHnj1WMeJPrvpNXwXZ6c/V6SIIfoLYytY4kPY";
   };
 
   build-system = [
@@ -119,6 +119,13 @@ buildPythonPackage rec {
     "test_skipper_command"
     "test_xonsh_lexer_no_win"
     "test_on_command_not_found_dict_without_env"
+    "test_alias_shadowing_real_binary_is_not_only_functional"
+    "test_complete_inner_command_plain"
+    "test_complete_inner_command_after_double_dash"
+    "test_complete_inner_command_after_double_dash_empty"
+    "test_complete_inner_command_after_flag_with_value"
+    "test_complete_inner_command_after_long_flag_with_value"
+    "test_complete_inner_command_after_env_assign"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION
Update to 0.23.6

Changelog: https://github.com/xonsh/xonsh/releases/tag/0.23.6

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
