### PR TITLE
wiiuse: Move lib to expected output path

### DIFF
--- a/pkgs/by-name/wi/wiiuse/package.nix
+++ b/pkgs/by-name/wi/wiiuse/package.nix
@@ -46,6 +46,15 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ [ (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic)) ];
 
+  # On Darwin (and Windows), upstream's CMakeLists.txt forcibly overrides
+  # CMAKE_INSTALL_LIBDIR to "lib", ignoring the value passed by the cmake
+  # setup hook, so the libraries end up in $out/lib instead of $lib/lib.
+  # Move them into the lib output manually.
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p $lib/lib
+    mv $out/lib/libwiiuse* $lib/lib/
+  '';
+
   meta = {
     description = "Feature complete cross-platform Wii Remote access library";
     mainProgram = "wiiuseexample";


### PR DESCRIPTION
The cmakefile for wiiuse [overwrites the install directory](https://github.com/wiiuse/wiiuse/blob/722efc1c58154127206ac05f6810e34a31cfd00a/CMakeLists.txt#L55). To fix this, move it to the expected output in postInstall.

Fixes #467945. Created during #ZurichZHF for NixOS 26.05 ZHF #516381.

Another attempt since #521318 was auto-closed by the force push to fix the commit subject.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

The package builds an example binary. Since I don't have a wiimote, I only checked that the example runs at all.

```
 % ./result/bin/wiiuseexample --help                                                                                                                                                   src/nixpkgs (fix/wiiuse) otter
wiiuse v0.15.6 loaded.
  De-facto official fork at http://github.com/wiiuse/wiiuse
  Original By: Michael Laforest <thepara[at]gmail{dot}com> <https://sourceforge.net/projects/wiiuse/>
No wiimotes found.
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
