### PR TITLE
nixos/avahi: migrate settings to rfc42

### DIFF
--- a/nixos/modules/services/audio/pulseaudio.nix
+++ b/nixos/modules/services/audio/pulseaudio.nix
@@ -295,8 +295,11 @@ in
         services.avahi.enable = true;
       })
       (lib.mkIf cfg.zeroconf.publish.enable {
-        services.avahi.publish.enable = true;
-        services.avahi.publish.userServices = true;
+        services.avahi.settings.publish = {
+          "disable-publishing" = false;
+          "disable-user-service-publishing" = false;
+          "publish-addresses" = true;
+        };
       })
       (lib.mkIf cfg.tcp.openFirewall {
         networking.firewall.allowedTCPPorts = [ cfg.tcp.port ];

--- a/nixos/modules/services/misc/guix/default.nix
+++ b/nixos/modules/services/misc/guix/default.nix
@@ -277,8 +277,11 @@ in
         # Guix uses Avahi (through guile-avahi) both for the auto-discovering and
         # advertising substitute servers in the local network.
         services.avahi.enable = lib.mkDefault true;
-        services.avahi.publish.enable = lib.mkDefault true;
-        services.avahi.publish.userServices = lib.mkDefault true;
+        services.avahi.settings.publish = {
+          "disable-publishing" = lib.mkDefault false;
+          "disable-user-service-publishing" = lib.mkDefault false;
+          "publish-addresses" = lib.mkDefault true;
+        };
 
         # It's similar to Nix daemon so there's no question whether or not this
         # should be sandboxed.

--- a/nixos/modules/services/networking/avahi-daemon.nix
+++ b/nixos/modules/services/networking/avahi-daemon.nix
@@ -7,45 +7,20 @@
 let
   cfg = config.services.avahi;
 
-  avahiDaemonConf =
-    with cfg;
-    pkgs.writeText "avahi-daemon.conf" ''
-      [server]
-      ${
-        # Users can set `networking.hostName' to the empty string, when getting
-        # a host name from DHCP.  In that case, let Avahi take whatever the
-        # current host name is; setting `host-name' to the empty string in
-        # `avahi-daemon.conf' would be invalid.
-        lib.optionalString (hostName != "") "host-name=${hostName}"
-      }
-      browse-domains=${lib.concatStringsSep ", " browseDomains}
-      use-ipv4=${lib.boolToYesNo ipv4}
-      use-ipv6=${lib.boolToYesNo ipv6}
-      ${lib.optionalString (
-        allowInterfaces != null
-      ) "allow-interfaces=${lib.concatStringsSep "," allowInterfaces}"}
-      ${lib.optionalString (
-        denyInterfaces != null
-      ) "deny-interfaces=${lib.concatStringsSep "," denyInterfaces}"}
-      ${lib.optionalString (domainName != null) "domain-name=${domainName}"}
-      allow-point-to-point=${lib.boolToYesNo allowPointToPoint}
-      ${lib.optionalString (cacheEntriesMax != null) "cache-entries-max=${toString cacheEntriesMax}"}
+  settingsFormat = pkgs.formats.ini {
+    mkKeyValue = lib.generators.mkKeyValueDefault {
+      mkValueString =
+        v: if lib.isBool v then lib.boolToYesNo v else lib.generators.mkValueStringDefault { } v;
+    } "=";
+    listToValue = lib.concatMapStringsSep ", " (lib.generators.mkValueStringDefault { });
+  };
 
-      [wide-area]
-      enable-wide-area=${lib.boolToYesNo wideArea}
-
-      [publish]
-      disable-publishing=${lib.boolToYesNo (!publish.enable)}
-      disable-user-service-publishing=${lib.boolToYesNo (!publish.userServices)}
-      publish-addresses=${lib.boolToYesNo (publish.userServices || publish.addresses)}
-      publish-hinfo=${lib.boolToYesNo publish.hinfo}
-      publish-workstation=${lib.boolToYesNo publish.workstation}
-      publish-domain=${lib.boolToYesNo publish.domain}
-
-      [reflector]
-      enable-reflector=${lib.boolToYesNo reflector}
-      ${extraConfig}
-    '';
+  avahiDaemonConf = pkgs.concatText "avahi-daemon.conf" [
+    (settingsFormat.generate "avahi-daemon.conf" (
+      lib.filterAttrsRecursive (_: v: v != null) cfg.settings
+    ))
+    (pkgs.writeText "avahi-daemon-extra.conf" cfg.extraConfig)
+  ];
 in
 {
   imports = [
@@ -69,6 +44,153 @@ in
     };
 
     package = lib.mkPackageOption pkgs "avahi" { };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = settingsFormat.type;
+
+        options = {
+          server = {
+            "host-name" = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              description = ''
+                Host name advertised on the LAN. If unset, Avahi will use the
+                system host name.
+              '';
+            };
+
+            "domain-name" = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              description = "Domain name for all advertisements.";
+            };
+
+            "browse-domains" = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              default = [ ];
+              description = "List of non-local DNS domains to be browsed.";
+            };
+
+            "use-ipv4" = lib.mkOption {
+              type = lib.types.bool;
+              default = true;
+              description = "Whether to use IPv4.";
+            };
+
+            "use-ipv6" = lib.mkOption {
+              type = lib.types.bool;
+              default = config.networking.enableIPv6;
+              defaultText = lib.literalExpression "config.networking.enableIPv6";
+              description = "Whether to use IPv6.";
+            };
+
+            "allow-interfaces" = lib.mkOption {
+              type = lib.types.nullOr (lib.types.listOf lib.types.str);
+              default = null;
+              description = ''
+                List of network interfaces that should be used by the
+                {command}`avahi-daemon`. Other interfaces will be ignored. If
+                `null`, all local interfaces except loopback and point-to-point
+                will be used.
+              '';
+            };
+
+            "deny-interfaces" = lib.mkOption {
+              type = lib.types.nullOr (lib.types.listOf lib.types.str);
+              default = null;
+              description = ''
+                List of network interfaces that should be ignored by the
+                {command}`avahi-daemon`. Other unspecified interfaces will be
+                used, unless `allow-interfaces` is set. This option takes
+                precedence over `allow-interfaces`.
+              '';
+            };
+
+            "allow-point-to-point" = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = ''
+                Whether to use POINTTOPOINT interfaces. Might make mDNS
+                unreliable due to usually large latencies with such links and
+                opens a potential security hole by allowing mDNS access from
+                Internet connections.
+              '';
+            };
+
+            "cache-entries-max" = lib.mkOption {
+              type = lib.types.nullOr lib.types.int;
+              default = null;
+              description = ''
+                Number of resource records to be cached per interface. Use 0 to
+                disable caching. Avahi daemon defaults to 4096 if not set.
+              '';
+            };
+          };
+
+          "wide-area"."enable-wide-area" = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = "Whether to enable wide-area service discovery.";
+          };
+
+          publish = {
+            "disable-publishing" = lib.mkOption {
+              type = lib.types.bool;
+              default = true;
+              description = "Whether to disable publishing in general.";
+            };
+
+            "disable-user-service-publishing" = lib.mkOption {
+              type = lib.types.bool;
+              default = true;
+              description = "Whether to disable publishing user services.";
+            };
+
+            "publish-addresses" = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = "Whether to register mDNS address records for all local IP addresses.";
+            };
+
+            "publish-hinfo" = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = ''
+                Whether to register a mDNS HINFO record which contains
+                information about the local operating system and CPU.
+              '';
+            };
+
+            "publish-workstation" = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = ''
+                Whether to register a service of type "_workstation._tcp" on the
+                local LAN.
+              '';
+            };
+
+            "publish-domain" = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = "Whether to announce the locally used domain name for browsing by other hosts.";
+            };
+          };
+
+          reflector."enable-reflector" = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = "Reflect incoming mDNS requests to all allowed network interfaces.";
+          };
+        };
+      };
+      default = { };
+      description = ''
+        Configuration for {file}`avahi-daemon.conf` as a Nix attribute set.
+        See {manpage}`avahi-daemon.conf(5)` for available options.
+      '';
+    };
 
     hostName = lib.mkOption {
       type = lib.types.str;
@@ -282,137 +404,180 @@ in
     debug = lib.mkEnableOption "debug logging";
   };
 
