### PR TITLE
util-linux: 2.42 -> 2.42.1

### DIFF
--- a/pkgs/by-name/ut/util-linux/package.nix
+++ b/pkgs/by-name/ut/util-linux/package.nix
@@ -43,11 +43,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "util-linux" + lib.optionalString isMinimal "-minimal";
-  version = "2.42";
+  version = "2.42.1";
 
   src = fetchurl {
     url = "mirror://kernel/linux/utils/util-linux/v${lib.versions.majorMinor finalAttrs.version}/util-linux-${finalAttrs.version}.tar.xz";
-    hash = "sha256-NFKyYLuqd11udJrDuyIRF4UAP8H0RJcAJcjaJt+nWOk=";
+    hash = "sha256-gukVjrEqmwtWnYThaH/tndGP6JzNjvWsNCchinwNf38=";
   };
 
   # Note: fetchpatch/fetchpatch2 cause infinite recursion with util-linuxMinimal.
@@ -57,38 +57,6 @@ stdenv.mkDerivation (finalAttrs: {
     # which isn't valid on NixOS (and a compatibility link on most other modern
     # distros anyway).
     ./rtcwake-search-PATH-for-shutdown.patch
-
-    # Fix compile of 2.42+ on Darwin.
-    # https://lore.kernel.org/util-linux/CAEUYr6ZjVX1bd-xcBGtFN_ZYwQnXDYsw7d1-7sTpF2BbgfrR+g@mail.gmail.com/T/#u
-    # Different fix than originally proposed; we just don't compile that file on Darwin now and the previous patch was able to be reverted.
-    # See: https://github.com/util-linux/util-linux/commit/6ccf20d2fd8e45eed70bd1b915c0d16f646bf133
-    (fetchurl {
-      name = "pidfd-utils-linux-only.patch";
-      url = "https://github.com/util-linux/util-linux/commit/afdade4a3d8e4e6070343c5576470c575719b81f.patch";
-      hash = "sha256-EnHsIhU6jaS4Qm+kQMP2an7Ay08nKbIO0MbU7Y2pwkU=";
-    })
-
-    # Musl does not define AT_HANDLE_FID, hard-code it if left undefined.
-    # https://github.com/util-linux/util-linux/pull/4203
-    (fetchurl {
-      name = "fix-musl-nsenter.patch";
-      url = "https://github.com/util-linux/util-linux/commit/000aff333e5c3a23967280cb0d6451fbbfc9c91b.patch";
-      hash = "sha256-6K3jRr2RsAfHnweBOlMn2F0h8hD3xjZobJ1pSlCQHw8=";
-    })
-
-    # `script` is broken with options after non-option args and has new memory leaks
-    # https://lore.kernel.org/util-linux/adi3573O-5gr9m2q@per.namespace.at/T/#t
-    # https://github.com/util-linux/util-linux/pull/4201
-    (fetchurl {
-      name = "script-fix-backwards-compat.patch";
-      url = "https://github.com/util-linux/util-linux/commit/70507ab9eaed10b8dd77b77d4ea25c11ee726bed.patch";
-      hash = "sha256-PpFtv8XOK36npCVSvdgKcxGQmkJtgdyMmlN+4yQuWS8=";
-    })
-    (fetchurl {
-      name = "script-fix-memory-leaks.patch";
-      url = "https://github.com/util-linux/util-linux/commit/2f1c12a49500ca7ed9c3d5e80664c1622925456b.patch";
-      hash = "sha256-9ZwA6sZwM1rQDoxV5x1KHLWxsFpI5CGWJqubtdEHj/I=";
-    })
   ];
 
   # We separate some of the utilities into their own outputs. This

--- a/pkgs/tools/package-management/nix/modular/tests/functional/package.nix
+++ b/pkgs/tools/package-management/nix/modular/tests/functional/package.nix
@@ -73,14 +73,6 @@ mkMesonDerivation (finalAttrs: {
       echo $PWD | grep tests/functional
     '';
 
-  # Test contains invocation of `script` broken by util-linux regression:
-  # https://github.com/util-linux/util-linux/commit/70507ab9eaed10b8dd77b77d4ea25c11ee726bed
-  preCheck =
-    assert util-linux.version == "2.42";
-    ''
-      echo "exit 77" > ../json.sh
-    '';
-
   mesonCheckFlags = [
     "--print-errorlogs"
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bugfix release allowing us to drop patches. Tested util-linuxMinimal and util-linux on the darwin community builder with a cherry-pick, pkgsMusl, and the normal pkgs set.

Changelog: https://lore.kernel.org/util-linux/dryjs4vfzzysrhuxa4khf7frezdmouv6ys5nqsx7u46nvk4mg6@z4o37akcrh6y/T/#u

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
