### PR TITLE
flare: clean bundle and dedup

### DIFF
--- a/pkgs/by-name/fl/flare/common.nix
+++ b/pkgs/by-name/fl/flare/common.nix
@@ -1,0 +1,12 @@
+{
+  lib,
+  nix-update-script,
+}:
+{
+  version = "1.15";
+  maintainers = with lib.maintainers; [
+    aanderse
+    McSinyx
+  ];
+  updateScript = nix-update-script { };
+}

--- a/pkgs/by-name/fl/flare/common.nix
+++ b/pkgs/by-name/fl/flare/common.nix
@@ -6,6 +6,7 @@
   version = "1.15";
   maintainers = with lib.maintainers; [
     aanderse
+    philocalyst
     McSinyx
   ];
   updateScript = nix-update-script { };

--- a/pkgs/by-name/fl/flare/engine.nix
+++ b/pkgs/by-name/fl/flare/engine.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   SDL2,
   SDL2_image,
@@ -10,9 +9,12 @@
   SDL2_ttf,
 }:
 
+let
+  common = import ./common.nix { inherit lib nix-update-script; };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "flare-engine";
-  version = "1.15";
+  inherit (common) version;
 
   src = fetchFromGitHub {
     owner = "flareteam";
@@ -21,9 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-QwrSMkJE8dNIODlmdi1c6qgTULhJP9HEV8wI7k5vHAA=";
   };
 
-  patches = [
-    ./desktop.patch
-  ];
+  patches = [ ./desktop.patch ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [
@@ -36,11 +36,8 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Free/Libre Action Roleplaying Engine";
     homepage = "https://github.com/flareteam/flare-engine";
-    maintainers = with lib.maintainers; [
-      aanderse
-      McSinyx
-    ];
     license = [ lib.licenses.gpl3Plus ];
     platforms = lib.platforms.unix;
+    inherit (common) maintainers;
   };
 })

--- a/pkgs/by-name/fl/flare/engine.nix
+++ b/pkgs/by-name/fl/flare/engine.nix
@@ -7,6 +7,7 @@
   SDL2_image,
   SDL2_mixer,
   SDL2_ttf,
+  nix-update-script,
 }:
 
 let
@@ -32,6 +33,10 @@ stdenv.mkDerivation (finalAttrs: {
     SDL2_mixer
     SDL2_ttf
   ];
+
+  passthru = {
+    inherit (common) updateScript;
+  };
 
   meta = {
     description = "Free/Libre Action Roleplaying Engine";

--- a/pkgs/by-name/fl/flare/game.nix
+++ b/pkgs/by-name/fl/flare/game.nix
@@ -2,13 +2,15 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
 }:
 
+let
+  common = import ./common.nix { inherit lib nix-update-script; };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "flare-game";
-  version = "1.15";
+  inherit (common) version;
 
   src = fetchFromGitHub {
     owner = "flareteam";
@@ -17,18 +19,14 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-IsVfP8wmrublAqoVix7gOA4u8CRmXdyNzagnaXyFsxc=";
   };
 
-  patches = [ ];
 
   nativeBuildInputs = [ cmake ];
 
   meta = {
     description = "Fantasy action RPG using the FLARE engine";
     homepage = "https://github.com/flareteam/flare-game";
-    maintainers = with lib.maintainers; [
-      aanderse
-      McSinyx
-    ];
     license = [ lib.licenses.cc-by-sa-30 ];
     platforms = lib.platforms.unix;
+    inherit (common) maintainers;
   };
 })

--- a/pkgs/by-name/fl/flare/game.nix
+++ b/pkgs/by-name/fl/flare/game.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   cmake,
+  nix-update-script,
 }:
 
 let
@@ -19,8 +20,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-IsVfP8wmrublAqoVix7gOA4u8CRmXdyNzagnaXyFsxc=";
   };
 
-
   nativeBuildInputs = [ cmake ];
+
+  passthru = {
+    inherit (common) updateScript;
+  };
 
   meta = {
     description = "Fantasy action RPG using the FLARE engine";

--- a/pkgs/by-name/fl/flare/package.nix
+++ b/pkgs/by-name/fl/flare/package.nix
@@ -5,10 +5,11 @@
   makeWrapper,
   stdenv,
   desktopToDarwinBundle,
+  nix-update-script,
 }:
 
 let
-  common = import ./common.nix { inherit lib; };
+  common = import ./common.nix { inherit lib nix-update-script; };
 in
 buildEnv {
   pname = "flare";

--- a/pkgs/by-name/fl/flare/package.nix
+++ b/pkgs/by-name/fl/flare/package.nix
@@ -3,35 +3,44 @@
   buildEnv,
   callPackage,
   makeWrapper,
+  stdenv,
+  desktopToDarwinBundle,
 }:
 
+let
+  common = import ./common.nix { inherit lib; };
+in
 buildEnv {
   pname = "flare";
-  version = "1.15";
+  inherit (common) version;
 
   paths = [
     (callPackage ./engine.nix { })
     (callPackage ./game.nix { })
   ];
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    makeWrapper
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ desktopToDarwinBundle ];
+
   postBuild = ''
     mkdir -p $out/bin
     makeWrapper $out/games/flare $out/bin/flare --chdir "$out/share/games/flare"
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    convertDesktopFiles "$out"
   '';
 
   meta = {
     description = "Fantasy action RPG using the FLARE engine";
     mainProgram = "flare";
     homepage = "https://flarerpg.org/";
-    maintainers = with lib.maintainers; [
-      aanderse
-      McSinyx
-    ];
     license = [
       lib.licenses.gpl3
       lib.licenses.cc-by-sa-30
     ];
     platforms = lib.platforms.unix;
+    inherit (common) maintainers;
   };
 }


### PR DESCRIPTION
removed broken field after local machine test<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- Did some work into reducing duplication of things like versioning as it was getting to me
- Did a lot of work to provide a .app bundle on darwin because that's really helpful!
- Added auto-update infrastructure

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
