### PR TITLE
veloren: fixed to support darwin

### DIFF
--- a/pkgs/by-name/ve/veloren/package.nix
+++ b/pkgs/by-name/ve/veloren/package.nix
@@ -3,10 +3,12 @@
   rustPlatform,
   fetchFromGitLab,
   pkg-config,
+  stdenv,
+
+  # Linux-only
   vulkan-loader,
   alsa-lib,
   udev,
-  shaderc,
   libxcb,
   libxkbcommon,
   autoPatchelfHook,
@@ -15,7 +17,12 @@
   libxcursor,
   libxrandr,
   wayland,
-  stdenv,
+
+  # Both platforms
+  shaderc,
+
+  # macOS-only
+  desktopToDarwinBundle,
 }:
 
 let
@@ -58,16 +65,23 @@ rustPlatform.buildRustPackage {
   '';
 
   nativeBuildInputs = [
-    autoPatchelfHook
     pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    desktopToDarwinBundle
   ];
 
   buildInputs = [
+    shaderc
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     alsa-lib
     udev
     libxcb
     libxkbcommon
-    shaderc
     stdenv.cc.cc # libgcc_s.so.1
   ];
 
@@ -92,7 +106,7 @@ rustPlatform.buildRustPackage {
   # Some tests require internet access
   doCheck = false;
 
-  appendRunpaths = [
+  appendRunpaths = lib.optionals stdenv.hostPlatform.isLinux [
     (lib.makeLibraryPath (
       [
         libx11
@@ -122,7 +136,7 @@ rustPlatform.buildRustPackage {
     homepage = "https://www.veloren.net";
     license = lib.licenses.gpl3Only;
     mainProgram = "veloren-voxygen";
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [
       rnhmjoj
       tomodachi94

--- a/pkgs/by-name/ve/veloren/package.nix
+++ b/pkgs/by-name/ve/veloren/package.nix
@@ -139,6 +139,7 @@ rustPlatform.buildRustPackage {
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [
       rnhmjoj
+      philocalyst
       tomodachi94
     ];
   };

--- a/pkgs/by-name/ve/veloren/package.nix
+++ b/pkgs/by-name/ve/veloren/package.nix
@@ -32,7 +32,6 @@ let
   timestamp = "1769191511";
   rev = "1d12f35edd6cdbfc1fb921c167cdd7beeeffe248";
 in
-
 rustPlatform.buildRustPackage {
   pname = "veloren";
   inherit version;
@@ -52,14 +51,16 @@ rustPlatform.buildRustPackage {
 
   postPatch = ''
     # Force vek to build in unstable mode
-    cat <<'EOF' | tee "$cargoDepsCopy"/*/vek-*/build.rs
+    tee "$cargoDepsCopy"/*/vek-*/build.rs > /dev/null <<'EOF'
     fn main() {
       println!("cargo:rustc-check-cfg=cfg(nightly)");
       println!("cargo:rustc-cfg=nightly");
     }
     EOF
+
     # Fix assets path
     substituteAllInPlace common/assets/src/lib.rs
+
     # Do not use mold, it produces broken binaries
     substituteInPlace .cargo/config.toml --replace-fail mold gold
   '';
@@ -127,6 +128,7 @@ rustPlatform.buildRustPackage {
     install -Dm644 assets/voxygen/net.veloren.veloren.desktop -t "$out/share/applications"
     install -Dm644 assets/voxygen/net.veloren.veloren.png -t "$out/share/icons/hicolor/256x256/apps"
     install -Dm644 assets/voxygen/net.veloren.veloren.metainfo.xml -t "$out/share/metainfo"
+
     # Assets directory
     mkdir -p "$out/share/veloren"; cp -ar assets "$out/share/veloren/"
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- Veloren looks super cool and I want to use it on Darwin!
- Made some chill and common formatting changes and approach differences (no heredoc)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
