### PR TITLE
libdwarf: 2.2.0 -> 2.3.1

### DIFF
--- a/pkgs/by-name/li/libdwarf/package.nix
+++ b/pkgs/by-name/li/libdwarf/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libdwarf";
-  version = "2.2.0";
+  version = "2.3.1";
 
   src = fetchFromGitHub {
     owner = "davea42";
     repo = "libdwarf-code";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-PJhhrNsYZNDKzLYJzF+eSJfEH1ehF/aeJrNjiEdFEas=";
+    hash = "sha256-azVCzQt9oA40YACa9PkdNt0D8vWRNHXXGoSFOYNJxgA=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Upstream release: https://github.com/davea42/libdwarf-code/releases/tag/v2.3.1