### PR TITLE
ipp-usb: fix cross

### DIFF
--- a/pkgs/by-name/ip/ipp-usb/package.nix
+++ b/pkgs/by-name/ip/ipp-usb/package.nix
@@ -23,7 +23,8 @@ buildGoModule (finalAttrs: {
     rm ipp-usb.8
     substituteInPlace Makefile \
       --replace-fail "install: all" "install: man" \
-      --replace-fail "/usr/" "/"
+      --replace-fail "/usr/" "/" \
+      --replace-fail "install -s" "install" # Nix already strips binaries in $out/sbin, this also fixes cross
     substituteInPlace systemd-udev/ipp-usb.service --replace-fail "/sbin" "$out/bin"
     for i in paths.go ipp-usb.8.md; do
       substituteInPlace $i --replace-fail "/usr" "$out"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Without this, ipp-usb fails to build when cross compiling.

```
ipp-usb-aarch64-linux> Running phase: installPhase
ipp-usb-aarch64-linux> ronn --roff --manual=ipp-usb.8 ipp-usb.8.md
ipp-usb-aarch64-linux>      roff: ./ipp-usb.8                                
ipp-usb-aarch64-linux> install -s -D -t /nix/store/ji6sxybx7l1cy9knnw7pjd73lir4y7gz-ipp-usb-armv6l-unknown-linux-gnueabihf-0.9.33/sbin ipp-usb
ipp-usb-aarch64-linux> install: cannot run 'strip': No such file or directory
ipp-usb-aarch64-linux> make: *** [Makefile:21: install] Error 1
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
