### PR TITLE
plymouth: 24.004.60 -> 26.134.222

### DIFF
--- a/pkgs/by-name/pl/plymouth/package.nix
+++ b/pkgs/by-name/pl/plymouth/package.nix
@@ -25,7 +25,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "plymouth";
-  version = "24.004.60";
+  version = "26.134.222";
 
   outputs = [
     "out"
@@ -36,8 +36,8 @@ stdenv.mkDerivation (finalAttrs: {
     domain = "gitlab.freedesktop.org";
     owner = "plymouth";
     repo = "plymouth";
-    rev = finalAttrs.version;
-    hash = "sha256-9JmZCm8bjteJTQrMSJeL4x2CAI6RpKowFUDSCcMS4MM=";
+    tag = finalAttrs.version;
+    hash = "sha256-TarN9NLWzYmE9GS/rtaa0w8SVOES86sUMZWbnsgRDHY=";
   };
 
   patches = [
@@ -48,13 +48,6 @@ stdenv.mkDerivation (finalAttrs: {
     # fix FHS hardcoded paths
     (replaceVars ./fix-paths.patch {
       fcmatch = "${fontconfig}/bin/fc-match";
-    })
-
-    # fix build without udev, see https://gitlab.freedesktop.org/plymouth/plymouth/-/merge_requests/382 - drop on next release
-    (fetchpatch {
-      name = "fix-build-without-udev.patch";
-      url = "https://gitlab.freedesktop.org/plymouth/plymouth/-/commit/f1ce78764482699b28f60c89af1a071ea0ae13ca.patch";
-      hash = "sha256-t5xt/scO8mVwESU8pFPTSXILd0FhmG/XRZ8O/4baQB8=";
     })
   ];
 


### PR DESCRIPTION
Release notes: https://gitlab.freedesktop.org/plymouth/plymouth/-/tags/26.134.222

## Things done

I've rebooted with this version of plymouth (with a password-protected LUKS volume) and everything seems to work correctly.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test