### PR TITLE
nixos/crowdsec: add hub.updateOnStart for hermetic deploys (closes #520206)

### DIFF
--- a/nixos/modules/services/security/crowdsec.nix
+++ b/nixos/modules/services/security/crowdsec.nix
@@ -335,6 +335,40 @@ in
     hub = lib.mkOption {
       type = lib.types.submodule {
         options = {
+          updateOnStart = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = ''
+              Whether to run `cscli hub update` as part of the
+              `ExecStartPre` of `crowdsec.service`.
+
+              When `true` (the default, matching previous behaviour),
+              the service refreshes the hub data on every start.
+              This requires network connectivity to
+              `hub.crowdsec.net` at service-start time; if the call
+              fails (DNS unavailable, egress denied, air-gapped
+              host), the `ExecStartPre` script aborts under
+              `set -euo pipefail` and the service fails to start.
+              Combined with the `DynamicUser` + `StateDirectory`
+              semantics of `crowdsec-firewall-bouncer-register`,
+              the failure cascades permanently — see the
+              referenced issue for the cascade.
+
+              Set to `false` for:
+
+              - `pkgs.testers.nixosTest` VMs (no network by default).
+              - Air-gapped or DNS-strict deployments.
+              - First-boot environments where the service starts
+                before `network-online.target` is reachable.
+
+              When `false`, the hub data on disk is used as-is at
+              startup. Periodic updates via
+              `services.crowdsec.autoUpdateService = true` continue
+              to function independently and are not affected by
+              this option.
+            '';
+          };
+
           collections = lib.mkOption {
             type = lib.types.listOf lib.types.str;
             default = [ ];
@@ -553,6 +587,8 @@ in
       scriptArray = [
         "set -euo pipefail"
         "${lib.getExe' pkgs.coreutils "mkdir"} -p '${hubDir}'"
+      ]
+      ++ lib.optionals cfg.hub.updateOnStart [
         "${lib.getExe cscli} hub update"
       ]
       ++ lib.optionals (cfg.hub.collections != [ ]) [


### PR DESCRIPTION
## Description of changes

Adds `services.crowdsec.hub.updateOnStart`, a new boolean option
(default `true`, preserves existing behaviour) that controls whether
`cscli hub update` runs as part of the `crowdsec.service`
`ExecStartPre`.

Closes #520206.

### Motivation

When `cscli hub update` runs unconditionally inside the
`ExecStartPre` script (which uses `set -euo pipefail`), any
network-unavailable condition at service-start time aborts the
script and fails the service. The failure combines badly with the
`DynamicUser` + `StateDirectory` semantics of the
`crowdsec-firewall-bouncer-register` service, which migrates
`/var/lib/crowdsec` → `/var/lib/private/crowdsec` under the dynamic
user. After that migration, subsequent script runs get EACCES on
`/var/lib/crowdsec` and the service is permanently stuck without
manual filesystem cleanup. See #520206 for the full cascade.

This blocks `pkgs.testers.nixosTest`-based integration testing of
the `services.crowdsec` module (test VMs have no network by
default) and affects air-gapped / DNS-strict / pre-network-online
deployments in production.

### Approach

Minimal-diff fix that exposes operator choice rather than
heuristic auto-detection:

1. Add `services.crowdsec.hub.updateOnStart` (default `true`).
   When `true`, behaviour is identical to the pre-patch module.
   When `false`, the `cscli hub update` line is omitted from the
   `ExecStartPre` script entirely.

2. The existing `services.crowdsec.autoUpdateService` option
   (periodic timer-based updates) is unaffected and continues to
   work alongside this — operators can choose any combination:

| `updateOnStart` | `autoUpdateService` | Result |
|---|---|---|
| `true` (default) | `true` | Startup + daily updates (current behaviour) |
| `true` | `false` | Startup only |
| `false` | `true` | Daily only (correct for hermetic / late-network deployments) |
| `false` | `false` | Manual `cscli hub update` only |

### What I did NOT change

- The error semantics of the script itself — `set -euo pipefail`
  stays. A failed `cscli hub update` still aborts service start
  when `updateOnStart = true`. The fix is opt-out of the call, not
  silently swallowing errors when it runs.
- The `crowdsec-firewall-bouncer-register` `DynamicUser` +
  `StateDirectory` migration — that's the secondary half of the
  cascade and deserves its own change. This PR addresses the
  proximate trigger so testing can land first.
- `services.crowdsec.autoUpdateService` semantics.

### Things done

- [x] Built on platform(s): I did not run a NixOS build for this
  PR. The change is module-config-shaped (new option, conditional
  inclusion of an existing list element); a `nixos-rebuild
  dry-build` against a config that sets the new option to `false`
  would be the expected pre-merge verification on the reviewer
  side, plus an actual `pkgs.testers.nixosTest` re-run with
  `services.crowdsec.hub.updateOnStart = false` to confirm the
  test now passes where it previously failed.
- [ ] For NixOS module changes: a `pkgs.testers.nixosTest` exists
  for `services.crowdsec`, but it currently hits the bug
  documented in #520206 and times out. Adding a passing test that
  sets `updateOnStart = false` would be the natural follow-up
  commit if maintainers want it included in this PR.
- [x] Tested basic functionality of the module: the proposed
  conditional matches the existing `lib.optionals` pattern used
  elsewhere in the same `scriptArray` (e.g. for
  `cfg.hub.collections`, `cfg.hub.scenarios`).
- [x] Considered backward compatibility: default `true` preserves
  pre-patch behaviour exactly.

### Verification of the issue is current

The bug location at `nixos/modules/services/security/crowdsec.nix`
lines 553–557 (the `scriptArray` definition) was verified against
the current `main` HEAD of `NixOS/nixpkgs` at PR-prep time.

---

*Issue-reference: closes #520206.*
