### PR TITLE
ci/github-script/reviewers: keep team members when revoking stale requests

### DIFF
--- a/ci/github-script/bot.js
+++ b/ci/github-script/bot.js
@@ -494,6 +494,7 @@ module.exports = async ({ github, context, core, dry }) => {
           owners,
           getUser,
           getTeam,
+          getTeamMembers,
         })
       }
     }

--- a/ci/github-script/reviewers.js
+++ b/ci/github-script/reviewers.js
@@ -12,6 +12,7 @@ async function handleReviewers({
   owners,
   getUser,
   getTeam,
+  getTeamMembers,
 }) {
   const pull_number = pull_request.number
 
@@ -158,6 +159,25 @@ async function handleReviewers({
   )
   log('reviewers - teams_not_yet_reached', teams_not_yet_reached.join(', '))
 
+  // Also keep members of teams_to_reach: GitHub's per-team code-review-assignment
+  // can turn a team request into individual bot-attributed adds.
+  const team_member_logins = new Set(
+    (
+      await Promise.all(
+        Array.from(teams_to_reach, async (slug) => {
+          const ms = await getTeamMembers(slug)
+          return ms.map(({ login }) => login.toLowerCase())
+        }),
+      )
+    ).flat(),
+  )
+  log(
+    'reviewers - team_member_logins',
+    Array.from(team_member_logins).join(', '),
+  )
+
+  const users_to_keep = users_to_reach.union(team_member_logins)
+
   // The usernames of bots that make review requests we may auto-revoke.
   const revokable_requesters = ['github-actions[bot]', 'nixpkgs-ci[bot]']
 
@@ -183,7 +203,7 @@ async function handleReviewers({
   // Pending requests no longer in the to_reach set, excluding the engaged
   // and anything not requested by our own bot.
   const users_to_remove = Array.from(
-    pending_users.difference(users_to_reach).difference(users_engaged),
+    pending_users.difference(users_to_keep).difference(users_engaged),
   ).filter((login) =>
     revokable_requesters.includes(last_request_actor_for_user.get(login)),
   )


### PR DESCRIPTION
GitHub has the ability to expand a team review request into individual review requests for a subset of team members. This PR accounts for that to prevent the revoke logic from removing those reviewers.

Fixes: https://redirect.github.com/NixOS/nixpkgs/pull/519758#issuecomment-4478985966

Tested on a custom harness (directly invoking `reviewers.js`) since dry-run requires API permissions I do not have.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
