### PR TITLE
[25.11] mysql80: 8.0.45 -> 8.0.46

### DIFF
--- a/pkgs/servers/sql/mysql/8.0.x.nix
+++ b/pkgs/servers/sql/mysql/8.0.x.nix
@@ -30,11 +30,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mysql";
-  version = "8.0.45";
+  version = "8.0.46";
 
   src = fetchurl {
     url = "https://dev.mysql.com/get/Downloads/MySQL-${lib.versions.majorMinor finalAttrs.version}/mysql-${finalAttrs.version}.tar.gz";
-    hash = "sha256-tDXyLmWMj8k7gWmPo0uaVjJaMEs/Pf+H8n+2dMkKu8s=";
+    hash = "sha256-4NGpiuUYjGpO/tdMdP8oEV1LeRvJ1ZGnjhTSCt7Wc0Q=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-46.html

Fixes CVE-2026-34270
Fixes CVE-2026-34271
Fixes CVE-2026-34276
Fixes CVE-2026-34308
Fixes CVE-2026-22009
Fixes CVE-2026-22017
Fixes CVE-2026-34303
Fixes CVE-2025-14017
Fixes CVE-2026-34318
Fixes CVE-2026-34317
Fixes CVE-2025-14017
Fixes CVE-2026-34318
Fixes CVE-2026-34317
Fixes CVE-2026-34319
Fixes CVE-2026-22004
Fixes CVE-2026-34304
Fixes CVE-2026-35236
Fixes CVE-2026-35237
Fixes CVE-2026-35238
Fixes CVE-2026-35239
Fixes CVE-2026-21998
Fixes CVE-2026-22005
Fixes CVE-2026-22002
Fixes CVE-2026-35240
Fixes CVE-2026-22015
Fixes CVE-2026-22001
Fixes CVE-2026-34293
Fixes CVE-2026-34267
Fixes CVE-2026-34278

https://www.oracle.com/security-alerts/cpuapr2026.html#AppendixMSQL

Not-cherry-picked-because: mysql80 has been dropped on unstable.


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 521295`
Commit: `0b80d02bb877e373f27e640e8a360f881fd3a520`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 29 packages built:</summary>
  <ul>
    <li>exim</li>
    <li>libmysqlconnectorcpp</li>
    <li>longview</li>
    <li>mylvmbackup</li>
    <li>mysql-workbench</li>
    <li>mysql80</li>
    <li>opendmarc</li>
    <li>percona-toolkit</li>
    <li>percona-xtrabackup (percona-xtrabackup_8_4)</li>
    <li>percona-xtrabackup_8_0</li>
    <li>perl538Packages.DBDmysql</li>
    <li>perl538Packages.MinionBackendmysql</li>
    <li>perl538Packages.Mojomysql</li>
    <li>perl538Packages.PerconaToolkit</li>
    <li>perl538Packages.Testmysqld</li>
    <li>perl538Packages.maatkit</li>
    <li>perlPackages.DBDmysql (perl540Packages.DBDmysql)</li>
    <li>perlPackages.MinionBackendmysql (perl540Packages.MinionBackendmysql)</li>
    <li>perlPackages.Mojomysql (perl540Packages.Mojomysql)</li>
    <li>perlPackages.PerconaToolkit (perl540Packages.PerconaToolkit)</li>
    <li>perlPackages.Testmysqld (perl540Packages.Testmysqld)</li>
    <li>perlPackages.maatkit (perl540Packages.maatkit)</li>
    <li>python312Packages.mysql-connector</li>
    <li>python313Packages.mysql-connector</li>
    <li>sqitchMysql</li>
    <li>sqlite3-to-mysql</li>
    <li>sympa</li>
    <li>vep</li>
    <li>zoneminder</li>
  </ul>
</details>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
