### PR TITLE
Neverball: bumped version and changes for darwin and linux

### DIFF
--- a/pkgs/by-name/ne/neverball/package.nix
+++ b/pkgs/by-name/ne/neverball/package.nix
@@ -47,14 +47,13 @@ stdenv.mkDerivation (finalAttrs: {
   dontPatchELF = true;
 
   postPatch = ''
-    sed -i -e 's@\./data@'$out/share/neverball/data@ share/base_config.h Makefile
-    sed -i -e 's@\./locale@'$out/share/neverball/locale@ share/base_config.h Makefile
-    sed -i -e 's@-lvorbisfile@-lvorbisfile${
-      lib.optionalString (!stdenv.hostPlatform.isDarwin) " -lX11"
-      + lib.optionalString stdenv.cc.isGNU " -lgcc_s"
-    }@' Makefile
+    substituteInPlace share/base_config.h Makefile \
+      --replace-fail './data' "$out/share/neverball/data" \
+      --replace-fail './locale' "$out/share/neverball/locale"
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace Makefile --replace-fail '-lvorbisfile' '-lvorbisfile -liconv'
+
     for game in ball putt; do
       pushd macosx/xcode/''${game}_items/
       substituteInPlace Info.plist --replace-fail '1.5.3' "$version"

--- a/pkgs/by-name/ne/neverball/package.nix
+++ b/pkgs/by-name/ne/neverball/package.nix
@@ -102,7 +102,10 @@ stdenv.mkDerivation (finalAttrs: {
       mit
       gpl3Only
     ];
-    maintainers = with lib.maintainers; [ Rhys-T ];
+    maintainers = with lib.maintainers; [
+      Rhys-T
+      philocalyst
+    ];
     platforms = with lib.platforms; linux ++ darwin;
   };
 })

--- a/pkgs/by-name/ne/neverball/package.nix
+++ b/pkgs/by-name/ne/neverball/package.nix
@@ -79,26 +79,41 @@ stdenv.mkDerivation (finalAttrs: {
   preConfigure = "export HOME=$TMPDIR";
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin $out/share/neverball
     cp -R data locale $out/share/neverball
-    ${
-      if stdenv.hostPlatform.isDarwin then
-        ''
-          mkdir -p $out/Applications/Never{ball,putt}.app/Contents/{MacOS,Resources}
-          for game in ball putt; do
-            cp never$game $out/Applications/Never$game.app/Contents/MacOS/Never$game
-            makeWrapper $out/Applications/Never$game.app/Contents/MacOS/Never$game $out/bin/never$game
-            cp macosx/xcode/''${game}_items/Info.plist $out/Applications/Never$game.app/Contents/Info.plist
-            cp -r macosx/icons/never$game.icns macosx/xcode/''${game}_items/English.lproj $out/Applications/Never$game.app/Contents/Resources/
-          done
-        ''
-      else
-        ''
-          cp neverball $out/bin
-          cp neverputt $out/bin
-        ''
-    }
-    cp mapc $out/bin
+
+    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+      mkdir -p $out/Applications/Never{ball,putt}.app/Contents/{MacOS,Resources}
+
+      for game in ball putt; do
+        cp never$game $out/Applications/Never$game.app/Contents/MacOS/Never$game
+        makeWrapper $out/Applications/Never$game.app/Contents/MacOS/Never$game $out/bin/never$game
+        cp macosx/xcode/''${game}_items/Info.plist $out/Applications/Never$game.app/Contents/Info.plist
+        cp -r macosx/icons/never$game.icns macosx/xcode/''${game}_items/English.lproj $out/Applications/Never$game.app/Contents/Resources/
+      done
+    ''}
+
+    cp mapc $out/bin;
+
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      install -Dm644 dist/neverball.desktop.in $out/share/applications/neverball.desktop
+      install -Dm644 dist/neverputt.desktop.in $out/share/applications/neverputt.desktop
+
+      for size in 16 24 32 48 64 128 256 512; do
+          install -Dm644 dist/neverputt_''${size}.png \
+            $out/share/icons/hicolor/''${size}x''${size}/apps/neverputt.png
+      done
+
+      install -Dm644 dist/neverball.appdata.xml $out/share/metainfo/neverball.metainfo.xml
+    ''}
+
+    install -Dm644 dist/neverball.6 $out/share/man/man6/neverball.6
+    install -Dm644 dist/neverputt.6 $out/share/man/man6/neverputt.6
+    install -Dm644 dist/mapc.1 $out/share/man/man1/mapc.1
+
+    runHook postInstall
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/ne/neverball/package.nix
+++ b/pkgs/by-name/ne/neverball/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   SDL2,
   libGL,
   libpng,
@@ -18,9 +18,12 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "neverball";
   version = "1.7.0-alpha.3";
