### PR TITLE
motus: sort attributes in a more logical order

### DIFF
--- a/pkgs/by-name/mo/motus/package.nix
+++ b/pkgs/by-name/mo/motus/package.nix
@@ -1,16 +1,17 @@
 {
   lib,
   fetchFromGitHub,
+  libxcb,
   nix-update-script,
   rustPlatform,
   stdenv,
-  libxcb,
   versionCheckHook,
   withClipboard ? true,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   __structuredAttrs = true;
+
   pname = "motus";
   version = "0.4.0";
 
@@ -23,8 +24,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-6MKEHnB2MJVB4cNvz3JYlhuzxhzsA+Pq5OkpLNoAEyU=";
 
-  buildAndTestSubdir = "crates/motus-cli";
-
   # The CLI crate version was not bumped to match the v0.4.0 release tag:
   # https://github.com/oleiade/motus/issues/58
   postPatch = ''
@@ -32,12 +31,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail '#[command(version = "0.3.1")]' '#[command(version = "${finalAttrs.version}")]'
   '';
 
-  buildNoDefaultFeatures = !withClipboard;
-
   buildInputs = lib.optionals (withClipboard && stdenv.hostPlatform.isLinux) [ libxcb ];
 
-  nativeInstallCheckInputs = [ versionCheckHook ];
+  buildAndTestSubdir = "crates/motus-cli";
+  buildNoDefaultFeatures = !withClipboard;
+
   doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
Follow up to #516408

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
