### PR TITLE
default-crate-overrides: add zstd-sys and fuser

### DIFF
--- a/pkgs/build-support/rust/default-crate-overrides.nix
+++ b/pkgs/build-support/rust/default-crate-overrides.nix
@@ -15,6 +15,7 @@
   fontconfig,
   foundationdb,
   freetype,
+  fuse3,
   gdk-pixbuf,
   glib,
   gmp,
@@ -43,6 +44,7 @@
   udev,
   webkitgtk_4_1,
   zlib,
+  zstd,
   buildPackages,
   ...
 }:
@@ -144,6 +146,11 @@
   freetype-sys = attrs: {
     nativeBuildInputs = [ cmake ];
     buildInputs = [ freetype ];
+  };
+
+  fuser = attrs: {
+    nativeBuildInputs = [ pkg-config ];
+    buildInputs = [ fuse3 ];
   };
 
   glib-sys = attrs: {
@@ -390,6 +397,12 @@
 
   xcb = attrs: {
     buildInputs = [ python3 ];
+  };
+
+  zstd-sys = attrs: {
+    ZSTD_SYS_USE_PKG_CONFIG = true;
+    nativeBuildInputs = [ pkg-config ];
+    buildInputs = [ zstd ];
   };
 
   atk-sys = attrs: {


### PR DESCRIPTION
zstd-sys: set ZSTD_SYS_USE_PKG_CONFIG so build.rs probes the system
libzstd via pkg-config instead of compiling the vendored C amalgamation
from scratch in every consumer.

fuser: with the default-on libfuse feature, build.rs discovers libfuse
via pkg-config and has no vendored fallback, so it fails in the sandbox
without pkg-config and fuse3 in scope.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
