### PR TITLE
tor-browser: 15.0.13 -> 15.0.14, mullvad-browser: 15.0.12 -> 15.0.14

### DIFF
--- a/pkgs/by-name/mu/mullvad-browser/package.nix
+++ b/pkgs/by-name/mu/mullvad-browser/package.nix
@@ -97,7 +97,7 @@ let
     ++ lib.optionals mediaSupport [ ffmpeg_7 ]
   );
 
-  version = "15.0.12";
+  version = "15.0.14";
 
   sources = {
     x86_64-linux = fetchurl {
@@ -109,7 +109,7 @@ let
         "https://tor.eff.org/dist/mullvadbrowser/${version}/mullvad-browser-linux-x86_64-${version}.tar.xz"
         "https://tor.calyxinstitute.org/dist/mullvadbrowser/${version}/mullvad-browser-linux-x86_64-${version}.tar.xz"
       ];
-      hash = "sha256-Tqfa9f2q4bv2KpotoDKvklEmHa5AF4ARp/qKxlVBomE=";
+      hash = "sha256-E/q2wXeTGcEhiAvUCrFKv34gc4vP4o3ZPjqkcS6Dxgk=";
     };
   };
 

--- a/pkgs/by-name/to/tor-browser/package.nix
+++ b/pkgs/by-name/to/tor-browser/package.nix
@@ -102,7 +102,7 @@ let
     ++ lib.optionals mediaSupport [ ffmpeg_7 ]
   );
 
-  version = "15.0.13";
+  version = "15.0.14";
 
   sources = {
     x86_64-linux = fetchurl {
@@ -112,7 +112,7 @@ let
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux-x86_64-${version}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux-x86_64-${version}.tar.xz"
       ];
-      hash = "sha256-v21pvipaEPj3WzDybQkDxHLefl14ZMCOJDQAvJatSSU=";
+      hash = "sha256-kxRtNraru8w/lAwwhAD2h6Q+CqFdS2DzV2FZHnNj9Q4=";
     };
 
     i686-linux = fetchurl {
@@ -122,7 +122,7 @@ let
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux-i686-${version}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux-i686-${version}.tar.xz"
       ];
-      hash = "sha256-RPJUoRZlY1upYivnnDxSLJI2hoVII56PY7BeCN87lOc=";
+      hash = "sha256-GHLeAyMrnwD5lC4NnwM72nZQeRN7AjrlS/zlOqfmjtw=";
     };
   };
 


### PR DESCRIPTION
Release announcement (TB): https://blog.torproject.org/new-release-tor-browser-15014/
Changelog (TB): https://gitlab.torproject.org/tpo/applications/tor-browser-build/-/raw/tbb-15.0.14-build1/projects/browser/Bundle-Data/Docs-TBB/ChangeLog.txt
Changelog (MB): https://gitlab.torproject.org/tpo/applications/tor-browser-build/-/raw/mb-15.0.14-build1/projects/browser/Bundle-Data/Docs-MB/ChangeLog.txt
Firefox ESR: https://www.firefox.com/en-US/firefox/140.11.0/releasenotes/

Mullvad Browser 15.0.13 was skipped upstream as it was a Tor Browser-only release that included no Firefox changes.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] i686-linux (TB only)
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
