### PR TITLE
python3Packages.nbdime: 4.0.3 -> 4.0.4

### DIFF
--- a/pkgs/development/python-modules/nbdime/default.nix
+++ b/pkgs/development/python-modules/nbdime/default.nix
@@ -14,7 +14,6 @@
   gitpython,
   jinja2,
   jupyter-server,
-  jupyter-server-mathjax,
   nbformat,
   pygments,
   requests,
@@ -22,19 +21,18 @@
 
   # tests
   gitMinimal,
-  pytest-tornado,
   pytestCheckHook,
   writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
   pname = "nbdime";
-  version = "4.0.3";
+  version = "4.0.4";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-YqtQp1goJSPEUBFEufMUIh27rtBAPBL9cPak/MUy7CQ=";
+    hash = "sha256-jNJez+61EF1WMjfX9k60dIBY+6m7qas4kqH/YeF3zhY=";
   };
 
   build-system = [
@@ -48,7 +46,6 @@ buildPythonPackage rec {
     gitpython
     jinja2
     jupyter-server
-    jupyter-server-mathjax
     nbformat
     pygments
     requests
@@ -57,7 +54,6 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     gitMinimal
-    pytest-tornado
     pytestCheckHook
     writableTmpDirAsHomeHook
   ];
@@ -91,7 +87,7 @@ buildPythonPackage rec {
 
   meta = {
     homepage = "https://github.com/jupyter/nbdime";
-    changelog = "https://github.com/jupyter/nbdime/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/jupyter/nbdime/blob/v${version}/CHANGELOG.md";
     description = "Tools for diffing and merging of Jupyter notebooks";
     license = lib.licenses.bsd3;
     maintainers = [ ];


### PR DESCRIPTION
Closes #490016. In addition, this PR removes some dependencies that upstream also removed (inspect pyproject.toml in diff [v4.3.0...v4.0.4](https://github.com/jupyter/nbdime/compare/v4.0.3...v4.0.4#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711))

Build failures in spsdk are due to pytest-notebook build failure and unrelated to nbdime, see [Hydra](https://hydra.nixos.org/build/328961191).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `06a59dcb2bc99dfa13d158ca5fe372562794026a`

---
### `x86_64-linux`
<details>
  <summary>:x: 8 packages failed to build:</summary>
  <ul>
    <li>python313Packages.pytest-notebook</li>
    <li>python313Packages.pytest-notebook.dist</li>
    <li>python313Packages.spsdk</li>
    <li>python313Packages.spsdk.dist</li>
    <li>python314Packages.pytest-notebook</li>
    <li>python314Packages.pytest-notebook.dist</li>
    <li>python314Packages.spsdk</li>
    <li>python314Packages.spsdk.dist</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 8 packages built:</summary>
  <ul>
    <li>python313Packages.jupyterlab-git</li>
    <li>python313Packages.jupyterlab-git.dist</li>
    <li>python313Packages.nbdime</li>
    <li>python313Packages.nbdime.dist</li>
    <li>python314Packages.jupyterlab-git</li>
    <li>python314Packages.jupyterlab-git.dist</li>
    <li>python314Packages.nbdime</li>
    <li>python314Packages.nbdime.dist</li>
  </ul>
</details>
