### PR TITLE
python3Packages.cvxpy: 1.8.2 -> 1.9.0

### DIFF
--- a/pkgs/development/python-modules/cvxpy/default.nix
+++ b/pkgs/development/python-modules/cvxpy/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
 
   # build-system
   numpy,
@@ -15,8 +14,10 @@
   cvxopt,
   highspy,
   osqp,
+  qdldl,
   scipy,
   scs,
+  sparsediffpy,
 
   # tests
   hypothesis,
@@ -27,7 +28,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "cvxpy";
-  version = "1.8.2";
+  version = "1.9.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -35,17 +36,8 @@ buildPythonPackage (finalAttrs: {
     owner = "cvxpy";
     repo = "cvxpy";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-MDKTuiePzqdIJlTRxbCOxoaEAisGx368iWbwKEB97QU=";
+    hash = "sha256-48tczmRdNExerlVTNMuRNi1dC5XhUSXNBwIGbJ9vFnU=";
   };
-
-  patches = [
-    # Upstream PR: https://github.com/cvxpy/cvxpy/pull/3290
-    (fetchpatch {
-      name = "highs-1.14.0.patch";
-      url = "https://github.com/cvxpy/cvxpy/commit/89f8d337d927457c2e308de8295dd83f274e40e7.patch";
-      hash = "sha256-BO878Kz5ZH5FHkxZugzT+n6wjsoOReqCZWM2HDvFqAw=";
-    })
-  ];
 
   postPatch =
     # too tight tolerance in tests (AssertionError)
@@ -68,8 +60,10 @@ buildPythonPackage (finalAttrs: {
     highspy
     numpy
     osqp
+    qdldl
     scipy
     scs
+    sparsediffpy
   ];
 
   nativeCheckInputs = [
@@ -86,6 +80,11 @@ buildPythonPackage (finalAttrs: {
   enabledTestPaths = [ "cvxpy" ];
 
   disabledTests = [
+    # Numerical assertions failing
+    "test_oprelcone_1_m1_k3_real"
+    "test_oprelcone_1_m3_k1_real"
+    "test_oprelcone_1_m4_k4_real"
+
     # Disable the slowest benchmarking tests, cuts test time in half
     "test_tv_inpainting"
     "test_diffcp_sdp_example"

--- a/pkgs/development/python-modules/sparsediffpy/default.nix
+++ b/pkgs/development/python-modules/sparsediffpy/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  cmake,
+  ninja,
+  numpy,
+  scikit-build-core,
+
+  # buildInputs
+  blas,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "sparsediffpy";
+  version = "0.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "SparseDifferentiation";
+    repo = "SparseDiffPy";
+    tag = "v${finalAttrs.version}";
+    # SparseDiffEngine is built from source and their cmake does not support finding it on the
+    # system. We fallback to using the git submodule approach for now.
+    fetchSubmodules = true;
+    hash = "sha256-4FiObnGIJSSH7BMkKS7y7rc4HYzDgMV7ym+wPZ/KHJ8=";
+  };
+
+  build-system = [
+    cmake
+    ninja
+    numpy
+    scikit-build-core
+  ];
+  dontUseCmakeConfigure = true;
+
+  buildInputs = [
+    blas
+  ];
+
+  dependencies = [
+    numpy
+  ];
+
+  pythonImportsCheck = [ "sparsediffpy" ];
+
+  # No tests
+  doCheck = false;
+
+  meta = {
+    description = "Python bindings for SparseDiffEngine, a C library for computing sparse Jacobians and Hessians";
+    homepage = "https://github.com/SparseDifferentiation/SparseDiffPy";
+    changelog = "https://github.com/SparseDifferentiation/SparseDiffPy/blob/${finalAttrs.src.tag}/RELEASES.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18323,6 +18323,8 @@ self: super: with self; {
 
   sparse = callPackage ../development/python-modules/sparse { };
 
+  sparsediffpy = callPackage ../development/python-modules/sparsediffpy { };
+
   spatial-image = callPackage ../development/python-modules/spatial-image { };
 
   spatialmath-python = callPackage ../development/python-modules/spatialmath-python { };


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/cvxpy/cvxpy/compare/v1.8.2...v1.9.0
Changelog: https://github.com/cvxpy/cvxpy/releases/tag/v1.9.0

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test