### PR TITLE
mountpoint-s3: 1.17.0 -> 1.22.3

### DIFF
--- a/pkgs/by-name/mo/mountpoint-s3/package.nix
+++ b/pkgs/by-name/mo/mountpoint-s3/package.nix
@@ -9,17 +9,17 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "mountpoint-s3";
-  version = "1.17.0";
+  version = "1.22.3";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "mountpoint-s3";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-uV0umUoJkYgmjWjv8GMnk5TRRbCCJS1ut3VV1HvkaAw=";
+    hash = "sha256-22tx8ozXkzBNAflDPc7cdfUh9TWD6aB/Fe/z/dPZ694=";
     fetchSubmodules = true;
   };
 
-  cargoHash = "sha256-zDgAGOuK0Jkmm554qZsaA/ABFhuupJ+WToO8HSPp7Xc=";
+  cargoHash = "sha256-SSSXqgJ3OERCVw81iXqXRRpVXgdwhlefHhI/qvQyl4g=";
 
   # thread 'main' panicked at cargo-auditable/src/collect_audit_data.rs:77:9:
   # cargo metadata failure: error: none of the selected packages contains these features: libfuse3
@@ -31,6 +31,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
     rustPlatform.bindgenHook
   ];
   buildInputs = [ fuse3 ];
+
+  # The S3CrtClient doctest in mountpoint-s3-client constructs a real client,
+  # which requires a TLS trust store unavailable in the sandbox.
+  cargoTestFlags = [
+    "--workspace"
+    "--lib"
+    "--bins"
+    "--tests"
+  ];
 
   checkFlags = [
     #thread 's3_crt_client::tests::test_expected_bucket_owner' panicked at mountpoint-s3-client/src/s3_crt_client.rs:1123:47:
@@ -44,9 +53,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--skip=s3_crt_client::tests::test_expected_bucket_owner"
     "--skip=s3_crt_client::tests::test_user_agent_with_prefix"
     "--skip=s3_crt_client::tests::test_user_agent_without_prefix"
+    "--skip=test_lookup_throttled_mock::both_list_and_head"
     "--skip=test_lookup_throttled_mock::head_object"
     "--skip=test_lookup_throttled_mock::list_object"
     "--skip=test_lookup_unhandled_error_mock"
+    "--skip=test_read_unhandled_error_mock"
     "--skip=tests::smoke"
     # fuse module not available on build machine ?
     #


### PR DESCRIPTION
## Summary

Bumps `mountpoint-s3` from 1.17.0 to 1.22.3. Release notes: https://github.com/awslabs/mountpoint-s3/blob/v1.22.3/CHANGELOG.md

The auto-update bot has been trying (and failing) to land this since 1.18.0. Each weekly attempt is visible at https://nixpkgs-update-logs.nix-community.org/mountpoint-s3/. The failures are two new tests + a doctest added upstream that construct a real ``S3CrtClient``, which needs a TLS trust store the Nix sandbox does not provide (``AWS_IO_TLS_ERROR_DEFAULT_TRUST_STORE_NOT_FOUND``).

This PR:
- bumps the version and refreshes ``src.hash`` and ``cargoHash``
- skips the two new mock tests (``test_lookup_throttled_mock::both_list_and_head``, ``test_read_unhandled_error_mock``) in the same style as the existing skip list
- sets ``cargoTestFlags`` to exclude doctests, since the second doctest in ``mountpoint-s3-client/src/lib.rs`` now also constructs an ``S3CrtClient``

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (``mount-s3``, ``mount-s3-log-analyzer``, ``file-system-benchmarks`` produced and dynamically linked correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)