### PR TITLE
numa: init at 0.20.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4149,6 +4149,13 @@
     githubId = 30717258;
     name = "bubblepipe";
   };
+  bubylou = {
+    email = "bubylou@pm.me";
+    matrix = "@bubylou:matrix.org";
+    github = "bubylou";
+    githubId = 3878640;
+    name = "Nicholas Malcolm";
+  };
   buckley310 = {
     email = "sean.bck@gmail.com";
     matrix = "@buckley310:matrix.org";

--- a/pkgs/by-name/nu/numa/package.nix
+++ b/pkgs/by-name/nu/numa/package.nix
@@ -1,0 +1,40 @@
+{
+  rustPlatform,
+  nix-update-script,
+  lib,
+  fetchFromGitHub,
+}:
+let
+  pname = "numa";
+  version = "0.20.0";
+  gitHash = "sha256-RCb3k8uDnF3bUXAoKbEM6xBC7S9sKyDRy+bjhodqPeg=";
+  cargoHash = "sha256-svTcUocOSHNmXcPQaBusOSh3oVb2kRbPS9Hy4XdVpv4=";
+
+  src = fetchFromGitHub {
+    owner = "razvandimescu";
+    repo = pname;
+    tag = "v${version}";
+    hash = gitHash;
+  };
+in
+rustPlatform.buildRustPackage {
+  inherit
+    pname
+    src
+    version
+    cargoHash
+    ;
+
+  __structuredAttrs = true;
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Portable DNS resolver in Rust";
+    homepage = "https://numa.rs";
+    changelog = "https://github.com/razvandimescu/numa/releases/tag/v${version}";
+    license = with lib.licenses; mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ bubylou ];
+    mainProgram = "numa";
+  };
+}


### PR DESCRIPTION
Portable DNS resolver in Rust — .numa local domains, ad blocking, developer overrides.

[Github](https://github.com/razvandimescu/numa)
[Homepage](https://numa.rs/)

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
