### PR TITLE
lomiri.qtmir: 0.8.0-unstable-2025-05-20 -> 0.8.0-unstable-2026-03-11

### DIFF
--- a/nixos/tests/lomiri.nix
+++ b/nixos/tests/lomiri.nix
@@ -142,16 +142,46 @@ let
       with machine.nested("Ensuring terminalTextColor {} stays present on the screen:".format(terminalTextColor)):
         retry(fn=check_for_color_continued_presence(terminalTextColor), timeout_seconds=5)
 
-    def ensure_lomiri_running() -> None:
+    def change_tty_back_forth(ttynumMain: int, ttynumDiff: int) -> None:
+      """
+      A qtmir bump made the image get stuck, a tty switch back and forth fixes it.
+      """
+
+      machine.send_key(f"ctrl-alt-f{ttynumDiff}")
+      machine.sleep(10)
+      machine.send_key(f"ctrl-alt-f{ttynumMain}")
+      machine.sleep(10)
+
+    def ensure_greeter_launched() -> None:
+      """
+      Ensure that Lomiri (in greeter mode) has started up and is responsive.
+      Execution will stop at the user selection.
+      """
+
+      machine.wait_for_unit("display-manager.service")
+      machine.wait_until_succeeds("pgrep -u lightdm -f 'lomiri --mode=greeter'")
+
+      # Start page shows current time
+      wait_for_text(r"(AM|PM)")
+
+      # Display "hangs" since qtmir bump? Not sure why. Switch to a different tty and back, and ensure that time is still shown
+      # Greeter runs on: tty1
+      change_tty_back_forth(1, 2)
+      wait_for_text(r"(AM|PM)")
+      machine.screenshot("lomiri_greeter_launched")
+
+      # Advance to user selection, to make sure display really isn't stuck anymore
+      machine.send_key("ret")
+      wait_for_text("${description}")
+      machine.screenshot("lomiri_greeter_login")
+
+    def ensure_lomiri_running(ttynumMain: int = 1, ttynumDiff: int = 2) -> None:
       """
       Ensure that Lomiri has finished starting up.
       """
 
       # Process runs
       machine.wait_until_succeeds("pgrep -u ${user} -f 'lomiri --mode=full-shell'")
-
-      # Output rendering from Lomiri has started when it starts printing performance diagnostics
-      machine.wait_for_console_text("Last frame took")
 
       # One of the last UI elements that loads is the clock. In the past, we could OCR for AM/PM to ensure it's there. That is now flaky.
       # The next best thing is to look for the launcher button, and ensure it stays around for awhile (DE doesn't crash).
@@ -160,6 +190,15 @@ let
         retry(check_for_color(launcherColor))
       with machine.nested("Ensuring launcherColor {} stays present on the screen:".format(launcherColor)):
         retry(fn=check_for_color_continued_presence(launcherColor), timeout_seconds=30)
+
+      # Display "hangs" since qtmir bump? Not sure why. Switch to a different tty and back, and ensure that launcher button is still shown
+      change_tty_back_forth(ttynumMain, ttynumDiff)
+      with machine.nested("Waiting for the screen to have launcherColor {} on it:".format(launcherColor)):
+        retry(check_for_color(launcherColor))
+
+      # First input seems to get dropped while Mir registers the new input device. Send a key that does nothing, to get that out of the way, and sleep a tiny bit for registration to finish.
+      machine.send_key("left")
+      machine.sleep(3)
 
       machine.screenshot("lomiri_launched")
 
@@ -358,17 +397,7 @@ in
 
           # Lomiri in greeter mode should work & be able to start a session
           with subtest("lomiri greeter works"):
-              machine.wait_for_unit("display-manager.service")
-              machine.wait_until_succeeds("pgrep -u lightdm -f 'lomiri --mode=greeter'")
-
-              # Start page shows current time
-              wait_for_text(r"(AM|PM)")
-              machine.screenshot("lomiri_greeter_launched")
-
-              # Advance to login part
-              machine.send_key("ret")
-              wait_for_text("${description}")
-              machine.screenshot("lomiri_greeter_login")
+              ensure_greeter_launched()
 
               # Login
               machine.send_chars("${password}\n")
@@ -771,24 +800,14 @@ in
 
             # Lomiri in greeter mode should use the correct keymap
             with subtest("lomiri greeter keymap works"):
