### PR TITLE
junit_4: init at 4.13.2

### DIFF
--- a/pkgs/by-name/ju/junit_4/0001-fix-everyItem-return-type-cast-for-hamcrest-2.patch
+++ b/pkgs/by-name/ju/junit_4/0001-fix-everyItem-return-type-cast-for-hamcrest-2.patch
@@ -1,0 +1,10 @@
+--- a/src/main/java/org/junit/matchers/JUnitMatchers.java
++++ b/src/main/java/org/junit/matchers/JUnitMatchers.java
+@@ -59,6 +59,7 @@ public class JUnitMatchers {
+      */
+     @Deprecated
++    @SuppressWarnings("unchecked")
+     public static <T> Matcher<Iterable<T>> everyItem(final Matcher<T> elementMatcher) {
+-        return CoreMatchers.everyItem(elementMatcher);
++        return (Matcher<Iterable<T>>) (Object) CoreMatchers.everyItem(elementMatcher);
+     }

--- a/pkgs/by-name/ju/junit_4/package.nix
+++ b/pkgs/by-name/ju/junit_4/package.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  jdk,
+  java-hamcrest,
+  stripJavaArchivesHook,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "junit";
+  version = "4.13.2";
+
+  src = fetchFromGitHub {
+    owner = "junit-team";
+    repo = "junit4";
+    rev = "r${finalAttrs.version}";
+    hash = "sha256-A6ZbmsECwP/hYqmIoU3rDvEX3V9Dx3FtCgAxpv8n8+Q=";
+  };
+
+  nativeBuildInputs = [
+    jdk
+    stripJavaArchivesHook
+  ];
+
+  propagatedBuildInputs = [ java-hamcrest ];
+
+  patches = [
+    # hamcrest 2.0+ changed everyItem return type from Matcher<Iterable<T>> to
+    # Matcher<Iterable<? extends T>>; cast through Object to satisfy old signature
+    ./0001-fix-everyItem-return-type-cast-for-hamcrest-2.patch
+  ];
+
+  postPatch = ''
+    # Generate Version.java from the template (Maven normally does this)
+    # The committed Version.java has a stale "4.13.2-SNAPSHOT" string
+    mv src/main/java/junit/runner/Version.java.template \
+       src/main/java/junit/runner/Version.java
+    substituteInPlace src/main/java/junit/runner/Version.java \
+      --replace-fail '@version@' '${finalAttrs.version}'
+
+    # @Factory was removed from hamcrest 2.0+; it was a no-op marker annotation
+    for f in \
+      src/main/java/org/junit/internal/matchers/ThrowableMessageMatcher.java \
+      src/main/java/org/junit/internal/matchers/StacktracePrintingMatcher.java \
+      src/main/java/org/junit/internal/matchers/ThrowableCauseMatcher.java; do
+      substituteInPlace "$f" \
+        --replace-fail $'import org.hamcrest.Factory;\n' "" \
+        --replace-fail $'    @Factory\n    ' "    "
+    done
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    mkdir -p build/classes
+
+    find src/main/java -name "*.java" > sources.txt
+
+    javac \
+      --release 8 \
+      -classpath "$(find ${java-hamcrest}/share/java -name '*.jar' | tr '\n' ':')" \
+      -encoding ISO-8859-1 \
+      -d build/classes \
+      @sources.txt
+
+    cp -r src/main/resources/. build/classes/ 2>/dev/null || true
+
+    jar cf junit-${finalAttrs.version}.jar -C build/classes .
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 junit-${finalAttrs.version}.jar $out/share/java/junit-${finalAttrs.version}.jar
+    ln -s $out/share/java/junit-${finalAttrs.version}.jar $out/share/java/junit.jar
+
+    runHook postInstall
+  '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    description = "JUnit 4 testing framework for Java";
+    homepage = "https://junit.org/junit4/";
+    license = lib.licenses.epl10;
+    maintainers = with lib.maintainers; [ airone01 ];
+    platforms = lib.platforms.all;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+  };
+})


### PR DESCRIPTION
This PR provides a package for the [JUnit framework](https://github.com/junit-team/junit-framework) in version 4 as `junit_4`. JUnit is a unit testing framework for Java and the JVM.

This package in v4 is needed for building modern Ant versions (and hence for Maven and Gradle later down the dependency graph).
I made the implementation in this PR in such a way that it does not require Maven for building (otherwise it would be circular).
This should be "pure", but it's worth noting that currently hamcrest (which is required by JUnit) is built with Gradle.

Upstream major ver is `6`, so we could make another `junit` package later.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
