### PR TITLE
[25.11] traefik: 3.6.10 -> 3.6.17

### DIFF
--- a/pkgs/by-name/tr/traefik/package.nix
+++ b/pkgs/by-name/tr/traefik/package.nix
@@ -8,16 +8,16 @@
 
 buildGo125Module (finalAttrs: {
   pname = "traefik";
-  version = "3.6.10";
+  version = "3.6.17";
 
   # Archive with static assets for webui
   src = fetchzip {
     url = "https://github.com/traefik/traefik/releases/download/v${finalAttrs.version}/traefik-v${finalAttrs.version}.src.tar.gz";
-    hash = "sha256-WYHHpS721dlkWdOEj+jwJkQ/vsiP2PnmFI50M9I8sbs=";
+    hash = "sha256-Tqm8Fb+3X/I3v1PG5qfgFMnhbBjKJ5i+3qfd7YuRzFI=";
     stripRoot = false;
   };
 
-  vendorHash = "sha256-q2uy0YrE1D8V0EopKWJLbq2hFcjn3oyanwNJ27yyC+k=";
+  vendorHash = "sha256-k61m/fnyA9GH57BsylqhUoRao+ujqyDdho9HQNICbhs=";
 
   proxyVendor = true;
 


### PR DESCRIPTION
changelog: https://github.com/traefik/traefik/releases/tag/v3.6.17
diff: https://github.com/traefik/traefik/compare/v3.6.10...v3.6.17

Closes #515459
Closes #520842
Closes #515461
Closes #520846
Closes #515457
Closes #515463
Closes #502603
Closes #504459
Closes #504456
Closes #502533
Closes #515458

Version [3.6.14](https://github.com/traefik/traefik/releases/tag/v3.6.14) contains partially breaking changes so we should proceed with caution.

<details>
<summary>nixpkgs-review</summary>

## `nixpkgs-review` result

Generated using [`nixpkgs-review-gha`](https://github.com/Defelo/nixpkgs-review-gha)

Command: `nixpkgs-review pr 521966`
Commit: [`a3a14edd3046c33f43da8c0de77cff6e97331509`](https://github.com/NixOS/nixpkgs/commit/a3a14edd3046c33f43da8c0de77cff6e97331509) ([subsequent changes](https://github.com/NixOS/nixpkgs/compare/a3a14edd3046c33f43da8c0de77cff6e97331509..pull/521966/head))
Merge: [`9e7ca8ad2e1922411d1082b91b148de49dd61761`](https://github.com/NixOS/nixpkgs/commit/9e7ca8ad2e1922411d1082b91b148de49dd61761)

Logs: https://github.com/Hythera/nixpkgs-review-gha/actions/runs/26105497538


---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>traefik</li>
  </ul>
</details>

---
### `aarch64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>traefik</li>
  </ul>
</details>

---
### `x86_64-darwin` (sandbox = relaxed)
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>traefik</li>
  </ul>
</details>

---
### `aarch64-darwin` (sandbox = relaxed)
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>traefik</li>
  </ul>
</details>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
