### PR TITLE
openttd: super cool refactor and end-to-end building!

### DIFF
--- a/pkgs/by-name/op/openttd/catcodec.nix
+++ b/pkgs/by-name/op/openttd/catcodec.nix
@@ -1,0 +1,28 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+}:
+
+stdenv.mkDerivation {
+  pname = "catcodec";
+  version = "0-unstable-2024-01-01";
+
+  src = fetchFromGitHub {
+    owner = "OpenTTD";
+    repo = "catcodec";
+    rev = "b8eb8f149520060b57433ab9d4b0703f905874a6";
+    hash = "sha256-6RJdhn45hq/wRGJ6m2r0aMLTnDxqP/J3Uv0+eH4Ni8E=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  preConfigure = ''
+    printf '1.0.0\t2024-01-01' > .version
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -m755 catcodec $out/bin/
+  '';
+}

--- a/pkgs/by-name/op/openttd/opengfx.nix
+++ b/pkgs/by-name/op/openttd/opengfx.nix
@@ -1,0 +1,45 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  openttd-nml,
+  openttd-grfcodec,
+  python3,
+  coreutils,
+  gnutar,
+}:
+
+stdenv.mkDerivation {
+  pname = "openttd-opengfx";
+  version = "8.0";
+
+  src = fetchFromGitHub {
+    owner = "OpenTTD";
+    repo = "OpenGFX";
+    tag = "8.0";
+    hash = "sha256-5kM+MlI+9xXX0igK6bywU1ebINjzUpvZwMes5/LqfmY=";
+  };
+
+  nativeBuildInputs = [
+    openttd-nml
+    openttd-grfcodec
+    python3
+    coreutils
+    gnutar
+  ];
+
+  preBuild = ''
+    printf '8.0\t20230404\t0\t' > .ottdrev
+  '';
+
+  makeFlags = [
+    "bundle_tar"
+    "MD5SUM=md5sum"
+    "CP_FLAGS=-rf"
+    "TAR=tar"
+  ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp *.tar $out/
+  '';
+}

--- a/pkgs/by-name/op/openttd/openmsx.nix
+++ b/pkgs/by-name/op/openttd/openmsx.nix
@@ -1,0 +1,49 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  openttd-nml,
+  python3,
+  coreutils,
+  gnutar,
+}:
+
+stdenv.mkDerivation {
+  pname = "openttd-openmsx";
+  version = "0.4.2";
+
+  src = fetchFromGitHub {
+    owner = "OpenTTD";
+    repo = "OpenMSX";
+    tag = "0.4.2";
+    hash = "sha256-l5yD2+iTk/3xa5wBpg6SOY5sMUYpUnUtEaIOrKJqQio=";
+  };
+
+  nativeBuildInputs = [
+    openttd-nml
+    python3
+    coreutils
+    gnutar
+  ];
+
+  postPatch = ''
+    substituteInPlace scripts/md5list.py \
+      --replace-fail "md5call = [\"md5\", \"-r\"]" "md5call = [\"md5sum\"]"
+  '';
+
+  preBuild = ''
+    printf '0.4.2\t20210601\t0\t' > .ottdrev
+  '';
+
+  makeFlags = [
+    "bundle_tar"
+    "PYTHON=python3"
+    "MD5SUM=md5sum"
+    "CP_FLAGS=-rf"
+    "TAR=tar"
+  ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp *.tar $out/
+  '';
+}

--- a/pkgs/by-name/op/openttd/opensfx.nix
+++ b/pkgs/by-name/op/openttd/opensfx.nix
@@ -1,0 +1,57 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  openttd-nml,
+  python3,
+  coreutils,
+  gnutar,
+  callPackage,
+}:
+
+let
+  catcodec = callPackage ./catcodec.nix { };
+in
+
+stdenv.mkDerivation {
+  pname = "openttd-opensfx";
+  version = "1.0.3";
+
+  src = fetchFromGitHub {
+    owner = "OpenTTD";
+    repo = "OpenSFX";
+    tag = "1.0.3";
+    hash = "sha256-VXxu6LD+TThHMY4PWjDtXTpochiMIch9Ru6G621P60o=";
+  };
+
+  nativeBuildInputs = [
+    openttd-nml
+    python3
+    coreutils
+    gnutar
+    catcodec
+  ];
+
+  postPatch = ''
+    substituteInPlace Makefile.in \
+      --replace-fail \
+        'ifneq ("$(shell which $(MD5SUM) 2>/dev/null)","")' \
+        'ifeq (1,1)'
+  '';
+
+  preBuild = ''
+    printf '1.0.3\t20230404\t0\t' > .ottdrev
+  '';
+
+  makeFlags = [
+    "bundle_tar"
+    "PYTHON=python3"
+    "MD5SUM=md5sum"
+    "CP_FLAGS=-rf"
+    "TAR=tar"
+  ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp *.tar $out/
+  '';
+}

--- a/pkgs/by-name/op/openttd/package.nix
+++ b/pkgs/by-name/op/openttd/package.nix
@@ -145,6 +145,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       jcumming
       fpletz
+      philocalyst
     ];
   };
 })

