### PR TITLE
ustreamer: make available as python package

### DIFF
--- a/nixos/tests/ustreamer.nix
+++ b/nixos/tests/ustreamer.nix
@@ -1,4 +1,7 @@
 { pkgs, ... }:
+let
+  test-output-filename = "snapshot.jpeg";
+in
 {
   name = "ustreamer-vmtest";
   nodes = {
@@ -43,13 +46,35 @@
           formats/2/height = 480
           formats/2/fps = 20/1, 15/2
         '';
+
+        test-stream-name = "test_stream.jpeg";
+
+        test-ustreamer-python =
+          pkgs.writers.writePython3Bin "test-ustreamer-python"
+            {
+              libraries = [ pkgs.python3Packages.ustreamer ];
+            }
+            ''
+              import ustreamer
+
+              with ustreamer.Memsink("${test-stream-name}") as sink:
+                  frame = sink.wait_frame()
+              with open("${test-output-filename}", "wb") as file:
+                  file.write(frame["data"])
+            '';
       in
       {
         services.ustreamer = {
           enable = true;
           device = "/dev/video9";
-          extraArgs = [ "--device-timeout=8" ];
+          extraArgs = [
+            "--device-timeout=8"
+            "--sink=${test-stream-name}"
+          ];
         };
+        environment.systemPackages = [
+          test-ustreamer-python
+        ];
         networking.firewall.allowedTCPPorts = [ 8080 ];
 
         boot.extraModulePackages = [ config.boot.kernelPackages.akvcam ];
@@ -68,5 +93,8 @@
 
     client.wait_for_unit("multi-user.target")
     client.succeed("curl http://camera:8080")
+
+    camera.succeed("test-ustreamer-python")
+    camera.wait_for_file('${test-output-filename}')
   '';
 }

--- a/pkgs/by-name/us/ustreamer/package.nix
+++ b/pkgs/by-name/us/ustreamer/package.nix
@@ -63,12 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     which
   ]
-  ++ lib.optionals withPython (
-    with python3Packages;
-    [
-      python
-    ]
-  );
+  ++ lib.optional withPython python3Packages.python;
 
   makeFlags = [
     "PREFIX=${placeholder "out"}"

--- a/pkgs/by-name/us/ustreamer/package.nix
+++ b/pkgs/by-name/us/ustreamer/package.nix
@@ -62,7 +62,13 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     pkg-config
     which
-  ];
+  ]
+  ++ lib.optionals withPython (
+    with python3Packages;
+    [
+      python
+    ]
+  );
 
   makeFlags = [
     "PREFIX=${placeholder "out"}"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21662,6 +21662,13 @@ self: super: with self; {
 
   usort = callPackage ../development/python-modules/usort { };
 
+  ustreamer = toPythonModule (
+    pkgs.ustreamer.override {
+      python3Packages = self;
+      withPython = true;
+    }
+  );
+
   utils = callPackage ../development/python-modules/utils { };
 
   utitools = callPackage ../development/python-modules/utitools { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Makes `ustreamer`'s python module available as `pythonPackages.ustreamer`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
