### PR TITLE
autorandr: add support for lid listener service

### DIFF
--- a/nixos/modules/services/misc/autorandr.nix
+++ b/nixos/modules/services/misc/autorandr.nix
@@ -273,6 +273,21 @@ let
         off
       '';
 
+  autorandrChangeScript = pkgs.writeShellScript "autorandr-change" ''
+    ${pkgs.autorandr}/bin/autorandr \
+      --batch \
+      --change \
+      --default ${cfg.defaultTarget} \
+      ${lib.optionalString cfg.ignoreLid "--ignore-lid"} \
+      ${lib.optionalString cfg.matchEdid "--match-edid"}
+  '';
+
+  autorandrLidListenerScript = pkgs.writeShellScript "autorandr-lid-listener" ''
+    stdbuf -oL ${pkgs.libinput}/bin/libinput debug-events | \
+      grep -E --line-buffered '^[[:space:]-]+event[0-9]+[[:space:]]+SWITCH_TOGGLE[[:space:]]' | \
+      while read line; do ${autorandrChangeScript}; done
+  '';
+
 in
 {
 
@@ -295,6 +310,12 @@ in
         default = false;
         type = lib.types.bool;
         description = "Treat outputs as connected even if their lids are closed";
+      };
+
+      enableLidListener = lib.mkOption {
+        default = false;
+        type = lib.types.bool;
+        description = "Whether to run the autorandr-lid-listener service";
       };
 
       matchEdid = lib.mkOption {
@@ -389,20 +410,25 @@ in
       startLimitIntervalSec = 5;
       startLimitBurst = 1;
       serviceConfig = {
-        ExecStart = ''
-          ${pkgs.autorandr}/bin/autorandr \
-            --batch \
-            --change \
-            --default ${cfg.defaultTarget} \
-            ${lib.optionalString cfg.ignoreLid "--ignore-lid"} \
-            ${lib.optionalString cfg.matchEdid "--match-edid"}
-        '';
+        ExecStart = autorandrChangeScript;
         Type = "oneshot";
         RemainAfterExit = false;
         KillMode = "process";
       };
     };
 
+    systemd.services.autorandr-lid-listener = lib.mkIf cfg.enableLidListener {
+      wantedBy = [ "multi-user.target" ];
+      description = "Runs autorandr whenever the lid state changes";
+
+      serviceConfig = {
+        ExecStart = autorandrLidListenerScript;
+        Type = "simple";
+        Restart = "always";
+        RestartSec = 30;
+        SyslogIdentifier = "autorandr";
+      };
+    };
   };
 
   meta.maintainers = with lib.maintainers; [ alexnortung ];


### PR DESCRIPTION
Add an option `enableLidListener` to `services.autorandr` which, when `true`, adds a systemd service `autorandr-lid-listener.service` listening to laptop lid events and triggering `autorandr --change`, effectively packaging [the service as defined in upstream](https://github.com/phillipberndt/autorandr/blob/e459be771cff7c06d80fb707a7e91cc053dea118/contrib/systemd/autorandr-lid-listener.service). To avoid code duplication, I also moved the former `ExecStart` of `autorandr.service` into a standalone script.

See also https://github.com/phillipberndt/autorandr/issues/104#issuecomment-1630353742

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test