### PR TITLE
python3Packages.bambi: 0.17.2 -> 0.18.0

### DIFF
--- a/pkgs/development/python-modules/bambi/default.nix
+++ b/pkgs/development/python-modules/bambi/default.nix
@@ -15,6 +15,8 @@
   matplotlib,
   pandas,
   pymc,
+  pytensor,
+  seaborn,
   sparse,
 
   # tests
@@ -26,23 +28,15 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "bambi";
-  version = "0.17.2";
+  version = "0.18.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "bambinos";
     repo = "bambi";
     tag = finalAttrs.version;
-    hash = "sha256-Vjv62cYDIuTLE7MxRt4Havy7DMOiMTyIixbs4LGFGGs=";
+    hash = "sha256-vxsjPYQkqvmB5oKKl29+xq1BPEzBTozz9/W5mICWI4A=";
   };
-
-  # TypeError: NDArray.record() missing 1 required keyword-only argument: 'in_warmup'
-  postPatch = ''
-    substituteInPlace bambi/backend/pymc.py \
-      --replace-fail \
-        "strace.record(point=dict(zip(varnames, value)))" \
-        "strace.record(point=dict(zip(varnames, value)), in_warmup=False)"
-  '';
 
   build-system = [
     setuptools
@@ -59,6 +53,8 @@ buildPythonPackage (finalAttrs: {
     matplotlib
     pandas
     pymc
+    pytensor
+    seaborn
     sparse
   ];
 
@@ -136,8 +132,7 @@ buildPythonPackage (finalAttrs: {
 
   disabledTestPaths = [
     # Tests require network access
-    "tests/test_interpret.py"
-    "tests/test_interpret_messages.py"
+    "tests/test_interpret_plots.py"
   ];
 
   pythonImportsCheck = [ "bambi" ];


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/bambinos/bambi/compare/0.17.2...0.18.0
Changelog: https://github.com/bambinos/bambi/releases/tag/0.18.0

cc @bcdarwin

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test