### PR TITLE
stackblur-go: 1.1.0 -> 1.1.1

### DIFF
--- a/pkgs/by-name/st/stackblur-go/package.nix
+++ b/pkgs/by-name/st/stackblur-go/package.nix
@@ -6,20 +6,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "stackblur-go";
-  version = "1.1.0";
+  version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "esimov";
     repo = "stackblur-go";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-y1Fov81mholhz+bLRYl+G7jhzcsFS5TUjQ3SUntD8E0=";
+    hash = "sha256-PGYMqpk98bGJSZbyYBcZBqaPS3syfYSOymq33C+DxNM=";
   };
 
   vendorHash = null;
-
-  postInstall = ''
-    mv $out/bin/cmd $out/bin/stackblur
-  '';
 
   ldflags = [
     "-s"


### PR DESCRIPTION
update to 1.1.1

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
