### PR TITLE
[25.11] coredns: 1.13.2 -> 1.14.3

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -405,6 +405,7 @@ in
   containers-tmpfs = runTest ./containers-tmpfs.nix;
   containers-unified-hierarchy = runTest ./containers-unified-hierarchy.nix;
   convos = runTest ./convos.nix;
+  coredns = runTest ./coredns.nix;
   corerad = runTest ./corerad.nix;
   corteza = runTest ./corteza.nix;
   cosmic = runTest {

--- a/nixos/tests/coredns.nix
+++ b/nixos/tests/coredns.nix
@@ -1,0 +1,42 @@
+{ pkgs, ... }:
+{
+  name = "coredns";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ johanot ];
+  };
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      environment.systemPackages = [ pkgs.dnsutils ];
+      services.coredns = {
+        enable = true;
+        config = ''
+          .:10053 {
+                ipecho {
+                  domain test.nixos.org
+                  ttl 2629800
+                }
+              }
+        '';
+        package = pkgs.coredns.override {
+          externalPlugins = [
+            {
+              name = "ipecho";
+              repo = "github.com/Eun/coredns-ipecho";
+              version = "224170ebca45cc59c6b071d280a18f42d1ff130c";
+              position = "start-of-file";
+            }
+          ];
+          vendorHash = "sha256-dNxHpXkiqz7B/JhZdxfZluIHFVXILlSm3XtB+v/EoMY=";
+        };
+      };
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("coredns.service")
+    machine.wait_for_open_port(10053)
+    machine.succeed("dig @127.0.0.1 -p 10053 127.0.0.2.test.nixos.org A +short | grep 127.0.0.2")
+  '';
+}

--- a/nixos/tests/coredns.nix
+++ b/nixos/tests/coredns.nix
@@ -28,7 +28,7 @@
               position = "start-of-file";
             }
           ];
-          vendorHash = "sha256-dNxHpXkiqz7B/JhZdxfZluIHFVXILlSm3XtB+v/EoMY=";
+          vendorHash = "sha256-MGgFbglyW/1CMhT1b83ETH70gRkz89s/Gp4seR2g7xI=";
         };
       };
     };

--- a/nixos/tests/coredns.nix
+++ b/nixos/tests/coredns.nix
@@ -28,7 +28,7 @@
               position = "start-of-file";
             }
           ];
-          vendorHash = "sha256-MGgFbglyW/1CMhT1b83ETH70gRkz89s/Gp4seR2g7xI=";
+          vendorHash = "sha256-66WNU+t/frHfbxexYdiXzgXKLxPyLnN6JuKnlG/kSQY=";
         };
       };
     };

