### PR TITLE
nchat: add optional Signal support via withSignal

### DIFF
--- a/pkgs/by-name/nc/nchat/go-libs-build-signal.patch
+++ b/pkgs/by-name/nc/nchat/go-libs-build-signal.patch
@@ -1,0 +1,30 @@
+diff --git c/lib/sgchat/CMakeLists.txt i/lib/sgchat/CMakeLists.txt
+--- c/lib/sgchat/CMakeLists.txt
++++ i/lib/sgchat/CMakeLists.txt
+@@ -20,8 +20,8 @@ install(TARGETS sgchat DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ target_common_config(sgchat)
+
+ # Dependency libraries
+-add_subdirectory(go)
+-add_dependencies(sgchat ref-cgosg)
++set(GO_LIBRARIES @libcgosg@/libcgosg.a)
++target_include_directories(sgchat PRIVATE @libcgosg@)
+
+ # Platform specifics
+ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+@@ -45,12 +45,12 @@ set_target_properties(sgchat PROPERTIES COMPILE_FLAGS
+ # Linking
+ message(STATUS "Go libraries: ${GO_LIBRARIES}")
+ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+-  target_link_libraries(sgchat PUBLIC ref-cgosg ncutil ${GO_LIBRARIES}
+-    -Wl,-w -Wl,-force_load,${LIBSIGNAL_FFI_PATH}
++  target_link_libraries(sgchat PUBLIC @libcgosg@/libcgosg.a ncutil ${GO_LIBRARIES}
++    -Wl,-w -Wl,-force_load,@libsignalFfi@/lib/libsignal_ffi.a
+     -lm -lz)
+ else()
+-  target_link_libraries(sgchat PUBLIC ref-cgosg ncutil ${GO_LIBRARIES}
+-    -Wl,--whole-archive ${LIBSIGNAL_FFI_PATH} -Wl,--no-whole-archive
++  target_link_libraries(sgchat PUBLIC @libcgosg@/libcgosg.a ncutil ${GO_LIBRARIES}
++    -Wl,--whole-archive @libsignalFfi@/lib/libsignal_ffi.a -Wl,--no-whole-archive
+     -ldl -lm -lz)
+ endif()

--- a/pkgs/by-name/nc/nchat/package.nix
+++ b/pkgs/by-name/nc/nchat/package.nix
@@ -4,6 +4,7 @@
   buildGoModule,
   fetchFromGitHub,
   replaceVars,
+  rustPlatform,
   file, # for libmagic
   ncurses,
   openssl,
@@ -11,9 +12,15 @@
   sqlite,
   zlib,
   cmake,
+  clang,
+  protobuf,
+  perl,
+  pkg-config,
+  git,
   gperf,
   nix-update-script,
   withWhatsApp ? true,
+  withSignal ? false,
 }:
 
 let
@@ -45,6 +52,95 @@ let
       runHook postBuild
     '';
   };
+
+  # Go cgo archive for the Signal backend (wraps mautrix-signal).
+  # Pattern mirrors libcgowm above.
+  libcgosg = buildGoModule {
+    pname = "nchat-sgchat-libcgosg";
+    inherit version src;
+
+    sourceRoot = "${src.name}/lib/sgchat/go";
+    vendorHash = "sha256-gj270rUfqNa3RzOmJrrxuaig2o0rUykFiqopALtyKKY=";
+
+    buildPhase = ''
+      runHook preBuild
+
+      mkdir -p $out/
+      go build -o $out/ -buildmode=c-archive
+      mv $out/go.a $out/libcgosg.a
+      ln -s $out/libcgosg.a $out/libref-cgosg.a
+      mv $out/go.h $out/libcgosg.h
+
+      runHook postBuild
+    '';
+  };
+
+  # libsignal_ffi static archive. Version pinned by nchat at
+  # lib/sgchat/go/ext/signal/pkg/libsignalgo/version.go. Upstream nchat's
+  # build-libsignal.sh downloads or builds this; we build from source so
+  # nothing is fetched at build time.
+  libsignalFfi = rustPlatform.buildRustPackage {
+    pname = "libsignal-ffi";
+    version = "0.87.5";
+
+    src = fetchFromGitHub {
+      owner = "signalapp";
+      repo = "libsignal";
+      tag = "v0.87.5";
+      hash = "sha256-xffBXvq1ikesIjw6cXfphnTIiyuMiUcY8h0pzSgfD8U=";
+    };
+
+    cargoHash = "sha256-MwAtUrLoSi/pjsBWOAd9JoepAueq17hkZCH21q72O3w=";
+
+    cargoBuildFlags = [
+      "--package"
+      "libsignal-ffi"
+    ];
+
+    nativeBuildInputs = [
+      cmake
+      clang
+      protobuf
+      perl
+      pkg-config
+      git # boring-sys' build script runs `git init` on its vendored boringssl
+      rustPlatform.bindgenHook # sets LIBCLANG_PATH so bindgen can find libclang.so
+    ];
+
+    env = {
+      RUSTFLAGS = "-Ctarget-feature=-crt-static";
+      PROTOC = "${protobuf}/bin/protoc";
+    };
+
+    # boring-sys' build script does `git init && git apply` on its vendored
+    # boringssl source. The build sandbox has no global git identity, so any
+    # downstream `git commit` would abort. Silence it with explicit env vars.
+    preBuild = ''
+      export GIT_AUTHOR_NAME=nix
+      export GIT_AUTHOR_EMAIL=nix@localhost
+      export GIT_COMMITTER_NAME=nix
+      export GIT_COMMITTER_EMAIL=nix@localhost
+    '';
+
+    doCheck = false;
+
+    # We only need the static library, not the cdylib or test binaries.
+    dontCargoInstall = true;
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/lib
+      cp target/*/release/libsignal_ffi.a $out/lib/
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "FFI static library from signalapp/libsignal, built for nchat";
+      homepage = "https://github.com/signalapp/libsignal";
+      license = lib.licenses.agpl3Only;
+      platforms = lib.platforms.unix;
+    };
+  };
 in
 stdenv.mkDerivation {
   pname = "nchat";
@@ -56,13 +152,19 @@ stdenv.mkDerivation {
     })
     # Don't use brew
     ./fix-darwin.patch
-  ];
+  ]
+  ++ lib.optional withSignal (
+    replaceVars ./go-libs-build-signal.patch {
+      inherit libcgosg libsignalFfi;
+    }
+  );
 
   nativeBuildInputs = [
     cmake
     gperf
     libcgowm
-  ];
+  ]
+  ++ lib.optional withSignal libcgosg;
 
   buildInputs = [
     file # for libmagic
@@ -76,6 +178,7 @@ stdenv.mkDerivation {
   cmakeFlags = [
     (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib")
     (lib.cmakeBool "HAS_WHATSAPP" withWhatsApp)
+    (lib.cmakeBool "HAS_SIGNAL" withSignal)
   ];
 
   passthru = {
@@ -86,13 +189,29 @@ stdenv.mkDerivation {
         "libcgowm"
       ];
     };
+  }
+  // lib.optionalAttrs withSignal {
+    inherit libcgosg libsignalFfi;
   };
 
   meta = {
-    description = "Terminal-based chat client with support for Telegram and WhatsApp";
+    description =
+      "Terminal-based chat client with support for Telegram"
+      + lib.optionalString withWhatsApp ", WhatsApp"
+      + lib.optionalString withSignal " and Signal";
     changelog = "https://github.com/d99kris/nchat/releases/tag/v${version}";
     homepage = "https://github.com/d99kris/nchat";
-    license = lib.licenses.mit;
+    # nchat itself is MIT. Linking libsignal_ffi (AGPLv3) into the build
+    # makes the combined distribution AGPLv3.
+    license =
+      if withSignal then
+        with lib.licenses;
+        [
+          mit
+          agpl3Only
+        ]
+      else
+        lib.licenses.mit;
     mainProgram = "nchat";
     maintainers = with lib.maintainers; [
       luftmensch-luftmensch


### PR DESCRIPTION
## Summary

Adds a `withSignal` toggle (default `false`) that pulls in nchat's third chat backend, mirroring the existing WhatsApp wiring.

The change is **opt-in by default** to avoid silently changing the license of an installed `nchat`: `libsignal_ffi` is AGPLv3 and gets statically linked into the combined binary. Existing users see no behavior change.

Mechanically:

- `libcgosg` — second `buildGoModule` wraps `lib/sgchat/go` (the bundled `mautrix-signal`) and produces `libcgosg.a`, mirroring the existing `libcgowm`.
- `libsignalFfi` — `rustPlatform.buildRustPackage` building `libsignal_ffi` from `signalapp/libsignal v0.87.5` (the version pinned by nchat at `lib/sgchat/go/ext/signal/pkg/libsignalgo/version.go`). Built from source — nothing is fetched at build time, sidestepping nchat's CMake-time download/build dance.
- `go-libs-build-signal.patch` — rewires `lib/sgchat/CMakeLists.txt` to consume the prebuilt archives instead of running nchat's in-tree build chain (mirrors what `go-libs-build.patch` already does for wmchat).
- `meta.license` becomes `[ mit agpl3Only ]` when Signal is enabled.
- `meta.description` is derived from the actually-enabled set of protocols.

## Build notes

Three details discovered while building, surfaced here so a reviewer doesn't need to rediscover them:

1. `boring-sys` (signalapp/boring fork at `signal-v5.0.2`) runs `git init` on its vendored boringssl during its build script → needs `git` in `nativeBuildInputs` and explicit `GIT_AUTHOR_*` / `GIT_COMMITTER_*` env vars in `preBuild`.
2. `bindgen` (pulled by boring-sys) needs `LIBCLANG_PATH` → use `rustPlatform.bindgenHook`.
3. `cargoBuildFlags = [ "--release" ]` collides with `cargoBuildHook`'s implicit `--profile release` (modern cargo rejects the combination) → just pass `--package libsignal-ffi`.

## Things done

- Built on platform:
  - [x] x86_64-linux (built locally + via `nixpkgs-review wip`)
  - [ ] aarch64-linux (untested; should work — `libsignal_ffi` upstream supports arm64, `boring-sys` does too)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests
  - [ ] Package tests at `passthru.tests` (none exist for nchat)
  - [ ] Tests in lib/tests or pkgs/test
- [x] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality:
  - `nchat --version` outputs the combined-AGPL distribution string (only appears when `HAS_SIGNAL=ON`)
  - `ldd` confirms `libsgchat.so` is linked
  - Default build (`withSignal = false`) verified unchanged (same closure as today)
  - Signal account linking not tested end-to-end (requires interactive phone-number / linked-device flow against a real Signal server)
- Nixpkgs Release Notes
  - [ ] N/A — additive change, default off.
- NixOS Release Notes
  - [ ] N/A — no module changes.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md — existing maintainers preserved, `nix-update-script` callback unchanged.

## Cross-platform notes for reviewers

The Darwin link line in `go-libs-build-signal.patch` is structurally analogous to the existing Linux patch (uses `-force_load` instead of `--whole-archive`) but **was not built on Darwin**. Reviewers with macOS sandboxes are warmly invited to flip `withSignal = true;` and report.
