### PR TITLE
python3Packages.rbtools: skip git-svn tests requiring svn checkout

### DIFF
--- a/pkgs/development/python-modules/rbtools/default.nix
+++ b/pkgs/development/python-modules/rbtools/default.nix
@@ -72,6 +72,7 @@ buildPythonPackage rec {
     "rbtools/diffs/tests/test_apple_diff_tool.py::AppleDiffToolTests::test_run_diff_file_with_text_differences" # AssertionError: b'---[38 chars]0000 +0000\n+++ /path2.txt\t2022-09-26 10:20:3[42 chars]ar\n' != b'---[38 chars]0000 -0700\n+++ /path2.txt\t2022-09-26 10:20:3[42 chars]ar\n'
     # rbtools.utils.process.RunProcessError: Unexpected error executing the command: svn co file:///build/source/rbtools/clients/tests/testdata/svn-repo /build/rbtools._bw2ih4g/working/svn-repo
     "rbtools/clients/tests/test_svn.py"
+    "rbtools/clients/tests/test_git.py::GitSubversionClientTests"
     "rbtools/utils/tests/test_source_tree.py"
     "rbtools/clients/tests/test_scanning.py::ScanningTests::test_scanning_nested_repos_1"
     "rbtools/clients/tests/test_scanning.py::ScanningTests::test_scanning_nested_repos_2"


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327836690)](https://hydra.nixos.org/build/327836690)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
