### PR TITLE
zombies: init at 0-unstable-2006-03-07

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4542,6 +4542,12 @@
     githubId = 53847249;
     name = "Casey Avila";
   };
+  castorNova2 = {
+    email = "solemnsquire@gmail.com";
+    github = "castorNova2";
+    githubId = 84083897;
+    name = "Nidhish Chauhan";
+  };
   catap = {
     email = "kirill@korins.ky";
     github = "catap";

--- a/pkgs/by-name/zo/zombies/package.nix
+++ b/pkgs/by-name/zo/zombies/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  fetchurl,
+  stdenv,
+  clisp,
+  makeWrapper,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "zombies";
+  version = "0-unstable-2006-03-07";
+
+  src = fetchurl {
+    url = "https://distractionandnonsense.com/zombies/zombies.lisp";
+    hash = "sha256-g2CkdGUlTYB5V3chZIhm8IwkxJkICkER6h80wcHVNmU=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 $src $out/share/zombies/zombies.lisp
+
+    makeWrapper ${clisp}/bin/clisp $out/bin/zombies \
+      --add-flags "$out/share/zombies/zombies.lisp"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Minimalist Common Lisp Zombies rougelike";
+    homepage = "https://distractionandnonsense.com/zombies/";
+    mainProgram = "zombies";
+    #The game is released under joke Zombie Public License (ZPL).
+    #This means you can use the code for anything you like.
+    license = lib.licenses.free;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ castorNova2 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Part of https://github.com/NixOS/nixpkgs/issues/380688

Adds a package of [Zombies!](https://distractionandnonsense.com/zombies/) which is a single-file roguelike written in Common Lisp.

- License: Zombie Public license(permissive joke license , equivalent to public domain)
- No dependency beyond clisp


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
