### PR TITLE
*mt32emu*: Add passthru.updateScript

### DIFF
--- a/pkgs/by-name/li/libmt32emu/package.nix
+++ b/pkgs/by-name/li/libmt32emu/package.nix
@@ -2,6 +2,10 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  gitUpdater,
+  nix,
+  writeShellApplication,
+  _experimental-update-script-combinators,
   cmake,
 }:
 
@@ -35,6 +39,58 @@ stdenv.mkDerivation (finalAttrs: {
       --replace '=''${exec_prefix}//' '=/' \
       --replace "$dev/$dev/" "$dev/"
   '';
+
+  passthru = {
+    # Otherwise x.y.z in version != x_y_z in tag, and bump to same version is attempted
+    unfixVersionScript = writeShellApplication {
+      name = "unfix-libmt32emu-version";
+
+      runtimeInputs = [
+        nix
+      ];
+
+      text = ''
+        export UPDATE_NIX_ATTR_PATH="''${UPDATE_NIX_ATTR_PATH:-libmt32emu}"
+
+        preUpdateScriptVersion="$(nix-instantiate . --eval --strict -A "$UPDATE_NIX_ATTR_PATH.version" | cut -d'"' -f2)"
+        unfixedVersion="''${preUpdateScriptVersion//\./_}"
+
+        pkgFile="$(nix-instantiate --eval -E "with import ./. {}; (builtins.unsafeGetAttrPos \"version\" $UPDATE_NIX_ATTR_PATH).file" | cut -d'"' -f2)"
+
+        sed -i -e "s/version = \"$preUpdateScriptVersion\"/version = \"$unfixedVersion\"/g" "$pkgFile"
+      '';
+    };
+
+    updateTagScript = gitUpdater {
+      rev-prefix = "libmt32emu_";
+    };
+
+    # gitUpdater lacks an option for modifying new tag
+    fixVersionScript = writeShellApplication {
+      name = "fix-libmt32emu-version";
+
+      runtimeInputs = [
+        nix
+      ];
+
+      text = ''
+        export UPDATE_NIX_ATTR_PATH="''${UPDATE_NIX_ATTR_PATH:-libmt32emu}"
+
+        postUpdateScriptVersion="$(nix-instantiate . --eval --strict -A "$UPDATE_NIX_ATTR_PATH.version" | cut -d'"' -f2)"
+        fixedVersion="''${postUpdateScriptVersion//_/.}"
+
+        pkgFile="$(nix-instantiate --eval -E "with import ./. {}; (builtins.unsafeGetAttrPos \"version\" $UPDATE_NIX_ATTR_PATH).file" | cut -d'"' -f2)"
+
+        sed -i -e "s/version = \"$postUpdateScriptVersion\"/version = \"$fixedVersion\"/g" "$pkgFile"
+      '';
+    };
+
+    updateScript = _experimental-update-script-combinators.sequence [
+      (lib.getExe finalAttrs.passthru.unfixVersionScript)
+      (finalAttrs.passthru.updateTagScript.command)
+      (lib.getExe finalAttrs.passthru.fixVersionScript)
+    ];
+  };
 
   meta = {
     homepage = "https://munt.sourceforge.net/";

--- a/pkgs/by-name/mt/mt32emu-qt/package.nix
+++ b/pkgs/by-name/mt/mt32emu-qt/package.nix
@@ -2,6 +2,10 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  gitUpdater,
+  nix,
+  writeShellApplication,
+  _experimental-update-script-combinators,
   alsa-lib,
   cmake,
   libpulseaudio,
@@ -69,6 +73,58 @@ stdenv.mkDerivation (finalAttrs: {
     mv $out/bin/mt32emu-qt.app $out/Applications/
     ln -s $out/{Applications/mt32emu-qt.app/Contents/MacOS,bin}/mt32emu-qt
   '';
+
+  passthru = {
+    # Otherwise x.y.z in version != x_y_z in tag, and bump to same version is attempted
+    unfixVersionScript = writeShellApplication {
+      name = "unfix-mt32emu-qt-version";
+
+      runtimeInputs = [
+        nix
+      ];
+
+      text = ''
+        export UPDATE_NIX_ATTR_PATH="''${UPDATE_NIX_ATTR_PATH:-mt32emu-qt}"
+
+        preUpdateScriptVersion="$(nix-instantiate . --eval --strict -A "$UPDATE_NIX_ATTR_PATH.version" | cut -d'"' -f2)"
+        unfixedVersion="''${preUpdateScriptVersion//\./_}"
+
+        pkgFile="$(nix-instantiate --eval -E "with import ./. {}; (builtins.unsafeGetAttrPos \"version\" $UPDATE_NIX_ATTR_PATH).file" | cut -d'"' -f2)"
+
+        sed -i -e "s/version = \"$preUpdateScriptVersion\"/version = \"$unfixedVersion\"/g" "$pkgFile"
+      '';
+    };
+
+    updateTagScript = gitUpdater {
+      rev-prefix = "mt32emu_qt_";
+    };
+
+    # gitUpdater lacks an option for modifying new tag
+    fixVersionScript = writeShellApplication {
+      name = "fix-mt32emu-qt-version";
+
+      runtimeInputs = [
+        nix
+      ];
+
+      text = ''
+        export UPDATE_NIX_ATTR_PATH="''${UPDATE_NIX_ATTR_PATH:-mt32emu-qt}"
+
+        postUpdateScriptVersion="$(nix-instantiate . --eval --strict -A "$UPDATE_NIX_ATTR_PATH.version" | cut -d'"' -f2)"
+        fixedVersion="''${postUpdateScriptVersion//_/.}"
+
+        pkgFile="$(nix-instantiate --eval -E "with import ./. {}; (builtins.unsafeGetAttrPos \"version\" $UPDATE_NIX_ATTR_PATH).file" | cut -d'"' -f2)"
+
+        sed -i -e "s/version = \"$postUpdateScriptVersion\"/version = \"$fixedVersion\"/g" "$pkgFile"
+      '';
+    };
+
+    updateScript = _experimental-update-script-combinators.sequence [
+      (lib.getExe finalAttrs.passthru.unfixVersionScript)
+      (finalAttrs.passthru.updateTagScript.command)
+      (lib.getExe finalAttrs.passthru.fixVersionScript)
+    ];
+  };
 
   meta = {
     homepage = "https://munt.sourceforge.net/";

--- a/pkgs/by-name/mt/mt32emu-smf2wav/package.nix
+++ b/pkgs/by-name/mt/mt32emu-smf2wav/package.nix
@@ -2,6 +2,10 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  gitUpdater,
+  nix,
+  writeShellApplication,
+  _experimental-update-script-combinators,
   cmake,
   glib,
   libmt32emu,
@@ -49,6 +53,58 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "munt_WITH_MT32EMU_QT" false)
     (lib.cmakeBool "munt_WITH_MT32EMU_SMF2WAV" true)
   ];
+
+  passthru = {
+    # Otherwise x.y.z in version != x_y_z in tag, and bump to same version is attempted
+    unfixVersionScript = writeShellApplication {
+      name = "unfix-mt32emu-smf2wav-version";
+
+      runtimeInputs = [
+        nix
+      ];
+
+      text = ''
+        export UPDATE_NIX_ATTR_PATH="''${UPDATE_NIX_ATTR_PATH:-mt32emu-smf2wav}"
+
+        preUpdateScriptVersion="$(nix-instantiate . --eval --strict -A "$UPDATE_NIX_ATTR_PATH.version" | cut -d'"' -f2)"
+        unfixedVersion="''${preUpdateScriptVersion//\./_}"
+
+        pkgFile="$(nix-instantiate --eval -E "with import ./. {}; (builtins.unsafeGetAttrPos \"version\" $UPDATE_NIX_ATTR_PATH).file" | cut -d'"' -f2)"
+
+        sed -i -e "s/version = \"$preUpdateScriptVersion\"/version = \"$unfixedVersion\"/g" "$pkgFile"
+      '';
+    };
+
+    updateTagScript = gitUpdater {
+      rev-prefix = "mt32emu_smf2wav_";
+    };
+
+    # gitUpdater lacks an option for modifying new tag
+    fixVersionScript = writeShellApplication {
+      name = "fix-mt32emu-smf2wav-version";
+
+      runtimeInputs = [
+        nix
+      ];
+
+      text = ''
+        export UPDATE_NIX_ATTR_PATH="''${UPDATE_NIX_ATTR_PATH:-mt32emu-smf2wav}"
+
+        postUpdateScriptVersion="$(nix-instantiate . --eval --strict -A "$UPDATE_NIX_ATTR_PATH.version" | cut -d'"' -f2)"
+        fixedVersion="''${postUpdateScriptVersion//_/.}"
+
+        pkgFile="$(nix-instantiate --eval -E "with import ./. {}; (builtins.unsafeGetAttrPos \"version\" $UPDATE_NIX_ATTR_PATH).file" | cut -d'"' -f2)"
+
+        sed -i -e "s/version = \"$postUpdateScriptVersion\"/version = \"$fixedVersion\"/g" "$pkgFile"
+      '';
+    };
+
+    updateScript = _experimental-update-script-combinators.sequence [
+      (lib.getExe finalAttrs.passthru.unfixVersionScript)
+      (finalAttrs.passthru.updateTagScript.command)
+      (lib.getExe finalAttrs.passthru.fixVersionScript)
+    ];
+  };
 
   meta = {
     homepage = "https://munt.sourceforge.net/";


### PR DESCRIPTION
To properly bump all the different components of Munt.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
