### PR TITLE
openroad: fix build on aarch64-darwin

### DIFF
--- a/pkgs/by-name/op/openroad/package.nix
+++ b/pkgs/by-name/op/openroad/package.nix
@@ -161,6 +161,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   qtWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ yosys ]}" ];
 
+  # The automatic Qt wrapper scan segfaults on Darwin; wrap executables explicitly.
+  dontWrapQtApps = stdenv.hostPlatform.isDarwin;
+
+  postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    wrapQtApp "$out/bin/sta"
+    wrapQtApp "$out/bin/openroad"
+  '';
+
   # Some tests are unstable on Darwin
   doCheck = !stdenv.hostPlatform.isDarwin;
 


### PR DESCRIPTION
## Things done

Fixes #518999.

`openroad` fails on aarch64-darwin during `wrapQtAppsHook` automatic executable discovery, after `installPhase` and before fixup completes. Disable the automatic Qt wrapper scan on Darwin and explicitly wrap the installed executables instead.

This keeps Linux behavior unchanged and preserves Darwin wrapping for both installed binaries:

- `$out/bin/openroad`
- `$out/bin/sta`

Built on platform:

- [x] aarch64-darwin

Tested:

- [x] `nix eval --json --impure --expr 'let darwin = import ./. { system = "aarch64-darwin"; }; linux = import ./. { system = "x86_64-linux"; }; in { darwinDontWrapQtApps = darwin.openroad.dontWrapQtApps; darwinPostFixup = darwin.openroad.postFixup; linuxDontWrapQtApps = linux.openroad.dontWrapQtApps; linuxPostFixupLength = builtins.stringLength linux.openroad.postFixup; mainProgram = darwin.openroad.meta.mainProgram; }'`
- [x] `git diff --check`
- [x] `nix build --file . openroad` on aarch64-darwin, result `/nix/store/kaxdmi1h18ngww8dwapj5jralx82g20s-openroad-26Q2`
- [x] `./result/bin/openroad -version` -> `26Q2`
- [x] `./result/bin/sta -version` -> `3.1.0`
