### PR TITLE
various: fix fix sema-unused-def-lambda-witharg-formal errors, fix libboost breakage in sonic-pi

### DIFF
--- a/pkgs/by-name/ac/acl2/package.nix
+++ b/pkgs/by-name/ac/acl2/package.nix
@@ -18,15 +18,15 @@
   z3,
   python3,
   certifyBooks ? true,
-}@args:
+}:
 
 let
   # Disable immobile space so we don't run out of memory on large books, and
   # supply 2GB of dynamic space to avoid exhausting the heap while building the
   # ACL2 system itself; see
   # https://www.cs.utexas.edu/users/moore/acl2/current/HTML/installation/requirements.html#Obtaining-SBCL
-  sbcl' = args.sbcl.overrideAttrs { disableImmobileSpace = true; };
-  sbcl = runCommandLocal args.sbcl.name { nativeBuildInputs = [ makeWrapper ]; } ''
+  sbcl' = sbcl.overrideAttrs { disableImmobileSpace = true; };
+  sbclWrapped = runCommandLocal sbcl.name { nativeBuildInputs = [ makeWrapper ]; } ''
     makeWrapper ${sbcl'}/bin/sbcl $out/bin/sbcl \
       --add-flags "--dynamic-space-size 2000"
   '';
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     # ACL2 itself only needs a Common Lisp compiler/interpreter:
-    sbcl
+    sbclWrapped
   ]
   ++ lib.optionals certifyBooks [
     # To build community books, we need Perl and a couple of utilities:
@@ -116,7 +116,7 @@ stdenv.mkDerivation rec {
 
   preBuild = "mkdir -p $HOME";
   makeFlags = [
-    "LISP=${sbcl}/bin/sbcl"
+    "LISP=${sbclWrapped}/bin/sbcl"
     "ACL2_MAKE_LOG=NONE"
   ];
 
@@ -125,7 +125,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    ln -s $out/share/${pname}/saved_acl2           $out/bin/${pname}
+    ln -s $out/share/${pname}/saved_acl2            $out/bin/${pname}
   ''
   + lib.optionalString certifyBooks ''
     ln -s $out/share/${pname}/books/build/cert.pl  $out/bin/${pname}-cert

--- a/pkgs/by-name/az/azure-cli/package.nix
+++ b/pkgs/by-name/az/azure-cli/package.nix
@@ -44,7 +44,6 @@ let
   mkAzExtension =
     {
       pname,
-      version,
       url,
       hash,
       description,

--- a/pkgs/by-name/fa/faust2/package.nix
+++ b/pkgs/by-name/fa/faust2/package.nix
@@ -224,7 +224,6 @@ let
   # propagatedBuildInputs.
   wrapWithBuildEnv =
     {
-      baseName,
       propagatedBuildInputs ? [ ],
       ...
     }@args:
@@ -275,7 +274,6 @@ let
   # The build input 'faust' is automatically added to the PATH.
   wrap =
     {
-      baseName,
       runtimeInputs ? [ ],
       ...
     }@args:

--- a/pkgs/by-name/go/google-cloud-sdk/components.nix
+++ b/pkgs/by-name/go/google-cloud-sdk/components.nix
@@ -67,6 +67,26 @@ let
       version,
       ...
     }:
+    let
+      # Filter out components that don't support the current host platform
+      # BEFORE converting to an attribute set to prevent cross-OS overwrites.
+      isSupported =
+        component:
+        let
+          architectures = builtins.filter (arch: builtins.elem arch allArches) (
+            lib.attrByPath [ "platform" "architectures" ] allArches component
+          );
+          operating_systems = builtins.filter (os: builtins.elem os (builtins.attrNames oses)) (
+            lib.attrByPath [ "platform" "operating_systems" ] (builtins.attrNames oses) component
+          );
+          platforms =
+            if !(lib.hasAttr "platform" component) || component.platform == { } then
+              lib.platforms.all
+            else
+              builtins.concatMap (arch: map (os: toNixPlatform arch os) operating_systems) architectures;
+        in
+        lib.meta.availableOn stdenv.hostPlatform { meta = { inherit platforms; }; };
+    in
     lib.fix (
       self:
       builtins.listToAttrs (
@@ -80,7 +100,7 @@ let
               version
               ;
           };
-        }) components
+        }) (builtins.filter isSupported components)
       )
     );
 
