### PR TITLE
docuseal: 2.4.4 -> 2.5.3

### DIFF
--- a/pkgs/by-name/do/docuseal/Gemfile.lock
+++ b/pkgs/by-name/do/docuseal/Gemfile.lock
@@ -179,7 +179,7 @@ GEM
     dotenv (3.2.0)
     drb (2.2.3)
     email_typo (0.2.3)
-    erb (6.0.2)
+    erb (6.0.4)
     erb_lint (0.9.0)
       activesupport
       better_html (>= 2.0.1)
@@ -256,7 +256,7 @@ GEM
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
     hashdiff (1.2.1)
-    hexapdf (1.6.0)
+    hexapdf (1.7.0)
       cmdparse (~> 3.0, >= 3.0.3)
       geom2d (~> 0.4, >= 0.4.1)
       openssl (>= 2.2.1)
@@ -318,7 +318,7 @@ GEM
     multi_json (1.19.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.3)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)
@@ -328,14 +328,14 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.19.2)
+    nokogiri (1.19.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.19.2-aarch64-linux-musl)
+    nokogiri (1.19.3-aarch64-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.19.2-arm64-darwin)
+    nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.2-x86_64-linux-musl)
+    nokogiri (1.19.3-x86_64-linux-musl)
       racc (~> 1.4)
     numo-narray-alt (0.10.3)
     oj (3.16.16)
@@ -661,4 +661,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.7.2
+   2.6.9

--- a/pkgs/by-name/do/docuseal/gemset.nix
+++ b/pkgs/by-name/do/docuseal/gemset.nix
@@ -868,10 +868,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0ar4nmvk1sk7drjigqyh9nnps3mxg625b8chfk42557p8i6jdrlz";
+      sha256 = "1ncmbdjf2bwmk0jf5cxywns9zbxyfiy4h4p3pzi7yddyjhv81qrq";
       type = "gem";
     };
-    version = "6.0.2";
+    version = "6.0.4";
   };
   erb_lint = {
     dependencies = [
@@ -1208,10 +1208,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "10i5826zgvk04jsn6yg7w72s1l5xghrapm6anay4g8w8l32jzqvq";
+      sha256 = "0ma1rv2hc51hlji4d3xflx610pq4222bw51sax434b7fayhh55fz";
       type = "gem";
     };
-    version = "1.6.0";
+    version = "1.7.0";
   };
   i18n = {
     dependencies = [ "concurrent-ruby" ];
@@ -1592,10 +1592,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1bgjhb65r1bl52wdym6wpbb0r3j7va8s44grggp0jvarfvw7bawv";
+      sha256 = "0ax0f0r97jm83q462vsrcbdxprs894fyyc44v62c48ihgb39hmcs";
       type = "gem";
     };
-    version = "0.6.3";
+    version = "0.6.4";
   };
   net-pop = {
     dependencies = [ "net-protocol" ];
@@ -1662,10 +1662,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0mhp90nf3g3yy5vgjnwd34czi6rbi0p7057vgngfmmdkknsxiz9q";
+      sha256 = "1s30b7h7qpyim30m8060xs415mbr3ci7i5hdg09chh1aqfx2qcbq";
       type = "gem";
     };
-    version = "1.19.2";
+    version = "1.19.3";
   };
   numo-narray-alt = {
     groups = [ "default" ];

--- a/pkgs/by-name/do/docuseal/package.nix
+++ b/pkgs/by-name/do/docuseal/package.nix
@@ -4,10 +4,9 @@
   fetchFromGitHub,
   bundlerEnv,
   nixosTests,
-  ruby_3_4,
+  ruby_4_0,
   pdfium-binaries,
   makeWrapper,
-  bundler,
   fetchYarnDeps,
   yarn,
   yarnConfigHook,
@@ -16,23 +15,20 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "docuseal";
-  version = "2.4.4";
-
-  bundler = bundler.override { ruby = ruby_3_4; };
+  version = "2.5.3";
 
   src = fetchFromGitHub {
     owner = "docusealco";
     repo = "docuseal";
     tag = finalAttrs.version;
-    hash = "sha256-GjWR0jxVRTs5KNbFDEcgCbG/HTJlJGYpbKf8+0YBSmk=";
+    hash = "sha256-9fDEj9gOBZrn4dNWf+QRCZs3gUv3Mx/YZLRx55ShS7E=";
     # https://github.com/docusealco/docuseal/issues/505#issuecomment-3153802333
     postFetch = "rm $out/db/schema.rb";
   };
 
   rubyEnv = bundlerEnv {
     name = "docuseal-gems";
-    ruby = ruby_3_4;
-    inherit (finalAttrs) bundler;
+    ruby = ruby_4_0;
     gemdir = ./.;
   };
 


### PR DESCRIPTION
Upstream uses Ruby 4.0.1 since v2.3.1.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
