### PR TITLE
auto-editor: 29.7.0 -> 30.3.0

### DIFF
--- a/pkgs/by-name/au/auto-editor/lock.json
+++ b/pkgs/by-name/au/auto-editor/lock.json
@@ -2,27 +2,27 @@
   "depends": [
     {
       "method": "fetchzip",
-      "path": "/nix/store/w556rbsnv2fxb229av2iq180ri9x0d9j-source",
-      "rev": "77469f58916369bc3863194cabb05238577fb257",
-      "sha256": "18wjz5yqzr1dz6286p2w02fk2xjr54l477g90bz4pskjcqrqnjbv",
-      "url": "https://github.com/khchen/tinyre/archive/77469f58916369bc3863194cabb05238577fb257.tar.gz",
-      "ref": "1.6.0",
+      "path": "/nix/store/63sp165yl6is029c8g5cn3550vq8pp1x-source",
+      "rev": "e9f0c49b234fd4a2038b752ab02703288346ce98",
+      "sha256": "1rwr4d150l0v14ccmwr13zi6fr8din1h8spivmxwkcfa66jm73j1",
+      "url": "https://github.com/WyattBlue/csort/archive/e9f0c49b234fd4a2038b752ab02703288346ce98.tar.gz",
+      "ref": "1.0.0",
       "packages": [
-        "tinyre"
+        "csort"
       ],
-      "srcDir": ""
+      "srcDir": "src"
     },
     {
       "method": "fetchzip",
-      "path": "/nix/store/6aph9sfwcws7pd2725fwjnibdfrv7qmw-source",
-      "rev": "f8f6bd34bfa3fe12c64b919059ad856a96efcba0",
-      "sha256": "11m1rb6rzk70kvskppf97ddzgf5fnh9crjziqc6hib0jgsm5d615",
-      "url": "https://github.com/nim-lang/checksums/archive/f8f6bd34bfa3fe12c64b919059ad856a96efcba0.tar.gz",
-      "ref": "v0.2.1",
+      "path": "/nix/store/f2xp1v0vnplwfjnk8nqsi7gd9pnb9gcv-source",
+      "rev": "b3dbc9c4d08e58c5b7bfad6dc7ef2ee52f2f4c08",
+      "sha256": "1v4rz42lwcazs6isi3kmjylkisr84mh0kgmlqycx4i885dn3g0l4",
+      "url": "https://github.com/cheatfate/nimcrypto/archive/b3dbc9c4d08e58c5b7bfad6dc7ef2ee52f2f4c08.tar.gz",
+      "ref": "v0.7.3^{}",
       "packages": [
-        "checksums"
+        "nimcrypto"
       ],
-      "srcDir": "src"
+      "srcDir": ""
     }
   ]
 }

--- a/pkgs/by-name/au/auto-editor/package.nix
+++ b/pkgs/by-name/au/auto-editor/package.nix
@@ -5,24 +5,13 @@
   buildNimPackage,
   fetchFromGitHub,
 
-  withHEVC ? true,
-  withWhisper ? false, # TODO: Investigate linker failure. See PR 476678
-  withVpx ? true,
-  withSvtAv1 ? true,
-  withCuda ? false,
-  withVpl ? stdenv.hostPlatform.isLinux,
-
   ffmpeg-full,
   yt-dlp,
   lame,
   libopus,
   libvpx,
   x264,
-  x265,
   dav1d,
-  svt-av1,
-  libvpl,
-  whisper-cpp,
 
   python3,
   python3Packages,
@@ -30,13 +19,13 @@
 
 buildNimPackage rec {
   pname = "auto-editor";
-  version = "29.7.0";
+  version = "30.3.0";
 
   src = fetchFromGitHub {
     owner = "WyattBlue";
     repo = "auto-editor";
     tag = version;
-    hash = "sha256-R1GnvFjC/nq/gIiX6rUxP7qR3IfpGfc4Ci28AIk4CfQ=";
+    hash = "sha256-1DFTT6dyIYlB3EMPf5eleXvRr1d29jmtt7GQfRpOkUE=";
   };
 
   lockFile = ./lock.json;
@@ -47,20 +36,16 @@ buildNimPackage rec {
     libopus
     x264
     dav1d
-  ]
-  ++ lib.optionals withHEVC [ x265 ]
-  ++ lib.optionals withWhisper [ whisper-cpp ]
-  ++ lib.optionals withVpx [ libvpx ]
-  ++ lib.optionals withSvtAv1 [ svt-av1 ]
-  ++ lib.optionals withVpl [ libvpl ];
+  ];
 
-  nimFlags =
-    lib.optionals withHEVC [ "-d:enable_hevc" ]
-    ++ lib.optionals withWhisper [ "-d:enable_whisper" ]
-    ++ lib.optionals withVpx [ "-d:enable_vpx" ]
-    ++ lib.optionals withSvtAv1 [ "-d:enable_svtav1" ]
-    ++ lib.optionals withCuda [ "-d:enable_cuda" ]
-    ++ lib.optionals withVpl [ "-d:enable_vpl" ];
+  env = {
+    # Nothing should be dynamically linked, as ffmpeg should already link it.
+    DISABLE_HEVC = "1";
+    DISABLE_WHISPER = "1";
+    DISABLE_VPX = "1";
+    DISABLE_SVTAV1 = "1";
+    DISABLE_VPL = "1";
+  };
 
   postPatch = ''
     substituteInPlace src/log.nim \


### PR DESCRIPTION
Bumped version, updated nim dependencies, removed some non-required build inputs.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
