### PR TITLE
aspellWithDicts: fix data-dir path

### DIFF
--- a/pkgs/development/libraries/aspell/aspell-with-dicts.nix
+++ b/pkgs/development/libraries/aspell/aspell-with-dicts.nix
@@ -30,7 +30,7 @@ buildEnv {
     pushd "${aspell}/bin"
     for prg in *; do
       if [ -f "$prg" ]; then
-        makeWrapper "${aspell}/bin/$prg" "$out/bin/$prg" --set ASPELL_CONF "dict-dir $out/lib/aspell; data-dir $out/share/aspell"
+        makeWrapper "${aspell}/bin/$prg" "$out/bin/$prg" --set ASPELL_CONF "dict-dir $out/lib/aspell; data-dir $out/lib/aspell"
       fi
     done
     popd


### PR DESCRIPTION
In 52a23a9 the configuration `data-dir $out/share/aspell` was introduced to make sure that `aspell --lang=<LANG> create master ...` finds the LANG.dat file. However, the correct location for language data files is $out/**lib**/aspell.  This confusion also broke filter discovery as described in #476684.

This commit fixes the location of language data files.

Note: `aspell --lang=<LANG> create master ...` will fail if the dictionary has not been installed in the environment via `aspellWithDicts (dict: [ dict.<LANG> ])` which is, IMHO, expected.

Fixes #476684


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
```
$ nix run 'nixpkgs#nixpkgs-review' -- rev fix-aspellwithdicts-filters
```
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
```
$ nix-build -E ' with import <nixpkgs> {}; (callPackage ./aspell-with-dicts.nix {}) (dicts: [ dicts.fr dicts.en ])' 
$ ./result/bin/aspell --lang=en --encoding=utf-8 create master /tmp/foo.en.rws <<(echo "foo") # OK
$ ./result/bin/aspell --lang=en_US --encoding=utf-8 create master /tmp/foo.en_US.rws <<(echo "foo") # Error expected, no en_US in dicts
Error: The language "en_US" is not known. This is probably because: the file "/nix/store/01lr7rypyp9m92i43ws1djs9phzyfb22-aspell-env/lib/aspell/en_US.dat" can not be opened for reading. 
$ ./result/bin/aspell filters
url            filter to skip URL like constructs
texinfo        filter for dealing with Texinfo documents
context        experimental filter for hiding delimited contexts
markdown       filter for Markdown/CommonMark documents
email          filter for skipping quoted text in email messages
html           filter for dealing with HTML documents
sgml           filter for dealing with generic SGML/XML documents
nroff          filter for dealing with Nroff documents
tex            filter for dealing with TeX/LaTeX documents
```
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `e7dd5593e843446a1daea0b730ba71fa58733be7`

---
### `x86_64-linux`