### PR TITLE
nixos/mozhi: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -28,6 +28,8 @@
 
 - [LibreChat](https://www.librechat.ai/), open-source self-hostable ChatGPT clone with Agents and RAG APIs. Available as [services.librechat](#opt-services.librechat.enable).
 
+- [Mozhi](https://codeberg.org/aryak/mozhi), an alternative translation frontend forked from SimplyTranslate. Available as [services.mozhi](#opt-services.mozhi.enable).
+
 - [nohang](https://github.com/hakavlad/nohang), a daemon for Linux that prevents out of memory (OOM) situations from affecting system responsiveness. Available as [services.nohang](#opt-services.nohang.enable)
 
 - [DankMaterialShell](https://danklinux.com), a complete desktop shell for Wayland compositors built with Quickshell. Available as [programs.dms-shell](#opt-programs.dms-shell.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1692,6 +1692,7 @@
   ./services/web-apps/monica.nix
   ./services/web-apps/moodle.nix
   ./services/web-apps/movim.nix
+  ./services/web-apps/mozhi.nix
   ./services/web-apps/netbox.nix
   ./services/web-apps/nextcloud-notify_push.nix
   ./services/web-apps/nextcloud-whiteboard-server.nix

--- a/nixos/modules/services/web-apps/mozhi.nix
+++ b/nixos/modules/services/web-apps/mozhi.nix
@@ -1,0 +1,141 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.mozhi;
+
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    types
+    mkIf
+    ;
+
+  engines = [
+    "google"
+    "reverso"
+    "deepl"
+    "libretranslate"
+    "yandex"
+    "mymemory"
+    "duckduckgo"
+  ];
+in
+{
+  options.services.mozhi = {
+    enable = mkEnableOption "the Mozhi alternative translation frontend";
+    package = mkPackageOption pkgs "mozhi" { };
+
+    openFirewall = mkEnableOption "" // {
+      description = "Whether to open the defined port in the firewall for the frontend.";
+    };
+
+    host = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      description = "The host to listen on. If null, defaults to listening on all interfaces.";
+      example = "127.0.0.1";
+    };
+
+    port = mkOption {
+      type = with types; nullOr types.port;
+      default = 3000;
+      description = "The port to listen on for this instance.";
+    };
+
+    libreTranslateURL = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      description = "The URL of LibreTranslate to use for querying an external instance.";
+      example = "https://lt.psf.lt";
+    };
+
+    preferAutoDetect = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether to prefer autodetection instead of specified/default source language for this instance.";
+      example = true;
+    };
+
+    sourceLang = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      description = "The default source language to use when translating from. If null, defaults to autodetect (or first available language in engines which don't support it).";
+      example = "en";
+    };
+
+    targetLang = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      description = "The default target language to use when translating to. If null, defaults to English.";
+      example = "de";
+    };
+
+    defaultEngine = mkOption {
+      type = with types; nullOr (types.enum engines);
+      default = null;
+      description = "The default engine to use on this instance. If not null, it must be enabled in the enabledEngines option.";
+      example = "libretranslate";
+    };
+
+    enabledEngines = mkOption {
+      type = types.listOf (types.enum engines);
+      default = engines;
+      description = "The list of engines to enable on this instance.";
+      example = [
+        "libretranslate"
+        "duckduckgo"
+      ];
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.enabledEngines != [ ];
+        message = "At least one engine must be enabled.";
+      }
+      {
+        assertion = cfg.defaultEngine == null || lib.elem cfg.defaultEngine cfg.enabledEngines;
+        message = "The specified default engine must be listed in enabledEngines.";
+      }
+    ];
+
+    systemd.services.mozhi = {
+      description = "Mozhi alternative translation frontend service";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      environment = {
+        MOZHI_HOST = mkIf (cfg.host != null) cfg.host;
+        MOZHI_PORT = toString cfg.port;
+        MOZHI_LIBRETRANSLATE_URL = mkIf (cfg.libreTranslateURL != null) cfg.libreTranslateURL;
+        MOZHI_DEFAULT_PREFER_AUTODETECT = toString cfg.preferAutoDetect;
+        MOZHI_DEFAULT_SOURCE_LANG = mkIf (cfg.sourceLang != null) cfg.sourceLang;
+        MOZHI_DEFAULT_TARGET_LANG = mkIf (cfg.targetLang != null) cfg.targetLang;
+        MOZHI_DEFAULT_ENGINE = mkIf (cfg.defaultEngine != null) cfg.defaultEngine;
+      }
+      // lib.listToAttrs (
+        map (engine: {
+          name = "MOZHI_${lib.toUpper engine}_ENABLED";
+          value = "true";
+        }) cfg.enabledEngines
+      );
+
+      serviceConfig = {
+        ExecStart = "${lib.getExe cfg.package} serve";
+        Restart = "always";
+        RestartSec = 10;
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.port ];
+  };
+
+  meta.maintainers = [ lib.maintainers.ryand56 ];
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
