### PR TITLE
buildRustCrate: emit a target manifest alongside test binaries

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/install-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/install-crate.nix
@@ -48,6 +48,15 @@ else
         -executable \
         -print0 | xargs --no-run-if-empty --null install --target $out/tests;
     fi
+    # Emit a manifest mapping each binary in $out/tests back to the cargo
+    # target it was compiled from (kind, target name, source file). The
+    # output filenames don't match cargo's naming for lib tests
+    # (metadata-hash suffix) or, historically, multi-file integration
+    # tests; recording the mapping at build time saves consumers from
+    # reverse-engineering lib.sh. Dotfile so existing $out/tests/* globs
+    # don't pick it up.
+    [ -f target/test-targets.jsonl ] || : > target/test-targets.jsonl
+    jq -s '.' target/test-targets.jsonl > $out/tests/.target-manifest.json
     # Real (non-test) binaries that integration tests may exec via
     # CARGO_BIN_EXE_<name>.
     if [ -d target/cargo-bin-exe ]; then

--- a/pkgs/build-support/rust/build-rust-crate/lib.sh
+++ b/pkgs/build-support/rust/build-rust-crate/lib.sh
@@ -6,6 +6,20 @@ echo_build_heading() {
   fi
 }
 
+# Append a test-target manifest entry. Each row maps an output binary
+# under target/{lib,bin}/ back to the cargo target it was compiled from
+# so downstream consumers (test runners, coverage tooling) don't have
+# to reverse-engineer the buildRustCrate naming scheme. Lines are
+# assembled into $out/tests/.target-manifest.json by install-crate.nix.
+# Args: kind (lib|bin|test), target name, binary basename, source file.
+record_test_target() {
+  mkdir -p target
+  jq -n -c \
+    --arg kind "$1" --arg target "$2" --arg bin "$3" --arg src "$4" \
+    '{kind: $kind, target: $target, bin: $bin, src: $src}' \
+    >> target/test-targets.jsonl
+}
+
 build_lib() {
   lib_src=$1
   echo_build_heading $lib_src ${libName}
@@ -72,12 +86,21 @@ build_bin() {
 build_lib_test() {
     local file="$1"
     EXTRA_RUSTC_FLAGS="--test $EXTRA_RUSTC_FLAGS" build_lib "$1" "$2"
+    # rustc with `--test -C extra-filename=-$metadata` writes the
+    # harness to target/lib/$CRATE_NAME-$metadata.
+    record_test_target lib "$CRATE_NAME" "$CRATE_NAME-$metadata" "$file"
 }
 
 build_bin_test() {
     local crate="$1"
     local file="$2"
+    # 3rd arg is the manifest kind so build_bin_test_file can mark its
+    # harnesses as `test` while crateBin / src/bin/* stay `bin`.
+    local kind="${3:-bin}"
     EXTRA_RUSTC_FLAGS="--test $EXTRA_RUSTC_FLAGS" build_bin "$1" "$2"
+    # build_bin renames the rustc output back to $crate, so the binary
+    # on disk has the same basename as the cargo target name.
+    record_test_target "$kind" "$crate" "$crate" "$file"
 }
 
 build_bin_test_file() {
@@ -94,7 +117,7 @@ build_bin_test_file() {
     if [[ "$file" == */main.rs ]]; then
         derived_crate_name="${derived_crate_name%_main}"
     fi
-    build_bin_test "$derived_crate_name" "$file"
+    build_bin_test "$derived_crate_name" "$file" test
 }
 
 # Add additional link options that were provided by the build script.

--- a/pkgs/build-support/rust/build-rust-crate/test/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/test/default.nix
@@ -3,6 +3,7 @@
   buildPackages,
   buildRustCrate,
   callPackage,
+  jq,
   releaseTools,
   runCommand,
   runCommandCC,
@@ -96,11 +97,13 @@ let
         removeAttrs crateArgs [
           "expectedTestOutputs"
           "expectedTestBinaries"
+          "expectedTestManifest"
         ]
       );
       hasTests = crateArgs.buildTests or false;
       expectedTestOutputs = crateArgs.expectedTestOutputs or null;
       expectedTestBinaries = crateArgs.expectedTestBinaries or [ ];
+      expectedTestManifest = crateArgs.expectedTestManifest or [ ];
       binaries = map (v: lib.escapeShellArg v.name) (crateArgs.crateBin or [ ]);
       isLib = crateArgs ? libName || crateArgs ? libPath;
       crateName = crateArgs.crateName or "nixtestcrate";
@@ -122,7 +125,10 @@ let
 
     runCommand "run-buildRustCrate-${crateName}-test"
       {
-        nativeBuildInputs = [ crate ];
+        nativeBuildInputs = [
+          crate
+          jq
+        ];
       }
       (
         if !hasTests then
@@ -145,6 +151,15 @@ let
               b:
               "test -x ${crate}/tests/${lib.escapeShellArg b} || { echo 'expected test binary \"${b}\" not found in:'; ls ${crate}/tests; exit 23; }"
             ) expectedTestBinaries}
+            ${lib.optionalString (expectedTestManifest != [ ]) ''
+              test -f ${crate}/tests/.target-manifest.json || { echo 'manifest missing'; exit 23; }
+              ${lib.concatMapStringsSep "\n" (e: ''
+                jq -e --arg kind ${lib.escapeShellArg e.kind} --arg target ${lib.escapeShellArg e.target} --arg bin ${lib.escapeShellArg e.bin} \
+                  '.[] | select(.kind == $kind and .target == $target and .bin == $bin)' \
+                  ${crate}/tests/.target-manifest.json > /dev/null \
+                  || { echo 'manifest missing entry: ${builtins.toJSON e}'; cat ${crate}/tests/.target-manifest.json; exit 23; }
+              '') expectedTestManifest}
+            ''}
             for file in ${crate}/tests/*; do
               $file 2>&1 >> $out
             done
@@ -434,6 +449,18 @@ rec {
           expectedTestBinaries = [
             "foo"
             "bar"
+          ];
+          expectedTestManifest = [
+            {
+              kind = "test";
+              target = "foo";
+              bin = "foo";
+            }
+            {
+              kind = "test";
+              target = "bar";
+              bin = "bar";
+            }
           ];
           expectedTestOutputs = [
             "test src_main ... ok"


### PR DESCRIPTION
When buildTests = true, the test harnesses written to $out/tests do not
carry their cargo target names: lib-test harnesses get a metadata-hash
suffix (`mycrate-1a2b3c4d5e`), and multi-file integration tests are named
by a path-derived rule that has already changed once (foo_main → foo,
48e5bec36dc3). Test runners, coverage tooling and custom harnesses that
need to map a binary back to its cargo target end up reverse-engineering
lib.sh's naming with bash globs and jq, treating internal helpers like
derived_crate_name as a stable interface.

The mapping is already known at the moment each harness is built. Record
it instead of discarding it: each test-build helper appends a line to
target/test-targets.jsonl, and install-crate.nix assembles those lines
into $out/tests/.target-manifest.json — a JSON array of
{kind, target, bin, src} entries.

The manifest is a dotfile so existing `for f in $out/tests/*` consumers
don't see it; it is only emitted when buildTests is set, so the common
case is unchanged. jq is already a nativeBuildInput.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
