### PR TITLE
mt32emu-*: Bump

### DIFF
--- a/pkgs/by-name/mt/mt32emu-qt/package.nix
+++ b/pkgs/by-name/mt/mt32emu-qt/package.nix
@@ -14,18 +14,18 @@
   portaudio,
   withJack ? stdenv.hostPlatform.isUnix,
   libjack2,
-  libsForQt5,
+  qt6Packages,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mt32emu-qt";
-  version = "1.11.1";
+  version = "1.12.1";
 
   src = fetchFromGitHub {
     owner = "munt";
     repo = "munt";
     tag = "mt32emu_qt_${lib.replaceString "." "_" finalAttrs.version}";
-    hash = "sha256-PqYPYnKPlnU3PByxksBscl4GqDRllQdmD6RWpy/Ura0=";
+    hash = "sha256-O9x+uL1QnixXNl/rTCnGwbutoCs6bI8vCmkhAWJW4Do=";
   };
 
   postPatch =
@@ -35,26 +35,19 @@ stdenv.mkDerivation (finalAttrs: {
       substituteInPlace CMakeLists.txt \
         --replace-fail 'add_subdirectory(mt32emu)' "" \
         --replace-fail 'add_dependencies(mt32emu-qt mt32emu)' ""
-    ''
-    # Bump CMake minimum to something our CMake supports
-    # Fixed treewide in https://github.com/munt/munt/commit/e6af0c7e5d63680716ab350467207c938054a0df
-    # Remove when version > 1.11.1
-    + ''
-      substituteInPlace CMakeLists.txt mt32emu_qt/CMakeLists.txt \
-        --replace-fail 'cmake_minimum_required(VERSION 2.8.12)' 'cmake_minimum_required(VERSION 2.8.12...3.27)'
     '';
 
   nativeBuildInputs = [
     cmake
     pkg-config
-    libsForQt5.wrapQtAppsHook
+    qt6Packages.wrapQtAppsHook
   ];
 
   buildInputs = [
     libmt32emu
     portaudio
-    libsForQt5.qtbase
-    libsForQt5.qtmultimedia
+    qt6Packages.qtbase
+    qt6Packages.qtmultimedia
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     alsa-lib
@@ -63,6 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional withJack libjack2;
 
   cmakeFlags = [
+    (lib.cmakeFeature "mt32emu-qt_WITH_QT_VERSION" "6")
     (lib.cmakeBool "mt32emu-qt_USE_PULSEAUDIO_DYNAMIC_LOADING" false)
     (lib.cmakeBool "munt_WITH_MT32EMU_QT" true)
     (lib.cmakeBool "munt_WITH_MT32EMU_SMF2WAV" false)

--- a/pkgs/by-name/mt/mt32emu-smf2wav/package.nix
+++ b/pkgs/by-name/mt/mt32emu-smf2wav/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mt32emu-smf2wav";
-  version = "1.9.0";
+  version = "1.9.2";
 
   src = fetchFromGitHub {
     owner = "munt";
     repo = "munt";
     rev = "mt32emu_smf2wav_${lib.replaceString "." "_" finalAttrs.version}";
-    sha256 = "sha256-XGds9lDfSiY0D8RhYG4TGyjYEVvVYuAfNSv9+VxiJEs=";
+    sha256 = "sha256-O9x+uL1QnixXNl/rTCnGwbutoCs6bI8vCmkhAWJW4Do=";
   };
 
   postPatch =
@@ -30,13 +30,6 @@ stdenv.mkDerivation (finalAttrs: {
       substituteInPlace CMakeLists.txt \
         --replace-fail 'add_subdirectory(mt32emu)' "" \
         --replace-fail 'add_dependencies(mt32emu-smf2wav mt32emu)' ""
-    ''
-    # Bump CMake minimum to something our CMake supports
-    # Fixed treewide in https://github.com/munt/munt/commit/e6af0c7e5d63680716ab350467207c938054a0df
-    # Remove when version > 1.9.0
-    + ''
-      substituteInPlace {./,mt32emu_smf2wav/,mt32emu_smf2wav/libsmf/}CMakeLists.txt \
-        --replace-fail 'cmake_minimum_required(VERSION 2.8.12)' 'cmake_minimum_required(VERSION 2.8.12...3.27)'
     '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
#521254 bumped only the core library of Munt. This now bumps the other components that depend on it. Also migrate `mt32emu-qt` to Qt6.

Version bumps themselves automated via the `passthru.updateScript`s submitted in #521302.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
