### PR TITLE
nixosTests.pam-zfs-key: fix dataset mounting

### DIFF
--- a/nixos/tests/pam/zfs-key.nix
+++ b/nixos/tests/pam/zfs-key.nix
@@ -11,6 +11,7 @@ in
     { ... }:
     {
       boot.supportedFilesystems = [ "zfs" ];
+      boot.zfs.forceImportRoot = false;
 
       networking.hostId = "12345678";
 
@@ -42,10 +43,10 @@ in
         machine.succeed("truncate -s 64M /testpool.img")
         machine.succeed("zpool create -O canmount=off '${pool}' /testpool.img")
         machine.succeed("zfs create -o canmount=off -p '${homes}'")
-        machine.succeed("echo ${userPassword} | zfs create -o canmount=noauto -o encryption=on -o keyformat=passphrase '${homes}/alice'")
-        machine.succeed("zfs unload-key '${homes}/alice'")
-        machine.succeed("echo ${mismatchPass} | zfs create -o canmount=noauto -o encryption=on -o keyformat=passphrase '${homes}/bob'")
-        machine.succeed("zfs unload-key '${homes}/bob'")
+        machine.succeed("echo ${userPassword} | zfs create -o encryption=on -o keyformat=passphrase '${homes}/alice'")
+        machine.succeed("zfs unmount '${homes}/alice' && zfs unload-key '${homes}/alice'")
+        machine.succeed("echo ${mismatchPass} | zfs create -o encryption=on -o keyformat=passphrase '${homes}/bob'")
+        machine.succeed("zfs unmount '${homes}/bob' && zfs unload-key '${homes}/bob'")
 
       with subtest("Switch to tty2"):
         machine.fail("pgrep -f 'agetty.*tty2'")


### PR DESCRIPTION
This fixes the build failure of the pam-zfs-key nixos test.

The test created ZFS datasets with `canmount=noauto`, but pam_zfs_key's mount_dataset() now checks `canmount == ZFS_CANMOUNT_ON` and skips mounting otherwise (added in
https://github.com/openzfs/zfs/commit/387ed5ca41). Use the default `canmount=on` and unmount before unloading the key to compensate for the auto-mount that happens when the key is loaded during creation.

This also silences the warning for forceImportRoot.

Assisted-by: opencode with DeepSeek V4 Flash Free
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
