### PR TITLE
nixos/fwupd: add enableGrubHook option

### DIFF
--- a/nixos/modules/services/hardware/fwupd.nix
+++ b/nixos/modules/services/hardware/fwupd.nix
@@ -31,8 +31,11 @@ let
   originalEtc =
     let
       mkEtcFile = n: lib.nameValuePair n { source = "${cfg.package}/etc/${n}"; };
+      etcFiles = lib.filter (
+        f: cfg.enableGrubHook || f != "grub.d/35_fwupd"
+      ) cfg.package.filesInstalledToEtc;
     in
-    lib.listToAttrs (map mkEtcFile cfg.package.filesInstalledToEtc);
+    lib.listToAttrs (map mkEtcFile etcFiles);
   extraTrustedKeys =
     let
       mkName = p: "pki/fwupd/${baseNameOf (toString p)}";
@@ -92,6 +95,19 @@ in
         example = [ "lvfs-testing" ];
         description = ''
           Enables extra remotes in fwupd. See `/etc/fwupd/remotes.d`.
+        '';
+      };
+
+      enableGrubHook = lib.mkOption {
+        type = lib.types.bool;
+        default = config.boot.loader.grub.enable;
+        defaultText = lib.literalExpression "config.boot.loader.grub.enable";
+        description = ''
+          Whether to install the `/etc/grub.d/35_fwupd` script that adds a
+          "Linux Firmware Updater" entry to the GRUB menu on the next
+          `grub-mkconfig` run. The script is shipped by upstream fwupd but
+          only meaningful when GRUB is the active bootloader; it is dead
+          weight under systemd-boot, rEFInd, Limine, etc.
         '';
       };
 


### PR DESCRIPTION
## Summary

fwupd ships `/etc/grub.d/35_fwupd`. The NixOS module symlinks every entry of `cfg.package.filesInstalledToEtc` into `/etc`, so this file is installed unconditionally — including under systemd-boot, rEFInd, Limine, etc., where it does nothing.

Gate it on a new `services.fwupd.enableGrubHook` option defaulting to `config.boot.loader.grub.enable`. Existing GRUB users see no change; everyone else gets a cleaner `/etc`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Assisted-by: claude-code with Opus 4.7 xhigh