### PR TITLE
jbig2enc: 0.30 -> 0.31

### DIFF
--- a/pkgs/by-name/jb/jbig2enc/package.nix
+++ b/pkgs/by-name/jb/jbig2enc/package.nix
@@ -11,20 +11,24 @@
   libtiff,
   python3,
   autoreconfHook,
+  pkg-config,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "jbig2enc";
-  version = "0.30";
+  version = "0.31";
 
   src = fetchFromGitHub {
     owner = "agl";
     repo = "jbig2enc";
     rev = finalAttrs.version;
-    hash = "sha256-B19l2NdMq+wWKQ5f/y5aoPiBtQnn6sqpaIoyIq+ugTg=";
+    hash = "sha256-UafMDNEMr+8keSgIXBNxnhR24qRrx7F0+ShleF/G2AQ=";
   };
 
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
 
   buildInputs = [
     leptonica


### PR DESCRIPTION
Update to 0.31. Add pkg-config as dependency.

Changelog:
https://github.com/agl/jbig2enc/releases/tag/0.31

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
