### PR TITLE
python3Packages.pydantic-{ai-slim,graph}: 1.95.1 -> 1.97.0; python3Packages.genai-prices: 0.0.59 -> 0.0.60

### DIFF
--- a/nixos/tests/web-apps/lasuite-docs.nix
+++ b/nixos/tests/web-apps/lasuite-docs.nix
@@ -14,12 +14,9 @@ in
     soyouzpanda
   ];
 
-  nodes.machine =
+  containers.machine =
     { pkgs, ... }:
     {
-      virtualisation.diskSize = 4 * 1024;
-      virtualisation.memorySize = 4 * 1024;
-
       networking.hosts."127.0.0.1" = [ domain ];
 
       environment.systemPackages = with pkgs; [

--- a/pkgs/development/python-modules/genai-prices/default.nix
+++ b/pkgs/development/python-modules/genai-prices/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "genai-prices";
-  version = "0.0.59";
+  version = "0.0.60";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pydantic";
     repo = "genai-prices";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ANYl6wxjAZYnzvKhMsmC2eyg33ngF8DaYd67KCBGHLg=";
+    hash = "sha256-txcaBPxIUssTlnDNhe2f9Jlr5LaZT1zIcJslMK3Bayk=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/packages/python";

--- a/pkgs/development/python-modules/pydantic-ai-slim/default.nix
+++ b/pkgs/development/python-modules/pydantic-ai-slim/default.nix
@@ -20,14 +20,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pydantic-ai-slim";
-  version = "1.95.1";
+  version = "1.97.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pydantic";
     repo = "pydantic-ai";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-JE5ufIfwEVtJ9OOdPnuQPiOOvmo63l6D7IsNIats39c=";
+    hash = "sha256-L18K1g77PeHlc7BdWalrMPOaBmdRErIXogiLcW57lq8=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/pydantic_ai_slim";

--- a/pkgs/development/python-modules/pydantic-graph/default.nix
+++ b/pkgs/development/python-modules/pydantic-graph/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pydantic-graph";
-  version = "1.95.1";
+  version = "1.97.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pydantic";
     repo = "pydantic-ai";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-JE5ufIfwEVtJ9OOdPnuQPiOOvmo63l6D7IsNIats39c=";
+    hash = "sha256-L18K1g77PeHlc7BdWalrMPOaBmdRErIXogiLcW57lq8=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/pydantic_graph";


### PR DESCRIPTION
https://github.com/pydantic/genai-prices/compare/v0.0.59...v0.0.60
https://github.com/pydantic/pydantic-ai/compare/v1.95.1...v1.97.0

Migrates the lasuite-docs tests to run in nspawn.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