-  config = lib.mkIf cfg.enable {
+  config = lib.mkMerge [
+    {
     warnings = [
       (lib.mkIf cfg.wideArea "Enabling `services.avahi.wideArea` exposes this system to `CVE-2024-52615`.")
     ];
+  }
+    {
+      services.avahi.settings = lib.mkMerge [
+        {
+          server = {
+            "browse-domains" = lib.mkDefault cfg.browseDomains;
+            "use-ipv4" = lib.mkDefault cfg.ipv4;
+            "use-ipv6" = lib.mkDefault cfg.ipv6;
+            "domain-name" = lib.mkDefault cfg.domainName;
+            "allow-point-to-point" = lib.mkDefault cfg.allowPointToPoint;
+          };
 
-    users.users.avahi = {
-      description = "avahi-daemon privilege separation user";
-      home = "/var/empty";
-      group = "avahi";
-      isSystemUser = true;
-    };
+          "wide-area"."enable-wide-area" = lib.mkDefault cfg.wideArea;
 
-    users.groups.avahi = { };
+          publish = {
+            "disable-publishing" = lib.mkDefault (!cfg.publish.enable);
+            "disable-user-service-publishing" = lib.mkDefault (!cfg.publish.userServices);
+            "publish-addresses" = lib.mkDefault (cfg.publish.userServices || cfg.publish.addresses);
+            "publish-hinfo" = lib.mkDefault cfg.publish.hinfo;
+            "publish-workstation" = lib.mkDefault cfg.publish.workstation;
+            "publish-domain" = lib.mkDefault cfg.publish.domain;
+          };
 
-    system.nssModules = lib.optional (cfg.nssmdns4 || cfg.nssmdns6) pkgs.nssmdns;
-    system.nssDatabases.hosts =
-      let
-        mdns =
-          if (cfg.nssmdns4 && cfg.nssmdns6) then
-            "mdns"
-          else if (!cfg.nssmdns4 && cfg.nssmdns6) then
-            "mdns6"
-          else if (cfg.nssmdns4 && !cfg.nssmdns6) then
-            "mdns4"
-          else
-            "";
-      in
-      lib.optionals (cfg.nssmdns4 || cfg.nssmdns6) (
-        lib.mkMerge [
-          (lib.mkBefore [ "${mdns}_minimal [NOTFOUND=return]" ]) # before resolve
-          (lib.mkAfter [ "${mdns}" ]) # after dns
-        ]
+          reflector."enable-reflector" = lib.mkDefault cfg.reflector;
+        }
+        (lib.mkIf (cfg.hostName != "") {
+          server."host-name" = lib.mkDefault cfg.hostName;
+        })
+        (lib.mkIf (cfg.allowInterfaces != null) {
+          server."allow-interfaces" = lib.mkDefault cfg.allowInterfaces;
+        })
+        (lib.mkIf (cfg.denyInterfaces != null) {
+          server."deny-interfaces" = lib.mkDefault cfg.denyInterfaces;
+        })
+        (lib.mkIf (cfg.cacheEntriesMax != null) {
+          server."cache-entries-max" = lib.mkDefault cfg.cacheEntriesMax;
+        })
+      ];
+    }
+
+    (lib.mkIf cfg.enable {
+      users.users.avahi = {
+        description = "avahi-daemon privilege separation user";
+        home = "/var/empty";
+        group = "avahi";
+        isSystemUser = true;
+      };
+
+      users.groups.avahi = { };
+
+      system.nssModules = lib.optional (cfg.nssmdns4 || cfg.nssmdns6) pkgs.nssmdns;
+      system.nssDatabases.hosts =
+        let
+          mdns =
+            if (cfg.nssmdns4 && cfg.nssmdns6) then
+              "mdns"
+            else if (!cfg.nssmdns4 && cfg.nssmdns6) then
+              "mdns6"
+            else if (cfg.nssmdns4 && !cfg.nssmdns6) then
+              "mdns4"
+            else
+              "";
+        in
+        lib.optionals (cfg.nssmdns4 || cfg.nssmdns6) (
+          lib.mkMerge [
+            (lib.mkBefore [ "${mdns}_minimal [NOTFOUND=return]" ]) # before resolve
+            (lib.mkAfter [ "${mdns}" ]) # after dns
+          ]
+        );
+
+      environment.systemPackages = [ cfg.package ];
+
+      environment.etc = (
+        lib.mapAttrs' (
+          n: v:
+          lib.nameValuePair "avahi/services/${n}.service" {
+            ${if lib.types.path.check v then "source" else "text"} = v;
+          }
+        ) cfg.extraServiceFiles
+>>>>>>> tntkqmnr 191d347d "nixos/avahi: migrate settings to rfc42" (rebased revision)
       );
 
-    environment.systemPackages = [ cfg.package ];
-
-    environment.etc = (
-      lib.mapAttrs' (
-        n: v:
-        lib.nameValuePair "avahi/services/${n}.service" {
-          ${if lib.types.path.check v then "source" else "text"} = v;
-        }
-      ) cfg.extraServiceFiles
-    );
-
-    systemd.sockets.avahi-daemon = {
-      description = "Avahi mDNS/DNS-SD Stack Activation Socket";
-      listenStreams = [ "/run/avahi-daemon/socket" ];
-      wantedBy = [ "sockets.target" ];
-      after = [
-        # Ensure that `/run/avahi-daemon` owned by `avahi` is created by `systemd.tmpfiles.rules` before the `avahi-daemon.socket`,
-        # otherwise `avahi-daemon.socket` will automatically create it owned by `root`, which will cause `avahi-daemon.service` to fail.
-        "systemd-tmpfiles-setup.service"
-      ];
-    };
-
-    systemd.tmpfiles.rules = [ "d /run/avahi-daemon - avahi avahi -" ];
-
-    systemd.services.avahi-daemon = {
-      description = "Avahi mDNS/DNS-SD Stack";
-      wantedBy = [ "multi-user.target" ];
-      requires = [ "avahi-daemon.socket" ];
-      documentation = [
-        "man:avahi-daemon(8)"
-        "man:avahi-daemon.conf(5)"
-        "man:avahi.hosts(5)"
-        "man:avahi.service(5)"
-      ];
-
-      # Make NSS modules visible so that `avahi_nss_support ()' can
-      # return a sensible value.
-      environment.LD_LIBRARY_PATH = config.system.nssModules.path;
-
-      path = [
-        pkgs.coreutils
-        cfg.package
-      ];
-
-      serviceConfig = {
-        NotifyAccess = "main";
-        BusName = "org.freedesktop.Avahi";
-        Type = "dbus";
-        ExecStart = "${cfg.package}/sbin/avahi-daemon --syslog -f ${avahiDaemonConf} ${lib.optionalString cfg.debug "--debug"}";
-        ConfigurationDirectory = "avahi/services";
-
-        # Hardening
-        CapabilityBoundingSet = [
-          # https://github.com/avahi/avahi/blob/v0.9-rc1/avahi-daemon/caps.c#L38
-          "CAP_SYS_CHROOT"
-          "CAP_SETUID"
-          "CAP_SETGID"
+      systemd.sockets.avahi-daemon = {
+        description = "Avahi mDNS/DNS-SD Stack Activation Socket";
+        listenStreams = [ "/run/avahi-daemon/socket" ];
+        wantedBy = [ "sockets.target" ];
+        after = [
+          # Ensure that `/run/avahi-daemon` owned by `avahi` is created by `systemd.tmpfiles.rules` before the `avahi-daemon.socket`,
+          # otherwise `avahi-daemon.socket` will automatically create it owned by `root`, which will cause `avahi-daemon.service` to fail.
+          "systemd-tmpfiles-setup.service"
         ];
-        DevicePolicy = "closed";
-        LockPersonality = true;
-        MemoryDenyWriteExecute = true;
-        NoNewPrivileges = true;
-        PrivateDevices = true;
-        PrivateTmp = true;
-        PrivateUsers = false;
-        ProcSubset = "pid";
-        ProtectClock = true;
-        ProtectControlGroups = true;
-        ProtectHome = true;
-        ProtectHostname = true;
-        ProtectKernelLogs = true;
-        ProtectKernelModules = true;
-        ProtectKernelTunables = true;
-        ProtectProc = "invisible";
-        ProtectSystem = "strict";
-        RestrictAddressFamilies = [
-          "AF_INET"
-          "AF_INET6"
-          "AF_NETLINK"
-          "AF_UNIX"
-        ];
-        RestrictNamespaces = true;
-        RestrictRealtime = true;
-        RestrictSUIDSGID = true;
-        SystemCallArchitectures = "native";
-        SystemCallFilter = [
-          "@system-service"
-          "~@privileged"
-          "@chown setgroups setresuid"
-        ];
-        UMask = "0077";
       };
-    };
 
-    services.dbus.enable = true;
-    services.dbus.packages = [ cfg.package ];
+      systemd.tmpfiles.rules = [ "d /run/avahi-daemon - avahi avahi -" ];
 
-    networking.firewall.allowedUDPPorts = lib.mkIf cfg.openFirewall [ 5353 ];
-  };
+      systemd.services.avahi-daemon = {
+        description = "Avahi mDNS/DNS-SD Stack";
+        wantedBy = [ "multi-user.target" ];
+        requires = [ "avahi-daemon.socket" ];
+        documentation = [
+          "man:avahi-daemon(8)"
+          "man:avahi-daemon.conf(5)"
+          "man:avahi.hosts(5)"
+          "man:avahi.service(5)"
+        ];
+
+        # Make NSS modules visible so that `avahi_nss_support ()' can
+        # return a sensible value.
+        environment.LD_LIBRARY_PATH = config.system.nssModules.path;
+
+        path = [
+          pkgs.coreutils
+          cfg.package
+        ];
+
+        serviceConfig = {
+          NotifyAccess = "main";
+          BusName = "org.freedesktop.Avahi";
+          Type = "dbus";
+          ExecStart = "${cfg.package}/sbin/avahi-daemon --syslog -f ${avahiDaemonConf} ${lib.optionalString cfg.debug "--debug"}";
+          ConfigurationDirectory = "avahi/services";
+
+          # Hardening
+          CapabilityBoundingSet = [
+            # https://github.com/avahi/avahi/blob/v0.9-rc1/avahi-daemon/caps.c#L38
+            "CAP_SYS_CHROOT"
+            "CAP_SETUID"
+            "CAP_SETGID"
+          ];
+          DevicePolicy = "closed";
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          NoNewPrivileges = true;
+          PrivateDevices = true;
+          PrivateTmp = true;
+          PrivateUsers = false;
+          ProcSubset = "pid";
+          ProtectClock = true;
+          ProtectControlGroups = true;
+          ProtectHome = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectProc = "invisible";
+          ProtectSystem = "strict";
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+            "AF_NETLINK"
+            "AF_UNIX"
+          ];
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          SystemCallArchitectures = "native";
+          SystemCallFilter = [
+            "@system-service"
+            "~@privileged"
+            "@chown setgroups setresuid"
+          ];
+          UMask = "0077";
+        };
+      };
+
+      services.dbus.enable = true;
+      services.dbus.packages = [ cfg.package ];
+
+      networking.firewall.allowedUDPPorts = lib.mkIf cfg.openFirewall [ 5353 ];
+    })
+  ];
 }

