### PR TITLE
fflas-ffpack, macaulay2: build with Accelerate on darwin

### DIFF
--- a/pkgs/by-name/ff/fflas-ffpack/package.nix
+++ b/pkgs/by-name/ff/fflas-ffpack/package.nix
@@ -52,15 +52,24 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     givaro
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
     blas
     lapack
   ];
 
   configureFlags = [
+    "--without-archnative"
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
     "--with-blas-libs=-lcblas"
     "--with-lapack-libs=-llapacke"
-    "--without-archnative"
   ];
+
+  preConfigure = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    configureFlagsArray+=(--with-blas-libs="-framework Accelerate")
+  '';
+
   doCheck = true;
 
   meta = {

--- a/pkgs/by-name/ma/macaulay2/package.nix
+++ b/pkgs/by-name/ma/macaulay2/package.nix
@@ -80,7 +80,6 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   buildInputs = [
-    blas
     boehmgc
     boost
     cddlib
@@ -114,6 +113,9 @@ stdenv.mkDerivation (finalAttrs: {
     readline
     singular
     xz
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    blas
   ]
   ++ lib.optionals stdenv.cc.isClang [
     llvmPackages.openmp
@@ -194,12 +196,6 @@ stdenv.mkDerivation (finalAttrs: {
   buildFlags = lib.optionals downloadDocs [
     "MakeDocumentation=false"
   ];
-
-  env.LDFLAGS = lib.concatStringsSep " " (
-    lib.optionals stdenv.hostPlatform.isDarwin [
-      "-lblas"
-    ]
-  );
 
   postInstall = ''
     substituteInPlace "$out/bin/M2" \


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/pull/519802#discussion_r3264121395.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
