### PR TITLE
dwarf-fortress: 53.11 -> 53.14

### DIFF
--- a/pkgs/games/dwarf-fortress/df.lock.json
+++ b/pkgs/games/dwarf-fortress/df.lock.json
@@ -1,28 +1,28 @@
 {
   "game": {
     "latest": {
-      "linux": "53.11",
+      "linux": "53.14",
       "darwin": "0.47.05"
     },
     "versions": {
-      "53.11": {
+      "53.14": {
         "df": {
-          "version": "53.11",
+          "version": "53.14",
           "urls": {
             "linux": {
-              "url": "https://www.bay12games.com/dwarves/df_53_11_linux.tar.bz2",
-              "outputHash": "sha256-Ss1SHsLr3V9aMWptIpd6PTO9ZmqPZiR8P97vNRBuLZs="
+              "url": "https://www.bay12games.com/dwarves/df_53_14_linux.tar.bz2",
+              "outputHash": "sha256-ZU/va7bblzh5UuPuuctjUHzEmcFLtzjXp9R86UV+G9k="
             }
           }
         },
         "hack": {
-          "version": "53.11-r1",
+          "version": "53.14-r2",
           "git": {
             "url": "https://github.com/DFHack/dfhack.git",
-            "revision": "53.11-r1",
-            "outputHash": "sha256-w2yfR9kOw13Ag3wxEHMXI9tVZMUwfgUWmrSVD1ViU4U="
+            "revision": "53.14-r2",
+            "outputHash": "sha256-UOmp84VoY/pam99T2ktAYH3N3cFMSIb9v8KOTZCof8U="
           },
-          "xmlRev": "d79288374802cc63b1507900030b32231ffd244b"
+          "xmlRev": "01aae95cacd98850e4f477c45a4b75f800bacecc"
         }
       },
       "52.05": {

--- a/pkgs/games/dwarf-fortress/dwarf-therapist/wrapper.nix
+++ b/pkgs/games/dwarf-fortress/dwarf-therapist/wrapper.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation {
         echo "It doesn't support DF $dfVersion out of the box, so we're doing it the hard way."
         export HOME="$(mktemp -dt dfhack.XXXXXX)"
         export XDG_DATA_HOME="$HOME/.local/share"
-        expect ${dfHackExpectScript}
+        expect ${dfHackExpectScript} | tr -d '\r'
         local ini="$XDG_DATA_HOME/df_linux/therapist.ini"
         if [ -f "$ini" ]; then
           if grep -q "$patched_md5" "$ini"; then

--- a/pkgs/games/dwarf-fortress/wrapper/default.nix
+++ b/pkgs/games/dwarf-fortress/wrapper/default.nix
@@ -281,18 +281,18 @@ lib.throwIf (enableTWBT' && !enableDFHack) "dwarf-fortress: TWBT requires DFHack
         export HOME="$(mktemp -dt dwarf-fortress.XXXXXX)"
       ''
       + lib.optionalString enableDFHack ''
-        expect ${dfHackExpectScript}
+        expect ${dfHackExpectScript} | tr -d '\r'
         df_home="$(find ~ -name "df_*" | head -n1)"
         test -f "$df_home/dfhack"
       ''
       + lib.optionalString isAtLeast50 ''
-        expect ${vanillaExpectScript true}
+        expect ${vanillaExpectScript true} | tr -d '\r'
         df_home="$(find ~ -name "df_*" | head -n1)"
         test ! -f "$df_home/dfhack"
         test -f "$df_home/libfmod_plugin.so"
       ''
       + ''
-        expect ${vanillaExpectScript false}
+        expect ${vanillaExpectScript false} | tr -d '\r'
         df_home="$(find ~ -name "df_*" | head -n1)"
         test ! -f "$df_home/dfhack"
         test ! -f "$df_home/libfmod_plugin.so"

--- a/pkgs/games/dwarf-fortress/wrapper/dwarf-fortress.in
+++ b/pkgs/games/dwarf-fortress/wrapper/dwarf-fortress.in
@@ -37,10 +37,18 @@ dfhack_files=(
   libdfhooks.so
   dfhack-config/default
   dfhack-config/init
+  dfhooks_*.ini
   hack/*
   stonesense/*
   *.init *.init-example
 )
+
+# May be stale top-level libdfhooks_*.so symlinks in $NIXPKGS_DF_HOME, fix them
+shopt -s nullglob
+for stale in "$NIXPKGS_DF_HOME"/libdfhooks_*.so; do
+  dfhack_files+=( "${stale##*/}" )
+done
+shopt -u nullglob
 
 if [ "${NIXPKGS_DF_EXE##*/}" == dfhack ]; then
   for i in "${dfhack_files[@]}"; do


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update fixing the new ini path.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
