### PR TITLE
rocq-mcp: init at 0.2.1-unstable-2026-05-06; python3Packages.pytanque: init at 0.2.

### DIFF
--- a/pkgs/by-name/ro/rocq-mcp/package.nix
+++ b/pkgs/by-name/ro/rocq-mcp/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "rocq-mcp";
+  version = "0.2.1-unstable-2026-05-06";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "LLM4Rocq";
+    repo = "rocq-mcp";
+    rev = "612dec76009237e89c52a85bd29c10a75e712831";
+    hash = "sha256-UdlwMv+bceC0xLTL+5q2l+1gKYrs6ChKAb01fIC+7dU=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    fastmcp
+    psutil
+    pytanque
+  ];
+
+  # Tests require a running pet-server (Petanque/coq-lsp).
+  doCheck = false;
+
+  pythonImportsCheck = [ "rocq_mcp" ];
+
+  meta = {
+    description = "MCP server for Rocq/Coq proof development";
+    homepage = "https://github.com/LLM4Rocq/rocq-mcp";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ remix7531 ];
+    mainProgram = "rocq-mcp";
+  };
+}

--- a/pkgs/development/python-modules/pytanque/default.nix
+++ b/pkgs/development/python-modules/pytanque/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  requests,
+  typing-extensions,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pytanque";
+  version = "0.2.2";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "LLM4Rocq";
+    repo = "pytanque";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1Hae21BuMdE6MjRdiBO7fcsuS4HzahOdLLhynAUox3I=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    requests
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  # Tests require a running pet-server (Petanque/coq-lsp).
+  doCheck = false;
+
+  pythonImportsCheck = [ "pytanque" ];
+
+  meta = {
+    description = "Python client for the Petanque JSON-RPC interface to coq-lsp";
+    homepage = "https://github.com/LLM4Rocq/pytanque";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ remix7531 ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15357,6 +15357,8 @@ self: super: with self; {
 
   pytankerkoenig = callPackage ../development/python-modules/pytankerkoenig { };
 
+  pytanque = callPackage ../development/python-modules/pytanque { };
+
   pytap2 = callPackage ../development/python-modules/pytap2 { };
 
   pytapo = callPackage ../development/python-modules/pytapo { };


### PR DESCRIPTION
Adds two new packages enabling the Rocq MCP toolchain:

- `python3Packages.pytanque` (0.2.2) — Python client for the Petanque JSON-RPC interface to coq-lsp. Upstream: https://github.com/LLM4Rocq/pytanque
- `rocq-mcp` — MCP (Model Context Protocol) server for Rocq/Coq proof development, built on FastMCP. Upstream: https://github.com/LLM4Rocq/rocq-mcp. Pinned to `main` (0.2.1) since 0.2.1 is unreleased upstream but is the first version requiring `fastmcp >= 3.1` and `psutil`, both now available in nixpkgs.

This was previously blocked on `fastmcp` 3 landing in nixpkgs; with `fastmcp` 3.2.3 in tree, both packages now build.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test