### PR TITLE
rapid-photo-downloader: change homepage to correct URL

### DIFF
--- a/pkgs/by-name/ra/rapid-photo-downloader/package.nix
+++ b/pkgs/by-name/ra/rapid-photo-downloader/package.nix
@@ -125,7 +125,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   meta = {
     description = "Photo and video importer for cameras, phones, and memory cards";
     mainProgram = "rapid-photo-downloader";
-    homepage = "https://www.damonlynch.net/rapid/";
+    homepage = "https://damonlynch.net/rapid/";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ philipdb ];


### PR DESCRIPTION
www.damonlynch.net returns a TLS certificate with the wrong CN, resulting in a browser error. The domain without the www returns a good TLS certificate. It's also the URL used on the project's GitHub.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.