### PR TITLE
python3Packages.psycopg2cffi: disable test_notify on python 3.13+

### DIFF
--- a/pkgs/development/python-modules/psycopg2cffi/default.nix
+++ b/pkgs/development/python-modules/psycopg2cffi/default.nix
@@ -7,6 +7,7 @@
   postgresql,
   postgresqlTestHook,
   pytestCheckHook,
+  pythonAtLeast,
   setuptools,
   six,
   stdenv,
@@ -54,6 +55,11 @@ buildPythonPackage rec {
   disabledTests = [
     # AssertionError: '{}' != []
     "testEmptyArray"
+  ];
+
+  disabledTestPaths = lib.optionals (pythonAtLeast "3.13") [
+    # testutils.script_to_py3 imports lib2to3, removed in 3.13
+    "psycopg2cffi/tests/psycopg2_tests/test_notify.py"
   ];
 
   env = {


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/329021279)](https://hydra.nixos.org/build/329021279)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
