### PR TITLE
rtg-tools: fix runtime issues

### DIFF
--- a/pkgs/by-name/rt/rtg-tools/package.nix
+++ b/pkgs/by-name/rt/rtg-tools/package.nix
@@ -52,9 +52,10 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail awk ${lib.getExe gawk} \
       --replace-fail "hostname -s" "${lib.getExe hostname} -s" \
       --replace-fail dirname ${lib.getExe' coreutils "dirname"} \
-      --replace-fail readlink ${lib.getExe' coreutils "readlink"}
+      --replace-fail readlink ${lib.getExe' coreutils "readlink"} \
+      --replace-fail cat ${lib.getExe' coreutils "cat"}
 
-    sed -i '/USER_JAVA_OPTS=$RTG_JAVA_OPTS/a mkdir -p $HOME/.config/rtg-tools'  installer/rtg
+    sed -i '/# Now write the selection to local config/i mkdir -p $HOME/.config/rtg-tools' installer/rtg
   '';
 
   checkPhase = ''


### PR DESCRIPTION
On Github runner, cat is no available in PATH.
Also, rtg-tools require a default configuration file but the current version in nixpkgs was not writing it.

This is a follow-up after more testing on #521102 .
Tested on real data.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
