### PR TITLE
python3Packages.librt: fix cross compilation

### DIFF
--- a/pkgs/development/python-modules/librt/default.nix
+++ b/pkgs/development/python-modules/librt/default.nix
@@ -6,6 +6,7 @@
   mypy-extensions,
   python,
   pytest,
+  stdenv,
 }:
 
 buildPythonPackage rec {
@@ -23,6 +24,18 @@ buildPythonPackage rec {
   # https://github.com/mypyc/librt/blob/v0.7.8/.github/workflows/buildwheels.yml#L90-L93
   postPatch = ''
     cp -rv lib-rt/* .
+
+    # build_setup.py patches CCompiler.spawn to inject architecture-specific
+    # SIMD flags based on platform.machine() (which returns the build arch instead
+    # of the target arch). When cross-compiling, this causes the compiler to abort
+    # with "unrecognized command-line option" errors.
+    #
+    # The patch below forces the use of the target architecture, in order
+    # to keep SIMD flags for x86_64 targets while avoiding them elsewhere.
+    substituteInPlace build_setup.py \
+      --replace-fail \
+        'X86_64 = platform.machine() in ("x86_64", "AMD64", "amd64")' \
+        'X86_64 = ${if stdenv.hostPlatform.isx86_64 then "True" else "False"}'
   '';
 
   build-system = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
# Description
build_setup.py patches CCompiler.spawn to inject architecture-specific SIMD flags based on platform.machine() (which returns the build arch instead of the target arch).
When cross-compiling, this causes the compiler to abort with "unrecognized command-line option" errors.

The patch below forces the use of the target architecture, in order to keep SIMD flags for x86_64 targets while avoiding them elsewhere.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] cross x86_64 -> aarch64
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
