### PR TITLE
halide: backport upstream simd_op_check_x86 zen4/zen5 fix

### DIFF
--- a/pkgs/by-name/ha/halide/package.nix
+++ b/pkgs/by-name/ha/halide/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   llvmPackages,
   fetchFromGitHub,
+  fetchpatch2,
   cmake,
   flatbuffers,
   libffi,
@@ -36,6 +37,19 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-A5EnZgXc9+L+bzWHftaL74nHmP8Jf0rnT5KJAAWvKis=";
   };
+
+  patches = [
+    # Backport: properly initialize bf16 inputs in simd_op_check.
+    (fetchpatch2 {
+      url = "https://github.com/halide/Halide/commit/acb58504f0ce02e07b8b9008668c8779d3561ec8.patch?full_index=1";
+      hash = "sha256-n9avTYe8JFYQKeJQBQQV9xoOoYp0imXD2GQgifRym/A=";
+    })
+    # Backport: add Zen4/Zen5/AVXVNNI feature flags to simd_op_check's can_run_code.
+    (fetchpatch2 {
+      url = "https://github.com/halide/Halide/commit/1b9be55dfaa162fad6a3ed3c6e8d83f966ce8af1.patch?full_index=1";
+      hash = "sha256-5f6Q2Q1pvimlFV3lCcMzIHMIze6A8TmnMjVpQ8/ceyg=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace src/runtime/CMakeLists.txt --replace-fail \


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/328835024)](https://hydra.nixos.org/build/328835024)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
