### PR TITLE
gpgme: 2.0.1 -> 2.1.0

### DIFF
--- a/pkgs/by-name/gp/gpgme/package.nix
+++ b/pkgs/by-name/gp/gpgme/package.nix
@@ -22,7 +22,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gpgme";
-  version = "2.0.1";
+  version = "2.1.0";
 
   outputs = [
     "out"
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnupg/gpgme/gpgme-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-ghqwaVyELqtRdSqBmAySsEEMfq3QQQP3kdXSpSZ4SWY=";
+    hash = "sha256-hBxepT/CYln0+/DovemC3qG4ocoMt35oHIKwUFZr+Ss=";
   };
 
   postPatch = ''
@@ -110,7 +110,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://gnupg.org/software/gpgme/index.html";
-    changelog = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gpgme.git;f=NEWS;hb=gpgme-${finalAttrs.version}";
+    changelog = "https://dev.gnupg.org/source/gpgme/browse/master/NEWS;gpgme-${finalAttrs.version}?as=remarkup";
     description = "Library for making GnuPG easier to use";
     longDescription = ''
       GnuPG Made Easy (GPGME) is a library designed to make access to GnuPG

--- a/pkgs/by-name/gp/gpgmepp/package.nix
+++ b/pkgs/by-name/gp/gpgmepp/package.nix
@@ -10,11 +10,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gpgmepp";
-  version = "2.0.0";
+  version = "2.1.0";
 
   src = fetchurl {
     url = "mirror://gnupg/gpgmepp/gpgmepp-${finalAttrs.version}.tar.xz";
-    hash = "sha256-1HlgScBnCKJvMJb3SO8JU0fho8HlcFYXAf6VLD9WU4I=";
+    hash = "sha256-V/gERo8CBFBLFyxrE5ywUSS0JjvnrVFJMsfExQYqFuI=";
   };
 
   postPatch = ''

--- a/pkgs/development/libraries/qgpgme/default.nix
+++ b/pkgs/development/libraries/qgpgme/default.nix
@@ -10,11 +10,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "qgpgme";
-  version = "2.0.0";
+  version = "2.1.0";
 
   src = fetchurl {
     url = "mirror://gnupg/qgpgme/qgpgme-${finalAttrs.version}.tar.xz";
-    hash = "sha256-FWRbJHXMphGOsu0zGzqNlELJ1AGcOEa6P20lMhtKYa0=";
+    hash = "sha256-WzL+s+7kp/lALSK3IGSAkI3EO7TfOCkXwHXFEhFvjwg=";
   };
 
   patches = [
@@ -28,6 +28,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_WITH_QT5" (lib.versions.major qtbase.version == "5"))
+    (lib.cmakeBool "BUILD_WITH_QT6" (lib.versions.major qtbase.version == "6"))
   ];
 
   buildInputs = [


### PR DESCRIPTION
Changelog: https://dev.gnupg.org/source/gpgme/browse/master/NEWS;gpgme-2.1.0?as=remarkup

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
