### PR TITLE
mhalo: init at 0-unstable-2024-09-14

### DIFF
--- a/pkgs/by-name/mh/mhalo/package.nix
+++ b/pkgs/by-name/mh/mhalo/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  pixman,
+  wayland,
+  wayland-protocols,
+  wayland-scanner,
+  tllist,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mhalo";
+  version = "0-unstable-2024-09-14";
+
+  src = fetchFromGitHub {
+    owner = "progandy";
+    repo = "mhalo";
+    rev = "3088f5152f66360828df0e7935b020f6500f540b";
+    hash = "sha256-AKardcq/vkU+bMsWSdPXQlrQgl3eer0xJdPvQvy0IVo=";
+  };
+
+  __structuredAttrs = true;
+
+  strictDeps = true;
+
+  depsBuildBuild = [ pkg-config ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    pixman
+    wayland
+    wayland-protocols
+    tllist
+  ];
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Mouse highlighter for Wayland";
+    homepage = "https://github.com/progandy/mhalo";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ eana ];
+    mainProgram = "mhalo";
+  };
+})


### PR DESCRIPTION
Add mhalo, a mouse highlighter for Wayland that draws a halo effect around the cursor. https://github.com/progandy/mhalo                                                                                                                                                                        

The package is Linux-only (Wayland dependency). Built and tested on x86_64-linux. Should work on aarch64-linux but has not been tested on that platform.

Note: This PR depends on #521861 (maintainers: add eana) being merged first, or merged together.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
