### PR TITLE
aerion: init at 0.3.2

### DIFF
--- a/pkgs/by-name/ae/aerion-creds/package.nix
+++ b/pkgs/by-name/ae/aerion-creds/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+}:
+
+let
+  version = "0.3.2";
+
+  archMap = {
+    "x86_64-linux" = "x86_64";
+    "aarch64-linux" = "aarch64";
+  };
+  sysArch =
+    archMap.${stdenv.hostPlatform.system}
+      or (throw "Unsupported architecture: ${stdenv.hostPlatform.system}");
+
+  shimHashes = {
+    "x86_64" = "sha256-8WvuQgWTJNe4UpmS6uSYDYm46sIqxJbwVZ/J3CRz0OI=";
+    "aarch64" = "sha256-4RvFbxJGwM70huziY2ELoCouTrtMasgoqFUncBeBFvU=";
+  };
+in
+stdenv.mkDerivation {
+  pname = "aerion-creds";
+  inherit version;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchurl {
+    url = "https://github.com/hkdb/aerion/releases/download/v${version}/flathub-build-env-v${version}-linux-${sysArch}";
+    hash = shimHashes.${sysArch};
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp $src $out/bin/aerion-creds
+    chmod +x $out/bin/aerion-creds
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "OAuth credentials shim for Aerion";
+    homepage = "https://github.com/hkdb/aerion";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ curious ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/by-name/ae/aerion/package.nix
+++ b/pkgs/by-name/ae/aerion/package.nix
@@ -1,0 +1,98 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  buildNpmPackage,
+  fetchFromGitHub,
+  pkg-config,
+  wrapGAppsHook3,
+  gtk3,
+  webkitgtk_4_1,
+  glib,
+
+  aerion-creds,
+  withOAuth ? false,
+}:
+
+let
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "hkdb";
+    repo = "aerion";
+    rev = "v${version}";
+    hash = "sha256-elmk4huz4mvc7t+5/ZM5AK2R4pSKrLsZM0HxWFmQldE=";
+  };
+
+  frontend = buildNpmPackage {
+    pname = "aerion-frontend";
+    inherit version src;
+
+    sourceRoot = "${src.name}/frontend";
+
+    npmDepsHash = "sha256-dC+xGwSqdzItIfDipAVIVnbUJHiFkmzanjV/5xFsbkc=";
+
+    buildPhase = ''
+      npm run build
+    '';
+
+    installPhase = ''
+      mkdir -p $out
+      cp -r dist/* $out/
+    '';
+  };
+
+in
+buildGoModule {
+  pname = "aerion";
+  inherit version src;
+
+  __structuredAttrs = true;
+
+  vendorHash = "sha256-ptsrOpJo3i+yRSCGuHynbzi+C+GD/mBmPuHqWSVV/+4=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    wrapGAppsHook3
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    gtk3
+    webkitgtk_4_1
+    glib
+  ];
+
+  tags = [
+    "production"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    "desktop"
+    "webkit2_41"
+  ];
+
+  preBuild = ''
+    mkdir -p frontend/dist
+    cp -r ${frontend}/* frontend/dist/
+  '';
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isLinux (
+    ''
+      install -Dm644 build/linux/aerion.png $out/share/pixmaps/io.github.hkdb.Aerion.png
+      install -Dm644 build/linux/aerion.desktop $out/share/applications/io.github.hkdb.Aerion.desktop
+    ''
+    + lib.optionalString withOAuth ''
+      rm -f $out/bin/aerion-creds
+      ln -s ${aerion-creds}/bin/aerion-creds $out/bin/aerion-creds
+    ''
+  );
+
+  meta = {
+    description = "An Open Source Lightweight E-Mail Client";
+    homepage = "https://github.com/hkdb/aerion";
+    license = lib.licenses.asl20;
+    mainProgram = "aerion";
+    maintainers = with lib.maintainers; [ curious ];
+  };
+}

--- a/pkgs/by-name/ae/aerion/package.nix
+++ b/pkgs/by-name/ae/aerion/package.nix
@@ -88,6 +88,11 @@ buildGoModule {
     ''
   );
 
+  passthru = {
+    inherit frontend;
+    updateScript = ./update.sh;
+  };
+
   meta = {
     description = "An Open Source Lightweight E-Mail Client";
     homepage = "https://github.com/hkdb/aerion";

--- a/pkgs/by-name/ae/aerion/update.sh
+++ b/pkgs/by-name/ae/aerion/update.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix nix-update nix-prefetch-scripts common-updater-scripts
+
+set -euo pipefail
+
+nixpkgs="$(git rev-parse --show-toplevel)"
+aerion_creds_file="$nixpkgs/pkgs/by-name/ae/aerion-creds/package.nix"
+
+version=$(list-git-tags --url=https://github.com/hkdb/aerion \
+  | grep -oP '^v\d+\.\d+\.\d+$' \
+  | sed 's/^v//' \
+  | sort -V \
+  | tail -1)
+
+echo "Updating aerion and aerion-creds to v$version"
+
+# Update version in creds file
+sed -i "s/version = \".*\";/version = \"$version\";/" "$aerion_creds_file"
+
+# Update creds binary hashes
+for arch in x86_64 aarch64; do
+    url="https://github.com/hkdb/aerion/releases/download/v$version/flathub-build-env-v$version-linux-$arch"
+    echo "  Fetching creds hash for $arch..."
+    hash=$(nix-prefetch-url --type sha256 "$url")
+    sri_hash=$(nix-hash --to-sri --type sha256 "$hash")
+    sed -i "s|\"$arch\" = \"sha256-[^\"]*\";|\"$arch\" = \"$sri_hash\";|" "$aerion_creds_file"
+done
+
+# Update main package (handles version, source hash, npmDepsHash, vendorHash)
+cd "$nixpkgs"
+nix-update --version="$version" --subpackage frontend aerion
+
+echo "Done!"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

**Motivation / Package Info**
Init `aerion` at version 0.3.2.
Aerion is a standalone, lightweight e-mail client inspired by Geary, built with Wails (Go/Svelte).
Homepage: https://github.com/hkdb/aerion

**Note to reviewers regarding OAuth Credentials:**
Aerion relies on hardcoded OAuth client IDs for Gmail and Microsoft login. Since Nix builds from source in a pure sandbox, these API keys are naturally missing, which disables the OAuth UI.

To solve this in unprivileged build environments (like Flathub and Nix), the upstream developer officially provides a shim binary (`flathub-build-env`) in their GitHub Releases. The application is explicitly hardcoded to look for this binary at `filepath.Join(filepath.Dir(exe), "aerion-creds")` to load the keys dynamically. 

This derivation uses `fetchurl` to grab the respective architecture's official shim and places it in `$out/bin/aerion-creds`. This restores full OAuth functionality while maintaining source build purity.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
