### PR TITLE
step-agent: init at 0.67.3

### DIFF
--- a/pkgs/by-name/st/step-agent/package.nix
+++ b/pkgs/by-name/st/step-agent/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  fetchurl,
+  installShellFiles,
+  stdenvNoCC,
+  stdenv,
+  autoPatchelfHook,
+  makeWrapper,
+  p11-kit,
+  polkit,
+  tpm2-openssl,
+  tpm2-tss,
+  nix-update-script,
+}:
+let
+  version = "0.67.3";
+
+  srcs = {
+    x86_64-linux = fetchurl {
+      url = "https://github.com/smallstep/step-agent-plugin/releases/download/v${version}/step-agent_${version}_linux_amd64.tar.gz";
+      sha256 = "sha256-sTZ6dNjyRwCWHWROUKCpq1rb8n9lT0cGOUOUpui9NJM=";
+    };
+
+    aarch64-linux = fetchurl {
+      url = "https://github.com/smallstep/step-agent-plugin/releases/download/v${version}/step-agent_${version}_linux_arm64.tar.gz";
+      sha256 = "sha256-0Vefuc+Xnx8x6Gu+WuS4zTHDIMepY593uFi3JKD+hrk=";
+    };
+  };
+in
+stdenvNoCC.mkDerivation {
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  inherit version;
+  pname = "step-agent";
+
+  src =
+    srcs.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+    autoPatchelfHook
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -vr ./step-agent $out/bin/step-agent
+    wrapProgram $out/bin/step-agent --prefix PATH : ${
+      lib.makeBinPath [
+        tpm2-tss
+        tpm2-openssl
+        polkit
+        p11-kit
+      ]
+    }
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "step-agent is an automated certificate management agent plugin for step-cli";
+    homepage = "https://github.com/smallstep/step-agent-plugin/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ Srylax ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    platforms = lib.platforms.linux;
+    mainProgram = "step-agent";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Adds the step-agent-plugin package from smallstep: https://github.com/smallstep/step-agent-plugin
There is no source available therefore we are using the binary from the github release

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
