### PR TITLE
OVMF-xen: init

### DIFF
--- a/pkgs/by-name/ov/OVMF-xen/package.nix
+++ b/pkgs/by-name/ov/OVMF-xen/package.nix
@@ -1,0 +1,17 @@
+{ lib, OVMF }:
+
+(OVMF.override {
+  projectDscPath = "OvmfPkg/OvmfXen.dsc";
+  fwPrefix = "OVMF";
+  metaPlatforms = builtins.filter (lib.hasPrefix "x86_64-") OVMF.meta.platforms;
+}).overrideAttrs
+  (oldAttrs: {
+    __structuredAttrs = true;
+
+    pname = "OVMF-xen";
+
+    meta = oldAttrs.meta // {
+      description = "Sample UEFI firmware for Xen guests";
+      teams = [ lib.teams.xen ];
+    };
+  })


### PR DESCRIPTION
This package builds OVMF with `OvmfXen.dsc`.

At least right now, it does what earlier implementation of `pkgs.OVMF-cloud-hypervisor` do: take `pkgs.OVMF`, use override to pass the project description path inside `OvmfPkg`. This gives us an OVMF package for Xen, instead of the default `OvmfPkgX64`, which is commonly used for the KVM+QEMU combination.

It can boot both HVM and PVH. EDK2 upstream has documented this in their [comment](https://github.com/tianocore/edk2/blob/b03a21a63e3bd001f52c527e5a57feddb53a690b/OvmfPkg/OvmfXen.fdf#L17-L20): While it's a flash device image which allows QEMU to boot it, it's also a valid ELF image for the Xen Project Hypervisor to boot as a kernel.

Previously we already had Grub images for Xen (`pkgs.grub2_pvgrub_image` and `pkgs.grub2_pvhgrub_image`), which were Grub compiled as ELF-flavor, kernel-like image. By using this, we eliminated the need of copying the DomUs' kernel to the Dom0, allowing the operators of DomUs to manage and upgrade their kernels on their own. However, they require `grub.cfg` to be found and limit the guest OS to only Linux. AFAIK, there is no viable method to boot FreeBSD as a PVH DomU with PvhGrub2, even though FreeBSD supports PVH.

OVMF as the PVH image/bootloader, on the other hand, gives more freedom. It allows the use of more standard UEFI bootloaders (systemd-boot, Limine, ...), and maybe even other operating systems if compatible with Xen PVH.

Right now the package is somehow sketchy. It's reused from the [earlier implementation](https://github.com/NixOS/nixpkgs/blob/d7a713c0b7e47c908258e71cba7a2d77cc8d71d5/pkgs/by-name/ov/OVMF-cloud-hypervisor/package.nix) of `pkgs.OVMF-cloud-hypervisor` while a few months ago the OVMF for CH package [was turned to a standalone package](https://github.com/NixOS/nixpkgs/commit/66ee3dd76ddc2325ce8b7ac6ce1dae35932c4f05) after new maintainers' adoption.

So I'd like to ping the team @NixOS/xen-project, should we also have a standalone package for OVMF, or is it necessary to do so? Also, by using `OVMF.override` there might be no room to plug a proper `meta`, and the package search will render the meta from `pkgs.OVMF`.

The last nitpick is the package name: using `OVMF-xen` for parity with `OVMF-cloud-hypervisor`. This is also opened to discussions.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
