### PR TITLE
llm-wiki: init at 0.4.10 [LLM-assisted contribution]

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9460,6 +9460,12 @@
     githubId = 4717341;
     name = "Brenton Horne";
   };
+  futile = {
+    name = "Felix Rath";
+    email = "felixm.rath@gmail.com";
+    github = "futile";
+    githubId = 1130337;
+  };
   fuuzetsu = {
     email = "fuuzetsu@fuuzetsu.co.uk";
     github = "Fuuzetsu";

--- a/pkgs/by-name/ll/llm-wiki/package.nix
+++ b/pkgs/by-name/ll/llm-wiki/package.nix
@@ -1,0 +1,115 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  nix-update-script,
+  rustPlatform,
+  cargo-tauri,
+  desktop-file-utils,
+  glib-networking,
+  libayatana-appindicator,
+  nodejs,
+  npmHooks,
+  openssl,
+  pdfium-binaries,
+  pkg-config,
+  protobuf,
+  webkitgtk_4_1,
+  wrapGAppsHook4,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "llm-wiki";
+  version = "0.4.10";
+
+  src = fetchFromGitHub {
+    owner = "nashsu";
+    repo = "llm_wiki";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-mXn2CNXYkOMJxVPlc4H/KRfM6wvEdC3GMaaZRr7U0LI=";
+  };
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+  cargoHash = "sha256-Bg+h1+NlUa2vJ0+g+ypFGhXkxyWB2mMqT82MYUOEmGo=";
+
+  npmDeps = fetchNpmDeps {
+    inherit (finalAttrs) src;
+    hash = "sha256-YGBpneK/qIMSvL+gIhBUSmolVm3S+h4E90e/s2ZEwks=";
+  };
+
+  __structuredAttrs = true;
+
+  postPatch =
+    # Like chiri/package.nix, patch libappindicator-sys to load Nix's appindicator library.
+    lib.optionalString stdenv.hostPlatform.isLinux ''
+      for libappindicatorRs in $cargoDepsCopy/*/libappindicator-sys-*/src/lib.rs; do
+        if [[ -f "$libappindicatorRs" ]]; then
+          substituteInPlace "$libappindicatorRs" \
+            --replace-fail "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
+        fi
+      done
+    ''
+    + ''
+      # Upstream ships bundled PDFium binaries and swaps the Linux ARM64
+      # library in CI. Use nixpkgs' pdfium-binaries instead, and keep the
+      # paths the same as what llm-wiki expects/does in CI.
+      # llm-wiki CI swapping pdfium can be seen here:
+      # https://github.com/nashsu/llm_wiki/blob/ea16fda6ea80fca68a3552f326d49870fb65dea5/.github/workflows/build.yml#L59-L72
+      rm -f \
+        src-tauri/pdfium/libpdfium.so \
+        src-tauri/pdfium/libpdfium-arm64.so \
+        src-tauri/pdfium/libpdfium.dylib \
+        src-tauri/pdfium/pdfium.dll
+      install -m644 ${pdfium-binaries}/lib/libpdfium${stdenv.hostPlatform.extensions.sharedLibrary} \
+        src-tauri/pdfium/libpdfium${stdenv.hostPlatform.extensions.sharedLibrary}
+    '';
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    nodejs
+    npmHooks.npmConfigHook
+    pkg-config
+    protobuf
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    desktop-file-utils
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    openssl
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    glib-networking
+    libayatana-appindicator
+    webkitgtk_4_1
+  ];
+
+  env.OPENSSL_NO_VENDOR = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Desktop application for building and maintaining structured wikis from documents with LLMs";
+    homepage = "https://github.com/nashsu/llm_wiki";
+    changelog = "https://github.com/nashsu/llm_wiki/releases/tag/v${finalAttrs.version}";
+    license = [ lib.licenses.gpl3Only ] ++ lib.toList pdfium-binaries.meta.license;
+    maintainers = with lib.maintainers; [ futile ];
+    mainProgram = "llm-wiki";
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      # Package uses binary PDFium libraries.
+      binaryNativeCode
+    ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+      "x86_64-darwin"
+      # Upstream publishes x86_64 Windows binaries, but cargo-tauri.hook does
+      # not support Windows.
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

# DISCLOSURE: THE COMMITS IN THIS PR WERE CREATED WITH LLM-ASSISTANCE.

I did _not_ use any LLM whatsoever to write this PR description.
I have carefully reviewed the LLM output and understand what the new package is doing, and have done my best to make sure it's high-quality.
This includes having looked up things that weren't clear to me, and where necessary improved them and/or left comment(s) to clear up _why_ things are being done. 
I have (also using AI) looked up similar packages and existing conventions in this repo to determine the solutions and styles that are most idiomatic in nixpkgs.
I have done this just like I would have if I had written the code myself, or when doing a code review.

Please let me know if I missed something.
I am interested in learning, but this is the first new package I contribute to nixpkgs (I have contributed package updates etc. before), so I might have gotten something wrong.

I fully intend to take responsibility for this new package, and I don't intend to simply pass off reviewer feedback to an LLM or anything like that.

That said, let's move on to actual content of this PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

This PR adds a new package, `llm-wiki`, which packages https://github.com/nashsu/llm_wiki, (mostly) building it from source.

I say "mostly" because the tool originally vendors a binary version of `pdfium`, which the package replaces with nixpkgs' `pdfium-binary`, but that is still a binary package (afaiu). That is the only binary part of the build (to the best of my knowledge).

I have only built this on x86_64-linux, but have made sure that it evals on all platforms the tool claims to support and that `cargo-tauri.hook` also supports.

This PR also adds myself to maintainer-list.nix, since I wasn't on it before.
The commit adding me to that is ordered _before_ (older-than) the commit introducing the new package.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
    - Building the package ran the app's own Rust-/Tauri-based tests
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
    - I did not think this change requires release notes, but please let me know if I should include them.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

Since this an LLM-_assisted_ contribution, I looked for guidance/policy around that, and found #514587. Following that (even though it's not yet merged, I thought it best to follow it nevertheless), I added the appropriate `Assisted-by:` git trailers, and am including the new checkbox that the PR suggests as well:
- [x] Follows the [automation/AI policy](https://github.com/emilazy/nixpkgs/blob/e0962eb971d9d404dcc76c9d7875b366df969113/CONTRIBUTING.md).

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
