### PR TITLE
cvc5: 1.3.3 → 1.3.4

### DIFF
--- a/pkgs/by-name/cv/cvc5/package.nix
+++ b/pkgs/by-name/cv/cvc5/package.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "cvc5";
-  version = "1.3.3";
+  version = "1.3.4";
 
   src = fetchFromGitHub {
     owner = "cvc5";
     repo = "cvc5";
     tag = "cvc5-${finalAttrs.version}";
-    hash = "sha256-tXhOMrf/sZwEZFWB2Amp9lApWEsfuPqaj9H7RmI733o=";
+    hash = "sha256-PZcOArSTyJzyd2DKT8K0aFC4RlVXgTCnkoU0f08KPfY=";
   };
 
   __structuredAttrs = true;

--- a/pkgs/by-name/is/isabelle/package.nix
+++ b/pkgs/by-name/is/isabelle/package.nix
@@ -14,6 +14,7 @@
   eprover-ho,
   cvc5,
   libpoly,
+  symfpu,
   csdp,
   rlwrap,
   perl,
@@ -107,6 +108,10 @@ let
     (cvc5.override {
       libpoly = libpoly.overrideAttrs {
         version = "0.2.0";
+        __intentionallyOverridingVersion = true;
+      };
+      symfpu = symfpu.overrideAttrs {
+        version = "0-unstable-2019-05-17";
         __intentionallyOverridingVersion = true;
       };
     }).overrideAttrs

--- a/pkgs/by-name/sy/symfpu/package.nix
+++ b/pkgs/by-name/sy/symfpu/package.nix
@@ -8,13 +8,23 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "symfpu";
-  version = "0-unstable-2019-05-17";
+  version = "1.2.0-unstable-2026-05-13";
 
   src = fetchFromGitHub {
     owner = "martin-cs";
     repo = "symfpu";
-    rev = "8fbe139bf0071cbe0758d2f6690a546c69ff0053";
-    sha256 = "1jf5lkn67q136ppfacw3lsry369v7mdr1rhidzjpbz18jfy9zl9q";
+    rev =
+      {
+        "1.2.0-unstable-2026-05-13" = "40bdec00e99f8ea1b96c3dac0a05eed11c541639";
+        "0-unstable-2019-05-17" = "8fbe139bf0071cbe0758d2f6690a546c69ff0053";
+      }
+      ."${finalAttrs.version}";
+    hash =
+      {
+        "1.2.0-unstable-2026-05-13" = "sha256-ho0tLWFlPozq5hD+qX6AQiCPxUuRPwnXe9dEfzXwSY0=";
+        "0-unstable-2019-05-17" = "sha256-ONGfvJMo/HXlbxHmkFs9O5nhs6aDM+XuNSPgY+ykxck=";
+      }
+      ."${finalAttrs.version}";
   };
 
   nativeBuildInputs = [ copyPkgconfigItems ];
@@ -35,6 +45,8 @@ stdenv.mkDerivation (finalAttrs: {
     # copyPkgconfigItems will substitute this in the pkg-config file
     includedir = "${placeholder "out"}/include";
   };
+
+  dontBuild = true;
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
symfpu: 0-unstable-2019-05-17 → 1.2.0-unstable-2026-05-13


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
