### PR TITLE
python3Packages.narwhals: fix build

### DIFF
--- a/pkgs/development/python-modules/narwhals/default.nix
+++ b/pkgs/development/python-modules/narwhals/default.nix
@@ -5,6 +5,7 @@
   dask,
   duckdb,
   fetchFromGitHub,
+  fetchpatch2,
   hatchling,
   hypothesis,
   ibis-framework,
@@ -31,6 +32,26 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-k7CeM8Q4JgKbkLisAaVrljro4diOf0K0immek6AI0vM=";
   };
+
+  patches = [
+    (fetchpatch2 {
+      name = "fix-dask-deprecationwarning.patch";
+      url = "https://github.com/narwhals-dev/narwhals/commit/254655af21872e8127f7fee9a9afbfb279f1eda2.patch?full_index=1";
+      # Exclude unrelated change to non-test code.
+      includes = [ "pyproject.toml" ];
+      hash = "sha256-tgz0b08P36CENOYFBILbicHhdB4BytXgFQk3nIxpw0A=";
+    })
+    (fetchpatch2 {
+      name = "fix-dask-deprecationwarning.patch";
+      url = "https://github.com/narwhals-dev/narwhals/commit/b92d5a840e08bdf7806947ffde27de856900c5ab.patch?full_index=1";
+      hash = "sha256-2lct6/MfViKnRjpEehNKqF6zdZVIkXi7tYxycDh/Hn8=";
+    })
+    (fetchpatch2 {
+      name = "ignore-polars-deprecation-warning-in-tests.patch";
+      url = "https://github.com/narwhals-dev/narwhals/commit/fb798716eb5f8835096d8f88d422baae2b22b3ce.patch?full_index=1";
+      hash = "sha256-pWi0y4S48aADJ1MA3kB9FsLuoA+HfZp5+AgEn69pUuA=";
+    })
+  ];
 
   build-system = [ hatchling ];
 


### PR DESCRIPTION
narwhals does not build on staging-next: a test checking for a specific error message fails, because that error message has changed (likely triggered by the polars upgrade to 1.40.1).

Apply upstream's fix, and apply two previous test fixes to get that last commit to apply. The other two commits update warnings ignored by the tests.

This makes the tests pass, but I have not further tested the result. Bumping narwhals to at least 2.20.0 may be a better fix.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  (tested by building a `python3.withPackages` with this and running the example from upstream's readme)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
