### PR TITLE
nixosTests.test-containers-bittorrent: enable in hydra

### DIFF
--- a/nixos/tests/nixos-test-driver/containers.nix
+++ b/nixos/tests/nixos-test-driver/containers.nix
@@ -2,7 +2,12 @@
 {
   name = "containers";
   meta.maintainers = with pkgs.lib.maintainers; [ jfly ];
-  # https://github.com/NixOS/infra/issues/987
+  # Relies upon /dev/net/tun, which is currently disabled in hydra due to
+  # security concerns [0].
+  # There is a PR [1] that will remove the requirement on /dev/net/tun. When/if
+  # that lands, we can run this test in hydra.
+  # [0]: https://github.com/NixOS/infra/issues/987#issuecomment-4261612652
+  # [1]: https://github.com/NixOS/nixpkgs/pull/512268
   meta.hydraPlatforms = [ ];
 
   nodes = {

--- a/nixos/tests/test-containers-bittorrent.nix
+++ b/nixos/tests/test-containers-bittorrent.nix
@@ -51,8 +51,6 @@ in
     maintainers = [
       lib.maintainers.kmein
     ];
-    # https://github.com/NixOS/infra/issues/987
-    hydraPlatforms = [ ];
   };
 
   containers = {


### PR DESCRIPTION
Now that https://github.com/NixOS/infra/pull/986 has landed, we can enable container based tests that don't require the ability for containers and vms to communicate.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
