### PR TITLE
tfenv: fix darwin `ggrep` lookup and writable config dir 

### DIFF
--- a/pkgs/by-name/tf/tfenv/package.nix
+++ b/pkgs/by-name/tf/tfenv/package.nix
@@ -61,7 +61,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     for f in $out/share/tfenv/bin/* $out/share/tfenv/libexec/*; do
       [ -f "$f" ] || continue
       wrapProgram "$f" \
-        --prefix PATH : "${runtimePath}:$out/share/tfenv/bin-extra"
+        --prefix PATH : "${runtimePath}:$out/share/tfenv/bin-extra" \
+        --run 'export TFENV_CONFIG_DIR=''${TFENV_CONFIG_DIR:-''${XDG_DATA_HOME:-''$HOME/.local/share}/tfenv}'
     done
 
     ln -s $out/share/tfenv/bin/tfenv $out/bin/tfenv

--- a/pkgs/by-name/tf/tfenv/package.nix
+++ b/pkgs/by-name/tf/tfenv/package.nix
@@ -4,14 +4,24 @@
   fetchFromGitHub,
   makeWrapper,
   nix-update-script,
-  unzip,
+  coreutils,
   curl,
+  gawk,
   gnugrep,
   gnused,
-  gawk,
-  coreutils,
+  unzip,
 }:
 
+let
+  runtimePath = lib.makeBinPath [
+    coreutils
+    curl
+    gawk
+    gnugrep
+    gnused
+    unzip
+  ];
+in
 stdenvNoCC.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
 
@@ -46,16 +56,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     for f in $out/share/tfenv/bin/* $out/share/tfenv/libexec/*; do
       [ -f "$f" ] || continue
       wrapProgram "$f" \
-        --prefix PATH : "${
-          lib.makeBinPath [
-            unzip
-            curl
-            gnugrep
-            gnused
-            gawk
-            coreutils
-          ]
-        }"
+        --prefix PATH : "${runtimePath}"
     done
 
     ln -s $out/share/tfenv/bin/tfenv $out/bin/tfenv

--- a/pkgs/by-name/tf/tfenv/package.nix
+++ b/pkgs/by-name/tf/tfenv/package.nix
@@ -55,10 +55,13 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   postFixup = ''
+    mkdir -p $out/share/tfenv/bin-extra
+    ln -s ${lib.getExe gnugrep} $out/share/tfenv/bin-extra/ggrep
+
     for f in $out/share/tfenv/bin/* $out/share/tfenv/libexec/*; do
       [ -f "$f" ] || continue
       wrapProgram "$f" \
-        --prefix PATH : "${runtimePath}"
+        --prefix PATH : "${runtimePath}:$out/share/tfenv/bin-extra"
     done
 
     ln -s $out/share/tfenv/bin/tfenv $out/bin/tfenv

--- a/pkgs/by-name/tf/tfenv/package.nix
+++ b/pkgs/by-name/tf/tfenv/package.nix
@@ -6,6 +6,7 @@
   nix-update-script,
   coreutils,
   curl,
+  findutils,
   gawk,
   gnugrep,
   gnused,
@@ -16,6 +17,7 @@ let
   runtimePath = lib.makeBinPath [
     coreutils
     curl
+    findutils
     gawk
     gnugrep
     gnused

--- a/pkgs/by-name/tf/tfenv/package.nix
+++ b/pkgs/by-name/tf/tfenv/package.nix
@@ -10,6 +10,7 @@
   gawk,
   gnugrep,
   gnused,
+  testers,
   unzip,
 }:
 
@@ -69,7 +70,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     ln -s $out/share/tfenv/bin/terraform $out/bin/terraform
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage.tfenv;
+    };
+  };
 
   meta = {
     description = "Terraform version manager";


### PR DESCRIPTION
## Fixes

- Darwin: `lib/helpers.sh::check_dependencies` prefers `ggrep` when present. The wrapper only shipped `grep`, so users on PATHs without Homebrew's `grep` formula hit inconsistent failures. Now symlinks `${gnugrep}/bin/grep` to a private `bin-extra/ggrep` on the wrapped PATH (no `$out/bin` pollution).
- `tfenv install` writes to `$TFENV_ROOT/versions`, which resolved to the read-only nix store. Wrapper now defaults `TFENV_CONFIG_DIR` to `${XDG_DATA_HOME:-$HOME/.local/share}/tfenv` if unset. Upstream already honors `TFENV_CONFIG_DIR` for state.
- Adds `findutils` to the wrapper PATH; `tfenv use`, `tfenv-list`, and `tfenv-version-name.sh` shell out to `\find`, which is missing from `coreutils` and breaks on clean Nix-only PATHs (both platforms).

## Polish

- Hoist `lib.makeBinPath` into a `let` binding, alphabetize inputs.
- Add `passthru.tests.version` so the wrapper is exercised on refresh.

## Verified

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
