### PR TITLE
default-crate-overrides: libsqlite3-sys: link system sqlite via pkg-config

### DIFF
--- a/pkgs/build-support/rust/default-crate-overrides.nix
+++ b/pkgs/build-support/rust/default-crate-overrides.nix
@@ -220,6 +220,7 @@
   };
 
   libsqlite3-sys = attrs: {
+    LIBSQLITE3_SYS_USE_PKG_CONFIG = true;
     nativeBuildInputs = [ pkg-config ];
     buildInputs = [ sqlite ];
   };


### PR DESCRIPTION
The libsqlite3-sys override adds pkg-config and sqlite to the build,
but never sets LIBSQLITE3_SYS_USE_PKG_CONFIG. libsqlite3-sys's build.rs
only routes through pkg-config (build_linked) when that env var is set;
otherwise the `bundled` Cargo feature wins and build.rs compiles the
vendored SQLite C amalgamation, ignoring the system sqlite that this
override goes to the trouble of providing.

This matters in practice because sqlx's `sqlite` feature chain
(sqlite -> sqlx-sqlite/bundled -> libsqlite3-sys/bundled) hard-enables
`bundled`, so for the large class of sqlx-on-sqlite users the existing
override was a silent no-op: pkg-config and sqlite were added to the
closure but never consulted.

Setting the env var is safe even with `bundled` resolved at the Cargo
level. The transitive `bundled_bindings` feature only copies precompiled
Rust bindings from the crate source (no bindgen, no C compilation), and
those bindings are compatible with any system libsqlite3 at least as new
as the crate's bundled copy -- which nixpkgs' sqlite is.

Mirrors the existing libgit2-sys override, which already sets the
analogous LIBGIT2_SYS_USE_PKG_CONFIG.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