--- a/pkgs/by-name/op/openttd/package.nix
+++ b/pkgs/by-name/op/openttd/package.nix
@@ -1,17 +1,18 @@
 {
   lib,
   stdenv,
-  fetchzip,
-  fetchpatch,
+  fetchFromGitHub,
   cmake,
   pkg-config,
-  SDL2,
   libpng,
   zlib,
   xz,
+  curl,
+
+  # Linux-only graphics/font stack (OpenTTD uses Cocoa/CoreText on Darwin)
+  SDL2,
   freetype,
   fontconfig,
-  curl,
   icu,
   harfbuzz,
   expat,
@@ -20,7 +21,9 @@
   withOpenGFX ? true,
   withOpenSFX ? true,
   withOpenMSX ? true,
-  withFluidSynth ? true,
+
+  # FluidSynth is unused on Darwin (CoreMIDI handles music there)
+  withFluidSynth ? !stdenv.hostPlatform.isDarwin,
   fluidsynth,
   soundfont-fluid,
   soundfont-name ? "FluidR3_GM2-2",
@@ -33,8 +36,10 @@
   pulseaudio,
   alsa-lib,
   libjack2,
+  apple-sdk,
   makeWrapper,
   buildPackages,
+  callPackage,
   versionCheckHook,
 }:
 
@@ -76,18 +81,23 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    SDL2
     libpng
     xz
     zlib
+    curl
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    SDL2
     freetype
     fontconfig