--- a/nixos/modules/services/networking/avahi-daemon.nix
+++ b/nixos/modules/services/networking/avahi-daemon.nix
@@ -15,10 +15,19 @@ let
     listToValue = lib.concatMapStringsSep ", " (lib.generators.mkValueStringDefault { });
   };
 
+  settings =
+    let
+      filteredSettings = lib.filterAttrsRecursive (_: v: v != null) cfg.settings;
+    in
+    filteredSettings
+    // {
+      server = lib.removeAttrs (filteredSettings.server or { }) (
+        lib.optional ((filteredSettings.server."host-name" or null) == "") "host-name"
+      );
+    };
+
   avahiDaemonConf = pkgs.concatText "avahi-daemon.conf" [
-    (settingsFormat.generate "avahi-daemon.conf" (
-      lib.filterAttrsRecursive (_: v: v != null) cfg.settings
-    ))
+    (settingsFormat.generate "avahi-daemon.conf" settings)
     (pkgs.writeText "avahi-daemon-extra.conf" cfg.extraConfig)
   ];
 in
@@ -26,9 +35,165 @@ in
   imports = [
     (lib.mkRenamedOptionModule
       [ "services" "avahi" "interfaces" ]
-      [ "services" "avahi" "allowInterfaces" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "server"
+        "allow-interfaces"
+      ]
     )
     (lib.mkRenamedOptionModule [ "services" "avahi" "nssmdns" ] [ "services" "avahi" "nssmdns4" ])
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "hostName" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "server"
+        "host-name"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "domainName" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "server"
+        "domain-name"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "browseDomains" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "server"
+        "browse-domains"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "ipv4" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "server"
+        "use-ipv4"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "ipv6" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "server"
+        "use-ipv6"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "allowInterfaces" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "server"
+        "allow-interfaces"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "denyInterfaces" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "server"
+        "deny-interfaces"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "allowPointToPoint" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "server"
+        "allow-point-to-point"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "wideArea" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "wide-area"
+        "enable-wide-area"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "reflector" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "reflector"
+        "enable-reflector"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "cacheEntriesMax" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "server"
+        "cache-entries-max"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "publish" "addresses" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "publish"
+        "publish-addresses"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "publish" "hinfo" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "publish"
+        "publish-hinfo"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "publish" "workstation" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "publish"
+        "publish-workstation"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "publish" "domain" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "publish"
+        "publish-domain"
+      ]
+    )
   ];
 
   options.services.avahi = {
@@ -62,7 +227,7 @@ in
 
             "domain-name" = lib.mkOption {
               type = lib.types.nullOr lib.types.str;
-              default = null;
+              default = "local";
               description = "Domain name for all advertisements.";
             };
 
@@ -192,70 +357,6 @@ in
       '';
     };
 
