### PR TITLE
nixos/shellhub-agent: keep sessions alive across `nixos-rebuild switch`

### DIFF
--- a/nixos/modules/services/networking/shellhub-agent.nix
+++ b/nixos/modules/services/networking/shellhub-agent.nix
@@ -75,9 +75,13 @@ in
     systemd.services.shellhub-agent = {
       description = "ShellHub Agent";
 
+      restartIfChanged = false;
+
       wantedBy = [ "multi-user.target" ];
-      requires = [ "local-fs.target" ];
-      wants = [ "network-online.target" ];
+      wants = [
+        "local-fs.target"
+        "network-online.target"
+      ];
       after = [
         "local-fs.target"
         "network.target"


### PR DESCRIPTION
The agent's child SSH sessions inherit its cgroup, so any stop of `shellhub-agent.service` kills the user's shell (and anything it runs) under the default `KillMode=control-group`. Two paths trigger that stop on `nixos-rebuild switch`: an explicit restart when the unit's store path changes, and a cascade from `Requires=local-fs.target`, which NixOS stops on every activation.

Set `restartIfChanged = false` and replace `requires=[local-fs.target]` with `wants=[local-fs.target]` to preserve ordering without the cascade.

Trade-off: the running agent is no longer refreshed automatically; `systemctl restart shellhub-agent` is needed to pick up a new version.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
