### PR TITLE
python3Packages.dagster: init at 1.13.5

### DIFF
--- a/pkgs/development/python-modules/dagster-cloud-cli/default.nix
+++ b/pkgs/development/python-modules/dagster-cloud-cli/default.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  pythonOlder,
+
+  hatchling,
+  setuptools,
+
+  click,
+  dagster-shared,
+  github3-py,
+  jinja2,
+  packaging,
+  pyyaml,
+  questionary,
+  requests,
+  typer,
+  validators,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "dagster-cloud-cli";
+  version = "1.13.5";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "dagster-io";
+    repo = "dagster";
+    tag = finalAttrs.version;
+    hash = "sha256-I/yve9ztaaV9AXnWkocFplgrhxCm6KI7bd/W9TawQOM=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/python_modules/libraries/dagster-cloud-cli";
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    click
+    dagster-shared
+    github3-py
+    jinja2
+    packaging
+    pyyaml
+    questionary
+    requests
+    setuptools
+    typer
+    validators
+  ];
+
+  doCheck = false;
+
+  pythonImportsCheck = [ "dagster_cloud_cli" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^(\\d+\\.\\d+\\.\\d+)$"
+    ];
+  };
+
+  meta = {
+    description = "Command-line interface for Dagster+ Cloud";
+    homepage = "https://github.com/dagster-io/dagster";
+    changelog = "https://github.com/dagster-io/dagster/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ silky ];
+    mainProgram = "dagster-cloud";
+  };
+})

--- a/pkgs/development/python-modules/dagster-dg-cli/default.nix
+++ b/pkgs/development/python-modules/dagster-dg-cli/default.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  pythonOlder,
+
+  hatchling,
+
+  dagster,
+  dagster-cloud-cli,
+  dagster-dg-core,
+  dagster-rest-resources,
+  typer,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "dagster-dg-cli";
+  version = "1.13.5";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "dagster-io";
+    repo = "dagster";
+    tag = finalAttrs.version;
+    hash = "sha256-I/yve9ztaaV9AXnWkocFplgrhxCm6KI7bd/W9TawQOM=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/python_modules/libraries/dagster-dg-cli";
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    dagster
+    dagster-cloud-cli
+    dagster-dg-core
+    dagster-rest-resources
+    typer
+  ];
+
+  doCheck = false;
+
+  pythonImportsCheck = [ "dagster_dg_cli" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^(\\d+\\.\\d+\\.\\d+)$"
+    ];
+  };
+
+  meta = {
+    description = "Developer-tooling CLI for Dagster projects";
+    homepage = "https://github.com/dagster-io/dagster";
+    changelog = "https://github.com/dagster-io/dagster/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ silky ];
+    mainProgram = "dg";
+  };
+})

--- a/pkgs/development/python-modules/dagster-dg-core/default.nix
+++ b/pkgs/development/python-modules/dagster-dg-core/default.nix
@@ -1,0 +1,92 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  pythonOlder,
+
+  hatchling,
+  setuptools,
+
+  click,
+  click-aliases,
+  dagster-cloud-cli,
+  dagster-shared,
+  gql,
+  jinja2,
+  jsonschema,
+  markdown,
+  packaging,
+  python-dotenv,
+  pyyaml,
+  rich,
+  tomlkit,
+  typer,
+  typing-extensions,
+  watchdog,
+  yaspin,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "dagster-dg-core";
+  version = "1.13.5";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "dagster-io";
+    repo = "dagster";
+    tag = finalAttrs.version;
+    hash = "sha256-I/yve9ztaaV9AXnWkocFplgrhxCm6KI7bd/W9TawQOM=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/python_modules/libraries/dagster-dg-core";
+
+  build-system = [ hatchling ];
+
+  # Upstream caps tomlkit<0.13.3 but nixpkgs ships 0.14.x.
+  pythonRelaxDeps = [
+    "tomlkit"
+  ];
+
+  dependencies = [
+    click
+    click-aliases
+    dagster-cloud-cli
+    dagster-shared
+    gql
+    jinja2
+    jsonschema
+    markdown
+    packaging
+    python-dotenv
+    pyyaml
+    rich
+    setuptools
+    tomlkit
+    typer
+    typing-extensions
+    watchdog
+    yaspin
+  ];
+
+  doCheck = false;
+
+  pythonImportsCheck = [ "dagster_dg_core" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^(\\d+\\.\\d+\\.\\d+)$"
+    ];
+  };
+
+  meta = {
+    description = "Core library shared by Dagster developer-tooling CLIs";
+    homepage = "https://github.com/dagster-io/dagster";
+    changelog = "https://github.com/dagster-io/dagster/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ silky ];
+  };
+})