-    hostName = lib.mkOption {
-      type = lib.types.str;
-      default = config.networking.hostName;
-      defaultText = lib.literalExpression "config.networking.hostName";
-      description = ''
-        Host name advertised on the LAN. If not set, avahi will use the value
-        of {option}`config.networking.hostName`.
-      '';
-    };
-
-    domainName = lib.mkOption {
-      type = lib.types.str;
-      default = "local";
-      description = ''
-        Domain name for all advertisements.
-      '';
-    };
-
-    browseDomains = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
-      default = [ ];
-      example = [
-        "0pointer.de"
-        "zeroconf.org"
-      ];
-      description = ''
-        List of non-local DNS domains to be browsed.
-      '';
-    };
-
-    ipv4 = lib.mkOption {
-      type = lib.types.bool;
-      default = true;
-      description = "Whether to use IPv4.";
-    };
-
-    ipv6 = lib.mkOption {
-      type = lib.types.bool;
-      default = config.networking.enableIPv6;
-      defaultText = lib.literalExpression "config.networking.enableIPv6";
-      description = "Whether to use IPv6.";
-    };
-
-    allowInterfaces = lib.mkOption {
-      type = lib.types.nullOr (lib.types.listOf lib.types.str);
-      default = null;
-      description = ''
-        List of network interfaces that should be used by the {command}`avahi-daemon`.
-        Other interfaces will be ignored. If `null`, all local interfaces
-        except loopback and point-to-point will be used.
-      '';
-    };
-
-    denyInterfaces = lib.mkOption {
-      type = lib.types.nullOr (lib.types.listOf lib.types.str);
-      default = null;
-      description = ''
-        List of network interfaces that should be ignored by the
-        {command}`avahi-daemon`. Other unspecified interfaces will be used,
-        unless {option}`allowInterfaces` is set. This option takes precedence
-        over {option}`allowInterfaces`.
-      '';
-    };
-
     openFirewall = lib.mkOption {
       type = lib.types.bool;
       default = true;
@@ -263,32 +364,6 @@ in
         Whether to open the firewall for UDP port 5353.
         Disabling this setting also disables discovering of network devices.
       '';
-    };
-
-    allowPointToPoint = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = ''
-        Whether to use POINTTOPOINT interfaces. Might make mDNS unreliable due to usually large
-        latencies with such links and opens a potential security hole by allowing mDNS access from Internet
-        connections.
-      '';
-    };
-
-    wideArea = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = ''
-        Whether to enable wide-area service discovery.
-
-        It is recommended to keep this options disabled as it exposes the system to `CVE-2024-52615`/`GHSA-x6vp-f33h-h32g`.
-      '';
-    };
-
-    reflector = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = "Reflect incoming mDNS requests to all allowed network interfaces.";
     };
 
     extraServiceFiles = lib.mkOption {
@@ -318,44 +393,17 @@ in
 
     publish = {
       enable = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
+        type = lib.types.nullOr lib.types.bool;
+        default = null;
+        visible = false;
         description = "Whether to allow publishing in general.";
       };
 
       userServices = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
+        type = lib.types.nullOr lib.types.bool;
+        default = null;
+        visible = false;
         description = "Whether to publish user services. Will set `addresses=true`.";
-      };
-
-      addresses = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = "Whether to register mDNS address records for all local IP addresses.";
-      };
-
-      hinfo = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = ''
-          Whether to register a mDNS HINFO record which contains information about the
-          local operating system and CPU.
-        '';
-      };
-
-      workstation = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = ''
-          Whether to register a service of type "_workstation._tcp" on the local LAN.
-        '';
-      };
-
-      domain = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = "Whether to announce the locally used domain name for browsing by other hosts.";
       };
     };
 
@@ -384,15 +432,6 @@ in
       '';
     };
 
