### PR TITLE
bifrost: init at 2.0.0; nixos/bifrost: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17630,6 +17630,12 @@
     githubId = 7802795;
     name = "Manoj Karthick";
   };
+  ManUtopiK = {
+    email = "emmanuel.salomon@gmail.com";
+    github = "ManUtopiK";
+    githubId = 188172;
+    name = "Emmanuel Salomon";
+  };
   maolonglong = {
     email = "shaolong.chen@outlook.it";
     github = "maolonglong";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -862,6 +862,7 @@
   ./services/misc/beanstalkd.nix
   ./services/misc/bees.nix
   ./services/misc/bepasty.nix
+  ./services/misc/bifrost.nix
   ./services/misc/blenderfarm.nix
   ./services/misc/calibre-server.nix
   ./services/misc/canto-daemon.nix

--- a/nixos/modules/services/misc/bifrost.nix
+++ b/nixos/modules/services/misc/bifrost.nix
@@ -1,0 +1,217 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib) types;
+
+  cfg = config.services.bifrost;
+  settingsFormat = pkgs.formats.json { };
+in
+{
+  options.services.bifrost = {
+    enable = lib.mkEnableOption "Bifrost, a high-performance LLM gateway with native MCP support";
+
+    package = lib.mkPackageOption pkgs "bifrost" { };
+
+    stateDir = lib.mkOption {
+      type = types.path;
+      default = "/var/lib/bifrost";
+      example = "/var/lib/bifrost";
+      description = ''
+        Application data directory (contains `config.json` and logs).
+        Must be a direct child of `/var/lib` so it works with systemd's
+        `StateDirectory=` and `DynamicUser=`.
+      '';
+    };
+
+    host = lib.mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      example = "0.0.0.0";
+      description = "Address Bifrost listens on.";
+    };
+
+    port = lib.mkOption {
+      type = types.port;
+      default = 8080;
+      example = 11111;
+      description = "Port Bifrost listens on.";
+    };
+
+    logLevel = lib.mkOption {
+      type = types.enum [
+        "debug"
+        "info"
+        "warn"
+        "error"
+      ];
+      default = "info";
+      description = "Logger verbosity.";
+    };
+
+    logStyle = lib.mkOption {
+      type = types.enum [
+        "json"
+        "pretty"
+      ];
+      default = "json";
+      description = "Logger output style.";
+    };
+
+    settings = lib.mkOption {
+      type = types.nullOr settingsFormat.type;
+      default = null;
+      example = {
+        providers = [
+          {
+            name = "openai";
+            enabled = true;
+            keys = [
+              {
+                name = "default";
+                value = "env.OPENAI_API_KEY";
+              }
+            ];
+          }
+        ];
+      };
+      description = ''
+        Optional content for `config.json` under {option}`services.bifrost.stateDir`.
+
+        When set, the file is written on service start, overwriting any existing
+        `config.json`. When `null`, Bifrost uses an existing `config.json` or
+        bootstraps from environment variables / the admin UI.
+
+        This ends up world-readable in the Nix store, so keep secrets out of it:
+        provider keys accept an `env.VARIABLE` reference, and the `postgres`
+        backends of `config_store` and `logs_store` accept a `password_command`
+        (an executable printing the password on stdout) instead of `password`.
+      '';
+    };
+
+    environment = lib.mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      example = {
+        BIFROST_ENV_LABEL = "prod";
+      };
+      description = ''
+        Extra environment variables for the Bifrost service.
+
+        These end up world-readable in the Nix store, so pass provider API keys
+        through {option}`services.bifrost.environmentFile` instead.
+      '';
+    };
+
+    environmentFile = lib.mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/run/secrets/bifrost.env";
+      description = ''
+        Environment file passed to the systemd service. Useful for passing
+        provider API keys without making them world-readable in the Nix store.
+      '';
+    };
+
+    openFirewall = lib.mkOption {
+      type = types.bool;
+      default = false;
+      description = "Open {option}`services.bifrost.port` in the firewall.";
+    };
+
+    extraArgs = lib.mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [
+        "-some-flag"
+        "value"
+      ];
+      description = "Extra CLI arguments passed to `bifrost-http`.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = builtins.dirOf (toString cfg.stateDir) == "/var/lib";
+        message = "services.bifrost.stateDir must be a direct child of /var/lib (e.g. /var/lib/bifrost) to work with systemd StateDirectory and DynamicUser.";
+      }
+    ];
+
+    systemd.services.bifrost =
+      let
+        stateDirStr = toString cfg.stateDir;
+        configFile =
+          if cfg.settings == null then null else settingsFormat.generate "bifrost-config.json" cfg.settings;
+      in
+      {
+        description = "Bifrost LLM gateway";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" ];
+
+        environment = cfg.environment;
+
+        preStart = lib.optionalString (configFile != null) ''
+          install -Dm600 "${configFile}" "${stateDirStr}/config.json"
+        '';
+
+        serviceConfig = {
+          ExecStart = lib.concatStringsSep " " (
+            [
+              (lib.getExe cfg.package)
+              "-host"
+              cfg.host
+              "-port"
+              (toString cfg.port)
+              "-app-dir"
+              stateDirStr
+              "-log-level"
+              cfg.logLevel
+              "-log-style"
+              cfg.logStyle
+            ]
+            ++ cfg.extraArgs
+          );
+
+          EnvironmentFile = lib.optional (cfg.environmentFile != null) cfg.environmentFile;
+
+          WorkingDirectory = cfg.stateDir;
+          StateDirectory = builtins.baseNameOf stateDirStr;
+          RuntimeDirectory = "bifrost";
+          RuntimeDirectoryMode = "0755";
+
+          DynamicUser = true;
+          DevicePolicy = "closed";
+          LockPersonality = true;
+          PrivateTmp = true;
+          PrivateUsers = true;
+          ProtectClock = true;
+          ProtectControlGroups = true;
+          ProtectHome = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectProc = "invisible";
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+            "AF_UNIX"
+          ];
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          SystemCallArchitectures = "native";
+          UMask = "0077";
+        };
+      };
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.port ];
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ ManUtopiK ];
+}

