### PR TITLE
hedgewars: on darwin

### DIFF
--- a/pkgs/by-name/he/hedgewars/cmake-darwin-arm64.patch
+++ b/pkgs/by-name/he/hedgewars/cmake-darwin-arm64.patch
@@ -1,0 +1,54 @@
+--- hedgewars-src-1.0.3/cmake_modules/platform.cmake	2021-06-23 14:58:09.000000000 -0400
++++ hedgewars-patch-work/cmake_modules/platform.cmake	2026-05-17 21:52:13.746344437 -0400
+@@ -45,6 +45,7 @@
+         string(REGEX MATCH "[pP][pP][cC]+" powerpc_build "${CMAKE_OSX_ARCHITECTURES}")
+         string(REGEX MATCH "[iI]386+" i386_build "${CMAKE_OSX_ARCHITECTURES}")
+         string(REGEX MATCH "[xX]86_64+" x86_64_build "${CMAKE_OSX_ARCHITECTURES}")
++        string(REGEX MATCH "[aA][rR][mM]64+" arm64_build "${CMAKE_OSX_ARCHITECTURES}")
+         if(x86_64_build)
+             add_flag_prepend(CMAKE_Pascal_FLAGS -Px86_64)
+         elseif(i386_build)
+@@ -51,6 +52,9 @@
+             add_flag_prepend(CMAKE_Pascal_FLAGS -Pi386)
+         elseif(powerpc_build)
+             add_flag_prepend(CMAKE_Pascal_FLAGS -Ppowerpc)
++        elseif(arm64_build)
++            add_flag_prepend(CMAKE_Pascal_FLAGS -Paarch64)
++            add_flag_prepend(CMAKE_Pascal_FLAGS -WM11.0)
+         else()
+             message(FATAL_ERROR "Unknown architecture present in CMAKE_OSX_ARCHITECTURES (${CMAKE_OSX_ARCHITECTURES})")
+         endif()
+@@ -58,6 +62,9 @@
+         if(num_of_archs GREATER 1)
+             message("*** Only one architecture in CMAKE_OSX_ARCHITECTURES is supported, picking the first one ***")
+         endif()
++    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
++        add_flag_prepend(CMAKE_Pascal_FLAGS -Paarch64)
++        add_flag_prepend(CMAKE_Pascal_FLAGS -WM11.0)
+     elseif(CMAKE_SIZEOF_VOID_P MATCHES "8")
+         #if that variable is not set check if we are on x86_64 and if so force it, else use default
+         add_flag_prepend(CMAKE_Pascal_FLAGS -Px86_64)
+--- hedgewars-src-1.0.3/hedgewars/CMakeLists.txt	2025-07-22 13:12:55.000000000 -0400
++++ hedgewars-patch-work/hedgewars/CMakeLists.txt	2026-05-17 21:52:13.747145614 -0400
+@@ -130,7 +130,20 @@
+     add_flag_append(CMAKE_Pascal_FLAGS "-k-framework -kOpenGL")
+ 
+     #set the correct library or framework style depending on the main SDL
+-    string(FIND "${SDL2_LIBRARIES}" "dylib" sdl_framework)
++    # In nixpkgs SDL2_LIBRARIES is a cmake target name (SDL2::SDL2), not a file path,
++    # so string(FIND "dylib") always fails. Force the dylib path and extract library
++    # directories from cmake imported-target properties for FPC -Fl search paths.
++    set(sdl_framework 1)
++    get_target_property(_sdl2_loc SDL2::SDL2 IMPORTED_LOCATION_RELEASE)
++    if(NOT _sdl2_loc)
++        get_target_property(_sdl2_loc SDL2::SDL2 IMPORTED_LOCATION)
++    endif()
++    get_filename_component(_sdl2_dir ${_sdl2_loc} PATH)
++    get_filename_component(_sdl2_image_dir ${SDL2_IMAGE_LIBRARY} PATH)
++    get_filename_component(_sdl2_mixer_dir ${SDL2_MIXER_LIBRARY} PATH)
++    get_filename_component(_sdl2_ttf_dir ${SDL2_TTF_LIBRARY} PATH)
++    get_filename_component(_sdl2_net_dir ${SDL2_NET_LIBRARY} PATH)
++    add_flag_append(CMAKE_Pascal_FLAGS "-Fl${_sdl2_dir} -Fl${_sdl2_image_dir} -Fl${_sdl2_mixer_dir} -Fl${_sdl2_ttf_dir} -Fl${_sdl2_net_dir}")
+     if(${sdl_framework} GREATER -1)
+         add_flag_append(CMAKE_Pascal_FLAGS "-k-lsdl2 -k-lsdl2_image -k-lsdl2_mixer -k-lsdl2_ttf -k-lsdl2_net")
+     else()

--- a/pkgs/by-name/he/hedgewars/package.nix
+++ b/pkgs/by-name/he/hedgewars/package.nix
@@ -143,6 +143,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       kragniz
       fpletz
+      philocalyst
     ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/he/hedgewars/package.nix