-    cacheEntriesMax = lib.mkOption {
-      type = lib.types.nullOr lib.types.int;
-      default = null;
-      description = ''
-        Number of resource records to be cached per interface. Use 0 to
-        disable caching. Avahi daemon defaults to 4096 if not set.
-      '';
-    };
-
     extraConfig = lib.mkOption {
       type = lib.types.lines;
       default = "";
@@ -406,45 +445,31 @@ in
 
   config = lib.mkMerge [
     {
-    warnings = [
+      warnings = [
       (lib.mkIf cfg.wideArea "Enabling `services.avahi.wideArea` exposes this system to `CVE-2024-52615`.")
-    ];
-  }
-    {
+    ]
+        lib.optional (cfg.publish.enable != null) ''
+          The option `services.avahi.publish.enable` is obsolete. Use
+          `services.avahi.settings.publish."disable-publishing" = false;` instead.
+        ''
+        ++ lib.optional (cfg.publish.userServices != null) ''
+          The option `services.avahi.publish.userServices` is obsolete. Use
+          `services.avahi.settings.publish."disable-user-service-publishing" = false;`
+          and `services.avahi.settings.publish."publish-addresses" = true;` instead.
+        '';
+
       services.avahi.settings = lib.mkMerge [
-        {
-          server = {
-            "browse-domains" = lib.mkDefault cfg.browseDomains;
-            "use-ipv4" = lib.mkDefault cfg.ipv4;
-            "use-ipv6" = lib.mkDefault cfg.ipv6;
-            "domain-name" = lib.mkDefault cfg.domainName;
-            "allow-point-to-point" = lib.mkDefault cfg.allowPointToPoint;
-          };
-
-          "wide-area"."enable-wide-area" = lib.mkDefault cfg.wideArea;
-
-          publish = {
-            "disable-publishing" = lib.mkDefault (!cfg.publish.enable);
-            "disable-user-service-publishing" = lib.mkDefault (!cfg.publish.userServices);
-            "publish-addresses" = lib.mkDefault (cfg.publish.userServices || cfg.publish.addresses);
-            "publish-hinfo" = lib.mkDefault cfg.publish.hinfo;
-            "publish-workstation" = lib.mkDefault cfg.publish.workstation;
-            "publish-domain" = lib.mkDefault cfg.publish.domain;
-          };
-
-          reflector."enable-reflector" = lib.mkDefault cfg.reflector;
-        }
-        (lib.mkIf (cfg.hostName != "") {
-          server."host-name" = lib.mkDefault cfg.hostName;
+        (lib.mkIf (config.networking.hostName != "") {
+          server."host-name" = lib.mkDefault config.networking.hostName;
         })
-        (lib.mkIf (cfg.allowInterfaces != null) {
-          server."allow-interfaces" = lib.mkDefault cfg.allowInterfaces;
+        (lib.mkIf (cfg.publish.enable != null) {
+          publish."disable-publishing" = lib.mkDefault (!cfg.publish.enable);
         })
-        (lib.mkIf (cfg.denyInterfaces != null) {
-          server."deny-interfaces" = lib.mkDefault cfg.denyInterfaces;
+        (lib.mkIf (cfg.publish.userServices != null) {
+          publish."disable-user-service-publishing" = lib.mkDefault (!cfg.publish.userServices);
         })
-        (lib.mkIf (cfg.cacheEntriesMax != null) {
-          server."cache-entries-max" = lib.mkDefault cfg.cacheEntriesMax;
+        (lib.mkIf (cfg.publish.userServices == true) {
+          publish."publish-addresses" = lib.mkDefault true;
         })
       ];
     }
@@ -488,7 +513,6 @@ in
             ${if lib.types.path.check v then "source" else "text"} = v;
           }
         ) cfg.extraServiceFiles
->>>>>>> tntkqmnr 191d347d "nixos/avahi: migrate settings to rfc42" (rebased revision)
       );
 
       systemd.sockets.avahi-daemon = {

--- a/nixos/modules/services/networking/avahi-daemon.nix
+++ b/nixos/modules/services/networking/avahi-daemon.nix
@@ -15,10 +15,19 @@ let
     listToValue = lib.concatMapStringsSep ", " (lib.generators.mkValueStringDefault { });
   };
 
+  settings =
+    let
+      filteredSettings = lib.filterAttrsRecursive (_: v: v != null) cfg.settings;
+    in
+    filteredSettings
+    // {
+      server = lib.removeAttrs (filteredSettings.server or { }) (
+        lib.optional ((filteredSettings.server."host-name" or null) == "") "host-name"
+      );
+    };
+
   avahiDaemonConf = pkgs.concatText "avahi-daemon.conf" [
-    (settingsFormat.generate "avahi-daemon.conf" (
-      lib.filterAttrsRecursive (_: v: v != null) cfg.settings
-    ))
+    (settingsFormat.generate "avahi-daemon.conf" settings)
     (pkgs.writeText "avahi-daemon-extra.conf" cfg.extraConfig)
   ];
 in
@@ -26,9 +35,165 @@ in
   imports = [
     (lib.mkRenamedOptionModule
       [ "services" "avahi" "interfaces" ]
-      [ "services" "avahi" "allowInterfaces" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "server"
+        "allow-interfaces"
+      ]
     )
     (lib.mkRenamedOptionModule [ "services" "avahi" "nssmdns" ] [ "services" "avahi" "nssmdns4" ])
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "hostName" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "server"
+        "host-name"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "domainName" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "server"
+        "domain-name"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "browseDomains" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "server"
+        "browse-domains"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "ipv4" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "server"
+        "use-ipv4"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "ipv6" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "server"
+        "use-ipv6"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "allowInterfaces" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "server"
+        "allow-interfaces"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "denyInterfaces" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "server"
+        "deny-interfaces"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "allowPointToPoint" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "server"
+        "allow-point-to-point"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "wideArea" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "wide-area"
+        "enable-wide-area"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "reflector" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "reflector"
+        "enable-reflector"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "cacheEntriesMax" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "server"
+        "cache-entries-max"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "publish" "addresses" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "publish"
+        "publish-addresses"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "publish" "hinfo" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "publish"
+        "publish-hinfo"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "publish" "workstation" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "publish"
+        "publish-workstation"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "avahi" "publish" "domain" ]
+      [
+        "services"
+        "avahi"
+        "settings"
+        "publish"
+        "publish-domain"
+      ]
+    )
   ];
 
   options.services.avahi = {
@@ -62,7 +227,7 @@ in
 
             domain-name = lib.mkOption {
               type = lib.types.nullOr lib.types.str;
-              default = null;
+              default = "local";
               description = "Domain name for all advertisements.";
             };
 
@@ -191,70 +356,6 @@ in
       '';
     };
 
-    hostName = lib.mkOption {
-      type = lib.types.str;
-      default = config.networking.hostName;
-      defaultText = lib.literalExpression "config.networking.hostName";
-      description = ''
-        Host name advertised on the LAN. If not set, avahi will use the value
-        of {option}`config.networking.hostName`.
-      '';
-    };
-
-    domainName = lib.mkOption {
-      type = lib.types.str;
-      default = "local";
-      description = ''
-        Domain name for all advertisements.
-      '';
-    };
-
-    browseDomains = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
-      default = [ ];
-      example = [
-        "0pointer.de"
-        "zeroconf.org"
-      ];
-      description = ''
-        List of non-local DNS domains to be browsed.
-      '';
-    };
-
-    ipv4 = lib.mkOption {
-      type = lib.types.bool;
-      default = true;
-      description = "Whether to use IPv4.";
-    };
-
-    ipv6 = lib.mkOption {
-      type = lib.types.bool;
-      default = config.networking.enableIPv6;
-      defaultText = lib.literalExpression "config.networking.enableIPv6";
-      description = "Whether to use IPv6.";
-    };
-
-    allowInterfaces = lib.mkOption {
-      type = lib.types.nullOr (lib.types.listOf lib.types.str);
-      default = null;
-      description = ''
-        List of network interfaces that should be used by the {command}`avahi-daemon`.
-        Other interfaces will be ignored. If `null`, all local interfaces
-        except loopback and point-to-point will be used.
-      '';
-    };
-
-    denyInterfaces = lib.mkOption {
-      type = lib.types.nullOr (lib.types.listOf lib.types.str);
-      default = null;
-      description = ''
-        List of network interfaces that should be ignored by the
-        {command}`avahi-daemon`. Other unspecified interfaces will be used,
-        unless {option}`allowInterfaces` is set. This option takes precedence
-        over {option}`allowInterfaces`.
-      '';
-    };
-
     openFirewall = lib.mkOption {
       type = lib.types.bool;
       default = true;
@@ -262,32 +363,6 @@ in
         Whether to open the firewall for UDP port 5353.
         Disabling this setting also disables discovering of network devices.
       '';
-    };
-
-    allowPointToPoint = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = ''
-        Whether to use POINTTOPOINT interfaces. Might make mDNS unreliable due to usually large
-        latencies with such links and opens a potential security hole by allowing mDNS access from Internet
-        connections.
-      '';
-    };
-
-    wideArea = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = ''
-        Whether to enable wide-area service discovery.
-
-        It is recommended to keep this options disabled as it exposes the system to `CVE-2024-52615`/`GHSA-x6vp-f33h-h32g`.
-      '';
-    };
-
-    reflector = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = "Reflect incoming mDNS requests to all allowed network interfaces.";
     };
 
     extraServiceFiles = lib.mkOption {
@@ -317,44 +392,17 @@ in
 
     publish = {
       enable = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
+        type = lib.types.nullOr lib.types.bool;
+        default = null;
+        visible = false;
         description = "Whether to allow publishing in general.";
       };
 
       userServices = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
+        type = lib.types.nullOr lib.types.bool;
+        default = null;
+        visible = false;
         description = "Whether to publish user services. Will set `addresses=true`.";
-      };
-
-      addresses = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = "Whether to register mDNS address records for all local IP addresses.";
-      };
-
-      hinfo = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = ''
-          Whether to register a mDNS HINFO record which contains information about the
-          local operating system and CPU.
-        '';
-      };
-
-      workstation = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = ''
-          Whether to register a service of type "_workstation._tcp" on the local LAN.
-        '';
-      };
-
-      domain = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = "Whether to announce the locally used domain name for browsing by other hosts.";
       };
     };
 
@@ -405,15 +453,6 @@ in
       '';
     };
 
