### PR TITLE
rocq-mcp: init at 0.2.1-unstable-2026-05-06; python3Packages.pytanque: init at 0.2.2

### DIFF
--- a/pkgs/by-name/ro/rocq-mcp/package.nix
+++ b/pkgs/by-name/ro/rocq-mcp/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "rocq-mcp";
+  version = "0.2.1-unstable-2026-05-06";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "LLM4Rocq";
+    repo = "rocq-mcp";
+    rev = "612dec76009237e89c52a85bd29c10a75e712831";
+    hash = "sha256-UdlwMv+bceC0xLTL+5q2l+1gKYrs6ChKAb01fIC+7dU=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    fastmcp
+    psutil
+    pytanque
+  ];
+
+  # Tests require a running pet-server (Petanque/coq-lsp).
+  doCheck = false;
+
+  pythonImportsCheck = [ "rocq_mcp" ];
+
+  meta = {
+    description = "MCP server for Rocq/Coq proof development";
+    homepage = "https://github.com/LLM4Rocq/rocq-mcp";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ remix7531 ];
+    mainProgram = "rocq-mcp";
+  };
+}

--- a/pkgs/development/python-modules/pytanque/default.nix
+++ b/pkgs/development/python-modules/pytanque/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  requests,
+  typing-extensions,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pytanque";
+  version = "0.2.2";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "LLM4Rocq";
+    repo = "pytanque";
+    tag = "v${version}";
+    hash = "sha256-1Hae21BuMdE6MjRdiBO7fcsuS4HzahOdLLhynAUox3I=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    requests
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  # Tests require a running pet-server (Petanque/coq-lsp).
+  doCheck = false;
+
+  pythonImportsCheck = [ "pytanque" ];
+
+  meta = {
+    description = "Python client for the Petanque JSON-RPC interface to coq-lsp";
+    homepage = "https://github.com/LLM4Rocq/pytanque";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ remix7531 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15357,6 +15357,8 @@ self: super: with self; {
 
   pytankerkoenig = callPackage ../development/python-modules/pytankerkoenig { };
 
+  pytanque = callPackage ../development/python-modules/pytanque { };
+
   pytap2 = callPackage ../development/python-modules/pytap2 { };
 
   pytapo = callPackage ../development/python-modules/pytapo { };


### PR DESCRIPTION
## Summary

Adds two new packages enabling the Rocq MCP toolchain on Nix:

- `python3Packages.pytanque` (0.2.2) — Python client for the Petanque JSON-RPC interface to coq-lsp (https://github.com/LLM4Rocq/pytanque).
- `rocq-mcp` (0.2.1-unstable-2026-05-06) — MCP server for Rocq/Coq proof development built on FastMCP (https://github.com/LLM4Rocq/rocq-mcp). Pinned to `main` since 0.2.1 is unreleased upstream but is the first version requiring `fastmcp >= 3.1` and `psutil`, both now available in nixpkgs.

This was previously blocked on fastmcp 3 landing in nixpkgs; with fastmcp 3.2.3 in tree, both packages now build.

### Things done

- Built `python3Packages.pytanque` and `rocq-mcp` on x86_64-linux.
- Verified the `rocq-mcp` entrypoint launches (FastMCP banner prints).
- Upstream tests for both packages require a running `pet-server`; `doCheck = false` with `pythonImportsCheck` kept as a smoke test.
- [x] Built on platform(s): x86_64-linux
- [ ] For new packages please note label "9.needs: package (maintainer)"