### PR TITLE
gnome2.gtksourceview: fix Darwin build

### DIFF
--- a/pkgs/desktops/gnome-2/desktop/gtksourceview/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/gtksourceview/default.nix
@@ -46,8 +46,12 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  # Fix build with gcc 14
-  env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
+  env = {
+    # Required by autoreconfHook to find gettext.m4 outside aclocal's default search path.
+    ACLOCAL = "aclocal -I ${gettext}/share/gettext/m4";
+    # Fix build with gcc 14.
+    NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
+  };
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
[![](https://hydra-banner.harinn.dev/build/329281946)](https://hydra.nixos.org/build/329281946)

ZHF: #516381

This PR fixes the `gnome2.gtksourceview` package build on `aarch64-darwin` (broken since #507470 updated autoconf) via the same pattern used by #425784, #426625, and #475284. See [this](https://lists.gnu.org/r/bug-gettext/2025-05/msg00041.html) for more context on those historical failures, and see the [autoconf 2.73 release notes](https://www.mail-archive.com/autotools-announce@gnu.org/msg00159.html) which mention the `autopoint` heuristic change that broke this particular package.

This build failure is Darwin-specific because autoreconf only runs on Darwin for this package.

Closes: #522127
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