-    cacheEntriesMax = lib.mkOption {
-      type = lib.types.nullOr lib.types.int;
-      default = null;
-      description = ''
-        Number of resource records to be cached per interface. Use 0 to
-        disable caching. Avahi daemon defaults to 4096 if not set.
-      '';
-    };
-
     extraConfig = lib.mkOption {
       type = lib.types.lines;
       default = "";
@@ -427,54 +466,40 @@ in
 
   config = lib.mkMerge [
     {
-    assertions = [
-      {
-        assertion = cfg.nssmdnsFull -> (cfg.nssmdns4 || cfg.nssmdns6);
-        message = ''
-          `services.avahi.nssmdnsFull` requires one or both of `services.avahi.nssmdns4` and/or `services.avahi.nssmdns6` to be enabled.
-        '';
-      }
-    ];
-
-    warnings = [
-      (lib.mkIf cfg.wideArea "Enabling `services.avahi.wideArea` exposes this system to `CVE-2024-52615`.")
-    ];
-  }
-    {
-      services.avahi.settings = lib.mkMerge [
+      assertions = [
         {
-          server = {
-            "browse-domains" = lib.mkDefault cfg.browseDomains;
-            "use-ipv4" = lib.mkDefault cfg.ipv4;
-            "use-ipv6" = lib.mkDefault cfg.ipv6;
-            "domain-name" = lib.mkDefault cfg.domainName;
-            "allow-point-to-point" = lib.mkDefault cfg.allowPointToPoint;
-          };
-
-          "wide-area"."enable-wide-area" = lib.mkDefault cfg.wideArea;
-
-          publish = {
-            "disable-publishing" = lib.mkDefault (!cfg.publish.enable);
-            "disable-user-service-publishing" = lib.mkDefault (!cfg.publish.userServices);
-            "publish-addresses" = lib.mkDefault (cfg.publish.userServices || cfg.publish.addresses);
-            "publish-hinfo" = lib.mkDefault cfg.publish.hinfo;
-            "publish-workstation" = lib.mkDefault cfg.publish.workstation;
-            "publish-domain" = lib.mkDefault cfg.publish.domain;
-          };
-
-          reflector."enable-reflector" = lib.mkDefault cfg.reflector;
+          assertion = cfg.nssmdnsFull -> (cfg.nssmdns4 || cfg.nssmdns6);
+          message = ''
+            `services.avahi.nssmdnsFull` requires one or both of `services.avahi.nssmdns4` and/or `services.avahi.nssmdns6` to be enabled.
+          '';
         }
-        (lib.mkIf (cfg.hostName != "") {
-          server."host-name" = lib.mkDefault cfg.hostName;
+      ];
+
+      warnings = [
+        (lib.mkIf cfg.wideArea "Enabling `services.avahi.wideArea` exposes this system to `CVE-2024-52615`.")
+      ]
+      ++ lib.optional (cfg.publish.enable != null) ''
+        The option `services.avahi.publish.enable` is obsolete. Use
+        `services.avahi.settings.publish."disable-publishing" = false;` instead.
+      ''
+      ++ lib.optional (cfg.publish.userServices != null) ''
+        The option `services.avahi.publish.userServices` is obsolete. Use
+        `services.avahi.settings.publish."disable-user-service-publishing" = false;`
+        and `services.avahi.settings.publish."publish-addresses" = true;` instead.
+      '';
+
+      services.avahi.settings = lib.mkMerge [
+        (lib.mkIf (config.networking.hostName != "") {
+          server."host-name" = lib.mkDefault config.networking.hostName;
         })
-        (lib.mkIf (cfg.allowInterfaces != null) {
-          server."allow-interfaces" = lib.mkDefault cfg.allowInterfaces;
+        (lib.mkIf (cfg.publish.enable != null) {
+          publish."disable-publishing" = lib.mkDefault (!cfg.publish.enable);
         })
-        (lib.mkIf (cfg.denyInterfaces != null) {
-          server."deny-interfaces" = lib.mkDefault cfg.denyInterfaces;
+        (lib.mkIf (cfg.publish.userServices != null) {
+          publish."disable-user-service-publishing" = lib.mkDefault (!cfg.publish.userServices);
         })
-        (lib.mkIf (cfg.cacheEntriesMax != null) {
-          server."cache-entries-max" = lib.mkDefault cfg.cacheEntriesMax;
+        (lib.mkIf (cfg.publish.userServices == true) {
+          publish."publish-addresses" = lib.mkDefault true;
         })
       ];
     }

--- a/nixos/modules/services/networking/avahi-daemon.nix
+++ b/nixos/modules/services/networking/avahi-daemon.nix
@@ -7,45 +7,20 @@
 let
   cfg = config.services.avahi;
 
-  avahiDaemonConf =
-    with cfg;
-    pkgs.writeText "avahi-daemon.conf" ''
-      [server]
-      ${
-        # Users can set `networking.hostName' to the empty string, when getting
-        # a host name from DHCP.  In that case, let Avahi take whatever the
-        # current host name is; setting `host-name' to the empty string in
-        # `avahi-daemon.conf' would be invalid.
-        lib.optionalString (hostName != "") "host-name=${hostName}"
-      }
-      browse-domains=${lib.concatStringsSep ", " browseDomains}
-      use-ipv4=${lib.boolToYesNo ipv4}
-      use-ipv6=${lib.boolToYesNo ipv6}
-      ${lib.optionalString (
-        allowInterfaces != null
-      ) "allow-interfaces=${lib.concatStringsSep "," allowInterfaces}"}
-      ${lib.optionalString (
-        denyInterfaces != null
-      ) "deny-interfaces=${lib.concatStringsSep "," denyInterfaces}"}
-      ${lib.optionalString (domainName != null) "domain-name=${domainName}"}
-      allow-point-to-point=${lib.boolToYesNo allowPointToPoint}
-      ${lib.optionalString (cacheEntriesMax != null) "cache-entries-max=${toString cacheEntriesMax}"}
+  settingsFormat = pkgs.formats.ini {
+    mkKeyValue = lib.generators.mkKeyValueDefault {
+      mkValueString =
+        v: if lib.isBool v then lib.boolToYesNo v else lib.generators.mkValueStringDefault { } v;
+    } "=";
+    listToValue = lib.concatMapStringsSep ", " (lib.generators.mkValueStringDefault { });
+  };
 
-      [wide-area]
-      enable-wide-area=${lib.boolToYesNo wideArea}
-
-      [publish]
-      disable-publishing=${lib.boolToYesNo (!publish.enable)}
-      disable-user-service-publishing=${lib.boolToYesNo (!publish.userServices)}
-      publish-addresses=${lib.boolToYesNo (publish.userServices || publish.addresses)}
-      publish-hinfo=${lib.boolToYesNo publish.hinfo}
-      publish-workstation=${lib.boolToYesNo publish.workstation}
-      publish-domain=${lib.boolToYesNo publish.domain}
-
-      [reflector]
-      enable-reflector=${lib.boolToYesNo reflector}
-      ${extraConfig}
-    '';
+  avahiDaemonConf = pkgs.concatText "avahi-daemon.conf" [
+    (settingsFormat.generate "avahi-daemon.conf" (
+      lib.filterAttrsRecursive (_: v: v != null) cfg.settings
+    ))
+    (pkgs.writeText "avahi-daemon-extra.conf" cfg.extraConfig)
+  ];
 in
 {
   imports = [
@@ -69,6 +44,152 @@ in
     };
 
     package = lib.mkPackageOption pkgs "avahi" { };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = settingsFormat.type;
+
+        options = {
+          server = {
+            "host-name" = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              description = ''
+                Host name advertised on the LAN. If unset, Avahi will use the
+                system host name.
+              '';
+            };
+
+            domain-name = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              description = "Domain name for all advertisements.";
+            };
+
+            browse-domains = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              default = [ ];
+              description = "List of non-local DNS domains to be browsed.";
+            };
+
+            use-ipv4 = lib.mkOption {
+              type = lib.types.bool;
+              default = true;
+              description = "Whether to use IPv4.";
+            };
+
+            use-ipv6 = lib.mkOption {
+              type = lib.types.bool;
+              default = config.networking.enableIPv6;
+              defaultText = lib.literalExpression "config.networking.enableIPv6";
+              description = "Whether to use IPv6.";
+            };
+
+            allow-interfaces = lib.mkOption {
+              type = lib.types.nullOr (lib.types.listOf lib.types.str);
+              default = null;
+              description = ''
+                List of network interfaces that should be used by the {command}`avahi-daemon`.
+                Other interfaces will be ignored. If `null`, all local interfaces
+                except loopback and point-to-point will be used.
+              '';
+            };
+
+            deny-interfaces = lib.mkOption {
+              type = lib.types.nullOr (lib.types.listOf lib.types.str);
+              default = null;
+              description = ''
+                List of network interfaces that should be ignored by the
+                {command}`avahi-daemon`. Other unspecified interfaces will be
+                used, unless `allow-interfaces` is set. This option takes
+                precedence over `allow-interfaces`.
+              '';
+            };
+
+            allow-point-to-point = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = ''
+                Whether to use POINTTOPOINT interfaces. Might make mDNS
+                unreliable due to usually large latencies with such links and
+                opens a potential security hole by allowing mDNS access from
+                Internet connections.
+              '';
+            };
+
+            cache-entries-max = lib.mkOption {
+              type = lib.types.nullOr lib.types.int;
+              default = null;
+              description = ''
+                Number of resource records to be cached per interface. Use 0 to
+                disable caching. Avahi daemon defaults to 4096 if not set.
+              '';
+            };
+          };
+
+          wide-area.enable-wide-area = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = "Whether to enable wide-area service discovery.";
+          };
+
+          publish = {
+            disable-publishing = lib.mkOption {
+              type = lib.types.bool;
+              default = true;
+              description = "Whether to disable publishing in general.";
+            };
+
+            disable-user-service-publishing = lib.mkOption {
+              type = lib.types.bool;
+              default = true;
+              description = "Whether to disable publishing user services.";
+            };
+
+            publish-addresses = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = "Whether to register mDNS address records for all local IP addresses.";
+            };
+
+            publish-hinfo = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = ''
+                Whether to register a mDNS HINFO record which contains
+                information about the local operating system and CPU.
+              '';
+            };
+
+            publish-workstation = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = ''
+                Whether to register a service of type "_workstation._tcp" on the
+                local LAN.
+              '';
+            };
+
+            publish-domain = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = "Whether to announce the locally used domain name for browsing by other hosts.";
+            };
+          };
+
+          reflector.enable-reflector = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = "Reflect incoming mDNS requests to all allowed network interfaces.";
+          };
+        };
+      };
+      default = { };
+      description = ''
+        Configuration for {file}`avahi-daemon.conf` as a Nix attribute set.
+        See {manpage}`avahi-daemon.conf(5)` for available options.
+      '';
+    };
 
     hostName = lib.mkOption {
       type = lib.types.str;
@@ -304,11 +425,8 @@ in
     debug = lib.mkEnableOption "debug logging";
   };
 
