### PR TITLE
texlivePackages: add mainProgram to all packages with a single binary

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/build-texlive-package.nix
+++ b/pkgs/tools/typesetting/tex/texlive/build-texlive-package.nix
@@ -83,9 +83,14 @@ let
   // lib.optionalAttrs hasCatalogue {
     homepage = "https://ctan.org/pkg/${catalogue}";
   }
-  // lib.optionalAttrs (args ? mainProgram) {
-    inherit (args) mainProgram;
+  // lib.optionalAttrs (mainProgram != null) {
+    inherit mainProgram;
   };
+
+  # if binfiles contains exactly one entry, use it as mainProgram, but allow overrides via args.mainProgram
+  mainProgram =
+    args.mainProgram
+      or (if builtins.length (args.binfiles or [ ]) == 1 then builtins.head args.binfiles else null);
 
   hasBinfiles = args ? binfiles && args.binfiles != [ ];
   hasDocfiles = sha512 ? doc;

--- a/pkgs/tools/typesetting/tex/texlive/tlpdb-overrides.nix
+++ b/pkgs/tools/typesetting/tex/texlive/tlpdb-overrides.nix
@@ -627,6 +627,4 @@ lib.recursiveUpdate orig rec {
       fi
     '';
   };
-
-  texcount.mainProgram = "texcount";
 }


### PR DESCRIPTION
Generalise #519754 to add `mainProgram` to all TeX Live packages which happen to have a single binary.

Annoyingly, this will cause a merge conflict with the other PRs in flight...

## Things done

~Note: no rebuild necessary.~ Actually, rebuilds happen. I didn't know that changing meta would do that.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