--- a/pkgs/by-name/co/coredns/package.nix
+++ b/pkgs/by-name/co/coredns/package.nix
@@ -78,6 +78,7 @@ buildGoModule (finalAttrs: {
     for src in ${toString (attrsToSources externalPlugins)}; do go get $src; done
     go mod vendor
     CC= GOOS= GOARCH= go generate
+    go mod vendor
     go mod tidy
   '';
 
@@ -134,6 +135,7 @@ buildGoModule (finalAttrs: {
   '';
 
   passthru.tests = {
+    coredns-external-plugins = nixosTests.coredns;
     kubernetes-single-node = nixosTests.kubernetes.dns-single-node;
     kubernetes-multi-node = nixosTests.kubernetes.dns-multi-node;
   };

--- a/pkgs/by-name/co/coredns/package.nix
+++ b/pkgs/by-name/co/coredns/package.nix
@@ -6,7 +6,7 @@
   installShellFiles,
   nixosTests,
   externalPlugins ? [ ],
-  vendorHash ? "sha256-bnNpJgy54wvTST1Jtfbd1ldLJrIzTW62TL7wyHeqz28=",
+  vendorHash ? "sha256-3cY4Nd2RX5OKnJaQ7StYDsyq27qE1VY4wGaY4wiDeFQ=",
 }:
 
 let
@@ -14,13 +14,13 @@ let
 in
 buildGoModule (finalAttrs: {
   pname = "coredns";
-  version = "1.13.2";
+  version = "1.14.1";
 
   src = fetchFromGitHub {
     owner = "coredns";
     repo = "coredns";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-9ggyFixdNy0t4UA8ZxU5oMUzA/8EB/k1jors4f8Q6YE=";
+    hash = "sha256-WcRX2BCWIQ8e0FYCIAzCdexz+Nl+/kKicQkhEw2AVMs=";
   };
 
   inherit vendorHash;
@@ -76,9 +76,9 @@ buildGoModule (finalAttrs: {
     }
     diff -u plugin.cfg.orig plugin.cfg || true
     for src in ${toString (attrsToSources externalPlugins)}; do go get $src; done
+    go mod vendor
     CC= GOOS= GOARCH= go generate
     go mod tidy
-    go mod vendor
   '';
 
   modInstallPhase = ''
@@ -106,6 +106,11 @@ buildGoModule (finalAttrs: {
     # it's a lint rather than a test of functionality, so it's safe to disable.
     substituteInPlace test/presubmit_test.go \
       --replace-fail "TestImportOrdering" "SkipImportOrdering"
+
+    substituteInPlace plugin/pkg/parse/transport_test.go \
+      --replace-fail \
+        "TestTransport" \
+        "SkipTransport"
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
     # loopback interface is lo0 on macos

--- a/pkgs/by-name/co/coredns/package.nix
+++ b/pkgs/by-name/co/coredns/package.nix
@@ -102,6 +102,12 @@ buildGoModule (finalAttrs: {
     substituteInPlace test/readme_test.go \
       --replace-fail "TestReadme" "SkipReadme"
 
+    substituteInPlace test/metrics_test.go \
+      --replace-fail "TestMetricsRewriteRequestSize" "SkipMetricsRewriteRequestSize"
+
+    substituteInPlace test/quic_test.go \
+      --replace-fail "TestQUICReloadDoesNotPanic" "SkipQUICReloadDoesNotPanic"
+
     # this test fails if any external plugins were imported.
     # it's a lint rather than a test of functionality, so it's safe to disable.
     substituteInPlace test/presubmit_test.go \

--- a/pkgs/by-name/co/coredns/package.nix
+++ b/pkgs/by-name/co/coredns/package.nix
@@ -32,60 +32,61 @@ buildGoModule (finalAttrs: {
     "man"
   ];
 
-  # Override the go-modules fetcher derivation to fetch plugins
-  modBuildPhase = ''
-    cp plugin.cfg plugin.cfg.orig
-    ${
-      (lib.concatMapStringsSep "\n" (
-        plugin:
-        let
-          position = plugin.position or "end-of-file";
-          formatPlugin = { name, repo, ... }: "${name}:${repo}";
-        in
-        if position == "end-of-file" then
-          "echo '${formatPlugin plugin}' >> plugin.cfg"
-        else if position == "start-of-file" then
-          "sed -i '1i ${formatPlugin plugin}' plugin.cfg"
-        else if lib.hasAttrByPath [ "before" ] position then
-          ''
-            if ! grep -q '^${position.before}:' plugin.cfg; then
-              echo 'Failed to insert ${plugin.name} before ${position.before} in plugin.cfg: ${position.before} is not in plugin.cfg'
-              exit 1
-            fi
-            sed -i '/^${position.before}:/i ${formatPlugin plugin}' plugin.cfg
-          ''
-        else if lib.hasAttrByPath [ "after" ] position then
-          ''
-            if ! grep -q '^${position.after}:' plugin.cfg; then
-              echo 'Failed to insert ${plugin.name} after ${position.after} in plugin.cfg: ${position.after} is not in plugin.cfg'
-              exit 1
-            fi
-            sed -i '/^${position.after}:/a ${formatPlugin plugin}' plugin.cfg
-          ''
-        else
-          throw ''
-            Unsupported position value in externalPlugin:
-              ${builtins.toJSON plugin}.
-            Valid values for position attr are:
-              - position = "end-of-file" (the default)
-              - position = "start-of-file"
-              - position.before = "{other plugin}"
-              - position.after = "{other plugin}"
-          ''
-      ) externalPlugins)
-    }
-    diff -u plugin.cfg.orig plugin.cfg || true
-    for src in ${toString (attrsToSources externalPlugins)}; do go get $src; done
-    go mod vendor
-    CC= GOOS= GOARCH= go generate
-    go mod vendor
-    go mod tidy
-  '';
+  overrideModAttrs = {
+    # Add plugins before vendoring the modules.
+    preBuild = ''
+      cp plugin.cfg plugin.cfg.orig
+      ${
+        (lib.concatMapStringsSep "\n" (
+          plugin:
+          let
+            position = plugin.position or "end-of-file";
+            formatPlugin = { name, repo, ... }: "${name}:${repo}";
+          in
+          if position == "end-of-file" then
+            "echo '${formatPlugin plugin}' >> plugin.cfg"
+          else if position == "start-of-file" then
+            "sed -i '1i ${formatPlugin plugin}' plugin.cfg"
+          else if lib.hasAttrByPath [ "before" ] position then
+            ''
+              if ! grep -q '^${position.before}:' plugin.cfg; then
+                echo 'Failed to insert ${plugin.name} before ${position.before} in plugin.cfg: ${position.before} is not in plugin.cfg'
+                exit 1
+              fi
+              sed -i '/^${position.before}:/i ${formatPlugin plugin}' plugin.cfg
+            ''
+          else if lib.hasAttrByPath [ "after" ] position then
+            ''
+              if ! grep -q '^${position.after}:' plugin.cfg; then
+                echo 'Failed to insert ${plugin.name} after ${position.after} in plugin.cfg: ${position.after} is not in plugin.cfg'
+                exit 1
+              fi
+              sed -i '/^${position.after}:/a ${formatPlugin plugin}' plugin.cfg
+            ''
+          else
+            throw ''
+              Unsupported position value in externalPlugin:
+                ${builtins.toJSON plugin}.
+              Valid values for position attr are:
+                - position = "end-of-file" (the default)
+                - position = "start-of-file"
+                - position.before = "{other plugin}"
+                - position.after = "{other plugin}"
+            ''
+        ) externalPlugins)
+      }
+      diff -u plugin.cfg.orig plugin.cfg || true
+      for src in ${toString (attrsToSources externalPlugins)}; do go get $src; done
+      GOFLAGS=''${GOFLAGS//-mod=vendor/} CC= GOOS= GOARCH= go generate
+      go mod tidy
+    '';
 
-  modInstallPhase = ''
-    mv -t vendor go.mod go.sum plugin.cfg
-    cp -r --reflink=auto vendor "$out"
-  '';
+    # Move the modified `go.mod`, `go.sum`, and `plugin.cfg` files into the
+    # vendor directory so we can retrieve them later in the `preBuild` hook.
+    postBuild = ''
+      mv -t vendor go.mod go.sum plugin.cfg
+    '';
+  };
 
   preBuild = ''
     chmod -R u+w vendor

--- a/pkgs/by-name/co/coredns/package.nix
+++ b/pkgs/by-name/co/coredns/package.nix
@@ -6,7 +6,7 @@
   installShellFiles,
   nixosTests,
   externalPlugins ? [ ],
-  vendorHash ? "sha256-qodzzBee+4NeZ+XifMknFPayBcWDmbyYq1R6Xhuras0=",
+  vendorHash ? "sha256-9LLTgIjOOMvYx4nhy+6X9bEBvqlKeTx//39q+YWXeHw=",
 }:
 
 let
@@ -14,13 +14,13 @@ let
 in
 buildGoModule (finalAttrs: {
   pname = "coredns";
-  version = "1.14.2";
+  version = "1.14.3";
 
   src = fetchFromGitHub {
     owner = "coredns";
     repo = "coredns";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-c0xXZnc0muXViPqMCJsD8TTGMbVCOKE49ElAHEPnKlw=";
+    hash = "sha256-Uk4oWsUxaGdLQzX5JywYzi7pmQHGo06uQdLeOkP4U/s";
   };
 
   inherit vendorHash;

--- a/pkgs/by-name/co/coredns/package.nix
+++ b/pkgs/by-name/co/coredns/package.nix
@@ -6,7 +6,7 @@
   installShellFiles,
   nixosTests,
   externalPlugins ? [ ],
-  vendorHash ? "sha256-3cY4Nd2RX5OKnJaQ7StYDsyq27qE1VY4wGaY4wiDeFQ=",
+  vendorHash ? "sha256-qodzzBee+4NeZ+XifMknFPayBcWDmbyYq1R6Xhuras0=",
 }:
 
 let
@@ -14,13 +14,13 @@ let
 in
 buildGoModule (finalAttrs: {
   pname = "coredns";
-  version = "1.14.1";
+  version = "1.14.2";
 
   src = fetchFromGitHub {
     owner = "coredns";
     repo = "coredns";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-WcRX2BCWIQ8e0FYCIAzCdexz+Nl+/kKicQkhEw2AVMs=";
+    hash = "sha256-c0xXZnc0muXViPqMCJsD8TTGMbVCOKE49ElAHEPnKlw=";
   };
 
   inherit vendorHash;


### PR DESCRIPTION
changelog: https://coredns.io/blog/
diff: https://github.com/coredns/coredns/compare/v1.13.2...v1.14.3

Backports #480354
Backports #483923
Backports #490875
Backports #497951
Backports #517990

Closes #517198
Closes #517193
Closes #517207
Closes #517195
Closes #517208
Closes #497572
Closes #497569

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
