### PR TITLE
maintainers: remove ciil

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5038,12 +5038,6 @@
     github = "cigrainger";
     githubId = 3984794;
   };
-  ciil = {
-    email = "simon@lackerbauer.com";
-    github = "ciil";
-    githubId = 3956062;
-    name = "Simon Lackerbauer";
-  };
   cilki = {
     github = "cilki";
     githubId = 10459406;

--- a/pkgs/applications/science/logic/abella/default.nix
+++ b/pkgs/applications/science/logic/abella/default.nix
@@ -54,10 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://abella-prover.org";
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [
-      bcdarwin
-      ciil
-    ];
+    maintainers = [ lib.maintainers.bcdarwin ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/gn/gnushogi/package.nix
+++ b/pkgs/by-name/gn/gnushogi/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "gnushogi";
     homepage = "https://www.gnu.org/software/gnushogi/";
     license = lib.licenses.gpl3;
-    maintainers = [ lib.maintainers.ciil ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/gs/gshogi/package.nix
+++ b/pkgs/by-name/gs/gshogi/package.nix
@@ -51,6 +51,6 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     mainProgram = "gshogi";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
-    maintainers = [ lib.maintainers.ciil ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/lb/lbreakout2/package.nix
+++ b/pkgs/by-name/lb/lbreakout2/package.nix
@@ -48,9 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Breakout clone from the LGames series";
     license = with lib.licenses; [ gpl2Plus ];
     mainProgram = "lbreakout2";
-    maintainers = with lib.maintainers; [
-      ciil
-    ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
     hydraPlatforms = lib.platforms.linux; # build hangs on both Darwin platforms, needs investigation
   };

--- a/pkgs/by-name/rs/rstudio/package.nix
+++ b/pkgs/by-name/rs/rstudio/package.nix
@@ -367,10 +367,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Set of integrated tools for the R language";
     homepage = "https://www.rstudio.com/";
     license = lib.licenses.agpl3Only;
-    maintainers = with lib.maintainers; [
-      ciil
-      tomasajt
-    ];
+    maintainers = [ lib.maintainers.tomasajt ];
     mainProgram = "rstudio" + lib.optionalString server "-server";
     # rstudio-server on darwin is only partially supported by upstream
     platforms = lib.platforms.linux ++ lib.optionals (!server) lib.platforms.darwin;


### PR DESCRIPTION
No [comments](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+commenter%3Aciil+sort%3Acreated-desc) since October 2024 despite 30 [review requests](https://github.com/NixOS/nixpkgs/pulls?q=sort%3Aupdated-desc+is%3Apr+created%3A%3E%3D2024-10-18+user-review-requested%3Aciil+). Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/006ecdbdeb4b1c7c4cbd8963d64e80be95348436/maintainers/README.md#losing-maintainer-status).

@ciil, if you object to being dropped please respond saying so within a week. Even if you don't make it, you are of course welcome back whenever you would like!

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
