### PR TITLE
home-assistant-custom-lovelace-modules.mini-media-player: 1.16.11 -> 1.6.12

### DIFF
--- a/pkgs/servers/home-assistant/custom-lovelace-modules/mini-media-player/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/mini-media-player/package.nix
@@ -6,16 +6,16 @@
 
 buildNpmPackage rec {
   pname = "mini-media-player";
-  version = "1.16.11";
+  version = "1.16.12";
 
   src = fetchFromGitHub {
     owner = "kalkih";
     repo = "mini-media-player";
     rev = "v${version}";
-    hash = "sha256-jbT+skF/WQmfPob6TZ7ff9mgnWvC9siE+WgFONXqGbw=";
+    hash = "sha256-hLQ8MHzBmvxqqgI18qmSePUOZBznCYg9cpHr/YcDHts=";
   };
 
-  npmDepsHash = "sha256-crF/KesvY5GvH14n9KrND5O7sJxsSV2Nbcod2stesvg=";
+  npmDepsHash = "sha256-gGOvBSHzBSl7eUpjuoddzZATL4GBluvbfxc8vjiZZgo=";
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
https://github.com/kalkih/mini-media-player/releases/tag/v1.16.12


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
