### PR TITLE
onlyoffice-documentserver: add document-{templates,formats}

### DIFF
--- a/pkgs/by-name/on/onlyoffice-documentserver/package.nix
+++ b/pkgs/by-name/on/onlyoffice-documentserver/package.nix
@@ -35,6 +35,12 @@ let
     tag = "v9.3.1.1";
     hash = "sha256-+52+MK/8DARJrQRbIpN5nk3j3J9cy6Wd1FDMnCVZKRE=";
   };
+  document-formats-src = fetchFromGitHub {
+    owner = "ONLYOFFICE";
+    repo = "document-formats";
+    tag = "v9.3.1.1";
+    hash = "sha256-HpGhV+PGbQ5hHH6mPQTAdFpBT3nUni4VtDxTExJypAc=";
+  };
   common = buildNpmPackage (finalAttrs: {
     name = "onlyoffice-server-Common";
     src = server-src;
@@ -190,6 +196,7 @@ let
       cp -r ${server-src}/schema/* $out/var/www/onlyoffice/documentserver/server/schema
 
       ln -s ${document-templates-src} $out/var/www/onlyoffice/documentserver/document-templates
+      ln -s ${document-formats-src} $out/var/www/onlyoffice/documentserver/document-formats
 
       ## required for bwrap --bind
       chmod u+w $out/var

--- a/pkgs/by-name/on/onlyoffice-documentserver/package.nix
+++ b/pkgs/by-name/on/onlyoffice-documentserver/package.nix
@@ -27,6 +27,14 @@ let
     tag = "v9.3.1.1";
     hash = "sha256-uN1L/4I7wrg0BqAAu3zdn8LqtdfJDAHnAMbCvzQnOvI=";
   };
+  # This is required but not included in the submodules for some reason.
+  # https://github.com/ONLYOFFICE/server/blob/34adaeeb4cc1e032a5cf188924880a25546dc67c/Makefile#L81-L83
+  document-templates-src = fetchFromGitHub {
+    owner = "ONLYOFFICE";
+    repo = "document-templates";
+    tag = "v9.3.1.1";
+    hash = "sha256-+52+MK/8DARJrQRbIpN5nk3j3J9cy6Wd1FDMnCVZKRE=";
+  };
   common = buildNpmPackage (finalAttrs: {
     name = "onlyoffice-server-Common";
     src = server-src;
@@ -180,6 +188,8 @@ let
 
       mkdir -p $out/var/www/onlyoffice/documentserver/server/schema
       cp -r ${server-src}/schema/* $out/var/www/onlyoffice/documentserver/server/schema
+
+      ln -s ${document-templates-src} $out/var/www/onlyoffice/documentserver/document-templates
 
       ## required for bwrap --bind
       chmod u+w $out/var


### PR DESCRIPTION
This is required for WOPI operations, otherwise the discovery endpoint will throw

```
mai 14 18:58:03 onlyoffice-wrapper[31901]: [2026-05-14T18:58:03.608]
[ERROR] [localhost] [docId] [userId] nodeJS - wopiDiscovery error:Error:
ENOENT: no such file or directory, scandir
'/var/www/onlyoffice/documentserver/document-templates/new/en-US/'
mai 14 18:58:03 onlyoffice-wrapper[31901]:     at async readdir
(node:internal/fs/promises:956:18)
mai 14 18:58:03 onlyoffice-wrapper[31901]:     at async
getTemplatesFolderExts
(/nix/store/hyjpbwg2ckaqb50ky8wcklj4ixnpx59g-onlyoffice-server-DocService/lib/node_modules/coauthoring/sources/wopiClient.js:126:24)
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
