### PR TITLE
gimp: 3.0.8 -> 3.2.4

### DIFF
--- a/pkgs/applications/graphics/gimp/default.nix
+++ b/pkgs/applications/graphics/gimp/default.nix
@@ -60,7 +60,7 @@
   gexiv2,
   harfbuzz,
   makeFontsConf,
-  mypaint-brushes1,
+  mypaint-brushes,
   libwebp,
   libheif,
   gjs,
@@ -84,7 +84,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gimp";
-  version = "3.0.8";
+  version = "3.2.4";
 
   outputs = [
     "out"
@@ -95,7 +95,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://download.gimp.org/gimp/v${lib.versions.majorMinor finalAttrs.version}/gimp-${finalAttrs.version}.tar.xz";
-    hash = "sha256-/rSYrMAbJoJ8/x/5Wqj7gs3Wpg16v3c8/NGavq/KM4Y=";
+    hash = "sha256-cxK8U+nG0tAFbKe5PxxrmHB5Rt2TT3FMIbh0bstgFYg=";
   };
 
   patches = [
@@ -105,43 +105,10 @@ stdenv.mkDerivation (finalAttrs: {
       cc_version = stdenv.cc.cc.name;
     })
 
-    # Use absolute paths instead of relying on PATH
-    # to make sure plug-ins are loaded by the correct interpreter.
-    # TODO: This now only appears to be used on Windows.
-    (replaceVars ./hardcode-plugin-interpreters.patch {
-      python_interpreter = python.interpreter;
-      PYTHON_EXE = null;
-    })
-
     # D-Bus configuration is not available in the build sandbox
     # so we need to pick up the one from the package.
     (replaceVars ./tests-dbus-conf.patch {
       session_conf = "${dbus.out}/share/dbus-1/session.conf";
-    })
-
-    # Allow calling tests from other directories.
-    # Required for the next patch.
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gimp/-/commit/fd58ab3bee7a79cb0a7870c6858f3b64c84a7917.patch";
-      hash = "sha256-fpysKWwt5rilqp7ukdWx7kutkDquL/6YhYjR1zQfu/Q=";
-    })
-
-    # Do not go through ui for save-and-export test.
-    # https://gitlab.gnome.org/GNOME/gimp/-/issues/15763
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gimp/-/commit/608ad0a528b5b31101c021d96aeb95558d207497.patch";
-      hash = "sha256-0oA5u+uAT0l3WT90fy0RGOR8xy/fGIHevBb69oUzfGs=";
-      excludes = [
-        # Other changes would prevent deletion, removing it from build is sufficient.
-        "app/tests/test-save-and-export.c"
-      ];
-    })
-
-    # Disable broken UI tests.
-    # https://gitlab.gnome.org/GNOME/gimp/-/issues/15763
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gimp/-/commit/c34fe3e94f1019eafcb38edf1c07bff12a57431e.patch";
-      hash = "sha256-yVauEpoGEOIfCXnGnWMGWjXbIDizDhJ3hipeCy3XSBM=";
     })
   ];
 
