### PR TITLE
ccfits: init at 2.7

### DIFF
--- a/pkgs/by-name/cc/ccfits/package.nix
+++ b/pkgs/by-name/cc/ccfits/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  cfitsio,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ccfits";
+  version = "2.7";
+
+  src = fetchurl {
+    url = "https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/ccfits/v${finalAttrs.finalPackage.version}/CCfits-${finalAttrs.finalPackage.version}.tar.gz";
+    hash = "sha256-9jVG0v7sv3MswIqqqAoutTNK2jf7JTAYG3NjpdvesBo=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+  enableParallelBuilding = true;
+
+  buildInputs = [ cfitsio ];
+
+  # $out/bin/cookbook only needed for manual tests
+  postInstall = ''
+    rm -rf $out/bin/
+  '';
+
+  meta = {
+    homepage = "https://heasarc.gsfc.nasa.gov/docs/software/fitsio/ccfits/";
+    description = "An object oriented interface to the cfitsio library";
+    longDescription = ''
+      CCfits is an object oriented interface to the cfitsio library. It is
+      designed to make the capabilities of cfitsio available to programmers
+      working in C++. It is written in ANSI C++ and implemented using the C++
+      Standard Library with namespaces, exception handling, and member
+      template functions.
+    '';
+    license = lib.licenses.cfitsio;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ panicgh ];
+  };
+})


### PR DESCRIPTION
ccfits is an object oriented interface to cfitsio.
* [repology page](https://repology.org/project/ccfits/versions) with overview of other distros that ship this library

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