-  config = lib.mkIf cfg.enable {
-    warnings = [
-      (lib.mkIf cfg.wideArea "Enabling `services.avahi.wideArea` exposes this system to `CVE-2024-52615`.")
-    ];
-
+  config = lib.mkMerge [
+    {
     assertions = [
       {
         assertion = cfg.nssmdnsFull -> (cfg.nssmdns4 || cfg.nssmdns6);
@@ -318,141 +436,186 @@ in
       }
     ];
 
-    users.users.avahi = {
-      description = "avahi-daemon privilege separation user";
-      home = "/var/empty";
-      group = "avahi";
-      isSystemUser = true;
-    };
+    warnings = [
+      (lib.mkIf cfg.wideArea "Enabling `services.avahi.wideArea` exposes this system to `CVE-2024-52615`.")
+    ];
+  }
+    {
+      services.avahi.settings = lib.mkMerge [
+        {
+          server = {
+            "browse-domains" = lib.mkDefault cfg.browseDomains;
+            "use-ipv4" = lib.mkDefault cfg.ipv4;
+            "use-ipv6" = lib.mkDefault cfg.ipv6;
+            "domain-name" = lib.mkDefault cfg.domainName;
+            "allow-point-to-point" = lib.mkDefault cfg.allowPointToPoint;
+          };
 
-    users.groups.avahi = { };
+          "wide-area"."enable-wide-area" = lib.mkDefault cfg.wideArea;
 
-    system.nssModules = lib.optional (cfg.nssmdns4 || cfg.nssmdns6) pkgs.nssmdns;
-    system.nssDatabases.hosts =
-      let
-        mdns =
-          if (cfg.nssmdns4 && cfg.nssmdns6) then
-            "mdns"
-          else if (!cfg.nssmdns4 && cfg.nssmdns6) then
-            "mdns6"
-          else if (cfg.nssmdns4 && !cfg.nssmdns6) then
-            "mdns4"
-          else
-            "";
-      in
-      lib.optionals (cfg.nssmdns4 || cfg.nssmdns6) (
-        lib.mkMerge [
-          (lib.mkBefore [ "${mdns}_minimal [NOTFOUND=return]" ]) # before resolve
-          (lib.mkAfter (lib.optional cfg.nssmdnsFull "${mdns}")) # after dns
-        ]
+          publish = {
+            "disable-publishing" = lib.mkDefault (!cfg.publish.enable);
+            "disable-user-service-publishing" = lib.mkDefault (!cfg.publish.userServices);
+            "publish-addresses" = lib.mkDefault (cfg.publish.userServices || cfg.publish.addresses);
+            "publish-hinfo" = lib.mkDefault cfg.publish.hinfo;
+            "publish-workstation" = lib.mkDefault cfg.publish.workstation;
+            "publish-domain" = lib.mkDefault cfg.publish.domain;
+          };
+
+          reflector."enable-reflector" = lib.mkDefault cfg.reflector;
+        }
+        (lib.mkIf (cfg.hostName != "") {
+          server."host-name" = lib.mkDefault cfg.hostName;
+        })
+        (lib.mkIf (cfg.allowInterfaces != null) {
+          server."allow-interfaces" = lib.mkDefault cfg.allowInterfaces;
+        })
+        (lib.mkIf (cfg.denyInterfaces != null) {
+          server."deny-interfaces" = lib.mkDefault cfg.denyInterfaces;
+        })
+        (lib.mkIf (cfg.cacheEntriesMax != null) {
+          server."cache-entries-max" = lib.mkDefault cfg.cacheEntriesMax;
+        })
+      ];
+    }
+
+    (lib.mkIf cfg.enable {
+      users.users.avahi = {
+        description = "avahi-daemon privilege separation user";
+        home = "/var/empty";
+        group = "avahi";
+        isSystemUser = true;
+      };
+
+      users.groups.avahi = { };
+
+      system.nssModules = lib.optional (cfg.nssmdns4 || cfg.nssmdns6) pkgs.nssmdns;
+      system.nssDatabases.hosts =
+        let
+          mdns =
+            if (cfg.nssmdns4 && cfg.nssmdns6) then
+              "mdns"
+            else if (!cfg.nssmdns4 && cfg.nssmdns6) then
+              "mdns6"
+            else if (cfg.nssmdns4 && !cfg.nssmdns6) then
+              "mdns4"
+            else
+              "";
+        in
+        lib.optionals (cfg.nssmdns4 || cfg.nssmdns6) (
+          lib.mkMerge [
+            (lib.mkBefore [ "${mdns}_minimal [NOTFOUND=return]" ]) # before resolve
+            (lib.mkAfter (lib.optional cfg.nssmdnsFull "${mdns}")) # after dns
+          ]
+        );
+
+      environment.systemPackages = [ cfg.package ];
+
+      environment.etc = (
+        lib.mapAttrs' (
+          n: v:
+          lib.nameValuePair "avahi/services/${n}.service" {
+            ${if lib.types.path.check v then "source" else "text"} = v;
+          }
+        ) cfg.extraServiceFiles
       );
 
-    environment.systemPackages = [ cfg.package ];
-
-    environment.etc = (
-      lib.mapAttrs' (
-        n: v:
-        lib.nameValuePair "avahi/services/${n}.service" {
-          ${if lib.types.path.check v then "source" else "text"} = v;
-        }
-      ) cfg.extraServiceFiles
-    );
-
-    systemd.sockets.avahi-daemon = {
-      description = "Avahi mDNS/DNS-SD Stack Activation Socket";
-      listenStreams = [ "/run/avahi-daemon/socket" ];
-      wantedBy = [ "sockets.target" ];
-      after = [
-        # Ensure that `/run/avahi-daemon` owned by `avahi` is created by `systemd.tmpfiles.rules` before the `avahi-daemon.socket`,
-        # otherwise `avahi-daemon.socket` will automatically create it owned by `root`, which will cause `avahi-daemon.service` to fail.
-        "systemd-tmpfiles-setup.service"
-      ];
-    };
-
-    systemd.tmpfiles.rules = [ "d /run/avahi-daemon - avahi avahi -" ];
-
-    systemd.services.avahi-daemon = {
-      description = "Avahi mDNS/DNS-SD Stack";
-      wantedBy = [ "multi-user.target" ];
-      requires = [ "avahi-daemon.socket" ];
-      documentation = [
-        "man:avahi-daemon(8)"
-        "man:avahi-daemon.conf(5)"
-        "man:avahi.hosts(5)"
-        "man:avahi.service(5)"
-      ];
-
-      # Make NSS modules visible so that `avahi_nss_support ()' can
-      # return a sensible value.
-      environment.LD_LIBRARY_PATH = config.system.nssModules.path;
-
-      path = [
-        pkgs.coreutils
-        cfg.package
-      ];
-
-      serviceConfig = {
-        NotifyAccess = "main";
-        BusName = "org.freedesktop.Avahi";
-        Type = "dbus";
-        ExecStart = "${cfg.package}/sbin/avahi-daemon --syslog -f ${avahiDaemonConf} ${lib.optionalString cfg.debug "--debug"}";
-        ConfigurationDirectory = "avahi/services";
-
-        # Hardening
-        CapabilityBoundingSet = [
-          # https://github.com/avahi/avahi/blob/v0.9-rc1/avahi-daemon/caps.c#L38
-          "CAP_SYS_CHROOT"
-          "CAP_SETUID"
-          "CAP_SETGID"
+      systemd.sockets.avahi-daemon = {
+        description = "Avahi mDNS/DNS-SD Stack Activation Socket";
+        listenStreams = [ "/run/avahi-daemon/socket" ];
+        wantedBy = [ "sockets.target" ];
+        after = [
+          # Ensure that `/run/avahi-daemon` owned by `avahi` is created by `systemd.tmpfiles.rules` before the `avahi-daemon.socket`,
+          # otherwise `avahi-daemon.socket` will automatically create it owned by `root`, which will cause `avahi-daemon.service` to fail.
+          "systemd-tmpfiles-setup.service"
         ];
-        DevicePolicy = "closed";
-        LockPersonality = true;
-        MemoryDenyWriteExecute = true;
-        NoNewPrivileges = true;
-        PrivateDevices = true;
-        PrivateTmp = true;
-        PrivateUsers = false;
-        ProcSubset = "pid";
-        ProtectClock = true;
-        ProtectControlGroups = true;
-        ProtectHome = true;
-        ProtectHostname = true;
-        ProtectKernelLogs = true;
-        ProtectKernelModules = true;
-        ProtectKernelTunables = true;
-        ProtectProc = "invisible";
-        ProtectSystem = "strict";
-        RestrictAddressFamilies = [
-          "AF_INET"
-          "AF_INET6"
-          "AF_NETLINK"
-          "AF_UNIX"
-        ];
-        RestrictNamespaces = true;
-        RestrictRealtime = true;
-        RestrictSUIDSGID = true;
-        SystemCallArchitectures = "native";
-        SystemCallFilter = [
-          "@system-service"
-          "~@privileged"
-          "@chown setgroups setresuid"
-        ]
-        ++ lib.optionals pkgs.stdenv.hostPlatform.is32bit [
-          # glibc's setresuid()/setgroups() invoke the kernel's 32-bit compat
-          # syscalls (setresuid32/setgroups32) on 32-bit architectures --
-          # distinct syscalls from the ones already allowlisted above, so
-          # without these 2, avahi-daemon is killed with SIGSYS as soon as it
-          # tries to drop privileges.
-          "setgroups32"
-          "setresuid32"
-        ];
-        UMask = "0077";
       };
-    };
 
-    services.dbus.enable = true;
-    services.dbus.packages = [ cfg.package ];
+      systemd.tmpfiles.rules = [ "d /run/avahi-daemon - avahi avahi -" ];
 
-    networking.firewall.allowedUDPPorts = lib.mkIf cfg.openFirewall [ 5353 ];
-  };
+      systemd.services.avahi-daemon = {
+        description = "Avahi mDNS/DNS-SD Stack";
+        wantedBy = [ "multi-user.target" ];
+        requires = [ "avahi-daemon.socket" ];
+        documentation = [
+          "man:avahi-daemon(8)"
+          "man:avahi-daemon.conf(5)"
+          "man:avahi.hosts(5)"
+          "man:avahi.service(5)"
+        ];
+
+        # Make NSS modules visible so that `avahi_nss_support ()' can
+        # return a sensible value.
+        environment.LD_LIBRARY_PATH = config.system.nssModules.path;
+
+        path = [
+          pkgs.coreutils
+          cfg.package
+        ];
+
+        serviceConfig = {
+          NotifyAccess = "main";
+          BusName = "org.freedesktop.Avahi";
+          Type = "dbus";
+          ExecStart = "${cfg.package}/sbin/avahi-daemon --syslog -f ${avahiDaemonConf} ${lib.optionalString cfg.debug "--debug"}";
+          ConfigurationDirectory = "avahi/services";
+
+          # Hardening
+          CapabilityBoundingSet = [
+            # https://github.com/avahi/avahi/blob/v0.9-rc1/avahi-daemon/caps.c#L38
+            "CAP_SYS_CHROOT"
+            "CAP_SETUID"
+            "CAP_SETGID"
+          ];
+          DevicePolicy = "closed";
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          NoNewPrivileges = true;
+          PrivateDevices = true;
+          PrivateTmp = true;
+          PrivateUsers = false;
+          ProcSubset = "pid";
+          ProtectClock = true;
+          ProtectControlGroups = true;
+          ProtectHome = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectProc = "invisible";
+          ProtectSystem = "strict";
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+            "AF_NETLINK"
+            "AF_UNIX"
+          ];
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          SystemCallArchitectures = "native";
+          SystemCallFilter = [
+            "@system-service"
+            "~@privileged"
+            "@chown setgroups setresuid"
+          ]
+          ++ lib.optionals pkgs.stdenv.hostPlatform.is32bit [
+            # glibc's setresuid()/setgroups() invoke the kernel's 32-bit compat
+            # syscalls (setresuid32/setgroups32) on 32-bit architectures --
+            # distinct syscalls from the ones already allowlisted above, so
+            # without these 2, avahi-daemon is killed with SIGSYS as soon as it
+            # tries to drop privileges.
+            "setgroups32"
+            "setresuid32"
+          ];
+          UMask = "0077";
+        };
+      };
+
+      services.dbus.enable = true;
+      services.dbus.packages = [ cfg.package ];
+
+      networking.firewall.allowedUDPPorts = lib.mkIf cfg.openFirewall [ 5353 ];
+    })
+  ];
 }

