### PR TITLE
python3Packages.upnpclient: init at 2.0.3

### DIFF
--- a/pkgs/development/python-modules/upnpclient/default.nix
+++ b/pkgs/development/python-modules/upnpclient/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  requests,
+  python-dateutil,
+  lxml,
+  ifaddr,
+  pytestCheckHook,
+  pytest-cov-stub,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "upnpclient";
+  version = "2.0.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "flyte";
+    repo = "upnpclient";
+    tag = finalAttrs.version;
+    hash = "sha256-bT7oNCYAKJvhCaSczLWnDAy+ULqhjP+3ZvFnIGAb+Ww=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    requests
+    python-dateutil
+    lxml
+    ifaddr
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+  ];
+
+  pythonImportsCheck = [ "upnpclient" ];
+
+  meta = {
+    description = "Python 3 library for accessing UPnP devices";
+    homepage = "https://github.com/flyte/upnpclient";
+    changelog = "https://github.com/flyte/upnpclient/blob/${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ eana ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20827,6 +20827,8 @@ self: super: with self; {
 
   uploadserver = callPackage ../development/python-modules/uploadserver { };
 
+  upnpclient = callPackage ../development/python-modules/upnpclient { };
+
   upnpy = callPackage ../development/python-modules/upnpy { };
 
   uproot = callPackage ../development/python-modules/uproot { };


### PR DESCRIPTION
Add upnpclient, a Python 3 library for discovering and interacting with UPnP devices on the local network. https://github.com/flyte/upnpclient

The package is pure Python (`py3-none-any`) and should work on all platforms, but has only been tested on `x86_64-linux` and `x86_64-darwin`.

Note: This PR depends on https://github.com/NixOS/nixpkgs/pull/521861 (maintainers: add eana) being merged first, or merged together.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
