### PR TITLE
home-assistant: 2026.5.2 -> 2026.5.3

### DIFF
--- a/pkgs/development/python-modules/aioimmich/default.nix
+++ b/pkgs/development/python-modules/aioimmich/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "aioimmich";
-  version = "0.14.0";
+  version = "0.14.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mib1185";
     repo = "aioimmich";
     tag = "v${version}";
-    hash = "sha256-p04FGEQXUGMGouy6bY0QW8rC7Ld5RaSoOV/UbAkmNwQ=";
+    hash = "sha256-wKB2WtC5zMEnT2wF9Ed0yW2w9c1p642SXJmy5jJrQQc=";
   };
 
   postPatch = ''

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2026.5.2";
+  version = "2026.5.3";
   components = {
     "3_day_blinds" =
       ps: with ps; [

--- a/pkgs/servers/home-assistant/custom-components/waste_collection_schedule/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/waste_collection_schedule/package.nix
@@ -20,13 +20,13 @@
 buildHomeAssistantComponent rec {
   owner = "mampfes";
   domain = "waste_collection_schedule";
-  version = "2.23.0";
+  version = "2.24.0";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "hacs_waste_collection_schedule";
     tag = "v${version}";
-    hash = "sha256-YZBIh828kYhRxoRe5uIUJY4ZPJuJYZKCfA6BF/Fx2nk=";
+    hash = "sha256-fCtgEfaoI9IVEpe3YMFb8IkzNmGalueZaGv9JpS35Ok=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -262,7 +262,7 @@ let
   extraBuildInputs = extraPackages python.pkgs;
 
   # Don't forget to run update-component-packages.py after updating
-  hassVersion = "2026.5.2";
+  hassVersion = "2026.5.3";
 
 in
 python.pkgs.buildPythonApplication rec {
@@ -283,13 +283,13 @@ python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     tag = version;
-    hash = "sha256-fKHYlXb1j5A6vQ3B/Pb2O7WD6t9ubsNQXc9f/gK79Pk=";
+    hash = "sha256-U3P97V/3+4eKMPyT6JzqLiDgei84iEOyWdknFvJBn1o=";
   };
 
   # Secondary source is pypi sdist for translations
   sdist = fetchPypi {
     inherit pname version;
-    hash = "sha256-Zt+I/gaIyVAAgL9MF3T0WxivqY3D28tdtJX+GLbSES0=";
+    hash = "sha256-SAeqGo+fTQG//Abix+6pjHKQJY1XBrNL7IexgqoXsYc=";
   };
 
   build-system = with python.pkgs; [

--- a/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
+++ b/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "pytest-homeassistant-custom-component";
-  version = "0.13.331";
+  version = "0.13.332";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "MatthewFlamm";
     repo = "pytest-homeassistant-custom-component";
     tag = version;
-    hash = "sha256-sFL2O/uPrb45c1QrLLwnAcII2sUO7BhuWA1MuzXJKTE=";
+    hash = "sha256-zkRmuNUmRVvnIwIx494xzFKT0/00GZzkVo6cva9tut4=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "homeassistant-stubs";
-  version = "2026.5.2";
+  version = "2026.5.3";
   pyproject = true;
 
   disabled = python.version != home-assistant.python.version;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "KapJI";
     repo = "homeassistant-stubs";
     tag = version;
-    hash = "sha256-BTYgsaOr82eqD2Cwf/Se1i2zUr6/cKgHaynCyGQKSAQ=";
+    hash = "sha256-kgfnT+qTsbB3T8PPsSA698QcxcM1o1QW8hLnfXjGm5M=";
   };
 
   build-system = [

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -146,6 +146,17 @@ let
       # [2026.5.2] Failed: Description not found for placeholder `modulation` in component.novy_cooker_hood.config.abort.no_compatible_transmitters
       "test_no_compatible_transmitters"
     ];
+    tractive = [
+      # [2026.5.3] Entity does not get set up
+      "test_binary_sensor"
+      "test_sensor"
+      "test_switch"
+      "test_switch_on"
+      "test_switch_off"
+      "test_switch_on_with_exception"
+      "test_switch_off_with_exception"
+      "test_switch_unavailable"
+    ];
     zeroconf = [
       # multicast socket bind, not possible in the sandbox
       "test_subscribe_discovery"


### PR DESCRIPTION
https://github.com/mib1185/aioimmich/releases/tag/v0.14.1
https://github.com/jnimmo/pyIntesisHome/releases/tag/1.8.8
https://github.com/home-assistant/core/releases/tag/2026.5.3

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
