### PR TITLE
python3Packages.tritonclient: 2.54.0 -> 2.68.0

### DIFF
--- a/pkgs/development/python-modules/tritonclient/default.nix
+++ b/pkgs/development/python-modules/tritonclient/default.nix
@@ -5,6 +5,7 @@
   fetchPypi,
   numpy,
   python-rapidjson,
+  urllib3,
   # optional dependencies
   aiohttp,
   geventhttpclient,
@@ -14,7 +15,7 @@
 
 let
   pname = "tritonclient";
-  version = "2.54.0";
+  version = "2.68.0";
   format = "wheel";
 in
 buildPythonPackage rec {
@@ -27,8 +28,8 @@ buildPythonPackage rec {
         x86_64-linux = "manylinux1_x86_64";
       };
       hashes = {
-        aarch64-linux = "e485a67c75121a2b58456bd6275086252dd72208674b0c85bd57a60f428b686f";
-        x86_64-linux = "53c326498e9036f99347a938d52abd819743e957223edec31ae3c9681e5a6065";
+        aarch64-linux = "sha256-RkHdD4yPvo85Fqts07XFsgiMUCFXWiWuHQqfGDznJGk=";
+        x86_64-linux = "sha256-7h98H/ipZk56193fhhaSR62Mnis4Wakn/ZhOrhWa4vc=";
       };
     in
     fetchPypi {
@@ -38,13 +39,14 @@ buildPythonPackage rec {
       platform =
         platforms.${stdenv.hostPlatform.system}
           or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
-      sha256 =
+      hash =
         hashes.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
     };
 
   propagatedBuildInputs = [
     numpy
     python-rapidjson
+    urllib3
   ];
 
   pythonImportsCheck = [ "tritonclient" ];


### PR DESCRIPTION
Diff: https://github.com/triton-inference-server/client/compare/r25.01...r26.04
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327165309)](https://hydra.nixos.org/build/327165309)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
