### PR TITLE
proxyt: init at 0.0.7

### DIFF
--- a/pkgs/by-name/pr/proxyt/package.nix
+++ b/pkgs/by-name/pr/proxyt/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "proxyt";
+  version = "0.0.7";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "jaxxstorm";
+    repo = "proxyt";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6+MgmhacH0oZY9ksZdBpv/tH4su8EBtHOiBIbR3ZXxo=";
+  };
+
+  vendorHash = "sha256-eAOU4DRnvfHdIc3cXMCAHbw7AZJWkEk/u3ae+K43CVc=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=github.com/jaxxstorm/proxyt/cmd.Version=${finalAttrs.version}"
+  ];
+
+  env = {
+    CGO_ENABLED = "0";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd proxyt \
+      --bash <($out/bin/proxyt completion bash) \
+      --fish <($out/bin/proxyt completion fish) \
+      --zsh <($out/bin/proxyt completion zsh)
+  '';
+
+  meta = {
+    changelog = "https://github.com/jaxxstorm/proxyt/releases/${finalAttrs.version}";
+    description = "Simple proxy for the Tailscale control plane";
+    homepage = "https://github.com/jaxxstorm/proxyt";
+    license = lib.licenses.mit;
+    mainProgram = "proxyt";
+    maintainers = with lib.maintainers; [ marie ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/jaxxstorm/proxyt

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
