### PR TITLE
nixos/gdm: update `gdm-greeter` user homes, add warning for pulseaudio

### DIFF
--- a/nixos/modules/services/display-managers/gdm.nix
+++ b/nixos/modules/services/display-managers/gdm.nix
@@ -44,6 +44,20 @@ let
   defaultSessionName = config.services.displayManager.defaultSession;
 
   setSessionScript = pkgs.callPackage ../x11/display-managers/account-service-util.nix { };
+
+  greeterUsers = lib.genAttrs' [ null 1 2 3 4 ] (
+    i:
+    let
+      # adding 1 to create `gdm-greeter{-2,-3,-4,-5}`
+      suffix = lib.optionalString (i != null) "-${toString (i + 1)}";
+    in
+    lib.nameValuePair "gdm-greeter${suffix}" {
+      isSystemUser = true;
+      uid = 60578 + (if i == null then 0 else i);
+      group = "gdm";
+      home = "/run/gdm/home/gdm-greeter${suffix}";
+    }
+  );
 in
 
 {
@@ -196,24 +210,8 @@ in
           group = "gdm";
           description = "GDM user";
         };
-
-        gdm-greeter = {
-          isSystemUser = true;
-          uid = 60578;
-          group = "gdm";
-          home = "/run/gdm";
-        };
       }
-
-      (lib.genAttrs' [ 1 2 3 4 ] (
-        i:
-        lib.nameValuePair "gdm-greeter-${toString i}" {
-          isSystemUser = true;
-          uid = 60578 + i;
-          group = "gdm";
-          home = "/run/gdm-${toString i}";
-        }
-      ))
+      greeterUsers
     ];
 
     users.groups.gdm.gid = config.ids.gids.gdm;
@@ -255,17 +253,20 @@ in
       };
     };
 
-    systemd.tmpfiles.rules = [
-      "d /run/gdm/.config 0711 gdm gdm"
-    ]
-    ++ lib.optionals config.services.pulseaudio.enable [
-      "d /run/gdm/.config/pulse 0711 gdm gdm"
-      "L+ /run/gdm/.config/pulse/${pulseConfig.name} - - - - ${pulseConfig}"
-    ]
-    ++ lib.optionals config.services.gnome.gnome-initial-setup.enable [
-      # Create stamp file for gnome-initial-setup to prevent it starting in GDM.
-      "f /run/gdm/.config/gnome-initial-setup-done 0711 gdm gdm - yes"
-    ];
+    systemd.tmpfiles.rules =
+      lib.optionals config.services.pulseaudio.enable (
+        lib.concatLists (
+          lib.mapAttrsToList (name: user: [
+            "d ${user.home}/.config 0711 ${name} gdm"
+            "d ${user.home}/.config/pulse 0711 ${name} gdm"
+            "L+ ${user.home}/.config/pulse/${pulseConfig.name} - - - - ${pulseConfig}"
+          ]) greeterUsers
+        )
+      )
+      ++ lib.optionals config.services.gnome.gnome-initial-setup.enable [
+        # Create stamp file for gnome-initial-setup to prevent it starting in GDM.
+        "f /run/gdm/gdm.ran-initial-setup 0711 gdm gdm - yes"
+      ];
 
     # Otherwise GDM will not be able to start correctly and display Wayland sessions
     systemd.packages = [

--- a/nixos/modules/services/display-managers/gdm.nix
+++ b/nixos/modules/services/display-managers/gdm.nix
@@ -44,10 +44,6 @@ let
   defaultSessionName = config.services.displayManager.defaultSession;
 
   setSessionScript = pkgs.callPackage ../x11/display-managers/account-service-util.nix { };
-
-  greeterEnvFile = pkgs.writeText "gdm-greeter-env" ''
-    DCONF_PROFILE=gdm
-  '';
 in
 
 {
@@ -455,12 +451,6 @@ in
               modulePath = "${config.security.pam.package}/lib/security/pam_env.so";
               settings.conffile = "/etc/pam/environment";
               settings.readenv = 0;
-            }
-            {
-              name = "env-greeter";
-              control = "required";
-              modulePath = "${config.security.pam.package}/lib/security/pam_env.so";
-              settings.envfile = greeterEnvFile;
             }
             {
               name = "systemd";

--- a/nixos/modules/services/display-managers/gdm.nix
+++ b/nixos/modules/services/display-managers/gdm.nix
@@ -200,6 +200,8 @@ in
 
   config = lib.mkIf cfg.enable {
 
+    warnings = lib.optional config.services.pulseaudio.enable "Support for Pulseaudio + gdm will be removed in NixOS 26.11";
+
     services.xserver.displayManager.lightdm.enable = false;
 
     users.users = lib.mkMerge [


### PR DESCRIPTION
This fixes gdm not being able to save config changes made on the log-in screen, such as turning on accessibility options.
`ibus-daemon` also currently coredumps multiple times when gdm starts because of the write protected home directory, which this PR also fixes. 
The previous workaround with the special pam env file is no longer needed; as was suggested in https://github.com/NixOS/nixpkgs/issues/458058#issuecomment-4442111721

There's more info in the commit messages too :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