-    curl
     icu
     harfbuzz
     expat
     glib
     pcre2
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    apple-sdk
   ]
   ++ lib.optionals withFluidSynth [
     fluidsynth
@@ -108,10 +118,32 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
+  cmakeFlags = lib.optionals stdenv.hostPlatform.isDarwin [
+    # macOS defaults OPTION_INSTALL_FHS to OFF (for .app bundle builds), but
+    # nixpkgs installs to the Nix store which needs a standard FHS layout so
+    # that all data lands under $out/share/games/openttd/ before we symlink
+    # it into the bundle's Contents/Resources/.
+    (lib.cmakeBool "OPTION_INSTALL_FHS" true)
+  ];
+
   postPatch = ''
+    printf '${finalAttrs.version}\t20250101\t0\t\t1\t1' > .ottdrev
+  ''
+  + lib.optionalString withFluidSynth ''
     substituteInPlace src/music/fluidsynth.cpp \
       --replace-fail "/usr/share/soundfonts/default.sf2" \
                      "${soundfont-fluid}/share/soundfonts/${soundfont-name}.sf2"
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      # PackageBundle.cmake unconditionally installs a fixup_bundle() rule that
+      # expects a .app bundle at $CMAKE_INSTALL_PREFIX/../MacOS/openttd.  With
+      # OPTION_INSTALL_FHS=ON we install to a standard FHS tree, so there is no bundle :(
+      substituteInPlace cmake/InstallAndPackage.cmake \
+        --replace-fail \
+          'include(PackageBundle)' \
+          'if(NOT OPTION_INSTALL_FHS)
+      include(PackageBundle)
+    endif()'
   '';
 
   postInstall =
@@ -123,6 +155,26 @@ stdenv.mkDerivation (finalAttrs: {
     ''
     + lib.optionalString withOpenMSX ''
       tar -xf ${openmsx}/*.tar -C $out/share/games/openttd/baseset
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      APP="$out/Applications/OpenTTD.app/Contents"
+      mkdir -p "$APP/MacOS" "$APP/Resources"
+
+      mv "$out/bin/openttd" "$APP/MacOS/openttd"
+      ln -s "../Applications/OpenTTD.app/Contents/MacOS/openttd" "$out/bin/openttd"
+
+      # Expose FHS data through Resources so CFBundle-based path lookup finds it.
+      for d in lang baseset ai game scripts; do
+        ln -s "$out/share/games/openttd/$d" "$APP/Resources/$d"
+      done
+
+      cp "$src/os/macosx/openttd.icns" "$APP/Resources/OpenTTD.icns"
+
+      cp "$src/os/macosx/Info.plist.in" "$APP/Info.plist"
+      substituteInPlace "$APP/Info.plist" \
+        --replace-fail $'\x24{CPACK_BUNDLE_NAME}' 'OpenTTD' \
+        --replace-fail '#CPACK_PACKAGE_VERSION#' '${finalAttrs.version}' \
+        --replace-fail $'\x24{CURRENT_YEAR}' '2025'
     '';
 
   meta = {
@@ -141,7 +193,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.openttd.org/";
     changelog = "https://cdn.openttd.org/openttd-releases/${finalAttrs.version}/changelog.md";
     license = lib.licenses.gpl2Only;
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [
       jcumming
       fpletz

--- a/pkgs/by-name/op/openttd/package.nix
+++ b/pkgs/by-name/op/openttd/package.nix
@@ -59,9 +59,11 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "openttd";
   version = "15.3";
 
-  src = fetchzip {
-    url = "https://cdn.openttd.org/openttd-releases/${finalAttrs.version}/openttd-${finalAttrs.version}-source.tar.xz";
-    hash = "sha256-xDpDEeWdAWMyA/I+ioQR98vwrL9WXYd5AjswJ4NuVMY=";
+  src = fetchFromGitHub {
+    owner = "OpenTTD";
+    repo = "OpenTTD";
+    tag = finalAttrs.version;
+    hash = "sha256-KVOCFZaSmdmG270YEcJpGe6AjqAKpYNhkv9IjXxmrM8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/op/openttd/package.nix
+++ b/pkgs/by-name/op/openttd/package.nix
@@ -39,20 +39,9 @@
 }:
 
 let
-  opengfx = fetchzip {
-    url = "https://cdn.openttd.org/opengfx-releases/8.0/opengfx-8.0-all.zip";
-    hash = "sha256-aqLEZ3EptxBZrYQd1IG6B1rSRJJTGIijKu2NIqpAYRA=";
-  };
-
-  opensfx = fetchzip {
-    url = "https://cdn.openttd.org/opensfx-releases/1.0.3/opensfx-1.0.3-all.zip";
-    hash = "sha256-QmfXizrRTu/fUcVOY7tCndv4t4BVW+fb0yUi8LgSYzM=";
-  };
-
-  openmsx = fetchzip {
-    url = "https://cdn.openttd.org/openmsx-releases/0.4.2/openmsx-0.4.2-all.zip";
-    hash = "sha256-ysNFIvo7iaLN8XoaeZuZQFLpBZlYUDLDg7rH6TabaHY=";
-  };
+  opengfx = callPackage ./opengfx.nix { };
+  opensfx = callPackage ./opensfx.nix { };
+  openmsx = callPackage ./openmsx.nix { };
 
   # OpenTTD builds and uses some of its own tools during the build and we need those to be available for cross-compilation.
   # Build the tools for buildPlatform with minimal dependencies, using the "OPTION_TOOLS_ONLY" flag.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- Sort of rethought the whole source-grabbing process! Now each little micro-source uses fetchgit instead of the tarball mechanism
- Put thought into the .app and .desktop output bundles
- General cleanup into modern nixpkgs patterns
- Have no idea if this works on linux! Should though!

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
