### PR TITLE
{python3Packages.py-,}arwen: init at 0.0.5-unstable-2026-04-07 

### DIFF
--- a/pkgs/by-name/ar/arwen/package.nix
+++ b/pkgs/by-name/ar/arwen/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "arwen";
+  version = "0.0.5-unstable-2026-04-07";
+
+  src = fetchFromGitHub {
+    owner = "nichmor";
+    repo = "arwen";
+    rev = "696351a8c208315b0dfd4a1e5c37288a689ccd2e";
+    hash = "sha256-6RW8BeKjoxeO8SBz/VdZGnrRW+EIKq5NtrFdM0lx0+o=";
+  };
+
+  cargoHash = "sha256-bj7YB7xNlfdrYYZv3CDuqkm+/pg+C1KwizPTlNqQWt8=";
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Cross-platform patching of shared libraries in Rust";
+    longDescription = ''
+      Arwen is a command-line utility and Rust library designed to modify
+      executable files and shared libraries.
+
+      Specifically, it targets the ELF format (commonly used on Linux, BSD, and
+      other Unix-like systems) and the Mach-O format (used on macOS and iOS).
+
+      It allows you to inspect and rewrite various properties within these
+      files that influence how they load and link with other libraries at
+      runtime.
+
+      Think of arwen as a modern, unified, Rust-based alternative to the
+      widely-used patchelf (for ELF files) and install_name_tool (for Mach-O
+      files). It combines the core functionalities of both into a single tool.
+    '';
+    homepage = "https://github.com/nichmor/arwen";
+    mainProgram = "arwen";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/development/python-modules/py-arwen/default.nix
+++ b/pkgs/development/python-modules/py-arwen/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildPythonPackage,
+  rustPlatform,
+  arwen,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "py-arwen";
+  pyproject = true;
+
+  inherit (arwen)
+    version
+    src
+    ;
+
+  sourceRoot = "${finalAttrs.src.name}/py-arwen";
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      sourceRoot
+      ;
+    hash = "sha256-SJ3RZ/kCfMJb26uaJEQzA2NXOCudyqbJpbvC4d/R/T8=";
+  };
+
+  nativeBuildInputs = with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    # conflicts with built module
+    rm -r arwen
+  '';
+
+  pythonImportsCheck = [
+    "arwen"
+  ];
+
+  meta = {
+    inherit (arwen.meta)
+      description
+      homepage
+      license
+      platforms
+      maintainers
+      teams
+      ;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13257,6 +13257,8 @@ self: super: with self; {
 
   py-aosmith = callPackage ../development/python-modules/py-aosmith { };
 
+  py-arwen = callPackage ../development/python-modules/py-arwen { };
+
   py-bip39-bindings = callPackage ../development/python-modules/py-bip39-bindings { };
 
   py-canary = callPackage ../development/python-modules/py-canary { };


### PR DESCRIPTION
[arwen](https://github.com/nichmor/arwen) is a cross-platform Rust implementation that combines functionality similar to `patchelf` (Linux) and `install_name_tool` (macOS) into a single, versatile tool for binary manipulation.

Work done as part of the [Nix@NGI](https://nixos.org/community/teams/ngi) packaging effort.

Relaed: https://github.com/ngi-nix/projects/issues/342

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
