### PR TITLE
quarto: fix #256074

### DIFF
--- a/pkgs/by-name/qu/quarto/package.nix
+++ b/pkgs/by-name/qu/quarto/package.nix
@@ -74,7 +74,14 @@ stdenv.mkDerivation (finalAttrs: {
 
     mkdir -p $out/bin $out/share
 
-    rm -r bin/tools
+    rm -r bin/tools/*
+
+    mkdir bin/tools/aarch64
+    mkdir bin/tools/x86_64
+
+    ln -s ${lib.makeBinPath [ pandoc ]}/pandoc bin/tools/x86_64/pandoc
+    ln -s ${lib.makeBinPath [ pandoc ]}/pandoc bin/tools/aarch64/pandoc
+
 
     mv bin/* $out/bin
     mv share/* $out/share

--- a/pkgs/by-name/qu/quarto/package.nix
+++ b/pkgs/by-name/qu/quarto/package.nix
@@ -69,6 +69,19 @@ stdenv.mkDerivation (finalAttrs: {
       ) "--set-default RETICULATE_PYTHON ${pythonWithPackages.interpreter}"}
   '';
 
+  # This patches quarto to be compatible with pandoc <3.8
+  # When pandoc updates, this fix will not be needed, and will probably break
+  postFixup = ''
+    substituteInPlace $out/bin/quarto.js \
+      --replace-fail 'kSyntaxHighlighting = "syntax-highlighting"' 'kSyntaxHighlighting = "highlight-style"' \
+      --replace-fail '"--syntax-highlighting"' '"--highlight-style"'
+    substituteInPlace $out/share/filters/modules/jog.lua \
+      --replace-fail "elseif tp == 'pandoc TableHead' or tp == 'pandoc TableFoot' or" "elseif tp == 'pandoc TableBody' or tp == 'TableBody' then
+          element.head = jogger(element.head)
+          element.body = jogger(element.body)
+        elseif tp == 'pandoc TableHead' or tp == 'pandoc TableFoot' or"
+  '';
+
   installPhase = ''
     runHook preInstall
 
@@ -80,7 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir bin/tools/x86_64
 
     ln -s ${lib.getExe pandoc} bin/tools/x86_64/pandoc
-    ln -s ${lib.makeBinPath [ pandoc ]}/pandoc bin/tools/aarch64/pandoc
+    ln -s ${lib.getExe pandoc} bin/tools/aarch64/pandoc
 
 
     mv bin/* $out/bin

--- a/pkgs/by-name/qu/quarto/package.nix
+++ b/pkgs/by-name/qu/quarto/package.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir bin/tools/aarch64
     mkdir bin/tools/x86_64
 
-    ln -s ${lib.makeBinPath [ pandoc ]}/pandoc bin/tools/x86_64/pandoc
+    ln -s ${lib.getExe pandoc} bin/tools/x86_64/pandoc
     ln -s ${lib.makeBinPath [ pandoc ]}/pandoc bin/tools/aarch64/pandoc
 
 


### PR DESCRIPTION
By symlinking the existing pandoc version to inside of quarto, it fixes https://github.com/NixOS/nixpkgs/issues/256074 . I have been using an override to get it fixed locally (see last comment on that issue).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

All tests fail because pandoc needs to be updated in order for it to work against the latest version of quarto. I could not figure out how to update pandoc for testing. :(

But it did at least build, run and work when I tried using an older version of quarto. 

Related issue: https://github.com/NixOS/nixpkgs/issues/519484