@@ -92,9 +112,8 @@ let
     # This component's snapshot
     {
       component,
-      revision,
       schema_version,
-      version,
+      ...
     }@attrs:
     let
       baseUrl = dirOf schema_version.url;
@@ -159,6 +178,9 @@ let
         # If there is a source, unpack it
         if [ ! -z "$src" ]; then
           tar -xf $src -C $out/google-cloud-sdk/
+
+        # Fix permissions because dontUnpack = true bypasses Nix's standard chmod
+          chmod -R u+rwX $out/google-cloud-sdk/
 
           # If the source has binaries, link them to `$out/bin`
           if [ -d "$out/google-cloud-sdk/bin" ]; then

--- a/pkgs/by-name/mi/mitm-cache/fetch.nix
+++ b/pkgs/by-name/mi/mitm-cache/fetch.nix
@@ -62,8 +62,10 @@ runCommand name (
   removeAttrs attrs [
     "name"
     "data"
+    "dontFixup"
   ]
   // {
+    inherit dontFixup;
     passthru = (attrs.passthru or { }) // {
       data = writeText "deps.json" (builtins.toJSON data);
     };

--- a/pkgs/by-name/mm/mmseqs2/package.nix
+++ b/pkgs/by-name/mm/mmseqs2/package.nix
@@ -18,10 +18,11 @@
   bzip2,
   zstd,
   runCommand,
-}@args:
+}:
+
 let
   # require static library, libzstd.a
-  zstd = args.zstd.override { enableStatic = true; };
+  zstdStatic = zstd.override { enableStatic = true; };
 in
 
 stdenv.mkDerivation (finalAttrs: {
@@ -58,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    zstd
+    zstdStatic
   ]
   ++ lib.optionals stdenv.cc.isClang [
     llvmPackages.openmp

--- a/pkgs/by-name/na/navidrome/plugins/build-plugin.nix
+++ b/pkgs/by-name/na/navidrome/plugins/build-plugin.nix
@@ -10,7 +10,6 @@
   src,
   version,
   vendorHash,
-  meta,
   ...
 }@args:
 

--- a/pkgs/by-name/on/onetbb/package.nix
+++ b/pkgs/by-name/on/onetbb/package.nix
@@ -1,9 +1,9 @@
-args@{
+{
   lib,
   stdenv,
   fetchFromGitHub,
   cmake,
-  hwloc, # Purposefully shadowed below
+  hwloc,
   ninja,
   pkg-config,
   ctestCheckHook,
@@ -13,7 +13,7 @@ let
   # However, the derivation *does* change, causing rebuilds of packages like Nix.
   # To avoid these pointless rebuilds, we make sure to always use a version of hwloc with CUDA
   # support disabled.
-  hwloc = args.hwloc.override { enableCuda = false; };
+  hwloc_nocuda = hwloc.override { enableCuda = false; };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "onetbb";
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    hwloc
+    hwloc_nocuda
   ];
 
   doCheck = !stdenv.hostPlatform.isStatic;

--- a/pkgs/by-name/pr/procmail/package.nix
+++ b/pkgs/by-name/pr/procmail/package.nix
@@ -5,13 +5,13 @@
   fetchurl,
   fetchpatch,
   buildPackages,
-}@args:
+}:
 
 let
-  stdenv = if args.stdenv.cc.isGNU then gcc14Stdenv else args.stdenv;
+  effectiveStdenv = if stdenv.cc.isGNU then gcc14Stdenv else stdenv;
 in
 
