### PR TITLE
marimo: 0.21.1 -> 0.23.6

### DIFF
--- a/pkgs/development/python-modules/marimo/default.nix
+++ b/pkgs/development/python-modules/marimo/default.nix
@@ -20,6 +20,7 @@
   pygments,
   pymdown-extensions,
   pyyaml,
+  pyzmq,
   ruff,
   starlette,
   tomlkit,
@@ -31,13 +32,13 @@
 }:
 buildPythonPackage rec {
   pname = "marimo";
-  version = "0.21.1";
+  version = "0.23.4";
   pyproject = true;
 
   # The github archive does not include the static assets
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-0YzuyKyptOHe9gJH4avi/sR2q+71Hi0NXRB56jf4b1U=";
+    hash = "sha256-jl8b14pzywTXdeZQRzz6t0UwO+dG8UGjZU3NJG3ipOY=";
   };
 
   build-system = [ uv-build ];
@@ -56,6 +57,7 @@ buildPythonPackage rec {
     pygments
     pymdown-extensions
     pyyaml
+    pyzmq
     ruff
     starlette
     tomlkit

--- a/pkgs/development/python-modules/marimo/default.nix
+++ b/pkgs/development/python-modules/marimo/default.nix
@@ -32,13 +32,13 @@
 }:
 buildPythonPackage rec {
   pname = "marimo";
-  version = "0.23.4";
+  version = "0.23.6";
   pyproject = true;
 
   # The github archive does not include the static assets
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-jl8b14pzywTXdeZQRzz6t0UwO+dG8UGjZU3NJG3ipOY=";
+    hash = "sha256-1jru7h6ep8rHm/JTDaupFRmRU9zk0Vb63nVGR0Z508o=";
   };
 
   build-system = [ uv-build ];


### PR DESCRIPTION
Supersedes #511368 — squashes @zeshi09's three commits into a single correctly-titled commit (authorship retained) and bumps further to 0.23.6.

Changes:
- `marimo: 0.21.1 -> 0.23.4` (squashed from #511368, adds `pyzmq` dependency)
- `marimo: 0.23.4 -> 0.23.6`

## Things done

- Built on platform:
  - [x] x86_64-linux
- [x] Tested basic functionality

cc @zeshi09