### PR TITLE
ocamlPackages.janeStreet: patch core_unix for correct version output

### DIFF
--- a/pkgs/development/ocaml-modules/janestreet/0.17.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.17.nix
@@ -6,6 +6,7 @@
   lib,
   openssl,
   zstd,
+  replaceVars,
 }:
 
 let
@@ -524,11 +525,16 @@ with self;
       timezone
       spawn
     ];
+    patches = [
+      (import ./insert_version_core_unix {
+        inherit replaceVars;
+        version = "0.17";
+      })
+    ];
     postPatch = ''
       patchShebangs unix_pseudo_terminal/src/discover.sh
     '';
     doCheck = false; # command_validate_parsing.exe is not specified in test build deps
-
   };
 
   csvfields = janePackage {

--- a/pkgs/development/ocaml-modules/janestreet/insert_version_core_unix/default.nix
+++ b/pkgs/development/ocaml-modules/janestreet/insert_version_core_unix/default.nix
@@ -1,0 +1,5 @@
+{
+  replaceVars,
+  version,
+}:
+replaceVars ./version-patch.patch { JANESTREET_MISSING_VERSION = version; }

--- a/pkgs/development/ocaml-modules/janestreet/insert_version_core_unix/version-patch.patch
+++ b/pkgs/development/ocaml-modules/janestreet/insert_version_core_unix/version-patch.patch
@@ -1,0 +1,25 @@
+diff --git a/command_unix/src/command_unix.ml b/command_unix/src/command_unix.ml
+index 5527c39..b2f7600 100644
+--- a/command_unix/src/command_unix.ml
++++ b/command_unix/src/command_unix.ml
+@@ -20,7 +20,7 @@ module For_unix = Command.Private.For_unix (struct
+   end
+ end)
+
+-let run = For_unix.run
++let run = For_unix.run ~version:"@JANESTREET_MISSING_VERSION@"
+ let shape = For_unix.shape
+
+ module Deprecated = struct
+diff --git a/command_unix/src/command_unix.mli b/command_unix/src/command_unix.mli
+index d9e81b3..93aeaac 100644
+--- a/command_unix/src/command_unix.mli
++++ b/command_unix/src/command_unix.mli
+@@ -32,7 +32,6 @@ open! Core
+ val run
+   :  ?add_validate_parsing_flag:bool
+   -> ?verbose_on_parse_error:bool
+-  -> ?version:string
+   -> ?build_info:string
+   -> ?argv:string list
+   -> ?extend:(string list -> string list)

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -938,6 +938,7 @@ let
                 lib
                 openssl
                 zstd
+                replaceVars
                 ;
             }
           else if lib.versionOlder "4.13.1" ocaml.version then


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes #495761.
Add a patch that inserts the version of janeStreet package that a given package set belongs to.

I'm not sure this is the right solution, but it does the trick. Let me know if I can improve it :+1:

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
