### PR TITLE
swtpm: 0.10.1 -> 0.10.1-unstable-2026-05-06

### DIFF
--- a/pkgs/by-name/sw/swtpm/package.nix
+++ b/pkgs/by-name/sw/swtpm/package.nix
@@ -7,7 +7,7 @@
   pkg-config,
   libtasn1,
   openssl,
-  fuse,
+  fuse3,
   glib,
   libseccomp,
   json-glib,
@@ -15,6 +15,7 @@
   unixtools,
   expect,
   socat,
+  gmp,
   gnutls,
   perl,
   makeWrapper,
@@ -27,20 +28,28 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "swtpm";
-  version = "0.10.1";
+  version = "0.10.1-unstable-2026-05-06"; # fuse3 support, switch to openssl, but does not yet require libtpms >= 0.11
 
   src = fetchFromGitHub {
     owner = "stefanberger";
     repo = "swtpm";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-N79vuI0FhawLyQtwVF6ABIvCmEaYefq/YkyrafUfUHE=";
+    rev = "74f272e337da2c2aa209140df85ddd43a285a2d9";
+    hash = "sha256-cviADrmSTagba9KmlfiQFS6x4W/C8vI2/HuPRqZFh2U=";
   };
 
   patches = [
     (fetchpatch {
-      name = "retry-nwwrite.patch";
-      url = "https://github.com/stefanberger/swtpm/commit/4da66c66f92438443e66b67555673c9cb898b0ae.patch";
-      hash = "sha256-TTS+ViN4g6EfNLrhvGPobcSQEbr/mEl9ZLZTWdxbifs=";
+      # some miscellaneous fixes
+      # - darwin support for socket open
+      # - fix a typoed format string
+      # - fix initializer lists to be compatible with clang
+      url = "https://github.com/stefanberger/swtpm/pull/1127.patch";
+      hash = "sha256-0DFf6LLdjv/wKcsjib1+AOJ3WWu83n5jA0Bx5/chlvc=";
+    })
+    (fetchpatch {
+      # better detection of `stat` util
+      url = "https://github.com/stefanberger/swtpm/pull/1128.patch";
+      hash = "sha256-Cgt8No15NA/eCBLuKsYLDwVWO89XohnTQ3znd4Ky6NM=";
     })
   ];
 
@@ -65,15 +74,17 @@ stdenv.mkDerivation (finalAttrs: {
     libtasn1
     glib
     json-glib
+    gmp
     gnutls
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
-    fuse
+    fuse3
     libseccomp
   ];
 
   configureFlags = [
     "--localstatedir=/var"
+    "--with-gnutls"
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     "--with-cuse"
@@ -87,39 +98,14 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Makefile tries to create the directory /var/lib/swtpm-localca, which fails
     substituteInPlace samples/Makefile.am \
-        --replace 'install-data-local:' 'do-not-execute:'
+        --replace-fail 'install-data-local:' 'do-not-execute:'
 
-    # Use the correct path to the certtool binary
+    # Use the correct path to the openssl binary
     # instead of relying on it being in the environment
     substituteInPlace src/swtpm_localca/swtpm_localca.c \
-      --replace \
-        '# define CERTTOOL_NAME "gnutls-certtool"' \
-        '# define CERTTOOL_NAME "${gnutls}/bin/certtool"' \
-      --replace \
-        '# define CERTTOOL_NAME "certtool"' \
-        '# define CERTTOOL_NAME "${gnutls}/bin/certtool"'
-
-    substituteInPlace tests/common --replace \
-        'CERTTOOL=gnutls-certtool;;' \
-        'CERTTOOL=certtool;;'
-
-    # Fix error on macOS:
-    # stat: invalid option -- '%'
-    # This is caused by the stat program not being the BSD version,
-    # as is expected by the test
-    substituteInPlace tests/common tests/sed-inplace --replace \
-        'if [[ "$(uname -s)" =~ (Linux|CYGWIN_NT-) ]]; then' \
-        'if [[ "$(uname -s)" =~ (Linux|Darwin|CYGWIN_NT-) ]]; then'
-
-    # Otherwise certtool seems to pick up the system language on macOS,
-    # which might cause a test to fail
-    substituteInPlace tests/test_swtpm_setup_create_cert --replace \
-        '$CERTTOOL' \
-        'LC_ALL=C.UTF-8 $CERTTOOL'
-
-    substituteInPlace tests/test_tpm2_swtpm_cert --replace \
-        'certtool' \
-        'LC_ALL=C.UTF-8 certtool'
+      --replace-fail \
+        '#define OPENSSL_TOOL  "openssl"' \
+        '#define OPENSSL_TOOL  "${lib.getExe openssl}"'
   '';
 
   # Workaround for https://github.com/stefanberger/swtpm/issues/795
@@ -129,6 +115,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   doCheck = true;
+  __darwinAllowLocalNetworking = true; # tests do socket things, requires local networking to pass
   enableParallelBuilding = true;
 
   outputs = [


### PR DESCRIPTION
Motivation is the migration from fuse2 to fuse3.

Part of https://github.com/NixOS/nixpkgs/pull/521536


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
