### PR TITLE
nixos/bash: Reset title bar only for interactive shells

### DIFF
--- a/nixos/modules/programs/bash/bash.nix
+++ b/nixos/modules/programs/bash/bash.nix
@@ -107,16 +107,24 @@ in
       };
 
       logout = lib.mkOption {
+        default = "";
+        description = ''
+          Shell script code called during bash shell logout.
+        '';
+        type = lib.types.lines;
+      };
+
+      interactiveLogout = lib.mkOption {
         # Reset the title bar when logging out.  This protects against a remote
         # NixOS system clobbering your local terminal's title bar when you SSH
         # into the remote NixOS system and then log out.
         #
         # For more details, see: https://superuser.com/a/339946
         default = ''
-          printf '\e]0;\a'
+          printf '\e]0;\a' >&2
         '';
         description = ''
-          Shell script code called during login bash shell logout.
+          Shell script code called during interactive bash shell logout.
         '';
         type = lib.types.lines;
       };
@@ -210,6 +218,10 @@ in
       __ETC_BASHLOGOUT_SOURCED=1
 
       ${cfg.logout}
+
+      if [ -n "$PS1" ]; then
+        ${cfg.interactiveLogout}
+      fi
 
       # Read system-wide modifications.
       if test -f /etc/bash_logout.local; then


### PR DESCRIPTION
printf '\e]0;\a' breaks Vagrant,
See https://github.com/NixOS/nixpkgs/issues/521679


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
