### PR TITLE
reflex-app: init at 2.0

### DIFF
--- a/pkgs/by-name/re/reflex-app/package.nix
+++ b/pkgs/by-name/re/reflex-app/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  unzip,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "reflex-app";
+  version = "2.0";
+
+  src = fetchurl {
+    url = "https://stuntsoftware.com/download/reflex_${finalAttrs.version}.zip";
+    hash = "sha256-2CfNMs9zDFyFgrIAuh37bB3wPjDDrGsyyFY65n0CtIk=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [ unzip ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications"
+    cp -R Reflex.app "$out/Applications"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Media key forwarder for Music and Spotify";
+    homepage = "https://stuntsoftware.com/reflex/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ iniw ];
+    platforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
A package for the darwin, binary-only app [Reflex](https://stuntsoftware.com/reflex/), which prevents Safari (or any other app) from stealing your media key inputs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
