### PR TITLE
pdf-parser: 0.7.10 -> 0.7.14

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15595,12 +15595,6 @@
     githubId = 4312404;
     name = "Chris Rendle-Short";
   };
-  lightdiscord = {
-    email = "root@arnaud.sh";
-    github = "lightdiscord";
-    githubId = 24509182;
-    name = "Arnaud Pascal";
-  };
   lightquantum = {
     email = "self@lightquantum.me";
     github = "PhotonQuantum";

--- a/pkgs/by-name/pd/pdf-parser/package.nix
+++ b/pkgs/by-name/pd/pdf-parser/package.nix
@@ -7,22 +7,19 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "pdf-parser";
-  version = "0.7.10";
+  version = "0.7.14";
   pyproject = false;
 
   src = fetchzip {
     url = "https://didierstevens.com/files/software/pdf-parser_V${
       lib.replaceStrings [ "." ] [ "_" ] finalAttrs.version
     }.zip";
-    hash = "sha256-RhgEGue3RcALjLXKOnnXyx/0subXHNuXfDg8hbO3VDg=";
+    hash = "sha256-oAmTzkBxwrXXSSimaN1Uo4wP+7ySrmyJNb9jD2uWglA=";
   };
 
   postPatch = ''
     # quote regular expressions correctly
     substituteInPlace pdf-parser.py \
-      --replace-fail \
-        "re.sub('" \
-        "re.sub(r'" \
       --replace-fail \
         "re.match('" \
         "re.match(r'"

--- a/pkgs/by-name/pd/pdf-parser/package.nix
+++ b/pkgs/by-name/pd/pdf-parser/package.nix
@@ -54,7 +54,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     '';
     homepage = "https://blog.didierstevens.com/programs/pdf-tools/";
     license = lib.licenses.publicDomain;
-    maintainers = [ lib.maintainers.lightdiscord ];
+    maintainers = with lib.maintainers; [ cbrxyz ];
     platforms = lib.platforms.all;
     mainProgram = "pdf-parser.py";
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Seems like the maintainer of this package hasn't been to active lately in nixpkgs, so I added myself!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## `nixpkgs-review` result for [#521280](https://github.com/NixOS/nixpkgs/pull/521280)

Generated using [`nixpkgs-review-gha`](https://github.com/Defelo/nixpkgs-review-gha)

Command: `nixpkgs-review pr 521280`
Commit: [`4a75b2d96e91b6c8864d96ad364d68656c81cf13`](https://github.com/NixOS/nixpkgs/commit/4a75b2d96e91b6c8864d96ad364d68656c81cf13) ([subsequent changes](https://github.com/NixOS/nixpkgs/compare/4a75b2d96e91b6c8864d96ad364d68656c81cf13..pull/521280/head))
Merge: [`f4d90d1d091e08f29e3a5099692abe935c2b9924`](https://github.com/NixOS/nixpkgs/commit/f4d90d1d091e08f29e3a5099692abe935c2b9924)

Logs: https://github.com/cbrxyz/nixpkgs-review-gha/actions/runs/25995867329


---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>pdf-parser</li>
  </ul>
</details>

---
### `aarch64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>pdf-parser</li>
  </ul>
</details>

---
### `x86_64-darwin` (sandbox = relaxed)
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>pdf-parser</li>
  </ul>
</details>

---
### `aarch64-darwin` (sandbox = relaxed)
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>pdf-parser</li>
  </ul>
</details>
