### PR TITLE
python3Packages.malduck: fix build on python 3.14

### DIFF
--- a/pkgs/development/python-modules/malduck/default.nix
+++ b/pkgs/development/python-modules/malduck/default.nix
@@ -9,6 +9,7 @@
   pefile,
   pycryptodomex,
   pyelftools,
+  pythonAtLeast,
   setuptools,
   pytestCheckHook,
   typing-extensions,
@@ -26,6 +27,11 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-Btx0HxiZWrb0TDpBokQGtBE2EDK0htONe/DwqlPgAd4=";
   };
+
+  patches = lib.optionals (pythonAtLeast "3.14") [
+    # python 3.14 ctypes rejects `_pack_` without `_layout_ = "ms"`.
+    ./python-3.14-ctypes-layout.patch
+  ];
 
   build-system = [ setuptools ];
 

--- a/pkgs/development/python-modules/malduck/python-3.14-ctypes-layout.patch
+++ b/pkgs/development/python-modules/malduck/python-3.14-ctypes-layout.patch
@@ -1,0 +1,10 @@
+--- a/malduck/structure.py
++++ b/malduck/structure.py
+@@ -53,6 +53,7 @@
+             fields.append((field, type_))
+ 
+         class Klass(ctypes.Structure):
++            _layout_ = "ms"
+             _pack_ = self._pack_
+             _fields_ = fields
+ 


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327145938)](https://hydra.nixos.org/build/327145938)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
