### PR TITLE
libretro: add melonDS DS core

### DIFF
--- a/pkgs/applications/emulators/libretro/cores/melonds-ds.nix
+++ b/pkgs/applications/emulators/libretro/cores/melonds-ds.nix
@@ -7,10 +7,96 @@
   libGL,
   git,
 }:
+let
+  date = fetchFromGitHub {
+    owner = "HowardHinnant";
+    repo = "date";
+    rev = "1ead6715dec030d340a316c927c877a3c4e5a00c";
+    hash = "sha256-0dlwfPFUpIUp45KxfJIcD7J7ls6csPGx//qSt9Wp2CI=";
+  };
+
+  embed-binaries = fetchFromGitHub {
+    owner = "andoalon";
+    repo = "embed-binaries";
+    rev = "078b62beba97e8192c99bfb16d5e17220cfc7598";
+    hash = "sha256-EkK+ZCbrZ2Y9wJ864OIwRWDfHcmxzKMco0QAkLOQOwY=";
+  };
+
+  fmt = fetchFromGitHub {
+    owner = "fmtlib";
+    repo = "fmt";
+    rev = "11.0.2";
+    hash = "sha256-IKNt4xUoVi750zBti5iJJcCk3zivTt7nU12RIf8pM+0=";
+  };
+  
+  glm = fetchFromGitHub {
+    owner = "g-truc";
+    repo = "glm";
+    rev = "e7970a8b26732f1b0df9690f7180546f8c30e48e";
+    hash = "sha256-VqNYg+rya0vUQ5dpvuz6hGAlVWiqArd/5yLxr9Vg8NA=";
+  };
+  
+  libretro-common = fetchFromGitHub {
+    owner = "JesseTG";
+    repo = "libretro-common";
+    rev = "8e2b884db16711a999a0e46a02a3dc0be294b048";
+    hash = "sha256-NYxi1BADUgMAtLfmYcOIhTAnmJ/LYd0OyfPKx6lorw4=";
+  };
+
+  libslirp = fetchFromGitHub {
+    owner = "JesseTG";
+    repo = "libslirp-mirror";
+    rev = "e61dbd459c8c06607b3a84694489427e8ec60f17";
+    hash = "sha256-WQIJjnNJHF63gNfznnrGt4jAzrhHfslOATsjcbfbAg4=";
+  };
+
+  melonDS = fetchFromGitHub {
+    owner = "JesseTG";
+    repo = "melonDS";
+    rev = "f6692dff8c0c53f77639a08e5e746a286312bb41";
+    hash = "sha256-EeXYibPV9BPazC/i5UqXEd4BKlIZbNbPNgpsoo4ws7k=";
+  };
+
+  pntr = fetchFromGitHub {
+    owner = "robloach";
+    repo = "pntr";
+    rev = "650237a524ea4fc953de7223a1587c83f2696794";
+    hash = "sha256-qGWPlHkcW/wavxRN76SHiEKCl2b1VZR+O9YrZOFZL0I=";
+  };
+
+  span-lite = fetchFromGitHub {
+    owner = "martinmoene";
+    repo = "span-lite";
+    rev = "00afc281a8c3c7657bb9c5b000d6e7082c1bbc7f";
+    hash = "sha256-EBSN8Bh1ymFyWTUPQ6OS9c75B/mJysNS2VIqR0qG9zI=";
+  };
+
+  # # tracy is not built by default
+  # tracy = fetchFromGitHub {
+  #   owner = "wolfpld";
+  #   repo = "tracy";
+  #   rev = "v0.11.1";
+  #   hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  # };
+
+  yamc = fetchFromGitHub {
+    owner = "yohhoy";
+    repo = "yamc";
+    rev = "4e015a7e8eb0d61c34e6928676c8c78881a72d73";
+    hash = "sha256-J5wAqF5yQ5KYArJJyKzaqscWsXq+KAPKXybYfVgasXs=";
+  };
+
+  zlib = fetchFromGitHub {
+    owner = "madler";
+    repo = "zlib";
+    rev = "v1.3.1";
+    hash = "sha256-TkPLWSN5QcPlL9D0kc/yhH0/puE9bFND24aj5NVDKYs=";
+  };
+in
 mkLibretroCore {
   core = "melonds-ds";
   version = "0-unstable-2026-03-03";
-
+  
   src = fetchFromGitHub {
     owner = "JesseTG";
     repo = "melonds-ds";
@@ -28,9 +114,25 @@ mkLibretroCore {
     git
   ];
 
+  cmakeFlags = [
+    "-DFETCHCONTENT_SOURCE_DIR_DATE=${date}"
+    "-DFETCHCONTENT_SOURCE_DIR_EMBED-BINARIES=${embed-binaries}"
+    "-DFETCHCONTENT_SOURCE_DIR_FMT=${fmt}"
+    "-DFETCHCONTENT_SOURCE_DIR_GLM=${glm}"
+    "-DFETCHCONTENT_SOURCE_DIR_LIBRETRO-COMMON=${libretro-common}"
+    "-DFETCHCONTENT_SOURCE_DIR_LIBSLIRP=${libslirp}"
+    "-DFETCHCONTENT_SOURCE_DIR_MELONDS=${melonDS}"
+    "-DFETCHCONTENT_SOURCE_DIR_PNTR=${pntr}"
+    "-DFETCHCONTENT_SOURCE_DIR_SPAN-LITE=${span-lite}"
+    # "-DFETCHCONTENT_SOURCE_DIR_TRACY=${tracy}" # not built by default
+    "-DFETCHCONTENT_SOURCE_DIR_YAMC=${yamc}"
+    "-DFETCHCONTENT_SOURCE_DIR_ZLIB=${zlib}"
+  ];
+
   meta = {
     description = "Enhanced remake of the melonDS core for libretro";
     homepage = "https://github.com/JesseTG/melonds-ds";
     license = lib.licenses.gpl3Plus;
   };
 }
+

--- a/pkgs/applications/emulators/libretro/cores/melonds-ds.nix
+++ b/pkgs/applications/emulators/libretro/cores/melonds-ds.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  cmake,
+  fetchFromGitHub,
+  mkLibretroCore,
+  libGLU,
+  libGL,
+  git,
+}:
+mkLibretroCore {
+  core = "melonds-ds";
+  version = "0-unstable-2026-03-03";
+
+  src = fetchFromGitHub {
+    owner = "JesseTG";
+    repo = "melonds-ds";
+    rev = "bac0256dc6a8736c5a228f57c562257e45fd49f3";
+    hash = "sha256-EeXYibPV9BPazC/i5UqXEd4BKlIZbNbPNgpsoo4ws7k=";
+  };
+
+  extraBuildInputs = [
+    libGLU
+    libGL
+  ];
+
+  extraNativeBuildInputs = [
+    cmake
+    git
+  ];
+
+  meta = {
+    description = "Enhanced remake of the melonDS core for libretro";
+    homepage = "https://github.com/JesseTG/melonds-ds";
+    license = lib.licenses.gpl3Plus;
+  };
+}

