### PR TITLE
[staging-next] nixos/system: fix build with structuredAttrs

### DIFF
--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -42,7 +42,7 @@ let
 
     ${config.system.systemBuilderCommands}
 
-    printf "%s" "$extraDependencies" > "$out/extra-dependencies"
+    printf "%s " "''${extraDependencies[@]}" > "$out/extra-dependencies"
 
     ${optionalString (!config.boot.isContainer && config.boot.bootspec.enable) ''
       ${config.boot.bootspec.writer}

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -410,7 +410,7 @@ in
             ln -s ${config.hardware.deviceTree.package} $out/dtbs
           ''}
 
-          echo -n "$kernelParams" > $out/kernel-params
+          echo -n "''${kernelParams[@]}" > $out/kernel-params
 
           ${optionalString config.boot.initrd.enable ''
             ln -s ${initrdPath} $out/initrd


### PR DESCRIPTION
Fixes two problems caused by enabling structuredAttrs in the system builder:

1. `echo -n "$kernelParams"` would only print the first kernel parameter in the list.
2. `printf "%s" "$extraDependencies"` would only print the first extra dependency in the list.

This fixes the following NixOS tests (only tested on `x86_64-linux`):

- `nixosTests.installer.lvm`
- `nixosTests.installer.separateBoot`
- `nixosTests.installer.simple`
- `nixosTests.installer.simpleUefiSystemdBoot`
- `nixosTests.ipv6`
- `nixosTests.misc`
- `nixosTests.predictable-interface-names.unpredictable`
- `nixosTests.predictable-interface-names.unpredictableNetworkd`
- `nixosTests.predictable-interface-names.unpredictableNetworkdSystemdStage1`
- `nixosTests.predictable-interface-names.unpredictableSystemdStage1`

## AI policy

An LLM was used to diagnose the root cause of the installer tests failures (problem number 2). The relevant commit has the `Assisted-by` trailer. 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
