### PR TITLE
discourse: 2026.1.3 -> 2026.1.4

### DIFF
--- a/nixos/tests/discourse.nix
+++ b/nixos/tests/discourse.nix
@@ -124,47 +124,55 @@ in
 
       environment.systemPackages =
         let
-          replyToEmail = pkgs.writeScriptBin "reply-to-email" ''
-            #!${pkgs.python3.interpreter}
-            import imaplib
-            import smtplib
-            import ssl
-            import email.header
-            from email import message_from_bytes
-            from email.message import EmailMessage
+          replyToEmail =
+            pkgs.writeScriptBin "reply-to-email"
+              # python
+              ''
+                #!${pkgs.python3.interpreter}
+                import imaplib
+                import smtplib
+                import ssl
+                import email.header
+                import sys
+                from email import message_from_bytes
+                from email.message import EmailMessage
 
-            with imaplib.IMAP4('localhost') as imap:
-                imap.login('alice', 'foobar')
-                imap.select()
-                status, data = imap.search(None, 'ALL')
-                assert status == 'OK'
+                with imaplib.IMAP4('localhost') as imap:
+                    imap.login('alice', 'foobar')
+                    imap.select()
+                    status, data = imap.search(None, 'ALL')
+                    assert status == 'OK'
 
-                nums = data[0].split()
-                assert len(nums) == 1
+                    nums = data[0].split()
+                    try:
+                      assert len(nums) == 1
+                    except AssertionError:
+                      print("No mail in IMAP mailbox yet...", file=sys.stderr)
+                      sys.exit(1)
 
-                status, msg_data = imap.fetch(nums[0], '(RFC822)')
-                assert status == 'OK'
+                    status, msg_data = imap.fetch(nums[0], '(RFC822)')
+                    assert status == 'OK'
 
-            msg = email.message_from_bytes(msg_data[0][1])
-            subject = str(email.header.make_header(email.header.decode_header(msg['Subject'])))
-            reply_to = email.header.decode_header(msg['Reply-To'])[0][0]
-            message_id = email.header.decode_header(msg['Message-ID'])[0][0]
-            date = email.header.decode_header(msg['Date'])[0][0]
+                msg = email.message_from_bytes(msg_data[0][1])
+                subject = str(email.header.make_header(email.header.decode_header(msg['Subject'])))
+                reply_to = email.header.decode_header(msg['Reply-To'])[0][0]
+                message_id = email.header.decode_header(msg['Message-ID'])[0][0]
+                date = email.header.decode_header(msg['Date'])[0][0]
 
-            ctx = ssl.create_default_context()
-            with smtplib.SMTP_SSL(host='${discourseDomain}', context=ctx) as smtp:
-                reply = EmailMessage()
-                reply['Subject'] = 'Re: ' + subject
-                reply['To'] = reply_to
-                reply['From'] = 'alice@${clientDomain}'
-                reply['In-Reply-To'] = message_id
-                reply['References'] = message_id
-                reply['Date'] = date
-                reply.set_content("Test reply.")
+                ctx = ssl.create_default_context()
+                with smtplib.SMTP_SSL(host='${discourseDomain}', context=ctx) as smtp:
+                    reply = EmailMessage()
+                    reply['Subject'] = 'Re: ' + subject
+                    reply['To'] = reply_to
+                    reply['From'] = 'alice@${clientDomain}'
+                    reply['In-Reply-To'] = message_id
+                    reply['References'] = message_id
+                    reply['Date'] = date
+                    reply.set_content("Test reply.")
 
-                smtp.send_message(reply)
-                smtp.quit()
-          '';
+                    smtp.send_message(reply)
+                    smtp.quit()
+              '';
         in
         [ replyToEmail ];
 

--- a/pkgs/by-name/di/discourse-mail-receiver/package.nix
+++ b/pkgs/by-name/di/discourse-mail-receiver/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   ruby,
   makeWrapper,
-  replace,
+  sd,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -19,8 +19,8 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    replace
     makeWrapper
+    sd
   ];
   buildInputs = [ ruby ];
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     mkdir -p $out/bin
 
-    replace-literal -f -r -e /etc/postfix /run/discourse-mail-receiver .
+    find . -type f -exec sd '/etc/postfix' '/run/discourse-mail-receiver' {} +
 
     cp -r receive-mail discourse-smtp-fast-rejection $out/bin/
     cp -r lib $out/

