### PR TITLE
cheat: 4.5.0 -> 5.1.0

### DIFF
--- a/pkgs/by-name/ch/cheat/package.nix
+++ b/pkgs/by-name/ch/cheat/package.nix
@@ -1,48 +1,44 @@
 {
+  stdenv,
   lib,
   fetchFromGitHub,
   buildGoModule,
   installShellFiles,
+  git,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "cheat";
-  version = "4.5.0";
+  version = "5.1.0";
 
   src = fetchFromGitHub {
     owner = "cheat";
     repo = "cheat";
     tag = finalAttrs.version;
-    sha256 = "sha256-RDfOdyQL9QICXZmgYCmz532iTuPdCW8GixajvEXmaUQ=";
+    hash = "sha256-0c8NZzzLxssMJffEWBI5L3leWWOU/Y0slPIg6bPKzfI=";
   };
-
-  subPackages = [ "cmd/cheat" ];
 
   nativeBuildInputs = [ installShellFiles ];
 
-  patches = [
-    (builtins.toFile "fix-zsh-completion.patch" ''
-      diff --git a/scripts/cheat.zsh b/scripts/cheat.zsh
-      index befe1b2..675c9f8 100755
-      --- a/scripts/cheat.zsh
-      +++ b/scripts/cheat.zsh
-      @@ -62,4 +62,4 @@ _cheat() {
-         esac
-       }
-
-      -compdef _cheat cheat
-      +_cheat "$@"
-    '')
+  nativeCheckInputs = [
+    git
   ];
 
   postInstall = ''
     installManPage doc/cheat.1
-    installShellCompletion scripts/cheat.{bash,fish,zsh}
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd cheat \
+      --bash <($out/bin/cheat --completion bash) \
+      --fish <($out/bin/cheat --completion fish) \
+      --zsh <($out/bin/cheat --completion zsh)
   '';
 
   vendorHash = null;
 
-  doCheck = false;
+  doCheck = true;
+
+  env.EDITOR = "cat";
 
   meta = {
     description = "Create and view interactive cheatsheets on the command-line";


### PR DESCRIPTION
update to 5.1.0

remove outdated patch
install shell completions using --completions

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
