### PR TITLE
[25.11] electron_42: init at 42.1.0, electron_{39,40,41}: updates

### DIFF
--- a/pkgs/development/tools/electron/binary/generic.nix
+++ b/pkgs/development/tools/electron/binary/generic.nix
@@ -180,6 +180,9 @@ let
     '';
 
     passthru.dist = finalAttrs.finalPackage + "/libexec/electron";
+
+    __structuredAttrs = true;
+    strictDeps = true;
   };
 
   darwin = finalAttrs: {

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -23,14 +23,14 @@
     },
     "39": {
         "hashes": {
-            "aarch64-darwin": "2c921ce845b4f5fa0abeb160f38f472ed486f7b1c8fb8a19f549a48f388bdbfa",
-            "aarch64-linux": "c0cb946a480b0f4a6dfdbed3287fd38b099b749696d7b9107e24287aa9eded97",
-            "armv7l-linux": "e16173659ba8d982ad5718309d0eb22f793c6a58e9c0fd2e518ef5f045d96b40",
-            "headers": "15alm4mx7ad4czrysnk7wds625y7rsz7ncr1djq8an8fdar3fnw0",
-            "x86_64-darwin": "5a42fa7665fa67570990b5b2608d2414692a8176033401ffc07b3f26fca3901d",
-            "x86_64-linux": "9473c2773377344fd8822fe0255a1d2bff00b4f4b3e1fe8acadea00164e56c33"
+            "aarch64-darwin": "f7e3ed2cc34dd2eba3f2a95234b576fe8082d35fb133e482102c08105f298572",
+            "aarch64-linux": "8d01f0063ce2cc83a68b5c723db813c2bb8621ff63ba2ddec786a589baef7247",
+            "armv7l-linux": "6e4d0d96b5ed98b9973868b8ea6234a5511cae866f15e586be7003a753b7afcc",
+            "headers": "0sb9biq3z92f32dklisiax9pk5kj8yhwvihchcsp6v4vag7jx45v",
+            "x86_64-darwin": "de5389b3a1a8803fa50e2a2c2a9a8816f1fd5d996ac66a217c04396109d42e6b",
+            "x86_64-linux": "92e8b031fa5327c78a972279fd75fc8503fcd1773401809f4557e4de583eabd1"
         },
-        "version": "39.8.9"
+        "version": "39.8.10"
     },
     "40": {
         "hashes": {

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -34,14 +34,14 @@
     },
     "40": {
         "hashes": {
-            "aarch64-darwin": "e83a97b7c7017ec36e9e19f5b20430769e89e701c2b337da2685c13854fe70f3",
-            "aarch64-linux": "5b73273177e96ebd6005b7020f84c085c4a531b1701db03c1963b2ac2c1ea551",
-            "armv7l-linux": "9bcf8d1efd4f5d1dc2188a2d5c614c74322ede5efa8cf65ed387764d9109d26c",
-            "headers": "0133jya39pg40s3x4r3ijyvx2lyvbkp70bfi49zpiwlqvna628i4",
-            "x86_64-darwin": "b75319477edba3ce5161f18cc5283bc28096c2359bc47bc87ad5d365ea097fd5",
-            "x86_64-linux": "2b5e33327bd5e180b3c1c0ec429fa06769ee96c0f956a35471b9409b51f45ada"
+            "aarch64-darwin": "c3dd4d70aeb214a5b755af59e4e5d7b5b743f3f662a8a452b0afc2741953b7a5",
+            "aarch64-linux": "cb4454ae64f00f43cef86f57d38eff9a6cef7b1e0690debc1dc81323f98e6e63",
+            "armv7l-linux": "d3a99f2f734b407ab7de45dbb992825089a2f9e351c470a5fea0273ec027a681",
+            "headers": "0x534f94ds3qavwh90a4l63wpsagscwnbzi8399z067d2ghyzh18",
+            "x86_64-darwin": "a73b879e5cfa880e0b82e0a75d7a2ba1c892715d2db95dc6578277e74c7b8a04",
+            "x86_64-linux": "35efe7401822e8d2e474e13788a6191362c7494dd1f7ae327b70087e0768a667"
         },
-        "version": "40.9.3"
+        "version": "40.10.0"
     },
     "41": {
         "hashes": {

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -45,14 +45,14 @@
     },
     "41": {
         "hashes": {
-            "aarch64-darwin": "7a98f47f4c4f49399d3a838e9150b8828d2f5bf8aa7db769657ae82fab21f9d0",
-            "aarch64-linux": "c2bc73bf42630cf233fc9701d1cabb1edc0c367f47c8c967d9263cf90585e37a",
-            "armv7l-linux": "f116698dae5a68d9e9d650d97bcae6ef0ac6457d03e86b422f47ed4d79275d7c",
-            "headers": "1w8rdbjanqkl1237ppcgrkwdng93gniv3mqfxqikv0rpsg2d7gi7",
-            "x86_64-darwin": "9d0accc2157df3eb3a15c79f27a9dd763099d96aa286041cc1ba9a3ce6aed737",
-            "x86_64-linux": "b20e03cf174f8e56e235127d784dff8161ef4bb9c6bbc3d9383130225eb1e2a2"
+            "aarch64-darwin": "091a58410a353b7f7fc5898ccb6cc31c6e5ea7acd8caedf448833713563efae2",
+            "aarch64-linux": "1d0c89698bcc3029d0c197a215679c14c65ab67086c4529d5ea90280f3d5bcc2",
+            "armv7l-linux": "5da1bdfee31dc8579f12bebda5bbe40fce85c4916a4a76b2f055ab69cae573c4",
+            "headers": "0j9gvjjq9qdvjj33h2xh6qdxxr29aj96y2qs3p0xvy1bc3li9hzn",
+            "x86_64-darwin": "3085b52fc90e81c0c3ed7f59b759f710b176c5a8989ced64a51618e8fd3e8a2e",
+            "x86_64-linux": "1d5364794dffe2493d74a9755d49ba37ecdfd3d19a8e2a38349cd9374adb19d4"
         },
-        "version": "41.3.0"
+        "version": "41.5.0"
     },
     "42": {
         "hashes": {

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -56,13 +56,13 @@
     },
     "42": {
         "hashes": {
-            "aarch64-darwin": "3c619bb8ec6a243142e392335382a3383739a9977ca85067cb1f31599ff993e5",
-            "aarch64-linux": "5531da08123d60d50c833997842e8371970bebe7d29261e00eaa83de948332b4",
-            "armv7l-linux": "a0ab195cff93c86ddf284b7ef44026b29ff3ec89dcc4a2f5024ff28e32ae5b60",
-            "headers": "193c7vyzly6yln4zr0b7v5vlzixl9wz59lfmgwd86h4fc79kj9na",
-            "x86_64-darwin": "49f6e7ebd60f84b687af933eda5e87dce9525e1139151ff4cfd53821d3285358",
-            "x86_64-linux": "83c7178dba2d0ce77e13743bf86beda75c6141caeeadb4340e1888bc96298b4b"
+            "aarch64-darwin": "0ed37214478e49e2865bffd686dea38335bc46067169ee39a5c1658d0734806e",
+            "aarch64-linux": "a08a4e6913804eb05cea798d8bd0aface4d1b88e9d07db86b779ea4a448be070",
+            "armv7l-linux": "6f4d8e17222a132479a0eceb6a8438fe5ed1637a53c60ed54a8d7f03232f08c3",
+            "headers": "0r0g3iaji6a7gx51bv2ijq23zpcz8ip8kmfy0x9fxqpm9angvins",
+            "x86_64-darwin": "9a32e6bb055af7295c32d82dc3c49e1b64dde3d1eee85b83e5d2019445938630",
+            "x86_64-linux": "e1b8b5b86d3fff69e2b3502586363d384085ee0578bd041fa5915fd0b557c4f1"
         },
-        "version": "42.0.0"
+        "version": "42.0.1"
     }
 }

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -45,14 +45,14 @@
     },
     "41": {
         "hashes": {
-            "aarch64-darwin": "107fc8fd403a73f75116d4e11a96ee00fffc3a7e1e3cf3d4d1d79128f547335e",
-            "aarch64-linux": "f369c35fa2c8180a4a04f91771df08b83fb135a4825660be09918d965c82dca7",
-            "armv7l-linux": "1190afe3f95008961781402bb52893cff7f0cd4cbeb8569df0b35c80a943c380",
+            "aarch64-darwin": "b41988e6aa105e550931d9d2eff15c0bb99c39871c2ff5af87f105c44edc5a7a",
+            "aarch64-linux": "b69fb25275d744e272afe3775aed0cce20c8ad2309744558089c33da92c0432a",
+            "armv7l-linux": "f318e60b182fc791ba90bd7c586ee7e1f603daf90925b64d7c295e8b7a610875",
             "headers": "1n1w2ngk44w9khbh4bnw6kfakawdxh3wii3hkynbjzj21swvqzrb",
-            "x86_64-darwin": "a31411ff1705bc52f260c283b42ae1320a1de7b2422a9ab8e7d44009c8100c75",
-            "x86_64-linux": "47a1cf28685b695e6c1cf6307ebb79a234122c2da9b2a87a80ccbb00cd8df037"
+            "x86_64-darwin": "fc802de570925bf75ca5911ffd8a8736232de2c742430938b2b621c79af93db4",
+            "x86_64-linux": "8f1bbd1ea46c5e4fc5f3ae9a04554de9da2fe0c65fbd8751b8493d2b39bf7a97"
         },
-        "version": "41.5.2"
+        "version": "41.6.1"
     },
     "42": {
         "hashes": {

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -56,13 +56,13 @@
     },
     "42": {
         "hashes": {
-            "aarch64-darwin": "0ed37214478e49e2865bffd686dea38335bc46067169ee39a5c1658d0734806e",
-            "aarch64-linux": "a08a4e6913804eb05cea798d8bd0aface4d1b88e9d07db86b779ea4a448be070",
-            "armv7l-linux": "6f4d8e17222a132479a0eceb6a8438fe5ed1637a53c60ed54a8d7f03232f08c3",
+            "aarch64-darwin": "98d097299eb08094d0df3312b2d6e8677069d8defdab891143628d4f82f46117",
+            "aarch64-linux": "1e700f7f3daef794cc45235e51c1172664aed49a4e7737b8896ddc398bff4d7d",
+            "armv7l-linux": "576a317dda0dc8ea150d5b6f792c3eb0631a5065ec9c100af954d1cabddde93a",
             "headers": "0r0g3iaji6a7gx51bv2ijq23zpcz8ip8kmfy0x9fxqpm9angvins",
-            "x86_64-darwin": "9a32e6bb055af7295c32d82dc3c49e1b64dde3d1eee85b83e5d2019445938630",
-            "x86_64-linux": "e1b8b5b86d3fff69e2b3502586363d384085ee0578bd041fa5915fd0b557c4f1"
+            "x86_64-darwin": "63b938cbe6696f67f172d8f7cb6c31a58c38853d03d33f047fcba8c628cc700f",
+            "x86_64-linux": "882047343a9e203c6cfc5d39b166ea9e025dd256943e0d3711f86725ad0e3bd9"
         },
-        "version": "42.0.1"
+        "version": "42.1.0"
     }
 }

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -53,5 +53,16 @@
             "x86_64-linux": "b20e03cf174f8e56e235127d784dff8161ef4bb9c6bbc3d9383130225eb1e2a2"
         },
         "version": "41.3.0"
+    },
+    "42": {
+        "hashes": {
+            "aarch64-darwin": "3c619bb8ec6a243142e392335382a3383739a9977ca85067cb1f31599ff993e5",
+            "aarch64-linux": "5531da08123d60d50c833997842e8371970bebe7d29261e00eaa83de948332b4",
+            "armv7l-linux": "a0ab195cff93c86ddf284b7ef44026b29ff3ec89dcc4a2f5024ff28e32ae5b60",
+            "headers": "193c7vyzly6yln4zr0b7v5vlzixl9wz59lfmgwd86h4fc79kj9na",
+            "x86_64-darwin": "49f6e7ebd60f84b687af933eda5e87dce9525e1139151ff4cfd53821d3285358",
+            "x86_64-linux": "83c7178dba2d0ce77e13743bf86beda75c6141caeeadb4340e1888bc96298b4b"
+        },
+        "version": "42.0.0"
     }
 }

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -34,14 +34,14 @@
     },
     "40": {
         "hashes": {
-            "aarch64-darwin": "70cc74c3c16f1d8536ed7095bac4eefadfa0ef27d2632507c0f7e3c137ed9ed7",
-            "aarch64-linux": "b732c89edcc45bd5d32135e0309f42dc76c0753501e002550e9459323f473634",
-            "armv7l-linux": "fc1f7800d1318578a0dabaa14485e8af915c34d94144c248f9d91e0f5b76dca5",
-            "headers": "0j9mqglwcp1rgcwm33qhlb4bydfjmy1si5f9z42kh7y6diz3361p",
-            "x86_64-darwin": "e5fcf17b02e1ce362ef60984ecc65f029766322d4adff6ee8c51d7331b6eedf0",
-            "x86_64-linux": "cfe272fedfd4f164be45f7c8c12736220a98b60bb888fa51fb830031118ee6e8"
+            "aarch64-darwin": "e83a97b7c7017ec36e9e19f5b20430769e89e701c2b337da2685c13854fe70f3",
+            "aarch64-linux": "5b73273177e96ebd6005b7020f84c085c4a531b1701db03c1963b2ac2c1ea551",
+            "armv7l-linux": "9bcf8d1efd4f5d1dc2188a2d5c614c74322ede5efa8cf65ed387764d9109d26c",
+            "headers": "0133jya39pg40s3x4r3ijyvx2lyvbkp70bfi49zpiwlqvna628i4",
+            "x86_64-darwin": "b75319477edba3ce5161f18cc5283bc28096c2359bc47bc87ad5d365ea097fd5",
+            "x86_64-linux": "2b5e33327bd5e180b3c1c0ec429fa06769ee96c0f956a35471b9409b51f45ada"
         },
-        "version": "40.9.2"
+        "version": "40.9.3"
     },
     "41": {
         "hashes": {

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -45,14 +45,14 @@
     },
     "41": {
         "hashes": {
-            "aarch64-darwin": "091a58410a353b7f7fc5898ccb6cc31c6e5ea7acd8caedf448833713563efae2",
-            "aarch64-linux": "1d0c89698bcc3029d0c197a215679c14c65ab67086c4529d5ea90280f3d5bcc2",
-            "armv7l-linux": "5da1bdfee31dc8579f12bebda5bbe40fce85c4916a4a76b2f055ab69cae573c4",
-            "headers": "0j9gvjjq9qdvjj33h2xh6qdxxr29aj96y2qs3p0xvy1bc3li9hzn",
-            "x86_64-darwin": "3085b52fc90e81c0c3ed7f59b759f710b176c5a8989ced64a51618e8fd3e8a2e",
-            "x86_64-linux": "1d5364794dffe2493d74a9755d49ba37ecdfd3d19a8e2a38349cd9374adb19d4"
+            "aarch64-darwin": "107fc8fd403a73f75116d4e11a96ee00fffc3a7e1e3cf3d4d1d79128f547335e",
+            "aarch64-linux": "f369c35fa2c8180a4a04f91771df08b83fb135a4825660be09918d965c82dca7",
+            "armv7l-linux": "1190afe3f95008961781402bb52893cff7f0cd4cbeb8569df0b35c80a943c380",
+            "headers": "1n1w2ngk44w9khbh4bnw6kfakawdxh3wii3hkynbjzj21swvqzrb",
+            "x86_64-darwin": "a31411ff1705bc52f260c283b42ae1320a1de7b2422a9ab8e7d44009c8100c75",
+            "x86_64-linux": "47a1cf28685b695e6c1cf6307ebb79a234122c2da9b2a87a80ccbb00cd8df037"
         },
-        "version": "41.5.0"
+        "version": "41.5.2"
     },
     "42": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/generic.nix
+++ b/pkgs/development/tools/electron/chromedriver/generic.nix
@@ -86,6 +86,9 @@ let
       install -m777 -D chromedriver $out/bin/chromedriver
       runHook postInstall
     '';
+
+    __structuredAttrs = true;
+    strictDeps = true;
   };
 
   darwin = {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -56,13 +56,13 @@
     },
     "42": {
         "hashes": {
-            "aarch64-darwin": "b304a7c5b5a5229b83d3278e46b3f110b57b4d84e1f707574cd3893787d631ab",
-            "aarch64-linux": "43468f7efacb056a856fd82e75d80ec84127471aa6fe2ca4473fd14abb352f91",
-            "armv7l-linux": "51fce5a32ad1c5ddcce0e064135f92e341d23b999a6f2c6a39511d1e1b2d4b8d",
+            "aarch64-darwin": "15f47f905b59c37a2c1845595001589a1867e03c627a1880a8d6599e8ff65b21",
+            "aarch64-linux": "81a094306b68190e27fd253958e2047d4786d6a19035d118089100257b1c64f1",
+            "armv7l-linux": "6dad4f6c6ed82445cb10a86f6878dd7cb86ec49e5e48a2837ee1526f209e510b",
             "headers": "0r0g3iaji6a7gx51bv2ijq23zpcz8ip8kmfy0x9fxqpm9angvins",
-            "x86_64-darwin": "096dc5dc3092115d04b12e97ae6ece62e665dab720c5ea5350e01fb306645314",
-            "x86_64-linux": "d22f2339736c092c35174a7d1d6e0ae6109fb4da8b05d7f5854c48630bd9331b"
+            "x86_64-darwin": "1328a03d7f4f08946984b51dee62e761375bc9c912887965fb2dd900e65b2dfb",
+            "x86_64-linux": "05ffcaa8ae2f71a153217b5ffcd4aad7aed5428a70beb84b02888eb9a4097f6e"
         },
-        "version": "42.0.1"
+        "version": "42.1.0"
     }
 }

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -56,13 +56,13 @@
     },
     "42": {
         "hashes": {
-            "aarch64-darwin": "da38f921a119f68b6aad5065ff7315cc89a939e934ff1baa74cd1dc9cf772bab",
-            "aarch64-linux": "02df20a172310591a55390713cb9acfb70d0dfd204e538e08bc119d4e35831d5",
-            "armv7l-linux": "b947fcbfcc3e0a9e5739151fec899e0438bea9127b6ba33f97adf0dbb962fc7d",
-            "headers": "193c7vyzly6yln4zr0b7v5vlzixl9wz59lfmgwd86h4fc79kj9na",
-            "x86_64-darwin": "9a3742bfd985429617e84c6c3ba5d0afa104baa29e6a8918d7383926aafccb99",
-            "x86_64-linux": "a1d92d643ebc92c8f08f53337f0308fc5aa97f871cf029ef34c9a3119a5c0f26"
+            "aarch64-darwin": "b304a7c5b5a5229b83d3278e46b3f110b57b4d84e1f707574cd3893787d631ab",
+            "aarch64-linux": "43468f7efacb056a856fd82e75d80ec84127471aa6fe2ca4473fd14abb352f91",
+            "armv7l-linux": "51fce5a32ad1c5ddcce0e064135f92e341d23b999a6f2c6a39511d1e1b2d4b8d",
+            "headers": "0r0g3iaji6a7gx51bv2ijq23zpcz8ip8kmfy0x9fxqpm9angvins",
+            "x86_64-darwin": "096dc5dc3092115d04b12e97ae6ece62e665dab720c5ea5350e01fb306645314",
+            "x86_64-linux": "d22f2339736c092c35174a7d1d6e0ae6109fb4da8b05d7f5854c48630bd9331b"
         },
-        "version": "42.0.0"
+        "version": "42.0.1"
     }
 }

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -45,14 +45,14 @@
     },
     "41": {
         "hashes": {
-            "aarch64-darwin": "d17d70f3162cdec8d95763bc26767ebc60845a0fbf4c4e0f55b5b6cf410605ec",
-            "aarch64-linux": "e041c9e752c2586fe22510f0080636936dfeda0d4d526d36b13bbf9d5c782b57",
-            "armv7l-linux": "496204ab8468280fb651ab0bea9f5dab19ba8a2cccc8dbe25d57ec68c6555f33",
+            "aarch64-darwin": "33852f5e551e18c43e1031492fe62153759fc7968bd14f9cc179673517e10bd0",
+            "aarch64-linux": "2f99b486290989bc4d756ffc0448c93c728e03d519872e492b1cadd5d5905885",
+            "armv7l-linux": "27d03e18b3e3e484ceb7f7f05ace5eda075a5a468223797d4ae988a75424b6d0",
             "headers": "1n1w2ngk44w9khbh4bnw6kfakawdxh3wii3hkynbjzj21swvqzrb",
-            "x86_64-darwin": "7bc2f7b2e5e6a94a3ac7a3bda65ca3b541e1a0d2d9a56e18a0b7f1d0de7d15d4",
-            "x86_64-linux": "010ac10d35640fa1c07968cc5902f72f95bf95b4ee12377281d3a9af820b20c4"
+            "x86_64-darwin": "5e47e5ae1d0401b32838a9074fc13d291b09bad0cb61a265ad5388ef9eb8ade7",
+            "x86_64-linux": "9921145c87cb6f279e5baa2c5af8763a4695c84bc5206273dbbb0385b493513c"
         },
-        "version": "41.5.2"
+        "version": "41.6.1"
     },
     "42": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -34,14 +34,14 @@
     },
     "40": {
         "hashes": {
-            "aarch64-darwin": "28ca9db3ddabf80d5bc413c8ffa624255748c6e60e7c50d094a1e5d4f2d20e9c",
-            "aarch64-linux": "4e98c3e2eed87a60aacc28a583507f51ebfffd373be6e74e21afa191da7e18bc",
-            "armv7l-linux": "706c334d3844d7944cd96a92d7db81d639caf7c53407a87565528e26d46c2ead",
-            "headers": "0133jya39pg40s3x4r3ijyvx2lyvbkp70bfi49zpiwlqvna628i4",
-            "x86_64-darwin": "eae91cae26fff687aa615b124728d64706e1d305be88594911e216631cdcc58b",
-            "x86_64-linux": "885d4b3675040fbf39d142a65280b2e8c07e78480b3e8393565dcd2689fb23ee"
+            "aarch64-darwin": "ed4e021fe841be3b04c6c4cf3968a1628b9d84ca07b5362aa54c377b3fde18f0",
+            "aarch64-linux": "bfb57aa77b06e2179c5076274f9d61615414c295e16eabd99206a7553c9eacdc",
+            "armv7l-linux": "8f35c8b25f98d18d5d5852d2b244e64183dfb61b10b9a64b0be579f450f2cb73",
+            "headers": "0x534f94ds3qavwh90a4l63wpsagscwnbzi8399z067d2ghyzh18",
+            "x86_64-darwin": "f2caf8c9fe1c5c38259881824adce6b11a5a482576d47d7dc113a950e9315bf8",
+            "x86_64-linux": "303345908d998a83b953c9f60a8b0f07e8fa82ed839260784a7b5c2fc517a86f"
         },
-        "version": "40.9.3"
+        "version": "40.10.0"
     },
     "41": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -53,5 +53,16 @@
             "x86_64-linux": "250c2f8382902f97754fa1ff4691f6608a2ac99489af58459017906aee66878f"
         },
         "version": "41.3.0"