--- a/pkgs/servers/web-apps/discourse/default.nix
+++ b/pkgs/servers/web-apps/discourse/default.nix
@@ -53,13 +53,13 @@
 }:
 
 let
-  version = "2026.1.3";
+  version = "2026.1.4";
 
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse";
     rev = "v${version}";
-    sha256 = "sha256-0jbO1rJQ0AISo7h+SZfovubReCjR2zT6KWX9LxBeFtE=";
+    sha256 = "sha256-kQYDKZIMsWByuCZQfUlwhoIew5QykVylRMh6xvrHIBY=";
   };
 
   pnpm = pnpm_10;

--- a/pkgs/servers/web-apps/discourse/rubyEnv/Gemfile.lock
+++ b/pkgs/servers/web-apps/discourse/rubyEnv/Gemfile.lock
@@ -304,7 +304,7 @@ GEM
     mini_sql (1.6.0)
     mini_suffix (0.3.3)
       ffi (~> 1.9)
-    minio_runner (1.0.0)
+    minio_runner (1.0.1)
     minitest (5.26.2)
     mocha (2.8.2)
       ruby2_keywords (>= 0.0.5)
@@ -1082,7 +1082,7 @@ CHECKSUMS
   mini_scheduler (0.18.0) sha256=d2f084f38da8d76c5844a92f0d6bd01fc9982a8b5e6c7679b6cf44c82da33503
   mini_sql (1.6.0) sha256=5296637f6a4af5bb43e06788037e9a2968ff9c8eb65928befcba8cb41f42d6ee
   mini_suffix (0.3.3) sha256=8d1d33f92f69a2247c9b7d27173235da90479d955cdb863b63a7f53843b722e7
-  minio_runner (1.0.0) sha256=ca0fc56a90c63b65a26cda632938c9075046835d41f4b9d1e165b0550eae0538
+  minio_runner (1.0.1) sha256=3675ad7abd79177b3fdd9f37e20fe46f7d4dcbb41f3f30a53db2207277241795
   minitest (5.26.2) sha256=f021118a6185b9ba9f5af71f2ba103ad770c75afde9f2ab8da512677c550cde3
   mocha (2.8.2) sha256=1f77e729db47e72b4ef776461ce20caeec2572ffdf23365b0a03608fee8f4eee
   msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732

--- a/pkgs/servers/web-apps/discourse/rubyEnv/gemset.nix
+++ b/pkgs/servers/web-apps/discourse/rubyEnv/gemset.nix
@@ -1781,10 +1781,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0f05mq75bc35w78vkx21bn1lcl07r4w2jqysdji6afy6j1mca3ya";
+      sha256 = "158p4ivp485j7njk0gqznk5lszbgwh7y4dwzvlzpn5vrpmxasx9n";
       type = "gem";
     };
-    version = "1.0.0";
+    version = "1.0.1";
   };
   minitest = {
     groups = [


### PR DESCRIPTION
https://releases.discourse.org/changelog/v2026.1.4/

Fixes:

- CVE-2026-44779
  Bot debug endpoints disclose whisper translation audit logs
- CVE-2026-44782
  GroupPostSerializer leaks hidden full names through reaction post association
- CVE-2026-44783
  Replying to a whisper lets non-whisperers create staff-only whisper posts
- CVE-2026-44786
  Public chat MessageBus broadcasts are not restricted to chat-eligible users
- CVE-2026-45085
  Chat misauthorization and information disclosure
- CVE-2026-44784
  Non-staff group owners can see email password in plaintext through group history
- CVE-2026-44785
  Hidden reply-to post raw can be disclosed through AI explain prompts
- CVE-2026-45775
  Cross-site backup access via path traversal in multisite local backups
- (CVE Pending)
  Don't leak restricted tag group names via tag info
- CVE-2026-34154
  Subscription access bypass in discourse-subscriptions plugin
- CVE-2026-33514
  Information Disclosure in Form Template API Due to Missing Authorization
- CVE-2026-44780
  Category queue reviewers can read raw incoming emails from queued posts
- (CVE Pending)
  Prevent webhook payload disclosure on event redelivery
- CVE-2026-32244
  Cached outdated summaries can leak removed content

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
