### PR TITLE
jellyfin-desktop: build the CEF version

### DIFF
--- a/pkgs/by-name/ce/cef-binary/package.nix
+++ b/pkgs/by-name/ce/cef-binary/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  cmake,
   glib,
   nss,
   nspr,
@@ -90,12 +91,18 @@ stdenv.mkDerivation {
     hash = selectSystem srcHashes;
   };
 
+  nativeBuildInputs = [ cmake ];
+
   dontStrip = true;
 
   dontPatchELF = true;
 
   installPhase = ''
     runHook preInstall
+
+    cd ../
+    install -Dm555 build/libcef_dll_wrapper/libcef_dll_wrapper.a $out/build/libcef_dll_wrapper/libcef_dll_wrapper.a
+    rm -rf build/
 
     sed 's/-O0/-O2/' -i cmake/cef_variables.cmake
     patchelf --set-rpath "${rpath}" --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" ${buildType}/chrome-sandbox

--- a/pkgs/by-name/je/jellyfin-desktop/package.nix
+++ b/pkgs/by-name/je/jellyfin-desktop/package.nix
@@ -1,95 +1,137 @@
 {
   lib,
-  fetchFromGitHub,
   stdenv,
-  cmake,
-  ninja,
-  python3,
+  fetchFromGitHub,
   kdePackages,
+  cmake,
+  pkg-config,
+  wayland-scanner,
+  rustc,
+  cargo,
+  rustPlatform,
+  cef-binary,
   mpv-unwrapped,
-  libcec,
-  SDL2,
-  libxrandr,
-  cacert,
-  nix-update-script,
+  mpv,
+  systemd,
+  libxkbcommon,
+  libGL,
+  libdrm,
+  wayland,
+  wayland-protocols,
+  libxcb,
+  libxcb-cursor,
+  libxcb-util,
+  ffmpeg,
 }:
+let
+  cef-binary' = cef-binary.override {
+    version = "147.0.14";
+    gitRevision = "76d2442";
+    chromiumVersion = "147.0.7727.138";
+
+    srcHashes = {
+      aarch64-linux = "";
+      x86_64-linux = "sha256-os7wAFJ+mVK65HCikvEjhMeQUj2ty7y+6Ad0OlOcbeA=";
+    };
+  };
+  mpv-unwrapped' = mpv-unwrapped.overrideAttrs {
+    version = "0.41.0-jellyfin-unstable-2026-04-30";
+    dontVersionCheck = true;
+
+    src = fetchFromGitHub {
+      owner = "andrewrabert";
+      repo = "mpv";
+      rev = "6242788263ca26352c902d9d336290492a32fa63";
+      hash = "sha256-52f4K3cNos1bHpVNbduP1hPckqm76DagbLh0u2YnOqg=";
+    };
+  };
+  mpv' = mpv.override { mpv-unwrapped = mpv-unwrapped'; };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "jellyfin-desktop";
-  version = "2.0.0";
+  version = "0-unstable-2026-05-18";
 
   src = fetchFromGitHub {
     owner = "jellyfin";
     repo = "jellyfin-desktop";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-ITlYOrMS6COx9kDRSBi4wM6mzL/Q2G5X9GbABwDIOe4=";
-    fetchSubmodules = true;
+    rev = "07719a2a2e85ff5e9aa28b9544e68a952c7b6b94";
+    hash = "sha256-on8dSiWmHrZoOKvztUV3ZuTu6uw5qasCmghHLxtUkzg=";
   };
-  patches = [
-    ./non-fatal-unique-app.patch
-  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace-fail /usr/share/plasma-wayland-protocols ${kdePackages.plasma-wayland-protocols}/share/plasma-wayland-protocols
+  '';
+
+  cargoRoot = "src";
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      cargoRoot
+      ;
+    hash = "sha256-ZLphrzZ3+I6CIFa2w/8suXPgeEb6omIkq7RC2XHSx1w=";
+  };
 
   nativeBuildInputs = [
     cmake
-    ninja
-    kdePackages.wrapQtAppsHook
-  ]
-  ++ lib.optional stdenv.hostPlatform.isDarwin python3;
+    pkg-config
+    wayland-scanner
 