+    },
+    "42": {
+        "hashes": {
+            "aarch64-darwin": "da38f921a119f68b6aad5065ff7315cc89a939e934ff1baa74cd1dc9cf772bab",
+            "aarch64-linux": "02df20a172310591a55390713cb9acfb70d0dfd204e538e08bc119d4e35831d5",
+            "armv7l-linux": "b947fcbfcc3e0a9e5739151fec899e0438bea9127b6ba33f97adf0dbb962fc7d",
+            "headers": "193c7vyzly6yln4zr0b7v5vlzixl9wz59lfmgwd86h4fc79kj9na",
+            "x86_64-darwin": "9a3742bfd985429617e84c6c3ba5d0afa104baa29e6a8918d7383926aafccb99",
+            "x86_64-linux": "a1d92d643ebc92c8f08f53337f0308fc5aa97f871cf029ef34c9a3119a5c0f26"
+        },
+        "version": "42.0.0"
     }
 }

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -45,14 +45,14 @@
     },
     "41": {
         "hashes": {
-            "aarch64-darwin": "f654e5cd471ff09f861fd7bc68a18866882881dab86b71e53aaac939ac286f16",
-            "aarch64-linux": "1781267ed7ecfe92457242edd5e8110470a24d3eff4d5fa6f4afc433f85292c5",
-            "armv7l-linux": "5e54790862956c39eae0ece135bd779d5c10a30b8749ff66e8896a58018af6ee",
-            "headers": "1w8rdbjanqkl1237ppcgrkwdng93gniv3mqfxqikv0rpsg2d7gi7",
-            "x86_64-darwin": "4b656ad287e5afe3efbcb371584fc8a602c8afa3322d4b19ba6550b42f15d3e9",
-            "x86_64-linux": "250c2f8382902f97754fa1ff4691f6608a2ac99489af58459017906aee66878f"
+            "aarch64-darwin": "dda48dfa1e5ffd6fa7b5eb1162da6feb50e7b37dd96ee1e1e4e7a0afb7aa90f2",
+            "aarch64-linux": "ebe2c881e74e6c450f90c1c0d60c0fa43f4bf6746fa6765d9aa13a060594afa9",
+            "armv7l-linux": "9440752e3ee9fa3c0397847476d6a96211ff6918808a0c7a65904f060d897e6a",
+            "headers": "0j9gvjjq9qdvjj33h2xh6qdxxr29aj96y2qs3p0xvy1bc3li9hzn",
+            "x86_64-darwin": "7edc3cfe9d522a02a474cd8def0c22b88f75f7e79d2ae1f91da48ec17ed08b47",
+            "x86_64-linux": "4da4ae10e1533237083bbb44e79c45c0719609b1a5b7e7eece6754b7468add18"
         },
-        "version": "41.3.0"
+        "version": "41.5.0"
     },
     "42": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -45,14 +45,14 @@
     },
     "41": {
         "hashes": {
-            "aarch64-darwin": "dda48dfa1e5ffd6fa7b5eb1162da6feb50e7b37dd96ee1e1e4e7a0afb7aa90f2",
-            "aarch64-linux": "ebe2c881e74e6c450f90c1c0d60c0fa43f4bf6746fa6765d9aa13a060594afa9",
-            "armv7l-linux": "9440752e3ee9fa3c0397847476d6a96211ff6918808a0c7a65904f060d897e6a",
-            "headers": "0j9gvjjq9qdvjj33h2xh6qdxxr29aj96y2qs3p0xvy1bc3li9hzn",
-            "x86_64-darwin": "7edc3cfe9d522a02a474cd8def0c22b88f75f7e79d2ae1f91da48ec17ed08b47",
-            "x86_64-linux": "4da4ae10e1533237083bbb44e79c45c0719609b1a5b7e7eece6754b7468add18"
+            "aarch64-darwin": "d17d70f3162cdec8d95763bc26767ebc60845a0fbf4c4e0f55b5b6cf410605ec",
+            "aarch64-linux": "e041c9e752c2586fe22510f0080636936dfeda0d4d526d36b13bbf9d5c782b57",
+            "armv7l-linux": "496204ab8468280fb651ab0bea9f5dab19ba8a2cccc8dbe25d57ec68c6555f33",
+            "headers": "1n1w2ngk44w9khbh4bnw6kfakawdxh3wii3hkynbjzj21swvqzrb",
+            "x86_64-darwin": "7bc2f7b2e5e6a94a3ac7a3bda65ca3b541e1a0d2d9a56e18a0b7f1d0de7d15d4",
+            "x86_64-linux": "010ac10d35640fa1c07968cc5902f72f95bf95b4ee12377281d3a9af820b20c4"
         },
-        "version": "41.5.0"
+        "version": "41.5.2"
     },
     "42": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -23,14 +23,14 @@
     },
     "39": {
         "hashes": {
-            "aarch64-darwin": "3d42fdf5593888c429b00ec93f6a82419a9d5c61a5d61570e579383f4c08f8cf",
-            "aarch64-linux": "276aedebc81eb62b7ae8f84066c8973fb7e9b273dbbea8362960d68ca87440d3",
-            "armv7l-linux": "fcc4530933f100a2aef219478bb15ead89da64da1b80e393152195b34468cec6",
-            "headers": "15alm4mx7ad4czrysnk7wds625y7rsz7ncr1djq8an8fdar3fnw0",
-            "x86_64-darwin": "f6a4774573be8922cd6b993e0d65af9d660b2648656ec26703ba8ee9b49f5b69",
-            "x86_64-linux": "dbff1ba3f73432215eb2968a00374a6f8e1028eae155c228fec034037e2deb14"
+            "aarch64-darwin": "c21e261f8047a51c5a2e8d5ad19fc66d9f389c215bd2ada680c3ea39618f3f90",
+            "aarch64-linux": "c6fa8afa312dd4fa13ab4c34ea1a97481f8225cf78f3cc8bbe2dedf27fa0f2b0",
+            "armv7l-linux": "68963e6ab1d9eae92776782f194a31c9c48db2371d6a4c70058b4495cc244d2b",
+            "headers": "0sb9biq3z92f32dklisiax9pk5kj8yhwvihchcsp6v4vag7jx45v",
+            "x86_64-darwin": "8e8c9feeec3416a79223fcdbd855c5df121567b341366d516ae6f7f15769498c",
+            "x86_64-linux": "90dc451e7faad8e2efb4aa6a01e74195b607896a29f168f2f60a8eaf92af0e33"
         },
-        "version": "39.8.9"
+        "version": "39.8.10"
     },
     "40": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -34,14 +34,14 @@
     },
     "40": {
         "hashes": {
-            "aarch64-darwin": "ceb0feda64be263d6bfa0173c25959315e127d8f5bcd6d6189b1bcef5b356528",
-            "aarch64-linux": "8c488eb7691bbaa8c5c9868db92339f768a739ac2de127561df2f45bcdc09107",
-            "armv7l-linux": "a3115eb15d6bc34b9fca833b8e573ed967aa5fe11e2b37ceec6ba6a2d3eb28e4",
-            "headers": "0j9mqglwcp1rgcwm33qhlb4bydfjmy1si5f9z42kh7y6diz3361p",
-            "x86_64-darwin": "525a0bb96790542274f6cbd13d5fba81e4f5a6e7f6f488e351eb64ae7fcd391a",
-            "x86_64-linux": "3704387a4f3073d2dfa03c6cfce7dca6d78f3ee0b7f600f9eb3eeacf54c18432"
+            "aarch64-darwin": "28ca9db3ddabf80d5bc413c8ffa624255748c6e60e7c50d094a1e5d4f2d20e9c",
+            "aarch64-linux": "4e98c3e2eed87a60aacc28a583507f51ebfffd373be6e74e21afa191da7e18bc",
+            "armv7l-linux": "706c334d3844d7944cd96a92d7db81d639caf7c53407a87565528e26d46c2ead",
+            "headers": "0133jya39pg40s3x4r3ijyvx2lyvbkp70bfi49zpiwlqvna628i4",
+            "x86_64-darwin": "eae91cae26fff687aa615b124728d64706e1d305be88594911e216631cdcc58b",
+            "x86_64-linux": "885d4b3675040fbf39d142a65280b2e8c07e78480b3e8393565dcd2689fb23ee"
         },
-        "version": "40.9.2"
+        "version": "40.9.3"
     },
     "41": {
         "hashes": {

--- a/pkgs/development/tools/electron/common.nix
+++ b/pkgs/development/tools/electron/common.nix
@@ -11,6 +11,7 @@
   npmHooks,
   yarn-berry_4,
   unzip,
+  writers,
 
   libnotify,
   libpulseaudio,
@@ -64,9 +65,19 @@ in
 
   npmRoot = "third_party/node";
 
+  missingHashes =
+    if (info.electron_yarn_data ? "missing_hashes") then
+      writers.writeJSON "missing-hashes.json" info.electron_yarn_data.missing_hashes
+    else
+      null;
   yarnOfflineCache = yarn-berry.fetchYarnBerryDeps {
     src = gclientDeps."src/electron".path;
-    hash = info.electron_yarn_hash;
+    hash = info.electron_yarn_data.hash;
+    missingHashes =
+      if (info.electron_yarn_data ? "missing_hashes") then
+        writers.writeJSON "missing-hashes.json" info.electron_yarn_data.missing_hashes
+      else
+        null;
   };
 
   dontYarnBerryInstallDeps = true; # we'll run the hook manually

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -56,10 +56,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-y2aqNUsE8XmM+SoLThECL2J5b4NVydj0WAoy7t4AiJg=",
+                    "hash": "sha256-7hMzrFN/W37fq4bNPk5910UHy/ItMkHol/SmK1Uip6c=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v39.8.9"
+                    "tag": "v39.8.10"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -1342,10 +1342,10 @@
                 "fetcher": "fetchFromGitiles"
             }
         },
-        "electron_yarn_hash": "sha256-HCnJJqfgcilB+Cl2OaezL9Uu1xk0ZBdVEXg2VDR1dwU=",
+        "electron_yarn_hash": "sha256-ZaVee6smW2Gf4tkC1xTTl4a4fBDXaeT7Mtt7del6l8o=",
         "modules": "140",
         "node": "22.22.1",
