### PR TITLE
proton-cachyos-slr-bin: init at cachyos-11.0-20260602-slr

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14042,6 +14042,11 @@
     email = "nixos@karpfen.dev";
     matrix = "@karpfen:matrix.org";
   };
+  Karrfy = {
+    name = "Jannis";
+    github = "Karrfy";
+    githubId = 193750820;
+  };
   kashw2 = {
     email = "supra4keanu@hotmail.com";
     github = "kashw2";

--- a/pkgs/by-name/pr/proton-cachyos-slr-bin/package.nix
+++ b/pkgs/by-name/pr/proton-cachyos-slr-bin/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  fetchzip,
+  writeScript,
+  proton-ge-bin,
+
+  steamDisplayName ? "Proton CachyOS slr",
+}:
+proton-ge-bin.overrideAttrs (
+  finalAttrs: _: {
+    strictDeps = true;
+    __structuredAttrs = true;
+
+    inherit steamDisplayName;
+
+    pname = "proton-cachyos-slr-bin";
+    version = "cachyos-11.0-20260602-slr";
+
+    src = fetchzip {
+      url = "https://github.com/CachyOS/proton-cachyos/releases/download/${finalAttrs.version}/proton-${finalAttrs.version}-x86_64.tar.xz";
+      hash = "sha256-m/B+WBVJZBpLUvzZZwJ4hGfjbzmohP7TBhfVt5bCzNQ=";
+    };
+
+    preFixup = ''
+      substituteInPlace "$steamcompattool/compatibilitytool.vdf" \
+        --replace-fail "proton-${finalAttrs.version}-x86_64" "${steamDisplayName}"
+    '';
+
+    passthru.updateScript = writeScript "update-proton-cachyos-slr" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p curl jq common-updater-scripts
+      repo="https://api.github.com/repos/CachyOS/proton-cachyos/releases/latest"
+      version="$(curl -sL "$repo" | jq '.tag_name' --raw-output)"
+      update-source-version proton-cachyos-slr-bin "$version"
+    '';
+
+    meta = {
+      description = ''
+        Compatibility tool for Steam Play based on Wine and additional components.
+        This version is build against the Steam Linux Runtime (SLR).
+
+        (This is intended for use in the `programs.steam.extraCompatPackages` option only.)
+      '';
+      homepage = "https://github.com/CachyOS/proton-cachyos";
+      license = lib.licenses.bsd3;
+      maintainers = with lib.maintainers; [
+        Karrfy
+      ];
+      platforms = [ "x86_64-linux" ];
+      sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    };
+  }
+)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

CachyOS's custom Proton compatibility layer fork with additional improvements.

Homepage: https://github.com/CachyOS/proton-cachyos

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
