### PR TITLE
gnat{,13,14,15,16}Packages: 25.0.0 -> 26.0.0, fix build

### DIFF
--- a/pkgs/development/ada-modules/gnatcoll/bindings.nix
+++ b/pkgs/development/ada-modules/gnatcoll/bindings.nix
@@ -14,6 +14,7 @@
   zlib,
   python3,
   ncurses,
+  enableShared ? !stdenv.hostPlatform.isStatic,
 }:
 
 let
@@ -34,15 +35,15 @@ let
   };
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gnatcoll-${component}";
-  version = "25.0.0";
+  version = "26.0.0";
 
   src = fetchFromGitHub {
     owner = "AdaCore";
     repo = "gnatcoll-bindings";
-    rev = "v${version}";
-    sha256 = "0ayc7zvv8w90v0xzhrjk2x88zrsk62xxcm27ya9crlp6affn5idk";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7XC/oA2/Z4ytmN3/36vUbYOKHQyinbM8AAINrgitJYY=";
   };
 
   nativeBuildInputs = [
@@ -59,22 +60,35 @@ stdenv.mkDerivation rec {
   ]
   ++ libsFor."${component}" or [ ];
 
-  # explicit flag for GPL acceptance because upstream
-  # allows a gcc runtime exception for all bindings
-  # except for readline (since it is GPL w/o exceptions)
-  buildFlags = lib.optionals (component == "readline") [
+  makeFlags = [
+    "--prefix"
+    (placeholder "out")
+  ]
+  ++ lib.optionals (!enableShared) [
+    "--library-types"
+    "static"
+  ];
+
+  buildFlags = [
+    "--target"
+    stdenv.hostPlatform.config
+  ]
+  ++ lib.optionals (component == "readline") [
+    # explicit flag for GPL acceptance because upstream
+    # allows a gcc runtime exception for all bindings
+    # except for readline (since it is GPL w/o exceptions)
     "--accept-gpl"
   ];
 
   buildPhase = ''
     runHook preBuild
-    ${python3.interpreter} ${component}/setup.py build --prefix $out $buildFlags
+    ${python3.interpreter} ${component}/setup.py build $makeFlags --jobs $NIX_BUILD_CORES $buildFlags
     runHook postBuild
   '';
 
   installPhase = ''
     runHook preInstall
-    ${python3.interpreter} ${component}/setup.py install --prefix $out
+    ${python3.interpreter} ${component}/setup.py install $makeFlags
     runHook postInstall
   '';
 
@@ -85,4 +99,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.all;
     maintainers = [ lib.maintainers.sternenseemann ];
   };
-}
+})

--- a/pkgs/development/ada-modules/gnatcoll/bindings.nix
+++ b/pkgs/development/ada-modules/gnatcoll/bindings.nix
@@ -97,6 +97,9 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/AdaCore/gnatcoll-bindings";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.all;
-    maintainers = [ lib.maintainers.sternenseemann ];
+    maintainers = with lib.maintainers; [
+      sternenseemann
+      sempiternal-aurora
+    ];
   };
 })

--- a/pkgs/development/ada-modules/gnatcoll/core.nix
+++ b/pkgs/development/ada-modules/gnatcoll/core.nix
@@ -72,7 +72,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/AdaCore/gnatcoll-core";
     description = "GNAT Components Collection - Core packages";
     license = lib.licenses.gpl3Plus;
