### PR TITLE
WIP: kibot: init at 1.9.0

### DIFF
--- a/pkgs/by-name/ki/kibot/package.nix
+++ b/pkgs/by-name/ki/kibot/package.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+
+  gitMinimal,
+  kicad,
+  librsvg,
+  ghostscript,
+  blender,
+  imagemagick,
+  pandoc,
+  texliveSmall,
+  xvfb-run,
+  zbar,
+}:
+python3.pkgs.buildPythonApplication (finalAttrs: {
+  pname = "kibot";
+  version = "1.9.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "INTI-CMNB";
+    repo = "KiBot";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7pPusm+X10FMB5Ckety/EDnlhRxBGLczfOdPh72wATg=";
+  };
+
+  postPatch = ''
+    substituteInPlace kibot/__main__.py \
+      --replace-fail "GS.kicad_share_path = '/usr/share/kicad'" "GS.kicad_share_path = '${kicad}'"
+
+    patchShebangs g*.sh
+    substituteInPlace g*.sh \
+      --replace-fail "pytest-3" "pytest"
+  '';
+
+  build-system = [ python3.pkgs.setuptools ];
+
+  dependencies = with python3.pkgs; [
+    kicad
+    pyyaml
+    xlsxwriter
+    colorama
+    requests
+    qrcodegen
+    markdown2
+    lark
+    wxpython
+    lxml
+  ];
+
+  nativeCheckInputs = [
+    python3.pkgs.pytest
+    python3.pkgs.coverage
+    gitMinimal
+    python3.pkgs.kiauto
+    python3.pkgs.kicad
+    librsvg
+    ghostscript
+    blender
+    imagemagick
+    pandoc
+    texliveSmall
+    xvfb-run
+    zbar
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    export HOME=$TMPDIR
+
+    xvfb-run ./g2.sh
+    xvfb-run ./g3.sh
+    xvfb-run ./g4.sh
+
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "Tool for generating fabrication and documentation files for KiCad";
+    homepage = "https://github.com/INTI-CMNB/KiBot";
+    license = lib.licenses.agpl3Only;
+    maintainers = [ lib.maintainers.ryand56 ];
+    mainProgram = "kibot";
+  };
+})

--- a/pkgs/by-name/ki/kidiff/package.nix
+++ b/pkgs/by-name/ki/kidiff/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  imagemagick,
+
+  makeFontsConf,
+  roboto,
+  ghostscript,
+  librsvg,
+}:
+python3.pkgs.buildPythonApplication (finalAttrs: {
+  pname = "kidiff";
+  version = "2.5.9";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "INTI-CMNB";
+    repo = "KiDiff";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-tIK8VwTk07NpIsEAC/XdKq2jSto7lacbNZUuqw9lkaM=";
+  };
+
+  postPatch = ''
+    substituteInPlace tests/utils/context.py \
+      --replace-fail "COVERAGE_SCRIPT = 'python3-coverage'" "COVERAGE_SCRIPT = 'coverage3'" \
+      --replace-fail "ae = int(res.stderr.decode())" "ae = int(res.stderr.decode().strip().split(' ')[0])"
+  '';
+
+  build-system = [ python3.pkgs.setuptools ];
+  dependencies = with python3.pkgs; [
+    kiauto
+    kicad
+  ];
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytestCheckHook
+    coverage
+    imagemagick
+    ghostscript
+    kiauto
+    kicad
+    librsvg
+  ];
+  pytestFlags = [ "--test_dir=kidiff_tests" ];
+
+  preCheck = ''
+    export HOME=$TMPDIR
+    export FONTCONFIG_FILE=${
+      makeFontsConf {
+        fontDirectories = [ roboto ];
+      }
+    }
+  '';
+
+  meta = {
+    description = "PDF file generator showing the diff between two KiCad PCB/SCH files";
+    homepage = "https://github.com/INTI-CMNB/KiDiff";
+    changelog = "https://github.com/INTI-CMNB/KiDiff/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.gpl2Only;
+    maintainers = [ lib.maintainers.ryand56 ];
+  };
+})

--- a/pkgs/development/python-modules/kiauto/default.nix
+++ b/pkgs/development/python-modules/kiauto/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  setuptools,
+
+  xvfbwrapper,
+  psutil,
+
+  kicadFull,
+  kicad,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "kiauto";
+  version = "2.3.7";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "INTI-CMNB";
+    repo = "KiAuto";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6USOb5iKjVKF6SOMVe5/TJoZHAUylCG0i5OjX88vZyU=";
+  };
+
+  postPatch = ''
+    substituteInPlace kiauto/misc.py \
+      --replace-fail "KICAD_SHARE = '/usr/share/kicad/'" "KICAD_SHARE = '${kicadFull}'"
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    xvfbwrapper
+    psutil
+    kicad
+  ];
+
+  pythonImportsCheck = [ "kiauto" ];
+
+  meta = {
+    description = "KiCad automation scripts library";
+    homepage = "https://github.com/INTI-CMNB/KiAuto";
+    changelog = "https://github.com/INTI-CMNB/KiAuto/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.ryand56 ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8393,6 +8393,10 @@ self: super: with self; {
 
   khanaa = callPackage ../development/python-modules/khanaa { };
 
+  kiauto = callPackage ../development/python-modules/kiauto {
+    kicadFull = pkgs.kicad;
+  };
+
   kicad = toPythonModule (pkgs.kicad.override { python3 = python; }).src;
 
   kicad-python = callPackage ../development/python-modules/kicad-python { };


### PR DESCRIPTION
Supersedes #505852
Still a WIP as I'm having issues with running tests on these

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
