### PR TITLE
tree-sitter: fix webUISupport build for 0.26.x

### DIFF
--- a/pkgs/by-name/tr/tree-sitter/package.nix
+++ b/pkgs/by-name/tr/tree-sitter/package.nix
@@ -152,7 +152,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   postPatch =
     lib.optionalString webUISupport ''
-      substituteInPlace cli/loader/src/lib.rs \
+      substituteInPlace crates/xtask/src/build_wasm.rs \
           --replace-fail 'let emcc_name = if cfg!(windows) { "emcc.bat" } else { "emcc" };' 'let emcc_name = "${lib.getExe' emscripten "emcc"}";'
     ''
     # when building on static platforms:

--- a/pkgs/by-name/tr/tree-sitter/package.nix
+++ b/pkgs/by-name/tr/tree-sitter/package.nix
@@ -20,6 +20,7 @@
   buildPackages,
   pkgsCross,
   makeBinaryWrapper,
+  lld,
   enableShared ? !stdenv.hostPlatform.isStatic,
   enableStatic ? stdenv.hostPlatform.isStatic,
   webUISupport ? false,
@@ -199,7 +200,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   postFixup = ''
     wrapProgram $out/bin/tree-sitter \
-      --set-default TREE_SITTER_WASI_SDK_PATH ${pkgsCross.wasi32.stdenv.cc}
+      --set-default TREE_SITTER_WASI_SDK_PATH ${pkgsCross.wasi32.stdenv.cc} \
+      --prefix PATH : ${lib.makeBinPath [ lld ]}
   '';
 
   # test result: FAILED. 120 passed; 13 failed; 0 ignored; 0 measured; 0 filtered out

--- a/pkgs/by-name/tr/tree-sitter/package.nix
+++ b/pkgs/by-name/tr/tree-sitter/package.nix
@@ -20,7 +20,6 @@
   buildPackages,
   pkgsCross,
   makeBinaryWrapper,
-  lld,
   enableShared ? !stdenv.hostPlatform.isStatic,
   enableStatic ? stdenv.hostPlatform.isStatic,
   webUISupport ? false,
@@ -112,6 +111,16 @@ let
 
   allGrammars = lib.filter (p: !(p.meta.broken or false)) (lib.attrValues builtGrammars);
 
+  wasiSdk = pkgsCross.wasi32.stdenv.cc;
+
+  wasiLinker = linkFarm "tree-sitter-wasi-linker" [
+    {
+      # Clang's wasm target looks for this unprefixed linker name.
+      name = "bin/wasm-ld";
+      path = "${wasiSdk.bintools.bintools}/bin/wasm32-unknown-wasi-wasm-ld";
+    }
+  ];
+
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tree-sitter";
@@ -174,7 +183,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   preBuild = lib.optionalString webUISupport ''
     mkdir -p .emscriptencache
     export EM_CACHE=$(pwd)/.emscriptencache
-    export TREE_SITTER_WASI_SDK_PATH=${pkgsCross.wasi32.stdenv.cc}
+    export TREE_SITTER_WASI_SDK_PATH=${wasiSdk}
     cargo run --package xtask -- build-wasm --debug
   '';
 
@@ -200,8 +209,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   postFixup = ''
     wrapProgram $out/bin/tree-sitter \
-      --set-default TREE_SITTER_WASI_SDK_PATH ${pkgsCross.wasi32.stdenv.cc} \
-      --prefix PATH : ${lib.makeBinPath [ lld ]}
+      --set-default TREE_SITTER_WASI_SDK_PATH ${wasiSdk} \
+      --prefix PATH : ${lib.makeBinPath [ wasiLinker ]}
   '';
 
   # test result: FAILED. 120 passed; 13 failed; 0 ignored; 0 measured; 0 filtered out

--- a/pkgs/by-name/tr/tree-sitter/package.nix
+++ b/pkgs/by-name/tr/tree-sitter/package.nix
@@ -18,6 +18,8 @@
   substitute,
   installShellFiles,
   buildPackages,
+  pkgsCross,
+  makeBinaryWrapper,
   enableShared ? !stdenv.hostPlatform.isStatic,
   enableStatic ? stdenv.hostPlatform.isStatic,
   webUISupport ? false,
@@ -133,6 +135,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeBuildInputs = [
     rustPlatform.bindgenHook
     which
+    makeBinaryWrapper
   ]
   ++ lib.optionals webUISupport [
     emscripten
@@ -170,6 +173,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   preBuild = lib.optionalString webUISupport ''
     mkdir -p .emscriptencache
     export EM_CACHE=$(pwd)/.emscriptencache
+    export TREE_SITTER_WASI_SDK_PATH=${pkgsCross.wasi32.stdenv.cc}
     cargo run --package xtask -- build-wasm --debug
   '';
 
@@ -191,6 +195,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --bash "${buildPackages.tree-sitter}"/share/bash-completion/completions/*.bash \
       --zsh "${buildPackages.tree-sitter}"/share/zsh/site-functions/* \
       --fish "${buildPackages.tree-sitter}"/share/fish/*/*
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/tree-sitter \
+      --set-default TREE_SITTER_WASI_SDK_PATH ${pkgsCross.wasi32.stdenv.cc}
   '';
 
   # test result: FAILED. 120 passed; 13 failed; 0 ignored; 0 measured; 0 filtered out


### PR DESCRIPTION
In tree-sitter 0.26, the loader was relocated from cli/loader/ to crates/loader/, and the emcc invocation moved into the xtask. build-wasm helper at crates/xtask/src/build_wasm.rs. Update the `substituteInPlace` target in `postPatch` accordingly so webUISupport builds again.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Closes #493699