-                machine.wait_for_unit("display-manager.service")
-                machine.wait_until_succeeds("pgrep -u lightdm -f 'lomiri --mode=greeter'")
-
-                # Start page shows current time
-                # And the greeter *actually* renders our wallpaper!
-                wait_for_text(r"(AM|PM|Lorem|ipsum)")
-                machine.screenshot("lomiri_greeter_launched")
-
-                # Advance to login part
-                machine.send_key("ret")
-                wait_for_text("${description}")
-                machine.screenshot("lomiri_greeter_login")
+                ensure_greeter_launched()
 
                 # Login
                 machine.send_chars("${pwInput}\n")
 
                 # And the desktop doesn't render the wallpaper anymore. Grumble grumble...
-                ensure_lomiri_running()
+                # When going lomiri(greeter) -> lomiri(desktop), we run on tty2
+                ensure_lomiri_running(2, 1)
 
             # Lomiri in desktop mode should use the correct keymap
             with subtest("lomiri session keymap works"):

--- a/pkgs/desktops/lomiri/development/qtmir/default.nix
+++ b/pkgs/desktops/lomiri/development/qtmir/default.nix
@@ -50,19 +50,24 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ];
 
-  postPatch = ''
-    # 10s timeout for Mir startup is too tight for VM tests on weaker hardwre (aarch64)
-    substituteInPlace src/platforms/mirserver/qmirserver_p.cpp \
-      --replace-fail 'const int timeout = RUNNING_ON_VALGRIND ? 100 : 10' 'const int timeout = RUNNING_ON_VALGRIND ? 900 : 90' \
-      --replace-fail 'const int timeout = 10' 'const int timeout = 90'
-
-    substituteInPlace CMakeLists.txt \
-      --replace-fail "\''${CMAKE_INSTALL_FULL_LIBDIR}/qt5/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}" \
-      --replace-fail "\''${CMAKE_INSTALL_FULL_LIBDIR}/qt5/plugins/platforms" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtPluginPrefix}/platforms" \
-
-    substituteInPlace data/xwayland.qtmir.desktop \
-      --replace-fail '/usr/bin/Xwayland' 'Xwayland'
-  '';
+  postPatch =
+    # 10s timeout for Mir startup is too tight for VM tests on weaker hardware (aarch64)
+    ''
+      substituteInPlace src/platforms/mirserver/qmirserver_p.cpp \
+        --replace-fail 'const int timeout = RUNNING_ON_VALGRIND ? 100 : 10' 'const int timeout = RUNNING_ON_VALGRIND ? 900 : 90' \
+        --replace-fail 'const int timeout = 10' 'const int timeout = 90'
+    ''
+    # Fix where Qt plugins & QML modules should be installed to. We don't use "qt5" for Qt5.
+    + ''
+      substituteInPlace CMakeLists.txt \
+        --replace-fail "\''${CMAKE_INSTALL_FULL_LIBDIR}/qt5/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}" \
+        --replace-fail "\''${CMAKE_INSTALL_FULL_LIBDIR}/qt5/plugins/platforms" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtPluginPrefix}/platforms"
+    ''
+    # Look up Xwayland in environment
+    + ''
+      substituteInPlace data/xwayland.qtmir.desktop \
+        --replace-fail '/usr/bin/Xwayland' 'Xwayland'
+    '';
 
   strictDeps = true;
 

--- a/pkgs/desktops/lomiri/development/qtmir/default.nix
+++ b/pkgs/desktops/lomiri/development/qtmir/default.nix
@@ -36,13 +36,13 @@ stdenv.mkDerivation (finalAttrs: {
   # Not regular qtmir, experimental support for Mir 2.x
   # Currently following https://gitlab.com/ubports/development/core/qtmir/-/tree/personal/sunweaver/debian-upstream
   pname = "qtmir-debian-upstream";
-  version = "0.8.0-unstable-2025-05-20";
+  version = "0.8.0-unstable-2026-03-11";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/qtmir";
-    rev = "b35762f5198873560138a810b387ae9401615c02";
-    hash = "sha256-v5mdu3XLK4F5O56GDItyeCFsFMey4JaNWwXRlgjKFMA=";
+    rev = "57d9e9763933a5d6ca696676ebdde934529a71fe";
+    hash = "sha256-xlMxBnEru4YK0BxUOd/jni9OTb6lZlw6nyHLNqdfY20=";
   };
 
   outputs = [

--- a/pkgs/desktops/lomiri/development/qtmir/default.nix
+++ b/pkgs/desktops/lomiri/development/qtmir/default.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitLab,
+  nixosTests,
   testers,
   cmake,
   cmake-extras,
@@ -125,7 +126,9 @@ stdenv.mkDerivation (finalAttrs: {
   # Tests currently unavailable when building with Mir2
   doCheck = false;
 
-  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  passthru.tests = nixosTests.lomiri // {
+    pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
 
   meta = {
     description = "QPA plugin to make Qt a Mir server";


### PR DESCRIPTION


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