@@ -216,7 +183,7 @@ stdenv.mkDerivation (finalAttrs: {
     libxmu
     glib-networking
     libmypaint
-    mypaint-brushes1
+    mypaint-brushes
     qoi
 
     # New file dialogue crashes with “Icon 'image-missing' not present in theme Symbolic” without an icon theme.
@@ -288,11 +255,6 @@ stdenv.mkDerivation (finalAttrs: {
     chmod +x plug-ins/python/{colorxhtml,file-openraster,foggify,gradients-save-as-css,histogram-export,palette-offset,palette-sort,palette-to-gradient,python-eval,spyro-plus}.py
     patchShebangs \
       plug-ins/python/{colorxhtml,file-openraster,foggify,gradients-save-as-css,histogram-export,palette-offset,palette-sort,palette-to-gradient,python-eval,spyro-plus}.py
-
-    # Use Python from environment not from Meson.
-    # https://gitlab.gnome.org/GNOME/gimp/-/merge_requests/2607
-    substituteInPlace meson.build \
-      --replace-fail "import('python').find_installation()" "import('python').find_installation('python3')"
 
     # Broken test
     # https://github.com/NixOS/nixpkgs/pull/484971#issuecomment-3846759517

--- a/pkgs/applications/graphics/gimp/hardcode-plugin-interpreters.patch
+++ b/pkgs/applications/graphics/gimp/hardcode-plugin-interpreters.patch
@@ -1,8 +1,0 @@
---- a/plug-ins/python/pygimp.interp.in
-+++ b/plug-ins/python/pygimp.interp.in
-@@ -2,4 +2,4 @@ python=@PYTHON_EXE@
- python3=@PYTHON_EXE@
- /usr/bin/python=@PYTHON_EXE@
- /usr/bin/python3=@PYTHON_EXE@
--:Python:E::py::python3:
-+:Python:E::py::@python_interpreter@:


### PR DESCRIPTION
changelog for 3.2.2 to 3.2.4

> - We’ve caught more cases where tools would accidentally rasterize link, text, and vector layers. For instance, the Edit > Fill with... menu options for colors and patterns now work the same as dragging and dropping colors onto non-raster layers. The Crop Tool now behaves more consistently and does not attempt to resize vector layers.
> - New contributor anenasa both reported and fixed an issue with the Text Outline feature being cut off with vertical oriented text.
> - One for the record books - Jehan fixed a bug in our XCF code that’s existed [since 1999](https://gitlab.gnome.org/GNOME/gimp/-/commit/803695d58ef6ca052fa88c02a9e3306a593201ae)! He’s also added code to correctly load XCFs made with and without this bug, as backwards compatibility with XCF project files is very important to us.
> - Sometimes a bug fix can create other, unrelated bugs. A fix we made in GIMP 3.2.2 caused some text layers to become uneditable after reloading them from an XCF file. Jehan found and fixed the new bug, so you should be able to edit both XCFs created in 3.2.2 and new ones.
> - Speaking of text, Gabriele Barbe has fixed an issue where rotating the canvas rather than the image could cause the on-canvas text editor to appear in the wrong place when moved.
> - New contributor balooii fixed a crash that could occur when selecting a non-existant filter tag in a plug-in like GFig.
> - Security contributors bb1abu, HanTul, Rakan Alotaib, JungWoo Park, and Bronson Yen studied our image import plug-ins and reported several possible issues. We appreciate their code review and mitigation suggestions! Gabriele Barbe and Alx Sa implemented their suggestions for APNG, PAA, PNG, DDS, PSP, PNM, PSD, JIF, PVR, TIM, XWD, and SFW files.
> - The [OpenRaster](https://www.openraster.org/) format stores layers as PNGs and notes their opacity in a separate settings file. Our export plug-in saved that setting but also exported the PNG with the same opacity, resulting in higher transparency when reloaded. We’ve fixed this so now layers are saved with 100% opacity, thus ensuring they reopen correctly.
> - New contributor Ahmed E. Yassin fixed a bug where exporting metadata in our [Metadata Viewer](https://docs.gimp.org/3.0/en/plug-in-metadata-viewer.html) could result in empty files.
> - New contributor Kaushik B fixed a bug in the Open as Layers feature where multi-layer XCF files would have their layer names changed on import.
> - Balooii also fixed an issue on Wayland where the tool cursor icon might disappear when moving it.
> - New contributor v4vansh resolved an issue where the image tab preview wouldn’t correctly update after switching between grayscale and RGB color modes.
> - Bruno Lopes added support for the macOS [ScreenCaptureKit](https://developer.apple.com/documentation/screencapturekit/) to our color picker feature. This allows us to use the newer API for macOS 12+.

https://www.gimp.org/news/2026/04/19/gimp-3-2-4-released/

very large further changelog from gimp for 3.2, as we're jumping from 3.0:

https://www.gimp.org/release-notes/gimp-3.2.html

there are a couple of cves of note here that have been fixed as part of this:

* https://www.cvedetails.com/cve/CVE-2026-0797/
* https://www.cvedetails.com/cve/CVE-2026-4887/
* https://www.cvedetails.com/cve/CVE-2026-2048/

this update removes a couple of patches that no longer work, as they were to work around broken tests that appear to have been removed per the comment chains in the referenced gitlab links:

* `./hardcode-plugin-interpreters.patch` was a windows-only patch and doesn't appear to be required to build anymore.
* `https://gitlab.gnome.org/GNOME/gimp/-/commit/fd58ab3bee7a79cb0a7870c6858f3b64c84a7917.patch` was removed as the upstream change it was patching in has been modified, and doesn't appear to be required anymore. this patch was to support the next two patches.
* `https://gitlab.gnome.org/GNOME/gimp/-/commit/608ad0a528b5b31101c021d96aeb95558d207497.patch` was removed as the upstream change it was patching in has been modified, and doesn't appear to be required anymore.\[[more detail](https://gitlab.gnome.org/GNOME/gimp/-/work_items/15763)\]
* `https://gitlab.gnome.org/GNOME/gimp/-/commit/c34fe3e94f1019eafcb38edf1c07bff12a57431e.patch` was removed as the upstream change it was patching has been modified, and doesn't appear to be required anymore. \[[more detail](https://gitlab.gnome.org/GNOME/gimp/-/work_items/15763)\]
* a substitute against `meson.build` replaced `import('python').find_installation()` with `import('python').find_installation('python3')`, upstream has altered the file and this doesn't appear to be required anymore, however the intricacies of meson are thankfully beyond me, so would appreciate a peep.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
