### PR TITLE
haskellPackages: various jailbreaks for QuickCheck 2.16

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1524,6 +1524,10 @@ with haskellLib;
   # https://github.com/jaspervdj/psqueues/issues/67
   psqueues = doJailbreak super.psqueues;
 
+  # 2026-05-17: allow QuickCheck 2.16
+  # https://github.com/fizruk/http-api-data/issues/157
+  http-api-data = doJailbreak super.http-api-data;
+
   # chell-quickcheck doesn't work with QuickCheck >= 2.15 with no known fix yet
   # https://github.com/typeclasses/chell/issues/5
   system-filepath = dontCheck super.system-filepath;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1159,9 +1159,6 @@ with haskellLib;
   # 2025-02-10: Too strict bounds on text < 2.1
   digestive-functors-blaze = doJailbreak super.digestive-functors-blaze;
 
-  # Too strict bound on QuickCheck <2.15
-  hgmp = doJailbreak super.hgmp;
-
   # Z3 removed aliases for boolean types in 4.12
   inherit
     (

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1550,9 +1550,7 @@ with haskellLib;
   system-filepath = dontCheck super.system-filepath;
   gnuidn = dontCheck super.gnuidn;
 
-  # Tests rely on `Int` being 64-bit: https://github.com/hspec/hspec/issues/431.
-  # Also, we need QuickCheck-2.14.x to build the test suite, which isn't easy in LTS-16.x.
-  # So let's not go there and just disable the tests altogether.
+  # Avoids infinite recursion
   hspec-core = dontCheck super.hspec-core;
 
   update-nix-fetchgit =

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1509,6 +1509,10 @@ with haskellLib;
   # Break infinite recursion via optparse-applicative (alternatively, dontCheck syb)
   prettyprinter-ansi-terminal = dontCheck super.prettyprinter-ansi-terminal;
 
+  # 2026-05-18: allow QuickCheck 2.16
+  # Already updated upstream, but not released on hackage, yet.
+  finite-typelits = warnAfterVersion "0.2.1.0" (doJailbreak super.finite-typelits);
+
   # 2026-05-16: allow QuickCheck 2.16
   # https://github.com/pcapriotti/optparse-applicative/issues/516
   optparse-applicative = doJailbreak super.optparse-applicative;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1540,6 +1540,10 @@ with haskellLib;
   # https://github.com/haskell/fgl/issues/119
   fgl = doJailbreak super.fgl;
 
+  # 2026-05-17: allow QuickCheck 2.16
+  # Sent Claude an email on 2026-05-18.
+  bitwise = doJailbreak super.bitwise;
+
   # chell-quickcheck doesn't work with QuickCheck >= 2.15 with no known fix yet
   # https://github.com/typeclasses/chell/issues/5
   system-filepath = dontCheck super.system-filepath;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1545,6 +1545,10 @@ with haskellLib;
   # https://github.com/snowleopard/alga/issues/324
   algebraic-graphs = doJailbreak super.algebraic-graphs;
 
+  # 2026-05-18: allow QuickCheck 2.16
+  # https://github.com/haskellari/binary-instances/pull/34/changes#r3257818178
+  binary-instances = doJailbreak super.binary-instances;
+
   # chell-quickcheck doesn't work with QuickCheck >= 2.15 with no known fix yet
   # https://github.com/typeclasses/chell/issues/5
   system-filepath = dontCheck super.system-filepath;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1323,8 +1323,8 @@ with haskellLib;
     '';
   }) (addExtraLibrary self.QuickCheck super.Chart-tests);
 
-  # 2026-01-17: too strict bounds on QuickCheck < 2.15
-  # https://github.com/hasufell/lzma-static/pull/15
+  # 2026-05-18: too strict bounds on QuickCheck < 2.16
+  # https://github.com/hasufell/lzma-static/issues/16
   xz = doJailbreak super.xz;
 
   ghcup =

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2101,7 +2101,7 @@ with haskellLib;
   # https://github.com/haskell-works/hw-string-parse/issues/43
   hw-string-parse = doJailbreak super.hw-string-parse;
 
