### PR TITLE
markitdown: add top-level alias

### DIFF
--- a/pkgs/by-name/ma/markitdown/package.nix
+++ b/pkgs/by-name/ma/markitdown/package.nix
@@ -1,0 +1,5 @@
+{ python3Packages }:
+
+(python3Packages.toPythonApplication python3Packages.markitdown).overrideAttrs (_: {
+  __structuredAttrs = true;
+})


### PR DESCRIPTION
Adds a top-level `markitdown` alias for `python3Packages.markitdown` using `toPythonApplication`. Mirrors the existing pattern used by `magika` (also a Python CLI that doubles as a library other Python packages depend on).

The library form at `python3Packages.markitdown` is unchanged and still available for downstream consumers like `markitdown-mcp`.

After this lands:
- `nix run nixpkgs#markitdown -- file.pdf` works directly
- `nix shell nixpkgs#markitdown` works directly
- No regression for existing users of `python3Packages.markitdown`

Built and tested locally against my fork via flake reference:
```
> nix build github:Yrrrrrf/nixpkgs/markitdown-top-level#markitdown
> nix run github:Yrrrrrf/nixpkgs/markitdown-top-level#markitdown -- --version
markitdown 0.1.4
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage]. *(Not run: this PR adds a 3-line `toPythonApplication` wrapper that doesn't change the rebuild set of any existing package.)*
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test