### PR TITLE
nixos/tests/jool: fix test

### DIFF
--- a/nixos/tests/jool.nix
+++ b/nixos/tests/jool.nix
@@ -306,8 +306,8 @@ in
         client.succeed("curl --fail -s http://[64:ff9b::203.0.113.16] | grep -q IPv4!")
 
       with subtest("Router BIB entries are correctly populated"):
-        router.succeed("jool bib display | grep -q 'Dynamic TCP.*2001:db8::8'")
-        router.succeed("jool bib display | grep -q 'Static TCP.*2001:db8::9'")
+        router.succeed("jool bib display --numeric | grep -q 'Dynamic TCP.*2001:db8::8'")
+        router.succeed("jool bib display --numeric | grep -q 'Static TCP.*2001:db8::9'")
 
       with subtest("WAN server can reach the LAN server"):
         homeserver.wait_for_open_port(80)


### PR DESCRIPTION
Closes issue #520902.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
