### PR TITLE
Revert "nixos/blueman: Add option to enable Blueman tray applet"

### DIFF
--- a/nixos/modules/services/desktops/blueman.nix
+++ b/nixos/modules/services/desktops/blueman.nix
@@ -13,12 +13,6 @@ in
   options = {
     services.blueman = {
       enable = lib.mkEnableOption "blueman, a bluetooth manager";
-
-      withApplet = lib.mkOption {
-        type = lib.types.bool;
-        default = true;
-        description = "Whether to spawn the Blueman tray applet.";
-      };
     };
   };
 
@@ -30,15 +24,5 @@ in
     services.dbus.packages = [ pkgs.blueman ];
 
     systemd.packages = [ pkgs.blueman ];
-
-    systemd.user.services.blueman-applet = lib.mkIf cfg.withApplet {
-      description = "Blueman tray applet";
-      wantedBy = [ "graphical-session.target" ];
-      partOf = [ "graphical-session.target" ];
-      serviceConfig = {
-        ExecStart = "${pkgs.blueman}/bin/blueman-applet";
-        Restart = "on-failure";
-      };
-    };
   };
 }


### PR DESCRIPTION
Reverts NixOS/nixpkgs#475107, the blueman package contains XDG autostart files, so this wrong PR is meaningless.

Closes https://github.com/NixOS/nixpkgs/issues/514705
Closes https://github.com/NixOS/nixpkgs/pull/516323