+++ b/pkgs/by-name/he/hedgewars/package.nix
@@ -1,12 +1,11 @@
 {
-  stdenv,
   SDL2_image,
+  stdenv,
   SDL2_ttf,
   SDL2_net,
   fpc,
   haskell,
   ffmpeg,
-  libglut,
   lib,
   fetchurl,
   cmake,
@@ -18,38 +17,72 @@
   libpng,
   libGL,
   libGLU,
+  libglut,
   physfs,
   qt5,
-  withServer ? true,
+  hicolor-icon-theme,
+  withServer ? !stdenv.isDarwin,
 }:
 
 let
   inherit (qt5) qtbase qttools wrapQtAppsHook;
-
-  ghc = haskell.packages.ghc94.ghcWithPackages (
-    pkgs: with pkgs; [
-      SHA
-      bytestring
-      entropy
-      hslogger
-      network
-      pkgs.zlib
-      random
-      regex-tdfa
-      sandi
-      utf8-string
-      vector
-    ]
-  );
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "hedgewars";
   version = "1.0.3";
 
+  # Fetchg is disabled due to adversarial auth conditions
   src = fetchurl {
     url = "https://hedgewars.org/download/releases/hedgewars-src-${finalAttrs.version}.tar.bz2";
     hash = "sha256-xcGHfAuuE1THXSuVJ7b5qfeemZMuXQix9vfeFwgGYTA=";
   };
