### PR TITLE
nix-heuristic-gc: 0.7.3 -> 0.7.4

### DIFF
--- a/pkgs/by-name/ni/nix-heuristic-gc/package.nix
+++ b/pkgs/by-name/ni/nix-heuristic-gc/package.nix
@@ -4,30 +4,34 @@
   lib,
   fetchFromGitHub,
   nixVersions,
+  pkg-config,
   boost,
   python3Packages,
 }:
 python3Packages.buildPythonPackage rec {
   pname = "nix-heuristic-gc";
-  version = "0.7.3";
+  version = "0.7.4";
   format = "setuptools";
   src = fetchFromGitHub {
     owner = "risicle";
     repo = "nix-heuristic-gc";
     tag = "v${version}";
-    hash = "sha256-aTwILsqqlV0DEm9AhDKd6HCB022BbebPH/VwzDgzS4E=";
+    hash = "sha256-T/PKn005gkALJP2FfHfWJj5UIRP9IYkvMOT3+kMY3Wo=";
   };
 
   # NIX_SYSTEM suggested at
   # https://github.com/NixOS/nixpkgs/issues/386184#issuecomment-2692433531
-  env.NIX_SYSTEM = nixVersions.nixComponents_2_30.nix-store.stdenv.hostPlatform.system;
+  env.NIX_SYSTEM = nixVersions.nixComponents_2_31.nix-store.stdenv.hostPlatform.system;
 
   buildInputs = [
     boost
-    nixVersions.nixComponents_2_30.nix-store
-    nixVersions.nixComponents_2_30.nix-main
+    nixVersions.nixComponents_2_31.nix-store
+    nixVersions.nixComponents_2_31.nix-main
     python3Packages.pybind11
     python3Packages.setuptools
+  ];
+  nativeBuildInputs = [
+    pkg-config
   ];
   propagatedBuildInputs = [
     python3Packages.humanfriendly


### PR DESCRIPTION
This allows us to bump the `nixComponents` version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
