### PR TITLE
dnsi and dnst: NLNetLabs's command-line DNS utilities

### DIFF
--- a/pkgs/by-name/dn/dnsi/package.nix
+++ b/pkgs/by-name/dn/dnsi/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  installShellFiles,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "dnsi";
+  version = "0.2.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "NLnetLabs";
+    repo = "dnsi";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-HWYn3IHUoH3248ZGCU9JKO3BALZqxiaNX1Q2+bHjw0A=";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  cargoHash = "sha256-uIW7EDL2ulg6qDizjw5iHtc5HqyEZDBoXJxWHZOmoqo=";
+
+  postInstall = ''
+    installManPage doc/*.1
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Command line tool to investigate the Domain Name System";
+    mainProgram = "dnsi";
+    homepage = "https://nlnetlabs.nl/projects/domain/dnsi/";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.skyesoss ];
+  };
+})

--- a/pkgs/by-name/dn/dnst/package.nix
+++ b/pkgs/by-name/dn/dnst/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  openssl,
+  installShellFiles,
+  makeWrapper,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "dnst";
+  version = "0.2.0-alpha2";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "NLnetLabs";
+    repo = "dnst";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-OpyOnBddbIdnJLchY5y2oMqK5JSXCTF8cC5KstJ7pnc=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+    makeWrapper
+  ];
+  buildInputs = [ openssl ];
+
+  cargoHash = "sha256-y048tMh5wBjAB7I8FK3pETn0j9S/h893JZb9sbOBdbo=";
+
+  postInstall = ''
+    mkdir -p $out/libexec
+    mv $out/bin/ldns $out/libexec
+    for tool in key2ds keygen notify nsec3-hash signzone; do
+      makeWrapper $out/libexec/ldns $out/bin/ldns-$tool --add-flag ldns-$tool
+    done
+
+    installManPage doc/manual/build/man/*.1
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Toolset to assist DNS operators with zone and nameserver maintenance";
+    mainProgram = "dnst";
+    homepage = "https://nlnetlabs.nl/projects/domain/dnst/";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.skyesoss ];
+  };
+})


### PR DESCRIPTION
This PR adds [`dnst`](https://github.com/NLnetLabs/dnst) and [`dnsi`](https://github.com/NLnetLabs/dnsi).
Both of these utilities are developed at [NLnet Labs](https://nlnetlabs.nl/projects/domain/dnsi/), and are more ergonomic replacements for DNS utilities such as `dig` and `delv`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
