### PR TITLE
netcap: 0.6.11 -> 0.9.0

### DIFF
--- a/pkgs/by-name/ne/netcap/ndpi_4_14.nix
+++ b/pkgs/by-name/ne/netcap/ndpi_4_14.nix
@@ -11,12 +11,12 @@
 
 ndpi.overrideAttrs (
   finalAttrs: prevAttrs: {
-    version = "4.0";
+    version = "4.14";
 
     src = fetchFromGitHub {
       inherit (prevAttrs.src) owner repo;
       tag = finalAttrs.version;
-      hash = "sha256-vWx6IVyxPJBgOkXpHdnvstvDGJbAtndFPtowpjLd32o=";
+      hash = "sha256-W8ZBWMQH6bRHl+fXmG3XLO37UxEnSgCVCgzfwy8N+OM=";
     };
 
     configureScript = "./autogen.sh";

--- a/pkgs/by-name/ne/netcap/package.nix
+++ b/pkgs/by-name/ne/netcap/package.nix
@@ -8,32 +8,63 @@
   libprotoident,
   libflowmanager,
   libtrace,
+  ndpi,
+  pkg-config,
+  protobuf,
+  protoc-gen-go,
+  yara-x,
   versionCheckHook,
   nix-update-script,
 }:
 let
-  ndpi = callPackage ./ndpi_4_0.nix { };
+  ndpi_4_14 = callPackage ./ndpi_4_14.nix { };
 in
 buildGoModule (finalAttrs: {
   pname = "netcap";
-  version = "0.6.11";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "dreadl0ck";
     repo = "netcap";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-SCBKOIC/s+rfrVWmryp9EBp7ARpZZcxymsnZWtEHrhk=";
+    hash = "sha256-hk0aPU+pQ+A90GvlFhCRpj4hRiFOcpcP64xznh50Kts=";
   };
 
-  vendorHash = "sha256-MvHrJLhcFA0fEgK+YT0rwI6wIwTGMcLWQt6AYkx1eZM=";
+  vendorHash = "sha256-DLjSeSXwA4zPVg3ISPqEHTihIp9uVu7dXv9bTSepsaI=";
+
+  nativeBuildInputs = [
+    pkg-config
+    protobuf
+    protoc-gen-go
+  ];
+
+  postPatch = ''
+    rm go.work go.work.sum
+  '';
+
+  preBuild = ''
+    # satisfiy go:embed
+    mkdir -p cmd/capture/webui/frontend/dist
+    touch cmd/capture/webui/frontend/dist/index.html
+
+    # generate protobuf types
+    # we need to patch the proto file to have a valid go_package
+    substituteInPlace netcap.proto --replace-fail 'option go_package = "types";' 'option go_package = "github.com/dreadl0ck/netcap/types";'
+    protoc --go_out=. --go_opt=paths=source_relative netcap.proto
+    mv netcap.pb.go types/
+
+    # Patch types to replace calling String() (panics) with string literal
+    find types -name "*.go" -exec sed -i 's/Type_NC_\([A-Za-z0-9_]*\).String()/"NC_\1"/g' {} +
+  '';
 
   subPackages = [ "cmd" ];
 
   buildInputs = [
     libpcap
+    yara-x
   ]
   ++ lib.optionals withDpi [
-    ndpi
+    ndpi_4_14
     libprotoident
     libflowmanager
     libtrace
@@ -50,14 +81,14 @@ buildGoModule (finalAttrs: {
 
   env = lib.optionalAttrs withDpi {
     CGO_LDFLAGS = toString [
-      "-L${ndpi}/lib"
+      "-L${ndpi_4_14}/lib"
       "-lndpi"
       "-L${libprotoident}/lib"
-      "-lndpi"
+      "-lprotoident"
     ];
 
     CGO_CFLAGS = toString [
-      "-I${ndpi}/include"
+      "-I${ndpi_4_14}/include"
       "-I${libprotoident}/include"
     ];
   };


### PR DESCRIPTION
update to 0.9.0

patch protobuf generation

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
