### PR TITLE
lib.customisation: add `prevScope` to `makeScope`'s output set

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -497,7 +497,7 @@ rec {
 
        A function that takes an attribute set `attrs` and returns what ends up as `callPackage` in the output.
 
-       Typical values are `callPackageWith` or the output attribute `newScope`.
+       Typical values are `callPackageWith`, for a basic scope, or another scope's `newScope` function, to extend that scope.
 
     2. `f` (`AttrSet -> AttrSet`)
 
@@ -517,6 +517,7 @@ rec {
     scope :: {
       callPackage :: ((AttrSet -> a) | Path) -> AttrSet -> a
       newScope = AttrSet -> scope
+      prevScope :: AttrSet -> ((AttrSet -> a) | Path) -> AttrSet -> a
       overrideScope = (scope -> scope -> AttrSet) -> scope
       packages :: AttrSet -> AttrSet
     }
@@ -536,7 +537,12 @@ rec {
 
     - `newScope` (`AttrSet -> scope`)
 
-      Takes an attribute set `attrs` and returns a scope that extends the original scope.
+      Constructs a new scope by extending this scope with the additional attribute set `attrs`.
+
+    - `prevScope` (`AttrSet -> ((AttrSet -> a) | Path) -> AttrSet -> a`)
+
+      The value of the argument `newScope` to this `makeScope` call.
+      This can be used to access the "outer" scope, particularly when there is a name clash with attributes in this scope.
 
     - `overrideScope` (`(scope -> scope -> AttrSet) -> scope`)
 
@@ -576,6 +582,7 @@ rec {
     {
       callPackage = «lambda»;
       newScope = «lambda»;
+      prevScope = «lambda»;
       overrideScope = «lambda»;
       packages = «lambda»;
       foo = «derivation»;
@@ -620,6 +627,7 @@ rec {
       // f self
       // {
         newScope = scope: newScope (self // scope);
+        prevScope = newScope;
         overrideScope = g: makeScope newScope (extends g f);
         packages = f;
       };

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -4804,6 +4804,7 @@ runTests {
             !lib.elem name [
               "callPackage"
               "newScope"
+              "prevScope"
               "overrideScope"
               "packages"
             ]


### PR DESCRIPTION
This adds `prevScope` (name subject to change) to the attribute set returned by `makeScope`. prevScope can be used to access the outer/parent scope of a nested package scope, which is particularly useful when there are name clashes.

## Example
Here, the parent scope is `basePackages` and the sub-scope is `ocamlPackages`. This shows some different usage. Note that the `prevScope` is a callPackage function with an additional scope argument in front, hence the `.prevScope {} ({ x }: x) {}` calls.
```nix
let
  pkgs = import (fetchTarball https://github.com/katrinafyi/nixpkgs/archive/patch-1.tar.gz) {};

in rec {
  basePackages = pkgs.lib.makeScope pkgs.lib.callPackageWith (_: {
    x = "parent scope";
  });

  ocamlPackages = pkgs.lib.makeScope basePackages.newScope (_: {
    x = "child scope";
  });

  x = ocamlPackages.x;
  x-using-prev = ocamlPackages.prevScope {} ({ x }: x) {};

  overriding = ocamlPackages.overrideScope (final: _: {
    parent-x = final.prevScope {} ({ x }: x) {};

    # we can now use x and parent-x side-by-side!
    combined = final.callPackage ({ x, parent-x }: x + parent-x) {};
  });

  # prevScope accesses basePackages directly and is not confused by overrides
  skips-override = (ocamlPackages.overrideScope (final: _: {
    x = "overriding scope";
  })).prevScope {} ({ x }: x) {};
}
```

... results in this:
```console
$ for attr in basePackages.x ocamlPackages.x x x-using-prev overriding.parent-x overriding.combined skips-override; do printf '%s = ' $attr; nix-instantiate ./prevscope.nix --eval -A $attr; done
basePackages.x = "parent scope"
ocamlPackages.x = "child scope"
x = "child scope"
x-using-prev = "parent scope"
overriding.parent-x = "parent scope"
overriding.combined = "child scopeparent scope"
skips-override = "parent scope"
```

## Discussion
Presently, when there is a clash between a parent scope and a sub-scope, the parent scope's package is inaccessible; it has to be accessed using a separate reference to the parent package set. This explicit reference to the parent is at risk of differing from the actual parent scope, e.g., in case of overrides. Moreover, the explicit reference also makes it *impossible* to write a portable self-contained overlay - it forces you to reference an external parent package set.

I'd like tips on how to add the tests. I've also made minor changes to other lines of the docs (this can be reverted if you want). I promise I'll fix the commits after review.

This change causes no rebuild of pkgs.hello.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
