### PR TITLE
wesnoth: simplified wrapping

### DIFF
--- a/pkgs/by-name/we/wesnoth/package.nix
+++ b/pkgs/by-name/we/wesnoth/package.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    "-DENABLE_SYSTEM_LUA=ON"
+    (lib.cmakeBool "ENABLE_SYSTEM_LUA" true)
     "-DBINARY_SUFFIX=${suffix}"
   ];
 
@@ -111,13 +111,15 @@ stdenv.mkDerivation (finalAttrs: {
     echo "APPL????" > "$app_contents/PkgInfo"
     mv $out/bin "$app_contents/MacOS"
     mv $out/share/wesnoth "$app_contents/Resources"
+
     pushd ../projectfiles/Xcode
-    substitute Info.plist "$app_contents/Info.plist" \
-      --replace-fail ''\'''${EXECUTABLE_NAME}' wesnoth${suffix} \
-      --replace-fail '$(PRODUCT_BUNDLE_IDENTIFIER)' org.wesnoth.Wesnoth${suffix} \
-      --replace-fail ''\'''${PRODUCT_NAME}' "$app_name"
-    cp -r Resources/SDLMain.nib "$app_contents/Resources/"
-    install -m0644 Resources/{container-migration.plist,icon.icns} "$app_contents/Resources"
+      substitute Info.plist "$app_contents/Info.plist" \
+        --replace-fail ''\'''${EXECUTABLE_NAME}' wesnoth${suffix} \
+        --replace-fail '$(PRODUCT_BUNDLE_IDENTIFIER)' org.wesnoth.Wesnoth${suffix} \
+        --replace-fail ''\'''${PRODUCT_NAME}' "$app_name"
+
+      cp -r Resources/SDLMain.nib "$app_contents/Resources/"
+      install -m0644 Resources/{container-migration.plist,icon.icns} "$app_contents/Resources"
     popd
 
     # Make the game and dedicated server binary available for shell users
@@ -152,7 +154,6 @@ stdenv.mkDerivation (finalAttrs: {
       reclaim the throne of Wesnoth, or take hand in any number of other
       adventures.
     '';
-
     homepage = "https://www.wesnoth.org/";
     changelog = "https://github.com/wesnoth/wesnoth/blob/${finalAttrs.version}/changelog.md";
     license = lib.licenses.gpl2Plus;

--- a/pkgs/by-name/we/wesnoth/package.nix
+++ b/pkgs/by-name/we/wesnoth/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   stdenv,
-  stdenvNoCC,
   fetchFromGitHub,
   cmake,
   pkg-config,
@@ -9,6 +8,7 @@
   SDL2_image,
   SDL2_mixer,
   SDL2_net,
+  makeBinaryWrapper,
   SDL2_ttf,
   pango,
   gettext,
@@ -55,7 +55,8 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     pkg-config
-  ];
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ makeBinaryWrapper ];
 
   buildInputs = [
     SDL2
@@ -122,13 +123,10 @@ stdenv.mkDerivation (finalAttrs: {
     # Make the game and dedicated server binary available for shell users
     mkdir -p "$out/bin"
     ln -s "$app_contents/MacOS/wesnothd${suffix}" "$out/bin/wesnothd${suffix}"
+
     # Symlinking the game binary is unsifficient as it would be unable to
     # find the bundle resources
-    cat << EOF > "$out/bin/wesnoth${suffix}"
-    #!${stdenvNoCC.shell}
-    open -na "$app_bundle" --args "\$@"
-    EOF
-    chmod +x "$out/bin/wesnoth${suffix}"
+    makeBinaryWrapper "$app_bundle/Contents/MacOS/wesnoth${suffix}" "$out/bin/wesnoth${suffix}"
   '';
 
   passthru.updateScript = nix-update-script {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- Been going through cool FOSS games lately and this one is really well done!
- Just had this one fix because why not ;)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