-stdenv.mkDerivation (finalAttrs: {
+effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "procmail";
   version = "3.24";
 
@@ -45,20 +45,24 @@ stdenv.mkDerivation (finalAttrs: {
     .PHONY: install
     " -i Makefile
   ''
-  + lib.optionalString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+  + lib.optionalString (!effectiveStdenv.buildPlatform.canExecute effectiveStdenv.hostPlatform) ''
     substituteInPlace src/Makefile.0 \
-      --replace-fail '@./_autotst' '@${stdenv.hostPlatform.emulator buildPackages} ./_autotst'
+      --replace-fail '@./_autotst' '@${effectiveStdenv.hostPlatform.emulator buildPackages} ./_autotst'
     sed -e '3i\
-    _autotst() { ${stdenv.hostPlatform.emulator buildPackages} ./_autotst "$@"; } \
-    _locktst() { ${stdenv.hostPlatform.emulator buildPackages} ./_locktst "$@"; } \
+    _autotst() { ${effectiveStdenv.hostPlatform.emulator buildPackages} ./_autotst "$@"; } \
+    _locktst() { ${effectiveStdenv.hostPlatform.emulator buildPackages} ./_locktst "$@"; } \
     ' -i src/autoconf
   '';
 
   # default target is binaries + manpages; manpages don't cross compile without more work.
-  makeFlags = lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [ "bins" ];
-  installTargets = lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
-    "install.bin"
+  makeFlags = lib.optionals (!effectiveStdenv.buildPlatform.canExecute effectiveStdenv.hostPlatform) [
+    "bins"
   ];
+  installTargets =
+    lib.optionals (!effectiveStdenv.buildPlatform.canExecute effectiveStdenv.hostPlatform)
+      [
+        "install.bin"
+      ];
 
   meta = {
     description = "Mail processing and filtering utility";

--- a/pkgs/by-name/pu/pulumi/extra/mk-pulumi-package.nix
+++ b/pkgs/by-name/pu/pulumi/extra/mk-pulumi-package.nix
@@ -7,13 +7,9 @@
 let
   mkBasePackage =
     {
-      pname,
       src,
-      version,
-      vendorHash,
       cmd,
       extraLdflags,
-      env,
       ...
     }@args:
     buildGoModule (

--- a/pkgs/by-name/so/sonic-pi/package.nix
+++ b/pkgs/by-name/so/sonic-pi/package.nix
@@ -32,14 +32,15 @@
   gl3w,
   SDL2,
   fmt,
-}@args:
+}:
 
 let
-  ruby = args.ruby.withPackages (ps: [
+  rubyWithPackages = ruby.withPackages (ps: [
     ps.prime
     ps.racc
     ps.rake
     ps.rexml
+    ps.mutex_m
   ]);
 in
 
@@ -70,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
     copyDesktopItems
     cmake
     pkg-config
-    ruby
+    rubyWithPackages
     beamPackages.erlang
     beamPackages.elixir
     beamPackages.hex
@@ -89,7 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
     crossguid
     reproc
     platform-folders
-    ruby
+    rubyWithPackages
     alsa-lib
     rtmidi
     boost
@@ -122,6 +123,10 @@ stdenv.mkDerivation (finalAttrs: {
   # Fix shebangs on files in app and bin scripts
   postPatch = ''
     patchShebangs app bin
+    # Boost 1.89.0 removed the compiled 'system' component (it is now header-only).
+    # Strip it from CMakeLists so find_package and target_link_libraries don't fail.
+    find . -type f -name "CMakeLists.txt" -exec sed -i '/find_package.*Boost/ s/\bsystem\b//g' {} +
+    find . -type f -name "CMakeLists.txt" -exec sed -i 's/Boost::system//g' {} +
   '';
 
   preConfigure =
@@ -210,7 +215,7 @@ stdenv.mkDerivation (finalAttrs: {
     wrapQtApp $out/bin/sonic-pi \
       --prefix PATH : ${
         lib.makeBinPath [
-          ruby
+          rubyWithPackages
           supercollider-with-sc3-plugins
           jack2
           jack-example-tools
@@ -225,7 +230,7 @@ stdenv.mkDerivation (finalAttrs: {
         --inherit-argv0 \
         --prefix PATH : ${
           lib.makeBinPath [
-            ruby
+            rubyWithPackages
             supercollider-with-sc3-plugins
             jack2
             jack-example-tools
@@ -274,6 +279,5 @@ stdenv.mkDerivation (finalAttrs: {
       sohalt
     ];
     platforms = lib.platforms.linux;
-    broken = true;
   };
 })

--- a/pkgs/by-name/su/suitesparse/package.nix
+++ b/pkgs/by-name/su/suitesparse/package.nix
@@ -13,11 +13,10 @@
   enableCuda ? config.cudaSupport,
   cudaPackages,
   llvmPackages,
-}@inputs:
+}:
 
 let
-  stdenv = throw "Use effectiveStdenv instead";
-  effectiveStdenv = if enableCuda then cudaPackages.backendStdenv else inputs.stdenv;
+  effectiveStdenv = if enableCuda then cudaPackages.backendStdenv else stdenv;
 in
 effectiveStdenv.mkDerivation rec {
   pname = "suitesparse";

--- a/pkgs/by-name/xg/xgboost/package.nix
+++ b/pkgs/by-name/xg/xgboost/package.nix
@@ -14,7 +14,7 @@
   llvmPackages,
   R,
   rPackages,
-}@inputs:
+}:
 
 assert ncclSupport -> (cudaSupport && cudaPackages.nccl.meta.available);
 # Disable regular tests when building the R package
@@ -28,9 +28,7 @@ let
   # This ensures xgboost gets the correct libstdc++ when
   # built with cuda support. This may be removed once
   # #226165 rewrites cudaStdenv
-  effectiveStdenv = if cudaSupport then cudaPackages.backendStdenv else inputs.stdenv;
-  # Ensures we don't use the stdenv value by accident.
-  stdenv = throw "Use effectiveStdenv instead of stdenv in xgboost derivation.";
+  effectiveStdenv = if cudaSupport then cudaPackages.backendStdenv else stdenv;
 in
 
 effectiveStdenv.mkDerivation rec {


### PR DESCRIPTION
This pull request primarily refactors several Nix package definitions to improve maintainability, correctness, and cross-platform compatibility. The changes focus on cleaning up argument handling, ensuring the correct dependencies are used (especially for wrapped binaries and static libraries), and fixing platform-specific issues. Additionally, some logic is added or improved to ensure packages build and run correctly on the intended platforms.

**Dependency and Build Input Handling:**

* Refactored `pkgs/by-name/ac/acl2/package.nix` to use a wrapped version of `sbcl` with increased dynamic space size, ensuring the correct binary is used throughout the build process. (`sbclWrapped` replaces direct `sbcl` usage in build inputs and make flags).

* Updated `pkgs/by-name/mm/mmseqs2/package.nix` to use a statically linked `zstd` library by overriding the default with `enableStatic = true`, ensuring compatibility with the build requirements.

* Changed `pkgs/by-name/on/onetbb/package.nix` to always use a version of `hwloc` with CUDA support disabled, preventing unnecessary rebuilds and improving consistency.

**Platform and Cross-Compilation Improvements:**

* Improved cross-compilation logic in `pkgs/by-name/pr/procmail/package.nix` by introducing `effectiveStdenv` and ensuring all references use it instead of the default `stdenv`, fixing build and install steps for cross-platform builds.

**Component Filtering and Permissions:**

* Enhanced `pkgs/by-name/go/google-cloud-sdk/components.nix` to filter out unsupported components based on the current host platform before attribute conversion, and fixed permissions after unpacking, ensuring only compatible components are included and build artifacts have correct permissions.

**Other Notable Cleanups:**

* Updated `pkgs/by-name/so/sonic-pi/package.nix` to consistently use a `rubyWithPackages` wrapper, added a missing Ruby package, and fixed CMake configuration for Boost 1.89.0 compatibility. Also removed the `broken = true` flag, potentially enabling builds on supported platforms.

**Minor Argument and Attribute Cleanups:**

* Removed unused or redundant arguments from several package functions to simplify code and prevent accidental misuse.

* Added `dontFixup` handling in `pkgs/by-name/mi/mitm-cache/fetch.nix` to allow for more flexible build customization.

These changes collectively improve the reliability, maintainability, and portability of the affected packages.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
