### PR TITLE
digidrie: init at 0.3.1

### DIFF
--- a/pkgs/by-name/di/digidrie/package.nix
+++ b/pkgs/by-name/di/digidrie/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  libGL,
+  libx11,
+  libjack2,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "digidrie";
+  version = "0.3.1";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "magnetophon";
+    repo = "DigiDrie";
+    tag = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-bmytfZ6/V9eoEnj5xLq3Yzlhy0VGEK6utsfS9OCYWd0=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libGL
+    libx11
+    libjack2
+  ];
+
+  sourceRoot = "${finalAttrs.src.name}/plugin/dpf";
+
+  postPatch = ''
+    patchShebangs generate-ttl.sh patch/apply.sh
+  '';
+
+  enableParallelBuilding = true;
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  meta = {
+    description = "Monophonic Faust synth with vector synthesis, CZ-style oscillators and macro morphing (DPF: JACK/LV2/VST2/VST3/CLAP)";
+    homepage = "https://github.com/magnetophon/DigiDrie";
+    license = lib.licenses.agpl3Only;
+    maintainers = [ lib.maintainers.magnetophon ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    mainProgram = "DigiDrie";
+  };
+})


### PR DESCRIPTION
A monster monophonic synth by yours truly.

https://github.com/magnetophon/DigiDrie

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