-  buildInputs = [
-    kdePackages.qtbase
-    kdePackages.qtdeclarative
-    kdePackages.qtwebchannel
-    kdePackages.qtwebengine
-    mpv-unwrapped
-
-    # input sources
-    libcec
-    SDL2
-
-    # frame rate switching
-    libxrandr
-    cacert
-  ]
-  ++ lib.optional (!stdenv.hostPlatform.isDarwin) kdePackages.mpvqt;
-
-  cmakeFlags = [
-    "-DCHECK_FOR_UPDATES=OFF"
-    # workaround for Qt cmake weirdness
-    "-DQT_DISABLE_NO_DEFAULT_PATH_IN_QT_PACKAGES=ON"
-  ]
-  ++ lib.optional stdenv.hostPlatform.isDarwin "-DUSE_STATIC_MPVQT=ON"
-  ++ lib.optional (!stdenv.hostPlatform.isDarwin) "-DUSE_STATIC_MPVQT=OFF";
-
-  qtWrapperArgs = [
-    "--set QT_STYLE_OVERRIDE Fusion"
-    "--set NIX_SSL_CERT_FILE ${cacert}/etc/ssl/certs/ca-bundle.crt"
+    rustc
+    cargo
+    rustPlatform.cargoSetupHook
+    rustPlatform.bindgenHook
   ];
 
-  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    mkdir -p $out/bin $out/Applications
-    mv "$out/Jellyfin Desktop.app" $out/Applications
-    ln -s "$out/Applications/Jellyfin Desktop.app/Contents/MacOS/Jellyfin Desktop" $out/bin/jellyfindesktop
+  cmakeFlags = [
+    "-DCEF_ROOT=${cef-binary'}"
+    "-DEXTERNAL_MPV_DIR=${mpv'}"
+  ];
+
+  buildInputs = [
+    systemd
+    libxkbcommon
+    libGL
+    libdrm
+    wayland
+    wayland-protocols
+    libxcb
+    libxcb-cursor
+    libxcb-util
+    ffmpeg
+  ];
+
+  postInstall = ''
+    # replace upstream vendoring with symlinks
+    rm $out/libmpv.so
+
+    for i in libEGL.so libGLESv2.so libcef.so libvk_swiftshader.so libvulkan.so.1 v8_context_snapshot.bin; do
+      rm -rf $out/$i
+      ln -s ${cef-binary'}/Release/$i $out/$i
+    done
+
+    for i in chrome_100_percent.pak chrome_200_percent.pak icudtl.dat locales resources.pak; do
+      rm -rf $out/$i
+      ln -s ${cef-binary'}/Resources/$i $out/$i
+    done
+
+    # install desktop file
+    install -Dm644 $src/resources/linux/org.jellyfin.JellyfinDesktop.desktop $out/share/applications/org.jellyfin.JellyfinDesktop.desktop
+    install -Dm644 $src/resources/linux/org.jellyfin.JellyfinDesktop.svg $out/share/icons/hicolor/scalable/apps/org.jellyfin.JellyfinDesktop.svg
+
+    # link binary into place
+    mkdir $out/bin
+    ln -s $out/jellyfin-desktop $out/bin/jellyfin-desktop
   '';
 
-  passthru.updateScript = nix-update-script { };
-
   meta = {
-    homepage = "https://github.com/jellyfin/jellyfin-desktop";
     description = "Jellyfin Desktop Client";
-    license = with lib.licenses; [
-      gpl2Only
-      mit
-    ];
-    platforms = [
-      "aarch64-linux"
-      "x86_64-linux"
-      "aarch64-darwin"
-      "x86_64-darwin"
-    ];
-    maintainers = with lib.maintainers; [
-      jojosch
-      paumr
-    ];
+    homepage = "https://github.com/jellyfin/jellyfin-desktop";
+    license = lib.licenses.gpl2Only;
+    maintainers = [ ];
     mainProgram = "jellyfin-desktop";
+    platforms = lib.platforms.all;
   };
 })


### PR DESCRIPTION
This is horrible. Someone shoot me.

GPU compositing is broken (why?), needs to be run with `--disable-gpu-compositing` to not immediately crash.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
