### PR TITLE
ultrastardx: on darwin

### DIFF
--- a/pkgs/by-name/ul/ultrastardx/package.nix
+++ b/pkgs/by-name/ul/ultrastardx/package.nix
@@ -36,12 +36,13 @@ let
     sqlite
     lua
     zlib
+    ffmpeg
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     libx11
     libGLU
     libGL
-    ffmpeg
   ];
-
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "ultrastardx";
@@ -58,19 +59,44 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     autoreconfHook
   ];
+
   buildInputs = [
     fpc
     libpng
   ]
   ++ sharedLibs;
 
-  preBuild =
-    let
-      items = lib.concatMapStringsSep " " (x: "-rpath ${lib.getLib x}/lib") sharedLibs;
-    in
-    ''
-      export NIX_LDFLAGS="$NIX_LDFLAGS ${items}"
-    '';
+  env = {
+    NIX_LDFLAGS = lib.concatMapStringsSep " " (x: "-rpath ${lib.getLib x}/lib") sharedLibs;
+  }
+  // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    MACOSX_DEPLOYMENT_TARGET = "10.13";
+  };
+
+  # fpc's fpc.cfg hardcodes -FD/Applications/Xcode.app/.../usr/bin to find `as`/`ld`,
+  # which is unreachable in the build sandbox and has no sysroot.
+  preBuild = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    export PFLAGS_EXTRA="-FD${lib.getBin stdenv.cc.bintools}/bin -XR$SDKROOT $PFLAGS_EXTRA"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    make macos-app
+    mkdir -p "$out/Applications" "$out/bin"
+    cp -R UltraStarDeluxe.app "$out/Applications/"
+    ln -s "$out/Applications/UltraStarDeluxe.app/Contents/MacOS/ultrastardx" \
+          "$out/bin/ultrastardx"
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    make install
+    install -Dm644 dists/ultrastardx.desktop \
+      "$out/share/applications/ultrastardx.desktop"
+  ''
+  + ''
+    runHook postInstall
+  '';
 
   # dlopened libgcc requires the rpath not to be shrunk
   dontPatchELF = true;
@@ -82,7 +108,8 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
       diogotcorreia
+      philocalyst
     ];
-    platforms = lib.platforms.linux;
+    platforms = with lib.platforms; linux ++ darwin ++ windows;
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
