### PR TITLE
ytree: 2.10 -> 2.12

### DIFF
--- a/pkgs/by-name/yt/ytree/0001-use-prefix-and-gzip-n.diff
+++ b/pkgs/by-name/yt/ytree/0001-use-prefix-and-gzip-n.diff
@@ -1,25 +1,22 @@
-diff -Naur ytree-2.06-old/Makefile ytree-2.06-new/Makefile
---- ytree-2.06-old/Makefile	2023-11-26 06:15:34.000000000 -0300
-+++ ytree-2.06-new/Makefile	2023-12-01 12:25:36.641958285 -0300
-@@ -11,13 +11,13 @@
- # ADD_CFLAGS: Add -DVI_KEYS if you want vi-cursor-keys
- #
-
--DESTDIR     = /usr
-+PREFIX      = /usr
-
+diff -Naur ytree-2.12-old/Makefile ytree-2.12-new/Makefile
+--- ytree-2.12-old/Makefile	2026-04-20 18:00:22.000000000 +0000
++++ ytree-2.12-new/Makefile	2026-05-17 12:00:00.000000000 +0000
+@@ -14,10 +14,11 @@
+ 
  ADD_CFLAGS  = # -DVI_KEYS
-
+ 
+-DESTDIR     = /usr
 -BINDIR      = $(DESTDIR)/bin
 -MANDIR      = $(DESTDIR)/share/man/man1
--MANESDIR    = $(DESTDIR)/share/man/es/man1
++PREFIX      = /usr
+ 
 +BINDIR      = $(DESTDIR)$(PREFIX)/bin
 +MANDIR      = $(DESTDIR)$(PREFIX)/share/man/man1
 +MANESDIR    = $(DESTDIR)$(PREFIX)/share/man/es/man1
-
-
+ 
  # Uncomment the lines for your system (default is linux)
-@@ -221,7 +221,7 @@
+ 
+@@ -218,7 +219,7 @@
  install:	$(MAIN)
  		if [ ! -e $(BINDIR) ]; then mkdir -p $(BINDIR); fi
  		install $(MAIN) $(BINDIR)

--- a/pkgs/by-name/yt/ytree/package.nix
+++ b/pkgs/by-name/yt/ytree/package.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ytree";
-  version = "2.10";
+  version = "2.12";
 
   src = fetchurl {
     url = "https://han.de/~werner/ytree-${finalAttrs.version}.tar.gz";
-    hash = "sha256-O7u9MvVoza4+A/xzWxeD2MumBaLKYFbRuXEUPX3dUX0=";
+    hash = "sha256-I2bS1fwfZERgMjhj5b6ZdFhLybLWbXJHFlqP8aCZERQ=";
   };
 
   patches = [


### PR DESCRIPTION
Update to 2.12. Fix patch for new version.

Upstream changelog:
New in 2.12

Fixed bug in CutFilename which may lead to compile error

New in 2.11

Removed clock due to interference with cursor handling and resizing (was experimental)
Support for UnixWare 7 (Thanks to Nishi)
InputString with UTF_8 suport
Some minor bugfixes

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
