### PR TITLE
ballerburg: fix Darwin build

### DIFF
--- a/pkgs/by-name/ba/ballerburg/package.nix
+++ b/pkgs/by-name/ba/ballerburg/package.nix
@@ -34,6 +34,16 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ SDL ];
 
+  # CMake's default framework search order on Darwin finds Kernel.framework
+  # headers while detecting SDL 1.2, which makes standard includes like
+  # <string.h> resolve to the wrong SDK header and breaks the build.
+  # Keep this package on the old Nixpkgs search order without restoring it
+  # globally: https://github.com/NixOS/nixpkgs/pull/455592
+  # CMake docs: https://cmake.org/cmake/help/latest/variable/CMAKE_FIND_FRAMEWORK.html
+  cmakeFlags = lib.optionals stdenv.hostPlatform.isDarwin [
+    "-DCMAKE_FIND_FRAMEWORK=LAST"
+  ];
+
   desktopItems = [
     (makeDesktopItem {
       name = "Ballerburg";


### PR DESCRIPTION
This PR fixes the `ballerburg` package build on `aarch64-darwin` (broken by #457894) by giving this specific package the `-DCMAKE_FIND_FRAMEWORK=LAST` flag, as has previously been suggested as a workaround for the removal of this flag from the global `setupHook` in #455592.

ZHF: #516381

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