--- a/pkgs/development/python-modules/dagster-graphql/default.nix
+++ b/pkgs/development/python-modules/dagster-graphql/default.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  pythonOlder,
+
+  hatchling,
+
+  dagster,
+  gql,
+  graphene,
+  requests,
+  requests-toolbelt,
+  starlette,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "dagster-graphql";
+  version = "1.13.5";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "dagster-io";
+    repo = "dagster";
+    tag = finalAttrs.version;
+    hash = "sha256-I/yve9ztaaV9AXnWkocFplgrhxCm6KI7bd/W9TawQOM=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/python_modules/dagster-graphql";
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    dagster
+    gql
+    graphene
+    requests
+    # Upstream depends on `gql[requests]`; pull in the `requests-toolbelt`
+    # transitive that the gql.transport.requests module imports at top level.
+    requests-toolbelt
+    starlette
+  ];
+
+  doCheck = false;
+
+  pythonImportsCheck = [ "dagster_graphql" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^(\\d+\\.\\d+\\.\\d+)$"
+    ];
+  };
+
+  meta = {
+    description = "GraphQL layer for interacting with a Dagster instance";
+    homepage = "https://github.com/dagster-io/dagster";
+    changelog = "https://github.com/dagster-io/dagster/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ silky ];
+    mainProgram = "dagster-graphql";
+  };
+})

--- a/pkgs/development/python-modules/dagster-pipes/default.nix
+++ b/pkgs/development/python-modules/dagster-pipes/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  pythonOlder,
+
+  hatchling,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "dagster-pipes";
+  version = "1.13.5";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "dagster-io";
+    repo = "dagster";
+    tag = finalAttrs.version;
+    hash = "sha256-I/yve9ztaaV9AXnWkocFplgrhxCm6KI7bd/W9TawQOM=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/python_modules/dagster-pipes";
+
+  build-system = [ hatchling ];
+
+  # Upstream tests require a full dagster checkout layout; rely on import check.
+  doCheck = false;
+
+  pythonImportsCheck = [ "dagster_pipes" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^(\\d+\\.\\d+\\.\\d+)$"
+    ];
+  };
+
+  meta = {
+    description = "Protocol for streaming structured metadata between Dagster and external processes";
+    homepage = "https://github.com/dagster-io/dagster";
+    changelog = "https://github.com/dagster-io/dagster/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ silky ];
+  };
+})

--- a/pkgs/development/python-modules/dagster-postgres/default.nix
+++ b/pkgs/development/python-modules/dagster-postgres/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+
+  hatchling,
+
+  dagster,
+  psycopg2,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "dagster-postgres";
+  # Tracks the Dagster libraries 0.X versioning (offset from core: 1.13.5 -> 0.29.5).
+  version = "0.29.5";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "dagster-io";
+    repo = "dagster";
+    tag = "1.13.5";
+    hash = "sha256-I/yve9ztaaV9AXnWkocFplgrhxCm6KI7bd/W9TawQOM=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/python_modules/libraries/dagster-postgres";
+
+  build-system = [ hatchling ];
+
+  # Upstream pins `psycopg2-binary`; nixpkgs builds `psycopg2` from source which
+  # exposes the same `psycopg2` Python import, so drop the pip-name constraint
+  # from the wheel's metadata and depend on `psycopg2` instead.
+  pythonRemoveDeps = [ "psycopg2-binary" ];
+
+  dependencies = [
+    dagster
+    psycopg2
+  ];
+
+  doCheck = false;
+
+  pythonImportsCheck = [ "dagster_postgres" ];
+
+  # nix-update-script is omitted: this package uses Dagster's offset library
+  # versioning (0.X.Y here vs the monorepo's 1.A.B tag), so both `version` and
+  # `src.tag` must move together on each bump. Update manually.
+
+  meta = {
+    description = "PostgreSQL storage backend for Dagster";
+    homepage = "https://github.com/dagster-io/dagster";
+    changelog = "https://github.com/dagster-io/dagster/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ silky ];
+  };
+})

