### PR TITLE
openclaw: 2026.5.7 -> 2026.5.12

### DIFF
--- a/pkgs/by-name/op/openclaw/package.nix
+++ b/pkgs/by-name/op/openclaw/package.nix
@@ -5,14 +5,17 @@
   fetchFromGitHub,
   fetchPnpmDeps,
   pnpmConfigHook,
-  pnpm_10,
+  pnpm_11,
   nodejs_22,
   makeWrapper,
   versionCheckHook,
   rolldown,
   installShellFiles,
-  version ? "2026.5.7",
+  version ? "2026.5.12",
 }:
+let
+  pnpm = pnpm_11.override { nodejs = nodejs_22; };
+in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "openclaw";
   version = version;
@@ -21,15 +24,15 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     owner = "openclaw";
     repo = "openclaw";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ICkq6YfMJVvRC93sM+7/q2JI82wUhjaYAI3pRzmTHYc=";
+    hash = "sha256-URuoljISNcDLuWUwOpZoFjPNVOmbThC9r00uShPR4Co=";
   };
 
-  pnpmDepsHash = "sha256-LXaRfZ0WY8VDpDc2zFr+Oel6AuYo6SiTrp37yokT1VU=";
+  pnpmDepsHash = "sha256-pLQoA9eyHD84E0Rp8MMqfu95tGJtDEMbY+fh0nHjdWo=";
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_10;
-    fetcherVersion = 3;
+    inherit pnpm;
+    fetcherVersion = 4;
     hash = finalAttrs.pnpmDepsHash;
   };
 
@@ -37,7 +40,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     pnpmConfigHook
-    pnpm_10
+    pnpm
     nodejs_22
     makeWrapper
     installShellFiles

--- a/pkgs/by-name/ro/rolldown/package.nix
+++ b/pkgs/by-name/ro/rolldown/package.nix
@@ -10,7 +10,7 @@
   cargo,
   rustc,
   cmake,
-  version ? "1.0.0-rc.12",
+  version ? "1.0.0",
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "rolldown";
@@ -22,13 +22,13 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "rolldown";
     repo = "rolldown";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-G26fPJElnIob1b94KqM5b2A64qs+x/d8FNrAsaN8BOI=";
+    hash = "sha256-EbxZe2JBj69F6bpPn4X7BTRE/dTb/mUIvvqw7oqhAe8=";
   };
   cargoDeps = rustPlatform.fetchCargoVendor {
     pname = "rolldown";
     version = finalAttrs.version;
     src = finalAttrs.src;
-    hash = "sha256-btGnMU+t8zij/gRfFp5p6h2/781IZM5AWvZNqC2dfNs=";
+    hash = "sha256-VDDbS45Lefs/4x0fU1rULgBtjzZJgL1t2lYwENPknEE=";
   };
   pnpmDeps = fetchPnpmDeps {
     pname = "rolldown";
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     src = finalAttrs.src;
     pnpm = pnpm_10;
     fetcherVersion = 3;
-    hash = "sha256-lQVbYV8S3P1+AQwF9PBDxJqbKf9jBAtwymKcxQ55FeQ=";
+    hash = "sha256-pq94ZI0WW9XJFzecdiM/PaOUp7DSSOWWjRO91rd8Xs4=";
   };
 
   # cmake is only needed for Rust build (mimalloc-sys), not for a top-level configure


### PR DESCRIPTION
## Description of changes

- `openclaw`: 2026.5.7 → 2026.5.12 (and switches to `pnpm_11`, which the new lockfile requires).
- `rolldown`: 1.0.0-rc.12 → 1.0.0 — required because openclaw 2026.5.12 pins `rolldown@1.0.0` exactly in its lockfile.

~~Targeting `staging-next` because rolldown 1.0.0 requires Rust 1.95 (oxc_transformer uses `if let` guards stabilized in 1.95), which is only on staging-next so far via 6534ba3f79b4.~~

Changelogs:
- https://github.com/openclaw/openclaw/releases/tag/v2026.5.12
- https://github.com/rolldown/rolldown/releases/tag/v1.0.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
