### PR TITLE
unvanquished: 0.56.1 -> 0.56.2

### DIFF
--- a/pkgs/by-name/un/unvanquished/package.nix
+++ b/pkgs/by-name/un/unvanquished/package.nix
@@ -34,7 +34,7 @@
 }:
 
 let
-  version = "0.56.1";
+  version = "0.56.2";
   binary-deps-version = "11";
 
   src = fetchFromGitHub {
@@ -42,7 +42,7 @@ let
     repo = "Unvanquished";
     tag = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-MIsHW56RYkh5xtidHpBOEwQQSsvGMEdAdGt5fQvqXxQ=";
+    hash = "sha256-+3y9UJAMfMDIO4feHTyb5IWIelRSsH6KF6WAtx7rric=";
   };
 
   unvanquished-binary-deps = stdenv.mkDerivation rec {
@@ -121,7 +121,7 @@ let
     pname = "unvanquished-assets";
     inherit version src;
 
-    outputHash = "sha256-HnWdOvi7fcKmktLVbdUfMnB8v3iHb1t7jEERUcYcxNg=";
+    outputHash = "sha256-lXhzrA30wiNtCvpl4xxrIyl5Vcd4TvSQAuBK73vZXHs=";
     outputHashMode = "recursive";
 
     nativeBuildInputs = [


### PR DESCRIPTION
https://unvanquished.net/unvanquished-0-56-2-quality/

I updated Unvanquished to the latest version (released last week) and tested the game by starting a LAN game. In NixOS-WSL 25.11, the game seems to work but runs a little slow. In a NixOS 25.11 VirtualBox VM, the main menu works, but when I start a local match, I get a black screen with HUD (only the heads-up display renders). I think this is due to VirtualBox's incomplete OpenGL support.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