--- a/pkgs/development/python-modules/dagster-rest-resources/default.nix
+++ b/pkgs/development/python-modules/dagster-rest-resources/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+
+  hatchling,
+
+  dagster-shared,
+  httpx,
+  pydantic,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "dagster-rest-resources";
+  # Tracks the Dagster libraries 0.X versioning (offset from core: 1.13.5 -> 0.29.5).
+  version = "0.29.5";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "dagster-io";
+    repo = "dagster";
+    tag = "1.13.5";
+    hash = "sha256-I/yve9ztaaV9AXnWkocFplgrhxCm6KI7bd/W9TawQOM=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/python_modules/libraries/dagster-rest-resources";
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    dagster-shared
+    httpx
+    pydantic
+  ];
+
+  doCheck = false;
+
+  pythonImportsCheck = [ "dagster_rest_resources" ];
+
+  # nix-update-script is omitted: this package uses Dagster's offset library
+  # versioning (0.X.Y here vs the monorepo's 1.A.B tag), so both `version` and
+  # `src.tag` must move together on each bump. Update manually.
+
+  meta = {
+    description = "REST API resource bindings for Dagster";
+    homepage = "https://github.com/dagster-io/dagster";
+    changelog = "https://github.com/dagster-io/dagster/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ silky ];
+  };
+})

--- a/pkgs/development/python-modules/dagster-shared/default.nix
+++ b/pkgs/development/python-modules/dagster-shared/default.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  pythonOlder,
+
+  hatchling,
+
+  packaging,
+  platformdirs,
+  pydantic,
+  pyyaml,
+  tomlkit,
+  typing-extensions,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "dagster-shared";
+  version = "1.13.5";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "dagster-io";
+    repo = "dagster";
+    tag = finalAttrs.version;
+    hash = "sha256-I/yve9ztaaV9AXnWkocFplgrhxCm6KI7bd/W9TawQOM=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/python_modules/libraries/dagster-shared";
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    packaging
+    platformdirs
+    pydantic
+    pyyaml
+    tomlkit
+    typing-extensions
+  ];
+
+  doCheck = false;
+
+  pythonImportsCheck = [ "dagster_shared" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^(\\d+\\.\\d+\\.\\d+)$"
+    ];
+  };
+
+  meta = {
+    description = "Shared utilities for the Dagster ecosystem";
+    homepage = "https://github.com/dagster-io/dagster";
+    changelog = "https://github.com/dagster-io/dagster/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ silky ];
+  };
+})

--- a/pkgs/development/python-modules/dagster-webserver/default.nix
+++ b/pkgs/development/python-modules/dagster-webserver/default.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  pythonOlder,
+
+  hatchling,
+
+  click,
+  dagster,
+  dagster-graphql,
+  starlette,
+  uvicorn,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "dagster-webserver";
+  version = "1.13.5";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "dagster-io";
+    repo = "dagster";
+    tag = finalAttrs.version;
+    hash = "sha256-I/yve9ztaaV9AXnWkocFplgrhxCm6KI7bd/W9TawQOM=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/python_modules/dagster-webserver";
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    click
+    dagster
+    dagster-graphql
+    starlette
+    uvicorn
+  ];
+
+  doCheck = false;
+
+  pythonImportsCheck = [ "dagster_webserver" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^(\\d+\\.\\d+\\.\\d+)$"
+    ];
+  };
+
+  meta = {
+    description = "Web UI and HTTP API server for Dagster";
+    homepage = "https://github.com/dagster-io/dagster";
+    changelog = "https://github.com/dagster-io/dagster/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ silky ];
+    mainProgram = "dagster-webserver";
+  };
+})

