### PR TITLE
updxy: init at 1.0-25.2

### DIFF
--- a/pkgs/by-name/ud/udpxy/package.nix
+++ b/pkgs/by-name/ud/udpxy/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gzip,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "udpxy";
+  version = "1.0-25.2";
+
+  src = fetchFromGitHub {
+    owner = "pcherenkov";
+    repo = finalAttrs.pname;
+    rev = finalAttrs.version;
+    hash = "sha256-v+w4Y6MyJqUrgwuYUYTZW0Zn1jhW4vEpgBEQyEjvkzg=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/chipmunk";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [ gzip ];
+
+  # The project uses -Werror which causes build failures with newer GCC versions
+  # due to warnings about strncpy truncation and other modern warning checks
+  postPatch = ''
+    substituteInPlace Makefile --replace "-Werror" ""
+  '';
+
+  installFlags = [
+    "PREFIX=$(out)"
+    "GZIP=${gzip}/bin/gzip"
+    "MANPAGE_DIR=$(out)/share/man/man1"
+  ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Lightweight UDP-to-HTTP multicast traffic relay daemon";
+    homepage = "https://github.com/pcherenkov/udpxy";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    mainProgram = finalAttrs.pname;
+    maintainers = with maintainers; [ bachp ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
 Package latest version of udpxy, a lightweight network-traffic relay daemon.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
