### PR TITLE
john: split out *2john scripts into john-data

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16633,6 +16633,12 @@
     githubId = 1433367;
     name = "Marc Fontaine";
   };
+  mag1cbyt3s = {
+    email = "ppeinecke@protonmail.com";
+    github = "Mag1cByt3s";
+    githubId = 48777549;
+    name = "MagicBytes";
+  };
   magicquark = {
     name = "magicquark";
     github = "magicquark";

--- a/pkgs/by-name/jo/john/package.nix
+++ b/pkgs/by-name/jo/john/package.nix
@@ -4,24 +4,17 @@
   fetchFromGitHub,
   unstableGitUpdater,
   openssl,
-  nss,
-  nspr,
-  libkrb5,
   gmp,
   zlib,
   libpcap,
-  re2,
-  gcc,
-  python3Packages,
+  python3,
   perl,
-  perlPackages,
   withOpenCL ? true,
   opencl-headers,
   ocl-icd,
   # include non-free ClamAV unrar code
   enableUnfree ? false,
   replaceVars,
-  makeWrapper,
 }:
 
 stdenv.mkDerivation {
@@ -70,63 +63,37 @@ stdenv.mkDerivation {
 
   buildInputs = [
     openssl
-    nss
-    nspr
-    libkrb5
     gmp
     zlib
     libpcap
-    re2
   ]
   ++ lib.optionals withOpenCL [
     opencl-headers
     ocl-icd
   ];
   nativeBuildInputs = [
-    gcc
-    python3Packages.wrapPython
-    perl
-    makeWrapper
+    python3 # for opencl_generate_dynamic_loader.py
+    perl # detected by configure; gates the crypt(3) format
   ];
-  propagatedBuildInputs =
-    # For pcap2john.py
-    (with python3Packages; [
-      dpkt
-      scapy
-      lxml
-    ])
-    ++ (with perlPackages; [
-      # For pass_gen.pl
-      DigestMD4
-      DigestSHA1
-      GetoptLong
-      # For 7z2john.pl
-      CompressRawLzma
-      # For sha-dump.pl
-      perlldap
-    ]);
-  # TODO: Get dependencies for radius2john.pl and lion2john-alt.pl
 
   enableParallelBuilding = true;
 
   postInstall = ''
-    mkdir -p "$out/bin" "$out/etc/john" "$out/share/john" "$out/share/doc/john" "$out/share/john/rules" "$out/share/john/opencl" "$out/${perlPackages.perl.libPrefix}"
+    mkdir -p "$out/bin" "$out/etc/john" "$out/share/john" "$out/share/doc/john" "$out/share/john/rules" "$out/share/john/opencl"
+    # Install the john binary and the compiled C *2john helpers only. The
+    # interpreted *.py / *.pl conversion scripts are shipped separately in the
+    # `john-data` package, since they pull in a large python/perl closure.
     find -L ../run -mindepth 1 -maxdepth 1 -type f -executable \
+      ! -name '*.py' ! -name '*.pl' \
       -exec cp -d {} "$out/bin" \;
     cp -vt "$out/etc/john" ../run/*.conf
     cp -vt "$out/share/john" ../run/*.chr ../run/password.lst
     cp -vt "$out/share/john/rules" ../run/rules/*.rule
     cp -vt "$out/share/john/opencl" ../run/opencl/*.cl ../run/opencl/*.h
     cp -vLrt "$out/share/doc/john" ../doc/*
-    cp -vt "$out/${perlPackages.perl.libPrefix}" ../run/lib/*
-  '';
-
-  postFixup = ''
-    wrapPythonPrograms
-
-    for i in $out/bin/*.pl; do
-      wrapProgram "$i" --prefix PERL5LIB : "$PERL5LIB:$out/${perlPackages.perl.libPrefix}"
-    done
+    # john.conf has `.include <rules/foo.rule>` resolved against
+    # $out/etc/john; the actual rule files live under share/john.
+    ln -s "$out/share/john/rules" "$out/etc/john/rules"
   '';
 
   passthru.updateScript = unstableGitUpdater {
@@ -143,6 +110,7 @@ stdenv.mkDerivation {
     maintainers = with lib.maintainers; [
       cherrykitten
       therealhammer
+      mag1cbyt3s
     ];
     platforms = lib.platforms.unix;
   };


### PR DESCRIPTION
Splits the interpreted `*2john` conversion scripts out of the core `john` package into a separate **`john-data`** package (#522355), mirroring the split done by Debian and [Kali](https://www.kali.org/tools/john/). This keeps the large python/perl runtime closure those scripts need out of the core package; `john` now ships only the binary and the compiled C helpers.

Rebased onto current `master` after #530092 - `john` is now based on `1.9.0-Jumbo-1-unstable-2026-06-07`. The original "fix the source hash / drop `-std=gnu17`" rationale no longer applies; this is now purely the split + cleanup.

Changes (the `john` side):

- Stop installing the interpreted `*.py` / `*.pl` scripts here; they move to the new `john-data` package (#522355), dropping the python/perl propagated closure and the `wrapPython` / `makeWrapper` machinery that only existed to wrap them.
- Drop unused `buildInputs` (`nss`, `nspr`, `libkrb5`, `re2`) and the redundant explicit `gcc`; the build only uses `$CC` and the supported-format set is unchanged.
- Symlink `etc/john/rules` -> `share/john/rules` so `john.conf`'s `.include <rules/*.rule>` directives resolve (e.g. `--rules=best64`).
- Add `mag1cbyt3s` as maintainer.

Related: #81418 (NixOS for pentesting). Follow-up package: #522355 - stacked on this PR, so **merge this first**.

Verified: `nix-build -A john --no-out-link` succeeds; `john --test=0` passes (`raw-md5`/`bcrypt`/`sha512crypt`); `--rules=best64` resolves; **456** formats supported; no python/perl in the runtime closure; no other nixpkgs package references the removed scripts.

_Disclosure: this PR was prepared with AI assistance, per the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy); all changes were reviewed and verified by the maintainer._

## Things done

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Ran `nixpkgs-review` on this PR.
- [x] Fits `CONTRIBUTING.md`, `pkgs/README.md`, `maintainers/README.md` and other READMEs.
- [x] Follows the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy).
