### PR TITLE
gpu-screen-recorder: 5.12.5 -> 5.13.8

### DIFF
--- a/pkgs/by-name/gp/gpu-screen-recorder/package.nix
+++ b/pkgs/by-name/gp/gpu-screen-recorder/package.nix
@@ -14,6 +14,7 @@
   wayland,
   wayland-scanner,
   vulkan-headers,
+  vulkan-loader,
   pipewire,
   libdrm,
   libva,
@@ -28,12 +29,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gpu-screen-recorder";
-  version = "5.12.5";
+  version = "5.13.8";
 
   src = fetchgit {
     url = "https://repo.dec05eba.com/gpu-screen-recorder";
     tag = finalAttrs.version;
-    hash = "sha256-cw3IejeWFhuFSzUgK2sv4LEa2ohHNx6C3T7+GhHljsY=";
+    hash = "sha256-0uYj9NA6KqORr7ag8OOMphWWyHU27ptuOs5q0lGLGLc=";
   };
 
   nativeBuildInputs = [
@@ -52,6 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
     wayland
     wayland-scanner
     vulkan-headers
+    vulkan-loader
     libdrm
     libva
     libxdamage


### PR DESCRIPTION
The `vulkan-loader` dependency is needed, because the build fails otherwise with this error:

```
...
Run-time dependency wayland-client found: YES 1.24.0
Run-time dependency vulkan found: NO (tried pkgconfig and system)

meson.build:75:4: ERROR: Dependency "vulkan" not found, tried pkgconfig and system
```

I asked ChatGPT "how to fix" the error to get the needed package name. I do not know why this specific packages is needed or what it does. As far as i understand, the fact that the build tooling does not complain anymore, does mean that it is correct. It could only not be the optimal dependency when multiple provide the same functionality. This is similarly done like using a search engine, only that that did not give me a useful answer.

Changes: https://git.dec05eba.com/gpu-screen-recorder/log/

I have burnout, severe depression and feel very tired, so please review carefully!

FYI @keenanweaver @AhmedAmrNabil

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
