### PR TITLE
python3Packages.pytest-pylint: fix tests with newer pytest

### DIFF
--- a/pkgs/development/python-modules/pytest-pylint/default.nix
+++ b/pkgs/development/python-modules/pytest-pylint/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  fetchpatch2,
   setuptools,
   pylint,
   pytest,
@@ -18,6 +19,17 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-iHZLjh1c+hiAkkjgzML8BQNfCMNfCwIi3c/qHDxOVT4=";
   };
+
+  patches = [
+    # Use pathlib.Path in plugin hooks for pytest 8.1+ compatibility.
+    (fetchpatch2 {
+      url = "https://github.com/carsongee/pytest-pylint/commit/62457e8013df106116fb2a62c7c44870103ff393.patch?full_index=1";
+      hash = "sha256-EnlHEe5uZkvrWO8B33xkQ3LCQ7Bj5/oLES//NP8vkwE=";
+    })
+    # Handle test output difference in pytest 9.
+    # https://github.com/carsongee/pytest-pylint/pull/196
+    ./pytest-9.patch
+  ];
 
   postPatch = ''
     substituteInPlace setup.py \

--- a/pkgs/development/python-modules/pytest-pylint/pytest-9.patch
+++ b/pkgs/development/python-modules/pytest-pylint/pytest-9.patch
@@ -1,0 +1,13 @@
+diff --git a/pytest_pylint/tests/test_pytest_pylint.py b/pytest_pylint/tests/test_pytest_pylint.py
+index 4c87ac336690defb2f2d472b389945c91fae5d31..f6478c018f5974acb2fdd95f1d461ca71e1302ba 100644
+--- a/pytest_pylint/tests/test_pytest_pylint.py
++++ b/pytest_pylint/tests/test_pytest_pylint.py
+@@ -38,7 +38,7 @@ def test_nodeid_no_dupepath(testdir):
+     testdir.makepyfile(app="import sys")
+     result = testdir.runpytest("--pylint", "--verbose")
+     assert re.search(
+-        r"^FAILED\s+app\.py::PYLINT$", result.stdout.str(), flags=re.MULTILINE
++        r"^FAILED\s+app\.py::PYLINT( |$)", result.stdout.str(), flags=re.MULTILINE
+     )
+
+


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327617845)](https://hydra.nixos.org/build/327617845)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