--- a/pkgs/by-name/bi/bifrost/package.nix
+++ b/pkgs/by-name/bi/bifrost/package.nix
@@ -1,0 +1,119 @@
+{
+  lib,
+  buildGo127Module,
+  buildNpmPackage,
+  fetchFromGitHub,
+  pkg-config,
+  sqlite,
+  nix-update-script,
+}:
+
+let
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "maximhq";
+    repo = "bifrost";
+    tag = "transports/v${version}";
+    hash = "sha256-scOAEWRrKEx6sz74scjJAbiW6EYaW6EaZPdyQUkVqqE=";
+  };
+
+  ui = buildNpmPackage {
+    pname = "bifrost-ui";
+    inherit version src;
+    sourceRoot = "${src.name}/ui";
+
+    npmDepsHash = "sha256-1eEw976l9xb0nLyoc5vUv1536EUvmdVtCBdz+FpprgQ=";
+
+    # The default `build` script also copies its output into the Go tree, which
+    # lies outside this source root; `build-enterprise` only runs the build.
+    npmBuildScript = "build-enterprise";
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p "$out/ui"
+      cp -R --no-preserve=all out/. "$out/ui/"
+      runHook postInstall
+    '';
+  };
+in
+buildGo127Module (finalAttrs: {
+  pname = "bifrost";
+  inherit version src;
+
+  __structuredAttrs = true;
+
+  modRoot = "transports";
+  subPackages = [ "bifrost-http" ];
+  vendorHash = "sha256-lIGk1klUBlAS4hAc8wlGOquea0QDEb33IRPvxv+FO9E=";
+
+  doCheck = false;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ sqlite ];
+
+  env.CGO_ENABLED = "1";
+
+  # The `transports` module references sibling modules via `replace` directives
+  # that point at relative paths inside the workspace. Re-declare them here so
+  # buildGoModule resolves them from the unpacked source tree.
+  postPatch = ''
+    cat >> transports/go.mod <<'EOF'
+
+    replace github.com/maximhq/bifrost/core => ../core
+    replace github.com/maximhq/bifrost/framework => ../framework
+    replace github.com/maximhq/bifrost/plugins/compat => ../plugins/compat
+    replace github.com/maximhq/bifrost/plugins/governance => ../plugins/governance
+    replace github.com/maximhq/bifrost/plugins/logging => ../plugins/logging
+    replace github.com/maximhq/bifrost/plugins/maxim => ../plugins/maxim
+    replace github.com/maximhq/bifrost/plugins/mocker => ../plugins/mocker
+    replace github.com/maximhq/bifrost/plugins/modelcatalogresolver => ../plugins/modelcatalogresolver
+    replace github.com/maximhq/bifrost/plugins/otel => ../plugins/otel
+    replace github.com/maximhq/bifrost/plugins/prompts => ../plugins/prompts
+    replace github.com/maximhq/bifrost/plugins/routing => ../plugins/routing
+    replace github.com/maximhq/bifrost/plugins/semanticcache => ../plugins/semanticcache
+    replace github.com/maximhq/bifrost/plugins/telemetry => ../plugins/telemetry
+    EOF
+  '';
+
+  # `goModules` inherits `postPatch` on its own, but also `preBuild`, which the
+  # module fetcher has no use for: it would pull the whole UI into the fetcher
+  # and rebuild it on every UI change.
+  overrideModAttrs = _: _: {
+    preBuild = "";
+  };
+
+  # Provide the pre-built UI for //go:embed all:ui inside bifrost-http.
+  preBuild = ''
+    rm -rf bifrost-http/ui
+    mkdir -p bifrost-http/ui
+    cp -R --no-preserve=all ${ui}/ui/. bifrost-http/ui/
+  '';
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.Version=${version}"
+  ];
+
+  passthru = {
+    inherit ui;
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "High-performance LLM gateway with native MCP support";
+    longDescription = ''
+      Bifrost is an OpenAI-compatible HTTP gateway that unifies access to 15+
+      LLM providers, exposes Model Context Protocol (MCP) servers behind a
+      single endpoint, and adds semantic caching, automatic failover and
+      weighted key selection.
+    '';
+    homepage = "https://github.com/maximhq/bifrost";
+    changelog = "https://github.com/maximhq/bifrost/releases/tag/transports/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ManUtopiK ];
+    mainProgram = "bifrost-http";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

Adds [Bifrost](https://github.com/maximhq/bifrost), an OpenAI-compatible HTTP gateway by Maxim AI that unifies access to 15+ LLM providers, exposes Model Context Protocol (MCP) servers behind a single endpoint, and adds semantic caching, automatic failover and weighted key selection. Apache-2.0.

Three commits:

- `maintainers: add ManUtopiK` — adds me to the maintainer list.
- `bifrost: init at 2.0.0` — package at `pkgs/by-name/bi/bifrost/`. Builds the admin UI (Vite + TanStack Router) with `buildNpmPackage` and the Go binary with `buildGo127Module`. CGO enabled for the bundled SQLite backend. Internal Go workspace dependencies (`core`, `framework`, `plugins/*`) are wired with `replace` directives appended to `transports/go.mod` since the source is shipped as a monorepo of independent modules.
- `nixos/bifrost: init` — adds `services.bifrost` at `nixos/modules/services/misc/bifrost.nix`. Options: `enable`, `package`, `host`, `port`, `stateDir`, `logLevel`, `logStyle`, `settings` (JSON `config.json`), `environment`, `environmentFile`, `openFirewall`, `extraArgs`. Hardened systemd unit with `DynamicUser=true`, `StateDirectory=`, and the usual protect/restrict directives.

### Notes

- Rebased on current master and updated to 2.0.0. The v2 breaking changes ([changelog](https://docs.getbifrost.ai/changelogs/v2.0.0), [migration guide](https://docs.getbifrost.ai/migration-guides/v2.0.0)) are confined to the HTTP API, the Go plugin interface and observability attribute names; the `bifrost-http` CLI flags used by the module (`-host`, `-port`, `-app-dir`, `-log-level`, `-log-style`) are unchanged, so `services.bifrost` needs no adjustment.
- v2 requires Go 1.27, hence `buildGo127Module`; rebased on a master that carries `go_1_27` 1.27.0.
- Upstream tags the `transports` Go module independently of the rest of the monorepo, so `tag = "transports/v${version}"`.
- No NixOS test in this PR: on startup Bifrost fetches its pricing datasheet from `getbifrost.ai` and exits with `failed to initialize pricing manager` when it cannot be reached (verified in a network-less namespace), which doesn't fly in the sandboxed test VM. Follow-up planned once a mock endpoint, a pre-seeded cache or an offline flag is feasible.
- Original Nix packaging upstream is by @ReStranger (in `nix/{packages,modules}/` of the source tree). This PR is a port to nixpkgs conventions.

### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`?
- [ ] Tested, as applicable:
  - [ ] NixOS test(s)
  - [x] Tested compilation of all packages that depend on this change using `nix-build -A bifrost`
  - [x] Tested basic functionality of all binary files — service starts and serves the embedded admin UI, initialises its SQLite store
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits CONTRIBUTING.md

cc @ReStranger for visibility — original packaging credits to you.