--- a/pkgs/development/python-modules/dagster/default.nix
+++ b/pkgs/development/python-modules/dagster/default.nix
@@ -1,0 +1,113 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  pythonOlder,
+
+  hatchling,
+
+  alembic,
+  antlr4-python3-runtime,
+  click,
+  coloredlogs,
+  dagster-pipes,
+  dagster-shared,
+  docstring-parser,
+  filelock,
+  grpcio,
+  grpcio-health-checking,
+  jinja2,
+  protobuf,
+  python-dotenv,
+  pytz,
+  requests,
+  rich,
+  six,
+  sqlalchemy,
+  structlog,
+  tabulate,
+  tomli,
+  toposort,
+  tqdm,
+  tzdata,
+  universal-pathlib,
+  watchdog,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "dagster";
+  version = "1.13.5";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "dagster-io";
+    repo = "dagster";
+    tag = finalAttrs.version;
+    hash = "sha256-I/yve9ztaaV9AXnWkocFplgrhxCm6KI7bd/W9TawQOM=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/python_modules/dagster";
+
+  build-system = [ hatchling ];
+
+  # Upstream's caps are tighter than nixpkgs' current versions:
+  # coloredlogs<=14.0 (nixpkgs ships 15.x) and protobuf<7 (nixpkgs ships 7.x).
+  pythonRelaxDeps = [
+    "coloredlogs"
+    "protobuf"
+  ];
+
+  dependencies = [
+    alembic
+    antlr4-python3-runtime
+    click
+    coloredlogs
+    dagster-pipes
+    dagster-shared
+    docstring-parser
+    filelock
+    grpcio
+    grpcio-health-checking
+    jinja2
+    protobuf
+    python-dotenv
+    pytz
+    requests
+    rich
+    six
+    sqlalchemy
+    structlog
+    tabulate
+    tomli
+    toposort
+    tqdm
+    tzdata
+    universal-pathlib
+    watchdog
+  ];
+
+  # FIXME: upstream test suite needs a full monorepo checkout and many extras;
+  # rely on pythonImportsCheck for smoke testing.
+  doCheck = false;
+
+  pythonImportsCheck = [ "dagster" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^(\\d+\\.\\d+\\.\\d+)$"
+    ];
+  };
+
+  meta = {
+    description = "Cloud-native orchestrator for data pipelines";
+    homepage = "https://github.com/dagster-io/dagster";
+    changelog = "https://github.com/dagster-io/dagster/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ silky ];
+    mainProgram = "dagster";
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3551,6 +3551,8 @@ self: super: with self; {
 
   dagster = callPackage ../development/python-modules/dagster { };
 
+  dagster-cloud-cli = callPackage ../development/python-modules/dagster-cloud-cli { };
+
   dagster-pipes = callPackage ../development/python-modules/dagster-pipes { };
 
   dagster-shared = callPackage ../development/python-modules/dagster-shared { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3561,6 +3561,8 @@ self: super: with self; {
 
   dagster-pipes = callPackage ../development/python-modules/dagster-pipes { };
 
+  dagster-postgres = callPackage ../development/python-modules/dagster-postgres { };
+
   dagster-rest-resources = callPackage ../development/python-modules/dagster-rest-resources { };
 
   dagster-shared = callPackage ../development/python-modules/dagster-shared { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3567,6 +3567,8 @@ self: super: with self; {
 
   dagster-shared = callPackage ../development/python-modules/dagster-shared { };
 
+  dagster-webserver = callPackage ../development/python-modules/dagster-webserver { };
+
   dahlia = callPackage ../development/python-modules/dahlia { };
 
   daiquiri = callPackage ../development/python-modules/daiquiri { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3553,6 +3553,8 @@ self: super: with self; {
 
   dagster-cloud-cli = callPackage ../development/python-modules/dagster-cloud-cli { };
 
+  dagster-dg-cli = callPackage ../development/python-modules/dagster-dg-cli { };
+
   dagster-dg-core = callPackage ../development/python-modules/dagster-dg-core { };
 
   dagster-pipes = callPackage ../development/python-modules/dagster-pipes { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3549,6 +3549,8 @@ self: super: with self; {
 
   daff = callPackage ../development/python-modules/daff { };
 
+  dagster-pipes = callPackage ../development/python-modules/dagster-pipes { };
+
   dahlia = callPackage ../development/python-modules/dahlia { };
 
   daiquiri = callPackage ../development/python-modules/daiquiri { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3549,6 +3549,8 @@ self: super: with self; {
 
   daff = callPackage ../development/python-modules/daff { };
 
+  dagster = callPackage ../development/python-modules/dagster { };
+
   dagster-pipes = callPackage ../development/python-modules/dagster-pipes { };
 
   dagster-shared = callPackage ../development/python-modules/dagster-shared { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3557,6 +3557,8 @@ self: super: with self; {
 
   dagster-dg-core = callPackage ../development/python-modules/dagster-dg-core { };
 
+  dagster-graphql = callPackage ../development/python-modules/dagster-graphql { };
+
   dagster-pipes = callPackage ../development/python-modules/dagster-pipes { };
 
   dagster-rest-resources = callPackage ../development/python-modules/dagster-rest-resources { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3553,6 +3553,8 @@ self: super: with self; {
 
   dagster-cloud-cli = callPackage ../development/python-modules/dagster-cloud-cli { };
 
+  dagster-dg-core = callPackage ../development/python-modules/dagster-dg-core { };
+
   dagster-pipes = callPackage ../development/python-modules/dagster-pipes { };
 
   dagster-shared = callPackage ../development/python-modules/dagster-shared { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3557,6 +3557,8 @@ self: super: with self; {
 
   dagster-pipes = callPackage ../development/python-modules/dagster-pipes { };
 
+  dagster-rest-resources = callPackage ../development/python-modules/dagster-rest-resources { };
+
   dagster-shared = callPackage ../development/python-modules/dagster-shared { };
 
   dahlia = callPackage ../development/python-modules/dahlia { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3551,6 +3551,8 @@ self: super: with self; {
 
   dagster-pipes = callPackage ../development/python-modules/dagster-pipes { };
 
+  dagster-shared = callPackage ../development/python-modules/dagster-shared { };
+
   dahlia = callPackage ../development/python-modules/dahlia { };
 
   daiquiri = callPackage ../development/python-modules/daiquiri { };


### PR DESCRIPTION
This PR adds the `dagster` ecosystem to nixpkgs: the data-orchestration framework, plus the companion libraries needed for a working installation. Dagster (https://github.com/dagster-io/dagster) is a peer of Apache Airflow and Prefect and was not previously packaged.

The packages are split as upstream publishes them on PyPI. Each commit is a self-contained `init` and the build order is the dependency order.

| Commit | Package | Version |
|---|---|---|
| 1 | `python3Packages.dagster-pipes` | 1.13.5 |
| 2 | `python3Packages.dagster-shared` | 1.13.5 |
| 3 | `python3Packages.dagster` | 1.13.5 |
| 4 | `python3Packages.dagster-cloud-cli` | 1.13.5 |
| 5 | `python3Packages.dagster-dg-core` | 1.13.5 |
| 6 | `python3Packages.dagster-rest-resources` | 0.29.5 |
| 7 | `python3Packages.dagster-dg-cli` | 1.13.5 |
| 8 | `python3Packages.dagster-graphql` | 1.13.5 |
| 9 | `python3Packages.dagster-postgres` | 0.29.5 |
| 10 | `python3Packages.dagster-webserver` | 1.13.5 |

The two `0.29.5` packages are not version-mismatched: Dagster's monorepo ships its `libraries/*` packages on a separate `0.X.Y` track that moves in lockstep with the core `1.A.B` release (offset by 1.0.0). The source is fetched from the same `1.13.5` monorepo tag for all ten derivations.

### Notes for reviewers

- **Build backend**: all sub-packages declare `hatchling` in `pyproject.toml`, so `build-system = [ hatchling ]` rather than `setuptools` (despite a couple of them also listing `setuptools` as a runtime dependency).
- **`pythonRelaxDeps`**: `dagster` relaxes `coloredlogs<=14.0` and `protobuf<7` (nixpkgs ships 15.x / 7.x); `dagster-dg-core` relaxes `tomlkit<0.13.3` (nixpkgs ships 0.14.x). All three are widely-compatible utility libraries.
- **`pythonRemoveDeps`**: `dagster-postgres` drops `psycopg2-binary` from the wheel metadata; it depends on nixpkgs' source-built `psycopg2`, which provides the same Python import.
- **`requests-toolbelt`** is added to `dagster-graphql`'s dependencies explicitly because upstream depends on `gql[requests]` and `gql.transport.requests` imports `requests_toolbelt` at module load.
- **`nix-update-script`** is intentionally omitted for `dagster-postgres` and `dagster-rest-resources` since the offset versioning needs both `version` and `src.tag` to move together; the derivations carry a comment explaining manual updates.
- **`doCheck = false`** on every package — Dagster's pytest suite needs the full monorepo checkout and many cloud-side fixtures; relying on `pythonImportsCheck` for smoke testing, matching the precedent set by `python3Packages.prefect`.

### Test plan

- All ten derivations built cleanly via `nix-build -A python3Packages.<name>`.
- Smoke-tested the CLIs:
  - `dagster --version` → `dagster, version 1.13.5`
  - `dg --help` → prints the developer-tooling top-level help
  - `dagster-webserver --version` → `dagster-webserver, version 1.13.5`
  - `dagster-cloud --help` and `dagster-graphql --help` invoke without error
- `nixfmt`-clean across all ten new files.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