--- a/pkgs/applications/emulators/libretro/default.nix
+++ b/pkgs/applications/emulators/libretro/default.nix
@@ -106,6 +106,8 @@ lib.makeScope newScope (self: {
 
   melonds = self.callPackage ./cores/melonds.nix { };
 
+  melonds-ds = self.callPackage ./cores/melonds-ds.nix { };
+
   mesen = self.callPackage ./cores/mesen.nix { };
 
   mesen-s = self.callPackage ./cores/mesen-s.nix { };


### PR DESCRIPTION
The `melonDS DS` core supersedes `melonDS` which is now deprecated, see below libretro docs for information on the new core:

<https://github.com/libretro/docs/blob/master/docs/library/melonds_ds.md>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux - failed build locally due to below git error
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage]. - failed build locally due to below git error
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking. - n/a
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module. - n/a
  - [ ] Module update: when the change is significant. - n/a
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## Maintainers

@aanderse @thiagokokada 

## Help needed

I am having trouble building with the command provided in the README. I am unsure what is incorrect in my implementation to cause the build to try and clone the incorrect URL, any help would be appreciated.

```sh
$ nix-build -A libretro.melonds-ds

.
.
.

Last 25 log lines:
       > Cloning into 'melonds-src'...
       > fatal: unable to access 'https://github.com/JesseTG/melonDS/': Could not resolve host: github.com
       > Cloning into 'melonds-src'...
       > fatal: unable to access 'https://github.com/JesseTG/melonDS/': Could not resolve host: github.com
       > Had to git clone more than once: 3 times.
       > CMake Error at melonds-subbuild/melonds-populate-prefix/tmp/melonds-populate-gitclone.cmake:50 (message):
       >   Failed to clone repository: 'https://github.com/JesseTG/melonDS'
```
