### PR TITLE
subunit: 1.4.5 -> 1.4.6

### DIFF
--- a/pkgs/by-name/su/subunit/package.nix
+++ b/pkgs/by-name/su/subunit/package.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "subunit";
-  version = "1.4.5";
+  version = "1.4.6";
 
   src = fetchFromGitHub {
     owner = "testing-cabal";
     repo = "subunit";
     tag = finalAttrs.version;
-    hash = "sha256-yM5mlYV7KyPRzPhnbDYBFLn4uiwxFFEotX2r6KcKAwA=";
+    hash = "sha256-vV/mmVruUH2siyOZOYiEQhjFgQ+xyS1EEbx5SS3Y5tA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/subunit/default.nix
+++ b/pkgs/development/python-modules/subunit/default.nix
@@ -11,6 +11,7 @@
   hypothesis,
   iso8601,
   pytestCheckHook,
+  pyyaml,
   setuptools,
   testscenarios,
   testtools,
@@ -50,14 +51,15 @@ buildPythonPackage {
     hypothesis
     fixtures
     pytestCheckHook
+    pyyaml
   ];
 
-  enabledTestPaths = [ "python/subunit" ];
+  enabledTestPaths = [ "python/tests" ];
 
   disabledTestPaths = [
     # these tests require testtools and don't work with pytest
-    "python/subunit/tests/test_output_filter.py"
-    "python/subunit/tests/test_test_protocol.py"
-    "python/subunit/tests/test_test_protocol2.py"
+    "python/tests/test_output_filter.py"
+    "python/tests/test_test_protocol.py"
+    "python/tests/test_test_protocol2.py"
   ];
 }


### PR DESCRIPTION
Supersedes #516849, the python module needed a few manual fixes.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
