### PR TITLE
pioneer: 20250501 -> 20260203

### DIFF
--- a/pkgs/by-name/pi/pioneer/package.nix
+++ b/pkgs/by-name/pi/pioneer/package.nix
@@ -22,20 +22,20 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pioneer";
-  version = "20250501";
+  version = "20260203";
 
   src = fetchFromGitHub {
     owner = "pioneerspacesim";
     repo = "pioneer";
     rev = finalAttrs.version;
-    hash = "sha256-bQ1JGndHbBM28SuAUybo9msC/nBXu6el1UY41BKJN5A=";
+    hash = "sha256-rffm5i8yHy8WXij8PGbBegA6uJ5B3ACpT7Wf9cWHfs4=";
   };
 
   postPatch = ''
     substituteInPlace contrib/lz4/CMakeLists.txt \
-      --replace-fail 'cmake_minimum_required(VERSION 3.4)' 'cmake_minimum_required(VERSION 3.13)'
+      --replace-fail 'cmake_minimum_required(VERSION 3.5)' 'cmake_minimum_required(VERSION 3.13)'
     substituteInPlace contrib/nanosockets/CMakeLists.txt \
-      --replace-fail 'cmake_minimum_required(VERSION 3.1)' 'cmake_minimum_required(VERSION 3.13)'
+      --replace-fail 'cmake_minimum_required(VERSION 3.5)' 'cmake_minimum_required(VERSION 3.13)'
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
pioneer: 20250501 -> 20260203

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I updated Pioneer from version 2025-05-01 to 2026-02-03. I tested it by starting a new game, and there was an immediate graphical glitch after undocking from Mars when running the game in NixOS in VirtualBox. Then I tried downloading the native Windows build and the graphics are fine, so it must be a VirtualBox bug related to VirtualBox's 3D acceleration using single-precision instead of double-precision float.

The patches to cmake_minimum_required have been slightly tweaked now that the minimum was bumped to 3.5 in both lz4 and nanosockets. CMake 4 requires at least v3.5 and CMake 3.31 warns about minimum_required ≤ 3.10. CMake 3.12 added support for version_max in a minimum_required call, but it looks like the two places being patched don't use a max version.

<details>

<summary> Glitch on VirtualBox with single-precision OpenGL floats </summary>

<img width="1280" height="748" alt="Pioneer OSS space game z-buffer glitch 2026-05-11.png" src="https://github.com/user-attachments/assets/0731c355-0bf8-4609-b5e9-4818775f9000" />

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
