### PR TITLE
aw-notify: fix Darwin build

### DIFF
--- a/pkgs/applications/office/activitywatch/aw-notify-desktop-notifier-6.patch
+++ b/pkgs/applications/office/activitywatch/aw-notify-desktop-notifier-6.patch
@@ -1,0 +1,72 @@
+diff --git a/aw_notify/main.py b/aw_notify/main.py
+index c749725..44dce5a 100644
+--- a/aw_notify/main.py
++++ b/aw_notify/main.py
+@@ -3,6 +3,7 @@
+ and send notifications to the user on predefined conditions.
+ """
+ 
++import asyncio
+ import logging
+ import sys
+ import threading
+@@ -23,7 +24,7 @@
+ import aw_client.queries
+ import click
+ from aw_core.log import setup_logging
+-from desktop_notifier import DesktopNotifier
++from desktop_notifier import DesktopNotifier, Icon
+ from typing_extensions import TypeAlias
+ 
+ logger = logging.getLogger(__name__)
+@@ -149,11 +150,20 @@ def notify(title: str, msg: str):
+     if notifier is None:
+         notifier = DesktopNotifier(
+             app_name="AW",
+-            app_icon=f"file://{icon_path}",
++            app_icon=Icon(uri=f"file://{icon_path}"),
+             notification_limit=10,
+         )
+ 
+     logger.info(f'Showing: "{title} - {msg}"')
+-    notifier.send_sync(title=title, message=msg)
++
++    # Get or create event loop
++    try:
++        loop = asyncio.get_running_loop()
++    except RuntimeError:
++        loop = asyncio.new_event_loop()
++        asyncio.set_event_loop(loop)
++
++    # Send notification
++    loop.run_until_complete(notifier.send(title=title, message=msg))
+ 
+ 
+ class CategoryAlert:
+diff --git a/pyproject.toml b/pyproject.toml
+index 314fe2f..0d6d5a9 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -13,15 +13,15 @@ packages = [{include = "aw_notify"}]
+ aw-notify = "aw_notify.main:main"
+ 
+ [tool.poetry.dependencies]
+-python = "^3.9,<3.12"
+-aw-client = "^0.5.13"
+-desktop-notifier = "^3.4.2"
+-rubicon-objc = { version = "^0.4.0", platform = "darwin" }
++python = ">=3.9,<3.14"
++aw-client = "^0.5.15"
++desktop-notifier = "^6.0.0"
++rubicon-objc = { version = "^0.5.0", platform = "darwin" }
+ 
+ [tool.poetry.group.dev.dependencies]
+ black = "*"
+ mypy = "*"
+-pyinstaller = "^6.6"
+-pytest = "^7.4"
++pyinstaller = "^6.12.0"
++pytest = "*"
+ 
+ [build-system]
+ requires = ["poetry-core"]

--- a/pkgs/applications/office/activitywatch/default.nix
+++ b/pkgs/applications/office/activitywatch/default.nix
@@ -159,6 +159,12 @@ rec {
     pyproject = true;
     build-system = [ python3Packages.poetry-core ];
 
+    patches = [
+      # Backport desktop-notifier 6 / rubicon-objc 0.5 support.
+      # https://github.com/ActivityWatch/aw-notify/pull/10
+      ./aw-notify-desktop-notifier-6.patch
+    ];
+
     dependencies = with python3Packages; [
       aw-client
       desktop-notifier


### PR DESCRIPTION
[![](https://hydra-banner.harinn.dev/build/329256373)](https://hydra.nixos.org/build/329256373)

ZHF: #516381

This PR fixes the `aw-notify` package build on `aarch64-darwin` (broken since #377253 updated `rubicon-objc` via #375144), by lightly adapting ActivityWatch/aw-notify#10 to apply to the source we're using in Nixpkgs.

This build failure is Darwin-specific because `rubicon-objc` is only a dependency of `aw-notify` on Darwin.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
