### PR TITLE
robotframework-tidy: disable tests broken by click 8.3.x flag_value regression

### DIFF
--- a/pkgs/by-name/ro/robotframework-tidy/package.nix
+++ b/pkgs/by-name/ro/robotframework-tidy/package.nix
@@ -33,6 +33,21 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   nativeCheckInputs = with python3.pkgs; [ pytestCheckHook ];
 
+  # click 8.3.x regression breaks `--list` / `--generate-config` optional-value flags (pallets/click#3130)
+  disabledTestPaths = [
+    "tests/utest/test_cli.py::TestCli::test_list_transformers[4---list]"
+    "tests/utest/test_cli.py::TestCli::test_list_transformers[4--l]"
+    "tests/utest/test_cli.py::TestCli::test_list_transformers[5---list]"
+    "tests/utest/test_cli.py::TestCli::test_list_transformers[5--l]"
+    "tests/utest/test_cli.py::TestCli::test_list_transformers[None---list]"
+    "tests/utest/test_cli.py::TestCli::test_list_transformers[None--l]"
+    "tests/utest/test_cli.py::TestCli::test_list_no_config"
+    "tests/utest/test_cli.py::TestGenerateConfig::test_generate_default_config"
+    "tests/utest/test_cli.py::TestGenerateConfig::test_generate_config_ignore_existing_config"
+    "tests/utest/test_cli.py::TestGenerateConfig::test_generate_config_with_cli_config"
+    "tests/utest/test_cli.py::TestGenerateConfig::test_missing_dependency"
+  ];
+
   meta = {
     description = "Code autoformatter for Robot Framework";
     homepage = "https://robotidy.readthedocs.io";


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327171432)](https://hydra.nixos.org/build/327171432)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
