### PR TITLE
yaziPlugins: update on 2026-05-20

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/bypass/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/bypass/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "bypass.yazi";
-  version = "0-unstable-2025-06-01";
+  version = "0-unstable-2026-05-17";
 
   src = fetchFromGitHub {
     owner = "Rolv-Apneseth";
     repo = "bypass.yazi";
-    rev = "c1e5fcf6eeed0bfceb57b9738da6db9d0fb8af56";
-    hash = "sha256-ZndDtTMkEwuIMXG4SGe4B95Nw4fChfFhxJHj+IY30Kc=";
+    rev = "4a0c70ec9122d884deb659ff620af0098314c136";
+    hash = "sha256-kho114UcjV90BDghZxUn2gZXtjY0tsE+C9ttlQZli6U=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/clipboard/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/clipboard/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "clipboard.yazi";
-  version = "0-unstable-2026-05-10";
+  version = "0-unstable-2026-05-20";
 
   src = fetchFromGitHub {
     owner = "XYenon";
     repo = "clipboard.yazi";
-    rev = "68b506d9a9c2c5dde01a078a589520f551d05fe5";
-    hash = "sha256-jNBwkcFb9i5Z6BSMfkTOyrK7HZohAT/yB3cxcCOG54w=";
+    rev = "a125df07ba69c893df0e22592e55c1130ce16fe4";
+    hash = "sha256-Q+8MGfeP7reX3nDl5V/HFxRYIayPKEQT5w0b+n73b5k=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/full-border/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/full-border/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "full-border.yazi";
-  version = "0-unstable-2026-04-22";
+  version = "0-unstable-2026-05-13";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "034efd687f689f1981ab0e5a7dd46c1e1b4a08c9";
-    hash = "sha256-JIb26wE0WBf9Ul0wYW1/XpQICVTsNLgWgkXvtC457zo=";
+    rev = "5d5c4803dd12bab4e4f19d606f8db0c871e6bec5";
+    hash = "sha256-cZlnrlgv8+SFeNgIW69q//i/apcpvAv41q5W8bJwVaI=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/git/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/git/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "git.yazi";
-  version = "0-unstable-2026-02-27";
+  version = "0-unstable-2026-05-09";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "0897e20d41b79a5ec8e80e645b041bb950547a0b";
-    hash = "sha256-tHOHWFH9E7aGrmHb8bUD1sLGU0OIdTjQ2p4SbJVfh/s=";
+    rev = "1db18bb5a1c962f95873654a7af1202abb98da60";
+    hash = "sha256-kcZGQB8Dfon8OipuAcNnCeRgTp/S0mQokADkuvEG4Lc=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mediainfo.yazi";
-  version = "0-unstable-2026-04-10";
+  version = "0-unstable-2026-05-19";
 
   src = fetchFromGitHub {
     owner = "boydaihungst";
     repo = "mediainfo.yazi";
-    rev = "49f5ab722d617a64b3bea87944e3e4e17ba3a46b";
-    hash = "sha256-PcGrFG06XiJYgBWq+c7fYsx1kjkCvIYRaBiWaJT+xkw=";
+    rev = "4f80288c7286efb7ea3ffb6193027f2f1a027473";
+    hash = "sha256-xxOM5cdAEGgUrcFViKWFgwwQdCYpsbvE+Ji0Gerk7UA=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mount/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mount/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mount.yazi";
-  version = "0-unstable-2026-04-09";
+  version = "0-unstable-2026-05-09";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "7749958b00d461d3c0fba4aa651940d778d1fc3f";
-    hash = "sha256-DZNhqIuGZIEEEH1TrCtAjZKa+7CWZeS1wO9aA9C0Eec=";
+    rev = "16e8ed382db5fc5ea9d179a2803d86859803fae0";
+    hash = "sha256-ALSuXdAGGcscQmGL2d6cDv6MzNiuzl52f9i1b3t+b1I=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/split-tabs/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/split-tabs/default.nix
@@ -6,13 +6,13 @@
 
 mkYaziPlugin {
   pname = "split-tabs.yazi";
-  version = "0-unstable-2026-05-13";
+  version = "0-unstable-2026-05-17";
 
   src = fetchFromGitHub {
     owner = "terrakok";
     repo = "split-tabs.yazi";
-    rev = "6da6089a0943bf5b9ee18942a890c294d4f227bc";
-    hash = "sha256-vIJNXmkIp5mjWuS/madKI/m9N8D4d6HaIyzeantrkig=";
+    rev = "da25bc0c02f669ef5d939bb03597f4ae557834ec";
+    hash = "sha256-Xb8XKEEZgNL5dZ8EAy9ELDcYGWGq2go+bwdlpydifi8=";
   };
 
   meta = {


### PR DESCRIPTION
- bypass: 0-unstable-2025-06-01 → 0-unstable-2026-05-17
  Compare: https://github.com/Rolv-Apneseth/bypass.yazi/compare/c1e5fcf6eeed0bfceb57b9738da6db9d0fb8af56...4a0c70ec9122d884deb659ff620af0098314c136
- clipboard: 0-unstable-2026-05-10 → 0-unstable-2026-05-20
  Compare: https://github.com/XYenon/clipboard.yazi/compare/68b506d9a9c2c5dde01a078a589520f551d05fe5...a125df07ba69c893df0e22592e55c1130ce16fe4
- full-border: 0-unstable-2026-04-22 → 0-unstable-2026-05-13
  Compare: https://github.com/yazi-rs/plugins/compare/034efd687f689f1981ab0e5a7dd46c1e1b4a08c9...5d5c4803dd12bab4e4f19d606f8db0c871e6bec5
- git: 0-unstable-2026-02-27 → 0-unstable-2026-05-09
  Compare: https://github.com/yazi-rs/plugins/compare/0897e20d41b79a5ec8e80e645b041bb950547a0b...1db18bb5a1c962f95873654a7af1202abb98da60
- mediainfo: 0-unstable-2026-04-10 → 0-unstable-2026-05-19
  Compare: https://github.com/boydaihungst/mediainfo.yazi/compare/49f5ab722d617a64b3bea87944e3e4e17ba3a46b...4f80288c7286efb7ea3ffb6193027f2f1a027473
- mount: 0-unstable-2026-04-09 → 0-unstable-2026-05-09
  Compare: https://github.com/yazi-rs/plugins/compare/7749958b00d461d3c0fba4aa651940d778d1fc3f...16e8ed382db5fc5ea9d179a2803d86859803fae0
- split-tabs: 0-unstable-2026-05-13 → 0-unstable-2026-05-17
  Compare: https://github.com/terrakok/split-tabs.yazi/compare/6da6089a0943bf5b9ee18942a890c294d4f227bc...da25bc0c02f669ef5d939bb03597f4ae557834ec


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
