### PR TITLE
python3Packages.bincopy: 20.1.0 -> 20.1.1

### DIFF
--- a/pkgs/development/python-modules/bincopy/default.nix
+++ b/pkgs/development/python-modules/bincopy/default.nix
@@ -9,12 +9,12 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "bincopy";
-  version = "20.1.0";
+  version = "20.1.1";
   format = "setuptools";
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    hash = "sha256-2KToy4Ltr7vjZ0FTN9GSbH2MRVYX5DvUsUVlN3K5uWU=";
+    hash = "sha256-6UpJi5pKvnZwPDdyqtRm8VY7T8mAnaeWXxG8dwlAk7k=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
* Closes #497836, resolves the merge conflict
* [Upstream diff](https://github.com/eerimoq/bincopy/compare/20.1.0...20.1.1)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `e304ad2dbba93206ec536a848965c5b6b76d9738`

---
### `x86_64-linux`
<details>
  <summary>:x: 4 packages failed to build:</summary>
  <ul>
    <li>python313Packages.spsdk</li>
    <li>python313Packages.spsdk.dist</li>
    <li>python314Packages.spsdk</li>
    <li>python314Packages.spsdk.dist</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 4 packages built:</summary>
  <ul>
    <li>python313Packages.bincopy</li>
    <li>python313Packages.bincopy.dist</li>
    <li>python314Packages.bincopy</li>
    <li>python314Packages.bincopy.dist</li>
  </ul>
</details>

spsdk currently fails due to pytest-notebook failing, see [Hydra](https://hydra.nixos.org/build/328961191).