### PR TITLE
hinoirisetr: init at 1.6.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28859,6 +28859,14 @@
     githubId = 110242808;
     name = "Vasilii Pustovoit";
   };
+  vavakado = {
+    email = "xor@vavakado.xyz";
+    github = "vavakado";
+    githubId = 80159210;
+    name = "Vladimir Rubin";
+    matrix = "@vavakado:imagisphe.re";
+    keys = [ { fingerprint = "A054 0374 CD37 2C71 FE6D  E0CF CAB7 4472 7F36 B524"; } ];
+  };
   vbgl = {
     email = "Vincent.Laporte@gmail.com";
     github = "vbgl";

--- a/pkgs/by-name/hi/hinoirisetr/package.nix
+++ b/pkgs/by-name/hi/hinoirisetr/package.nix
@@ -1,0 +1,60 @@
+{
+  fetchFromForgejo,
+  installShellFiles,
+  lib,
+  libnotify,
+  pandoc,
+  patchelf,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "hinoirisetr";
+  version = "1.6.3";
+
+  __structuredAttrs = true;
+
+  src = fetchFromForgejo {
+    domain = "git.vavakado.xyz";
+    owner = "me";
+    repo = "hinoirisetr";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-XgIeeVCnlntf2RopA6SMuFCgbqTlTEZv6V5ezjEHVKA=";
+  };
+
+  cargoHash = "sha256-lydS9TWb+Y1PPC7C3Mn6KNVX1fsooAcDKJeKMnXWZY0=";
+
+  nativeBuildInputs = [
+    installShellFiles
+    pandoc
+    patchelf
+  ];
+
+  buildInputs = [
+    libnotify
+  ];
+
+  postFixup = ''
+    patchelf --add-rpath "${lib.getLib libnotify}/lib" $out/bin/hinoirisetr
+  '';
+
+  postBuild = ''
+    pandoc manpages/hinoirisetr.1.md -s -t man -o hinoirisetr.1
+  '';
+
+  postInstall = ''
+    installManPage hinoirisetr.1
+  '';
+
+  meta = {
+    description = "a lightweight daemon that automatically adjusts your screen's color temperature and gamma";
+    homepage = "https://git.vavakado.xyz/me/hinoirisetr";
+    changelog = "https://git.vavakado.xyz/me/hinoirisetr/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      vavakado
+    ];
+    mainProgram = "hinoirisetr";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Hinoirisetr is a native screen dimmer for wayland, which smoothly transitions into night mode based on time.

https://git.vavakado.xyz/me/hinoirisetr

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