-  # 2025-09-03: allow QuickCheck 2.15
+  # 2026-05-18: allow QuickCheck 2.16
   # https://github.com/haskell-works/hw-prim/issues/150
   hw-prim = lib.pipe super.hw-prim [
     (warnAfterVersion "0.6.3.2")

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1550,6 +1550,10 @@ with haskellLib;
   # https://github.com/haskellari/binary-instances/pull/34/changes#r3257818178
   binary-instances = doJailbreak super.binary-instances;
 
+  # 2026-05-18: allow QuickCheck 2.16
+  # https://github.com/haskell/os-string/pull/42
+  os-string_2_0_10 = doJailbreak super.os-string_2_0_10;
+
   # chell-quickcheck doesn't work with QuickCheck >= 2.15 with no known fix yet
   # https://github.com/typeclasses/chell/issues/5
   system-filepath = dontCheck super.system-filepath;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1902,8 +1902,7 @@ with haskellLib;
   hadolint = doJailbreak super.hadolint;
 
   # Too strict bounds on
-  # QuickCheck (<2.15): https://github.com/kapralVV/Unique/issues/12
-  # hashable (<1.5): https://github.com/kapralVV/Unique/issues/11#issuecomment-3088832168
+  # extra <= 1.8
   Unique = doJailbreak super.Unique;
 
   # Too strict bound on tasty-quickcheck (<0.11)

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1520,6 +1520,10 @@ with haskellLib;
   # https://github.com/pcapriotti/optparse-applicative/issues/516
   optparse-applicative = doJailbreak super.optparse-applicative;
 
+  # 2026-05-17: allow QuickCheck 2.16
+  # https://github.com/jaspervdj/psqueues/issues/67
+  psqueues = doJailbreak super.psqueues;
+
   # chell-quickcheck doesn't work with QuickCheck >= 2.15 with no known fix yet
   # https://github.com/typeclasses/chell/issues/5
   system-filepath = dontCheck super.system-filepath;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1548,6 +1548,10 @@ with haskellLib;
   # https://github.com/haskell-hvr/lzma/issues/45
   lzma = doJailbreak super.lzma;
 
+  # 2026-05-17: allow QuickCheck 2.16
+  # https://github.com/snowleopard/alga/issues/324
+  algebraic-graphs = doJailbreak super.algebraic-graphs;
+
   # chell-quickcheck doesn't work with QuickCheck >= 2.15 with no known fix yet
   # https://github.com/typeclasses/chell/issues/5
   system-filepath = dontCheck super.system-filepath;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -445,10 +445,6 @@ with haskellLib;
   # https://github.com/sol/ghc-bench/issues/81
   ghc-bench = dontCheck super.ghc-bench;
 
-  # Needs QuickCheck >= 2.16
-  # https://github.com/input-output-hk/io-sim/issues/248
-  io-sim = dontCheck super.io-sim;
-
   # Test suites broken by hakyll 4.16, but lib is still okay
   # https://github.com/LaurentRDC/hakyll-images/issues/14
   hakyll-images = dontCheck super.hakyll-images;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1528,6 +1528,10 @@ with haskellLib;
   # https://github.com/fizruk/http-api-data/issues/157
   http-api-data = doJailbreak super.http-api-data;
 
+  # 2026-05-17: allow QuickCheck 2.16
+  # https://github.com/Gabriella439/Haskell-Nix-Derivation-Library/issues/30
+  nix-derivation = doJailbreak super.nix-derivation;
+
   # chell-quickcheck doesn't work with QuickCheck >= 2.15 with no known fix yet
   # https://github.com/typeclasses/chell/issues/5
   system-filepath = dontCheck super.system-filepath;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1536,6 +1536,10 @@ with haskellLib;
   # https://github.com/haskell-hvr/uuid/issues/101
   uuid = doJailbreak super.uuid;
 
+  # 2026-05-17: allow QuickCheck 2.16
+  # https://github.com/haskell/fgl/issues/119
+  fgl = doJailbreak super.fgl;
+
   # chell-quickcheck doesn't work with QuickCheck >= 2.15 with no known fix yet
   # https://github.com/typeclasses/chell/issues/5
   system-filepath = dontCheck super.system-filepath;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1040,9 +1040,6 @@ with haskellLib;
   # This packages compiles 4+ hours on a fast machine. That's just unreasonable.
   CHXHtml = dontDistribute super.CHXHtml;
 
-  # Avoid "QuickCheck >=2.3 && <2.10" dependency we cannot fulfill in lts-11.x.
-  test-framework = dontCheck super.test-framework;
-
   # Test suite won't compile against tasty-hunit 0.10.x.
   binary-parsers = dontCheck super.binary-parsers;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2692,6 +2692,10 @@ with haskellLib;
   # 2025-04-09: jailbreak to allow hedgehog >= 1.5
   hw-int = warnAfterVersion "0.0.2.0" (doJailbreak super.hw-int);
 
+  # 2026-05-17: allow hedgehog 1.6
+  # https://github.com/hedgehogqa/haskell-hedgehog-classes/pull/65
+  hedgehog-classes = doJailbreak super.hedgehog-classes;
+
   # 2025-04-09: jailbreak to allow tasty-quickcheck >= 0.11
   bzlib = warnAfterVersion "0.5.2.0" (doJailbreak super.bzlib);
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1532,6 +1532,10 @@ with haskellLib;
   # https://github.com/Gabriella439/Haskell-Nix-Derivation-Library/issues/30
   nix-derivation = doJailbreak super.nix-derivation;
 
+  # 2026-05-17: allow QuickCheck 2.16
+  # https://github.com/haskell-hvr/uuid/issues/101
+  uuid = doJailbreak super.uuid;
+
   # chell-quickcheck doesn't work with QuickCheck >= 2.15 with no known fix yet
   # https://github.com/typeclasses/chell/issues/5
   system-filepath = dontCheck super.system-filepath;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -288,6 +288,7 @@ with haskellLib;
 
   vector = overrideCabal (old: {
     # 2026-05-16: allow QuickCheck 2.16
+    # https://github.com/haskell/vector/issues/562
     jailbreak = true;
     # vector-doctest seems to be broken when executed via ./Setup test
     testTargets = [
@@ -503,6 +504,7 @@ with haskellLib;
 
   attoparsec = overrideCabal (drv: {
     # 2025-05-17: allow QuickCheck 2.16
+    # https://github.com/haskell/attoparsec/issues/236
     jailbreak = true;
     # Fix t_iter test which fails randomly, but frequently. No upstream feedback so far.
     # https://github.com/haskell/attoparsec/issues/232
@@ -1515,6 +1517,7 @@ with haskellLib;
   prettyprinter-ansi-terminal = dontCheck super.prettyprinter-ansi-terminal;
 
   # 2026-05-16: allow QuickCheck 2.16
+  # https://github.com/pcapriotti/optparse-applicative/issues/516
   optparse-applicative = doJailbreak super.optparse-applicative;
 
   # chell-quickcheck doesn't work with QuickCheck >= 2.15 with no known fix yet

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1544,6 +1544,10 @@ with haskellLib;
   # Sent Claude an email on 2026-05-18.
   bitwise = doJailbreak super.bitwise;
 
+  # 2026-05-17: allow QuickCheck 2.16
+  # https://github.com/haskell-hvr/lzma/issues/45
+  lzma = doJailbreak super.lzma;
+
   # chell-quickcheck doesn't work with QuickCheck >= 2.15 with no known fix yet
   # https://github.com/typeclasses/chell/issues/5
   system-filepath = dontCheck super.system-filepath;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2585,7 +2585,7 @@ with haskellLib;
     + (drv.postPatch or "");
   }) super.pdftotext;
 
-  # QuickCheck <2.15
+  # Allow QuickCheck 2.16
   # https://github.com/google/proto-lens/issues/403
   proto-lens-arbitrary = doJailbreak super.proto-lens-arbitrary;
 

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -2771,7 +2771,6 @@ broken-packages:
   - hGelf # failure in job https://hydra.nixos.org/build/233203909 at 2023-09-02
   - hgeometric # failure in job https://hydra.nixos.org/build/233197856 at 2023-09-02
   - hgis # failure in job https://hydra.nixos.org/build/233200418 at 2023-09-02
-  - hgmp # failure in job https://hydra.nixos.org/build/307519217 at 2025-09-19
   - hgom # failure in job https://hydra.nixos.org/build/233255569 at 2023-09-02
   - hgopher # failure in job https://hydra.nixos.org/build/233222066 at 2023-09-02
   - HGraphStorage # failure in job https://hydra.nixos.org/build/233217988 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -1570,7 +1570,6 @@ dont-distribute-packages:
  - hmeap-utils
  - hmep
  - HMock
- - hMPC
  - hmt-diagrams
  - hnix-store-db
  - HNM


### PR DESCRIPTION
WIP; still need to create upstream issues and such

fyi @sternenseemann

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
