### PR TITLE
Inventree: remove coverage and reduce pname usage

### DIFF
--- a/pkgs/by-name/in/inventree/package.nix
+++ b/pkgs/by-name/in/inventree/package.nix
@@ -208,24 +208,24 @@ python3Packages.buildPythonApplication rec {
       # Don't need to bother with a non-maintained library from ages ago
       substituteInPlace src/backend/InvenTree/InvenTree/settings.py --replace-fail "django_slowtests.testrunner.DiscoverSlowestTestsRunner" "django.test.runner.DiscoverRunner"
 
-      mkdir -p $out/lib/${pname}/src/backend/InvenTree/web/
-      cp -r src $out/lib/${pname}
-      ln -s ${frontend}/static $out/lib/${pname}/src/backend/InvenTree/web
+      mkdir -p $out/lib/inventree/src/backend/InvenTree/web/
+      cp -r src $out/lib/inventree
+      ln -s ${frontend}/static $out/lib/inventree/src/backend/InvenTree/web
 
-      chmod +x $out/lib/${pname}/src/backend/InvenTree/manage.py
+      chmod +x $out/lib/inventree/src/backend/InvenTree/manage.py
 
-      makeWrapper $out/lib/${pname}/src/backend/InvenTree/manage.py $out/bin/${pname} \
-        --prefix PYTHONPATH : "${pythonPath}:$out/lib/${pname}/src/backend/InvenTree" \
+      makeWrapper $out/lib/inventree/src/backend/InvenTree/manage.py $out/bin/inventree \
+        --prefix PYTHONPATH : "${pythonPath}:$out/lib/inventree/src/backend/InvenTree" \
         --set INVENTREE_COMMIT_HASH abcdef \
         --set INVENTREE_COMMIT_DATE 1970-01-01
 
       makeWrapper ${lib.getExe python3Packages.gunicorn} $out/bin/gunicorn \
-        --prefix PYTHONPATH : "${pythonPath}:$out/${python3.sitePackages}":"${pythonPath}:$out/lib/${pname}/src/backend/InvenTree" \
+        --prefix PYTHONPATH : "${pythonPath}:$out/${python3.sitePackages}":"${pythonPath}:$out/lib/inventree/src/backend/InvenTree" \
         --set INVENTREE_COMMIT_HASH abcdef \
         --set INVENTREE_COMMIT_DATE 1970-01-01
 
       # Generate static assets
-      pushd $out/lib/${pname}/src/backend/InvenTree &>/dev/null
+      pushd $out/lib/inventree/src/backend/InvenTree &>/dev/null
       export INVENTREE_STATIC_ROOT=$out/lib/inventree/static
       export INVENTREE_MEDIA_ROOT=$(mktemp -d)
       export INVENTREE_BACKUP_DIR=$(mktemp -d)

--- a/pkgs/by-name/in/inventree/package.nix
+++ b/pkgs/by-name/in/inventree/package.nix
@@ -283,7 +283,6 @@ python3Packages.buildPythonApplication rec {
     pytest-django
     pytest-env
     invoke
-    coverage
     pdfminer-six
     tblib
     pytest


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
