### PR TITLE
[25.11] nixos/swap: please shellcheck

### DIFF
--- a/nixos/modules/config/swap.nix
+++ b/nixos/modules/config/swap.nix
@@ -297,7 +297,7 @@ in
               ${lib.optionalString (sw.size != null) ''
                 currentSize=$(( $(stat -c "%s" "$DEVICE" 2>/dev/null || echo 0) / 1024 / 1024 ))
                 if [[ ! -b "$DEVICE" && "${toString sw.size}" != "$currentSize" ]]; then
-                  if [[ $(stat -f -c %T "$(dirname "$DEVICE")") == "btrfs" ]]; then
+                  if [[ "$(stat -f -c %T "$(dirname "$DEVICE")")" == "btrfs" ]]; then
                     # Use btrfs mkswapfile to speed up the creation of swapfile.
                     rm -f "$DEVICE"
                     btrfs filesystem mkswapfile --size "${toString sw.size}M" --uuid clear "$DEVICE"
@@ -330,6 +330,7 @@ in
                 mkswap ${sw.realDevice}
               ''}
             '';
+            enableStrictShellChecks = true;
 
             unitConfig.RequiresMountsFor = [ "${dirOf sw.device}" ];
             unitConfig.DefaultDependencies = false; # needed to prevent a cycle

--- a/nixos/modules/config/swap.nix
+++ b/nixos/modules/config/swap.nix
@@ -297,7 +297,7 @@ in
               ${lib.optionalString (sw.size != null) ''
                 currentSize=$(( $(stat -c "%s" "$DEVICE" 2>/dev/null || echo 0) / 1024 / 1024 ))
                 if [[ ! -b "$DEVICE" && "${toString sw.size}" != "$currentSize" ]]; then
-                  if [[ $(stat -f -c %T $(dirname "$DEVICE")) == "btrfs" ]]; then
+                  if [[ $(stat -f -c %T "$(dirname "$DEVICE")") == "btrfs" ]]; then
                     # Use btrfs mkswapfile to speed up the creation of swapfile.
                     rm -f "$DEVICE"
                     btrfs filesystem mkswapfile --size "${toString sw.size}M" --uuid clear "$DEVICE"
@@ -308,7 +308,7 @@ in
 
                     echo "Creating swap file using dd and mkswap."
                     dd if=/dev/zero of="$DEVICE" bs=1M count=${toString sw.size} status=progress
-                    ${lib.optionalString (!sw.randomEncryption.enable) "mkswap ${sw.realDevice}"}
+                    ${lib.optionalString (!sw.randomEncryption.enable) "mkswap \"${sw.realDevice}\""}
                   fi
                 fi
               ''}


### PR DESCRIPTION
Backports of #457346 & #466869
Fixes #469102

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
