### PR TITLE
tomb: build extras/kdf-keys

### DIFF
--- a/pkgs/by-name/to/tomb/package.nix
+++ b/pkgs/by-name/to/tomb/package.nix
@@ -12,11 +12,12 @@
   gnupg,
   lib,
   libargon2,
+  libgcrypt,
   lsof,
   makeBinaryWrapper,
   nix-update-script,
   pinentry-curses,
-  stdenvNoCC,
+  stdenv,
   util-linuxMinimal,
   versionCheckHook,
   zsh,
@@ -41,7 +42,7 @@ let
   ];
 
 in
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tomb";
   version = "2.13";
 
@@ -55,6 +56,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ makeBinaryWrapper ];
 
   buildInputs = [
+    libgcrypt
     pinentry-curses
     zsh
   ];
@@ -68,11 +70,20 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     sed -i 's/VERSION=".*"/VERSION="${finalAttrs.version}"/' tomb
   '';
 
+  buildPhase = ''
+    runHook preBuild
+
+    make -C extras/kdf-keys
+
+    runHook postBuild
+  '';
+
   installPhase = ''
     runHook preInstall
 
     install -D -m755 -t $out/bin tomb
     install -D -m644 -t $out/share/man/man1/ doc/tomb.1
+    make -C extras/kdf-keys DESTDIR=$out PREFIX= install
 
     wrapProgram $out/bin/tomb \
       --prefix PATH : $out/bin:${lib.makeBinPath runtimeDependencies}


### PR DESCRIPTION
https://github.com/dyne/Tomb/blob/master/INSTALL.md#extraskdf-keys

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
