### PR TITLE
ap-visual-sorting: init at 1.0.0

### DIFF
--- a/pkgs/by-name/ap/ap-visual-sorting/package.nix
+++ b/pkgs/by-name/ap/ap-visual-sorting/package.nix
@@ -13,13 +13,13 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "cedric-star";
     repo = "ap-visual-sorting";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-SPUfhQD4i04W3Om/qhcDGSs0/0qzv5EyijU43EovyZo="; # placeholder
+    hash = "sha256-DEIN-HASH-HIER=";
   };
 
-  buildInputs = [ raylib ];
+  __structuredAttrs = true; # NPV-166
+  strictDeps = true; # NPV-164
 
-  # Falls dein Makefile kein PREFIX/DESTDIR unterstützt:
-  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+  buildInputs = [ raylib ];
 
   installPhase = ''
     runHook preInstall
@@ -32,8 +32,8 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Visualize sorting algorithms written in C";
     homepage = "https://github.com/cedric-star/ap-visual-sorting";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ]; # deinen GitHub-Namen hier, nach PR
+    maintainers = [ ];
     mainProgram = "ap-visual-sorting";
-    platforms = lib.platforms.linux; # raylib hat Einschränkungen
+    platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ap/ap-visual-sorting/package.nix
+++ b/pkgs/by-name/ap/ap-visual-sorting/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  raylib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ap-visual-sorting";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "cedric-star";
+    repo = "ap-visual-sorting";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-SPUfhQD4i04W3Om/qhcDGSs0/0qzv5EyijU43EovyZo="; # placeholder
+  };
+
+  buildInputs = [ raylib ];
+
+  # Falls dein Makefile kein PREFIX/DESTDIR unterstützt:
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp MySorter $out/bin/ap-visual-sorting
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Visualize sorting algorithms written in C";
+    homepage = "https://github.com/cedric-star/ap-visual-sorting";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ]; # deinen GitHub-Namen hier, nach PR
+    mainProgram = "ap-visual-sorting";
+    platforms = lib.platforms.linux; # raylib hat Einschränkungen
+  };
+})

--- a/pkgs/by-name/ap/ap-visual-sorting/package.nix
+++ b/pkgs/by-name/ap/ap-visual-sorting/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "cedric-star";
     repo = "ap-visual-sorting";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-DEIN-HASH-HIER=";
+    hash = "sha256-SPUfhQD4i04W3Om/qhcDGSs0/0qzv5EyijU43EovyZo="; 
   };
 
   __structuredAttrs = true; # NPV-166

--- a/pkgs/by-name/ap/ap-visual-sorting/package.nix
+++ b/pkgs/by-name/ap/ap-visual-sorting/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "cedric-star";
     repo = "ap-visual-sorting";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-SPUfhQD4i04W3Om/qhcDGSs0/0qzv5EyijU43EovyZo="; 
+    hash = "sha256-SPUfhQD4i04W3Om/qhcDGSs0/0qzv5EyijU43EovyZo=";
   };
 
   __structuredAttrs = true; # NPV-166


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
