### PR TITLE
accurse: init at 0.1.0-unstable-2025-02-16

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -31017,6 +31017,12 @@
     github = "zuzuleinen";
     githubId = 944919;
   };
+  zwartemees = {
+    email = "zwartemees@gmail.com";
+    name = "Mees";
+    github = "zwartemees";
+    githubId = 60814194;
+  };
   zx2c4 = {
     email = "Jason@zx2c4.com";
     github = "zx2c4";

--- a/pkgs/by-name/ac/accurse/package.nix
+++ b/pkgs/by-name/ac/accurse/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  librsvg,
+  xcursorgen,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "accurse";
+  version = "0.1.0-unstable-2025-07-03";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "ATM-Jahid";
+    repo = "accurse";
+    rev = "0779b0309f1eef3d2aa541ba31390a11ccbeab9b";
+    hash = "sha256-l6IxoH0WgmD1NuOJAe8EIfxTUbuAUnPXWHPB4bpL5Ec=";
+  };
+
+  build-system = [
+    python3Packages.hatchling
+  ];
+
+  dependencies = [
+    python3Packages.lxml
+  ];
+
+  makeWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    (lib.makeBinPath [
+      librsvg
+      xcursorgen
+    ])
+  ];
+
+  meta = {
+    description = "Atomsky's cursor package";
+    homepage = "https://github.com/ATM-Jahid/accurse";
+    license = lib.licenses.agpl3Only;
+    mainProgram = "accurse";
+    maintainers = with lib.maintainers; [ zwartemees ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Initial release of `accurse`, a CLI tool to compile and manage hyprcursor and xcursor themes from SVG assets. 

It handles automated shape mirroring, scaling, and hotspot re-calculations, utilizing a unified configuration file.

### Links
- **Homepage:** https://github.com/ATM-Jahid/accurse
- **License:** GNU AGPLv3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
