### PR TITLE
linuxPackages.rtl8188eus-aircrack: switch to gglluukk's fork

### DIFF
--- a/pkgs/os-specific/linux/rtl8188eus-aircrack/default.nix
+++ b/pkgs/os-specific/linux/rtl8188eus-aircrack/default.nix
@@ -8,20 +8,20 @@
 
 stdenv.mkDerivation {
   pname = "rtl8188eus-aircrack";
-  version = "${kernel.version}-unstable-2024-09-18";
+  version = "${kernel.version}-unstable-2026-06-22";
 
   src = fetchFromGitHub {
-    owner = "aircrack-ng";
+    owner = "gglluukk";
     repo = "rtl8188eus";
-    rev = "f969c544ab6100da3d80a5709e077f920f2df698";
-    sha256 = "sha256-uwO2nDDff4t0PZw3mLWmUPOHHftDgoaBaWMXQKHQunI=";
+    rev = "cbeae98cb423378dfd5e5efb63290fe43a6ed965";
+    hash = "sha256-wiWG0ndtQML/h88alNyQOX64krpJOf56HyB8LW5dYbA=";
   };
 
   prePatch = ''
     substituteInPlace ./Makefile \
-      --replace /lib/modules/ "${kernel.dev}/lib/modules/" \
-      --replace /sbin/depmod \# \
-      --replace '$(MODDESTDIR)' "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
+      --replace-fail /lib/modules/ "${kernel.dev}/lib/modules/" \
+      --replace-fail /sbin/depmod \# \
+      --replace-fail '$(MODDESTDIR)' "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
   '';
 
   hardeningDisable = [ "pic" ];
@@ -36,9 +36,8 @@ stdenv.mkDerivation {
 
   meta = {
     description = "RealTek RTL8188eus WiFi driver with monitor mode & frame injection support";
-    homepage = "https://github.com/aircrack-ng/rtl8188eus";
+    homepage = "https://github.com/gglluukk/rtl8188eus";
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ moni ];
-    broken = kernel.kernelAtLeast "6.17";
   };
 }


### PR DESCRIPTION
Kali has [switched to](https://gitlab.com/kalilinux/packages/realtek-rtl8188eus-dkms/-/blob/kali/master/debian/control?ref_type=heads) gglluukk's fork. Perhaps we can do the same?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
