### PR TITLE
[Backport release.25.11] Firefox: 150.0.3 -> 151.0; 140.10.2esr -> 140.11.0esr

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,1859 +1,1859 @@
 {
-  version = "150.0.3";
+  version = "151.0";
   sources = [
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/ach/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ach/firefox-151.0.tar.xz";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "b110d79a025db3f1250e0015f126e17326e31c6eba8ba991f7e8f7ec92438d55";
+      sha256 = "a5a76be506df358bbae61cdc6784823d394c2b002684eecf338341ab5c446663";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/af/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/af/firefox-151.0.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "88c2649644c313a6d739fdaabe6e2708f737fcea3a01f9e735e0b5ae901fb95a";
+      sha256 = "2678780a72e4f57161eacc44199210e1400d22d3dcea56453507ba01be55530f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/an/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/an/firefox-151.0.tar.xz";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "dc6a77a941b1838a4c123aa010432b93e5f89ad58ba92e18229a6dda9f4a4dad";
+      sha256 = "c0b0420bebbf728d49ac4e8722eff64eecc66d4bf859e93d43133c4c17aa11c9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/ar/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ar/firefox-151.0.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "6b2757524aa7c6fdcef222d88c20b83131da70287d0834d1a0c970deb71580be";
+      sha256 = "9de18d9a1d1f01e2545c82efb9364052b15fe7daff002a5057e03c9f3b2c2171";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/ast/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ast/firefox-151.0.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "667a267dd94b629b984c58147e46c56afd179ee0459c9cedd6b8834b8e5fabf9";
+      sha256 = "89fc9a1a8996fb329c86afde7e48c905d47594582176f36f8dc00a658b456d83";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/az/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/az/firefox-151.0.tar.xz";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "7c16a8304cb3847487514a8ce645649973d442ca48642d4791de95cc921b137a";
+      sha256 = "83cdd42b96cf2949f7276787889c1bc669d7bae6d948340b977effd0a0c797fc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/be/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/be/firefox-151.0.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "1c6a3b08fa09ea90cc26b8b2ba74936b7eec8e8a2ba3c49390bda93736829e2f";
+      sha256 = "fea2becc0482203bf95707b85021df967621e7e6a48b5663e117d8ff2267b24f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/bg/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/bg/firefox-151.0.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "f3c61e0b87003a323f824d819a545f7dee8a60d3e4804612816b69b87d5345b1";
+      sha256 = "2c7ce49a800913424a0a00f3674dca3a25cb30d3a5093348d4916d8b7a439c5d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/bn/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/bn/firefox-151.0.tar.xz";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "82cdccc9c40bd3e18c416a46219bfb2f6ddc3b5b5be1270b618377dec5e25262";
+      sha256 = "1606962c0a5f3b6d9eb75fdd05d1ca221585057748564fd0521d6af1ea55cf37";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/br/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/br/firefox-151.0.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "f42d5b6ef018ebeecace0a91d12c6deb891613e1bc00710e0b7d41de461bd4e8";
+      sha256 = "30ffca3e5261fa6b14915e36a057757013a0b78e5a6a27cc78443bcea28563da";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/bs/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/bs/firefox-151.0.tar.xz";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "b8b6f26430a0e8fbb38c4ef678247f754f5399b47ccfeaffe4fdb229b4db2d0c";
+      sha256 = "638080f855f5ed767666c270c1f0a7af7132f60b02e3d4aec377a806ccdd7476";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/ca-valencia/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ca-valencia/firefox-151.0.tar.xz";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "4d6f35ed64701809ea8f988ea0a16e95f189cf7142cba0667232461364ebd0af";
+      sha256 = "ca0653846f1b9015be4b001f136d1fccdcdaba39a1d563c3db8c7701b4b2bcfa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/ca/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ca/firefox-151.0.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "4dc354f71b7639e65d5056c9e40d920ca96c9c61eb0e8d0564648b7961f4969e";
+      sha256 = "4f041b300b31b163e9fde50f33b82351b43295f6f20af14095ac0d46c5beaacf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/cak/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/cak/firefox-151.0.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "1c93b4be443a73952956c4f10d76ca26b3b1d01747e75827d7479831b3a92963";
+      sha256 = "46d0f9346e0a3c1b1fc94a529db75a9b6a31468481face0b9b6a1489a493c24d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/cs/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/cs/firefox-151.0.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "c4ddba4015be9f07f6d50c0bd02e70d7f6d4b328efe4645ed5362e5b63c4e23d";
+      sha256 = "de972f37854c2958db42f5f017eb4ce1d564365bbb71b310ebd810922b507149";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/cy/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/cy/firefox-151.0.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "e68a6ae874cc708ddf7e0fa6220d3a79a94fe9a8953178df34eb014aab6ad14f";
+      sha256 = "e02ddd1b459c9d9a8c0ea3e87d6210eb0f48936dce911d38c0a84ade4e801fa8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/da/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/da/firefox-151.0.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "76ddb9c43712fb52f03b3a6cfdf0842a5e2226734b7e174949484db0b496d804";
+      sha256 = "aec2b1b944ffc2a52862eaf125cf236ff56cc03b4e1e8cfdc1e587de8d26fb9c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/de/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/de/firefox-151.0.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "1dfdaab8fe8a71f69ac23b9e51e68bc4754db56096c824af62373fd8f3f42720";
+      sha256 = "ed2b60c73db03b28d0ee2a135afc23489e911b55adf423ea2b6298d8afafb206";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/dsb/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/dsb/firefox-151.0.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "62a87ab977bf84178aff68e57fb57d800b9865acc17d217f7aa1f13d3f86f9a5";
+      sha256 = "7328eb1d6abd3b579fd882ee6d55c5e6365d7d0f9238fbf5b2695780b6b647a7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/el/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/el/firefox-151.0.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "592faf30bd51a727ccad2b3baf85b4118c7e6c0558ce6eb1302c2299784c374f";
+      sha256 = "f64b8b1cdc959187bb48b9cc1b6f59793a0cbcc2906c82091605074870a075f5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/en-CA/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/en-CA/firefox-151.0.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "01b678402f9f20ef3e0eeab4436aec920a676ba5c1c784009ac22ac905120991";
+      sha256 = "68ae97f7a4bffeed62c5810dc8b47939919ea7fc37fd237ccb2f225dd05cd692";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/en-GB/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/en-GB/firefox-151.0.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "e59e003251ee575389df00ad1f6b2a359a5984cd79309f014698fcb2041310a2";
+      sha256 = "33c96a93750ac75ddb55f751d747442413d2b41a0f186c75384aec90b9b7b0a6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/en-US/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/en-US/firefox-151.0.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "cb679bcceaef49ac38b671b66e78fa1ccc3e603555fe9d79ce16b4b55a388b91";
+      sha256 = "8ff8557a5ca3903ebbc1d18570684075f623465be5e362d63a95b3acc523f824";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/eo/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/eo/firefox-151.0.tar.xz";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "46831e655a7f314f16f7a4be415187059eb97b9f967e68a1557afe45d59dd590";
+      sha256 = "f1eacece6c91eaa07e086c4cc5ef5361e83f8832032f515cd5dacffdf8a547bb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/es-AR/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/es-AR/firefox-151.0.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "0b05b0dd72bfce1d2076570605ab02838bcc0649a465ec4147bf9e7d4f139279";
+      sha256 = "bde1ba71c68851b60ea720b0f5d629baf21710b67222c7444b76cda306c5afd3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/es-CL/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/es-CL/firefox-151.0.tar.xz";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "da6a0c053acf0b1e49f066471467547ae0dda617331e979d03854da720bd4ddf";
+      sha256 = "18db222688543a1a8b08c8f26c3305ba00649a25b2283647cccfd6a994f3ca59";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/es-ES/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/es-ES/firefox-151.0.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "658f734bb3b9ad5d3113cb8fb8c5137c7ec582f645071b0e7e312af664bb0b54";
+      sha256 = "1653505adfaad6bc1d2dfd72845bb476331683e11c42a3f79f1093c334ec493c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/es-MX/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/es-MX/firefox-151.0.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "aef367df499e1994fad49760409bbbce50249b112aa2d760911dd6794f1d828c";
+      sha256 = "bddaa285441594afff25907ff70b1ffb04fb459fe3409c86d513f99bed6e6c16";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/et/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/et/firefox-151.0.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "7970b9c1a8df297640a4a75ecf7f987d6c9ad1a81b827b95a25c679ea6f06c4d";
+      sha256 = "6aa74d1dec6b0b11ae56f3a416d3b3d0526be9ce2371a770a926a7f8374afd19";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/eu/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/eu/firefox-151.0.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "785515b7aa70db97cdcd1f2b6a8ed96f69d6d86ddd92da822c833e60cb7cb3db";
+      sha256 = "ef86f5dd4bb5ec021b3dbb13db89644a8f183948e09f7515e57b2080940ae994";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/fa/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/fa/firefox-151.0.tar.xz";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "c14f0edec796668457cdcaa39ae991e74c81955d19c2bdee203fb1f4d7d21c2e";
+      sha256 = "c2f629d4c8f15057b96f6ae592c3cc16e72c7866137e09401af51b728bc2c5e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/ff/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ff/firefox-151.0.tar.xz";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "1a0369b2f14c69411f54dd1c46c7f4410ac7d7577a9700557858f75355e42de3";
+      sha256 = "94ba483a64b80511ffb566424c60f5f77937a2141fff865c214365b67ba81a3a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/fi/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/fi/firefox-151.0.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "2f05be2b87cb88ed71532540bb0b760f45dc120e0db9975a89428eed3cf9f49e";
+      sha256 = "fdf9bb2d329421e07ac79ebf7cbd860889804963936b9e5149c8bfe9a6895175";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/fr/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/fr/firefox-151.0.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "1aa3f2a047b5095487fe29bd6359a807c3c481a0302d4fd2b5693690dda553d2";
+      sha256 = "de54178a0380a57b38ff6cb944105bf7937d9aa116e193f7d279b58a8f466d01";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/fur/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/fur/firefox-151.0.tar.xz";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "55e8cc652e576bf553f2404cf726a12f1ae86bfc8e927ec6f6e73323ca7fc784";
+      sha256 = "6712064abdf6578299b8a4c0c2e090200d8cf1c23ae8304973d06be13c197506";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/fy-NL/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/fy-NL/firefox-151.0.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "c1bff6ec2b0920b61bd395ef00cbc610354edd7d1791774ad8b47e0d8a644342";
+      sha256 = "b7f3672bdba80059b4cf22c94acea7dd7cac47c31d2948f16ada9885ea98e65a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/ga-IE/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ga-IE/firefox-151.0.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "745d777b25fc46ff5b58afeec4f3c6a0499833f3294c5690b6a62480efec9085";
+      sha256 = "60a8ac9ade98ce8b582406b60bb02219d72b507d59d39759265e6e3617d2a361";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/gd/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/gd/firefox-151.0.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "eb94eaf391a79e6ee45be37bbecd9afd52fc142469e0198d7db0de528cf0ab10";
+      sha256 = "0295116c9db870de81de3d9402667801940f1ce86f01abb59841055aca2fd708";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/gl/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/gl/firefox-151.0.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "22ea7a5936bf686bbb693852c0adf21e42ef84ed8275beb766f2007f14ef4f27";
+      sha256 = "73327accfc87945fb50172ab7e460ff457e2173a81821594f25c529e73a09051";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/gn/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/gn/firefox-151.0.tar.xz";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "58d46df41de1c854ce334835850992cb21a9640ef3d7e043b6abd3b95acc1335";
+      sha256 = "41be6729fab3b4caa59cee438a1ef9569cb5edf863679546163cbb2c4c74550a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/gu-IN/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/gu-IN/firefox-151.0.tar.xz";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "b48a14634ee0642b21dacc7e6d38d6645659d1607796e305f083bc815711de92";
+      sha256 = "4ae5d1be64034316b4ec013dccb3d553cd001a0b1fb157b23c428dcccddec8f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/he/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/he/firefox-151.0.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "da8b260d4a5af7347760d6b18dee7a7a7b49a4893209aea4e738479122f67e55";
+      sha256 = "c20dbb8107bac56fe3a5b8a80b5add649a345b58f8fb7247f41b5559fa65d587";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/hi-IN/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/hi-IN/firefox-151.0.tar.xz";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "cdad6d1a38aa72de0021179bddea83be1dee79f9727fd2739f6c5228aac3e596";
+      sha256 = "5f189fd5aca90cd10bc07e4e6a0f0ef7ebd113be34e064d4e06ce76420160be1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/hr/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/hr/firefox-151.0.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "b5b6b93f52d043d185cb2d6503f4bb6dd66c04bde58622b0b4adeb885842315a";
+      sha256 = "3defb65ec98e3f2a1122c19695238247a70102fbdfede4acbe5cdac2e55e156d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/hsb/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/hsb/firefox-151.0.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "8d6fd77cceaf9f2cabb1f65e856ad539fd187c302e6b7903458d759520b93923";
+      sha256 = "3378387b0b9921e811124f0bdb778b738a5e5a98747f55e68e92fa32a9f33203";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/hu/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/hu/firefox-151.0.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "874d79e05564fb70ac94ae99fffe5c88ea38b2d40eb433d25bebc5175a5b7149";
+      sha256 = "4ee2039fbb3ff5342d4c8c40a04dfbd03b4edfb7b9bc773cbe361813e5123d83";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/hy-AM/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/hy-AM/firefox-151.0.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "1925cf8a11406ea67412b1111fa1f25d3f328044486be84ec187382f5b72381e";
+      sha256 = "acd5e851802bc446013596ef0c1e42f0baeda5bdee194b912eafad0b9f44bf19";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/ia/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ia/firefox-151.0.tar.xz";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "f095c529089f392312867c18f73dee2614b6f24f868a1dafd9c494d172ae8896";
+      sha256 = "5682d525831b08638cde736942e09e41cee33fd4f09954d975f20329bc9828bc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/id/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/id/firefox-151.0.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "24d3aaa147ff7e644da345344e61ca8cb37ef2139915b384a15fe6d004a5e535";
+      sha256 = "d8819f3ac8b15604ae75d385fec91623e127a27ddcffb1fafdea4d340ab24e0e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/is/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/is/firefox-151.0.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "a1ce21f7c83a3ccc3491fe14cb33ed714791892efbc0924cde78af16fad193b4";
+      sha256 = "7cf148001db49c7e9ffcc99cebec6f3c33c5b55ec9a39f67098d0157ed7e3aa9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/it/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/it/firefox-151.0.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "f749900f86d6d019d834623fe70881761318094c84e415251f74a4fe55505d81";
+      sha256 = "f0d3f5e44975ae57004089d1a6f3852df7d6895eed8a19c99c03b0d68baf8432";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/ja/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ja/firefox-151.0.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "3f539fdac0bf494694666510b05426ebff87279a19161725e997b00ca126a950";
+      sha256 = "051c8121400cd48eb31de084de36067319eedc2a7f7a741674def831704ef48d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/ka/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ka/firefox-151.0.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "76a12a3a66d14f97c24255e9a00a8364adaa583e3ab85c097434320f10b7aa4a";
+      sha256 = "214d50dd8ad9978f36165d4bfeaf4ff29f0b2638b735d722c599067150a7b78f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/kab/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/kab/firefox-151.0.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "db5fddc015628c1db3bc605c4e752d2dbbecc7dbebd3c556646a7abf94cc4d85";
+      sha256 = "4eaba0a8dbfe33cea09a6fd8fdbee810a252cfdb459077ef158461001053a163";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/kk/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/kk/firefox-151.0.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "f8e91d4ba7cdcdf93ce2f6b7832987c28285bd775e093ebef9b0d3235d4a6617";
+      sha256 = "01304cce83ee42b05f1ed2874313fae712bcadc27a403aac9aa0189c24dc04d6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/km/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/km/firefox-151.0.tar.xz";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "643514091766594647ab583049b386fb391bd2789b78bf760dd4f37888d9a332";
+      sha256 = "823a55f2e80fb42091dc06edcb4637f0f118ea6714e6584aa7daaaea6dfb70a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/kn/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/kn/firefox-151.0.tar.xz";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "f0af1711504be1683799f7a00cd44e129b59c3e0b2237a3aa2b04c25ac693f7b";
+      sha256 = "7d0657004dd58983151b206bc4344e6ed7865b1b97c6e66f8b33b97484e72a27";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/ko/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ko/firefox-151.0.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "7c3c1e484677f678bd6d1c9a4a8ae7145edfc88d406031a61634e7f221689bef";
+      sha256 = "b2cc1ae32477a9020aa5f7133678b8ecd39df9dec14ee834aa87929c6f3ffd1f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/lij/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/lij/firefox-151.0.tar.xz";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "490c760720d8af5cdc56058b0d7dc17a9695e1f8f2c867f55750ada9de41cc4f";
+      sha256 = "7d919594a4282695c54cb023e857e8a00c1502eaaab92d53ad94ed85ec77878d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/lt/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/lt/firefox-151.0.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "2cfc6f4310adcd7a848fead558f410d10b26a6bd38826473b9fd5101e469efa6";
+      sha256 = "dc64657b46d99ff0e79553c26dd082cbcff18da23e3a1439c7fe8fb16f78e350";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/lv/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/lv/firefox-151.0.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "a43c6c335e8da84b91fedd9367814e6c5692ffcf85239f39dc0ec3a7fbe61f26";
+      sha256 = "4fb0f0f9a2084eb497df9d5d2743eb1695098b9e1de0ebb1b2ff1d4503185671";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/mk/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/mk/firefox-151.0.tar.xz";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "81f85f4c78d7d0b151ace4bf2719409322e08dd2abf19302b3e6a022c02ca32e";
+      sha256 = "fc658480be05cb3d9196cf196d6c73535a76248d6c4d71607808efcf9c1f1741";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/mr/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/mr/firefox-151.0.tar.xz";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "a8d46f0c5cfa6148d2410e93d1bbf9d4b3f263d6eb1b68d71a5adb0e66e86c5b";
+      sha256 = "879e9051bc452e19c14b2106f517bf2a6706f5640f4035619f3d1ae665d4f693";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/ms/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ms/firefox-151.0.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "81d651d5b913aee2fd9469c2076c2e247dd381b927d9459c1f1cb029883df749";
+      sha256 = "7603b8dd2ade484d72d38e59581975a37bafde52c7abf3adeaa6a0257fc05bd5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/my/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/my/firefox-151.0.tar.xz";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "7441547d3f8547214420cbcc930635baa4bb348589d6e3ee413f12881a281653";
+      sha256 = "fa40162961669df54755432acec901041f1f0eb5348d96e9833fff53e1ffbfe1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/nb-NO/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/nb-NO/firefox-151.0.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "1ef8884724b9eb19dac94bdcd2e9ba8d70e32fb733064d21be175396140750e4";
+      sha256 = "ed971ddae3ff471101a0e5e7a349cd2a8ae33caa971af2490359688af5603f20";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/ne-NP/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ne-NP/firefox-151.0.tar.xz";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "1d0c27f7ef131f257e2b72d4fee3e1028ddd5ac1cba7e69d335431c1f2cc6c96";
+      sha256 = "dafb39613109054ec59882a2d2a011c4e3e1e8b1e8425214e5efd67edc543d3d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/nl/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/nl/firefox-151.0.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "47e6716b923a42dc99a746e7a8c2824de77768c52af1d37561d9400669d746fb";
+      sha256 = "d13c193297807eab501b3a268d3e2c3378509f6f5c3694e14516a8772e6f87cd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/nn-NO/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/nn-NO/firefox-151.0.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "3d3f6664d205794fcb2802e26763082efb48602271a89ef3e40d8c9f647dd9cc";
+      sha256 = "e3aab38123b129e7274eedb47b12e7fe614bb2d3b5db8916f206057a6f611aa5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/oc/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/oc/firefox-151.0.tar.xz";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "19b98aad2118211bd538bbe17fb2079ffd83735edc5609483871bc621613f5f5";
+      sha256 = "24570c0a704b4955b66f50972595e000dae514ec8faadd64fced24c680bf7620";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/pa-IN/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/pa-IN/firefox-151.0.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "8ca6dc0c63aae6fada75497d9ad8159ae8a602e840e4427e12024eb1ae869a30";
+      sha256 = "c1d0d10ad699ae98bff12df474fa5c88b36afa22a34654efca28b3c1011c325a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/pl/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/pl/firefox-151.0.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "7a64dbfaa6fce9cf34331008013de0dfcee9dadb6f02f164afbc3604ade5b3d2";
+      sha256 = "168b01c00acdd364c323d39b8144b23e4da54471950496c7389c3be43a5ecb0a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/pt-BR/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/pt-BR/firefox-151.0.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "830824327328f9267203681fee852af84912eca734fb32a9ff924f2fb47185f9";
+      sha256 = "75b9850e8ddcbf144609b6ff737cdd5e05d674e2af899cbed26a44f80868d346";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/pt-PT/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/pt-PT/firefox-151.0.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "08da83ba17317717d28c4f56ebb5505d3002af50fedd38f0640c2dc203e3888a";
+      sha256 = "adb608c47a46f4840e280dae4279c146c3d1a36b1204c3ff630480f5023e2c05";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/rm/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/rm/firefox-151.0.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "4c7f41735317d8f00e0af96cf257b0943afa080cb8e1098d1fd4c07ecc9f24e4";
+      sha256 = "22bc13a10e7f94db2f91cc22e1562339d0d69c59e668c35c9cbe37bfab488041";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/ro/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ro/firefox-151.0.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "9fdf91169d564f70ab89a7bf690c05035444c29afa64715b06bb410b59cacff5";
+      sha256 = "7d774462f72d5dcb6137ae42c51484b29da8fc9f5c00b30be41671b9cb7940c6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/ru/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ru/firefox-151.0.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "55387683c3ee7b1eb97e36830a1fbbc67b2249cfe90dba8260e8f2c7010fd57f";
+      sha256 = "41e9a27b194f047759fb1ce94f7a79e3e5538c40dcaf1b2235dc7088c5d1eecb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/sat/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/sat/firefox-151.0.tar.xz";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "a97632c8c724cf478ed890bd01a7f6edf5d4052949c287b3bb304a9b58652f55";
+      sha256 = "b5cd47ad373c9d1168ab081b3cb948bd566c934d99df377b71bc9e0e70e64c70";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/sc/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/sc/firefox-151.0.tar.xz";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "53570d38e3c74e6f380e2d8d7f54cd31eb6d5d8de186a8727bcf1adef61ea247";
+      sha256 = "a08c3ee253655fe5b6505062331a6a4697534090cd2da7f13253dfb743f4148d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/sco/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/sco/firefox-151.0.tar.xz";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "7fd18819e67a648daf64dba6d80bcb7349cee865b2c1653b1a09fb2ac9d74064";
+      sha256 = "f7f5ddf183b9efd2a7f2c527d672ed472e2e66f9de2abdafe4e450c400fb6277";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/si/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/si/firefox-151.0.tar.xz";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "cd5a37080dfff288c9b34cc5a345eca808cfe7c163e05d3eae382f499a19a24e";
+      sha256 = "ece465b47735bd672da91e4446380536c703844684dc2083641179f72e935bba";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/sk/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/sk/firefox-151.0.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "758b474a3f175d08ce236b46d821ecb619bd038a6a1ec0b351c873fc8ee3d731";
+      sha256 = "8f446f6f88db393cd8bb23d54ea6bc4a048ba22a458649773c5adf132c2726c8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/skr/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/skr/firefox-151.0.tar.xz";
       locale = "skr";
       arch = "linux-x86_64";
-      sha256 = "76a5af24cae928fa8e75eca1ddeeb341d8b3db7c764ab5fe2983ce76fe5f971f";
+      sha256 = "809a46d9f569f214b8f84df27190acd20d4ca81d596cb801dd0b49c20877b318";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/sl/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/sl/firefox-151.0.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "8ea2c59728d235f6ede416dfc4b9c0c68667383ec902235bbda0978cc83efd63";
+      sha256 = "978575c6e1f15315575641c5c466f7776edc28b707539bbc8de6baf1a0a76647";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/son/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/son/firefox-151.0.tar.xz";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "10f3ef71708c527e100e15314d02263331f413af014529115bdb9e92511a0029";
+      sha256 = "aee5ec60a06e0f15371fe9a753377952b4be38d68dc2d28fe8eec4efe498a6f4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/sq/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/sq/firefox-151.0.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "e1d234ac615a6be12521e9298e7a05009bfeb20d5fe79bf0d5c6c700c7711254";
+      sha256 = "cfb2365bd00aaa111c74d72f535534b204e3fdc56ed13ecd3ce9ed5170b31324";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/sr/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/sr/firefox-151.0.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "580acdf2e8ea44817cbb47027b25848c271e367d1b8d634d919c0be45639d8cf";
+      sha256 = "c678b10aecdcc118d64dc4880abd90460d9a8a4c156dad1e7f8614a0b58c46da";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/sv-SE/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/sv-SE/firefox-151.0.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "b42b665b3333970d5b80e4faa81c7ed8088fde7e25bb11dd7e834f48d1ea5b5e";
+      sha256 = "5be1cef027daa6513289e5462dc7faa4e2471c683f11279bd8713e72c5ac8e45";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/szl/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/szl/firefox-151.0.tar.xz";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "ad4ee3459216f4de9a4591aa6bf377f7c242c79b1bcde7edcd039eb2aa62a627";
+      sha256 = "ed732c3160e2cdb0a2890e3d6cf5553b8b10913a8bd2bab20f1184acaf045bf0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/ta/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ta/firefox-151.0.tar.xz";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "414619fa8c15531f898ae1ce59e6b3f02d97054c910148427a501eee05539d7b";
+      sha256 = "fc50ee0a5ecff1f88dee5382e8235373e3c9607bc0fe43884cd17e54317a1e5f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/te/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/te/firefox-151.0.tar.xz";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "62739c34dbddc93ea442a85095995ce95f0812c7ce86e1b6075fcfa41608d048";
+      sha256 = "352ded5957561e7891bd52aaf2339d8aa8d40112b99fae1007513d4556a9bace";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/tg/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/tg/firefox-151.0.tar.xz";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "48348263b0e806c68a99c4f451da31f4b0e360d371783ebbc1fb24d97b4eaf0b";
+      sha256 = "ef03eabaf3c5631c85026f6bebddc3b745be0b1f4bdb81ef30ffca7566ecba0d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/th/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/th/firefox-151.0.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "07180251e6a4a94506bfcd1546ded10307d825a7847a9bbc861308da647d706a";
+      sha256 = "692df7973e0757f5559d644073d63f721c85016d9ec5fca99f7e4319a778c211";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/tl/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/tl/firefox-151.0.tar.xz";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "75d2ddb6c1293653b96b7e334d4a42d65aceff197b39d8a46f0db2d08f82bb69";
+      sha256 = "a24216ca2b1ecd9803b8783394ac200af4444d6607d109c6925486dcd394c2d0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/tr/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/tr/firefox-151.0.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "392fdbf3dca29ff825ae6ea818e16a5b0518daef775d28eb600d655a3f5aeae3";
+      sha256 = "334b0e6b19f88b4e9a339ffd08eb36a68c5b056809e30c44677e9e79704e430b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/trs/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/trs/firefox-151.0.tar.xz";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "38d0f308c6f01e87119e72e2c78bc04887051cfe19a1d081c95836522a312ac1";
+      sha256 = "83699dda01b1d87ebc038543ab8c942f4709dda3ecf9e008025c5fe324099754";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/uk/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/uk/firefox-151.0.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "f6e5ae5a73b2e5df4b9803c6c4cf70e8033b7a900cdce9feca2ce15a84c3fba3";
+      sha256 = "b5d36836fdc9fcbd13af2172e139c4c7a619616ab6c363da4772a4dab15c6379";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/ur/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ur/firefox-151.0.tar.xz";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "1114389bfa8b4fa878c8a682955659705c4e5746cf91a7d613dca0133a364a1e";
+      sha256 = "c1be7be733aac68adcc6e36c1cee0b4da633c425fb7e52aad06cd9dbb9e8f48a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/uz/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/uz/firefox-151.0.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "ddd541250de960a71494b9533e66fbe17b0b4ee3133e55b4fafc3b3620cc0227";
+      sha256 = "208cb307466f94f0a20645c80e1ffdea9b77206da623eb46ae8448eb6f68b5b0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/vi/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/vi/firefox-151.0.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "1cc1aa1b8bcd7fccf73d8357a9ff666cf1ba6e94821e8b22e4aa210be202ebe1";
+      sha256 = "eba173f003dc1666b9310bca22e2c5603c61dedf33d9f8bf9ddee2ff57541578";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/xh/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/xh/firefox-151.0.tar.xz";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "1bbbe449feddf3c3bcfbd5b51b2227c5e656b4b2c3f0458525c5d2f542d2dd7e";
+      sha256 = "a5bc75166b5635d9562653b68247e7d5d1c321a9523c5b5050eee0a47aaa002f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/zh-CN/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/zh-CN/firefox-151.0.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "6a9bd9c8c197826c1fccc8a5823ca6f81c04eb685d07fc65d3e494dad773d7bd";
+      sha256 = "097c3b40899efc6f925ae517b095d250d27a6144607d033aa39dfb41d2784871";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-x86_64/zh-TW/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/zh-TW/firefox-151.0.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "e9e9b9b715f609afeefed53b9bce5560106470859ea8cd725886ff6a6534ceba";
+      sha256 = "51a74af0d6cc092b62c64d9b2a01a8d126a7603ff1956a8191801946f4068356";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/ach/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ach/firefox-151.0.tar.xz";
       locale = "ach";
       arch = "linux-aarch64";
-      sha256 = "609142b2e36f495780fc6cbf9b429d00653d9e5b266aba4d0fbbd6235be69659";
+      sha256 = "4d4c66823249c61e40cb6b934118d9abe23a3c29310f1456b994dd4c5eb5115f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/af/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/af/firefox-151.0.tar.xz";
       locale = "af";
       arch = "linux-aarch64";
-      sha256 = "7ae1c6de8c829c840fcc417070b0e24c1dc8f058fff6434aeccb127777396e68";
+      sha256 = "453a26ab55010c644c668de23a0f53fd8967a132aeac0686f48d5ac5387c545e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/an/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/an/firefox-151.0.tar.xz";
       locale = "an";
       arch = "linux-aarch64";
-      sha256 = "7b25462a271226f660e46fe72c3c915794daef4823e1b6bf1c847868033ba145";
+      sha256 = "5c954cc7a6b1cb58b24e6d44c3183dede5fd923bd7f6a7ad9e1be74a825fb898";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/ar/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ar/firefox-151.0.tar.xz";
       locale = "ar";
       arch = "linux-aarch64";
-      sha256 = "8e290a30cc7df79c249d4799cbb458a5385bf456e2d8eb6691220719f73013c6";
+      sha256 = "7cdb9b1a1bd08fdb2058ae8d1561c286e47aa32abcb775cbf6208451e6c47807";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/ast/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ast/firefox-151.0.tar.xz";
       locale = "ast";
       arch = "linux-aarch64";
-      sha256 = "f63b32b398fa7838e13a4009584d5b32b71351ac9f4da40d069b5e8f16797b02";
+      sha256 = "5e8fcdba1ff9a9a0a85d64e9822faeb1ccc76c116f0928c3e26d886cf4a29ea8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/az/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/az/firefox-151.0.tar.xz";
       locale = "az";
       arch = "linux-aarch64";
-      sha256 = "d6bb3bcf504899c291197bd6fd1e253cbe30966cf8525d0ca98d151f250275f0";
+      sha256 = "8fcc0a17ea899271eb0d57f835621a8cda4a654a5d15f76aa2ddcca59903f4e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/be/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/be/firefox-151.0.tar.xz";
       locale = "be";
       arch = "linux-aarch64";
-      sha256 = "c1104590bfbcf7893a91d210eabf6c596e0567cd1ca2e3adf09af108f12c8a26";
+      sha256 = "c203d795c605785b174db9de567adbcb31476361a6664316848327ba6a4f3995";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/bg/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/bg/firefox-151.0.tar.xz";
       locale = "bg";
       arch = "linux-aarch64";
-      sha256 = "8c67f2a9ba38319798b87dd1c5dab1d32e5433a6e153aeb2a42eec6009316fd8";
+      sha256 = "dfd0ea5a0ea0a160450c169f631cf95739ddc4d6f5e0744342a492f6d8c766d4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/bn/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/bn/firefox-151.0.tar.xz";
       locale = "bn";
       arch = "linux-aarch64";
-      sha256 = "dd99bb4b20bcfcb6ee207a626f55c2cafa690212554696dc39b8f1ff99ce4c0e";
+      sha256 = "c187bc56514729c7a348443e0993838757fd31421a23f8b22bbb7c3d231f4dd5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/br/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/br/firefox-151.0.tar.xz";
       locale = "br";
       arch = "linux-aarch64";
-      sha256 = "e0a1cbb25bbecb6e6d353bb26635eae3123a916d65cf5aba8d110f8a9cd33740";
+      sha256 = "7041ed716353625317361cdf45443c500fb2f85a8a7befbc0cc5d7ed6ed615a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/bs/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/bs/firefox-151.0.tar.xz";
       locale = "bs";
       arch = "linux-aarch64";
-      sha256 = "6058300cef0b3dcea5d0a6668a781c4d6460d0970120419325cc82e147ae674e";
+      sha256 = "2d6fffa260bf99eb84776da218b9faf1ed99c0ad0bf779a58d25a8e4f4620ed4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/ca-valencia/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ca-valencia/firefox-151.0.tar.xz";
       locale = "ca-valencia";
       arch = "linux-aarch64";
-      sha256 = "fdc4dd4cd9142227929defe2c029c6870ad6653925c8e092c99a46cfd6030f3c";
+      sha256 = "7ac0936aaeaf180f2c0c7150d3e73635178d79e928ac5cfd859507d8b26040f7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/ca/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ca/firefox-151.0.tar.xz";
       locale = "ca";
       arch = "linux-aarch64";
-      sha256 = "4e0b515065940e05744d4ae8b7f2bd8a530a576d285ee9349f0157bacc7666e7";
+      sha256 = "c14784c510d47787690b6bcf9f15f27fdaa672b0e3c26bdf06a4e39c0ed0024e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/cak/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/cak/firefox-151.0.tar.xz";
       locale = "cak";
       arch = "linux-aarch64";
-      sha256 = "32b7ef7ddc8f85d727b950af7eb120206a4da390cf8871e8cec2f95f480646bf";
+      sha256 = "ce40bf71a941255a9f845cb21cba068c7100a3d10b8314570ad149ce1cc7dcf3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/cs/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/cs/firefox-151.0.tar.xz";
       locale = "cs";
       arch = "linux-aarch64";
-      sha256 = "2a2e86c4adb60d7d695e4c9ca215e688a4cc2abb152565b6fad27e37f7ff805f";
+      sha256 = "502fbbcf920da48afe40fc60a99b4537675ce814697dd03e6fc67bde131e03e3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/cy/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/cy/firefox-151.0.tar.xz";
       locale = "cy";
       arch = "linux-aarch64";
-      sha256 = "504abf3b27c3f832d2a493be02cea13bbbeb96832ed99846eb32d880848f899b";
+      sha256 = "66876956205c2b99db209620c6729e3d14a5c7cda4e00fcff3c21510925ca338";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/da/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/da/firefox-151.0.tar.xz";
       locale = "da";
       arch = "linux-aarch64";
-      sha256 = "1454d2610c666c9e0927e0b143cbf6a2df391da9089beb0d6c445fad8542881d";
+      sha256 = "3df00da062bebc7057c049cf34a1cb052462c4718f0396955f730ffd4b80b1a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/de/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/de/firefox-151.0.tar.xz";
       locale = "de";
       arch = "linux-aarch64";
-      sha256 = "634e3f3a68b84f4121f7b99879c5abe126f14c727ef9d64c76b50cf331d2b7b4";
+      sha256 = "fedfb8c6d357e25afff212f85686447cb1a2963e43e5a9efeb6da824e4c0da12";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/dsb/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/dsb/firefox-151.0.tar.xz";
       locale = "dsb";
       arch = "linux-aarch64";
-      sha256 = "9caeb08a987b1538005243ed70145c30285297f0cd1c580e87e919cc9c85f51d";
+      sha256 = "752b6a1f2e2a34574dd8f7414b878d2b8f76bf5b0ceb36732d7341e53e9a75a6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/el/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/el/firefox-151.0.tar.xz";
       locale = "el";
       arch = "linux-aarch64";
-      sha256 = "e7e809d616c80a7249fdc9cffe0ecf8fc590517ba7e8f25b29af1b991ddc68ce";
+      sha256 = "f31ddcbca79f41600184d8c9dbda56618a64442d904f57bb878bc0adf18713ce";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/en-CA/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/en-CA/firefox-151.0.tar.xz";
       locale = "en-CA";
       arch = "linux-aarch64";
-      sha256 = "78c9869393a40d6c72b19d9ee8de6160fc59272751e37f84b9e10800b4763abf";
+      sha256 = "55ba52d8e39e61f634f0d066184c4dc1fe3fbf6619afb8d3bdef5f0295f03223";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/en-GB/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/en-GB/firefox-151.0.tar.xz";
       locale = "en-GB";
       arch = "linux-aarch64";
-      sha256 = "8f2567a4425d62e619b099bb592109c803e7b16e0250afc0feb1b1544ec76f86";
+      sha256 = "1175a01cf65e2994623e1a0a22b151f2d6fe4d9f41d5ab2288ee0bd24fc3c886";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/en-US/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/en-US/firefox-151.0.tar.xz";
       locale = "en-US";
       arch = "linux-aarch64";
-      sha256 = "04dba22d48149121d04b3c934ad4b505b38ea13c652f394ee645a65c8148d56f";
+      sha256 = "d4da9e278e933238a2cb873ecacd4cbb00e3b6d4b35fbbe3aa949c4bdd816230";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/eo/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/eo/firefox-151.0.tar.xz";
       locale = "eo";
       arch = "linux-aarch64";
-      sha256 = "5576dc2eb993c9f79c6f0e58e898abb98eb2840eea040dddaf9d15a48baddf92";
+      sha256 = "f82c3e6030f5f4148ebd65552a159da6d1eb0c0170c19748ae098b749d92dbfb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/es-AR/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/es-AR/firefox-151.0.tar.xz";
       locale = "es-AR";
       arch = "linux-aarch64";
-      sha256 = "523e5dcb8eba0696e2d0fd9235327b34e1b22eb66161bb515983632a078194d6";
+      sha256 = "bbcf0d66e2177c47f8e1f8ab02b0939561fefec733931acfbf3f31f66dc4ddf7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/es-CL/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/es-CL/firefox-151.0.tar.xz";
       locale = "es-CL";
       arch = "linux-aarch64";
-      sha256 = "4ce1ba60a5a56b5141d9c93484215e0cc83f17a05d022efa2d84ed27294f161b";
+      sha256 = "2b46e200f7e6e862ae01183c46fe1c970eedf516c649449c32dfe56cb5a36658";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/es-ES/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/es-ES/firefox-151.0.tar.xz";
       locale = "es-ES";
       arch = "linux-aarch64";
-      sha256 = "980ffe716e56d63e220d063ed295870fc448dfbe5977c41e1cff001cc8d8322b";
+      sha256 = "7430ac325d6a226f186203979ba0372357ee13f8389f6ca00771639713095ee7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/es-MX/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/es-MX/firefox-151.0.tar.xz";
       locale = "es-MX";
       arch = "linux-aarch64";
-      sha256 = "03e4991204f5d8e792c55c0fed319965298d8a4ae938d4edae5b21cad5490aa8";
+      sha256 = "261bddd2daab4bd05a641e76c34d4437678f4c8df0c8b569e60cda01ebfe71b8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/et/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/et/firefox-151.0.tar.xz";
       locale = "et";
       arch = "linux-aarch64";
-      sha256 = "1680a1eb650aecd296821e284a23b23c00c8161d14c5a5bf440cfa04217baedf";
+      sha256 = "acd971403e78b3ad1a1fe4dc0b204920dded7bd6e87c277b019d3c82561c1dd8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/eu/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/eu/firefox-151.0.tar.xz";
       locale = "eu";
       arch = "linux-aarch64";
-      sha256 = "8589a59a69c7a41b2ada5047bf41f73c498bcb567df64e0cbe3b34ba04dcfb23";
+      sha256 = "856051d95bf03e4ef51c381380e6e2c76716d01aa7b9857e2fe40d8b6da0fb23";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/fa/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/fa/firefox-151.0.tar.xz";
       locale = "fa";
       arch = "linux-aarch64";
-      sha256 = "0e7463b8bd40d2c80b1fd682779c59c6e2201673cec74d444c8094e83b87d837";
+      sha256 = "340947ba7768ee52c8961f6536080d469e6cac8242994da3dec313365394f87d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/ff/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ff/firefox-151.0.tar.xz";
       locale = "ff";
       arch = "linux-aarch64";
-      sha256 = "c4871f073a8361302073221f3018bf507ed7c7622f5d76e8aed5640d4bf46bb1";
+      sha256 = "07abc0addba4524c2edb1bfb98aacf3845598f0361c94dea184743b5785c3a16";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/fi/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/fi/firefox-151.0.tar.xz";
       locale = "fi";
       arch = "linux-aarch64";
-      sha256 = "8a7014b69f9bd97a308451fcff32d49b81d71ef8665fb9adac5472d322e0036b";
+      sha256 = "2227beb7fe0a3563a38f02378a4fc81bea5f01567815ae74b02321ed78c5fdcb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/fr/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/fr/firefox-151.0.tar.xz";
       locale = "fr";
       arch = "linux-aarch64";
-      sha256 = "018b5680940243ea75fbc8bf5c400e0ac56105a4acaca1949bf211e5a0bb6ddc";
+      sha256 = "bbdd8e6c1a20f906078b0847d25418c60798f9f016f99109c4244ac97137765a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/fur/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/fur/firefox-151.0.tar.xz";
       locale = "fur";
       arch = "linux-aarch64";
-      sha256 = "6da3116767ea86e63471666baf9556cbd2b3414d5e5678b8552239e518832b7e";
+      sha256 = "3d7387c47f35b3d9388b9d4cebfcd1b0250b0034215a134352088b8a3cfefcc5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/fy-NL/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/fy-NL/firefox-151.0.tar.xz";
       locale = "fy-NL";
       arch = "linux-aarch64";
-      sha256 = "a83ee94f813fbde530450fb7474c5103898ea3bc96d2c69d2a49165158330c0e";
+      sha256 = "2bead167fc0cc24819a13fddc3cbd19f227dfd692636f6eaee01bd1300229358";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/ga-IE/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ga-IE/firefox-151.0.tar.xz";
       locale = "ga-IE";
       arch = "linux-aarch64";
-      sha256 = "55d5b536906007d90667eb45ed5aa2712f01d7efcf2cefd1bb342e9c9caead4a";
+      sha256 = "897eab817a35c7438ed35a1eb8c9172fa26871027f8a76a74b804d3aeace3f32";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/gd/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/gd/firefox-151.0.tar.xz";
       locale = "gd";
       arch = "linux-aarch64";
-      sha256 = "0eb5db71cb9924e7d514fa9c69d87b637ac4b8a2337a5a9c1cab2703086a89a4";
+      sha256 = "47b26129774bedbc8b713555385c5441fc14a22ca8d338e9a903c80cb71e0c70";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/gl/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/gl/firefox-151.0.tar.xz";
       locale = "gl";
       arch = "linux-aarch64";
-      sha256 = "d13e92fe4f4bf1f7bde9fb3c4256eca0ecd4b33469a54e566750c22a7d930760";
+      sha256 = "5f94849277f41eaa2721be4f5cb46b885307922d84b9200210ec2c57e36f0e5f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/gn/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/gn/firefox-151.0.tar.xz";
       locale = "gn";
       arch = "linux-aarch64";
-      sha256 = "c950481f0ce79058facb0284b5d701ec4e89f53537c463f18d6db0772f7794ca";
+      sha256 = "31caf29f7b061b7b3d4c606751f0c96b86756edfd8bb49c048e1ff929a807e8a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/gu-IN/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/gu-IN/firefox-151.0.tar.xz";
       locale = "gu-IN";
       arch = "linux-aarch64";
-      sha256 = "4f4b0a720f1d9fd1163c7b32476000cbda79aa645dcd92afd8b5ab0e4422fd63";
+      sha256 = "36f94e92406eec7e824b8d1a966b2efb21a5e2da5cc1eaa83d22000280445b92";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/he/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/he/firefox-151.0.tar.xz";
       locale = "he";
       arch = "linux-aarch64";
-      sha256 = "bc4e36dc5a79db5ff3f8cacf334177fbda100f4be1d9762c555c2d9cd42af15b";
+      sha256 = "4fd6527bfdbb0e891b356aa794f2a4d44175a5b22a02f769b25b03d7dc3c02e9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/hi-IN/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/hi-IN/firefox-151.0.tar.xz";
       locale = "hi-IN";
       arch = "linux-aarch64";
-      sha256 = "06cf47c19ae73c097342ade1a936fcda8290b3b57c50655add4342843ab458fa";
+      sha256 = "8eb2e5af2d641c13754a814acf81b74c4fad13d83ac39352e9927ca7e4965615";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/hr/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/hr/firefox-151.0.tar.xz";
       locale = "hr";
       arch = "linux-aarch64";
-      sha256 = "ee82c974d8c16d1498435299af9926c3ad508bca18eb6d41b3eca68182a07f44";
+      sha256 = "3a943323402b86a0e0fb28308c2e31325832861043fb3b9fb7d5e99e04470701";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/hsb/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/hsb/firefox-151.0.tar.xz";
       locale = "hsb";
       arch = "linux-aarch64";
-      sha256 = "b0e6dbb6e9f39d889a5ae6137b0b00b8e7d26ca4ff8bd6d84b8a8581ff2340e6";
+      sha256 = "45d8c6b8183c58b6cc6c5c142ee65573328f1f18af4324fd90d6c7499135740b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/hu/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/hu/firefox-151.0.tar.xz";
       locale = "hu";
       arch = "linux-aarch64";
-      sha256 = "1762cd4150d8ea4ce442d61e13c645bc7cc000e49bcf2c6eb186cade8c6865ad";
+      sha256 = "301003aab101cfc707ff2408bec65c2ace19e503dca65ab870c5a8e445a00a4b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/hy-AM/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/hy-AM/firefox-151.0.tar.xz";
       locale = "hy-AM";
       arch = "linux-aarch64";
-      sha256 = "dd813c5bbdae53745982f7be3b962f310a2058a97a8cca08e2ac244e457de56c";
+      sha256 = "f381477388be8bdf53ce9532511755211585f564a2b3168bf01d86584baf8c4b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/ia/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ia/firefox-151.0.tar.xz";
       locale = "ia";
       arch = "linux-aarch64";
-      sha256 = "92060ca5ac712853903c4c25d5f1008b8c0edc321ca7d07872b18d61a7528fe7";
+      sha256 = "63f12016855425d4e7df1f17ed3b1c379e72ea7418019c83b534635b021bba3b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/id/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/id/firefox-151.0.tar.xz";
       locale = "id";
       arch = "linux-aarch64";
-      sha256 = "86e494b77a5df88f83cae19fe119a6b4c5fe787c899dba3657450accac2c2372";
+      sha256 = "cd3270e929525fa75553cdc86bccc4c811ec3fe7115f3ae8f562df8e6e2ed4a7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/is/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/is/firefox-151.0.tar.xz";
       locale = "is";
       arch = "linux-aarch64";
-      sha256 = "e303c74ec09e5e9c412684b85c6fe674d9a6a8f99eaae5ec4c8fdee7258cce41";
+      sha256 = "804e9e3ad94148f42ec2c9a8fb78a85acfe8024638ea1ac60bdfd415e1924eb1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/it/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/it/firefox-151.0.tar.xz";
       locale = "it";
       arch = "linux-aarch64";
-      sha256 = "75286030038c669c8603019f21015468ef08ca952d48e0febc1cc3734afec7e8";
+      sha256 = "a2588cb97bc2faf6855034d7b571b9db4b960798b2bac7998e6f5dd596ec550b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/ja/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ja/firefox-151.0.tar.xz";
       locale = "ja";
       arch = "linux-aarch64";
-      sha256 = "99d3c66cbf605b18a417ac7e8503504bdc5d130f7b65943f748cb05a1e419473";
+      sha256 = "aaf4dada0d1499109f651d8e9c372f1530ed8ba0989a9860bb49165646b95156";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/ka/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ka/firefox-151.0.tar.xz";
       locale = "ka";
       arch = "linux-aarch64";
-      sha256 = "e21892a51e7e89eed7be2232abf3f4e0295803c08f300da780b50bd217ce244f";
+      sha256 = "223d84dc1a58cd4bd90bb31571e601c23d6f4642e6045d9ed038741100c9887f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/kab/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/kab/firefox-151.0.tar.xz";
       locale = "kab";
       arch = "linux-aarch64";
-      sha256 = "444382155f323ff8bfd5079ab3cd2e153d8ea9d95c4dc3bd6aa4372ccb9d5ef1";
+      sha256 = "f41adc567742bed4db9a5432516afbf7974379743418b9bc25aa4860cf7e6886";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/kk/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/kk/firefox-151.0.tar.xz";
       locale = "kk";
       arch = "linux-aarch64";
-      sha256 = "4b0d60ca1778052e23fcf8302889e3b8ed03cb4b4383410f7a3c48bf4058503b";
+      sha256 = "47102d0dd408d7a0be7fd4f2ff258db6ff14bd40c5e57368dfadf93bbd2920fc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/km/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/km/firefox-151.0.tar.xz";
       locale = "km";
       arch = "linux-aarch64";
-      sha256 = "52645c40e961b1cc03b5d9db4a661311e1bd071331756a440d13fead456be462";
+      sha256 = "e190fbaa4880a3ecf065d1add6fc171f26005d6bfbf7f7429281a10a41648c13";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/kn/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/kn/firefox-151.0.tar.xz";
       locale = "kn";
       arch = "linux-aarch64";
-      sha256 = "4cf67abfd7d553b4d67b340f047644e0fa0bdab7db657e2d4562a44d6fb9146a";
+      sha256 = "6707476be236bd6ca950e1fcc0ddb173b10ad3b5b6dce23caa4f3929cb740b73";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/ko/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ko/firefox-151.0.tar.xz";
       locale = "ko";
       arch = "linux-aarch64";
-      sha256 = "9c710febcd8cd5a0c4f292bcfeef26c86fa4d8cf9a3f195afc068751489da97e";
+      sha256 = "472c7c2b8dcef4b1674f88e7cb076c368cb9d4d1bb83944f385ca082afacfd3a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/lij/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/lij/firefox-151.0.tar.xz";
       locale = "lij";
       arch = "linux-aarch64";
-      sha256 = "55cab9d3e0d0a4a8a4c0cbeb98d0bf6a93e48d8a0fd4f2c6bfecd89601f8d99d";
+      sha256 = "be6a8a248d747a363ebc5e780476706e557404d5747190c64226426a5bc40cf8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/lt/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/lt/firefox-151.0.tar.xz";
       locale = "lt";
       arch = "linux-aarch64";
-      sha256 = "1095dba04b0fdd6e8f62cd101519dc70b58c06514ec8fe29129a4c25f5b7d760";
+      sha256 = "5af4b0d97be054271513a59a9b06ac14b647125f62c926cecac8ad27affe3b84";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/lv/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/lv/firefox-151.0.tar.xz";
       locale = "lv";
       arch = "linux-aarch64";
-      sha256 = "a62e5dd7258dfc90718dd1e4e7225c966563cb1cbc69c932d0a39bd2700bf0b1";
+      sha256 = "9d76aa87ff3076db11ebe18718177333a16de585e93fbf00c53331f01baad2ab";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/mk/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/mk/firefox-151.0.tar.xz";
       locale = "mk";
       arch = "linux-aarch64";
-      sha256 = "6f02418ed0b7d9b9d83c383db8c9af514d73dedd591bf7a23f953512dfdce720";
+      sha256 = "af70014688638ef15ca8468211fe85d0ade71a9a9214823b6c3a0e2ed9625fef";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/mr/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/mr/firefox-151.0.tar.xz";
       locale = "mr";
       arch = "linux-aarch64";
-      sha256 = "95f79acc5f0351e7328602bc10da43e71c839f3a836e5ebad73d6032e19e368e";
+      sha256 = "0641fb7c9db0e897f6787f0a35fb592551d481194486368366f537e2816d73c1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/ms/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ms/firefox-151.0.tar.xz";
       locale = "ms";
       arch = "linux-aarch64";
-      sha256 = "1b5990fb87358ceef5f038a13e12eb1d0a84f54c97daf0c40e4f7d831fd88559";
+      sha256 = "e65b4c42da3e6dea72916bf1e1e1b96ddccdccae54a3310794702168b4ccf4b2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/my/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/my/firefox-151.0.tar.xz";
       locale = "my";
       arch = "linux-aarch64";
-      sha256 = "3727df44bf1b33d427b62a93bcfd5e3532fc85294847a88da9fd1c0b4b96be3b";
+      sha256 = "f18ac1d33d9caf22a22be663ebdb60036239ae23ed3ffd4812fd54ece35632d7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/nb-NO/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/nb-NO/firefox-151.0.tar.xz";
       locale = "nb-NO";
       arch = "linux-aarch64";
-      sha256 = "711f96f135b3016b4652992f931308a842d62ef3fd91579756a2696c77a513f8";
+      sha256 = "6494946da10f46f8f5b8f73791fe65fd4afdf782d479673d0dcb79b3561f48ee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/ne-NP/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ne-NP/firefox-151.0.tar.xz";
       locale = "ne-NP";
       arch = "linux-aarch64";
-      sha256 = "ece69ded232925d5b75c07c7cead942426827f7b8935389905c4da7d4cf04596";
+      sha256 = "4715032337151369371dc87b354e2aef30becdd883c474e975552a0eb2f3aaee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/nl/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/nl/firefox-151.0.tar.xz";
       locale = "nl";
       arch = "linux-aarch64";
-      sha256 = "7f25b5d90624642259d2173bdca8efeaef7e41e71fa89fdab50173b503c5f99a";
+      sha256 = "03218d3d7f1779faba98c87a60f0400537d221ed032053307564ae88e99408cf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/nn-NO/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/nn-NO/firefox-151.0.tar.xz";
       locale = "nn-NO";
       arch = "linux-aarch64";
-      sha256 = "04f6d46292fb789ba4139fd2801bde18b9152fd8d5d515959e3107d0deec6763";
+      sha256 = "5b963090678584cbbefb4ff1796a0cbd5a0f6b00e62cbc1f5b107a75496e8071";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/oc/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/oc/firefox-151.0.tar.xz";
       locale = "oc";
       arch = "linux-aarch64";
-      sha256 = "795230f7a96e1624bb6a341b8a172c12e89b584b4a5bc3cede089e58e7153600";
+      sha256 = "5aff1aa7a6dc0f965c880c251438a43b87eec32eb89f454a9af880ff555be780";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/pa-IN/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/pa-IN/firefox-151.0.tar.xz";
       locale = "pa-IN";
       arch = "linux-aarch64";
-      sha256 = "bfdc3ba2dde0a62cbad1bd1b0e4fc6334f9ee4b66e75c59b8b40fe744eb8b6cb";
+      sha256 = "a6a3db8b68c023cfaa9b3ce0108db6deab426c6980635560dfd55c6d74faf0ab";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/pl/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/pl/firefox-151.0.tar.xz";
       locale = "pl";
       arch = "linux-aarch64";
-      sha256 = "89479a1a75575fad97879f0a13fcb9e3583e8f6a2cfff99dfb0f86985cdddaff";
+      sha256 = "3ac9a58d9b919c0cf7ee6ed320a4df15eaa9232ea6bb24eed5bec973d6384648";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/pt-BR/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/pt-BR/firefox-151.0.tar.xz";
       locale = "pt-BR";
       arch = "linux-aarch64";
-      sha256 = "dc454c03cf7ebcb9e13266e30a12219a11599be49b5c8b8d94b64cf65800607c";
+      sha256 = "b31f2ba16bbe34aa2966e8664b97ec98fdae095372fe8c46276e178cbd55b5a2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/pt-PT/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/pt-PT/firefox-151.0.tar.xz";
       locale = "pt-PT";
       arch = "linux-aarch64";
-      sha256 = "7032f11e50ab917d5f53846a2e09e70bb9a163ecb8dc3eec1e041af943e8b42e";
+      sha256 = "fa78b348228d366fe77f8ba9d2dabac76d125b351e43c6d90c4ca4797e99f776";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/rm/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/rm/firefox-151.0.tar.xz";
       locale = "rm";
       arch = "linux-aarch64";
-      sha256 = "c76935fe32c69581dfe49a71d68cd173f830cc6e9a84f652d69360d946b89d95";
+      sha256 = "1005ee1c52ac5f4a65dc8188a342cf9cb247761dd0e248333898b49204575d57";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/ro/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ro/firefox-151.0.tar.xz";
       locale = "ro";
       arch = "linux-aarch64";
-      sha256 = "ee62d2d12b2acb2d8544478621f3c5e8ac7ae76de14252999640424efce68534";
+      sha256 = "d056b0d8f85957b5b0b6437158885ec779d400eab51f09d9430ef6c4c89a35e5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/ru/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ru/firefox-151.0.tar.xz";
       locale = "ru";
       arch = "linux-aarch64";
-      sha256 = "dc93bcfd05d4a49027aa530216156d34a1f882bbc9e4c6a66cb35eb940bacc3f";
+      sha256 = "2ba3f9a81865c0c779901fb77292136ccd37788ce26fc52d8c9656cffc9550c0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/sat/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/sat/firefox-151.0.tar.xz";
       locale = "sat";
       arch = "linux-aarch64";
-      sha256 = "047ce0f2aba3c43238c475fcd9827dbfe77028fd5baa2be92ad149effe47362b";
+      sha256 = "3e5064f43181292186a7d6b4ec80f5e788c0114abeeb6901f9408bb1dee035a7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/sc/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/sc/firefox-151.0.tar.xz";
       locale = "sc";
       arch = "linux-aarch64";
-      sha256 = "9e07f64f3c67682451fcb28bc6b40074101f959cb8f7e2a648a209a8368cef47";
+      sha256 = "fcf533c590a06c80fdebc594b436501ee2041296783f5342565f138a587fed96";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/sco/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/sco/firefox-151.0.tar.xz";
       locale = "sco";
       arch = "linux-aarch64";
-      sha256 = "ff09ea9b2d5bc328eb6aef2f5e44e79c914087db873390843465ebcfde2084cf";
+      sha256 = "8e94cfafbef16aea4e0194517ec08ce42db5fd3323f35ead72fc3df667c0393e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/si/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/si/firefox-151.0.tar.xz";
       locale = "si";
       arch = "linux-aarch64";
-      sha256 = "01cc154a4fc995101e834b2e50cd4c410314904f6bdda8ac1037f47b31b8bad6";
+      sha256 = "3261a60c1cd7408daadebff15297820035270927431d0810dc4ac174bb28257b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/sk/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/sk/firefox-151.0.tar.xz";
       locale = "sk";
       arch = "linux-aarch64";
-      sha256 = "0dbb0c589a5a72e18485c510f8ca5d10a1a8e714a0d61a64e33751340f951b7b";
+      sha256 = "0f4f25d0a21d0b7e0fb7b740cc07f9c51dc9652dfb0d6d082902ee2883a85f12";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/skr/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/skr/firefox-151.0.tar.xz";
       locale = "skr";
       arch = "linux-aarch64";
-      sha256 = "813eabfefc00872793aa67dd7146125dd8c901cbce6ba20b20778aa417514736";
+      sha256 = "4d3d9d93aa6df5af0aa9d97f5e0a8e49b3d95a3c8786905a57dd53411b3ee4d2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/sl/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/sl/firefox-151.0.tar.xz";
       locale = "sl";
       arch = "linux-aarch64";
-      sha256 = "89f31ce36efc94fdba2437829c2d3142deb58c52f189863ac1a972c1dc96fa3b";
+      sha256 = "8930a0146a6aaf89f8dbb619f25b9a48035835d5509f235b83e4e141ff3d0185";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/son/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/son/firefox-151.0.tar.xz";
       locale = "son";
       arch = "linux-aarch64";
-      sha256 = "21cdefc0e9ed59b9e38959c2d854db1dd0155a2868a982ea579f995adf565835";
+      sha256 = "435cd666d88654aeff6e036c4cb60fc971370168284a16d3748430a8b5860abf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/sq/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/sq/firefox-151.0.tar.xz";
       locale = "sq";
       arch = "linux-aarch64";
-      sha256 = "b9a6996b964bc3549978d9e4ff27606d48d5ef3d6f613aaa8e639287c62de50d";
+      sha256 = "524059ec4d47efd0b766e23025651a9962a25cce63f96aaead3749022024a2d2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/sr/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/sr/firefox-151.0.tar.xz";
       locale = "sr";
       arch = "linux-aarch64";
-      sha256 = "72965e30194e03d273150ef3cfaf76d2cec6764a09a2e2c0e439089d53d996e7";
+      sha256 = "60d098e365ea1a884f73e763d529cacac64367b50c511664b8479a689d6183d1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/sv-SE/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/sv-SE/firefox-151.0.tar.xz";
       locale = "sv-SE";
       arch = "linux-aarch64";
-      sha256 = "692be357be645a6bfeefd2e602863495beb193205bcf7c22556c62df91c9d6b8";
+      sha256 = "ade0f10936ba4f48f691bbb3ff8133ce1c00aeb1641fa5f79860db893f9eb035";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/szl/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/szl/firefox-151.0.tar.xz";
       locale = "szl";
       arch = "linux-aarch64";
-      sha256 = "7ee22dee8d511641992808a49642d6c550070814fe4365bc7775fab12f4bb718";
+      sha256 = "0ad2833df04891dc189bd25e2f8886cbea70b2f21196fc4e4abbebfd3cbfae13";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/ta/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ta/firefox-151.0.tar.xz";
       locale = "ta";
       arch = "linux-aarch64";
-      sha256 = "0f6a8885c331cb628b20432ea71fb7c09f90b9c069a29152d7ba69dcb9d60294";
+      sha256 = "f600771a35906f42bfb09ac50a431ccca238f077b3da8780f04df1b6d776efec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/te/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/te/firefox-151.0.tar.xz";
       locale = "te";
       arch = "linux-aarch64";
-      sha256 = "c2919357686479cb86eb1644ff6817c219ccc7f6e429c215e681c023102f5012";
+      sha256 = "6f4209f11c65ff3d64e375ea036bb169a8bf2c940d018f02f06858011ad0e107";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/tg/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/tg/firefox-151.0.tar.xz";
       locale = "tg";
       arch = "linux-aarch64";
-      sha256 = "7a58b99b0f9caec85c6b5a6288900ea62f18b037af2dee71477d91e105775c2d";
+      sha256 = "971a9c98354226f8b64dc53b365c4de5c42e05873998c4b7d6196225bf70a315";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/th/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/th/firefox-151.0.tar.xz";
       locale = "th";
       arch = "linux-aarch64";
-      sha256 = "f20ea4b0bff9cdc210bffe06dfc9efb4cec7ab597a1147507b438a3c96b4e97e";
+      sha256 = "6b2b5855f3fb5baa289dd08b70ed12c7eb9f711788ad6953cfcd091104da4668";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/tl/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/tl/firefox-151.0.tar.xz";
       locale = "tl";
       arch = "linux-aarch64";
-      sha256 = "cc3b683248ecbff2bb9e77cfc2b70b1c4d1d0f0a365cfd81a1e1485185584053";
+      sha256 = "d39a71d80a7c5e3d9b50cfe72a592660e9a1274f9f9d037ece91392e4eb02621";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/tr/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/tr/firefox-151.0.tar.xz";
       locale = "tr";
       arch = "linux-aarch64";
-      sha256 = "381162cb8eaef72a56adb6ca4b89326a4073c34ddeab88dd45c10c53934f33fe";
+      sha256 = "6a1ca8f4adcc89e91fed8262ab27e3b121513ee2e1395c357df5287b88ba8908";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/trs/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/trs/firefox-151.0.tar.xz";
       locale = "trs";
       arch = "linux-aarch64";
-      sha256 = "bdc9aef10bbefd59609d6851b2ebd977bcca4118135797f6dd000f3c103e1b06";
+      sha256 = "cfcbe9876f5631870f8e8234e3ba88043d212efb98fe53f92d6881a04e5e9a04";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/uk/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/uk/firefox-151.0.tar.xz";
       locale = "uk";
       arch = "linux-aarch64";
-      sha256 = "7b04226407a07e5b5d6edc8690f6921352863b3a7a1f3ba1967a1e09ae2cf863";
+      sha256 = "eaa24d387af026dec90897796ea339bff915d44d00b9d5b2d69f05c0f1019511";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/ur/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ur/firefox-151.0.tar.xz";
       locale = "ur";
       arch = "linux-aarch64";
-      sha256 = "96ccb73f09bbca1ce94ebe429faa32f05101381faffcfe9d6ba626bed81addb5";
+      sha256 = "b1451aaadb1361f38e5392473d8bb60180b5277e86704fac2fe6abe4aaa18ec8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/uz/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/uz/firefox-151.0.tar.xz";
       locale = "uz";
       arch = "linux-aarch64";
-      sha256 = "fbaad41c98c45387cd7589d47379a0888af4fb4b01deb7331c5628b603db1341";
+      sha256 = "4d1d48ed78db3e2f995a76bf60f49cb5f69502166a826ebd4c3c3e19d5c32b95";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/vi/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/vi/firefox-151.0.tar.xz";
       locale = "vi";
       arch = "linux-aarch64";
-      sha256 = "d3c0440cd82b2fab56d82caf07cb30860f8bf5f31aba40d822338db9c7703ad2";
+      sha256 = "71ad190c7d6a0ae9f615680be9138dfda59735abd8a8995341fd964f0583f629";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/xh/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/xh/firefox-151.0.tar.xz";
       locale = "xh";
       arch = "linux-aarch64";
-      sha256 = "b986d2a7932256045a05bab515b78ac0fdbdfdda5d0ff1a5a05fb3d9cc4445e6";
+      sha256 = "2fd567ecac47f6b92ee2562fa4472958e688d512fbeaba20f1f968560259daff";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/zh-CN/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/zh-CN/firefox-151.0.tar.xz";
       locale = "zh-CN";
       arch = "linux-aarch64";
-      sha256 = "9a0d3fdf58281e5bffe133e51493cb751b66269b55565e9bb19b1ad1f73210d0";
+      sha256 = "2a5312e573d7c883fa984a28bc7174ebef73dc6814a9690a4d59652cf6c59b7b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/linux-aarch64/zh-TW/firefox-150.0.3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/zh-TW/firefox-151.0.tar.xz";
       locale = "zh-TW";
       arch = "linux-aarch64";
-      sha256 = "9cd8e386f22ff6ef51dd7195c65e46a44451532fb1bb6ae28882705005b35f99";
+      sha256 = "8263f9fdad943430a35ad735ed550512f1c05773d49365e61ac9f5ab6ee9a4c7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/ach/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ach/Firefox%20151.0.dmg";
       locale = "ach";
       arch = "mac";
-      sha256 = "e8ae2695a5a924a1b12e494f0443c00039050e290173f6076c905319b5540ed5";
+      sha256 = "2d39a1c9e5973b5608b8b96e688c4fa118dce9dff46a83d023ec21c2ad95e0db";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/af/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/af/Firefox%20151.0.dmg";
       locale = "af";
       arch = "mac";
-      sha256 = "0e8a5d5958cc30dd6b8f4f5dd442f2ab5b8a940d040f4bcc97ba1691e40fbe68";
+      sha256 = "8be5f0a52046e841f3bcf7e99c66f907f8bbe27ec68d20de7c22eb952b83502f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/an/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/an/Firefox%20151.0.dmg";
       locale = "an";
       arch = "mac";
-      sha256 = "cbfecc85abee0af5c14d66a84a26effd83a683ee8644a5219b65230cf6a8d467";
+      sha256 = "0b8dc181726ef44249ece9c7c7ac7b68b6ca861d1c8a934875769cfbbc2eb127";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/ar/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ar/Firefox%20151.0.dmg";
       locale = "ar";
       arch = "mac";
-      sha256 = "0c21d9fb70eff0ce10797322d084a3676c029796f162cbd3963fa5c13978b77f";
+      sha256 = "7028f599f7cb009df4934670c60988a160e69a4db92890560e17c1ffb8f45fa7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/ast/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ast/Firefox%20151.0.dmg";
       locale = "ast";
       arch = "mac";
-      sha256 = "8806f5b47079fe1c1c6479e9a31492f3c9061e14ecd3e60b39c633f415b874fc";
+      sha256 = "8f3b2aab5f194eb6fd925efee31b553e8d2373dfa72388a687935e9d4f857115";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/az/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/az/Firefox%20151.0.dmg";
       locale = "az";
       arch = "mac";
-      sha256 = "a2acf3511ff915ac00b646158ac8d32060bfaac7e81778ea1eab7b85dffcdd01";
+      sha256 = "e052f1df0ad6b23e8134a248afe884adcf2f2aa6f7826d4f91dbbede14353f13";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/be/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/be/Firefox%20151.0.dmg";
       locale = "be";
       arch = "mac";
-      sha256 = "890a3eaeea505c47f47708774f07251c9131f4db666df07818adcaa794c9fd2b";
+      sha256 = "b5fe8f4bbaff0340469fdcff80ea43856edac81083de408ff0a601f7fd5f5ba5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/bg/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/bg/Firefox%20151.0.dmg";
       locale = "bg";
       arch = "mac";
-      sha256 = "2d48e85de949f8c838c65f6f2fad1a7c1f46946d21b62aaeab1572ebcb821695";
+      sha256 = "c61d5c3cc6a283affcdafd9a543be25eace71dc3a0cb5552df99d6020637ef1b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/bn/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/bn/Firefox%20151.0.dmg";
       locale = "bn";
       arch = "mac";
-      sha256 = "60b170e50f4744bb0c7c07dd106620f1a9cd83410ea4a2d4834bf1936eca8c7c";
+      sha256 = "117d920b15830d40cd942c92bb06d65dc68ea8039d9b8713caaf4e7ebc91a70b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/br/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/br/Firefox%20151.0.dmg";
       locale = "br";
       arch = "mac";
-      sha256 = "23ab7073bec0f4891e046ea8e57dc229135763dcf1c5f623128d1cdffc05806b";
+      sha256 = "22dfba1d0eef3c8b47c933b5731bcad3b8e468bf57fecf5aba128f916ce0e02b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/bs/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/bs/Firefox%20151.0.dmg";
       locale = "bs";
       arch = "mac";
-      sha256 = "99a134fa46e6ee82022baf13314c2d358f9e52fa92afbec21493dce96cd2e0ee";
+      sha256 = "17260432f94af0fb8be4e8fcd02af222dbcc1a18813909e3988524277de298b6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/ca-valencia/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ca-valencia/Firefox%20151.0.dmg";
       locale = "ca-valencia";
       arch = "mac";
-      sha256 = "975f2b2d5476d684bbe8cb93f1277310ab349f9a7bbb0eccf58edd933e09601d";
+      sha256 = "4de7f7f242af6f3f69f0a3106e339d512d2e8c2a9e19463efe1f3391dcf25e6d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/ca/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ca/Firefox%20151.0.dmg";
       locale = "ca";
       arch = "mac";
-      sha256 = "33e99e6eb159a550fdfdf2e44f22976c7b077b11c7241d0833aada3bb72be202";
+      sha256 = "6f47a78a307c208ac05d1b2990d827388d228255292984a6ced2edf7541bdae3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/cak/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/cak/Firefox%20151.0.dmg";
       locale = "cak";
       arch = "mac";
-      sha256 = "2b4ede387d5e9d31295f9245f7f30e688762399e8226af87a5e104402d72376a";
+      sha256 = "28ab337e4e849994cc84cb21f810f35cadb208fe0537c094f03a1c23d3db62f0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/cs/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/cs/Firefox%20151.0.dmg";
       locale = "cs";
       arch = "mac";
-      sha256 = "51036fa2a9304c14eb303925eb2ebc20d5505eb3f34c2d8a76e03bc11ef37359";
+      sha256 = "120d79c879655e340809439593d5acde0b923fb09436dcad4ab8ead2a54c20e9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/cy/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/cy/Firefox%20151.0.dmg";
       locale = "cy";
       arch = "mac";
-      sha256 = "dac0584eca0c4a994c0b2d9dac5c10f53c2dfd8026bfa84a725bce3933b7c50f";
+      sha256 = "21a8a9617c45ef59cd8124d6ac6f767b3608a3964291aed503b0c4e970301f91";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/da/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/da/Firefox%20151.0.dmg";
       locale = "da";
       arch = "mac";
-      sha256 = "9bab22669f339811aa0516aa268fab6de11898c72e4efedc618f8f7e8d838b28";
+      sha256 = "77e80b452fcbfd0144a0a0fe22c5862e0086b6260e4e2422db36dbfd1ba7580a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/de/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/de/Firefox%20151.0.dmg";
       locale = "de";
       arch = "mac";
-      sha256 = "f1b77c24b0770a91cbeb9b85a2d20751c51f356d4c211f980092870f01b10954";
+      sha256 = "3b55f70332a89617ccf0708e17201c2d08d7e63ef60e3a982a3db9b27c184050";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/dsb/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/dsb/Firefox%20151.0.dmg";
       locale = "dsb";
       arch = "mac";
-      sha256 = "b93444135677cffac412f12f5ac766317cdda3f5e32a24d4884efc0f86ba887f";
+      sha256 = "5b3f0ef2edfa4c8121f4c991d8dfcd21429fa2a5b07e4cb50ad93f50edec9d3f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/el/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/el/Firefox%20151.0.dmg";
       locale = "el";
       arch = "mac";
-      sha256 = "af83a167a76091f9b11d4ca7fd1c6ee7a1d88927fb2794a2e835eab138f0b914";
+      sha256 = "22b40a82ac79d718984d72ef997fcab82e2d1bc196866bab1076097d42c75b25";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/en-CA/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/en-CA/Firefox%20151.0.dmg";
       locale = "en-CA";
       arch = "mac";
-      sha256 = "ada93df0f999dd630533782672b217746fd078d0f3d11ec4d71258592c132e6f";
+      sha256 = "88788f4a518bb4472da7d0b34a5ad8f9e81ec3602dfecce54c7a8e37e97e435f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/en-GB/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/en-GB/Firefox%20151.0.dmg";
       locale = "en-GB";
       arch = "mac";
-      sha256 = "c458dcec2f782b136fb2f8d62ca2b6a4e22c7b3eced14a750be2aff3ea0a9cb0";
+      sha256 = "c16fad26df7572f2bce210e8e9665287529802b102031a7055998e8154e9dfd8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/en-US/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/en-US/Firefox%20151.0.dmg";
       locale = "en-US";
       arch = "mac";
-      sha256 = "5f8571d35b883c9c210ad4249f25c6a46e7861291a440f65d5249587dd1b9051";
+      sha256 = "5a56ebd8f0f8cec94a86e04c6793e1d1502b40206f5d4c86fff5b7a270e84f6b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/eo/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/eo/Firefox%20151.0.dmg";
       locale = "eo";
       arch = "mac";
-      sha256 = "7b4eff49a39756f94df479ff34b3b56d1eff0aa9395ea5f0b40e52308edf2788";
+      sha256 = "0c456aa7549ed28c1c0f832dfe7a13706c1806e40c561c74aefc00aa5b8fcbfa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/es-AR/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/es-AR/Firefox%20151.0.dmg";
       locale = "es-AR";
       arch = "mac";
-      sha256 = "f4e9edf4aea02d38471eb82da9d80c63cf208bad8af9a0bef910615e4e629701";
+      sha256 = "8129602f5cfa38743608d6e49f6226654f9342111a6acbe78db23bb959781d4d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/es-CL/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/es-CL/Firefox%20151.0.dmg";
       locale = "es-CL";
       arch = "mac";
-      sha256 = "4aa6c514462a56e22c6b426b431de9c32e0349a9670bda4184a84ae621eeb89e";
+      sha256 = "daf2793a2592caa18c828f988b5d1619af175548998c9cf2fd4f5043e18b7961";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/es-ES/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/es-ES/Firefox%20151.0.dmg";
       locale = "es-ES";
       arch = "mac";
-      sha256 = "82773c9fd996c73cd6e05680f2cf3ae7c9f12b5516c30cd21225d06f81e8cf67";
+      sha256 = "ba86083477a736ef1f0fa524e246b1585dc67ed47b2fd78b3aba287504f87972";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/es-MX/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/es-MX/Firefox%20151.0.dmg";
       locale = "es-MX";
       arch = "mac";
-      sha256 = "e7f3fa4b2345686320f1435aa3daa4fdb2caf0f4504f3e22f7b8c3f8b516cc83";
+      sha256 = "3f775b73be767c849d6be8d7c73241f94b42feddb1b47cdb8aa1ed505c1de70c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/et/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/et/Firefox%20151.0.dmg";
       locale = "et";
       arch = "mac";
-      sha256 = "6b5b0d5868361bf749566a3ee95f05726b8a9520f3fa8f49f19cb232eac98113";
+      sha256 = "c6c693338ef422c671e0efc1196ec9d1c7aae91636f374890fdec06766492f59";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/eu/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/eu/Firefox%20151.0.dmg";
       locale = "eu";
       arch = "mac";
-      sha256 = "770930621d030d269d6c63c257df8658d2166492bd919b31b3085a422e27bccc";
+      sha256 = "e5428751b2dface5a8832d24e4f7b38934eb45841dba78081c3f1ef36138a3fd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/fa/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/fa/Firefox%20151.0.dmg";
       locale = "fa";
       arch = "mac";
-      sha256 = "4914bc4051c3b6f874a776c753286bfb4e40d0745e81e884c6aaab6d1383c98f";
+      sha256 = "f6e6c6bd4c17586a6a4e344549ecf23967fd441eee47d2c3e23d97c5c045dbdc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/ff/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ff/Firefox%20151.0.dmg";
       locale = "ff";
       arch = "mac";
-      sha256 = "af896a691d5b553af37ab0f93fe35ec8d6b39ddee02a03f021d103ca8243835c";
+      sha256 = "74dc9142a8a5265e0641c5d5ae089c8235494c832c4b3a15ff09936983e1e1df";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/fi/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/fi/Firefox%20151.0.dmg";
       locale = "fi";
       arch = "mac";
-      sha256 = "d8a835962ec3e686a352fbfb1233a16df5cdbdc92b609d4fb3e096186c6c1d39";
+      sha256 = "54d1871001103db13cbef39663d0ac4ac41331f38eef2610a8d06eeeb40d06b9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/fr/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/fr/Firefox%20151.0.dmg";
       locale = "fr";
       arch = "mac";
-      sha256 = "72e51bf0646850992ca8c32f6c3e8ce39dcc84c8a22ab4cd7b03d4ac69a58095";
+      sha256 = "2945ac1a35e68af52bd2bdb74fb59ddee58cce3abb160bdc694e7064ebcff603";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/fur/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/fur/Firefox%20151.0.dmg";
       locale = "fur";
       arch = "mac";
-      sha256 = "27d41d26843037ef5502720800b8c6da817034b95b5f45c875c4bf550834333d";
+      sha256 = "ee76ab05b432cb78775bd9cca54a5fe905a08cbdb42e1f06764f7f296a4c0b0e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/fy-NL/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/fy-NL/Firefox%20151.0.dmg";
       locale = "fy-NL";
       arch = "mac";
-      sha256 = "926ee5ce083e36b8a4281a5f7c8701a5a59df81ae5528e1d78d3959f99faa935";
+      sha256 = "cd2d505f1741ce5f7d2200f5c2517e6f7f63d1f340ea376cdf5a8c8e9f5039a5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/ga-IE/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ga-IE/Firefox%20151.0.dmg";
       locale = "ga-IE";
       arch = "mac";
-      sha256 = "7eb2bce5237ca16ef9b5efe779db8ba971b359585dda4aed5c545dd4e9ba6d33";
+      sha256 = "cc8c74663db69d805c23da0856346e597b4bbcd251b3b52a728d9d8c129fe613";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/gd/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/gd/Firefox%20151.0.dmg";
       locale = "gd";
       arch = "mac";
-      sha256 = "a9a930725ab54c733c69fa06c225fe5c3777c7bc7d93da7f6a105e942584702b";
+      sha256 = "dcb0b2764b3fa3e93e528a05aaa03cabc39253840e18be466405a025b1c0575e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/gl/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/gl/Firefox%20151.0.dmg";
       locale = "gl";
       arch = "mac";
-      sha256 = "37ae24543295bc361bfa0f795362ddc0758f9b55cd82c61654215af1b5d64861";
+      sha256 = "c1e820cedc7afd360c557b8224c53f4159192fd832fd2b038beeb6ba93c2c031";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/gn/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/gn/Firefox%20151.0.dmg";
       locale = "gn";
       arch = "mac";
-      sha256 = "b40090fc93099d9d52c23a65b3e9fc5566c29b06cea88029ee6e889622a7933b";
+      sha256 = "df38dafe76adf333ed0e81a9d9e7bc97bd910cebd79ad6da32f5eaeb425fd98a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/gu-IN/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/gu-IN/Firefox%20151.0.dmg";
       locale = "gu-IN";
       arch = "mac";
-      sha256 = "83da49cd4b1476f4e3ee2219359aa074f9af3dec5a25108aff43db2c333ad6d6";
+      sha256 = "26d84919cdd099354972323eea2b64208192caa27f8fa0f69b0db2335fa18815";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/he/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/he/Firefox%20151.0.dmg";
       locale = "he";
       arch = "mac";
-      sha256 = "cfe9ab63e4804a6812d337dde73a9262794d908810b9ea369f33dadfe9b4a7f5";
+      sha256 = "494c384d75c51522cdc5217ecc29a35f098f198a28da6a23eff63227cacb153b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/hi-IN/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/hi-IN/Firefox%20151.0.dmg";
       locale = "hi-IN";
       arch = "mac";
-      sha256 = "ad1b35ed3168b36f5f0f4760f74330e63c6e49efd8a74861f8190d9ce5f6e950";
+      sha256 = "9064ab85dc7a42948451b9e150b4585c47d4089e7f146de8f16b1792bc443d67";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/hr/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/hr/Firefox%20151.0.dmg";
       locale = "hr";
       arch = "mac";
-      sha256 = "e02958f7a01985c60594aef5695380ffcda616002cc5b7b018de5ed6ae06a636";
+      sha256 = "22ab7c8e498aaa52f2fa7663c6192909eb6cb405bd798c8ef35c03c8ee2e2069";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/hsb/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/hsb/Firefox%20151.0.dmg";
       locale = "hsb";
       arch = "mac";
-      sha256 = "724e2539c3745281b1f192561fec68cf0914dfdc39ababee6822a7515e65146b";
+      sha256 = "72d2c2f7039cb69a42d2d01c82fedc2ca554e52efc99c0b3b7268f4c4c4642f1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/hu/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/hu/Firefox%20151.0.dmg";
       locale = "hu";
       arch = "mac";
-      sha256 = "d9df70f955e3cf5b4b03103b55bb37643f16f45f97f85cf4899504ecc959556d";
+      sha256 = "1327fab2b176372242def645c46959f8febde709d6a299ddd919c6cc38000aab";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/hy-AM/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/hy-AM/Firefox%20151.0.dmg";
       locale = "hy-AM";
       arch = "mac";
-      sha256 = "185f9577a3586b41da331e8644f6ee9c6e994351eddf1120bfc252fbb5b00734";
+      sha256 = "bf05209da18f1d4663060f3c42f52c0314e9984fe00a2b2f138ce25697f08180";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/ia/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ia/Firefox%20151.0.dmg";
       locale = "ia";
       arch = "mac";
-      sha256 = "3110216636adbfc604cf0f5a090f2eb01865950cc28ed8a415c79dc76777e7d5";
+      sha256 = "5610bc3dd092016a20bfd5c7940ef91290849e62483307741b5beb743240e9b9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/id/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/id/Firefox%20151.0.dmg";
       locale = "id";
       arch = "mac";
-      sha256 = "0b7ee8aba93743ef892544438c4ad576d41215b80e555c72803d9ad8510123b6";
+      sha256 = "de75e525827afa8c03fa62ded7780ba5f4e3ce180c0de1242b77be2740969f67";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/is/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/is/Firefox%20151.0.dmg";
       locale = "is";
       arch = "mac";
-      sha256 = "fe63d0e97bf99d2d6c0a2af0e48b16a80b8c862089f77fbc38604ed03300641a";
+      sha256 = "3591c354f0975e79913a69ff048485b1249ff414455c0c5ba13410a21c1e3b74";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/it/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/it/Firefox%20151.0.dmg";
       locale = "it";
       arch = "mac";
-      sha256 = "c32bb7add419622fa307550d18ad0aeeac7a8847df6985d92497b43ed5f15507";
+      sha256 = "9cf1462c22df347a242c92dae5d153ee1ddfd42ebee1dca034a0ef34d997280b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/ja-JP-mac/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ja-JP-mac/Firefox%20151.0.dmg";
       locale = "ja-JP-mac";
       arch = "mac";
-      sha256 = "901a19dbe4ee46adbba5449945a3a62e6417f2570a95206dbb07f271445cf729";
+      sha256 = "a67be8388093814c626245ce0ea734e8b5a53f4ccbba48b89de311ba71d43ec8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/ka/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ka/Firefox%20151.0.dmg";
       locale = "ka";
       arch = "mac";
-      sha256 = "9a1dffc9ce781bc55f438ea43821af4c00a9ed92ba0996008aa6f2b180e684a6";
+      sha256 = "adf1a3db37bb1f7a744b0a7cb135a819eb94c0a6caf8496d69bac538be4fe268";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/kab/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/kab/Firefox%20151.0.dmg";
       locale = "kab";
       arch = "mac";
-      sha256 = "ea417a9de5abf8bbc1837918b9daedde5bcb979f0c70d2254fecaa88e703ed5c";
+      sha256 = "3d8ead23bb995c813cb304ea50a38e4afc0fca0d6b831471e9271951813df3f6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/kk/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/kk/Firefox%20151.0.dmg";
       locale = "kk";
       arch = "mac";
-      sha256 = "71bdb3b9018c91d7e95b07e31dc7aabbef10e4cd0ca1942ef744f00cd46d08e6";
+      sha256 = "b45cf0fd8f0be04696760fb611741f73699cf082475a978aff67d11c8b3a5972";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/km/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/km/Firefox%20151.0.dmg";
       locale = "km";
       arch = "mac";
-      sha256 = "37ca745cf17225e93e762335941b1d8f4dcf8a451aa35fada56d83536cc6e47c";
+      sha256 = "0c2f3d9fe97fae3e821c31f8a8c3a090002d846f8d02137ed86f1fac582bb7fb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/kn/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/kn/Firefox%20151.0.dmg";
       locale = "kn";
       arch = "mac";
-      sha256 = "d12f4a7e78443401d49b05126eb7ca68c03a1c4ed0c00a0e4b0c8f8c04fd9391";
+      sha256 = "a8047cb9522f2409c602615395dad280a4a32f196d8dca06c42ecf20d213e47b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/ko/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ko/Firefox%20151.0.dmg";
       locale = "ko";
       arch = "mac";
-      sha256 = "7cda3e9460d47bb4c157b6b4ef53f6b5cea232c2792afffd8d0e36b59c1e57c3";
+      sha256 = "621da9205b74cd355981a24e11b543ba722f27d29d74156ce5cd5e0a9a90ca7f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/lij/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/lij/Firefox%20151.0.dmg";
       locale = "lij";
       arch = "mac";
-      sha256 = "5422f51a5601f7c8fe83297718c37047c445ad17e285fb6dde6a90b72f3ea9be";
+      sha256 = "c165dba6a98a0f0bd2d48f818629b44399e8d291214d6ba839a6f6958dab40f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/lt/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/lt/Firefox%20151.0.dmg";
       locale = "lt";
       arch = "mac";
-      sha256 = "b3e3d297c92344c887bf5afe44b2bf22329952c9185fd2023245d330741cf985";
+      sha256 = "70fdfc57cfa3b0ad1d57bc5ce579d2954165926e63313e04b771b22036242f3d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/lv/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/lv/Firefox%20151.0.dmg";
       locale = "lv";
       arch = "mac";
-      sha256 = "b01354ae7740de84b79ee856177a13a18fc3ee3d3327e9a618d75ed360dcd14b";
+      sha256 = "e90b1aa53118af4d3046792837b58fe65fce664da1767727946e441a91ddf1fc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/mk/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/mk/Firefox%20151.0.dmg";
       locale = "mk";
       arch = "mac";
-      sha256 = "6baf5e0ebb48e3d5132a8dcdc98c3f69825a7bc43761c487fdcc5cb3db0eacf7";
+      sha256 = "f9e174c7311bd790b02f1e021c844f8c3e2ac7ac265daf058fd28bbf7ff62595";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/mr/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/mr/Firefox%20151.0.dmg";
       locale = "mr";
       arch = "mac";
-      sha256 = "7b6b3622edf010b37a063046668bdafd756a6a63243beb3c8923aec2f54cfd0a";
+      sha256 = "86535dc3590026331e65d0a3f8694516ce1b63fe7f14a4ccbf58409092aa5e9d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/ms/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ms/Firefox%20151.0.dmg";
       locale = "ms";
       arch = "mac";
-      sha256 = "22a92621ae75cc55d6e279536fe2c2563f09b27c6656012b075ffdd124be3d2c";
+      sha256 = "770d89f8cc096bfae6a4180cbb4e19bd825969d15df507d94d47d02ec9138548";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/my/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/my/Firefox%20151.0.dmg";
       locale = "my";
       arch = "mac";
-      sha256 = "85d3b1800e689e59e39613c9bb63114cc8b2df179e60361d6190deb3d65be2ad";
+      sha256 = "5045dd5fe643b89c53a9b9a3613e5ea3151b156c2d72746194a1157289812b37";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/nb-NO/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/nb-NO/Firefox%20151.0.dmg";
       locale = "nb-NO";
       arch = "mac";
-      sha256 = "e663a126591a1f9b47de2f71ec86e94b9e1d0b621db467dec5a8d2152fb9ecb5";
+      sha256 = "504c14ac25a53f2bd2bf05313deee0041451298b17feb2c1edc4d48ac9272f24";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/ne-NP/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ne-NP/Firefox%20151.0.dmg";
       locale = "ne-NP";
       arch = "mac";
-      sha256 = "402d1401776ccb5db7ec837186cc37424f7f222d84f7ba91bed481ca38a72e0f";
+      sha256 = "c7654eaaa3d5b688a15e362d9b6e9585a8fa694fcae5792554a9fe76ea02d89d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/nl/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/nl/Firefox%20151.0.dmg";
       locale = "nl";
       arch = "mac";
-      sha256 = "891bb5f1c7d1ea14bc9f51156749b03eaa94e2875a64c31d61e62007a0ce3609";
+      sha256 = "86e00a8576dfc96a24dd8665429fba11fa5ae5dc27dd167f933c18aabe556b70";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/nn-NO/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/nn-NO/Firefox%20151.0.dmg";
       locale = "nn-NO";
       arch = "mac";
-      sha256 = "770e0fabedd7439bb1b826b97e118a9ed64e2f269945661d84e5dbf84f0892af";
+      sha256 = "b8464fa7815ddf1bb973d17886508963933155babcda7de34ef9ff0c6d9ea916";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/oc/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/oc/Firefox%20151.0.dmg";
       locale = "oc";
       arch = "mac";
-      sha256 = "2a23add47b0d2e7350e4a6d04984bdb0b00fafc338121a0e61003f5e319a5faa";
+      sha256 = "0c8c12574a6d828192a4de214b8f3e6a756ab639973269513f7923ff3e5fa434";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/pa-IN/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/pa-IN/Firefox%20151.0.dmg";
       locale = "pa-IN";
       arch = "mac";
-      sha256 = "85a207f03caa2d95bcf830453e8fa5d0f73629843926677c1e8d6186251df52d";
+      sha256 = "876e6d2171eb62635c4367e3128820e95f0cb3aec515cf012e7107d08b45ce3f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/pl/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/pl/Firefox%20151.0.dmg";
       locale = "pl";
       arch = "mac";
-      sha256 = "961442a2fd5b94fdbfc51b933d61771c4214db204d0e55ef21393bdc62fa22f1";
+      sha256 = "7e86dc6d6694d904f8171733a28aed0765a87a647bb4e5a10ace3bcaa08448e5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/pt-BR/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/pt-BR/Firefox%20151.0.dmg";
       locale = "pt-BR";
       arch = "mac";
-      sha256 = "ac6be7f9ee80d5875450b4420ed84609359830d400b3011fb24b04d841129709";
+      sha256 = "f88ab74590262ab6e1bcc2535e3b868314ee796f9609c44eacadba3eb99f91ae";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/pt-PT/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/pt-PT/Firefox%20151.0.dmg";
       locale = "pt-PT";
       arch = "mac";
-      sha256 = "97f1b97c11c233a0a3bf2500abf6166c540e1b076642c5a136c057677c01455a";
+      sha256 = "c342cb4d4d3df34ef828da83a2546f33c759dc7c6d1c04d0394686a78bee690b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/rm/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/rm/Firefox%20151.0.dmg";
       locale = "rm";
       arch = "mac";
-      sha256 = "0ce80f7ade8ed4118f84be6091376efb64c37182f1c4804c04bbe0fdd1f62886";
+      sha256 = "122b5a994623c84e693c35498f4b36773cb76d32b3cd235b2ad04789ce252796";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/ro/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ro/Firefox%20151.0.dmg";
       locale = "ro";
       arch = "mac";
-      sha256 = "7f743a18dd74829b30bea2dd3628bc0399828eb05bde59b96eef4f7bd57ff5d2";
+      sha256 = "ae0a2867d250c02f7776afd9a8887d4654289eb36c0ad23945f30e7948ecfbf6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/ru/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ru/Firefox%20151.0.dmg";
       locale = "ru";
       arch = "mac";
-      sha256 = "ac473a9f9a5c20c047adf8d2f3d5a1763e4c50b2741a7b71fa2612b1eec4efbd";
+      sha256 = "244c044943ff9591226a2c92515a15e09253e7068525a5f7cb24936e2a2f847f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/sat/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/sat/Firefox%20151.0.dmg";
       locale = "sat";
       arch = "mac";
-      sha256 = "cc2980f8672f373cd6696abeaedc7097eff260e854a0e8bce369d6c045120644";
+      sha256 = "a5e29a336d1f81b3d3a75bd59513beb9e3c5850c4f491b04e93e36b46012a43e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/sc/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/sc/Firefox%20151.0.dmg";
       locale = "sc";
       arch = "mac";
-      sha256 = "039a17f7bb6c873a6a0de6dace38e3df347142197565377f4643ff22661e3ce0";
+      sha256 = "335b9b760f23d8d0c4e9933f3e8746cf4e247e75774e01eda6bc88e4384c0072";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/sco/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/sco/Firefox%20151.0.dmg";
       locale = "sco";
       arch = "mac";
-      sha256 = "68730269b06ca731c9d1f9cbc6ab82a91372bc494e0b1023a37d9fa82e11c8e0";
+      sha256 = "fccbaf475e1ba4b5644c64bc8e5f4a7a88dfb1141fb0f6327f20c50983c84157";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/si/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/si/Firefox%20151.0.dmg";
       locale = "si";
       arch = "mac";
-      sha256 = "822777516a694b414a35712bf61f39b101db561ff2f0e448466ff4c0345f0d2a";
+      sha256 = "0d03aa6b67c7962090bbed14e62dd9d1a63e44a0338fb9381375620f41040258";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/sk/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/sk/Firefox%20151.0.dmg";
       locale = "sk";
       arch = "mac";
-      sha256 = "6863372b22c2d76b01671a6242dafe9647c6d2fbd2c9dcfe54bbe93a6121cff4";
+      sha256 = "3b7e1c53d442480f5a50afc87cef5953d94699644b98f8746e781a281714f548";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/skr/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/skr/Firefox%20151.0.dmg";
       locale = "skr";
       arch = "mac";
-      sha256 = "029aa8558c6f560ce4637c43d7fc086eaaeab986a3e2c92dbc7378a483c36d5b";
+      sha256 = "421feade271b0aca61414fd055f51325a13bf54d437a2621a46a324c6a41adb0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/sl/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/sl/Firefox%20151.0.dmg";
       locale = "sl";
       arch = "mac";
-      sha256 = "bab7a494619596c4cda635cea3732380ed2ce34e8fc15f53921f8baa87e4c9cc";
+      sha256 = "e174fb1265627a40caea4108cca38bac85e46a1823632535c921c957f8361e45";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/son/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/son/Firefox%20151.0.dmg";
       locale = "son";
       arch = "mac";
-      sha256 = "ac913600795043b745984fde40e4d950fd2aeceeb7d4e1d866bd2d7066602de6";
+      sha256 = "a29eb1bc927328a78584fc8f117c58e604fcba36905d4abba74100e52d4a57e4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/sq/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/sq/Firefox%20151.0.dmg";
       locale = "sq";
       arch = "mac";
-      sha256 = "c5c9dec59bdc67f0cbe058087e1eae42676ee9957f9719815e061b4daefc2c90";
+      sha256 = "c9073770bc330544949f0f901112739bfe888a41af3749375a2ea7038b8f3e6e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/sr/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/sr/Firefox%20151.0.dmg";
       locale = "sr";
       arch = "mac";
-      sha256 = "1c3080670f7818f2eb608672ed54e65ad779fceffefe752aaa145c370b5cae80";
+      sha256 = "74607510bb2575113c821e56607e62827717e06870b8666bf6ef663bb4daec5c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/sv-SE/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/sv-SE/Firefox%20151.0.dmg";
       locale = "sv-SE";
       arch = "mac";
-      sha256 = "ea551e72ffb100d4752670749e91140a41ad6dd51a2fb525ae7b77ee147f1cc3";
+      sha256 = "4e76f9aa8133041935eff88ee21b5adc8ffe15f02252ad8673e3ecb99377ed70";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/szl/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/szl/Firefox%20151.0.dmg";
       locale = "szl";
       arch = "mac";
-      sha256 = "21f77eb96ae1919fb6962710d1d29a2fb0ffb98c98a9aca1afb2113caee6f099";
+      sha256 = "3e7d86c71324b143d5762f10bde04f4d0b895fbde28e4b21dedcfcea0a180f4e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/ta/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ta/Firefox%20151.0.dmg";
       locale = "ta";
       arch = "mac";
-      sha256 = "3501bd6cb767caca3c1f6a757798a4bc3455581c9dac914f2fa7cc046d6d1585";
+      sha256 = "0aaca54a0ee8102bc0299e4cab82ee8a670dc51f0e73bdcd4c2de08324a201ef";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/te/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/te/Firefox%20151.0.dmg";
       locale = "te";
       arch = "mac";
-      sha256 = "bd8218021ffdce5e463fc3ebebf74847b5af2d5e147697342ed8b4a363796fa4";
+      sha256 = "b49fda7de1e4c0c95fb5d698a28047f04b0f15690a55871f5f36621d857281c5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/tg/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/tg/Firefox%20151.0.dmg";
       locale = "tg";
       arch = "mac";
-      sha256 = "dae25caf5ee31d427ebad3770a1bb8d08e0c1006d22c91714913063fa71c52bd";
+      sha256 = "8f12714be8dc4c81b5f6c1eeb33ffe7725e007d8edee0ab53b9326aa2c5071d1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/th/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/th/Firefox%20151.0.dmg";
       locale = "th";
       arch = "mac";
-      sha256 = "489ff8653146a3402e1c6fb0b8744fc2fa81b3b623b74a60398b7cf6e4e5bd9e";
+      sha256 = "80a4d667c786351e4d04a780d6a6831e22ec8b80037581812c68198885311977";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/tl/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/tl/Firefox%20151.0.dmg";
       locale = "tl";
       arch = "mac";
-      sha256 = "5ba52d4da7ec57dddbc018ea804dda9c3fc8d8fa6a4a2e3a865323eb1b1cb27d";
+      sha256 = "294263d9357a91402efd918b79d2e92bc2636466f854cab9d410805204a3dcba";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/tr/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/tr/Firefox%20151.0.dmg";
       locale = "tr";
       arch = "mac";
-      sha256 = "f42fbfc00a13bdb29e8b0559adf301982b8f2b83ea9f9614b133a199fc17657c";
+      sha256 = "1a22023cc6a4cecc08b04bc22839cc8bc01bb4d9fb28d4239073184dd9ae6964";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/trs/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/trs/Firefox%20151.0.dmg";
       locale = "trs";
       arch = "mac";
-      sha256 = "e8c9d7e3b9388626d49a0db946ced95976df466767255a3bfadda2e73ef4d254";
+      sha256 = "b18b06eae54c6652c208396458396c8ead950834915a88a6488862348c9dd3d0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/uk/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/uk/Firefox%20151.0.dmg";
       locale = "uk";
       arch = "mac";
-      sha256 = "58c5c1bab11a3d7fc71bfd378e550b73af0603de46bfa2321c87f2f7949ed57f";
+      sha256 = "ee44556242a0cac4a0dcb1d5b007671efca606332ff0b1243fca47aaba2a3546";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/ur/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ur/Firefox%20151.0.dmg";
       locale = "ur";
       arch = "mac";
-      sha256 = "f2eff77673038ca84605b9d97c9e26f47af4f496beec66f78111f937da91db3a";
+      sha256 = "1be4f462041efe4c60436b4ad09b6527b88d067e22a174211a327f8da5a731c4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/uz/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/uz/Firefox%20151.0.dmg";
       locale = "uz";
       arch = "mac";
-      sha256 = "bc5dc6aac0072857184a523836625eb719942171f8a66c9e639d116f5b09eab3";
+      sha256 = "207de25a1f96078edb35740833460b353e2420c7d298563a6253c24622fddc71";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/vi/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/vi/Firefox%20151.0.dmg";
       locale = "vi";
       arch = "mac";
-      sha256 = "e65af322e7d097b3cd1b82fd5859cc6600a181e1334a3d36f8e7b2ab978b3525";
+      sha256 = "e85b424cd12810f18763820917015fe3cbb2c676601a0acf75fb174512eede81";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/xh/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/xh/Firefox%20151.0.dmg";
       locale = "xh";
       arch = "mac";
-      sha256 = "ae8861a01f24f03ec3cd45c300f7a2cd180a2d397b6f84e504ec64a732839d48";
+      sha256 = "67a8917b40174c3ec119d4a6409460074436dd304a4d146fcf32f6e1f4e77348";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/zh-CN/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/zh-CN/Firefox%20151.0.dmg";
       locale = "zh-CN";
       arch = "mac";
-      sha256 = "9d87f092b3763947aa2a3ac5921742c8f4fd1e20eda9a297b15593142a7c815c";
+      sha256 = "0b5dbff8b10723780f6fd8cf269b249821c1bfd8b405180aefadf42276e2dbb7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.3/mac/zh-TW/Firefox%20150.0.3.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/zh-TW/Firefox%20151.0.dmg";
       locale = "zh-TW";
       arch = "mac";
-      sha256 = "9b920ba0ce9fa04f2be5b4469a69443f1700df3edd13b03447dfa778c07a5d92";
+      sha256 = "8723fddad3820f5b2ff3d4e5f25d75b52de0434e1243324902f09f101d7d862f";
     }
   ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages/firefox-esr-140.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages/firefox-esr-140.nix
@@ -9,11 +9,11 @@
 
 buildMozillaMach rec {
   pname = "firefox";
-  version = "140.10.2esr";
+  version = "140.11.0esr";
   applicationName = "Firefox ESR";
   src = fetchurl {
     url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-    sha512 = "bda7d5e6d59a2ad310e3f3e6e8ec05c78222edce266671d5d454dfa3e8f0086add3b9c0099db907cb62b2587ed47026ba7b3aa4f0406693d142d8d91b818d551";
+    sha512 = "d06adb3ef4de1324e3d61872d70de31ab08ac013f33903549bed28c6ebcc5b4dee94bb36388282c1935d77d1a564079f3adbf08d6bb80284a899cbb3d861300c";
   };
 
   meta = {

--- a/pkgs/applications/networking/browsers/firefox/packages/firefox.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages/firefox.nix
@@ -9,10 +9,10 @@
 
 buildMozillaMach rec {
   pname = "firefox";
-  version = "150.0.3";
+  version = "151.0";
   src = fetchurl {
     url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-    sha512 = "8452da61200f8ee66790d3fff230ca84b2ac9291af2b57e018486c50f938c53c6fb4943fe6cfe1e99b9783466fb00bf707fa006293753ac698618fc1e3b70a4a";
+    sha512 = "5e6b01236c6aad17889c1d33614637a13e41d659c3306b2dadf13ab50d91a36d1269fae6d405d31351e4defe589f47f31c0798b66ad87438720f5779bcb90401";
   };
 
   meta = {


### PR DESCRIPTION
https://www.firefox.com/en-US/firefox/151.0/releasenotes/
https://www.firefox.com/en-US/firefox/140.11.0/releasenotes/

Backport of #521564

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