-        "version": "39.8.9"
+        "version": "39.8.10"
     },
     "40": {
         "chrome": "144.0.7559.236",

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -4058,5 +4058,1377 @@
         "modules": "145",
         "node": "24.15.0",
         "version": "41.3.0"
+    },
+    "42": {
+        "chrome": "148.0.7778.96",
+        "chromium": {
+            "deps": {
+                "gn": {
+                    "hash": "sha256-BTPD8WM1pVAMkFDlHekMdWFGyf63KdhKkKwsqikqoBQ=",
+                    "rev": "6e8dcdebbadf4f8aa75e6a4b6e0bdf89dce1513a",
+                    "version": "0-unstable-2026-04-01"
+                }
+            },
+            "version": "148.0.7778.96"
+        },
+        "chromium_npm_hash": "sha256-JuVcY8iFRDWcPcP4Pg+qm5rnTXkiVfNsqSkXbDWqsE8=",
+        "deps": {
+            "src": {
+                "args": {
+                    "hash": "sha256-jtHzApRzYLz3lwvLJdK9uoGlEeMJl9BPkHpfkYdemhc=",
+                    "postFetch": "rm -rf $(find $out/third_party/blink/web_tests ! -name BUILD.gn -mindepth 1 -maxdepth 1); rm -r $out/content/test/data; rm -rf $out/courgette/testdata; rm -r $out/extensions/test/data; rm -r $out/media/test/data; ",
+                    "tag": "148.0.7778.96",
+                    "url": "https://chromium.googlesource.com/chromium/src.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/chrome/test/data/perf/canvas_bench": {
+                "args": {
+                    "hash": "sha256-svOuyBGKloBLM11xLlWCDsB4PpRjdKTBdW2UEW4JQjM=",
+                    "rev": "a7b40ea5ae0239517d78845a5fc9b12976bfc732",
+                    "url": "https://chromium.googlesource.com/chromium/canvas_bench.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/chrome/test/data/perf/frame_rate/content": {
+                "args": {
+                    "hash": "sha256-t4kcuvH0rkPBkcdiMsoNQaRwU09eU+oSvyHDiAHrKXo=",
+                    "rev": "c10272c88463efeef6bb19c9ec07c42bc8fe22b9",
+                    "url": "https://chromium.googlesource.com/chromium/frame_rate/content.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/chrome/test/data/xr/webvr_info": {
+                "args": {
+                    "hash": "sha256-BsAPwc4oEWri0TlqhyxqFNqKdfgVSrB0vQyISmYY4eg=",
+                    "rev": "c58ae99b9ff9e2aa4c524633519570bf33536248",
+                    "url": "https://chromium.googlesource.com/external/github.com/toji/webvr.info.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/docs/website": {
+                "args": {
+                    "hash": "sha256-Trkan7bzRaLFlTkRfNGh7ssoZ3QpMh+mxQacsSM+d2I=",
+                    "rev": "44319eca109f9678595924a90547c1f6650d8664",
+                    "url": "https://chromium.googlesource.com/website.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/electron": {
+                "args": {
+                    "hash": "sha256-CYTvfDRyheyg6A8D98NrIyG9/seXTwxm8N2ObC2C7fM=",
+                    "owner": "electron",
+                    "repo": "electron",
+                    "tag": "v42.0.0"
+                },
+                "fetcher": "fetchFromGitHub"
+            },
+            "src/media/cdm/api": {
+                "args": {
+                    "hash": "sha256-GsaRxLnsz1jrFZ3m5tv65d1dioG23uJnmfa+WD7XcFc=",
+                    "rev": "33c977516b3dfe5b065bc298aa74175e1999ab51",
+                    "url": "https://chromium.googlesource.com/chromium/cdm.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/net/third_party/quiche/src": {
+                "args": {
+                    "hash": "sha256-yKMmfdSBvbB3T042TJbZ1Mw+y0kyfHP0knQVFWAFPTg=",
+                    "rev": "21ffbe4c7b717d00d2d768c259b5b330fd754ac3",
+                    "url": "https://quiche.googlesource.com/quiche.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/testing/libfuzzer/fuzzers/wasm_corpus": {
+                "args": {
+                    "hash": "sha256-gItDOfNqm1tHlmelz3l2GGdiKi9adu1EpPP6U7+8EQY=",
+                    "rev": "1df5e50a45db9518a56ebb42cb020a94a090258b",
+                    "url": "https://chromium.googlesource.com/v8/fuzzer_wasm_corpus.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/angle": {
+                "args": {
+                    "hash": "sha256-3KVTEBcnQTn99ccdKzylzUvua2jlS4g8/nfIDdLk6ug=",
+                    "rev": "cc0e3572e8789f4a184dd9714a04b3d98ae81015",
+                    "url": "https://chromium.googlesource.com/angle/angle.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/angle/third_party/VK-GL-CTS/src": {
+                "args": {
+                    "hash": "sha256-3jx4QVR9nB3WggfrORGJGifmJQhAYVSPusa7RlR16qg=",
+                    "rev": "f52e89f885064b9109501bca16c813bb29389993",
+                    "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/VK-GL-CTS"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/angle/third_party/glmark2/src": {
+                "args": {
+                    "hash": "sha256-VebUALLFKwEa4+oE+jF8mBSzhJd6aflphPmcK1Em8bw=",
+                    "rev": "6edcf02205fd1e8979dc3f3964257a81959b80c8",
+                    "url": "https://chromium.googlesource.com/external/github.com/glmark2/glmark2"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/angle/third_party/rapidjson/src": {
+                "args": {
+                    "hash": "sha256-btUl1a/B0sXwf/+hyvCvVJjWqIkXfVYCpHm3TeBuOxk=",
+                    "rev": "781a4e667d84aeedbeb8184b7b62425ea66ec59f",
+                    "url": "https://chromium.googlesource.com/external/github.com/Tencent/rapidjson"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/anonymous_tokens/src": {
+                "args": {
+                    "hash": "sha256-eJP45x3vXOG1rWvRl/0H0c2IV7nQ/9dYjAzJGHHszdc=",
+                    "rev": "fdff40da0398d2c229308aed169345f6ff1a150f",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/anonymous-tokens.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/boringssl/src": {
+                "args": {
+                    "hash": "sha256-fZc95YrREDbf0YcO6zahIjdX6TcRJANcH9MrkLIIIHw=",
+                    "rev": "d8be2b4a71155bf82da092ef543176351eeb59ff",
+                    "url": "https://boringssl.googlesource.com/boringssl.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/breakpad/breakpad": {
+                "args": {
+                    "hash": "sha256-igcX5XwacIwoGbqIcZKwlJYpRWl9Uc32WdpXyHO7UVA=",
+                    "rev": "8be0e3114685fcc1589561067282edf75ea1259a",
+                    "url": "https://chromium.googlesource.com/breakpad/breakpad.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/cast_core/public/src": {
+                "args": {
+                    "hash": "sha256-yQxm1GMMne80bLl1P7OAN3bJLz1qRNAvou2/5MKp2ig=",
+                    "rev": "f5ee589bdaea60418f670fa176be15ccb9a34942",
+                    "url": "https://chromium.googlesource.com/cast_core/public"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/catapult": {
+                "args": {
+                    "hash": "sha256-aHlf8gw3KxbKoyyajP4w586iYybx7HSkcKtLcZIgiDE=",
+                    "rev": "4f1d71f6841d210b3a06ab3ef2e2ed679af0ee56",
+                    "url": "https://chromium.googlesource.com/catapult.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/catapult/third_party/webpagereplay": {
+                "args": {
+                    "hash": "sha256-KcFUlQMltsMm4WlTVMLzZXfrvu67ffkKjmBcruwZye0=",
+                    "rev": "be48b5e3387780790ecc7723434b6ea6733bcc33",
+                    "url": "https://chromium.googlesource.com/webpagereplay.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/ced/src": {
+                "args": {
+                    "hash": "sha256-ySG74Rj2i2c/PltEgHVEDq+N8yd9gZmxNktc56zIUiY=",
+                    "rev": "ba412eaaacd3186085babcd901679a48863c7dd5",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/compact_enc_det.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/clang-format/script": {
+                "args": {
+                    "hash": "sha256-f+BbQ6xIubloSzx/MhPSZ8ymCskmS+9+epDGtPjZqXc=",
+                    "rev": "c2725e0622e1a86d55f14514f2177a39efea4a0e",
+                    "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/clang/tools/clang-format.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/cld_3/src": {
+                "args": {
+                    "hash": "sha256-C3MOMBUy9jgkT9BAi/Fgm2UH4cxRuwSBEcRl3hzM2Ss=",
+                    "rev": "b48dc46512566f5a2d41118c8c1116c4f96dc661",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/cld_3.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/colorama/src": {
+                "args": {
+                    "hash": "sha256-6ZTdPYSHdQOLYMSnE+Tp7PgsVTs3U2awGu9Qb4Rg/tk=",
+                    "rev": "3de9f013df4b470069d03d250224062e8cf15c49",
+                    "url": "https://chromium.googlesource.com/external/colorama.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/compiler-rt/src": {
+                "args": {
+                    "hash": "sha256-q6syHriTR8TCQSqTWbbAkVVK0a/i4wojdEGN7sWGxUY=",
+                    "rev": "76287b5da8e155135536c8e3a67432d97d74fe3a",
+                    "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/compiler-rt.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/content_analysis_sdk/src": {
+                "args": {
+                    "hash": "sha256-f5Jmk1MiGjaRdLun+v/GKVl8Yv9hOZMTQUSxgiJalcY=",
+                    "rev": "9a408736204513e0e95dd2ab3c08de0d95963efc",
+                    "url": "https://chromium.googlesource.com/external/github.com/chromium/content_analysis_sdk.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/cpu_features/src": {
+                "args": {
+                    "hash": "sha256-E8LoVzhe+TAmARWZTSuINlsVhzpUJMxPPCGe/dHZcyA=",
+                    "rev": "936b9ab5515dead115606559502e3864958f7f6e",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/cpu_features.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/cpuinfo/src": {
+                "args": {
+                    "hash": "sha256-LnLtCMMRg+DwB7MijBdt/tmCKD/zN5y2oTgXlYw3hTg=",
+                    "rev": "7607ca500436b37ad23fb8d18614bec7796b68a7",
+                    "url": "https://chromium.googlesource.com/external/github.com/pytorch/cpuinfo.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/crabbyavif/src": {
+                "args": {
+                    "hash": "sha256-x1MRNtGLmwlRNenoQKz2Bgm3J5eHlNiJZtzhT9lttmk=",
+                    "rev": "7466a44ac80893803d4a7168b98dc6cd02d1fe2d",
+                    "url": "https://chromium.googlesource.com/external/github.com/webmproject/CrabbyAvif.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/crc32c/src": {
+                "args": {
+                    "hash": "sha256-KBraGaO5LmmPP+p8RuDogGldbTWdNDK+WzF4Q09keuE=",
+                    "rev": "d3d60ac6e0f16780bcfcc825385e1d338801a558",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/crc32c.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/cros-components/src": {
+                "args": {
+                    "hash": "sha256-7wx73HZ6aqXQvLxwX6XnJAPefi/t47gIhvDH3FRT1j4=",
+                    "rev": "fb512780dcc5ba4b5be9e8a3118919002077c760",
+                    "url": "https://chromium.googlesource.com/external/google3/cros_components.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/cros_system_api": {
+                "args": {
+                    "hash": "sha256-a/mAa1+if6B1FHe9crO8PDpc3o8M+CeIuXjXT0lwZOY=",
+                    "rev": "c27a09148de373889e5d2bf616c4e85a68050ae2",
+                    "url": "https://chromium.googlesource.com/chromiumos/platform2/system_api.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/crossbench": {
+                "args": {
+                    "hash": "sha256-Hxazf58z9imnGO1aj2NRtsQ+BYrfAuIuZscADpr1NVI=",
+                    "rev": "c179f7919aade97c5cff64d14b9171736e7aaef9",
+                    "url": "https://chromium.googlesource.com/crossbench.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/crossbench-web-tests": {
+                "args": {
+                    "hash": "sha256-7vCQw91L2c97dnVdrJ53zL8hi0KZffDJJjk7GaG3b/U=",
+                    "rev": "b19e4e52c33fb8a105c3fc99598b0b9b4bc59752",
+                    "url": "https://chromium.googlesource.com/chromium/web-tests.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/dav1d/libdav1d": {
+                "args": {
+                    "hash": "sha256-iKq6TYscIBK4ydv+0msNV3tcs82Ljk5ZNr954Qv2lII=",
+                    "rev": "d69235dd804b24c04ed05639cffcc912cd6cfd75",
+                    "url": "https://chromium.googlesource.com/external/github.com/videolan/dav1d.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/dawn": {
+                "args": {
+                    "hash": "sha256-ihnVPCk9412UzCmoABWVUhiGaIdIYxiYMkk43KDqpg8=",
+                    "rev": "19696dd088b8ed5804e2f02a8f83f5afdb3e99e3",
+                    "url": "https://dawn.googlesource.com/dawn.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/dawn/third_party/EGL-Registry/src": {
+                "args": {
+                    "hash": "sha256-Z6DwLfgQ1wsJXz0KKJyVieOatnDmx3cs0qJ6IEgSq1A=",
+                    "rev": "7dea2ed79187cd13f76183c4b9100159b9e3e071",
+                    "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/EGL-Registry"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/dawn/third_party/OpenGL-Registry/src": {
+                "args": {
+                    "hash": "sha256-K3PcRIiD3AmnbiSm5TwaLs4Gu9hxaN8Y91WMKK8pOXE=",
+                    "rev": "5bae8738b23d06968e7c3a41308568120943ae77",
+                    "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/OpenGL-Registry"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/dawn/third_party/directx-headers/src": {
+                "args": {
+                    "hash": "sha256-0Miw1Cy/jmOo7bLFBOHuTRDV04cSeyvUEyPkpVsX9DA=",
+                    "rev": "980971e835876dc0cde415e8f9bc646e64667bf7",
+                    "url": "https://chromium.googlesource.com/external/github.com/microsoft/DirectX-Headers"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/dawn/third_party/dxc": {
+                "args": {
+                    "hash": "sha256-z+yIuVweIyLdOiZDRfSppjTRoYq8S93+JNUla4Umot8=",
+                    "rev": "eb67a9085c758516d940e1ce3fed0acfb6518209",
+                    "url": "https://chromium.googlesource.com/external/github.com/microsoft/DirectXShaderCompiler"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/dawn/third_party/dxheaders": {
+                "args": {
+                    "hash": "sha256-0Miw1Cy/jmOo7bLFBOHuTRDV04cSeyvUEyPkpVsX9DA=",
+                    "rev": "980971e835876dc0cde415e8f9bc646e64667bf7",
+                    "url": "https://chromium.googlesource.com/external/github.com/microsoft/DirectX-Headers"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/dawn/third_party/glfw3/src": {
+                "args": {
+                    "hash": "sha256-4QSD1/uxWfYZPMjShB0h639eqAfuBRXAVfOm6BbZCBs=",
+                    "rev": "043378876a67b092f5d0d3d9748660121a336dd3",
+                    "url": "https://chromium.googlesource.com/external/github.com/glfw/glfw"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/dawn/third_party/webgpu-cts": {
+                "args": {
+                    "hash": "sha256-eTAwnTiAHq8rmbw7u9nAwSuAlS5adStUJKfITlYkcgU=",
+                    "rev": "09fdb847d90d0b5bfe57068ce2eb9283cb77fc7f",
+                    "url": "https://chromium.googlesource.com/external/github.com/gpuweb/cts"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/dawn/third_party/webgpu-headers/src": {
+                "args": {
+                    "hash": "sha256-yE3/mfhqc7YtVNg4f/nrUpuRUGRjOzdwl++vPvd+mvc=",
+                    "rev": "7d3186c3dd2c708703524027b46b8703534ab3cc",
+                    "url": "https://chromium.googlesource.com/external/github.com/webgpu-native/webgpu-headers"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/depot_tools": {
+                "args": {
+                    "hash": "sha256-s9uvmYHCJKWnNhztmOPb+OHj/HbGo30PupwT4mHWjnM=",
+                    "rev": "41c40cfaec7ee3bf0423c59925d8b23982a601f1",
+                    "url": "https://chromium.googlesource.com/chromium/tools/depot_tools.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/devtools-frontend/src": {
+                "args": {
+                    "hash": "sha256-1pr3+RK519m+wtcacJB3PcDTL+qSHlOn1ctxpoLzTf8=",
+                    "rev": "6efd6eb1d85fd67fdcc2385c54fa56c524bec3f7",
+                    "url": "https://chromium.googlesource.com/devtools/devtools-frontend"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/dom_distiller_js/dist": {
+                "args": {
+                    "hash": "sha256-yuEBD2XQlV3FGI/i7lTmJbCqzeBiuG1Qow8wvsppGJw=",
+                    "rev": "199de96b345ada7c6e7e6ba3d2fa7a6911b8767d",
+                    "url": "https://chromium.googlesource.com/chromium/dom-distiller/dist.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/domato/src": {
+                "args": {
+                    "hash": "sha256-fYxoA0fxKe9U23j+Jp0MWj4m7RfsRpM0XjF6/yOhX1I=",
+                    "rev": "053714bccbda79cf76dac3fee48ab2b27f21925e",
+                    "url": "https://chromium.googlesource.com/external/github.com/googleprojectzero/domato.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/dragonbox/src": {
+                "args": {
+                    "hash": "sha256-j6swuGgYGfiFcK3iqd4EKTeU92rZHKTbF5T1fcak/ko=",
+                    "rev": "beeeef91cf6fef89a4d4ba5e95d47ca64ccb3a44",
+                    "url": "https://chromium.googlesource.com/external/github.com/jk-jeon/dragonbox.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/eigen3/src": {
+                "args": {
+                    "hash": "sha256-9AHpSqemqdwXoMiP3hH1YuEd3+nrudeVGTpInw+8BU4=",
+                    "rev": "a3074053a614df7a3896cb4edbcba40222a5f549",
+                    "url": "https://chromium.googlesource.com/external/gitlab.com/libeigen/eigen.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/electron_node": {
+                "args": {
+                    "hash": "sha256-Y4FP+AstENp1uTYBo8HeTRDwvKClTdrZ4RztLeHNP3k=",
+                    "owner": "nodejs",
+                    "repo": "node",
+                    "tag": "v24.15.0"
+                },
+                "fetcher": "fetchFromGitHub"
+            },
+            "src/third_party/emoji-segmenter/src": {
+                "args": {
+                    "hash": "sha256-KdQdKBBipEBRT8UmNGao6yCB4m2CU8/SrMVvcXlb5qE=",
+                    "rev": "955936be8b391e00835257059607d7c5b72ce744",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/emoji-segmenter.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/engflow-reclient-configs": {
+                "args": {
+                    "hash": "sha256-aZXYPj9KYBiZnljqOLlWJWS396Fg3EhjiQLZmkwCBsY=",
+                    "owner": "EngFlow",
+                    "repo": "reclient-configs",
+                    "rev": "955335c30a752e9ef7bff375baab5e0819b6c00d"
+                },
+                "fetcher": "fetchFromGitHub"
+            },
+            "src/third_party/expat/src": {
+                "args": {
+                    "hash": "sha256-tLz4RejYQ/kFXhsWTduuGcinfUkqxYKPCpsou+WlvBc=",
+                    "rev": "f31adfd584b7f6c50bbf4d22eb928538ffc9145a",
+                    "url": "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/farmhash/src": {
+                "args": {
+                    "hash": "sha256-5n58VEUxa/K//jAfZqG4cXyfxrp50ogWDNYcgiXVHdc=",
+                    "rev": "816a4ae622e964763ca0862d9dbd19324a1eaf45",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/farmhash.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/fast_float/src": {
+                "args": {
+                    "hash": "sha256-CG5je117WYyemTe5PTqznDP0bvY5TeXn8Vu1Xh5yUzQ=",
+                    "rev": "cb1d42aaa1e14b09e1452cfdef373d051b8c02a4",
+                    "url": "https://chromium.googlesource.com/external/github.com/fastfloat/fast_float.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/federated_compute/src": {
+                "args": {
+                    "hash": "sha256-Cp0WQBbqWvPdrKCMQhH4Z6zl6YlIPLjafWZEwdkYWlc=",
+                    "rev": "eb170f645b270c7979edb863fd2cf8edab2b2fd1",
+                    "url": "https://chromium.googlesource.com/external/github.com/google-parfait/federated-compute.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/ffmpeg": {
+                "args": {
+                    "hash": "sha256-JHAicFKBvtkwmZPRBKYPT6JVqYqF8hyXxU0H7kfgCBs=",
+                    "rev": "b5e18fb9da84e26ceef30d4e4886696bf59337c0",
+                    "url": "https://chromium.googlesource.com/chromium/third_party/ffmpeg.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/flac": {
+                "args": {
+                    "hash": "sha256-LZFAJf8mF14XvXYvvBoLHGied2P7o23LUxszDpZLe8E=",
+                    "rev": "e7108e2ed031547c3759217819a032065c820d73",
+                    "url": "https://chromium.googlesource.com/chromium/deps/flac.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/flatbuffers/src": {
+                "args": {
+                    "hash": "sha256-gV1hn1iHI7knFEXy3Oii97mLRZYJUBiBlTh6/sqOoXg=",
+                    "rev": "a86afae9399bbe631d1ea0783f8816e780e236cc",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/flatbuffers.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/fontconfig/src": {
+                "args": {
+                    "hash": "sha256-Oo4ewK86dbEkO5EXyGWvdmsPHa8Wk1BHQah784vIem0=",
+                    "rev": "d62c2ab268d1679335daa8fb0ea6970f35224a76",
+                    "url": "https://chromium.googlesource.com/external/fontconfig.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/fp16/src": {
+                "args": {
+                    "hash": "sha256-CR7h1d9RFE86l6btk4N8vbQxy0KQDxSMvckbiO87JEg=",
+                    "rev": "3d2de1816307bac63c16a297e8c4dc501b4076df",
+                    "url": "https://chromium.googlesource.com/external/github.com/Maratyszcza/FP16.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/freetype/src": {
+                "args": {
+                    "hash": "sha256-H5RzBFYWIp/QYKyeBM2wfuX7FvXHPbhCAp7qne5Zvhw=",
+                    "rev": "99b479dc34728936b006679a31e12b8cf432fc55",
+                    "url": "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/fuzztest/src": {
+                "args": {
+                    "hash": "sha256-Pvz+CWTBcWE0N0yfNGZhXDgUrGeIaCNfEjP1jYmF6G0=",
+                    "rev": "800c545cf9d6e9c01328a1974f93a7e6564a74fd",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/fuzztest.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/fxdiv/src": {
+                "args": {
+                    "hash": "sha256-LjX5kivfHbqCIA5pF9qUvswG1gjOFo3CMpX0VR+Cn38=",
+                    "rev": "63058eff77e11aa15bf531df5dd34395ec3017c8",
+                    "url": "https://chromium.googlesource.com/external/github.com/Maratyszcza/FXdiv.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/gemmlowp/src": {
+                "args": {
+                    "hash": "sha256-e6AeRhZioIiTG5R+IA9g2GBqI4o74wijJYmqINLOtQs=",
+                    "rev": "16e8662c34917be0065110bfcd9cc27d30f52fdf",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/gemmlowp.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/glslang/src": {
+                "args": {
+                    "hash": "sha256-vSbMdTjlRVvYLi5ZvTVmfe76oAQ4AhqyD+ohvkvIYIs=",
+                    "rev": "715c8500e7cd67f2eba9e60e98852a1ed49d2f15",
+                    "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/glslang"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/google_benchmark/src": {
+                "args": {
+                    "hash": "sha256-GfqY2d+Nd7ovNrXxzTRm/AYWj7GuxIO6FawzUEzwOVA=",
+                    "rev": "188e8278990a9069ffc84441cb5a024fd0bede37",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/benchmark.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/googletest/src": {
+                "args": {
+                    "hash": "sha256-gJhv3DQQSP5BQ6GmDobq42/Gkx4AbOg/ZS80bM0WpEw=",
+                    "rev": "4fe3307fb2d9f86d19777c7eb0e4809e9694dde7",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/googletest.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/harfbuzz/src": {
+                "args": {
+                    "hash": "sha256-/RT2OPWFiVwFqmNS4o+gE0JrcVO1cQDkCkgrSEe7BzE=",
+                    "rev": "4fc96139259ebc35f40118e0382ac8037d928e5c",
+                    "url": "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/highway/src": {
+                "args": {
+                    "hash": "sha256-HNrlqtAs1vKCoSJ5TASs34XhzjEbLW+ISco1NQON+BI=",
+                    "rev": "84379d1c73de9681b54fbe1c035a23c7bd5d272d",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/highway.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/hunspell_dictionaries": {
+                "args": {
+                    "hash": "sha256-mYDPXa64IOKLMNiBiMqDrQMR7gDPI+vdyVc+M7E+ddc=",
+                    "rev": "cccf64a8acc951afe3f47fee023908e55699bc58",
+                    "url": "https://chromium.googlesource.com/chromium/deps/hunspell_dictionaries.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/icu": {
+                "args": {
+                    "hash": "sha256-yQ55MGzqkVkp/arTlmKqySBvQFtaPaBk9UUAFE0imhE=",
+                    "rev": "ff7995a708a10ab44db101358083c7f74752da9f",
+                    "url": "https://chromium.googlesource.com/chromium/deps/icu.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/ink/src": {
+                "args": {
+                    "hash": "sha256-uDaK/cDA52Cn+ioPW2bXAJze1eW8TK3xF7+bl/Ylh6Y=",
+                    "rev": "9d5367423281a8fcf5bc1c418e20477a992b270a",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/ink.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/ink_stroke_modeler/src": {
+                "args": {
+                    "hash": "sha256-W5HgVe0v9O/EuhpKMHp83PLq4p6cuBul3QUGLYdF6rY=",
+                    "rev": "da42d439389c90ec7574f0381ec53e7f5be0c2eb",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/ink-stroke-modeler.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/instrumented_libs": {
+                "args": {
+                    "hash": "sha256-5cb9qhSEzb941pF5HH0Br+x9wEH7MiGwQttvErb2mZo=",
+                    "rev": "e8cb570a9a2ee9128e2214c73417ad2a3c47780b",
+                    "url": "https://chromium.googlesource.com/chromium/third_party/instrumented_libraries.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/jetstream/main": {
+                "args": {
+                    "hash": "sha256-ZpU0ONqIVmY2VR0MxqtYj8KPNlK0L21gLJuT/Ff7KI8=",
+                    "rev": "de88e36ae91d5bd13126fa4cc4b0e0346d779842",
+                    "url": "https://chromium.googlesource.com/external/github.com/WebKit/JetStream.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/jetstream/v2.2": {
+                "args": {
+                    "hash": "sha256-zucA2tqNOsvjhwYQKZ5bFUC73ZF/Fu7KpBflSelvixw=",
+                    "rev": "2145cedef4ca2777b792cb0059d3400ee2a6153c",
+                    "url": "https://chromium.googlesource.com/external/github.com/WebKit/JetStream.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/jsoncpp/source": {
+                "args": {
+                    "hash": "sha256-bSLNcoYBz3QCt5VuTR056V9mU2PmBuYBa0W6hFg2m8Q=",
+                    "rev": "42e892d96e47b1f6e29844cc705e148ec4856448",
+                    "url": "https://chromium.googlesource.com/external/github.com/open-source-parsers/jsoncpp.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/leveldatabase/src": {
+                "args": {
+                    "hash": "sha256-a1fcVI9Vsm1qE17Fnx5UxwOy4ZFMMJ0OKwNs/gZHYQI=",
+                    "rev": "7ee830d02b623e8ffe0b95d59a74db1e58da04c5",
+                    "url": "https://chromium.googlesource.com/external/leveldb.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libFuzzer/src": {
+                "args": {
+                    "hash": "sha256-TDi1OvYClJKmEDikanKVTmy8uxUXJ95nuVKo5u+uFPM=",
+                    "rev": "bea408a6e01f0f7e6c82a43121fe3af4506c932e",
+                    "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/compiler-rt/lib/fuzzer.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libaddressinput/src": {
+                "args": {
+                    "hash": "sha256-rX7LQNUgk5ZljUrayD1a/SUrBrvpomW0Cs0KBw3lYu4=",
+                    "rev": "e20690c8d5178bb282641d5eb06ef0298ff4cbc5",
+                    "url": "https://chromium.googlesource.com/external/libaddressinput.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libaom/source/libaom": {
+                "args": {
+                    "hash": "sha256-LaBEcVcSB8WB9ZNRgPSiGaKdQL5f3wll2sPb9OhN5SE=",
+                    "rev": "b63f30b6d30028a3d7d9c5223def8f3ad97dcc4c",
+                    "url": "https://aomedia.googlesource.com/aom.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libc++/src": {
+                "args": {
+                    "hash": "sha256-7O/X2JW8ghkPTjmFZmT9cgG3Ui5zk3gUb436KlPww34=",
+                    "rev": "7ab65651aed6802d2599dcb7a73b1f82d5179d05",
+                    "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxx.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libc++abi/src": {
+                "args": {
+                    "hash": "sha256-L5CUvhpOLS+NBNGssCv0pY9rsDFuAI0LlPjXQRfy62A=",
+                    "rev": "8f11bb1d4438d0239d0dfc1bd9456a9f31629dda",
+                    "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxxabi.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libdrm/src": {
+                "args": {
+                    "hash": "sha256-kOaTjBeo4IsfWEk/JBTNId5ikrnpoc9DEjIl7DUd2yE=",
+                    "rev": "369990d9660a387f618d0eedc341eb285016243b",
+                    "url": "https://chromium.googlesource.com/chromiumos/third_party/libdrm.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libgav1/src": {
+                "args": {
+                    "hash": "sha256-gisU0p0HDL7Po/ZXIIZVOTnxnOuVvSE/FYo9DaEUFfo=",
+                    "rev": "40f58ed32ff39071c3f2a51056dbc49a070af0dc",
+                    "url": "https://chromium.googlesource.com/codecs/libgav1.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libipp/libipp": {
+                "args": {
+                    "hash": "sha256-GzLVt6RIN+FgOpcK61ya5lvdIIhQRciAb/ISIirWogY=",
+                    "rev": "4be5f77f672a3a9f1bbf3c935fb0ea8b3f86ce61",
+                    "url": "https://chromium.googlesource.com/chromiumos/platform2/libipp.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libjpeg_turbo": {
+                "args": {
+                    "hash": "sha256-KGeB/lTjhm8DQBDZVSPENvZEGSHeLTkviJrYsFh5vEM=",
+                    "rev": "d1f5f2393e0d51f840207342ae86e55a86443288",
+                    "url": "https://chromium.googlesource.com/chromium/deps/libjpeg_turbo.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/liblouis/src": {
+                "args": {
+                    "hash": "sha256-EI/uaHXe0NlqdEw764q0SjerThYEVLRogUlmrsZwXnY=",
+                    "rev": "9700847afb92cb35969bdfcbbfbbb74b9c7b3376",
+                    "url": "https://chromium.googlesource.com/external/liblouis-github.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libpfm4/src": {
+                "args": {
+                    "hash": "sha256-t4LMG38GksMEM5DktyJ0qLUX1biXErQ57MaMtd7hoeo=",
+                    "rev": "977a25bb3dfe45f653a6cee71ffaae9a92fc3095",
+                    "url": "https://chromium.googlesource.com/external/git.code.sf.net/p/perfmon2/libpfm4.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libphonenumber/dist": {
+                "args": {
+                    "hash": "sha256-ZbuDrZEUVp/ekjUP8WO/FsjAomRjeDBptT4nQZvTVi4=",
+                    "rev": "9d46308f313f2bf8dbce1dfd4f364633ca869ca7",
+                    "url": "https://chromium.googlesource.com/external/libphonenumber.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libprotobuf-mutator/src": {
+                "args": {
+                    "hash": "sha256-EaEC6R7SzqLw4QjEcWXFXhZc84lNBp6RSa9izjGnWKE=",
+                    "rev": "7bf98f78a30b067e22420ff699348f084f802e12",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/libprotobuf-mutator.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libsrtp": {
+                "args": {
+                    "hash": "sha256-xC//VEFrI94nCkyLnRa6uQ+hJQqe41v0Qjm4LJ7K84I=",
+                    "rev": "e8383771af8aa4096f5bcfe3743a5ea128f88a9a",
+                    "url": "https://chromium.googlesource.com/chromium/deps/libsrtp.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libsync/src": {
+                "args": {
+                    "hash": "sha256-aI7Exie3AmTy8R/Ua5lua0lCwMO1k4wMS6cxulU6iD8=",
+                    "rev": "d29ac04dc81e6b072c091c5b1342a282765ea250",
+                    "url": "https://chromium.googlesource.com/aosp/platform/system/core/libsync.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libunwind/src": {
+                "args": {
+                    "hash": "sha256-JW4kqpVTCFDN4WZE2S5gEkX1O7eDycl+adm3KGlUoTU=",
+                    "rev": "6ca46ff28e3578c57cbead6f233969eb3dabc176",
+                    "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libunwind.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libva-fake-driver/src": {
+                "args": {
+                    "hash": "sha256-em/8rNqwv6szlxyji7mnYr3nObSW/x3OzEEnkiLuqpI=",
+                    "rev": "a9bcab9cd6b15d4e3634ca44d5e5f7652c612194",
+                    "url": "https://chromium.googlesource.com/chromiumos/platform/libva-fake-driver.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libvpx/source/libvpx": {
+                "args": {
+                    "hash": "sha256-RyYnkLYafiS6kQKeOmzohtxFRXudDzgEmQkG+qKHozc=",
+                    "rev": "47ac1ec7f3de7d7cb3d070844c427c8f1fa9d6fc",
+                    "url": "https://chromium.googlesource.com/webm/libvpx.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libwebm/source": {
+                "args": {
+                    "hash": "sha256-Lzfs15Us8MDDQYvLRVf6xKg9A76aXPnTukx/A8Mf7rw=",
+                    "rev": "b7a1e4767fbb02ad467f45ba378e858e897028da",
+                    "url": "https://chromium.googlesource.com/webm/libwebm.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libwebp/src": {
+                "args": {
+                    "hash": "sha256-a7F97BEnwpdx9W8OsVnz+NfIYW+J1XVDSi38KsIZIfI=",
+                    "rev": "c00d83f6642e7838a12bb03bca94237f03cc2e00",
+                    "url": "https://chromium.googlesource.com/webm/libwebp.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libyuv": {
+                "args": {
+                    "hash": "sha256-DW7PuRqA1x0K8/uJbxBJ4Cn9YEPFhZ9vhuGVVyGKK98=",
+                    "rev": "30809ff64a9ca5e45f86439c0d474c2d3eef3d05",
+                    "url": "https://chromium.googlesource.com/libyuv/libyuv.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/litert/src": {
+                "args": {
+                    "hash": "sha256-rcEPZNSV0DiDrmoBCtJ07wFzzpmpM93jG4jYaEdNWvI=",
+                    "rev": "588075c77c6895cce6397d41d2890b1aa0a14372",
+                    "url": "https://chromium.googlesource.com/external/github.com/google-ai-edge/LiteRT.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/llvm-libc/src": {
+                "args": {
+                    "hash": "sha256-OWe2lAT5XbADWuxHgg53lZiU0My/ys86FEXvn4zlVx0=",
+                    "rev": "2a826f2fda3cf8d75b47cbc3bb1d9b244f13a6ab",
+                    "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libc.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/lss": {
+                "args": {
+                    "hash": "sha256-89CdA7vBYudbko0nAIyHcpHMXqFZHC05kwRIUmeEWGo=",
+                    "rev": "29164a80da4d41134950d76d55199ea33fbb9613",
+                    "url": "https://chromium.googlesource.com/linux-syscall-support.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/material_color_utilities/src": {
+                "args": {
+                    "hash": "sha256-Y85XU+z9W6tvmDNHJ/dXQnUKXvvDkO3nH/kUJRLqbc4=",
+                    "rev": "13434b50dcb64a482cc91191f8cf6151d90f5465",
+                    "url": "https://chromium.googlesource.com/external/github.com/material-foundation/material-color-utilities.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/minigbm/src": {
+                "args": {
+                    "hash": "sha256-9HwvjTETerbQ7YKXH9kUB2eWa8PxGWMAJfx1jAluhrs=",
+                    "rev": "3018207f4d89395cc271278fb9a6558b660885f5",
+                    "url": "https://chromium.googlesource.com/chromiumos/platform/minigbm.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/nan": {
+                "args": {
+                    "hash": "sha256-Tq6whJBeGlJhF7/ctFOEgb1W12Tu/HGNTC5ujQtk+Qk=",
+                    "owner": "nodejs",
+                    "repo": "nan",
+                    "rev": "675cefebca42410733da8a454c8d9391fcebfbc2"
+                },
+                "fetcher": "fetchFromGitHub"
+            },
+            "src/third_party/nasm": {
+                "args": {
+                    "hash": "sha256-0KsHYi76IaVNwk0dBhem2AnUXd9PpeS+jUsY+zPmeJ8=",
+                    "rev": "45252858722aad12e545819b2d0f370eb865431b",
+                    "url": "https://chromium.googlesource.com/chromium/deps/nasm.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/nearby/src": {
+                "args": {
+                    "hash": "sha256-Mwuo2RlKweqZPkDw4OcJDD+QNRiXVysSyzLdjHsG1mA=",
+                    "rev": "0bad8b0c9877f92eeeb550654f1ea51a71a085e4",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/nearby-connections.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/neon_2_sse/src": {
+                "args": {
+                    "hash": "sha256-4OzG4wIPwnKbFD9LG+stxHt5O4qB85ZIXVeSrNqDAyM=",
+                    "rev": "662a85912e8f86ec808f9b15ce77f8715ba53316",
+                    "url": "https://chromium.googlesource.com/external/github.com/intel/ARM_NEON_2_x86_SSE.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/nlohmann_json/src": {
+                "args": {
+                    "hash": "sha256-t+ygFLws+E4D0Avia7swt4wruaDFaAT6shN6tl92q8k=",
+                    "rev": "75d9166a68355d2cd5a98bfd1a75a3a3dae8f071",
+                    "url": "https://chromium.googlesource.com/external/github.com/nlohmann/json.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/oak/src": {
+                "args": {
+                    "hash": "sha256-+ouwII+i5CbWoJ3NAxQPmczofzkPwtZTtjIPaXyyXt8=",
+                    "rev": "96c00a6c99ac382f3f3a8f376bc7a70890d1adaa",
+                    "url": "https://chromium.googlesource.com/external/github.com/project-oak/oak.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/openh264/src": {
+                "args": {
+                    "hash": "sha256-tf0lnxATCkoq+xRti6gK6J47HwioAYWnpEsLGSA5Xdg=",
+                    "rev": "652bdb7719f30b52b08e506645a7322ff1b2cc6f",
+                    "url": "https://chromium.googlesource.com/external/github.com/cisco/openh264"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/openscreen/src": {
+                "args": {
+                    "hash": "sha256-hRDFnoqAH4HoWZ3oTWlzNge2nwlxpUC/GEq0MQVzBw8=",
+                    "rev": "448a19d1f24e0f8ce85ad0c1c6a50cf370ae69d7",
+                    "url": "https://chromium.googlesource.com/openscreen"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/openscreen/src/buildtools": {
+                "args": {
+                    "hash": "sha256-sWkgWY2rXVQK83WBVaZxCupQsS/8BtlgagNBQywScPE=",
+                    "rev": "eca5f0685c48ed59ff06077cb18cee00934249dd",
+                    "url": "https://chromium.googlesource.com/chromium/src/buildtools"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/openscreen/src/third_party/tinycbor/src": {
+                "args": {
+                    "hash": "sha256-fMKBFUSKmODQyg4hKIa1hwnEKIV6WBbY1Gb8DOSnaHA=",
+                    "rev": "d393c16f3eb30d0c47e6f9d92db62272f0ec4dc7",
+                    "url": "https://chromium.googlesource.com/external/github.com/intel/tinycbor.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/ots/src": {
+                "args": {
+                    "hash": "sha256-kiUXrXsaGOzPkKh0dVmU1I13WHt0Stzj7QLMqHN9FbU=",
+                    "rev": "46bea9879127d0ff1c6601b078e2ce98e83fcd33",
+                    "url": "https://chromium.googlesource.com/external/github.com/khaledhosny/ots.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/pdfium": {
+                "args": {
+                    "hash": "sha256-qd3Oa/JFzoI5hKDY2/OQAzdr2z9srUj0H6oKz0R516U=",
+                    "rev": "a78c62d93a8f514ea2cd98a70bd1d21226be9d93",
+                    "url": "https://pdfium.googlesource.com/pdfium.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/perfetto": {
+                "args": {
+                    "hash": "sha256-jVih4xWota4SZQi4yEtaIP+4qgD03OsELt2aaulIXik=",
+                    "rev": "46432bb2a7a60e10fcee516f1692e6846d098a8d",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/perfetto.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/protobuf-javascript/src": {
+                "args": {
+                    "hash": "sha256-1o6N9+1wsQSu1B4w5LlGlwzIUmuPCIYHPqwOyt234ZM=",
+                    "rev": "e6d763860001ba1a76a63adcff5efb12b1c96024",
+                    "url": "https://chromium.googlesource.com/external/github.com/protocolbuffers/protobuf-javascript"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/pthreadpool/src": {
+                "args": {
+                    "hash": "sha256-Es9QNblzo5b+x4K7myQJwIiUKvqyP16QExWPhGqqDO8=",
+                    "rev": "9003ee6c137cea3b94161bd5c614fb43be523ee1",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/pthreadpool.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/pyelftools": {
+                "args": {
+                    "hash": "sha256-rEnt08K90/Psfa+SQgTUG3YGrhp4/udXG9VKIwPM7pk=",
+                    "rev": "8047437615d66d3267ac0134834b80e70639d572",
+                    "url": "https://chromium.googlesource.com/chromiumos/third_party/pyelftools.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/pywebsocket3/src": {
+                "args": {
+                    "hash": "sha256-WEqqu2/7fLqcf/2/IcD7/FewRSZ6jTgVlVBvnihthYQ=",
+                    "rev": "50602a14f1b6da17e0b619833a13addc6ea78bc2",
+                    "url": "https://chromium.googlesource.com/external/github.com/GoogleChromeLabs/pywebsocket3.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/quic_trace/src": {
+                "args": {
+                    "hash": "sha256-JmK7nmHg/BfXvFNG2oMpOV83EF+LwVLdwL6qX5FGREs=",
+                    "rev": "352288a06d2c83ae68b5a402b2219f4678be9f39",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/quic-trace.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/re2/src": {
+                "args": {
+                    "hash": "sha256-oEU+dz8ax1S36+f9OysjB0GnQj8mjZx1VsZ/UgckdDI=",
+                    "rev": "972a15cedd008d846f1a39b2e88ce48d7f166cbd",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/re2.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/readability/src": {
+                "args": {
+                    "hash": "sha256-lFsHXk4kEkzIbHgJiLTgeiKqiGOErzUwADo8WSZlnec=",
+                    "rev": "d7949dc47dd9ed9ee1d3b34ffdcf3bce28cde435",
+                    "url": "https://chromium.googlesource.com/external/github.com/mozilla/readability.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/ruy/src": {
+                "args": {
+                    "hash": "sha256-4To1BMUgzj2/sV7USN9W0CgHnpRmaktEspfhwWWeVBc=",
+                    "rev": "2af88863614a8298689cc52b1a47b3fcad7be835",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/ruy.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/search_engines_data/resources": {
+                "args": {
+                    "hash": "sha256-UPP47dgdXxr+LPvTcEc6gi89OxmvdKD3CdwV4wKXvwQ=",
+                    "rev": "2ecec7b3a56bcb5d7a4a1fc9bc71d7e1cda2a8d1",
+                    "url": "https://chromium.googlesource.com/external/search_engines_data.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/securemessage/src": {
+                "args": {
+                    "hash": "sha256-GS4ccnuiqxMs/LVYAtvSlVAYFp4a5GoZsxcriTX3k78=",
+                    "rev": "fa07beb12babc3b25e0c5b1f38c16aa8cb6b8f84",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/securemessage.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/skia": {
+                "args": {
+                    "hash": "sha256-HsKHffZWTls362kjokxzdhaxb/xJD1g70VHGk9l6GVM=",
+                    "rev": "afe8b760ada5128164f9826866b4381a3463df41",
+                    "url": "https://skia.googlesource.com/skia.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/smhasher/src": {
+                "args": {
+                    "hash": "sha256-OgZQwkQcVgRMf62ROGuY+3zQhBoWuUSP4naTmSKdq8s=",
+                    "rev": "0ff96f7835817a27d0487325b6c16033e2992eb5",
+                    "url": "https://chromium.googlesource.com/external/smhasher.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/snappy/src": {
+                "args": {
+                    "hash": "sha256-jUwnjbaqXz7fgI2TPRK7SlUPQUVzcpjp4ZlFbEzwA+o=",
+                    "rev": "32ded457c0b1fe78ceb8397632c416568d6714a0",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/snappy.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/speedometer/main": {
+                "args": {
+                    "hash": "sha256-oF8ELo2qmkgaTpNzBLaC3A6gyf2iFv+FQNPGwdGqzVU=",
+                    "rev": "e2e2538900938c5d6819e9456bf33d48f806c96c",
+                    "url": "https://chromium.googlesource.com/external/github.com/WebKit/Speedometer.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/speedometer/v2.0": {
+                "args": {
+                    "hash": "sha256-p7WUS8gZUaS+LOm7pNmRkwgxjx+V8R6yy7bbaEHaIs4=",
+                    "rev": "732af0dfe867f8815e662ac637357e55f285dbbb",
+                    "url": "https://chromium.googlesource.com/external/github.com/WebKit/Speedometer.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/speedometer/v2.1": {
+                "args": {
+                    "hash": "sha256-0z5tZlz32fYh9I1ALqfLm2WWO8HiRBwt0hcmgKQhaeM=",
+                    "rev": "8bf7946e39e47c875c00767177197aea5727e84a",
+                    "url": "https://chromium.googlesource.com/external/github.com/WebKit/Speedometer.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/speedometer/v3.0": {
+                "args": {
+                    "hash": "sha256-qMQ4naX+4uUu3vtzzinjkhxX9/dNoTwj6vWCu4FdQmU=",
+                    "rev": "8d67f28d0281ac4330f283495b7f48286654ad7d",
+                    "url": "https://chromium.googlesource.com/external/github.com/WebKit/Speedometer.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/speedometer/v3.1": {
+                "args": {
+                    "hash": "sha256-G89mrrgRaANT1vqzhKPQKemHbz56YwR+oku7rlRoCHw=",
+                    "rev": "1386415be8fef2f6b6bbdbe1828872471c5d802a",
+                    "url": "https://chromium.googlesource.com/external/github.com/WebKit/Speedometer.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/spirv-cross/src": {
+                "args": {
+                    "hash": "sha256-H43M9DXfEuyKuvo6rjb5k0KEbYOSFodbPJh8ZKY4PQg=",
+                    "rev": "b8fcf307f1f347089e3c46eb4451d27f32ebc8d3",
+                    "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Cross"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/spirv-headers/src": {
+                "args": {
+                    "hash": "sha256-UKBVs2s05hP+paPq1dZFaUEQQ9Kx9acHxYUyJVx22eY=",
+                    "rev": "6dd7ba990830f7c15ac1345ff3b43ef6ffdad216",
+                    "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Headers"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/spirv-tools/src": {
+                "args": {
+                    "hash": "sha256-8Xtzq8WOdFEw+uEJqMW39LLHt2m165K9OJsIFZuifoM=",
+                    "rev": "2d14d2e76aa7de72404b17078eda15c20a6a0389",
+                    "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Tools"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/sqlite/src": {
+                "args": {
+                    "hash": "sha256-SfvLfBKdPjFvZ7CzUeFMcyoHdCzQgNRQwZyzb6MRtJg=",
+                    "rev": "508ab21dc25702ed6690c4dd77da209a6bcd1239",
+                    "url": "https://chromium.googlesource.com/chromium/deps/sqlite.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/squirrel.mac": {
+                "args": {
+                    "hash": "sha256-4GfKQg0u3c9GI+jl3ixESNqWXQJKRMi+00QT0s2Shqw=",
+                    "owner": "Squirrel",
+                    "repo": "Squirrel.Mac",
+                    "rev": "0e5d146ba13101a1302d59ea6e6e0b3cace4ae38"
+                },
+                "fetcher": "fetchFromGitHub"
+            },
+            "src/third_party/squirrel.mac/vendor/Mantle": {
+                "args": {
+                    "hash": "sha256-ykR4JFDJyajpzubzptjrxC9WUbGBTma5YLaBiPB6y0s=",
+                    "owner": "Mantle",
+                    "repo": "Mantle",
+                    "rev": "2a8e2123a3931038179ee06105c9e6ec336b12ea"
+                },
+                "fetcher": "fetchFromGitHub"
+            },
+            "src/third_party/squirrel.mac/vendor/ReactiveObjC": {
+                "args": {
+                    "hash": "sha256-/MCqC1oFe3N9TsmfVLgl+deR6qHU6ZFQQjudb9zB5Mo=",
+                    "owner": "ReactiveCocoa",
+                    "repo": "ReactiveObjC",
+                    "rev": "74ab5baccc6f7202c8ac69a8d1e152c29dc1ea76"
+                },
+                "fetcher": "fetchFromGitHub"
+            },
+            "src/third_party/swiftshader": {
+                "args": {
+                    "hash": "sha256-h0utcwCnzwhFufggkBNeA674x2Kqwu4sz3jQ/9eoQv0=",
+                    "rev": "89556131bf9d48af3c5c9fbb9a3322e706da89a3",
+                    "url": "https://swiftshader.googlesource.com/SwiftShader.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/text-fragments-polyfill/src": {
+                "args": {
+                    "hash": "sha256-4rW2u1cQAF4iPWHAt1FvVXIpz2pmI901rEPks/w/iFA=",
+                    "rev": "c036420683f672d685e27415de0a5f5e85bdc23f",
+                    "url": "https://chromium.googlesource.com/external/github.com/GoogleChromeLabs/text-fragments-polyfill.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/tflite/src": {
+                "args": {
+                    "hash": "sha256-r2b+/VBffxsh1sRM2xcFiBx9K6GD6FsaQXpfFMBFUag=",
+                    "rev": "de8d7f65b6eb670e4dad0225d0d6f99bebaab559",
+                    "url": "https://chromium.googlesource.com/external/github.com/tensorflow/tensorflow.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/ukey2/src": {
+                "args": {
+                    "hash": "sha256-aaLs6ZS+CdBlCJ6ZhsmdAPFxiBIij6oufsDcNeRSV1E=",
+                    "rev": "0275885d8e6038c39b8a8ca55e75d1d4d1727f47",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/ukey2.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/vulkan-deps": {
+                "args": {
+                    "hash": "sha256-VOyN618wzyyO2Wh18gCnw+FCr/NbegX3A/54MClyhwc=",
+                    "rev": "0ced1107c62836f439f684a5696c4bd69e09fce3",
+                    "url": "https://chromium.googlesource.com/vulkan-deps"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/vulkan-headers/src": {
+                "args": {
+                    "hash": "sha256-/yolWlC7ruRiJ0gSdCoSlqL9+j2uJAh+o+H0OG37pq4=",
+                    "rev": "afe9eb980aa928a66d1c9c06f38c55dd59868720",
+                    "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Headers"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/vulkan-loader/src": {
+                "args": {
+                    "hash": "sha256-8ParcURRRU3eS9Oej/vHTwOwvYy3HsVJsKh2wQLKUgM=",
+                    "rev": "df84d2be47457a8dfd7eb66f8c2b031683bd1ba5",
+                    "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Loader"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/vulkan-tools/src": {
+                "args": {
+                    "hash": "sha256-tmTD/waVX/duaKXvj0FNUS+ncL1agM73kK7pEfHEsSA=",
+                    "rev": "90bf5bc4fd8bea0d300f6564af256a51a34124b8",
+                    "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Tools"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/vulkan-utility-libraries/src": {
+                "args": {
+                    "hash": "sha256-B3GXmwJEvnGcER5DJt0FGrwqNi3t8iV6VgX8uOrExlU=",
+                    "rev": "48b1fd1a65e436bae806cb6180c9338846b9de97",
+                    "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Utility-Libraries"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/vulkan-validation-layers/src": {
+                "args": {
+                    "hash": "sha256-GqjVHxtda1a47+9G+nqh4qNMJmQaUdZNMUGQ8kAIIkk=",
+                    "rev": "ac146eef210b6f52b842111c5d3419ab32a7293f",
+                    "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-ValidationLayers"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/vulkan_memory_allocator": {
+                "args": {
+                    "hash": "sha256-yBCs3zfqs/60htsZAOscjcyKhVbAWE6znweuXcs1oKo=",
+                    "rev": "cb0597213b0fcb999caa9ed08c2f88dc45eb7d50",
+                    "url": "https://chromium.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/wayland-protocols/gtk": {
+                "args": {
+                    "hash": "sha256-75XNnLkF5Lt1LMRGT+T61k0/mLa3kkynfN+QWvZ0LiQ=",
+                    "rev": "40ebed3a03aef096addc0af09fec4ec529d882a0",
+                    "url": "https://chromium.googlesource.com/external/github.com/GNOME/gtk.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/wayland-protocols/kde": {
+                "args": {
+                    "hash": "sha256-Dmcp/2ms/k7NxPPmPkp0YNfM9z2Es1ZO0uX10bc7N2Y=",
+                    "rev": "0b07950714b3a36c9b9f71fc025fc7783e82926e",
+                    "url": "https://chromium.googlesource.com/external/github.com/KDE/plasma-wayland-protocols.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/wayland-protocols/src": {
+                "args": {
+                    "hash": "sha256-tdpEK7soY0aKSk6VD4nulH7ORubX8RfjXYmNAd/cWKY=",
+                    "rev": "efbc060534be948b63e1f395d69b583eebba3235",
+                    "url": "https://chromium.googlesource.com/external/anongit.freedesktop.org/git/wayland/wayland-protocols.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/wayland/src": {
+                "args": {
+                    "hash": "sha256-5iG0HaPXJCEo027TuyXlJQNGluTaAPlvwQDFbiYOEJQ=",
+                    "rev": "736d12ac67c20c60dc406dc49bb06be878501f86",
+                    "url": "https://chromium.googlesource.com/external/anongit.freedesktop.org/git/wayland/wayland.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/webdriver/pylib": {
+                "args": {
+                    "hash": "sha256-k5qx4xyO83jPtHaMh6aMigMJ3hsytFdFQOcZLmwPEYo=",
+                    "rev": "1e954903022e9386b9acf452c24f4458dd4c4fc1",
+                    "url": "https://chromium.googlesource.com/external/github.com/SeleniumHQ/selenium/py.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/webgl/src": {
+                "args": {
+                    "hash": "sha256-Aax2hr/9Zq6Avk+TMU1OMBLGshUL6hyRTX6eoOQesqM=",
+                    "rev": "216b10fafd3f6a900c715a8c758a4c7f9883b030",
+                    "url": "https://chromium.googlesource.com/external/khronosgroup/webgl.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/webgpu-cts/src": {
+                "args": {
+                    "hash": "sha256-eTAwnTiAHq8rmbw7u9nAwSuAlS5adStUJKfITlYkcgU=",
+                    "rev": "09fdb847d90d0b5bfe57068ce2eb9283cb77fc7f",
+                    "url": "https://chromium.googlesource.com/external/github.com/gpuweb/cts.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/webpagereplay": {
+                "args": {
+                    "hash": "sha256-KcFUlQMltsMm4WlTVMLzZXfrvu67ffkKjmBcruwZye0=",
+                    "rev": "be48b5e3387780790ecc7723434b6ea6733bcc33",
+                    "url": "https://chromium.googlesource.com/webpagereplay.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/webrtc": {
+                "args": {
+                    "hash": "sha256-jTJv53qt971Va5q6MaULysYiChBVmsFYxG9fzkcE0ak=",
+                    "rev": "9600e77d854090669817d22aa2fc941ee92aaacd",
+                    "url": "https://webrtc.googlesource.com/src.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/weston/src": {
+                "args": {
+                    "hash": "sha256-PySen9syu0OshtlHAZw666FeSQXdnsV8nlW9RmxgapM=",
+                    "rev": "b65be9e699847c975440108a42f05412cc7fddac",
+                    "url": "https://chromium.googlesource.com/external/anongit.freedesktop.org/git/wayland/weston.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/wuffs/src": {
+                "args": {
+                    "hash": "sha256-373d2F/STcgCHEq+PO+SCHrKVOo6uO1rqqwRN5eeBCw=",
+                    "rev": "e3f919ccfe3ef542cfc983a82146070258fb57f8",
+                    "url": "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/xnnpack/src": {
+                "args": {
+                    "hash": "sha256-xal21wjgeql3MjQXw6F1ezcRsnhVKod5jv0nYWroJ1o=",
+                    "rev": "1812bbe2928a32f26c5e48466712ba6460cf290c",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/XNNPACK.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/zstd/src": {
+                "args": {
+                    "hash": "sha256-futF0sM6z9HAl6AMJwUULBRByN92FTBjRIzYb2vBFGg=",
+                    "rev": "3ae099b48dfcfe02b1b3ba81ab85457f8a922e9f",
+                    "url": "https://chromium.googlesource.com/external/github.com/facebook/zstd.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/v8": {
+                "args": {
+                    "hash": "sha256-x2FGL3J+JaWO1m6jBrcayR7Vlz90fYEAuufm4PULYyM=",
+                    "rev": "ddc9a95905de5268332a8f0216dc2bc67d26e829",
+                    "url": "https://chromium.googlesource.com/v8/v8.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            }
+        },
+        "electron_yarn_hash": "sha256-I/HGEtkahqPv50a7t8leo6jPRV2qyNJSw5SKjwS3SjY=",
+        "modules": "146",
+        "node": "24.15.0",
+        "version": "42.0.0"
     }
 }

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -2696,7 +2696,7 @@
         "version": "40.9.3"
     },
     "41": {
-        "chrome": "146.0.7680.188",
+        "chrome": "146.0.7680.216",
         "chromium": {
             "deps": {
                 "gn": {
@@ -2705,15 +2705,15 @@
                     "version": "0-unstable-2026-02-05"
                 }
             },
-            "version": "146.0.7680.188"
+            "version": "146.0.7680.216"
         },
         "chromium_npm_hash": "sha256-ByB1Ea5tduIJZXyydeBWsoS8OPABOgwHe+dNXRssdvc=",
         "deps": {
             "src": {
                 "args": {
-                    "hash": "sha256-EKShXS1zF3TWCNLj8gCxjXlr80rA99QGM9ip28kgQH0=",
+                    "hash": "sha256-US3KELmSThwFAYS73Wh8w/6F5JjjE3/QnJ32axIoS1U=",
                     "postFetch": "rm -rf $(find $out/third_party/blink/web_tests ! -name BUILD.gn -mindepth 1 -maxdepth 1); rm -r $out/content/test/data; rm -rf $out/courgette/testdata; rm -r $out/extensions/test/data; rm -r $out/media/test/data; ",
-                    "tag": "146.0.7680.188",
+                    "tag": "146.0.7680.216",
                     "url": "https://chromium.googlesource.com/chromium/src.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -2752,10 +2752,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-x3XSMSq1GuSTwQuOqbg9hCaMCoKx8UPGMDtJu5y1qfA=",
+                    "hash": "sha256-z7ev2g8h3ne4RopyS7C+X9J5cR64QDXNU5VZ0pzoErI=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v41.3.0"
+                    "tag": "v41.5.0"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -2785,8 +2785,8 @@
             },
             "src/third_party/angle": {
                 "args": {
-                    "hash": "sha256-u/2B+93xg1sMlg+R9zjAFXpyjgLCyzB7JY4bjLafFFE=",
-                    "rev": "d1100603964278cd89c5eb94707fbca242c788bf",
+                    "hash": "sha256-W820GLtq3Nyw75kNRXwZZNVQjKgT9TzCXA2zU2q2QeM=",
+                    "rev": "f27a667c64ebf41644efa31e66c52dce26824a4f",
                     "url": "https://chromium.googlesource.com/angle/angle.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -2977,8 +2977,8 @@
             },
             "src/third_party/dawn": {
                 "args": {
-                    "hash": "sha256-ATTNb61RG7hS1mapDw0o4ZyBeny4ONI8ZjJLpmbQaKU=",
-                    "rev": "10fb89e3179bb7443e66911eb3c795c7aaf022e5",
+                    "hash": "sha256-Tjc7KNI4gqYgE7jg/pE2H4BpE00LQD4bgrw7pRm/ssI=",
+                    "rev": "a94afcc3f32ac522df1383bb80b78680c7b1de70",
                     "url": "https://dawn.googlesource.com/dawn.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -3347,8 +3347,8 @@
             },
             "src/third_party/libaom/source/libaom": {
                 "args": {
-                    "hash": "sha256-hLddZzWBQZ/MEF5fcCiju5ibNPSb+zhahlxdLaczdsE=",
-                    "rev": "446588f90da2e3372a9352d3b2ba8ab3f342c8ce",
+                    "hash": "sha256-SkaXi8kd2WlwE/t+Mb9n60SWiUhQksJsSW/x/mgmMco=",
+                    "rev": "b5d2fb00c10392da233017c223b1a5662bc7bb0c",
                     "url": "https://aomedia.googlesource.com/aom.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -3467,8 +3467,8 @@
             },
             "src/third_party/libvpx/source/libvpx": {
                 "args": {
-                    "hash": "sha256-/FtYzbcOgOlaaWCoJfYns5oye7DoRZx1/xew3lN7tAM=",
-                    "rev": "e83e25f791932202256479052f18bdd03a091147",
+                    "hash": "sha256-XxoaxHT0UjHY2M5YriB0iERQYdSAOA4lCiBxctmU1H4=",
+                    "rev": "d45dc9655773862fbdaef40c449b919e815ac878",
                     "url": "https://chromium.googlesource.com/webm/libvpx.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -3628,8 +3628,8 @@
             },
             "src/third_party/pdfium": {
                 "args": {
-                    "hash": "sha256-/reVJqqKSGUX1INmwOPQabPodYwlbhlxTIO0pAlnJnY=",
-                    "rev": "9e6326d6112c90f525c5f85cd7e39318bc705317",
+                    "hash": "sha256-H2YIwVZByH1rsSScgEnzcRtHLwxfEBr00tgMBHX5yiM=",
+                    "rev": "436c484cff819ca5c12374a6c4896127f8bcf27e",
                     "url": "https://pdfium.googlesource.com/pdfium.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -3724,8 +3724,8 @@
             },
             "src/third_party/skia": {
                 "args": {
-                    "hash": "sha256-2/Deen9OwDgDRrm5j7Rw27Z2JUX1thX7mnKWRLJbEvM=",
-                    "rev": "30d129c8800b5626c46fb83fa62db10b9b22b319",
+                    "hash": "sha256-Nj7Hgzdf0DCNsQAjGyiq1+lvDd9J78M5N1jdL1wa9HU=",
+                    "rev": "ef5f213b0436c53fdf59184d9536eb5ee5aa8084",
                     "url": "https://skia.googlesource.com/skia.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -3999,8 +3999,8 @@
             },
             "src/third_party/webrtc": {
                 "args": {
-                    "hash": "sha256-2yynA/qNvjP6KN2jShDuwnaSMJ1xRduWP4xsbODPDOE=",
-                    "rev": "70d86bbfaeeadffb1193c2aad245edd23ef251ef",
+                    "hash": "sha256-m+ylEOjCbCdlQ9+6lEaFSUXig3x2kWFa8PNdOADRVEU=",
+                    "rev": "2964e45d0fc4552b6ffe8789061f8fd2a96dca38",
                     "url": "https://webrtc.googlesource.com/src.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -4047,8 +4047,8 @@
             },
             "src/v8": {
                 "args": {
-                    "hash": "sha256-NFz9p4EWq46Tm+Y/hBXk4Vb0Ljy/s1BTbuiMH351IJs=",
-                    "rev": "f09a91282a26caa91d016c962d785d852cfdec36",
+                    "hash": "sha256-SRHjAvmBRo9SMgShF3Ma+1HcIBdWL+JKQk4QTjL+vp8=",
+                    "rev": "f9116f3bf9a50b0f7925daacfdc6fed503a9dbe2",
                     "url": "https://chromium.googlesource.com/v8/v8.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -4057,7 +4057,7 @@
         "electron_yarn_hash": "sha256-tPI7O7xlvDjU5+krILVB6JhLpftMq4Bn8+KIKMjBVgA=",
         "modules": "145",
         "node": "24.15.0",
-        "version": "41.3.0"
+        "version": "41.5.0"
     },
     "42": {
         "chrome": "148.0.7778.96",

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -1404,10 +1404,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-wTKT4XA0ylL5uUZWfp9XhxiGUkfXrtEzw3Pw+nGwr4w=",
+                    "hash": "sha256-jXPyJKuxYcACj9uvGmnTC3gv5YO/5sxQ9LUuM33Dnf0=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v40.9.2"
+                    "tag": "v40.9.3"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -2693,7 +2693,7 @@
         "electron_yarn_hash": "sha256-0P2Kt1uJA0lmZjIOr4Bpu6NDl4CwEKEgRz/B92oCs9M=",
         "modules": "143",
         "node": "24.14.1",
-        "version": "40.9.2"
+        "version": "40.9.3"
     },
     "41": {
         "chrome": "146.0.7680.188",

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -2796,10 +2796,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-HFGxrfVNBU+JkNGBglJryTm+hCDBqLgg0NRXt8QHOOs=",
+                    "hash": "sha256-0i3h/60XFgtX3/uJ5wI36o1EU0nKn0HawXBzv8RJuKs=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v41.5.2"
+                    "tag": "v41.6.1"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -4099,7 +4099,7 @@
             }
         },
         "electron_yarn_data": {
-            "hash": "sha256-Ry8gzsdaR61djEgF+MpXAYGK00lRD5ZLq3cLUV1prFs=",
+            "hash": "sha256-BfyakV8UL4Dgc8wGDesri+gCRqGrX9Am7AOmNhrateQ=",
             "missing_hashes": {
                 "@oxfmt/binding-android-arm-eabi@npm:0.42.0": "42c08d87ce491086843070241f8777fa2cb968f4a08f67b3f6c33a8f67e0b3eac50eae146daede743e90e3bc32326951c5188814eea02e9c3e4a9764a4b492ba",
                 "@oxfmt/binding-android-arm64@npm:0.42.0": "73e6609498d05c655c6a435af9f3e4f341137c260c7ae27fbb0377573574ca5200bd9f187aa90d442879733bbd0c4e91ae023c3b4579c9a57413a0b2922c023a",
@@ -4143,7 +4143,7 @@
         },
         "modules": "145",
         "node": "24.15.0",
-        "version": "41.5.2"
+        "version": "41.6.1"
     },
     "42": {
         "chrome": "148.0.7778.97",

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -4202,10 +4202,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-uv2I4EVje8Dd5FgoC6jJOiISbd5kBbqI37so45R+Qy4=",
+                    "hash": "sha256-QVWPIw2G5ai9dCLZ6K1ZuJKydMFexA17X1gtB3XeXKc=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v42.0.1"
+                    "tag": "v42.1.0"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -5513,7 +5513,7 @@
             }
         },
         "electron_yarn_data": {
-            "hash": "sha256-PT4mxXZ2Dcao7/iouNhrFZbGwO7kFbdJANFfA8UR4Ew=",
+            "hash": "sha256-jNlIaaXY6CMDkmA+4a9HFJhHBOw0KkLhn16ysSYVyk8=",
             "missing_hashes": {
                 "@oxfmt/binding-android-arm-eabi@npm:0.42.0": "42c08d87ce491086843070241f8777fa2cb968f4a08f67b3f6c33a8f67e0b3eac50eae146daede743e90e3bc32326951c5188814eea02e9c3e4a9764a4b492ba",
                 "@oxfmt/binding-android-arm64@npm:0.42.0": "73e6609498d05c655c6a435af9f3e4f341137c260c7ae27fbb0377573574ca5200bd9f187aa90d442879733bbd0c4e91ae023c3b4579c9a57413a0b2922c023a",
@@ -5557,6 +5557,6 @@
         },
         "modules": "146",
         "node": "24.15.0",
-        "version": "42.0.1"
+        "version": "42.1.0"
     }
 }

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -4146,7 +4146,7 @@
         "version": "41.5.2"
     },
     "42": {
-        "chrome": "148.0.7778.96",
+        "chrome": "148.0.7778.97",
         "chromium": {
             "deps": {
                 "gn": {
@@ -4155,15 +4155,15 @@
                     "version": "0-unstable-2026-04-01"
                 }
             },
-            "version": "148.0.7778.96"
+            "version": "148.0.7778.97"
         },
         "chromium_npm_hash": "sha256-JuVcY8iFRDWcPcP4Pg+qm5rnTXkiVfNsqSkXbDWqsE8=",
         "deps": {
             "src": {
                 "args": {
-                    "hash": "sha256-jtHzApRzYLz3lwvLJdK9uoGlEeMJl9BPkHpfkYdemhc=",
+                    "hash": "sha256-nr/bMzJ+4b7/WeT3yG6rddGHvBi51ZzDTdQLIvJYBtg=",
                     "postFetch": "rm -rf $(find $out/third_party/blink/web_tests ! -name BUILD.gn -mindepth 1 -maxdepth 1); rm -r $out/content/test/data; rm -rf $out/courgette/testdata; rm -r $out/extensions/test/data; rm -r $out/media/test/data; ",
-                    "tag": "148.0.7778.96",
+                    "tag": "148.0.7778.97",
                     "url": "https://chromium.googlesource.com/chromium/src.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -4202,10 +4202,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-CYTvfDRyheyg6A8D98NrIyG9/seXTwxm8N2ObC2C7fM=",
+                    "hash": "sha256-uv2I4EVje8Dd5FgoC6jJOiISbd5kBbqI37so45R+Qy4=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v42.0.0"
+                    "tag": "v42.0.1"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -5512,9 +5512,51 @@
                 "fetcher": "fetchFromGitiles"
             }
         },
-        "electron_yarn_hash": "sha256-I/HGEtkahqPv50a7t8leo6jPRV2qyNJSw5SKjwS3SjY=",
+        "electron_yarn_data": {
+            "hash": "sha256-PT4mxXZ2Dcao7/iouNhrFZbGwO7kFbdJANFfA8UR4Ew=",
+            "missing_hashes": {
+                "@oxfmt/binding-android-arm-eabi@npm:0.42.0": "42c08d87ce491086843070241f8777fa2cb968f4a08f67b3f6c33a8f67e0b3eac50eae146daede743e90e3bc32326951c5188814eea02e9c3e4a9764a4b492ba",
+                "@oxfmt/binding-android-arm64@npm:0.42.0": "73e6609498d05c655c6a435af9f3e4f341137c260c7ae27fbb0377573574ca5200bd9f187aa90d442879733bbd0c4e91ae023c3b4579c9a57413a0b2922c023a",
+                "@oxfmt/binding-darwin-arm64@npm:0.42.0": "ed0f486a5085942727e255a9c14bfd99756d4af3ad2c2e702bfb7ab682fc9041d5327f3e89dc4dbfc9a09a6c884dbc9a79a46c720435c5ad2f2fe3f48bb9c3ac",
+                "@oxfmt/binding-darwin-x64@npm:0.42.0": "b607e67171aa33717f7fe80d9d5c8ca816ff30dbbd2b41c4b129977c749c62a4bb1f6829aa95c564d15246c98689ba153fc003a09a1549e2f3316810b35463be",
+                "@oxfmt/binding-freebsd-x64@npm:0.42.0": "c038e53f42083a56d548bd2b89765d1b36150c874e83a41631dfa039fe4fd999475a4a5a99414e43fe44654abdbdfb78c17f53fb482ba3bdc9d22f5641931a41",
+                "@oxfmt/binding-linux-arm-gnueabihf@npm:0.42.0": "79d0b84f3281c7935eb153a53b7032fbb159357580cbcac721096d87ceb124e40863c0b7786ff1b94ad2cdc9b1beabe37e972e1b959423af028e6dea0fc8e0b6",
+                "@oxfmt/binding-linux-arm-musleabihf@npm:0.42.0": "c67dfa0553ba44f0585c3bba85efcbbd42b63b59f177302693fa83cc7b6fe6a6f2509c972cae9b367eb7cd36e8578209657ac4928cf329bf816fa4bfc578d2c1",
+                "@oxfmt/binding-linux-arm64-gnu@npm:0.42.0": "f8507b36f7f2673a4d6db227ed2e98f94d30f81275820d0d25e5e6b0b9b20c7f4cc32b646ae02aac0068b90ba3d47bcbd85ad789b27f028b8ea07e168ec731ce",
+                "@oxfmt/binding-linux-arm64-musl@npm:0.42.0": "c4d0406e36248b4a8ddd62ac2d7c1b6648d23fb2b1eee471e3965d6c411b2dedfc681d227adcff50bbff5f786727bef31420610564691887cdecb50d7f1f7587",
+                "@oxfmt/binding-linux-ppc64-gnu@npm:0.42.0": "12b0eb3cff0807f898dd2e47de5712c8b57d2373108135e87f1de69902204c0527b383753983388f32e48749c479ce0f6247fbc927a2e035b2fb1f6c31ae5df7",
+                "@oxfmt/binding-linux-riscv64-gnu@npm:0.42.0": "aff4c5104769388174a69f5f4ad418f33e86ff1286117072e2200b7217aa9d30375ffb4deeabd728aac7975ed5e79832ac725725df9ff2ea6f819aef5e166353",
+                "@oxfmt/binding-linux-riscv64-musl@npm:0.42.0": "710b0b9fc2d999a66b2c9e656e40e74e71d820d8670d5ee64dc36d373f1132a0c3ddcbedba6130f832b9e8abbb0988ab95de7a6ddd4657007f05fea4a3631835",
+                "@oxfmt/binding-linux-s390x-gnu@npm:0.42.0": "8fc8ee6c1ea3369d3f7ec2f6dbe3fe846663c8e10a0ea976b1b2e150117359580d7efc904f5da0ead2f59066b1e17076aa09c1c4f2544071c29b623ada15da70",
+                "@oxfmt/binding-linux-x64-gnu@npm:0.42.0": "d46d962752e0e2978cbd9b552a0d4bebde69fa9581512dfda33e7bc645c849e2787ef6a4e2ae825e7d2abf68b895c90c4a351387d2f0d2ba336e990c54e245f0",
+                "@oxfmt/binding-linux-x64-musl@npm:0.42.0": "e757b0b12ccf6e7355e2a3123fa0bea0908e1f220b7bb3601c18203bc78f1157be8364af9df3ca56f9c0bb123aeecbf058df31a9ee12612e1149b9c6228dc6f9",
+                "@oxfmt/binding-openharmony-arm64@npm:0.42.0": "fe85007d6e7e7c1b6662a9756267de459fc7213af9ddf6f0494397d9d666a452d4a1a6f6fe6ce288d8dd4763d07b52b4534cc177bdf0e5613559f144b78e8fbb",
+                "@oxfmt/binding-win32-arm64-msvc@npm:0.42.0": "04bd529ea236c23d8dc73d95acd365612ab489b0e6a4bdd976302b933b92dcc11d4d1629e2294036f16c1e1f5120140547f65060a9e2dc8adbb21f790e2eca39",
+                "@oxfmt/binding-win32-ia32-msvc@npm:0.42.0": "9775afa164de049416abf481f062b8c670cd27a70d82a0868fa61749f741e777a76eb0a57a9ef276f158a35741d90a856a492777a0a9f17c9ac01ead32935fe3",
+                "@oxfmt/binding-win32-x64-msvc@npm:0.42.0": "5c38197ac6f874c2622b68a531b9fc9a221de05aa09c40717bba775f658680ebf964db7aa41c12271f90261bf50713cd4ebb2c10f12bf33cf2103fb9d67a88bb",
+                "@oxlint/binding-android-arm-eabi@npm:1.61.0": "64a0e4e724ec776f7bf88926b9544484ac4b8b7c906539073683281d0de4d887494aabad654807336f8c306cbc2bbd2cbf218c780fa02ce7b8cd2c9c280a886c",
+                "@oxlint/binding-android-arm64@npm:1.61.0": "fcbef757ed0eecbddb90e3818315614dbd4bdba7f9e8aa23255d39d12dd2ee5cd1bc5608f2d236b3028330bad7ba741e7dc3569d06373dabade10bcafb056de7",
+                "@oxlint/binding-darwin-arm64@npm:1.61.0": "1ff458a5cde78b3b3f7852dad86ef6e430732361b81e5ac5712f83a237725bde05d67980beced4361416abb376dc6a6384435f2a4932a62c5794a58ca01b9d73",
+                "@oxlint/binding-darwin-x64@npm:1.61.0": "3e09d59d46985c2652ee3fa3560215df05eebf470f2acd3fb502d303f661e3d75861a8908a1b215e3912e5da23673cc517862e06be21be6c95770fc5848778ef",
+                "@oxlint/binding-freebsd-x64@npm:1.61.0": "8f7141e3a7a0334836ea9f333d76fb6a12e145533cda2f485fff536b725193595a172c154b402d0eff3b14e13a36b3a0a14629987bcbf8faa444d9213c5e78d8",
+                "@oxlint/binding-linux-arm-gnueabihf@npm:1.61.0": "2bf2eb6e1e6a3339822464e7f66f52824348ea5b4b0a2f87ed5fdfe6b7b993bb2ea0346e59dc68ec78030a3c4b8784810a2bb88edb69de99aacdda03606a35cf",
+                "@oxlint/binding-linux-arm-musleabihf@npm:1.61.0": "53d57e4693087ddd6e9104651f3200d11276aa8bf261ffe07c91908b7ba6dee0aaa58d74f3b58ad256b8dfb4689fee0e205d9479550b87a898644396afb1de55",
+                "@oxlint/binding-linux-arm64-gnu@npm:1.61.0": "b19d95033889b7a22e29b6b38a84c913f5e087015354de8ea52e60e8d067ecdbcedcecd49df2d3338e1ce5d579e079efaa43ee67ca626e92b619d41aa18277ae",
+                "@oxlint/binding-linux-arm64-musl@npm:1.61.0": "b61ede290d57073065e20161ae54d36d4700a814e6e62abc63e8e4f18558598e22695fcb9b14c67ce8aec50de2b733d6183f873d65de491936fbf7e1b9fbb59e",
+                "@oxlint/binding-linux-ppc64-gnu@npm:1.61.0": "7d0cb33713ce1716a0ddbc100b79eb888ad20af74c0c924db01b0b27c33677717f3f7a0f6d341ec0637ab0ec2dbc5033fea4154cf88b6c9513b1796b6a53ddf3",
+                "@oxlint/binding-linux-riscv64-gnu@npm:1.61.0": "a6c8ad8419110bbfc35f12256058fb0c31816f328a089bd6424ba03d582ebaed71f39ce673f77767dd17e2a4ed021789106a580d99e5f0a1f097ab3cf916f7a8",
+                "@oxlint/binding-linux-riscv64-musl@npm:1.61.0": "64e6073f588b995f509dccb6b66060a1cfeb5cea08613edf1a3f7819992ccce3a3f9539cd2b1962231a472f12c4ffa325600bbcc9279ada400b993488989470e",
+                "@oxlint/binding-linux-s390x-gnu@npm:1.61.0": "93b84e9694a451b023a2fbf2ca3cad533b5ea947bd89f6a8b95433cf12b6bb86bdbceb51188a5a5914a51a9e0ecca02abc6b0d656ce9616d8904eb8ebbaf84a8",
+                "@oxlint/binding-linux-x64-gnu@npm:1.61.0": "49d0ba0286946d633d933e2ae575a38dfef9f6570380d141f2bcdf10b09cba192a87767e5fd6cbeb115c23eae9c7241830c022180ada5bc96131badcc65c3d31",
+                "@oxlint/binding-linux-x64-musl@npm:1.61.0": "54567fcd74360d287a85ff18ce82c2691c0fea7f87e720f0390a621acf2422f64cafd135deebf329831fcac7cfe66389c8e6a5dcb8f8427ea6d4b3446ddeeab0",
+                "@oxlint/binding-openharmony-arm64@npm:1.61.0": "011ffbfde581da50b130705d59e0a043b4e6858dea1fc6fd100c7a2aa511179726769197a6868809a7040a28f454c0481a832c667b44b10820c0300b74a0b6f7",
+                "@oxlint/binding-win32-arm64-msvc@npm:1.61.0": "d5f962f94acfb6a882b04eb9ba33e05e2896b96cb6ab7b44c70aff55be93c633c6c88884d4f3f65f82ab88b6535c6034f4e9a7141bcfff23ad24efd0cb7bab78",
+                "@oxlint/binding-win32-ia32-msvc@npm:1.61.0": "f2902478c85eb95665cf3c4021cc4cdd3ea98f8863d9a311a6f2532059d1c8cc3c36c9e0eac7b459827cd03c4c7e6803bb96939d7476f3289df9362aaadd4710",
+                "@oxlint/binding-win32-x64-msvc@npm:1.61.0": "e4a5cf6c8db10fdf1cda748ab368357260e1fcab8df5819587b940613f55e57a729e99641119ff074d5aea59de16f4563322e01be5ac27d1349c9ca14d60302d"
+            }
+        },
         "modules": "146",
         "node": "24.15.0",
-        "version": "42.0.0"
+        "version": "42.0.1"
     }
 }

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -1406,10 +1406,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-jXPyJKuxYcACj9uvGmnTC3gv5YO/5sxQ9LUuM33Dnf0=",
+                    "hash": "sha256-H4mLOoA2fdI5yF1qnXC1s1+BVO/ouxXOHh2ZzqJVAVc=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v40.9.3"
+                    "tag": "v40.10.0"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -1743,10 +1743,10 @@
             },
             "src/third_party/electron_node": {
                 "args": {
-                    "hash": "sha256-WJSNbXox5oT6WQXARbl9B+DcEaHrCpu96s5Pvq48bfE=",
+                    "hash": "sha256-Y4FP+AstENp1uTYBo8HeTRDwvKClTdrZ4RztLeHNP3k=",
                     "owner": "nodejs",
                     "repo": "node",
-                    "tag": "v24.14.1"
+                    "tag": "v24.15.0"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -2692,10 +2692,52 @@
                 "fetcher": "fetchFromGitiles"
             }
         },
-        "electron_yarn_hash": "sha256-0P2Kt1uJA0lmZjIOr4Bpu6NDl4CwEKEgRz/B92oCs9M=",
+        "electron_yarn_data": {
+            "hash": "sha256-x9ct6hQ2DW4oxFej+5WAQhHMkGqzEsz1Tta2nA77T3w=",
+            "missing_hashes": {
+                "@oxfmt/binding-android-arm-eabi@npm:0.42.0": "42c08d87ce491086843070241f8777fa2cb968f4a08f67b3f6c33a8f67e0b3eac50eae146daede743e90e3bc32326951c5188814eea02e9c3e4a9764a4b492ba",
+                "@oxfmt/binding-android-arm64@npm:0.42.0": "73e6609498d05c655c6a435af9f3e4f341137c260c7ae27fbb0377573574ca5200bd9f187aa90d442879733bbd0c4e91ae023c3b4579c9a57413a0b2922c023a",
+                "@oxfmt/binding-darwin-arm64@npm:0.42.0": "ed0f486a5085942727e255a9c14bfd99756d4af3ad2c2e702bfb7ab682fc9041d5327f3e89dc4dbfc9a09a6c884dbc9a79a46c720435c5ad2f2fe3f48bb9c3ac",
+                "@oxfmt/binding-darwin-x64@npm:0.42.0": "b607e67171aa33717f7fe80d9d5c8ca816ff30dbbd2b41c4b129977c749c62a4bb1f6829aa95c564d15246c98689ba153fc003a09a1549e2f3316810b35463be",
+                "@oxfmt/binding-freebsd-x64@npm:0.42.0": "c038e53f42083a56d548bd2b89765d1b36150c874e83a41631dfa039fe4fd999475a4a5a99414e43fe44654abdbdfb78c17f53fb482ba3bdc9d22f5641931a41",
+                "@oxfmt/binding-linux-arm-gnueabihf@npm:0.42.0": "79d0b84f3281c7935eb153a53b7032fbb159357580cbcac721096d87ceb124e40863c0b7786ff1b94ad2cdc9b1beabe37e972e1b959423af028e6dea0fc8e0b6",
+                "@oxfmt/binding-linux-arm-musleabihf@npm:0.42.0": "c67dfa0553ba44f0585c3bba85efcbbd42b63b59f177302693fa83cc7b6fe6a6f2509c972cae9b367eb7cd36e8578209657ac4928cf329bf816fa4bfc578d2c1",
+                "@oxfmt/binding-linux-arm64-gnu@npm:0.42.0": "f8507b36f7f2673a4d6db227ed2e98f94d30f81275820d0d25e5e6b0b9b20c7f4cc32b646ae02aac0068b90ba3d47bcbd85ad789b27f028b8ea07e168ec731ce",
+                "@oxfmt/binding-linux-arm64-musl@npm:0.42.0": "c4d0406e36248b4a8ddd62ac2d7c1b6648d23fb2b1eee471e3965d6c411b2dedfc681d227adcff50bbff5f786727bef31420610564691887cdecb50d7f1f7587",
+                "@oxfmt/binding-linux-ppc64-gnu@npm:0.42.0": "12b0eb3cff0807f898dd2e47de5712c8b57d2373108135e87f1de69902204c0527b383753983388f32e48749c479ce0f6247fbc927a2e035b2fb1f6c31ae5df7",
+                "@oxfmt/binding-linux-riscv64-gnu@npm:0.42.0": "aff4c5104769388174a69f5f4ad418f33e86ff1286117072e2200b7217aa9d30375ffb4deeabd728aac7975ed5e79832ac725725df9ff2ea6f819aef5e166353",
+                "@oxfmt/binding-linux-riscv64-musl@npm:0.42.0": "710b0b9fc2d999a66b2c9e656e40e74e71d820d8670d5ee64dc36d373f1132a0c3ddcbedba6130f832b9e8abbb0988ab95de7a6ddd4657007f05fea4a3631835",
+                "@oxfmt/binding-linux-s390x-gnu@npm:0.42.0": "8fc8ee6c1ea3369d3f7ec2f6dbe3fe846663c8e10a0ea976b1b2e150117359580d7efc904f5da0ead2f59066b1e17076aa09c1c4f2544071c29b623ada15da70",
+                "@oxfmt/binding-linux-x64-gnu@npm:0.42.0": "d46d962752e0e2978cbd9b552a0d4bebde69fa9581512dfda33e7bc645c849e2787ef6a4e2ae825e7d2abf68b895c90c4a351387d2f0d2ba336e990c54e245f0",
+                "@oxfmt/binding-linux-x64-musl@npm:0.42.0": "e757b0b12ccf6e7355e2a3123fa0bea0908e1f220b7bb3601c18203bc78f1157be8364af9df3ca56f9c0bb123aeecbf058df31a9ee12612e1149b9c6228dc6f9",
+                "@oxfmt/binding-openharmony-arm64@npm:0.42.0": "fe85007d6e7e7c1b6662a9756267de459fc7213af9ddf6f0494397d9d666a452d4a1a6f6fe6ce288d8dd4763d07b52b4534cc177bdf0e5613559f144b78e8fbb",
+                "@oxfmt/binding-win32-arm64-msvc@npm:0.42.0": "04bd529ea236c23d8dc73d95acd365612ab489b0e6a4bdd976302b933b92dcc11d4d1629e2294036f16c1e1f5120140547f65060a9e2dc8adbb21f790e2eca39",
+                "@oxfmt/binding-win32-ia32-msvc@npm:0.42.0": "9775afa164de049416abf481f062b8c670cd27a70d82a0868fa61749f741e777a76eb0a57a9ef276f158a35741d90a856a492777a0a9f17c9ac01ead32935fe3",
+                "@oxfmt/binding-win32-x64-msvc@npm:0.42.0": "5c38197ac6f874c2622b68a531b9fc9a221de05aa09c40717bba775f658680ebf964db7aa41c12271f90261bf50713cd4ebb2c10f12bf33cf2103fb9d67a88bb",
+                "@oxlint/binding-android-arm-eabi@npm:1.62.0": "ca066c115156993090f95062fa734ebc241619587b9b29db8f63ef70835a55762a8839487d360e92aacf9aab1851546076b7abc90208f9a3671ba0883b09fbba",
+                "@oxlint/binding-android-arm64@npm:1.62.0": "4519779ba0454b083cfff6e6cf955fbb7ef33700ae63a5eb418a105311adcb6c227bffab2b22be38b742ddec6deaa2370ea27bc6e325876ce21cf12dacd7d6b6",
+                "@oxlint/binding-darwin-arm64@npm:1.62.0": "35df3bec6216822a5c511800541703d0ce7605a9517a34f73a5e59746bbcac3ee7ffb440888aaef5a68d566dd772469b74c66b79c7c413e097e9cd240e0a261f",
+                "@oxlint/binding-darwin-x64@npm:1.62.0": "9f0ccc7228a5a9b41e56281959847725a1287ff7f86670cf2c104c37ed79cbc408f3117d46358da62b95355b25a89704c5d00f9aca894a9e179315546993719c",
+                "@oxlint/binding-freebsd-x64@npm:1.62.0": "062402a1a4fb00abfde96433f54ac74dc1bdb84f1698d49b0de6711220c2da8853b2c74aebebdba0189c1e22547db928548b29b8aa38ec3a8d7523298be12d84",
+                "@oxlint/binding-linux-arm-gnueabihf@npm:1.62.0": "584ca793611955a1952e7caa4aa16a8d00d535999daac5bffa4ead8f543b0a351da6b4c71c5e04f8a3c31d06d4f9a8b7c2762409d586549e5533acf989ce10df",
+                "@oxlint/binding-linux-arm-musleabihf@npm:1.62.0": "a82dc3aba571055bb67499d0235987b854ae5512779f415f7748e58d10dfa19799c777c1b316cbfdeae3f3c951bd4a584e52881c09b19d8aa050b097151b3788",
+                "@oxlint/binding-linux-arm64-gnu@npm:1.62.0": "d9ca6087f45ec1f3b259ab1127e5f9fd50df68954de8094a9fe6ac1a01d50beafbf015b71c16dad5509ab8919067693bdb0ac0dcd62f08f0afa7688b7178e565",
+                "@oxlint/binding-linux-arm64-musl@npm:1.62.0": "d1b64d5d0218125b0c71838ef7a51b88b81e9b3cf810aaf1100c6605bf5efbafe93d6728b880f1e9f4360af2e5019af249a781d7a39d7f905b3be51055981ddf",
+                "@oxlint/binding-linux-ppc64-gnu@npm:1.62.0": "d3e3043345012fb8892d3fcfc83b18c55c5a6f494ba5f5689108656ecee71c389df4e1ebac6ebad75357074cb9a23278281ef19d271b5517ff7e9b514db5e00d",
+                "@oxlint/binding-linux-riscv64-gnu@npm:1.62.0": "d969682bec86433e5b0a199fc3cdf6c25a2ff3355ea1e123e9476612a2560d1f69ef81e0911e616f75ed6024f9e6394f970876c791eab438c7bcbf5f834c9c89",
+                "@oxlint/binding-linux-riscv64-musl@npm:1.62.0": "45aa7bc86e51cb61c8519be2ce4a8bf92d6d9e92dde07c0b31655d0b317c5198ff95e0454467a9b6edbe730d72343cdb4cb8293db2c6234dd43af95038e86b4d",
+                "@oxlint/binding-linux-s390x-gnu@npm:1.62.0": "60e79cbfe33de0eecee4ace00502224c5e92fc3f2db385c291d5c256efe2e3222599172e907567505e08a46a11242b1ccffa7afb3945f1266bcfb1e23d4dcb61",
+                "@oxlint/binding-linux-x64-gnu@npm:1.62.0": "31bbec2b606af01f990b6b53c8878090d8fe8ec9c27642276217c2ead3b3f3c06e9ce1934180de0c1b6a1a7e8b2106862f6f74e7e5eca7303f7aa5441168469e",
+                "@oxlint/binding-linux-x64-musl@npm:1.62.0": "9c7095d2a94920d943a3023f5f186f040329fffa0dc9320b9c2b3fa5c18e16473b5ef93e69e68692f4721112ba45e6a27887f4f9d3a82cfc23cfa5716b79776c",
+                "@oxlint/binding-openharmony-arm64@npm:1.62.0": "1cd0b8e6148685f74f261410b55abd9443b39938f69a42d770da61c08864af96d1251c6ff90d07625466b7dc1997ed25956a8924f49ac1b29ab0ed776f8d74cc",
+                "@oxlint/binding-win32-arm64-msvc@npm:1.62.0": "b8598eefbede42c7c8327e3d3d5e13cf85a0e4c1d261b6f30ce72533e1156eee12c7e5723a2e2fedda8c485fffab12c452b8ac7edc42557615449fbdc6872753",
+                "@oxlint/binding-win32-ia32-msvc@npm:1.62.0": "14276c38660c8920bc8dc2afd231c4a722d682b4a8e8230879441b4fb4714ff72a0adebf6be8d3bcbc2e92b3da6e737d60d9a8c9dd35b076a78dc78598b209a2",
+                "@oxlint/binding-win32-x64-msvc@npm:1.62.0": "07f46eb801dda09aaa911fdbb09a1676bb954ab5e183b34bf61c51281fc697c37ef9912cb99d9f79e8053e98d31661e6a312719231841eb7a3bc6e037b4674a4"
+            }
+        },
         "modules": "143",
-        "node": "24.14.1",
-        "version": "40.9.3"
+        "node": "24.15.0",
+        "version": "40.10.0"
     },
     "41": {
         "chrome": "146.0.7680.216",

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -2796,10 +2796,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-z7ev2g8h3ne4RopyS7C+X9J5cR64QDXNU5VZ0pzoErI=",
+                    "hash": "sha256-HFGxrfVNBU+JkNGBglJryTm+hCDBqLgg0NRXt8QHOOs=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v41.5.0"
+                    "tag": "v41.5.2"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -4098,10 +4098,52 @@
                 "fetcher": "fetchFromGitiles"
             }
         },
-        "electron_yarn_hash": "sha256-tPI7O7xlvDjU5+krILVB6JhLpftMq4Bn8+KIKMjBVgA=",
+        "electron_yarn_data": {
+            "hash": "sha256-Ry8gzsdaR61djEgF+MpXAYGK00lRD5ZLq3cLUV1prFs=",
+            "missing_hashes": {
+                "@oxfmt/binding-android-arm-eabi@npm:0.42.0": "42c08d87ce491086843070241f8777fa2cb968f4a08f67b3f6c33a8f67e0b3eac50eae146daede743e90e3bc32326951c5188814eea02e9c3e4a9764a4b492ba",
+                "@oxfmt/binding-android-arm64@npm:0.42.0": "73e6609498d05c655c6a435af9f3e4f341137c260c7ae27fbb0377573574ca5200bd9f187aa90d442879733bbd0c4e91ae023c3b4579c9a57413a0b2922c023a",
+                "@oxfmt/binding-darwin-arm64@npm:0.42.0": "ed0f486a5085942727e255a9c14bfd99756d4af3ad2c2e702bfb7ab682fc9041d5327f3e89dc4dbfc9a09a6c884dbc9a79a46c720435c5ad2f2fe3f48bb9c3ac",
+                "@oxfmt/binding-darwin-x64@npm:0.42.0": "b607e67171aa33717f7fe80d9d5c8ca816ff30dbbd2b41c4b129977c749c62a4bb1f6829aa95c564d15246c98689ba153fc003a09a1549e2f3316810b35463be",
+                "@oxfmt/binding-freebsd-x64@npm:0.42.0": "c038e53f42083a56d548bd2b89765d1b36150c874e83a41631dfa039fe4fd999475a4a5a99414e43fe44654abdbdfb78c17f53fb482ba3bdc9d22f5641931a41",
+                "@oxfmt/binding-linux-arm-gnueabihf@npm:0.42.0": "79d0b84f3281c7935eb153a53b7032fbb159357580cbcac721096d87ceb124e40863c0b7786ff1b94ad2cdc9b1beabe37e972e1b959423af028e6dea0fc8e0b6",
+                "@oxfmt/binding-linux-arm-musleabihf@npm:0.42.0": "c67dfa0553ba44f0585c3bba85efcbbd42b63b59f177302693fa83cc7b6fe6a6f2509c972cae9b367eb7cd36e8578209657ac4928cf329bf816fa4bfc578d2c1",
+                "@oxfmt/binding-linux-arm64-gnu@npm:0.42.0": "f8507b36f7f2673a4d6db227ed2e98f94d30f81275820d0d25e5e6b0b9b20c7f4cc32b646ae02aac0068b90ba3d47bcbd85ad789b27f028b8ea07e168ec731ce",
+                "@oxfmt/binding-linux-arm64-musl@npm:0.42.0": "c4d0406e36248b4a8ddd62ac2d7c1b6648d23fb2b1eee471e3965d6c411b2dedfc681d227adcff50bbff5f786727bef31420610564691887cdecb50d7f1f7587",
+                "@oxfmt/binding-linux-ppc64-gnu@npm:0.42.0": "12b0eb3cff0807f898dd2e47de5712c8b57d2373108135e87f1de69902204c0527b383753983388f32e48749c479ce0f6247fbc927a2e035b2fb1f6c31ae5df7",
+                "@oxfmt/binding-linux-riscv64-gnu@npm:0.42.0": "aff4c5104769388174a69f5f4ad418f33e86ff1286117072e2200b7217aa9d30375ffb4deeabd728aac7975ed5e79832ac725725df9ff2ea6f819aef5e166353",
+                "@oxfmt/binding-linux-riscv64-musl@npm:0.42.0": "710b0b9fc2d999a66b2c9e656e40e74e71d820d8670d5ee64dc36d373f1132a0c3ddcbedba6130f832b9e8abbb0988ab95de7a6ddd4657007f05fea4a3631835",
+                "@oxfmt/binding-linux-s390x-gnu@npm:0.42.0": "8fc8ee6c1ea3369d3f7ec2f6dbe3fe846663c8e10a0ea976b1b2e150117359580d7efc904f5da0ead2f59066b1e17076aa09c1c4f2544071c29b623ada15da70",
+                "@oxfmt/binding-linux-x64-gnu@npm:0.42.0": "d46d962752e0e2978cbd9b552a0d4bebde69fa9581512dfda33e7bc645c849e2787ef6a4e2ae825e7d2abf68b895c90c4a351387d2f0d2ba336e990c54e245f0",
+                "@oxfmt/binding-linux-x64-musl@npm:0.42.0": "e757b0b12ccf6e7355e2a3123fa0bea0908e1f220b7bb3601c18203bc78f1157be8364af9df3ca56f9c0bb123aeecbf058df31a9ee12612e1149b9c6228dc6f9",
+                "@oxfmt/binding-openharmony-arm64@npm:0.42.0": "fe85007d6e7e7c1b6662a9756267de459fc7213af9ddf6f0494397d9d666a452d4a1a6f6fe6ce288d8dd4763d07b52b4534cc177bdf0e5613559f144b78e8fbb",
+                "@oxfmt/binding-win32-arm64-msvc@npm:0.42.0": "04bd529ea236c23d8dc73d95acd365612ab489b0e6a4bdd976302b933b92dcc11d4d1629e2294036f16c1e1f5120140547f65060a9e2dc8adbb21f790e2eca39",
+                "@oxfmt/binding-win32-ia32-msvc@npm:0.42.0": "9775afa164de049416abf481f062b8c670cd27a70d82a0868fa61749f741e777a76eb0a57a9ef276f158a35741d90a856a492777a0a9f17c9ac01ead32935fe3",
+                "@oxfmt/binding-win32-x64-msvc@npm:0.42.0": "5c38197ac6f874c2622b68a531b9fc9a221de05aa09c40717bba775f658680ebf964db7aa41c12271f90261bf50713cd4ebb2c10f12bf33cf2103fb9d67a88bb",
+                "@oxlint/binding-android-arm-eabi@npm:1.61.0": "64a0e4e724ec776f7bf88926b9544484ac4b8b7c906539073683281d0de4d887494aabad654807336f8c306cbc2bbd2cbf218c780fa02ce7b8cd2c9c280a886c",
+                "@oxlint/binding-android-arm64@npm:1.61.0": "fcbef757ed0eecbddb90e3818315614dbd4bdba7f9e8aa23255d39d12dd2ee5cd1bc5608f2d236b3028330bad7ba741e7dc3569d06373dabade10bcafb056de7",
+                "@oxlint/binding-darwin-arm64@npm:1.61.0": "1ff458a5cde78b3b3f7852dad86ef6e430732361b81e5ac5712f83a237725bde05d67980beced4361416abb376dc6a6384435f2a4932a62c5794a58ca01b9d73",
+                "@oxlint/binding-darwin-x64@npm:1.61.0": "3e09d59d46985c2652ee3fa3560215df05eebf470f2acd3fb502d303f661e3d75861a8908a1b215e3912e5da23673cc517862e06be21be6c95770fc5848778ef",
+                "@oxlint/binding-freebsd-x64@npm:1.61.0": "8f7141e3a7a0334836ea9f333d76fb6a12e145533cda2f485fff536b725193595a172c154b402d0eff3b14e13a36b3a0a14629987bcbf8faa444d9213c5e78d8",
+                "@oxlint/binding-linux-arm-gnueabihf@npm:1.61.0": "2bf2eb6e1e6a3339822464e7f66f52824348ea5b4b0a2f87ed5fdfe6b7b993bb2ea0346e59dc68ec78030a3c4b8784810a2bb88edb69de99aacdda03606a35cf",
+                "@oxlint/binding-linux-arm-musleabihf@npm:1.61.0": "53d57e4693087ddd6e9104651f3200d11276aa8bf261ffe07c91908b7ba6dee0aaa58d74f3b58ad256b8dfb4689fee0e205d9479550b87a898644396afb1de55",
+                "@oxlint/binding-linux-arm64-gnu@npm:1.61.0": "b19d95033889b7a22e29b6b38a84c913f5e087015354de8ea52e60e8d067ecdbcedcecd49df2d3338e1ce5d579e079efaa43ee67ca626e92b619d41aa18277ae",
+                "@oxlint/binding-linux-arm64-musl@npm:1.61.0": "b61ede290d57073065e20161ae54d36d4700a814e6e62abc63e8e4f18558598e22695fcb9b14c67ce8aec50de2b733d6183f873d65de491936fbf7e1b9fbb59e",
+                "@oxlint/binding-linux-ppc64-gnu@npm:1.61.0": "7d0cb33713ce1716a0ddbc100b79eb888ad20af74c0c924db01b0b27c33677717f3f7a0f6d341ec0637ab0ec2dbc5033fea4154cf88b6c9513b1796b6a53ddf3",
+                "@oxlint/binding-linux-riscv64-gnu@npm:1.61.0": "a6c8ad8419110bbfc35f12256058fb0c31816f328a089bd6424ba03d582ebaed71f39ce673f77767dd17e2a4ed021789106a580d99e5f0a1f097ab3cf916f7a8",
+                "@oxlint/binding-linux-riscv64-musl@npm:1.61.0": "64e6073f588b995f509dccb6b66060a1cfeb5cea08613edf1a3f7819992ccce3a3f9539cd2b1962231a472f12c4ffa325600bbcc9279ada400b993488989470e",
+                "@oxlint/binding-linux-s390x-gnu@npm:1.61.0": "93b84e9694a451b023a2fbf2ca3cad533b5ea947bd89f6a8b95433cf12b6bb86bdbceb51188a5a5914a51a9e0ecca02abc6b0d656ce9616d8904eb8ebbaf84a8",
+                "@oxlint/binding-linux-x64-gnu@npm:1.61.0": "49d0ba0286946d633d933e2ae575a38dfef9f6570380d141f2bcdf10b09cba192a87767e5fd6cbeb115c23eae9c7241830c022180ada5bc96131badcc65c3d31",
+                "@oxlint/binding-linux-x64-musl@npm:1.61.0": "54567fcd74360d287a85ff18ce82c2691c0fea7f87e720f0390a621acf2422f64cafd135deebf329831fcac7cfe66389c8e6a5dcb8f8427ea6d4b3446ddeeab0",
+                "@oxlint/binding-openharmony-arm64@npm:1.61.0": "011ffbfde581da50b130705d59e0a043b4e6858dea1fc6fd100c7a2aa511179726769197a6868809a7040a28f454c0481a832c667b44b10820c0300b74a0b6f7",
+                "@oxlint/binding-win32-arm64-msvc@npm:1.61.0": "d5f962f94acfb6a882b04eb9ba33e05e2896b96cb6ab7b44c70aff55be93c633c6c88884d4f3f65f82ab88b6535c6034f4e9a7141bcfff23ad24efd0cb7bab78",
+                "@oxlint/binding-win32-ia32-msvc@npm:1.61.0": "f2902478c85eb95665cf3c4021cc4cdd3ea98f8863d9a311a6f2532059d1c8cc3c36c9e0eac7b459827cd03c4c7e6803bb96939d7476f3289df9362aaadd4710",
+                "@oxlint/binding-win32-x64-msvc@npm:1.61.0": "e4a5cf6c8db10fdf1cda748ab368357260e1fcab8df5819587b940613f55e57a729e99641119ff074d5aea59de16f4563322e01be5ac27d1349c9ca14d60302d"
+            }
+        },
         "modules": "145",
         "node": "24.15.0",
-        "version": "41.5.0"
+        "version": "41.5.2"
     },
     "42": {
         "chrome": "148.0.7778.96",

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -1342,7 +1342,9 @@
                 "fetcher": "fetchFromGitiles"
             }
         },
-        "electron_yarn_hash": "sha256-ZaVee6smW2Gf4tkC1xTTl4a4fBDXaeT7Mtt7del6l8o=",
+        "electron_yarn_data": {
+            "hash": "sha256-ZaVee6smW2Gf4tkC1xTTl4a4fBDXaeT7Mtt7del6l8o="
+        },
         "modules": "140",
         "node": "22.22.1",
         "version": "39.8.10"

--- a/pkgs/development/tools/electron/update.py
+++ b/pkgs/development/tools/electron/update.py
@@ -113,17 +113,35 @@ def get_chromium_gn_source(chromium_tag: str) -> dict:
         }
     }
 
+
 @memory.cache
-def get_electron_yarn_hash(electron_tag: str) -> str:
+def get_electron_yarn_data(electron_tag: str) -> dict:
     print(f"yarn-berry-fetcher prefetch", file=sys.stderr)
     with tempfile.TemporaryDirectory() as tmp_dir:
         with open(tmp_dir + "/yarn.lock", "w") as f:
             f.write(get_electron_file(electron_tag, "yarn.lock"))
-        return (
-            subprocess.check_output(["yarn-berry-fetcher", "prefetch", tmp_dir + "/yarn.lock"])
+        missing_hashes_str = (
+            subprocess.check_output(
+                ["yarn-berry-fetcher", "missing-hashes", tmp_dir + "/yarn.lock"]
+            )
             .decode("utf-8")
-            .strip()
         )
+        missing_hashes = json.loads(missing_hashes_str)
+        cmd = ["yarn-berry-fetcher", "prefetch", tmp_dir + "/yarn.lock"]
+        if missing_hashes:
+            with open(tmp_dir + "/missing-hashes.json", "w") as f:
+                f.write(missing_hashes_str)
+            cmd.append(tmp_dir + "/missing-hashes.json")
+        hash = subprocess.check_output(cmd).decode("utf-8").strip()
+
+        data = {
+            "hash": hash,
+        }
+        if missing_hashes:
+            data["missing_hashes"] = missing_hashes
+
+        return data
+
 
 @memory.cache
 def get_chromium_npm_hash(chromium_tag: str) -> str:
@@ -143,7 +161,12 @@ def get_chromium_npm_hash(chromium_tag: str) -> str:
 def get_update(major_version: str, m: str, gclient_data: any) -> Tuple[str, dict]:
 
     tasks = []
-    a = lambda: (("electron_yarn_hash", get_electron_yarn_hash(gclient_data["src/electron"]["args"]["tag"])))
+    a = lambda: (
+        (
+            "electron_yarn_data",
+            get_electron_yarn_data(gclient_data["src/electron"]["args"]["tag"]),
+        )
+    )
     tasks.append(delayed(a)())
     a = lambda: (
         (

--- a/pkgs/development/tools/electron/wrapper.nix
+++ b/pkgs/development/tools/electron/wrapper.nix
@@ -40,5 +40,9 @@ stdenv.mkDerivation {
     unwrapped = electron-unwrapped;
     inherit (electron-unwrapped) headers dist;
   };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
   inherit (electron-unwrapped) meta;
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6090,6 +6090,7 @@ with pkgs;
     electron-chromedriver_39
     electron-chromedriver_40
     electron-chromedriver_41
+    electron-chromedriver_42
     ;
 
   inherit

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6122,6 +6122,10 @@ with pkgs;
           src = electron-source.electron_41;
           bin = electron_41-bin;
         };
+        electron_42 = getElectronPkg {
+          src = electron-source.electron_42;
+          bin = electron_42-bin;
+        };
       }
     )
     electron_37
@@ -6129,6 +6133,7 @@ with pkgs;
     electron_39
     electron_40
     electron_41
+    electron_42
     ;
   electron = electron_41;
   electron-bin = electron_41-bin;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6081,6 +6081,7 @@ with pkgs;
     electron_39-bin
     electron_40-bin
     electron_41-bin
+    electron_42-bin
     ;
 
   inherit (callPackages ../development/tools/electron/chromedriver { })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Manual backport of #517263.

The difference in yarn hashes and update script is required, because the lock file format changed with `yarn-berry` version 4.14, but 25.11 has `yarn-berry` version 4.11.
Future `electron` backports to 25.11 will need to re-generate hashes with the update script in the `release-25.11` branch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
