### PR TITLE
zsync: 0.6.3-unstable-2025-05-29 -> 0.6.4

### DIFF
--- a/pkgs/by-name/zs/zsync/package.nix
+++ b/pkgs/by-name/zs/zsync/package.nix
@@ -3,17 +3,18 @@
   stdenv,
   fetchFromGitHub,
   autoreconfHook,
+  perl,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "zsync";
-  version = "0.6.3-unstable-2025-05-29";
+  version = "0.6.4";
 
   src = fetchFromGitHub {
     owner = "cph6";
     repo = "zsync";
-    rev = "a5cb28f923dd3cfdeb65e2930dd1faa727c2abf8";
-    hash = "sha256-gJs1P83AKWGipspeoFCSibZH+X6mmj3aL4+yjGO2YJo=";
+    tag = finalAttrs.version;
+    hash = "sha256-qZSjh23snJHWmrIUxRvpu5pZ1G3rJcnl08WGEEM+0Jw=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/c";
@@ -41,9 +42,14 @@ stdenv.mkDerivation (finalAttrs: {
     autoreconfHook
   ];
 
+  doCheck = true;
+
+  nativeCheckInputs = [ perl ];
+
   meta = {
-    homepage = "https://github.com/cph6/zsync";
     description = "File distribution system using the rsync algorithm";
+    homepage = "https://github.com/cph6/zsync";
+    changelog = "https://github.com/cph6/zsync/raw/refs/tags/${finalAttrs.src.tag}/c/NEWS";
     license = lib.licenses.artistic2;
     maintainers = with lib.maintainers; [
       viric


### PR DESCRIPTION
Diff: https://github.com/cph6/zsync/compare/a5cb28f923dd3cfdeb65e2930dd1faa727c2abf8...0.6.4

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
