### PR TITLE
nixos: Remove inaccurate systemd stage 1 TODO comments

### DIFF
--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -1114,7 +1114,6 @@ in
           -> all (dev: dev.preOpenCommands == "" && dev.postOpenCommands == "") (attrValues luks.devices);
         message = "boot.initrd.luks.devices.<name>.preOpenCommands and postOpenCommands is not supported by systemd stage 1. Please bind a service to cryptsetup.target or cryptsetup-pre.target instead.";
       }
-      # TODO
       {
         assertion = config.boot.initrd.systemd.enable -> !luks.gpgSupport;
         message = systemdStage1HardwareKeyAssertionMessage "boot.initrd.luks.gpgSupport";
@@ -1123,7 +1122,6 @@ in
         assertion = config.boot.initrd.systemd.enable -> !luks.fido2Support;
         message = systemdStage1HardwareKeyAssertionMessage "boot.initrd.luks.fido2Support";
       }
-      # TODO
       {
         assertion = config.boot.initrd.systemd.enable -> !luks.yubikeySupport;
         message = systemdStage1HardwareKeyAssertionMessage "boot.initrd.luks.yubikeySupport";

--- a/nixos/modules/tasks/encrypted-devices.nix
+++ b/nixos/modules/tasks/encrypted-devices.nix
@@ -119,7 +119,6 @@ in
         );
         forceLuksSupportInInitrd = true;
       };
-      # TODO: systemd stage 1
       postMountCommands = lib.mkIf (!config.boot.initrd.systemd.enable) (
         concatMapStrings (
           dev:


### PR DESCRIPTION
- `gpgSupport` and `yubikeySupport` won't be supported
- `fileSystems.<name>.encrypted` actually already works correctly


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