-  src = fetchurl {
-    url = "https://neverball.org/neverball-${finalAttrs.version}.tar.gz";
-    sha256 = "184gm36c6p6vaa6gwrfzmfh86klhnb03pl40ahsjsvprlk667zkk";
+
+  src = fetchFromGitHub {
+    owner = "Neverball";
+    repo = "neverball";
+    tag = finalAttrs.version;
+    hash = "sha256-C6zXAQEjaiuo3v/ihvyXnJhK0kTPzC0sxLOgY9bFdgk=";
   };
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/by-name/ne/neverball/package.nix
+++ b/pkgs/by-name/ne/neverball/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  fetchpatch,
   SDL2,
   libGL,
   libpng,
@@ -18,20 +17,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "neverball";
-  version = "1.6.0";
+  version = "1.7.0-alpha.3";
   src = fetchurl {
     url = "https://neverball.org/neverball-${finalAttrs.version}.tar.gz";
     sha256 = "184gm36c6p6vaa6gwrfzmfh86klhnb03pl40ahsjsvprlk667zkk";
   };
-  patches = [
-    # Pull upstream fix for -fno-common toolchains
-    #   https://github.com/Neverball/neverball/pull/198
-    (fetchpatch {
-      name = "fno-common.patch";
-      url = "https://github.com/Neverball/neverball/commit/a42492b8db06934c7a794630db92e3ff6ebaadaa.patch";
-      sha256 = "0sqyxfwpl4xxra8iz87j5rxzwani16xra2xl4l5z61shvq30308h";
-    })
-  ];
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     iconv

--- a/pkgs/by-name/ne/neverball/package.nix
+++ b/pkgs/by-name/ne/neverball/package.nix
@@ -11,8 +11,10 @@
   libvorbis,
   gettext,
   physfs,
+  curl,
   iconv,
   makeBinaryWrapper,
+  copyDesktopItems,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -26,10 +28,15 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-C6zXAQEjaiuo3v/ihvyXnJhK0kTPzC0sxLOgY9bFdgk=";
   };
 
-  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-    iconv
-    makeBinaryWrapper
-  ];
+  nativeBuildInputs =
+    lib.optionals stdenv.hostPlatform.isDarwin [
+      iconv
+      makeBinaryWrapper
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      copyDesktopItems
+    ];
+
   buildInputs = [
     libpng
     SDL2
@@ -39,6 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     libvorbis
     gettext
     physfs
+    curl
   ]
   ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
     libx11

--- a/pkgs/by-name/ne/neverball/package.nix
+++ b/pkgs/by-name/ne/neverball/package.nix
@@ -56,11 +56,13 @@ stdenv.mkDerivation (finalAttrs: {
 
     for game in ball putt; do
       pushd macosx/xcode/''${game}_items/
-      substituteInPlace Info.plist --replace-fail '1.5.3' "$version"
-      iconv -f UTF-16LE -t UTF-8 English.lproj/InfoPlist.strings > English.lproj/InfoPlist.strings.tmp
-      substituteInPlace English.lproj/InfoPlist.strings.tmp --replace-fail '1.5.3' "$version" --replace-fail '2002-2009' '2002-2014'
-      iconv -f UTF-8 -t UTF-16LE English.lproj/InfoPlist.strings.tmp > English.lproj/InfoPlist.strings
-      rm English.lproj/InfoPlist.strings.tmp
+        substituteInPlace Info.plist --replace-fail '1.5.3' "$version"
+        iconv -f UTF-16LE -t UTF-8 English.lproj/InfoPlist.strings > English.lproj/InfoPlist.strings.tmp
+
+        substituteInPlace English.lproj/InfoPlist.strings.tmp --replace-fail '1.5.3' "$version"
+        iconv -f UTF-8 -t UTF-16LE English.lproj/InfoPlist.strings.tmp > English.lproj/InfoPlist.strings
+
+        rm English.lproj/InfoPlist.strings.tmp
       popd
     done
   '';

--- a/pkgs/by-name/ne/neverball/package.nix
+++ b/pkgs/by-name/ne/neverball/package.nix
@@ -96,6 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     homepage = "https://neverball.org/";
     description = "Tilt the floor to roll a ball";
+    changelog = "https://github.com/Neverball/neverball/releases/tag/${finalAttrs.version}";
     license = with lib.licenses; [
       gpl2Plus
       ijg
@@ -107,5 +108,6 @@ stdenv.mkDerivation (finalAttrs: {
       philocalyst
     ];
     platforms = with lib.platforms; linux ++ darwin;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- Got fully up and working on Darwin with nice app bundle
- Did a lot of maintenance on readability and all of that so super swell!
- Updated as well!
- Meta section is expanded but unsure if mainProgram should be neverball (there's also neverputt)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
