### PR TITLE
python3Packages.powerapi: fix build with python 3.14

### DIFF
--- a/pkgs/development/python-modules/powerapi/default.nix
+++ b/pkgs/development/python-modules/powerapi/default.nix
@@ -11,6 +11,8 @@
   pytest-cov-stub,
   pytest-timeout,
   pytestCheckHook,
+  pythonAtLeast,
+  pythonOlder,
   pyzmq,
   setproctitle,
   setuptools,
@@ -38,11 +40,14 @@ buildPythonPackage rec {
   ];
 
   optional-dependencies = {
-    influxdb = [ influxdb-client ];
     kubernetes = [ kubernetes ];
     mongodb = [ pymongo ];
     # opentsdb = [ opentsdb-py ];
     prometheus = [ prometheus-client ];
+  }
+  // lib.optionalAttrs (pythonOlder "3.14") {
+    # influxdb-client depends on reactivex, which is disabled on 3.14
+    influxdb = [ influxdb-client ];
   };
 
   nativeCheckInputs = [
@@ -55,7 +60,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "powerapi" ];
 
-  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+  # multiprocessing pickling fails: darwin sandbox + py3.14 weakref change
+  disabledTests = lib.optionals (stdenv.hostPlatform.isDarwin || pythonAtLeast "3.14") [
     "test_puller"
     "TestDispatcher"
     "TestK8sProcessor"


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327617611)](https://hydra.nixos.org/build/327617611)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
