### PR TITLE
xen: Use OVMF-xen (`OvmfXen`) instead of generic OVMF `OvmfPkgX64`

### DIFF
--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -36,7 +36,7 @@
   withIPXE ? true,
   ipxe,
   withOVMF ? true,
-  OVMF,
+  OVMF-xen,
   withSeaBIOS ? true,
   seabios-qemu,
 
@@ -276,7 +276,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--disable-qemu-traditional"
     "--with-system-qemu"
     (if withSeaBIOS then "--with-system-seabios=${seabios-qemu.firmware}" else "--disable-seabios")
-    (if withOVMF then "--with-system-ovmf=${OVMF.mergedFirmware}" else "--disable-ovmf")
+    (if withOVMF then "--with-system-ovmf=${OVMF-xen.mergedFirmware}" else "--disable-ovmf")
     (if withIPXE then "--with-system-ipxe=${ipxe.firmware}" else "--disable-ipxe")
     (enableFeature withFlask "xsmpolicy")
   ];


### PR DESCRIPTION
Needs #521333

Fixes #458070 

Back when we switched from fat Xen, we linked the Xen package against SeaBIOS, OVMF and iPXE from Nixpkgs. But the OVMF from Nixpkgs, is intended for the KVM+QEMU combination, using it for Xen HVM will sometimes cause unexpected issues, due to incorrect handling of firmware personality.

I did some experiments with the current implementation:

- NixOS built elsewhere with `xen_blkfront` installed: ok
- NixOS Live CD: failed (DomU crash stop after OS selection and boot-loop)
- Windows 11 Installation CD: failed (BSOD with `0xc0000225`)
- Pre-installed Windows 11: failed (auto-repair, then BSOD with `0xc0000411`)
- Pre-installed Windows 11, PV driver installed: failed (same)

By pointing `--with-system-ovmf` to `OVMF-xen`, all issues mentioned above just disappear.

This issue was also [reported on Fedora Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2170730). They mentioned that the EDK2 upstream has removed Xen support from `OvmfPkgX64` in favor of `OvmfXen`, with version `edk2-stable202108`.

@NixOS/xen-project 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
