### PR TITLE
rebels-in-the-sky: 1.6.0 -> 1.6.1

### DIFF
--- a/pkgs/by-name/re/rebels-in-the-sky/package.nix
+++ b/pkgs/by-name/re/rebels-in-the-sky/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  fetchpatch,
   rustPlatform,
   cmake,
   pkg-config,
@@ -14,16 +15,24 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rebels-in-the-sky";
-  version = "1.6.0";
+  version = "1.6.1";
 
   src = fetchFromGitHub {
     owner = "ricott1";
     repo = "rebels-in-the-sky";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-P0GPdMTOomqNQ6WLfZnASO1FiD7DJTHj/a8eoYzAvAY=";
+    hash = "sha256-alXqHtaGtv2zPt1OpNyEwHpQ+GKhS8xqOQFa5PvCsqc=";
   };
 
-  cargoHash = "sha256-Ldy/1Gv1qguWQ2lLk0jiiq7nM9r85LY7pXkXf2nCUA0=";
+  cargoHash = "sha256-PvSOjuK1cObDuZeAKYEEqwezCuv7RM1W/aimrc4QV28=";
+
+  cargoPatches = [
+    (fetchpatch {
+      # The lock file was updated after the release
+      url = "https://github.com/ricott1/rebels-in-the-sky/commit/4cd33144b7e2e6297c5e0d6a6a0e46bc976279d0.patch";
+      hash = "sha256-HUzABNtpBgts7rtuPB/OCtCTQk+XsLGEOyRRgy3uIdI=";
+    })
+  ];
 
   patches = lib.optionals (!withRadio) [
     ./disable-radio.patch


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Changelog: https://github.com/ricott1/rebels-in-the-sky/releases/tag/v1.6.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