+
+  patches = lib.optionals stdenv.isDarwin [
+    ./cmake-darwin-arm64.patch
+  ];
+
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-Wno-deprecated-declarations -Wno-format-security";
+
+  postPatch = ''
+    # cmake >= 3.20 rejects get_target_property with LOCATION.
+    substituteInPlace misc/liblua/CMakeLists.txt \
+      --replace-fail 'get_target_property(lua_fullpath lua LOCATION)' \
+                     'set(lua_fullpath "$<TARGET_FILE:lua>")'
+  ''
+  + lib.optionalString stdenv.isDarwin ''
+    # Anchor the bundle prefix to the Nix store path so cmake installs into
+    # $out/Hedgewars.app/... rather than a bare relative path outside the store.
+    substituteInPlace cmake_modules/paths.cmake \
+      --replace-fail \
+        'set(CMAKE_INSTALL_PREFIX "Hedgewars.app/Contents/MacOS/")' \
+        'set(CMAKE_INSTALL_PREFIX "''${CMAKE_INSTALL_PREFIX}/Hedgewars.app/Contents/MacOS/")'
+
+    # hedgewars passes the full physfs dylib path to -Fl but should pass the dir.
+    substituteInPlace hedgewars/CMakeLists.txt \
+      --replace-fail \
+        'add_flag_append(CMAKE_Pascal_FLAGS "-Fl''${PHYSFS_LIBRARY}")' \
+        'add_flag_append(CMAKE_Pascal_FLAGS "-Fl''${PHYSFS_LIBRARY_DIR}")'
+
+    # Apple SDK 14+ no longer ships libz.tbd, so FPC cannot find it via the
+    # baked-in SDK path.
+    substituteInPlace hedgewars/CMakeLists.txt \
+      --replace-fail \
+        'add_flag_append(CMAKE_Pascal_FLAGS "-k-L''${PNG_LIBRARY_DIR} -Fl''${PNG_LIBRARY_DIR}")' \
+        'add_flag_append(CMAKE_Pascal_FLAGS "-k-L''${PNG_LIBRARY_DIR} -Fl''${PNG_LIBRARY_DIR} -Fl${zlib.out}/lib")'
+
+    # SDLInteraction.h explicitly undefs and resets MAC_OS_X_VERSION_MIN_REQUIRED
+    # to MAC_OS_X_VERSION_10_6 (= 1060) just before including SDL_mixer.h.
+    substituteInPlace QTfrontend/util/SDLInteraction.h \
+      --replace-fail 'MAC_OS_X_VERSION_10_6' 'MAC_OS_X_VERSION_10_7'
+
+  '';
+
+  preConfigure = lib.optionalString stdenv.isDarwin ''
+    # Reset to 10.13 so the Nix clang wrapper emits -mmacos-version-min=10.13
+    # rather than the nixpkgs apple-sdk default of 14.0, which would make
+    # MAC_OS_X_VERSION_MIN_REQUIRED resolve below the value sdl2-compat requires.
+    export MACOSX_DEPLOYMENT_TARGET=10.13
+  '';
 
   nativeBuildInputs = [
     cmake
@@ -67,35 +100,76 @@ stdenv.mkDerivation (finalAttrs: {
     fpc
     lua5_1
     ffmpeg
-    libglut
     physfs
     qtbase
+    hicolor-icon-theme
   ]
-  ++ lib.optional withServer ghc;
-
-  cmakeFlags = [
-    "-DNOVERSIONINFOUPDATE=ON"
-    "-DNOSERVER=${if withServer then "OFF" else "ON"}"
+  ++ lib.optionals (!stdenv.isDarwin) [
+    libGL
+    libGLU
+    libglut
+  ]
+  ++ lib.optionals withServer [
+    (haskell.packages.ghc948.ghcWithPackages (
+      hpkgs: with hpkgs; [
+        SHA
+        aeson
+        bytestring
+        entropy
+        hslogger
+        mtl
+        network
+        network-bsd
+        random
+        regex-tdfa
+        sandi
+        text
+        utf8-string
+        vector
+        yaml
+        zlib
+      ]
+    ))
   ];
 
-  env.NIX_LDFLAGS = lib.concatMapStringsSep " " (e: "-rpath ${e}/lib") [
+  cmakeFlags = [
+    (lib.cmakeBool "NOVERSIONINFOUPDATE" true)
+    (lib.cmakeBool "NOSERVER" (!withServer))
+  ]
+  ++ lib.optionals stdenv.isDarwin [
+    # Prevents fixup_bundle from running (it needs OggVorbis and fails in sandbox).
+    (lib.cmakeBool "SKIPBUNDLE" true)
+    (lib.cmakeOptionType "STRING" "CMAKE_OSX_DEPLOYMENT_TARGET" "10.13")
+    (lib.cmakeBool "NOAUTOUPDATE" true)
+  ];
+
+  # runtimeDependencies adds -rpath entries via cc-wrapper so the Qt frontend
+  # and C helpers can find these libraries without LD_LIBRARY_PATH at runtime.
+  runtimeDependencies = [
     SDL2.out
     SDL2_image
     SDL2_mixer
     SDL2_net
     SDL2_ttf
-    libGL
-    libGLU
     libpng.out
     lua5_1
     physfs
     zlib.out
+  ]
+  ++ lib.optionals (!stdenv.isDarwin) [
+    libGL
+    libGLU
   ];
 
-  qtWrapperArgs = [
-    "--prefix"
-    "LD_LIBRARY_PATH"
-    ":"
+  # Build system isn't well-behaved
+  env.NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-framework Foundation -framework AppKit -lobjc";
+
+  # wrapQtAppsHook would wrap every executable it finds, including dylibs in
+  # Frameworks/, replacing them with shell scripts dyld cannot load.
+  dontWrapQtApps = stdenv.isDarwin;
+
+  qtWrapperArgs = lib.optionals (!stdenv.isDarwin) [
+    "--prefix LD_LIBRARY_PATH:"
     (lib.makeLibraryPath [
       libGL
       libGLU
@@ -104,16 +178,43 @@ stdenv.mkDerivation (finalAttrs: {
     ])
   ];
 
+  postFixup = lib.optionalString stdenv.isDarwin ''
+    wrapQtApp "$out/Hedgewars.app/Contents/MacOS/hedgewars"
+  '';
+
+  postInstall =
+    lib.optionalString (!stdenv.isDarwin) ''
+      install -Dm644 "$out/share/hedgewars/Data/misc/hedgewars.desktop" \
+        "$out/share/applications/hedgewars.desktop"
+
+      substituteInPlace "$out/share/applications/hedgewars.desktop" \
+        --replace-fail "Exec=hedgewars" "Exec=$out/bin/hedgewars"
+
+      for size in 16 32 48 64 128 256 512; do
+        install -Dm644 "$NIX_BUILD_TOP/$sourceRoot/misc/hedgewars.png" \
+          "$out/share/icons/hicolor/''${size}x''${size}/apps/hedgewars.png"
+      done
+
+      install -Dm644 "$out/share/hedgewars.metainfo.xml" \
+        "$out/share/metainfo/hedgewars.metainfo.xml"
+    ''
+    + lib.optionalString stdenv.isDarwin ''
+      # Expose the bundle binary on PATH so that wrapQtAppsHook wraps it and
+      # it is accessible without invoking the .app bundle directly.
+      mkdir -p "$out/bin"
+      ln -s "$out/Hedgewars.app/Contents/MacOS/hedgewars" "$out/bin/hedgewars"
+    ''
+    + ''
+      install -Dm644 "$NIX_BUILD_TOP/$sourceRoot/Fonts_LICENSE.txt" \
+        "$out/share/licenses/hedgewars/Fonts_LICENSE.txt"
+    '';
+
   meta = {
     description = "Funny turn-based artillery game, featuring fighting hedgehogs";
     homepage = "https://hedgewars.org/";
     license = with lib.licenses; [
       gpl2Only
-
-      # Assets
       fdl12Only
-
-      # Fonts
       bitstreamVera
       asl20
     ];
@@ -138,13 +239,14 @@ stdenv.mkDerivation (finalAttrs: {
       the island, or through a hole in the bottom of it), it is thrown off
       either side of the arena or when its health is reduced, typically from
       contact with explosions, to zero (the damage dealt to the attacked
-      hedgehog or hedgehogs after a player's or CPU turn is shown only when
-      all movement on the battlefield has ceased).'';
+      hedgehog or hedgehogs after a player's or CPU turn is shown only after
+      all movement on the battlefield has ceased).
+    '';
     maintainers = with lib.maintainers; [
       kragniz
       fpletz
       philocalyst
     ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.all;
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- Got this packaged and bundled for Darwin!
- Includes a patch to tamper down some cmake and fpc issues
- General cleanup (description wording, cmake bool flags, documentation).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
