### PR TITLE
dexed: Vendor unmerged Darwin patch

### DIFF
--- a/pkgs/by-name/de/dexed/dexed-fix-min-macos-version.patch
+++ b/pkgs/by-name/de/dexed/dexed-fix-min-macos-version.patch
@@ -1,0 +1,52 @@
+From e41f1b8147bb6a5b7e9330a7ec6a598a1e74a524 Mon Sep 17 00:00:00 2001
+From: Linus Vettiger <linus4123@gmail.com>
+Date: Sat, 16 May 2026 19:09:40 +0200
+Subject: [PATCH] Bump minimum macOS version
+
+---
+ CMakeLists.txt                      | 2 +-
+ Dexed.jucer                         | 4 ++--
+ assets/installers/make_macos_pkg.sh | 2 +-
+ 3 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f81961f5..8cc09541 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -19,7 +19,7 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "iOS")
+ #    set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer" CACHE STRING "" FORCE)
+ #    set(CMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM "XXXXXXXXXX" CACHE STRING "" FORCE)
+ else()
+-    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version" FORCE)
++    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.10" CACHE STRING "Minimum OS X deployment version" FORCE)
+ endif()
+ 
+ if (CMAKE_BUILD_TYPE STREQUAL "Release")
+diff --git a/Dexed.jucer b/Dexed.jucer
+index d01029ca..b747f805 100644
+--- a/Dexed.jucer
++++ b/Dexed.jucer
+@@ -180,8 +180,8 @@
+                        osxCompatibility="10.10 SDK" osxArchitecture="Native" enablePluginBinaryCopyStep="1"
+                        macOSDeploymentTarget="10.10"/>
+         <CONFIGURATION name="Release" isDebug="0" optimisation="3" targetName="Dexed"
+-                       osxSDK="10.10 SDK" osxCompatibility="10.9 SDK" enablePluginBinaryCopyStep="1"
+-                       macOSBaseSDK="10.10" macOSDeploymentTarget="10.9"/>
++                       osxSDK="10.10 SDK" osxCompatibility="10.10 SDK" enablePluginBinaryCopyStep="1"
++                       macOSBaseSDK="10.10" macOSDeploymentTarget="10.10"/>
+       </CONFIGURATIONS>
+       <MODULEPATHS>
+         <MODULEPATH id="juce_gui_extra" path="./assets/JUCE/modules"/>
+diff --git a/assets/installers/make_macos_pkg.sh b/assets/installers/make_macos_pkg.sh
+index 642d97c4..3103e698 100755
+--- a/assets/installers/make_macos_pkg.sh
++++ b/assets/installers/make_macos_pkg.sh
+@@ -128,7 +128,7 @@ fi
+ cat > $TMPDIR/distribution.xml << XMLEND
+ <?xml version="1.0" encoding="utf-8"?>
+ <installer-gui-script minSpecVersion="1">
+-    <os-version min="10.9"/>
++    <os-version min="10.10"/>
+     <title>${PRODUCT} ${VERSION}</title>
+     <license file="License.txt" />
+     <readme file="Readme.rtf" />

--- a/pkgs/by-name/de/dexed/package.nix
+++ b/pkgs/by-name/de/dexed/package.nix
@@ -5,7 +5,6 @@
   gitUpdater,
   cmake,
   pkg-config,
-  fetchpatch,
   libx11,
   libxrandr,
   libxinerama,
@@ -29,12 +28,8 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [
-    (fetchpatch {
-      name = "fix-min-macos-version";
-      # https://github.com/asb2m10/dexed/pull/523
-      url = "https://github.com/asb2m10/dexed/commit/e41f1b8147bb6a5b7e9330a7ec6a598a1e74a524.patch";
-      sha256 = "sha256-8ZrAirXUACk8BJUPfA/LQORCUOqjSTsKoS9HFyrkvV8=";
-    })
+    # Remove when https://github.com/asb2m10/dexed/pull/523 merged & in release
+    ./dexed-fix-min-macos-version.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/521027#discussion_r3254938219

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