--- a/nixos/modules/services/networking/shairport-sync.nix
+++ b/nixos/modules/services/networking/shairport-sync.nix
@@ -124,8 +124,11 @@ in
     ];
 
     services.avahi.enable = true;
-    services.avahi.publish.enable = true;
-    services.avahi.publish.userServices = true;
+    services.avahi.settings.publish = {
+      "disable-publishing" = false;
+      "disable-user-service-publishing" = false;
+      "publish-addresses" = true;
+    };
 
     services.shairport-sync.settings = {
       general.output_backend = lib.mkDefault "pulseaudio";

--- a/nixos/tests/avahi.nix
+++ b/nixos/tests/avahi.nix
@@ -18,11 +18,13 @@
           services.avahi = {
             enable = true;
             nssmdns4 = true;
-            publish.addresses = true;
-            publish.domain = true;
-            publish.enable = true;
-            publish.userServices = true;
-            publish.workstation = true;
+            settings.publish = {
+              "disable-publishing" = false;
+              "disable-user-service-publishing" = false;
+              "publish-addresses" = true;
+              "publish-domain" = true;
+              "publish-workstation" = true;
+            };
             extraServiceFiles.ssh = "${pkgs.avahi}/etc/avahi/services/ssh.service";
             debug = true;
           };

--- a/nixos/tests/avahi.nix
+++ b/nixos/tests/avahi.nix
@@ -19,11 +19,13 @@
           services.avahi = {
             enable = true;
             nssmdns4 = true;
-            publish.addresses = true;
-            publish.domain = true;
-            publish.enable = true;
-            publish.userServices = true;
-            publish.workstation = true;
+            settings.publish = {
+              disable-publishing = false;
+              disable-user-service-publishing = false;
+              publish-addresses = true;
+              publish-domain = true;
+              publish-workstation = true;
+            };
             extraServiceFiles.ssh = "${pkgs.avahi}/etc/avahi/services/ssh.service";
             debug = true;
           };


### PR DESCRIPTION


## Things done

I wanted to enable uncovered features and it seemed harder than necessary.
I asked codex to migrate to RFC42 and here is the result. Now that it's in freeform mode, we could probably remove some of the minor hardcoded options/descriptions. I did not do that though to ease review.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