-    maintainers = [ lib.maintainers.sternenseemann ];
+    maintainers = with lib.maintainers; [
+      sternenseemann
+      sempiternal-aurora
+    ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/development/ada-modules/gnatcoll/core.nix
+++ b/pkgs/development/ada-modules/gnatcoll/core.nix
@@ -4,7 +4,6 @@
   gnat,
   gprbuild,
   fetchFromGitHub,
-  fetchpatch2,
   which,
   python3,
   rsync,
@@ -18,25 +17,16 @@
 # gnatcoll-projects depends on gnatcoll-core
 assert enableGnatcollProjects -> enableGnatcollCore;
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gnatcoll-core";
-  version = "25.0.0";
+  version = "26.0.0";
 
   src = fetchFromGitHub {
     owner = "AdaCore";
     repo = "gnatcoll-core";
-    rev = "v${version}";
-    sha256 = "1srnh7vhs46c2zy4hcy4pg0a0prghfzlpv7c82k0jan384yz1g6g";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-oTFUdcx14TavJ2kxBEbfZVWvKEurcOpd5U7n1QZ+fZI=";
   };
-
-  patches = [
-    # Fix compilation with GNAT 16
-    (fetchpatch2 {
-      name = "gnatcoll-core-gnat-16.patch";
-      url = "https://github.com/AdaCore/gnatcoll-core/commit/b266466e0a05b30615ec43d72782c345470455b9.patch?full_index=1";
-      hash = "sha256-rG0D1y2dbXA2M2Arnto+f7iAhg3yCfTPDbDRN+pMJKQ=";
-    })
-  ];
 
   postPatch = ''
     patchShebangs */*.gpr.py
@@ -85,4 +75,4 @@ stdenv.mkDerivation rec {
     maintainers = [ lib.maintainers.sternenseemann ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/development/ada-modules/gnatcoll/db.nix
+++ b/pkgs/development/ada-modules/gnatcoll/db.nix
@@ -50,7 +50,7 @@ let
 in
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "25.0.0";
+  version = "26.0.0";
   # executables don't adhere to the string gnatcoll-* scheme
   pname =
     if onlyExecutable then
@@ -61,8 +61,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "AdaCore";
     repo = "gnatcoll-db";
-    rev = "v${finalAttrs.version}";
-    sha256 = "0q35ii0aa4hh59v768l5cilg1b30a4ckcvlbfy0lkcbp3rcfnbz3";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-XkJLD2t7LelfDxZKEPCK1xkG19CSd8OnN3jOfdbfekg=";
   };
 
   # Link executables dynamically unless specified by the platform,

--- a/pkgs/development/ada-modules/gnatcoll/db.nix
+++ b/pkgs/development/ada-modules/gnatcoll/db.nix
@@ -105,7 +105,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "GNAT Components Collection - Database packages";
     homepage = "https://github.com/AdaCore/gnatcoll-db";
     license = lib.licenses.gpl3Plus;
-    maintainers = [ lib.maintainers.sternenseemann ];
+    maintainers = with lib.maintainers; [
+      sternenseemann
+      sempiternal-aurora
+    ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/development/ada-modules/gnatprove/0001-fix-install-fsf-16.patch
+++ b/pkgs/development/ada-modules/gnatprove/0001-fix-install-fsf-16.patch
@@ -1,0 +1,42 @@
+From 8a65c41a15b0c6bec4fe660d0e3711eb13bc4821 Mon Sep 17 00:00:00 2001
+From: sempiternal-aurora
+ <78790545+sempiternal-aurora@users.noreply.github.com>
+Date: Wed, 27 May 2026 17:28:21 +1000
+Subject: [PATCH] fix install
+
+---
+ Makefile | 18 +++++++++---------
+ 1 file changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 4ec7f693fc..088c60e9f3 100644
+--- a/Makefile
++++ b/Makefile
+@@ -108,15 +108,15 @@ install:
+ 	$(CP) share/spark/theories/*mlw $(THEORIESDIR)
+ 	$(CP) share/spark/runtimes/README $(RUNTIMESDIR)
+ 	@echo "Generate Coq files by preprocessing context files:"
+-	$(MAKE) -C include generate
+-	$(CP) include/src/*.ad? $(INCLUDEDIR)
+-	mkdir -p $(INCLUDEDIR)/full
+-	mkdir -p $(INCLUDEDIR)/light
+-	$(CP) include/src/full/*.ad? $(INCLUDEDIR)/full
+-	$(CP) include/src/light/*.ad? $(INCLUDEDIR)/light
+-	$(CP) include/*.gpr $(LIBDIR)
+-	$(CP) include/*.gpr.templ $(LIBDIR)
+-	$(CP) include/proof $(LIBDIR)
++	# $(MAKE) -C include generate
++	# $(CP) include/src/*.ad? $(INCLUDEDIR)
++	# mkdir -p $(INCLUDEDIR)/full
++	# mkdir -p $(INCLUDEDIR)/light
++	# $(CP) include/src/full/*.ad? $(INCLUDEDIR)/full
++	# $(CP) include/src/light/*.ad? $(INCLUDEDIR)/light
++	# $(CP) include/*.gpr $(LIBDIR)
++	# $(CP) include/*.gpr.templ $(LIBDIR)
++	# $(CP) include/proof $(LIBDIR)
+ 
+ doc: $(DOC)
+ 
+-- 
+2.54.0
+

--- a/pkgs/development/ada-modules/gnatprove/default.nix
+++ b/pkgs/development/ada-modules/gnatprove/default.nix
@@ -251,7 +251,10 @@ stdenv.mkDerivation {
   meta = {
     description = "Software development technology specifically designed for engineering high-reliability applications";
     homepage = "https://github.com/AdaCore/spark2014";
-    maintainers = [ lib.maintainers.jiegec ];
+    maintainers = with lib.maintainers; [
+      jiegec
+      sempiternal-aurora
+    ];
     license = lib.licenses.gpl3;
     platforms = lib.platforms.all;
   };

--- a/pkgs/development/ada-modules/gnatprove/default.nix
+++ b/pkgs/development/ada-modules/gnatprove/default.nix
@@ -1,10 +1,15 @@
 {
   stdenv,
   lib,
+  fetchurl,
   fetchFromGitHub,
   gnat,
   gnatcoll-core,
+  gnatcoll-gmp,
+  gnatcoll-iconv,
   gprbuild,
+  sarif-ada,
+  vss-extra,
   python3,
   ocamlPackages,
   makeWrapper,
@@ -14,20 +19,91 @@ let
   gnat_version = lib.versions.major gnat.version;
 
   # gnatprove fsf-14 requires gpr2 from a special branch
-  gpr2_24_2_next =
-    (gpr2.override {
-      # pregenerated kb db is not included
-      gpr2kbdir = "${gprbuild}/share/gprconfig";
+  gpr2_24_2_next = gpr2.overrideAttrs (
+    final: _: {
+      version = "24.2.0-next";
+      src = fetchFromGitHub {
+        owner = "AdaCore";
+        repo = "gpr";
+        tag = "v${final.version}";
+        hash = "sha256-Tp+N9VLKjVWs1VRPYE0mQY3rl4E5iGb8xDoNatEYBg4=";
+      };
+      patches = [ ];
+    }
+  );
+
+  # gnatprove fsf-15 requires gnatcoll/gpr2 version 25.0.0
+  gnatcoll-core_25 = gnatcoll-core.overrideAttrs (
+    final: _: {
+      version = "25.0.0";
+
+      src = fetchFromGitHub {
+        owner = "AdaCore";
+        repo = "gnatcoll-core";
+        tag = "v${final.version}";
+        hash = "sha256-z7zwPUHDKgmmQOzsS7+DL1+gwLvEM0j8F8wQDfeBNus=";
+      };
+    }
+  );
+  gnatcoll-iconv_25 =
+    (gnatcoll-iconv.override {
+      gnatcoll-core = gnatcoll-core_25;
     }).overrideAttrs
-      (old: rec {
-        version = "24.2.0-next";
-        src = fetchFromGitHub {
-          owner = "AdaCore";
-          repo = "gpr";
-          rev = "v${version}";
-          hash = "sha256-Tp+N9VLKjVWs1VRPYE0mQY3rl4E5iGb8xDoNatEYBg4=";
-        };
-      });
+      (
+        final: _: {
+          version = "25.0.0";
+
+          src = fetchFromGitHub {
+            owner = "AdaCore";
+            repo = "gnatcoll-bindings";
+            tag = "v${final.version}";
+            hash = "sha256-s8VinVPm0syS8kdU1rswU+ePUBdTZvg72CBxtPc/zCs=";
+          };
+        }
+      );
+  gnatcoll-gmp_25 =
+    (gnatcoll-gmp.override {
+      gnatcoll-core = gnatcoll-core_25;
+    }).overrideAttrs
+      (
+        final: _: {
+          version = "25.0.0";
+
+          src = fetchFromGitHub {
+            owner = "AdaCore";
+            repo = "gnatcoll-bindings";
+            tag = "v${final.version}";
+            hash = "sha256-s8VinVPm0syS8kdU1rswU+ePUBdTZvg72CBxtPc/zCs=";
+          };
+        }
+      );
+  gpr2_25 =
+    (gpr2.override {
+      # Comes with a pre-generated kb config
+      gpr2kbdir = null;
+      gnatcoll-core = gnatcoll-core_25;
+      gnatcoll-iconv = gnatcoll-iconv_25;
+      gnatcoll-gmp = gnatcoll-gmp_25;
+    }).overrideAttrs
+      (
+        final: _: {
+          version = "25.0.0";
+          src = fetchurl {
+            url = "https://github.com/AdaCore/gpr/releases/download/v25.0.0/gpr2-with-gprconfig_kb-25.0.tgz";
+            hash = "sha256-bhOJvAALpbZUbxer370M2h7vbJby3gOOJdwuWERe3rY=";
+          };
+          patches = [ ];
+        }
+      );
+
+  gpr2' =
+    {
+      "14" = gpr2_24_2_next;
+      "15" = gpr2_25;
+      "16" = gpr2;
+    }
+    ."${gnat_version}" or null;
+  gnatcoll-core' = if gnat_version == "15" then gnatcoll-core_25 else gnatcoll-core;
 
   # TODO:
   # Build why3 (github.com/AdaCore/why3) as separate package and not as submodule.
@@ -43,13 +119,6 @@ let
     };
 
   spark2014 = {
-    "12" = {
-      src = fetchSpark2014 {
-        rev = "ab34e07080a769b63beacc141707b5885c49d375"; # branch fsf-12
-        hash = "sha256-7pe3eWitpxmqzjW6qEIEuN0qr2IR+kJ7Ssc9pTBcCD8=";
-      };
-      commit_date = "2022-05-25";
-    };
     "13" = {
       src = fetchSpark2014 {
         rev = "12db22e854defa9d1c993ef904af1e72330a68ca"; # branch fsf-13
@@ -80,7 +149,7 @@ let
     };
     "15" = {
       src = fetchSpark2014 {
-        rev = "22bf1510e0829ba74f9d8d686badb65c7365ee91";
+        rev = "22bf1510e0829ba74f9d8d686badb65c7365ee91"; # branch fsf-15
         hash = "sha256-KjAWMgMT3Tp/s/DQ20ZZajty9Zrv8aPFocwgv5LkjSw=";
       };
       patches = [
@@ -92,6 +161,20 @@ let
       ];
       commit_date = "2025-06-10";
     };
+    "16" = {
+      src = fetchSpark2014 {
+        rev = "42554fc241fcd1fdf08d3a2feccb3f86912acbc0"; # branch fsf-16
+        hash = "sha256-3dkEVrgBu5ks4O/08DEaVfbeQ9qaDo2DJA9mH1XnI+0=";
+      };
+      patches = [
+        # Disable Coq related targets which are missing in the fsf-16 branch
+        ./0001-fix-install-fsf-16.patch
+
+        # Suppress warnings on aarch64: https://github.com/AdaCore/spark2014/issues/54
+        ./0002-mute-aarch64-warnings.patch
+      ];
+      commit_date = "2026-01-05";
+    };
   };
 
   thisSpark =
@@ -101,7 +184,7 @@ let
 in
 stdenv.mkDerivation {
   pname = "gnatprove";
-  version = "fsf-${gnat_version}_${thisSpark.commit_date}";
+  version = "${gnat_version}-fsf-${thisSpark.commit_date}";
 
   src = thisSpark.src;
 
@@ -120,7 +203,8 @@ stdenv.mkDerivation {
   ]);
 
   buildInputs = [
-    gnatcoll-core
+    gnatcoll-core'
+    gpr2'
   ]
   ++ (with ocamlPackages; [
     ocamlgraph
@@ -134,12 +218,10 @@ stdenv.mkDerivation {
     sexplib
     yojson_2
   ])
-  ++ (lib.optionals (gnat_version == "14") [
-    gpr2_24_2_next
-  ])
-  ++ (lib.optionals (gnat_version == "15") [
-    gpr2
-  ]);
+  ++ lib.optionals (lib.versionAtLeast gnat.version "16") [
+    sarif-ada
+    vss-extra
+  ];
 
   propagatedBuildInputs = [
     gprbuild

--- a/pkgs/development/ada-modules/gpr2/default.nix
+++ b/pkgs/development/ada-modules/gpr2/default.nix
@@ -81,7 +81,10 @@ stdenv.mkDerivation (finalAttrs: {
       llvm-exception
       gpl3Only
     ];
-    maintainers = with lib.maintainers; [ heijligen ];
+    maintainers = with lib.maintainers; [
+      heijligen
+      sempiternal-aurora
+    ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/development/ada-modules/gpr2/default.nix
+++ b/pkgs/development/ada-modules/gpr2/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   gprbuild,
   which,
   gnat,
@@ -9,18 +9,21 @@
   gnatcoll-core,
   gnatcoll-iconv,
   gnatcoll-gmp,
+  fetchpatch2,
   enableShared ? !stdenv.hostPlatform.isStatic,
   # kb database source, if null assume it is pregenerated
-  gpr2kbdir ? null,
+  gpr2kbdir ? "${gprbuild}/share/gprconfig",
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gpr2";
-  version = "25.0.0";
+  version = "26.0.0";
 
-  src = fetchurl {
-    url = "https://github.com/AdaCore/gpr/releases/download/v${version}/gpr2-with-gprconfig_kb-${lib.versions.majorMinor version}.tgz";
-    sha512 = "70fe0fcf541f6d3d90a34cab1638bbc0283dcd765c000406e0cfb73bae1817b30ddfe73f3672247a97c6b6bfc41900bc96a4440ca0c660f9c2f7b9d3cc8f8dcf";
+  src = fetchFromGitHub {
+    owner = "AdaCore";
+    repo = "gpr";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-HoD0TuhOinPGYB7gnLtJ0Zonz4RK4HA3IoOFe5NxfUE=";
   };
 
   nativeBuildInputs = [
@@ -37,6 +40,20 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optionals (gpr2kbdir != null) [
     "GPR2KBDIR=${gpr2kbdir}"
+  ];
+
+  patches = [
+    # gpr2-log.ads:140:09: error: completion of nonlimited type cannot be limited
+    # gpr2-log.ads:140:09: error: component "Ref" of type "Reference_Type" has limited type
+    (fetchpatch2 {
+      url = "https://github.com/AdaCore/gpr/commit/43bb629645c3f558bbba5e3cf4b5902dddae3a6a.patch?full_index=1";
+      hash = "sha256-EeqlHLoQEQdEnbre38UHxBgsfSUNksXnU3oOtBKw5Ek=";
+    })
+    # gpr2-tree_internal.adb:1926:18: error: actual for aliased formal "Container" has wrong accessibility in return (RM 6.4.1(6.4))
+    (fetchpatch2 {
+      url = "https://github.com/AdaCore/gpr/commit/12c649aa4d4c4e334b8271ac619500532aaeb21f.patch?full_index=1";
+      hash = "sha256-jp8VZGgyiVeJZTpdeAnHf2VrCc58/MMYfyjiOSaMx6w=";
+    })
   ];
 
   configurePhase = ''
@@ -61,12 +78,10 @@ stdenv.mkDerivation rec {
     description = "Framework for analyzing the GNAT Project (GPR) files";
     homepage = "https://github.com/AdaCore/gpr";
     license = with lib.licenses; [
-      asl20
+      llvm-exception
       gpl3Only
     ];
     maintainers = with lib.maintainers; [ heijligen ];
     platforms = lib.platforms.all;
-    # TODO(@sternenseemann): investigate failure with gnat 13
-    broken = lib.versionOlder gnat.version "14";
   };
-}
+})

--- a/pkgs/development/ada-modules/gprbuild/boot.nix
+++ b/pkgs/development/ada-modules/gprbuild/boot.nix
@@ -106,7 +106,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Multi-language extensible build tool";
     homepage = "https://github.com/AdaCore/gprbuild";
     license = lib.licenses.gpl3Plus;
-    maintainers = [ lib.maintainers.sternenseemann ];
+    maintainers = with lib.maintainers; [
+      sternenseemann
+      sempiternal-aurora
+    ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/development/ada-modules/gprbuild/boot.nix
+++ b/pkgs/development/ada-modules/gprbuild/boot.nix
@@ -8,28 +8,15 @@
   xmlada, # for src
 }:
 
-let
-  version = "25.0.0";
-
-  gprConfigKbSrc = fetchFromGitHub {
-    name = "gprconfig-kb-${version}-src";
-    owner = "AdaCore";
-    repo = "gprconfig_kb";
-    rev = "v${version}";
-    sha256 = "09x1njq0i0z7fbwg0mg39r5ghy7369avbqvdycfj67lpmw17gb1r";
-  };
-in
-
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gprbuild-boot";
-  inherit version;
+  version = "26.0.0";
 
   src = fetchFromGitHub {
-    name = "gprbuild-${version}";
     owner = "AdaCore";
     repo = "gprbuild";
-    rev = "v${version}";
-    sha256 = "1mqsmc0q5bzg8223ls18kbvaz6mhzjz7ik8d3sqhhn24c0j6wjaw";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-j9UQw275cfCkYdmDyc4g2LuFSrqXmWGV66AaykctKSA=";
   };
 
   nativeBuildInputs = [
@@ -37,19 +24,21 @@ stdenv.mkDerivation {
     which
   ];
 
-  # Fix compilation with GNAT 16
-  patches = lib.optionals (lib.versionAtLeast gnat.version "16") [
-    # gpr-compilation-process.adb:44:29: error: operator for type "String" is not declared in "Env_Maps"
-    (fetchpatch2 {
-      url = "https://github.com/AdaCore/gprbuild/commit/6421e350274b3018a26bd058b1c90d033b053f71.patch?full_index=1";
-      hash = "sha256-u9bmr8abmthlyHoeqW5nS2CnaxXmbx6WVwhemxVtw+0=";
-    })
-    # gpr-compilation-protocol.adb:981:13: error: "time_t" is undefined
-    (fetchpatch2 {
-      url = "https://github.com/AdaCore/gprbuild/commit/6b6be939d69d534beb7faca17664d7a1ffa9c81e.patch?full_index=1";
-      hash = "sha256-YUjBvA4bBsrCB46o5WVHOZR6qOf2bkMg+A9qlystDbc=";
-    })
-  ];
+  patches =
+    lib.optionals (lib.versionOlder gnat.version "15") [
+      # gpr-compilation-protocol.adb:982:27: error: "To_Unix_Time_64" not declared in "Conversions"
+      (fetchpatch2 {
+        url = "https://github.com/AdaCore/gprbuild/commit/5c89819c8d84ca4a75663d3720185f5ed2d8fae6.patch?full_index=1";
+        hash = "sha256-sZ+XfU9DDzRBVY/QYDWZS1xuR9BF2pa+QvoHHi5/IY4=";
+      })
+    ]
+    ++ lib.optionals (lib.versionAtLeast gnat.version "16") [
+      # gpr-compilation-process.adb:44:29: error: operator for type "String" is not declared in "Env_Maps"
+      (fetchpatch2 {
+        url = "https://github.com/AdaCore/gprbuild/commit/6421e350274b3018a26bd058b1c90d033b053f71.patch?full_index=1";
+        hash = "sha256-u9bmr8abmthlyHoeqW5nS2CnaxXmbx6WVwhemxVtw+0=";
+      })
+    ];
 
   postPatch = ''
     # The Makefile uses gprbuild to build gprbuild which
@@ -84,7 +73,7 @@ stdenv.mkDerivation {
 
     ./bootstrap.sh \
       --with-xmlada=${xmlada.src} \
-      --with-kb=${gprConfigKbSrc} \
+      --with-kb=${finalAttrs.finalPackage.passthru.gprconfig_kb} \
       --prefix=$out
 
     # Install custom compiler description which can detect nixpkgs'
@@ -104,6 +93,15 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
+  passthru = {
+    gprconfig_kb = fetchFromGitHub {
+      owner = "AdaCore";
+      repo = "gprconfig_kb";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-Ugzn03z93ZoRRkgq3XSeIsvCb2IKh2WWj7TWzqTos70=";
+    };
+  };
+
   meta = {
     description = "Multi-language extensible build tool";
     homepage = "https://github.com/AdaCore/gprbuild";
@@ -111,4 +109,4 @@ stdenv.mkDerivation {
     maintainers = [ lib.maintainers.sternenseemann ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/development/ada-modules/gprbuild/default.nix
+++ b/pkgs/development/ada-modules/gprbuild/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation {
     src
     setupHooks
     meta
+    passthru
     ;
 
   nativeBuildInputs = [

--- a/pkgs/development/ada-modules/sarif-ada/default.nix
+++ b/pkgs/development/ada-modules/sarif-ada/default.nix
@@ -1,0 +1,109 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gprbuild,
+  gnat,
+  vss-extra,
+  vss-text,
+  enableShared ? !stdenv.hostPlatform.isStatic,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sarif-ada";
+  version = "26.0.0-unstable-2025-10-21";
+
+  src = fetchFromGitHub {
+    owner = "AdaCore";
+    repo = "sarif-ada";
+    rev = "7201a4b1993cafe9c3c44eeb07be81ae3bdd9342";
+    hash = "sha256-0p3d4hZ8OFyQIMFAPjEWAd6mAOaRKwiefwqUkWyx950=";
+  };
+
+  nativeBuildInputs = [
+    gnat
+    gprbuild
+  ];
+
+  propagatedBuildInputs = [
+    vss-extra
+    vss-text
+  ];
+
+  env = {
+    PREFIX = placeholder "out";
+    GPRDIR = "${finalAttrs.env.PREFIX}/share/gpr";
+    LIBDIR = "${finalAttrs.env.PREFIX}/lib";
+    BINDIR = "${finalAttrs.env.PREFIX}/bin";
+    INSTALL_PROJECT_DIR = finalAttrs.env.GPRDIR;
+    INSTALL_INCLUDE_DIR = "${finalAttrs.env.PREFIX}/include/sarif_ada";
+    INSTALL_EXEC_DIR = finalAttrs.env.BINDIR;
+    INSTALL_LIBRARY_DIR = finalAttrs.env.LIBDIR;
+    INSTALL_ALI_DIR = "${finalAttrs.env.INSTALL_LIBRARY_DIR}/sarif_ada";
+  };
+
+  # Based on the vss-text makefile
+  # Use this over the built in makefile to allow building shared libraries
+  buildPhase = ''
+    runHook preBuild
+
+    gprbuild -p -j$NIX_BUILD_CORES $GPRFLAGS -XSARIF_BUILD_PROFILE=release \
+      -XSARIF_ADA_LIBRARY_TYPE=static -XVSS_LIBRARY_TYPE=static sarif_ada.gpr
+    gprbuild -p -j$NIX_BUILD_CORES $GPRFLAGS -XSARIF_BUILD_PROFILE=validation \
+      -XSARIF_ADA_LIBRARY_TYPE=static -XVSS_LIBRARY_TYPE=static sarif_ada.gpr
+  ''
+  + lib.optionalString enableShared ''
+    gprbuild -p -j$NIX_BUILD_CORES $GPRFLAGS -XSARIF_BUILD_PROFILE=release \
+      -XSARIF_ADA_LIBRARY_TYPE=static-pic -XVSS_LIBRARY_TYPE=static-pic sarif_ada.gpr
+    gprbuild -p -j$NIX_BUILD_CORES $GPRFLAGS -XSARIF_BUILD_PROFILE=validation \
+      -XSARIF_ADA_LIBRARY_TYPE=static-pic -XVSS_LIBRARY_TYPE=static-pic sarif_ada.gpr
+    gprbuild -p -j$NIX_BUILD_CORES $GPRFLAGS -XSARIF_BUILD_PROFILE=release \
+      -XSARIF_ADA_LIBRARY_TYPE=relocatable -XVSS_LIBRARY_TYPE=relocatable sarif_ada.gpr
+    gprbuild -p -j$NIX_BUILD_CORES $GPRFLAGS -XSARIF_BUILD_PROFILE=validation \
+      -XSARIF_ADA_LIBRARY_TYPE=relocatable -XVSS_LIBRARY_TYPE=relocatable sarif_ada.gpr
+  ''
+  + ''
+
+    runHook postBuild
+  '';
+
+  # Makefile has no install target
+  installPhase = ''
+    runHook preInstall
+
+    gprinstall $GPRFLAGS -XSARIF_BUILD_PROFILE=release \
+      -XSARIF_ADA_LIBRARY_TYPE=static -XVSS_LIBRARY_TYPE=static --build-name=static \
+      --build-var=LIBRARY_TYPE --build-var=SARIF_ADA_LIBRARY_TYPE \
+      --prefix=$PREFIX --exec-subdir=$INSTALL_EXEC_DIR \
+      --lib-subdir=$INSTALL_ALI_DIR/static --project-subdir=$INSTALL_PROJECT_DIR \
+      --link-lib-subdir=$INSTALL_LIBRARY_DIR --sources-subdir=$INSTALL_INCLUDE_DIR \
+      -f -p -P sarif_ada.gpr --install-name=sarif_ada
+  ''
+  + lib.optionalString enableShared ''
+    gprinstall $GPRFLAGS -XSARIF_BUILD_PROFILE=release \
+      -XSARIF_ADA_LIBRARY_TYPE=static-pic -XVSS_LIBRARY_TYPE=static-pic --build-name=static-pic \
+      --build-var=LIBRARY_TYPE --build-var=SARIF_ADA_LIBRARY_TYPE \
+      --prefix=$PREFIX --exec-subdir=$INSTALL_EXEC_DIR \
+      --lib-subdir=$INSTALL_ALI_DIR/static-pic --project-subdir=$INSTALL_PROJECT_DIR \
+      --link-lib-subdir=$INSTALL_LIBRARY_DIR --sources-subdir=$INSTALL_INCLUDE_DIR \
+      -f -p -P sarif_ada.gpr --install-name=sarif_ada
+    gprinstall $GPRFLAGS -XSARIF_BUILD_PROFILE=release \
+      -XSARIF_ADA_LIBRARY_TYPE=relocatable -XVSS_LIBRARY_TYPE=relocatable --build-name=relocatable \
+      --build-var=LIBRARY_TYPE --build-var=SARIF_ADA_LIBRARY_TYPE \
+      --prefix=$PREFIX --exec-subdir=$INSTALL_EXEC_DIR \
+      --lib-subdir=$INSTALL_ALI_DIR/relocatable --project-subdir=$INSTALL_PROJECT_DIR \
+      --link-lib-subdir=$INSTALL_LIBRARY_DIR --sources-subdir=$INSTALL_INCLUDE_DIR \
+      -f -p -P sarif_ada.gpr --install-name=sarif_ada
+  ''
+  + ''
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "An Ada library for parsing and producing SARIF reports";
+    homepage = "https://github.com/AdaCore/sarif-ada";
+    license = lib.licenses.llvm-exception;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.sempiternal-aurora ];
+  };
+})

--- a/pkgs/development/ada-modules/vss-extra/default.nix
+++ b/pkgs/development/ada-modules/vss-extra/default.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gprbuild,
+  gnat,
+  vss-text,
+  enableShared ? !stdenv.hostPlatform.isStatic,
+}:
+
+let
+  makeTarget = if enableShared then "all-libs" else "libs-release_static";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vss-extra";
+  version = "26.0.0";
+
+  src = fetchFromGitHub {
+    owner = "AdaCore";
+    repo = "vss-extra";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-J13v2Rx2Yl06Fhs+FmyVEul0tfS2Xw/qsIdWXUrls9c=";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail "-j0" "-j$NIX_BUILD_CORES"
+  '';
+
+  nativeBuildInputs = [
+    gnat
+    gprbuild
+  ];
+
+  propagatedBuildInputs = [
+    vss-text
+  ];
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  buildFlags = [
+    "build-${makeTarget}"
+  ];
+
+  # Cannot run the checks, as it requires downloading extra test data
+  doCheck = false;
+
+  installTargets = [
+    "install-${makeTarget}"
+  ];
+
+  meta = {
+    description = "Ada libraries for JSON, Regexp, XML and more";
+    homepage = "https://github.com/AdaCore/vss-extra";
+    license = lib.licenses.llvm-exception;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.sempiternal-aurora ];
+  };
+})

--- a/pkgs/development/ada-modules/vss-text/default.nix
+++ b/pkgs/development/ada-modules/vss-text/default.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gprbuild,
+  gnat,
+  fetchpatch2,
+  enableShared ? !stdenv.hostPlatform.isStatic,
+}:
+
+let
+  makeTarget = if enableShared then "all-libs" else "libs-release_static";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vss-text";
+  version = "26.0.0";
+
+  src = fetchFromGitHub {
+    owner = "AdaCore";
+    repo = "vss-text";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-mSp5mmXHODLs2npVnjgTPpGSxVqIETdZCBulvBoK6dI=";
+  };
+
+  patches = [
+    # vss-strings-cursors-iterators-characters.adb:24:64: error: actual for aliased formal "Position" has wrong accessibility in return (RM 6.4.1(6.4))
+    (fetchpatch2 {
+      url = "https://github.com/AdaCore/vss-text/commit/7dd4c487cac67b822104f65160c97aa252055c96.patch?full_index=1";
+      hash = "sha256-8ObEEQEKYr7UH86sg57s81JrSOXVj4k/zb2S/mRa/J0=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail "-j0" "-j$NIX_BUILD_CORES"
+  '';
+
+  nativeBuildInputs = [
+    gnat
+    gprbuild
+  ];
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  buildFlags = [
+    "build-${makeTarget}"
+  ];
+
+  # Cannot run the checks, as it requires downloading extra test data
+  doCheck = false;
+
+  installTargets = [
+    "install-${makeTarget}"
+  ];
+
+  meta = {
+    description = "A high level Unicode text processing library.";
+    homepage = "https://github.com/AdaCore/vss-text";
+    license = lib.licenses.llvm-exception;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.sempiternal-aurora ];
+  };
+})

--- a/pkgs/development/ada-modules/xmlada/default.nix
+++ b/pkgs/development/ada-modules/xmlada/default.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  autoreconfHook269,
   gnat,
   # use gprbuild-boot since gprbuild proper depends
   # on this xmlada derivation.
@@ -10,19 +11,23 @@
 
 stdenv.mkDerivation rec {
   pname = "xmlada";
-  version = "25.0.0";
+  version = "26.0.0";
 
   src = fetchFromGitHub {
-    name = "xmlada-${version}-src";
     owner = "AdaCore";
     repo = "xmlada";
-    rev = "v${version}";
-    sha256 = "sha256-UMJiXSHMS8+X5gyV1nmC29gF71BFnz7LNPQnwUMD3Yg=";
+    tag = "v${version}";
+    hash = "sha256-+7SaLykENypvpx/C5a93DBjusltFNEsVH1pTkfsKwPU=";
   };
 
   nativeBuildInputs = [
     gnat
     gprbuild-boot
+    autoreconfHook269
+  ];
+
+  makeFlags = [
+    "PROCESSORS=$(NIX_BUILD_CORES)"
   ];
 
   meta = {

--- a/pkgs/development/ada-modules/xmlada/default.nix
+++ b/pkgs/development/ada-modules/xmlada/default.nix
@@ -33,7 +33,10 @@ stdenv.mkDerivation rec {
   meta = {
     description = "XML/Ada: An XML parser for Ada";
     homepage = "https://github.com/AdaCore/xmlada";
-    maintainers = [ lib.maintainers.sternenseemann ];
+    maintainers = with lib.maintainers; [
+      sternenseemann
+      sempiternal-aurora
+    ];
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.all;
   };

--- a/pkgs/top-level/ada-packages.nix
+++ b/pkgs/top-level/ada-packages.nix
@@ -21,14 +21,14 @@ makeScopeWithSplicing' {
 
       xmlada = self.callPackage ../development/ada-modules/xmlada { };
 
-      gnatprove =
-        # They haven't released a version of gnatprove for gnat16 yet
-        if lib.versionOlder gnat.version "16" then
-          self.callPackage ../development/ada-modules/gnatprove {
-            ocamlPackages = pkgs.ocaml-ng.ocamlPackages_4_14;
-          }
-        else
-          null;
+      sarif-ada = self.callPackage ../development/ada-modules/sarif-ada { };
+
+      vss-text = self.callPackage ../development/ada-modules/vss-text { };
+      vss-extra = self.callPackage ../development/ada-modules/vss-extra { };
+
+      gnatprove = self.callPackage ../development/ada-modules/gnatprove {
+        ocamlPackages = pkgs.ocaml-ng.ocamlPackages_4_14;
+      };
 
       gnatcoll-core = self.callPackage ../development/ada-modules/gnatcoll/core.nix { };
 
@@ -66,11 +66,15 @@ makeScopeWithSplicing' {
       gnatcoll-postgres = self.callPackage ../development/ada-modules/gnatcoll/db.nix {
         component = "postgres";
       };
-      gnatcoll-sql = self.callPackage ../development/ada-modules/gnatcoll/db.nix { component = "sql"; };
+      gnatcoll-sql = self.callPackage ../development/ada-modules/gnatcoll/db.nix {
+        component = "sql";
+      };
       gnatcoll-sqlite = self.callPackage ../development/ada-modules/gnatcoll/db.nix {
         component = "sqlite";
       };
-      gnatcoll-xref = self.callPackage ../development/ada-modules/gnatcoll/db.nix { component = "xref"; };
+      gnatcoll-xref = self.callPackage ../development/ada-modules/gnatcoll/db.nix {
+        component = "xref";
+      };
       gnatcoll-db2ada = self.callPackage ../development/ada-modules/gnatcoll/db.nix {
         component = "gnatcoll_db2ada";
       };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

A general project to update the various gnat packages and fix their build. Also hopefully bump the default gnat version to match the default gcc version. Draft because there's still things to fix, including:
- [x] `gnat15Packages.gnatprove` doesn't build right now. This is a regression, but I'm not sure why. Need to investigate.
  - My current hypothesis is a mismatch between the gprbuild and gpr2 versions, but I'm still investigating
  - We need to use gpr2 v25 to build the fsf-15 branch, as the API changed
  - And we need gnatcoll 25 because of a mismatch of hashes between gpr2 and gnatcoll
- [x] `gnat` fails building on `x86_64-darwin` without the apple xcode command line tools installed. (see #522847)
  - This is because the precompiled gnat binaries we use set default sysroots that I can't seem to override
  - That, and the assembler doesn't support `--sysroot` overrides.
  - Need to figure out how to properly wrap the precompiled binary to make it find all the libraries.
- [x] upstream alire project provides prebuilt gnat13 and 14 binaries for aarch64-linux, but not gnat15. (see #522847)
  - Might be possible to download these and use them to bootstrap gnat on aarch64-linux
  - Testing shows that it has the same problem as `x86_64-darwin` right now, so need to fix that before testing can be done

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
