### PR TITLE
python3Packages.warp-lang: refresh dynamic-link.patch for 1.11.0

### DIFF
--- a/pkgs/development/python-modules/warp-lang/dynamic-link.patch
+++ b/pkgs/development/python-modules/warp-lang/dynamic-link.patch
@@ -1,11 +1,9 @@
-diff --git a/build_llvm.py b/build_llvm.py
-index 1aa8631a..2304ce1f 100644
 --- a/build_llvm.py
 +++ b/build_llvm.py
-@@ -346,34 +346,24 @@ def build_warp_clang_for_arch(args, lib_name: str, arch: str) -> None:
- 
-         clang_dll_path = os.path.join(build_path, f"bin/{lib_name}")
- 
+@@ -378,34 +378,24 @@
+
+         clang_dll_path = os.path.join(build_path, "bin", lib_name)
+
 -        if args.build_llvm:
 -            # obtain Clang and LLVM libraries from the local build
 -            install_path = os.path.join(llvm_install_path, f"{args.mode}-{arch}")
@@ -13,7 +11,7 @@ index 1aa8631a..2304ce1f 100644
 -        else:
 -            # obtain Clang and LLVM libraries from packman
 -            fetch_prebuilt_libraries(arch)
--            libpath = os.path.join(base_path, f"_build/host-deps/llvm-project/release-{arch}/lib")
+-            libpath = os.path.join(base_path, "_build", "host-deps", "llvm-project", f"release-{arch}", "lib")
 -
 -        libs = []
 -
@@ -23,7 +21,7 @@ index 1aa8631a..2304ce1f 100644
 +        libs = ["LLVM", "clang-cpp"]
 +        install_paths = ["@LLVM_LIB@", "@LIBCLANG_LIB@"]
 +        libpaths = [os.path.join(install_path, "lib") for install_path in install_paths]
- 
+
          if os.name == "nt":
              libs.append("Version.lib")
              libs.append("Ws2_32.lib")
@@ -44,4 +42,3 @@ index 1aa8631a..2304ce1f 100644
              libs.append("-lpthread")
              libs.append("-ldl")
              if sys.platform != "darwin":
-


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327166928)](https://hydra.nixos.org/build/327166928)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
