### PR TITLE
python3Packages.pytask: 0.5.8 -> 0.6.0

### DIFF
--- a/pkgs/development/python-modules/pytask/default.nix
+++ b/pkgs/development/python-modules/pytask/default.nix
@@ -4,35 +4,35 @@
   fetchFromGitHub,
   hatchling,
   hatch-vcs,
-  attrs,
   click,
   click-default-group,
+  cloudpickle,
+  git,
+  msgspec,
+  nbmake,
   networkx,
   optree,
   packaging,
+  pexpect,
   pluggy,
+  pytest-xdist,
+  pytestCheckHook,
   rich,
   sqlalchemy,
-  universal-pathlib,
-  pytestCheckHook,
-  cloudpickle,
-  nbmake,
-  pexpect,
-  pytest-xdist,
   syrupy,
-  git,
+  universal-pathlib,
 }:
 
 buildPythonPackage rec {
   pname = "pytask";
-  version = "0.5.8";
+  version = "0.6.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pytask-dev";
     repo = "pytask";
     tag = "v${version}";
-    hash = "sha256-tQUvqqbFUO3cw+dVPfCKiYyhwX31vqUBXr7GrRfPC+A=";
+    hash = "sha256-l7jQAUBb8iW5S8Am2cMCgqYcvtLq8UgEhrCNnSx9N1E=";
   };
 
   build-system = [
@@ -41,27 +41,34 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
-    attrs
     click
     click-default-group
-    networkx
+    msgspec
     optree
     packaging
     pluggy
     rich
     sqlalchemy
     universal-pathlib
-  ];
+  ]
+  ++ msgspec.optional-dependencies.toml;
+
+  optional-dependencies = {
+    dag = [ networkx ];
+  };
 
   nativeCheckInputs = [
-    pytestCheckHook
     cloudpickle
     git
     nbmake
     pexpect
     pytest-xdist
+    pytestCheckHook
     syrupy
-  ];
+  ]
+  ++ lib.concatAttrValues optional-dependencies;
+
+  pytestFlags = [ "--snapshot-warn-unused" ];
 
   # The test suite runs the installed command for e2e tests
   preCheck = ''
@@ -73,12 +80,12 @@ buildPythonPackage rec {
     "test_download_file"
     # Racy
     "test_more_nested_pytree_and_python_node_as_return_with_names"
-    # Without uv, subprocess unexpectedly doesn't fail
-    "test_pytask_on_a_module_that_uses_the_functional_api"
     # Timeout
     "test_pdb_interaction_capturing_twice"
     "test_pdb_interaction_capturing_simple"
   ];
+
+  pythonImportsCheck = [ "pytask" ];
 
   meta = {
     description = "Workflow management system that facilitates reproducible data analyses";


### PR DESCRIPTION
Release: https://github.com/pytask-dev/pytask/releases/tag/v0.6.0
Diff: https://github.com/pytask-dev/pytask/compare/v0.5.8...v0.6.0
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327156479)](https://hydra.nixos.org/build/327156479)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
