### PR TITLE
nixpkgs-plugin-update: add updater tests

### DIFF
--- a/pkgs/development/python-modules/nixpkgs-plugin-update/default.nix
+++ b/pkgs/development/python-modules/nixpkgs-plugin-update/default.nix
@@ -4,6 +4,7 @@
   uv-build,
   gitpython,
   packaging,
+  pytestCheckHook,
   ruff,
   mypy,
 }:
@@ -23,12 +24,13 @@ buildPythonPackage {
   ];
 
   nativeCheckInputs = [
-    ruff
     mypy
+    pytestCheckHook
+    ruff
   ];
 
-  postInstallCheck = ''
-    ruff check
+  preCheck = ''
+    ruff check src tests
     mypy
   '';
 

--- a/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/pyproject.toml
+++ b/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/pyproject.toml
@@ -13,8 +13,14 @@ build-backend = "uv_build"
 [dependency-groups]
 dev = [
     "mypy>=1.18.2",
+    "pytest>=8.0",
     "ruff>=0.14.1",
 ]
 
 [tool.mypy]
 packages = ["nixpkgs_plugin_update"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = [
+    "SLF001", # Tests exercise internal updater boundary helpers directly.
+]

--- a/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/src/nixpkgs_plugin_update/__init__.py
+++ b/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/src/nixpkgs_plugin_update/__init__.py
@@ -237,7 +237,7 @@ class Repo:
         loaded = json.loads(data)
         return loaded
 
-    def prefetch(self, ref: str) -> str:
+    def prefetch(self, ref: str, has_submodules: bool | None = None) -> str:
         log.info("Prefetching %s", self.uri)
         loaded = self._prefetch(ref)
         return loaded["sha256"]
@@ -459,8 +459,11 @@ class RepoGitHub(Repo):
             new_repo = RepoGitHub(owner=new_owner, repo=new_name, branch=self._branch)
             self.redirect = new_repo
 
-    def prefetch(self, commit: str) -> str:
-        if self.has_submodules():
+    def prefetch(self, commit: str, has_submodules: bool | None = None) -> str:
+        if has_submodules is None:
+            has_submodules = self.has_submodules()
+
+        if has_submodules:
             sha256 = super().prefetch(commit)
         else:
             sha256 = self.prefetch_github(commit)
@@ -1208,9 +1211,9 @@ def prefetch_plugin(
     has_submodules = p.repo.has_submodules()
     log.debug(f"prefetch {p.name}")
     sha256 = (
-        p.repo.prefetch(f"{GIT_TAGS_PREFIX}{source_tag}")
+        p.repo.prefetch(f"{GIT_TAGS_PREFIX}{source_tag}", has_submodules=has_submodules)
         if source_tag
-        else p.repo.prefetch(commit)
+        else p.repo.prefetch(commit, has_submodules=has_submodules)
     )
     license_spdx_id = (
         current_plugin.license

--- a/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/src/nixpkgs_plugin_update/__init__.py
+++ b/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/src/nixpkgs_plugin_update/__init__.py
@@ -40,7 +40,7 @@ AUTO_BRANCH = ""
 VERSION_DATE_PATTERN = re.compile(r"(\d{4}-\d{2}-\d{2})$")
 VERSION_TAG_PATTERN = re.compile(r"^(.+?)-unstable-")
 NON_RELEASE_TAG_PREFIXES = ("pre-",)
-RELEASE_VERSION_PATTERN = re.compile(r"^[^\d]*(\d[\w.@-]*)$")
+RELEASE_VERSION_PATTERN = re.compile(r"^[^\d]*(\d[\w.@+-]*)$")
 
 LOG_LEVELS = {
     logging.getLevelName(level): level
@@ -127,8 +127,18 @@ def select_latest_tag(
 
 def first_release_tag(tags: list[str]) -> str | None:
     for tag in tags:
-        if normalize_release_version(tag) is not None:
-            return tag
+        normalized_tag = normalize_release_version(tag)
+        if normalized_tag is None:
+            continue
+
+        try:
+            version = parse_version(normalized_tag)
+            if version.is_prerelease or version.is_devrelease:
+                continue
+        except InvalidVersion:
+            pass
+
+        return tag
 
     return None
 
@@ -419,7 +429,7 @@ class RepoGitHub(Repo):
 
             recent_tags = [node["name"] for node in repo["refs"]["nodes"]]
             if not recent_tags:
-                return None
+                return self._get_latest_tag_from_fallbacks()
 
             latest_tag = first_release_tag(recent_tags)
             return latest_tag if latest_tag is not None else recent_tags[0]
@@ -634,6 +644,29 @@ def make_unstable_version(date: datetime, last_tag: str | None) -> str:
     return f"{tag_part}-unstable-{date_str}"
 
 
+def newer_version_tag(first_tag: str | None, second_tag: str | None) -> str | None:
+    if first_tag is None:
+        return second_tag
+    if second_tag is None:
+        return first_tag
+
+    first_version = normalize_release_version(first_tag)
+    second_version = normalize_release_version(second_tag)
+    if first_version is None:
+        return second_tag
+    if second_version is None:
+        return first_tag
+
+    try:
+        return (
+            first_tag
+            if parse_version(first_version) >= parse_version(second_version)
+            else second_tag
+        )
+    except InvalidVersion:
+        return first_tag if first_version >= second_version else second_tag
+
+
 def get_commit_target(
     repo: Repo,
     branch: str,
@@ -673,6 +706,7 @@ def select_plugin_target(
             and current_plugin.tag is None
             and current_plugin.date.date() > release_date.date()
         ):
+            latest_tag = newer_version_tag(current_plugin.last_tag, latest_tag)
             return get_commit_target(plugin_desc.repo, "HEAD", latest_tag)
 
     return release_commit, release_date, release_version, latest_tag

--- a/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/src/nixpkgs_plugin_update/__init__.py
+++ b/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/src/nixpkgs_plugin_update/__init__.py
@@ -25,7 +25,7 @@ from multiprocessing.dummy import Pool
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Any, Callable
-from urllib.parse import urljoin, urlparse, urlsplit
+from urllib.parse import unquote, urljoin, urlparse, urlsplit
 
 import git
 from packaging.version import InvalidVersion, parse as parse_version
@@ -141,6 +141,16 @@ def first_release_tag(tags: list[str]) -> str | None:
         return tag
 
     return None
+
+
+def tag_from_github_atom_href(href: str) -> str | None:
+    path = urlparse(href).path
+    marker = "/releases/tag/"
+    if marker in path:
+        return unquote(path.split(marker, 1)[1])
+
+    tag_name = Path(path).name
+    return unquote(tag_name) if tag_name else None
 
 
 class Repo:
@@ -359,7 +369,7 @@ class RepoGitHub(Repo):
             if not href:
                 continue
 
-            tag_name = Path(urlparse(href).path).name
+            tag_name = tag_from_github_atom_href(href)
             if tag_name:
                 tags.append(tag_name)
 

--- a/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/tests/helpers.py
+++ b/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/tests/helpers.py
@@ -1,11 +1,16 @@
 import io
 import json
+from collections.abc import Sequence
 from datetime import datetime
+
+import urllib.request
 
 import nixpkgs_plugin_update as update
 
 
 GITHUB_REPO_URL = "https://github.com/owner/repo"
+GITHUB_LICENSE_URL = "https://api.github.com/repos/owner/repo/license"
+GITHUB_TAGS_ATOM_URL = f"{GITHUB_REPO_URL}/tags.atom"
 
 
 class JsonResponse(io.BytesIO):
@@ -35,6 +40,37 @@ class BinaryResponse(io.BytesIO):
 
     def geturl(self) -> str:
         return self.url
+
+
+def atom_feed(*tags: str) -> bytes:
+    entries = "\n".join(
+        f'      <entry><link href="{GITHUB_REPO_URL}/releases/tag/{tag}" /></entry>'
+        for tag in tags
+    )
+    return f"""<?xml version="1.0" encoding="utf-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom">
+{entries}
+    </feed>
+    """.encode()
+
+
+def git_ls_remote_tags(*tags: str) -> bytes:
+    return "".join(
+        f"{index:040x}\trefs/tags/{tag}\n" for index, tag in enumerate(tags)
+    ).encode()
+
+
+def graphql_tags(*tags: str) -> dict[str, object]:
+    return {
+        "data": {
+            "repository": {
+                "refs": {
+                    "nodes": [{"name": tag} for tag in tags],
+                },
+            },
+        },
+    }
+
 
 class FakeRepo:
     def __init__(
@@ -114,6 +150,27 @@ class FakeCache:
 
     def __bool__(self) -> bool:
         return True
+
+
+class BoundaryRecorder:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, object, object]] = []
+
+    def record_urlopen(
+        self,
+        request: urllib.request.Request,
+        timeout: int,
+    ) -> None:
+        headers = dict(request.header_items())
+        self.calls.append(
+            ("urlopen", request.full_url, {"timeout": timeout, **headers})
+        )
+
+    def record_check_output(
+        self, cmd: Sequence[str], kwargs: dict[str, object]
+    ) -> None:
+        self.calls.append(("check_output", tuple(cmd), dict(kwargs)))
+
 
 def plugin_desc(repo: FakeRepo, branch: str = update.AUTO_BRANCH) -> update.PluginDesc:
     return update.PluginDesc(repo=repo, branch=branch, alias=None)

--- a/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/tests/helpers.py
+++ b/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/tests/helpers.py
@@ -1,0 +1,144 @@
+import io
+import json
+from datetime import datetime
+
+import nixpkgs_plugin_update as update
+
+
+GITHUB_REPO_URL = "https://github.com/owner/repo"
+
+
+class JsonResponse(io.BytesIO):
+    def __init__(self, data: object) -> None:
+        payload = data if isinstance(data, str) else json.dumps(data)
+        super().__init__(payload.encode("utf-8"))
+
+    def __enter__(self) -> "JsonResponse":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.close()
+
+
+class BinaryResponse(io.BytesIO):
+    def __init__(
+        self, data: bytes = b"", url: str = "https://github.com/owner/repo"
+    ) -> None:
+        super().__init__(data)
+        self.url = url
+
+    def __enter__(self) -> "BinaryResponse":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.close()
+
+    def geturl(self) -> str:
+        return self.url
+
+class FakeRepo:
+    def __init__(
+        self,
+        *,
+        name: str = "repo",
+        latest_tag: str | None = None,
+        latest_commit: tuple[str, datetime] | None = None,
+        refs: dict[str, tuple[str, datetime]] | None = None,
+        uri: str = "https://example.com/owner/repo",
+        license_spdx_id: str | None = None,
+        has_submodules: bool = False,
+        redirect: update.Repo | None = None,
+    ) -> None:
+        self.uri = uri
+        self._name = name
+        self._branch = ""
+        self.redirect = redirect
+        self.latest_tag = latest_tag
+        self.latest_commit_result = latest_commit
+        self.refs = refs or {}
+        self.license_spdx_id = license_spdx_id
+        self.has_submodules_result = has_submodules
+        self.get_latest_tag_calls = 0
+        self.latest_commit_calls = 0
+        self.resolve_ref_calls: list[str] = []
+        self.has_submodules_calls = 0
+        self.prefetch_calls: list[str] = []
+        self.prefetch_call_details: list[tuple[str, bool | None]] = []
+        self.license_calls = 0
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def get_latest_tag(self) -> str | None:
+        self.get_latest_tag_calls += 1
+        return self.latest_tag
+
+    def latest_commit(self) -> tuple[str, datetime]:
+        self.latest_commit_calls += 1
+        if self.latest_commit_result is None:
+            raise AssertionError("latest_commit called without configured result")
+        return self.latest_commit_result
+
+    def resolve_ref(self, ref: str) -> tuple[str, datetime]:
+        self.resolve_ref_calls.append(ref)
+        if ref not in self.refs:
+            raise AssertionError(f"resolve_ref called with unexpected ref: {ref}")
+        return self.refs[ref]
+
+    def has_submodules(self) -> bool:
+        self.has_submodules_calls += 1
+        return self.has_submodules_result
+
+    def prefetch(self, ref: str, has_submodules: bool | None = None) -> str:
+        self.prefetch_calls.append(ref)
+        self.prefetch_call_details.append((ref, has_submodules))
+        return "sha256-prefetched"
+
+    def get_license_spdx_id(self, fallback_license: str | None = None) -> str | None:
+        self.license_calls += 1
+        return self.license_spdx_id or fallback_license
+
+
+class FakeCache:
+    def __init__(self, values: dict[str, update.Plugin] | None = None) -> None:
+        self.values = values or {}
+
+    def __getitem__(self, key: str) -> update.Plugin | None:
+        return self.values.get(key)
+
+    def __setitem__(self, key: str, value: update.Plugin | None) -> None:
+        if value is None:
+            raise AssertionError("Cache values must be Plugin instances")
+        self.values[key] = value
+
+    def __bool__(self) -> bool:
+        return True
+
+def plugin_desc(repo: FakeRepo, branch: str = update.AUTO_BRANCH) -> update.PluginDesc:
+    return update.PluginDesc(repo=repo, branch=branch, alias=None)
+
+
+def plugin(
+    *,
+    name: str = "repo",
+    commit: str = "commit-current",
+    has_submodules: bool = False,
+    sha256: str = "sha256-current",
+    version: str = "1.0.0",
+    date: datetime | None = None,
+    last_tag: str | None = "v1.0.0",
+    tag: str | None = None,
+    license: str | None = None,
+) -> update.Plugin:
+    return update.Plugin(
+        name=name,
+        commit=commit,
+        has_submodules=has_submodules,
+        sha256=sha256,
+        version=version,
+        date=date,
+        last_tag=last_tag,
+        tag=tag,
+        license=license,
+    )

--- a/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/tests/test_github.py
+++ b/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/tests/test_github.py
@@ -14,6 +14,14 @@ from helpers import (
 )
 
 
+def assert_git_tags_called_once(git_tags: Mock, repo: update.RepoGitHub) -> None:
+    git_tags.assert_called_once_with(
+        ["git", "ls-remote", "--tags", "--refs", repo.uri],
+        stderr=subprocess.STDOUT,
+        timeout=10,
+    )
+
+
 def test_github_execute_graphql_sends_expected_request(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -103,6 +111,7 @@ def test_github_get_latest_tag_sends_real_graphql_tag_query(
     request, _timeout = requests[0]
     payload = json.loads(request.data or b"{}")
     assert 'refs(refPrefix: "refs/tags/", first: 20' in payload["query"]
+    assert "direction: DESC" in payload["query"]
     assert "TAG_COMMIT_DATE" in payload["query"]
     assert "name" in payload["query"]
 
@@ -112,18 +121,128 @@ def test_github_get_latest_tag_falls_back_on_rate_limit(
 ) -> None:
     repo = update.RepoGitHub("owner", "repo", "")
     repo.token = "token"
-    monkeypatch.setattr(
-        repo,
-        "_execute_graphql",
-        Mock(return_value={"errors": [{"type": "RATE_LIMIT"}]}),
+    calls: list[tuple[str, object]] = []
+    graphql = Mock(
+        side_effect=lambda query, variables: (
+            calls.append(("graphql", variables)) or {"errors": [{"type": "RATE_LIMIT"}]}
+        )
     )
-    monkeypatch.setattr(
-        repo,
-        "_get_latest_tag_from_fallbacks",
-        Mock(return_value="v1.0.0"),
-    )
+    fallback = Mock(side_effect=lambda: calls.append(("fallback", None)) or "v1.0.0")
+    monkeypatch.setattr(repo, "_execute_graphql", graphql)
+    monkeypatch.setattr(repo, "_get_latest_tag_from_fallbacks", fallback)
 
     assert repo.get_latest_tag() == "v1.0.0"
+    assert calls == [
+        ("graphql", {"owner": "owner", "name": "repo"}),
+        ("fallback", None),
+    ]
+    graphql.assert_called_once()
+    fallback.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    "graphql_response",
+    [
+        {"data": {"repository": None}},
+        {"data": {"repository": {"refs": None}}},
+        {"data": {"repository": {"refs": {}}}},
+        {"data": {"repository": {"refs": {"nodes": []}}}},
+        {"data": {"repository": {"refs": {"nodes": [{"missing": "name"}]}}}},
+        {"errors": [{"message": "backend temporarily unavailable"}]},
+    ],
+)
+def test_github_get_latest_tag_falls_back_on_realistic_bad_graphql_payloads(
+    monkeypatch: pytest.MonkeyPatch, graphql_response: dict[str, object]
+) -> None:
+    repo = update.RepoGitHub("owner", "repo", "")
+    repo.token = "token"
+    calls: list[tuple[str, object]] = []
+    graphql = Mock(
+        side_effect=lambda query, variables: (
+            calls.append(("graphql", variables)) or graphql_response
+        )
+    )
+    fallback = Mock(side_effect=lambda: calls.append(("fallback", None)) or "v1.2.3")
+    monkeypatch.setattr(repo, "_execute_graphql", graphql)
+    monkeypatch.setattr(repo, "_get_latest_tag_from_fallbacks", fallback)
+
+    assert repo.get_latest_tag() == "v1.2.3"
+    assert calls == [
+        ("graphql", {"owner": "owner", "name": "repo"}),
+        ("fallback", None),
+    ]
+    graphql.assert_called_once()
+    fallback.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    (
+        "graphql_result",
+        "atom_result",
+        "expected_tag",
+        "expect_git_fallback",
+    ),
+    [
+        pytest.param(
+            graphql_tags(),
+            atom_feed("nightly", "v2.0.0"),
+            "v2.0.0",
+            False,
+            id="empty-graphql-uses-atom",
+        ),
+        pytest.param(
+            {"errors": [{"message": "backend unavailable"}]},
+            b"<feed",
+            "v2.0.0",
+            True,
+            id="bad-graphql-and-atom-use-git",
+        ),
+        pytest.param(
+            urllib.error.URLError("offline"),
+            atom_feed("v1.2.3"),
+            "v1.2.3",
+            False,
+            id="graphql-transport-error-uses-atom",
+        ),
+    ],
+)
+def test_github_get_latest_tag_fallback_call_order(
+    monkeypatch: pytest.MonkeyPatch,
+    graphql_result: dict[str, object] | urllib.error.URLError,
+    atom_result: bytes,
+    expected_tag: str,
+    expect_git_fallback: bool,
+) -> None:
+    repo = update.RepoGitHub("owner", "repo", "")
+    repo.token = "token"
+    calls: list[str] = []
+    git_tags = Mock(return_value=git_ls_remote_tags("v1.9.0", "v2.0.0"))
+
+    def fake_urlopen(
+        request: urllib.request.Request, timeout: int
+    ) -> JsonResponse | BinaryResponse:
+        calls.append(request.full_url)
+        assert timeout == 10
+        if request.full_url == "https://api.github.com/graphql":
+            if isinstance(graphql_result, urllib.error.URLError):
+                raise graphql_result
+            return JsonResponse(graphql_result)
+        if request.full_url == GITHUB_TAGS_ATOM_URL:
+            return BinaryResponse(atom_result)
+        raise AssertionError(f"unexpected request: {request.full_url}")
+
+    monkeypatch.setattr(update.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(update.subprocess, "check_output", git_tags)
+
+    assert repo.get_latest_tag() == expected_tag
+    assert calls == [
+        "https://api.github.com/graphql",
+        GITHUB_TAGS_ATOM_URL,
+    ]
+    if expect_git_fallback:
+        assert_git_tags_called_once(git_tags, repo)
+    else:
+        git_tags.assert_not_called()
 
 
 def test_github_get_latest_tag_raises_on_bad_auth(
@@ -143,23 +262,14 @@ def test_github_get_latest_tag_raises_on_bad_auth(
 
 def test_github_recent_tags_parses_atom_feed(monkeypatch: pytest.MonkeyPatch) -> None:
     repo = update.RepoGitHub("owner", "repo", "")
-    xml = b"""<?xml version="1.0" encoding="utf-8"?>
-    <feed xmlns="http://www.w3.org/2005/Atom">
-      <entry>
-        <link href="https://github.com/owner/repo/releases/tag/nightly" />
-      </entry>
-      <entry>
-        <link href="https://github.com/owner/repo/releases/tag/v1.2.3" />
-      </entry>
-    </feed>
-    """
-    monkeypatch.setattr(
-        update.urllib.request,
-        "urlopen",
-        Mock(return_value=BinaryResponse(xml)),
-    )
+    urlopen = Mock(return_value=BinaryResponse(atom_feed("nightly", "v1.2.3")))
+    monkeypatch.setattr(update.urllib.request, "urlopen", urlopen)
 
     assert repo._get_recent_tags_from_atom() == ["nightly", "v1.2.3"]
+    request = urlopen.call_args.args[0]
+    assert isinstance(request, urllib.request.Request)
+    assert request.full_url == GITHUB_TAGS_ATOM_URL
+    assert urlopen.call_args.kwargs == {"timeout": 10}
 
 
 def test_github_recent_tags_ignores_incomplete_atom_entries(
@@ -192,55 +302,80 @@ def test_github_fallback_tag_feed_selects_first_release(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repo = update.RepoGitHub("owner", "repo", "")
-    monkeypatch.setattr(
-        repo,
-        "_get_recent_tags_from_atom",
-        Mock(return_value=["nightly", "v1.2.0", "v1.3.0"]),
-    )
+    atom = Mock(return_value=["v1.2.0-rc1", "nightly", "v1.2.0", "v1.3.0"])
+    git_tags = Mock()
+    monkeypatch.setattr(repo, "_get_recent_tags_from_atom", atom)
+    monkeypatch.setattr(update.subprocess, "check_output", git_tags)
 
     assert repo._get_latest_tag_from_fallbacks() == "v1.2.0"
+    atom.assert_called_once_with()
+    git_tags.assert_not_called()
+
+
+def test_github_fallback_tag_feed_retries_atom_before_git(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = update.RepoGitHub("owner", "repo", "")
+    urlopen = Mock(side_effect=urllib.error.URLError("offline"))
+    sleep = Mock()
+    git_tags = Mock(return_value=git_ls_remote_tags("v1.9.0", "v2.0.0"))
+    monkeypatch.setattr(update.urllib.request, "urlopen", urlopen)
+    monkeypatch.setattr(update.time, "sleep", sleep)
+    monkeypatch.setattr(update.subprocess, "check_output", git_tags)
+
+    assert repo._get_latest_tag_from_fallbacks() == "v2.0.0"
+    assert urlopen.call_count == 4
+    assert [call.args[0].full_url for call in urlopen.call_args_list] == [
+        GITHUB_TAGS_ATOM_URL,
+        GITHUB_TAGS_ATOM_URL,
+        GITHUB_TAGS_ATOM_URL,
+        GITHUB_TAGS_ATOM_URL,
+    ]
+    assert [call.kwargs for call in urlopen.call_args_list] == [
+        {"timeout": 10},
+        {"timeout": 10},
+        {"timeout": 10},
+        {"timeout": 10},
+    ]
+    assert [call.args[0] for call in sleep.call_args_list] == [3, 6, 12]
+    assert_git_tags_called_once(git_tags, repo)
 
 
 def test_github_fallback_tag_feed_uses_git_tags_when_atom_is_malformed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repo = update.RepoGitHub("owner", "repo", "")
-    monkeypatch.setattr(
-        repo,
-        "_get_recent_tags_from_atom",
-        Mock(side_effect=update.ET.ParseError("bad xml")),
+    atom = Mock(side_effect=update.ET.ParseError("bad xml"))
+    git_tags = Mock(
+        return_value=git_ls_remote_tags(
+            "v1.9.9",
+            "nightly",
+            "v1.10.0-rc1",
+            "sign-test",
+            "v1.10.0",
+            "v1.2.0",
+        )
     )
-    monkeypatch.setattr(
-        update.subprocess,
-        "check_output",
-        Mock(
-            return_value=(
-                b"0000000000000000000000000000000000000000\trefs/tags/nightly\n"
-                b"1111111111111111111111111111111111111111\trefs/tags/v1.2.0\n"
-                b"2222222222222222222222222222222222222222\trefs/tags/v1.3.0\n"
-            )
-        ),
-    )
+    monkeypatch.setattr(repo, "_get_recent_tags_from_atom", atom)
+    monkeypatch.setattr(update.subprocess, "check_output", git_tags)
 
-    assert repo._get_latest_tag_from_fallbacks() == "v1.3.0"
+    assert repo._get_latest_tag_from_fallbacks() == "v1.10.0"
+    atom.assert_called_once_with()
+    assert_git_tags_called_once(git_tags, repo)
 
 
 def test_github_fallback_tag_feed_returns_none_when_all_sources_fail(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repo = update.RepoGitHub("owner", "repo", "")
-    monkeypatch.setattr(
-        repo,
-        "_get_recent_tags_from_atom",
-        Mock(side_effect=urllib.error.URLError("offline")),
-    )
-    monkeypatch.setattr(
-        update.subprocess,
-        "check_output",
-        Mock(side_effect=subprocess.CalledProcessError(1, ["git", "ls-remote"])),
-    )
+    atom = Mock(side_effect=urllib.error.URLError("offline"))
+    git_tags = Mock(side_effect=subprocess.CalledProcessError(1, ["git", "ls-remote"]))
+    monkeypatch.setattr(repo, "_get_recent_tags_from_atom", atom)
+    monkeypatch.setattr(update.subprocess, "check_output", git_tags)
 
     assert repo._get_latest_tag_from_fallbacks() is None
+    atom.assert_called_once_with()
+    assert_git_tags_called_once(git_tags, repo)
 
 
 def test_github_latest_commit_parses_atom_feed(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -253,11 +388,8 @@ def test_github_latest_commit_parses_atom_feed(monkeypatch: pytest.MonkeyPatch) 
       </entry>
     </feed>
     """
-    monkeypatch.setattr(
-        update.urllib.request,
-        "urlopen",
-        Mock(return_value=BinaryResponse(xml)),
-    )
+    urlopen = Mock(return_value=BinaryResponse(xml))
+    monkeypatch.setattr(update.urllib.request, "urlopen", urlopen)
 
     assert repo.latest_commit() == (
         "abcdef123456",

--- a/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/tests/test_github.py
+++ b/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/tests/test_github.py
@@ -9,8 +9,12 @@ import pytest
 import nixpkgs_plugin_update as update
 from helpers import (
     GITHUB_REPO_URL,
+    GITHUB_TAGS_ATOM_URL,
     BinaryResponse,
     JsonResponse,
+    graphql_tags,
+    atom_feed,
+    git_ls_remote_tags,
 )
 
 
@@ -262,10 +266,12 @@ def test_github_get_latest_tag_raises_on_bad_auth(
 
 def test_github_recent_tags_parses_atom_feed(monkeypatch: pytest.MonkeyPatch) -> None:
     repo = update.RepoGitHub("owner", "repo", "")
-    urlopen = Mock(return_value=BinaryResponse(atom_feed("nightly", "v1.2.3")))
+    urlopen = Mock(
+        return_value=BinaryResponse(atom_feed("nightly", "v1.2.3", "release/1.2.3"))
+    )
     monkeypatch.setattr(update.urllib.request, "urlopen", urlopen)
 
-    assert repo._get_recent_tags_from_atom() == ["nightly", "v1.2.3"]
+    assert repo._get_recent_tags_from_atom() == ["nightly", "v1.2.3", "release/1.2.3"]
     request = urlopen.call_args.args[0]
     assert isinstance(request, urllib.request.Request)
     assert request.full_url == GITHUB_TAGS_ATOM_URL

--- a/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/tests/test_github.py
+++ b/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/tests/test_github.py
@@ -1,0 +1,463 @@
+import json
+import subprocess
+import urllib.error
+from datetime import datetime
+from unittest.mock import Mock
+
+import pytest
+
+import nixpkgs_plugin_update as update
+from helpers import (
+    GITHUB_REPO_URL,
+    BinaryResponse,
+    JsonResponse,
+)
+
+
+def test_github_execute_graphql_sends_expected_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = update.RepoGitHub("owner", "repo", "")
+    repo.token = "token"
+    captured: dict[str, object] = {}
+
+    def fake_urlopen(request: urllib.request.Request, timeout: int) -> JsonResponse:
+        captured["request"] = request
+        captured["timeout"] = timeout
+        return JsonResponse({"data": {"ok": True}})
+
+    monkeypatch.setattr(update.urllib.request, "urlopen", fake_urlopen)
+
+    assert repo._execute_graphql("query", {"owner": "owner", "name": "repo"}) == {
+        "data": {"ok": True}
+    }
+    request = captured["request"]
+    assert isinstance(request, urllib.request.Request)
+    assert request.full_url == "https://api.github.com/graphql"
+    assert request.get_header("Authorization") == "token token"
+    assert request.get_header("Content-type") == "application/json"
+    assert json.loads(request.data or b"{}") == {
+        "query": "query",
+        "variables": {"owner": "owner", "name": "repo"},
+    }
+    assert captured["timeout"] == 10
+
+
+def test_github_get_latest_tag_without_token_uses_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = update.RepoGitHub("owner", "repo", "")
+    repo.token = ""
+    fallback = Mock(return_value="v1.2.3")
+    graphql = Mock()
+    monkeypatch.setattr(repo, "_get_latest_tag_from_fallbacks", fallback)
+    monkeypatch.setattr(repo, "_execute_graphql", graphql)
+
+    assert repo.get_latest_tag() == "v1.2.3"
+    fallback.assert_called_once_with()
+    graphql.assert_not_called()
+
+
+def test_github_get_latest_tag_selects_first_recent_stable_release(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = update.RepoGitHub("owner", "repo", "")
+    repo.token = "token"
+    graphql = Mock(
+        return_value=graphql_tags(
+            "v1.2.0-dev",
+            "v1.2.0-rc1",
+            "nightly",
+            "v1.2.0",
+            "v1.3.0",
+        )
+    )
+    fallback = Mock()
+    monkeypatch.setattr(
+        repo,
+        "_execute_graphql",
+        graphql,
+    )
+    monkeypatch.setattr(repo, "_get_latest_tag_from_fallbacks", fallback)
+
+    assert repo.get_latest_tag() == "v1.2.0"
+    graphql.assert_called_once()
+    assert graphql.call_args.args[1] == {"owner": "owner", "name": "repo"}
+    fallback.assert_not_called()
+
+
+def test_github_get_latest_tag_sends_real_graphql_tag_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = update.RepoGitHub("owner", "repo", "")
+    repo.token = "token"
+    requests: list[tuple[urllib.request.Request, int]] = []
+
+    def fake_urlopen(request: urllib.request.Request, timeout: int) -> JsonResponse:
+        requests.append((request, timeout))
+        return JsonResponse(graphql_tags("nightly", "v2.1.0"))
+
+    monkeypatch.setattr(update.urllib.request, "urlopen", fake_urlopen)
+
+    assert repo.get_latest_tag() == "v2.1.0"
+    request, _timeout = requests[0]
+    payload = json.loads(request.data or b"{}")
+    assert 'refs(refPrefix: "refs/tags/", first: 20' in payload["query"]
+    assert "TAG_COMMIT_DATE" in payload["query"]
+    assert "name" in payload["query"]
+
+
+def test_github_get_latest_tag_falls_back_on_rate_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = update.RepoGitHub("owner", "repo", "")
+    repo.token = "token"
+    monkeypatch.setattr(
+        repo,
+        "_execute_graphql",
+        Mock(return_value={"errors": [{"type": "RATE_LIMIT"}]}),
+    )
+    monkeypatch.setattr(
+        repo,
+        "_get_latest_tag_from_fallbacks",
+        Mock(return_value="v1.0.0"),
+    )
+
+    assert repo.get_latest_tag() == "v1.0.0"
+
+
+def test_github_get_latest_tag_raises_on_bad_auth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = update.RepoGitHub("owner", "repo", "")
+    repo.token = "token"
+    monkeypatch.setattr(
+        repo,
+        "_execute_graphql",
+        Mock(side_effect=urllib.error.HTTPError("", 403, "", {}, None)),
+    )
+
+    with pytest.raises(RuntimeError, match="refresh GITHUB_TOKEN"):
+        repo.get_latest_tag()
+
+
+def test_github_recent_tags_parses_atom_feed(monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = update.RepoGitHub("owner", "repo", "")
+    xml = b"""<?xml version="1.0" encoding="utf-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom">
+      <entry>
+        <link href="https://github.com/owner/repo/releases/tag/nightly" />
+      </entry>
+      <entry>
+        <link href="https://github.com/owner/repo/releases/tag/v1.2.3" />
+      </entry>
+    </feed>
+    """
+    monkeypatch.setattr(
+        update.urllib.request,
+        "urlopen",
+        Mock(return_value=BinaryResponse(xml)),
+    )
+
+    assert repo._get_recent_tags_from_atom() == ["nightly", "v1.2.3"]
+
+
+def test_github_recent_tags_ignores_incomplete_atom_entries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = update.RepoGitHub("owner", "repo", "")
+    xml = b"""<?xml version="1.0" encoding="utf-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom">
+      <entry>
+        <title>missing link</title>
+      </entry>
+      <entry>
+        <link />
+      </entry>
+      <entry>
+        <link href="https://github.com/owner/repo/releases/tag/v1.2.3" />
+      </entry>
+    </feed>
+    """
+    monkeypatch.setattr(
+        update.urllib.request,
+        "urlopen",
+        Mock(return_value=BinaryResponse(xml)),
+    )
+
+    assert repo._get_recent_tags_from_atom() == ["v1.2.3"]
+
+
+def test_github_fallback_tag_feed_selects_first_release(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = update.RepoGitHub("owner", "repo", "")
+    monkeypatch.setattr(
+        repo,
+        "_get_recent_tags_from_atom",
+        Mock(return_value=["nightly", "v1.2.0", "v1.3.0"]),
+    )
+
+    assert repo._get_latest_tag_from_fallbacks() == "v1.2.0"
+
+
+def test_github_fallback_tag_feed_uses_git_tags_when_atom_is_malformed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = update.RepoGitHub("owner", "repo", "")
+    monkeypatch.setattr(
+        repo,
+        "_get_recent_tags_from_atom",
+        Mock(side_effect=update.ET.ParseError("bad xml")),
+    )
+    monkeypatch.setattr(
+        update.subprocess,
+        "check_output",
+        Mock(
+            return_value=(
+                b"0000000000000000000000000000000000000000\trefs/tags/nightly\n"
+                b"1111111111111111111111111111111111111111\trefs/tags/v1.2.0\n"
+                b"2222222222222222222222222222222222222222\trefs/tags/v1.3.0\n"
+            )
+        ),
+    )
+
+    assert repo._get_latest_tag_from_fallbacks() == "v1.3.0"
+
+
+def test_github_fallback_tag_feed_returns_none_when_all_sources_fail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = update.RepoGitHub("owner", "repo", "")
+    monkeypatch.setattr(
+        repo,
+        "_get_recent_tags_from_atom",
+        Mock(side_effect=urllib.error.URLError("offline")),
+    )
+    monkeypatch.setattr(
+        update.subprocess,
+        "check_output",
+        Mock(side_effect=subprocess.CalledProcessError(1, ["git", "ls-remote"])),
+    )
+
+    assert repo._get_latest_tag_from_fallbacks() is None
+
+
+def test_github_latest_commit_parses_atom_feed(monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = update.RepoGitHub("owner", "repo", "main")
+    xml = b"""<?xml version="1.0" encoding="utf-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom">
+      <entry>
+        <updated>2024-02-03T04:05:06Z</updated>
+        <link href="https://github.com/owner/repo/commit/abcdef123456" />
+      </entry>
+    </feed>
+    """
+    monkeypatch.setattr(
+        update.urllib.request,
+        "urlopen",
+        Mock(return_value=BinaryResponse(xml)),
+    )
+
+    assert repo.latest_commit() == (
+        "abcdef123456",
+        datetime(2024, 2, 3, 4, 5, 6),
+    )
+    request = urlopen.call_args.args[0]
+    assert isinstance(request, urllib.request.Request)
+    assert request.full_url == f"{GITHUB_REPO_URL}/commits/main.atom"
+    assert urlopen.call_args.kwargs == {"timeout": 10}
+
+
+def test_github_latest_commit_records_redirected_repository(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = update.RepoGitHub("old-owner", "old-repo", "main")
+    xml = b"""<?xml version="1.0" encoding="utf-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom">
+      <entry>
+        <updated>2024-02-03T04:05:06Z</updated>
+        <link href="https://github.com/new-owner/new-repo/commit/abcdef123456" />
+      </entry>
+    </feed>
+    """
+    urlopen = Mock(
+        return_value=BinaryResponse(
+            xml,
+            url="https://github.com/new-owner/new-repo/commits/main.atom",
+        )
+    )
+    monkeypatch.setattr(update.urllib.request, "urlopen", urlopen)
+
+    assert repo.latest_commit() == (
+        "abcdef123456",
+        datetime(2024, 2, 3, 4, 5, 6),
+    )
+    assert urlopen.call_count == 1
+    assert isinstance(repo.redirect, update.RepoGitHub)
+    assert repo.redirect.owner == "new-owner"
+    assert repo.redirect.repo == "new-repo"
+
+
+def test_github_resolve_ref_uses_latest_commit_for_branch_without_redirect_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = update.RepoGitHub("owner", "repo", "main")
+    latest_commit = Mock(return_value=("abcdef123456", datetime(2024, 2, 3, 4, 5, 6)))
+    check_ref_redirect = Mock()
+    base_resolve_ref = Mock(side_effect=AssertionError("unexpected base resolve"))
+    monkeypatch.setattr(repo, "latest_commit", latest_commit)
+    monkeypatch.setattr(repo, "_check_ref_redirect", check_ref_redirect)
+    monkeypatch.setattr(update.Repo, "resolve_ref", base_resolve_ref)
+
+    assert repo.resolve_ref("main") == ("abcdef123456", datetime(2024, 2, 3, 4, 5, 6))
+    latest_commit.assert_called_once_with()
+    check_ref_redirect.assert_not_called()
+    base_resolve_ref.assert_not_called()
+
+
+def test_github_check_ref_redirect_requests_encoded_ref_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = update.RepoGitHub("owner", "repo", "main")
+    urlopen = Mock(
+        return_value=BinaryResponse(
+            b"",
+            url=f"{GITHUB_REPO_URL}/tree/refs%2Ftags%2Fv1.2.3",
+        )
+    )
+    monkeypatch.setattr(update.urllib.request, "urlopen", urlopen)
+
+    repo._check_ref_redirect("refs/tags/v1.2.3")
+
+    request = urlopen.call_args.args[0]
+    assert isinstance(request, urllib.request.Request)
+    assert request.full_url == f"{GITHUB_REPO_URL}/tree/refs%2Ftags%2Fv1.2.3"
+    assert urlopen.call_args.kwargs == {"timeout": 10}
+
+
+def test_github_has_submodules_retries_transient_url_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = update.RepoGitHub("owner", "repo", "main")
+    urlopen = Mock(
+        side_effect=[
+            urllib.error.URLError("offline"),
+            urllib.error.URLError("offline"),
+            urllib.error.URLError("offline"),
+            BinaryResponse(b""),
+        ]
+    )
+    sleep = Mock()
+    monkeypatch.setattr(update.urllib.request, "urlopen", urlopen)
+    monkeypatch.setattr(update.time, "sleep", sleep)
+
+    assert repo.has_submodules() is True
+    assert urlopen.call_count == 4
+    assert [call.args[0] for call in sleep.call_args_list] == [3, 6, 12]
+
+
+def test_github_has_submodules_does_not_retry_404(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = update.RepoGitHub("owner", "repo", "main")
+    urlopen = Mock(side_effect=urllib.error.HTTPError("", 404, "", {}, None))
+    monkeypatch.setattr(update.urllib.request, "urlopen", urlopen)
+    monkeypatch.setattr(update.time, "sleep", Mock())
+
+    assert repo.has_submodules() is False
+    urlopen.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("provided_flag", "discovered", "expected", "should_discover"),
+    [
+        pytest.param(None, False, "sha256-github", True, id="discover-no-submodules"),
+        pytest.param(None, True, "sha256-git", True, id="discover-submodules"),
+        pytest.param(False, True, "sha256-github", False, id="explicit-no-submodules"),
+        pytest.param(True, False, "sha256-git", False, id="explicit-submodules"),
+    ],
+)
+def test_github_prefetch_routes_by_submodule_status(
+    monkeypatch: pytest.MonkeyPatch,
+    provided_flag: bool | None,
+    discovered: bool,
+    expected: str,
+    should_discover: bool,
+) -> None:
+    repo = update.RepoGitHub("owner", "repo", "")
+    prefetch_github = Mock(return_value="sha256-github")
+    base_prefetch = Mock(return_value="sha256-git")
+    has_submodules_lookup = Mock(return_value=discovered)
+    monkeypatch.setattr(repo, "has_submodules", has_submodules_lookup)
+    monkeypatch.setattr(repo, "prefetch_github", prefetch_github)
+    monkeypatch.setattr(update.Repo, "prefetch", base_prefetch)
+
+    assert repo.prefetch("abcdef", has_submodules=provided_flag) == expected
+    if should_discover:
+        has_submodules_lookup.assert_called_once_with()
+    else:
+        has_submodules_lookup.assert_not_called()
+
+    if expected == "sha256-git":
+        base_prefetch.assert_called_once_with("abcdef")
+        prefetch_github.assert_not_called()
+    else:
+        prefetch_github.assert_called_once_with("abcdef")
+        base_prefetch.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("urlopen_result", "fallback_license", "expected"),
+    [
+        pytest.param(
+            JsonResponse({"license": {"spdx_id": "MIT"}}),
+            None,
+            "MIT",
+            id="spdx",
+        ),
+        pytest.param(
+            JsonResponse({"license": {"spdx_id": "NOASSERTION"}}),
+            None,
+            None,
+            id="noassertion",
+        ),
+        pytest.param(
+            urllib.error.HTTPError("", 404, "", {}, None),
+            "MIT",
+            None,
+            id="missing-license",
+        ),
+        pytest.param(
+            urllib.error.URLError("offline"),
+            "MIT",
+            "MIT",
+            id="transient-error",
+        ),
+    ],
+)
+def test_github_license_returns_expected_spdx_or_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    urlopen_result: JsonResponse | urllib.error.HTTPError | urllib.error.URLError,
+    fallback_license: str | None,
+    expected: str | None,
+) -> None:
+    repo = update.RepoGitHub("owner", "repo", "")
+    repo.token = "token"
+    urlopen = Mock(
+        side_effect=urlopen_result
+        if isinstance(urlopen_result, urllib.error.URLError)
+        else None,
+        return_value=urlopen_result
+        if not isinstance(urlopen_result, urllib.error.URLError)
+        else None,
+    )
+    monkeypatch.setattr(update.urllib.request, "urlopen", urlopen)
+
+    assert repo.get_license_spdx_id(fallback_license) == expected
+    urlopen.assert_called_once()
+    request = urlopen.call_args.args[0]
+    assert isinstance(request, urllib.request.Request)
+    assert request.full_url == "https://api.github.com/repos/owner/repo/license"
+    assert request.get_header("Authorization") == "token token"
+    assert urlopen.call_args.kwargs == {"timeout": 10}

--- a/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/tests/test_tags.py
+++ b/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/tests/test_tags.py
@@ -14,6 +14,9 @@ import nixpkgs_plugin_update as update
         ("v0.10.x", "0.10.x"),
         ("ver.4.2", "4.2"),
         ("vim7.4", "7.4"),
+        ("release-2024.10", "2024.10"),
+        ("v1.0.0+build", "1.0.0+build"),
+        ("v1.0.0-post1", "1.0.0-post1"),
     ],
 )
 def test_normalize_release_version_accepts_real_world_tags(
@@ -39,36 +42,21 @@ def test_normalize_release_version_rejects_non_release_tags(tag: str) -> None:
                 "nightly",
                 "sign-test",
             ],
-            update.normalize_release_version,
-        )
-        == "yocto-5.3.3"
-    )
-
-
-def test_select_latest_tag_handles_real_release_candidate_noise() -> None:
-    assert (
-        update.select_latest_tag(
-            [
-                "v0.10.0-dev",
-                "v0.10.0-rc1",
-                "v0.10.0",
-                "pre-nvim-0.10",
-                "nightly",
-            ],
-            update.normalize_release_version,
-        )
-        == "v0.10.0"
-    )
-
-
-def test_select_latest_tag_keeps_date_release_tags_comparable() -> None:
-    assert (
-        update.select_latest_tag(
-            ["2025-07-10", "2025-07-09", "2024-12-31", "stable"],
-            update.normalize_release_version,
-        )
-        == "2025-07-10"
-    )
+            "yocto-5.3.3",
+        ),
+        (
+            ["v0.10.0-dev", "v0.10.0-rc1", "v0.10.0", "pre-nvim-0.10", "nightly"],
+            "v0.10.0",
+        ),
+        (["v1.9.9", "v1.10.0-rc1", "nightly", "v1.10.0", "v1.2.0"], "v1.10.0"),
+        (["v1.0.0", "v1.0.0+build", "v1.0.0-post1", "stable"], "v1.0.0-post1"),
+        (["2025-07-10", "2025-07-09", "2024-12-31", "stable"], "2025-07-10"),
+    ],
+)
+def test_select_latest_tag_prefers_best_release_version(
+    tags: list[str], expected: str
+) -> None:
+    assert update.select_latest_tag(tags, update.normalize_release_version) == expected
 
 
 def test_select_latest_tag_falls_back_to_max_invalid_tag() -> None:
@@ -77,3 +65,12 @@ def test_select_latest_tag_falls_back_to_max_invalid_tag() -> None:
 
 def test_first_release_tag_uses_api_recency_order() -> None:
     assert update.first_release_tag(["nightly", "v1.2.0", "v1.3.0"]) == "v1.2.0"
+
+
+def test_first_release_tag_skips_prerelease_noise() -> None:
+    assert (
+        update.first_release_tag(
+            ["v0.10.0-dev", "v0.10.0-rc1", "nightly", "v0.10.0"]
+        )
+        == "v0.10.0"
+    )

--- a/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/tests/test_tags.py
+++ b/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/tests/test_tags.py
@@ -1,0 +1,79 @@
+import pytest
+
+import nixpkgs_plugin_update as update
+
+
+@pytest.mark.parametrize(
+    ("tag", "expected"),
+    [
+        ("v2.5.1", "2.5.1"),
+        ("yocto-6.0_M3", "6.0_M3"),
+        ("v88.1-1.0.0", "88.1-1.0.0"),
+        ("13.2@1", "13.2@1"),
+        ("2025-07-10", "2025-07-10"),
+        ("v0.10.x", "0.10.x"),
+        ("ver.4.2", "4.2"),
+        ("vim7.4", "7.4"),
+    ],
+)
+def test_normalize_release_version_accepts_real_world_tags(
+    tag: str, expected: str
+) -> None:
+    assert update.normalize_release_version(tag) == expected
+
+
+@pytest.mark.parametrize("tag", ["legacy", "sign-test", "pre-nvim-0.10"])
+def test_normalize_release_version_rejects_non_release_tags(tag: str) -> None:
+    assert update.normalize_release_version(tag) is None
+
+
+@pytest.mark.parametrize(
+    ("tags", "expected"),
+    [
+        (
+            [
+                "yocto-4.0.999",
+                "yocto-5.0",
+                "yocto-5.3.3",
+                "yocto-6.0_M3",
+                "nightly",
+                "sign-test",
+            ],
+            update.normalize_release_version,
+        )
+        == "yocto-5.3.3"
+    )
+
+
+def test_select_latest_tag_handles_real_release_candidate_noise() -> None:
+    assert (
+        update.select_latest_tag(
+            [
+                "v0.10.0-dev",
+                "v0.10.0-rc1",
+                "v0.10.0",
+                "pre-nvim-0.10",
+                "nightly",
+            ],
+            update.normalize_release_version,
+        )
+        == "v0.10.0"
+    )
+
+
+def test_select_latest_tag_keeps_date_release_tags_comparable() -> None:
+    assert (
+        update.select_latest_tag(
+            ["2025-07-10", "2025-07-09", "2024-12-31", "stable"],
+            update.normalize_release_version,
+        )
+        == "2025-07-10"
+    )
+
+
+def test_select_latest_tag_falls_back_to_max_invalid_tag() -> None:
+    assert update.select_latest_tag(["stable", "release"]) == "stable"
+
+
+def test_first_release_tag_uses_api_recency_order() -> None:
+    assert update.first_release_tag(["nightly", "v1.2.0", "v1.3.0"]) == "v1.2.0"

--- a/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/tests/test_targets.py
+++ b/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/tests/test_targets.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import Mock
@@ -17,66 +18,66 @@ def tag_ref(tag: str) -> str:
     return f"{update.GIT_TAGS_PREFIX}{tag}"
 
 
-def test_auto_branch_without_current_plugin_prefers_release() -> None:
-    repo = FakeRepo(
-        latest_tag="v1.1.0",
-        refs={tag_ref("v1.1.0"): ("commit-release", RELEASE_DATE)},
-    )
-
-    assert update.select_plugin_target(plugin_desc(repo), None, "v1.1.0") == (
-        "commit-release",
-        RELEASE_DATE,
-        "1.1.0",
-        "v1.1.0",
-    )
-
-
-def test_commit_tracked_plugin_newer_than_release_stays_on_commit() -> None:
-    repo = FakeRepo(
-        latest_commit=("commit-head", HEAD_DATE),
-        refs={tag_ref("v1.1.0"): ("commit-release", RELEASE_DATE)},
-    )
-    current = plugin(
-        version="1.0.0-unstable-2024-01-20",
-        date=datetime(2024, 1, 20, tzinfo=timezone.utc),
-    )
-
-    assert update.select_plugin_target(plugin_desc(repo), current, "v1.1.0") == (
-        "commit-head",
-        HEAD_DATE,
-        "1.1.0-unstable-2024-02-01",
-        None,
-    )
-    assert repo.latest_commit_calls == 1
-    assert repo.resolve_ref_calls == [tag_ref("v1.1.0")]
-
-
-def test_commit_tracked_plugin_equal_to_release_switches_to_release() -> None:
-    repo = FakeRepo(
-        refs={tag_ref("v1.1.0"): ("commit-release", RELEASE_DATE)},
-    )
-    current = plugin(
-        version="1.0.0-unstable-2024-01-15",
-        date=RELEASE_DATE,
-    )
-
-    assert update.select_plugin_target(plugin_desc(repo), current, "v1.1.0") == (
-        "commit-release",
-        RELEASE_DATE,
-        "1.1.0",
-        "v1.1.0",
-    )
-
-
-def test_no_usable_release_falls_back_to_latest_commit() -> None:
-    repo = FakeRepo(latest_commit=("commit-head", HEAD_DATE))
-
-    assert update.select_plugin_target(plugin_desc(repo), None, "prerelease") == (
-        "commit-head",
-        HEAD_DATE,
-        "0-unstable-2024-02-01",
-        None,
-    )
+@pytest.mark.parametrize(
+    (
+        "repo",
+        "current",
+        "latest_tag",
+        "expected",
+    ),
+    [
+        (
+            FakeRepo(refs={tag_ref("v1.1.0"): ("commit-release", RELEASE_DATE)}),
+            None,
+            "v1.1.0",
+            ("commit-release", RELEASE_DATE, "1.1.0", "v1.1.0"),
+        ),
+        (
+            FakeRepo(
+                latest_commit=("commit-head", HEAD_DATE),
+                refs={tag_ref("v1.1.0"): ("commit-release", RELEASE_DATE)},
+            ),
+            plugin(
+                version="1.0.0-unstable-2024-01-20",
+                date=datetime(2024, 1, 20, tzinfo=timezone.utc),
+            ),
+            "v1.1.0",
+            ("commit-head", HEAD_DATE, "1.1.0-unstable-2024-02-01", None),
+        ),
+        (
+            FakeRepo(
+                latest_commit=("commit-head", HEAD_DATE),
+                refs={tag_ref("v1.3.1"): ("commit-release", RELEASE_DATE)},
+            ),
+            plugin(
+                version="1.4-rc1-unstable-2024-01-20",
+                date=datetime(2024, 1, 20, tzinfo=timezone.utc),
+                last_tag="1.4-rc1",
+            ),
+            "v1.3.1",
+            ("commit-head", HEAD_DATE, "1.4-rc1-unstable-2024-02-01", None),
+        ),
+        (
+            FakeRepo(refs={tag_ref("v1.1.0"): ("commit-release", RELEASE_DATE)}),
+            plugin(version="1.0.0-unstable-2024-01-15", date=RELEASE_DATE),
+            "v1.1.0",
+            ("commit-release", RELEASE_DATE, "1.1.0", "v1.1.0"),
+        ),
+        (
+            FakeRepo(latest_commit=("commit-head", HEAD_DATE)),
+            None,
+            "prerelease",
+            ("commit-head", HEAD_DATE, "0-unstable-2024-02-01", None),
+        ),
+    ],
+)
+def test_auto_branch_selects_expected_target(
+    repo: FakeRepo,
+    current: update.Plugin | None,
+    latest_tag: str,
+    expected: tuple[str, datetime, str, str | None],
+) -> None:
+    assert update.select_plugin_target(plugin_desc(repo), current, latest_tag) == expected
 
 
 def test_explicit_branch_bypasses_release_heuristic() -> None:
@@ -89,6 +90,90 @@ def test_explicit_branch_bypasses_release_heuristic() -> None:
         "1.1.0-unstable-2024-03-01",
         None,
     )
+
+
+def test_get_current_plugins_handles_realistic_mixed_eval_output(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        update,
+        "run_nix_expr",
+        Mock(
+            return_value={
+                "friendly-name": {
+                    "pname": "actual.nvim",
+                    "version": "2.4.0",
+                    "homePage": "https://github.com/owner/actual.nvim",
+                    "checksum": {
+                        "rev": "release-commit",
+                        "submodules": False,
+                        "sha256": "sha256-release",
+                        "tag": "v2.4.0",
+                    },
+                    "license": "Apache-2.0",
+                },
+                "unstable-plugin": {
+                    "pname": "unstable-plugin",
+                    "version": "1.9.0-unstable-2024-05-06",
+                    "homePage": "https://github.com/owner/unstable-plugin",
+                    "checksum": {
+                        "rev": "unstable-commit",
+                        "submodules": True,
+                        "sha256": "sha256-unstable",
+                    },
+                },
+            }
+        ),
+    )
+    editor = update.Editor("vim", tmp_path, "unused")
+
+    plugins = editor.get_current_plugins(update.FetchConfig(1, "token"), str(tmp_path))
+
+    tagged_desc, tagged = plugins[0]
+    unstable_desc, unstable = plugins[1]
+    assert tagged_desc.name == "friendly-name"
+    assert tagged_desc.branch == update.AUTO_BRANCH
+    assert tagged_desc.repo.name == "actual.nvim"
+    assert tagged_desc.repo.token == "token"
+    assert tagged.name == "actual.nvim"
+    assert tagged.tag == "v2.4.0"
+    assert tagged.date is None
+    assert tagged.last_tag is None
+    assert tagged.license == "Apache-2.0"
+    assert unstable_desc.name == "unstable-plugin"
+    assert unstable_desc.branch == update.AUTO_BRANCH
+    assert unstable.tag is None
+    assert unstable.date == datetime(2024, 5, 6)
+    assert unstable.last_tag == "1.9.0"
+    assert unstable.has_submodules is True
+    assert unstable.license is None
+
+
+def test_get_current_plugins_rejects_unparseable_unstable_version(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        update,
+        "run_nix_expr",
+        Mock(
+            return_value={
+                "bad-plugin": {
+                    "pname": "bad-plugin",
+                    "version": "unstable",
+                    "homePage": "https://github.com/owner/bad-plugin",
+                    "checksum": {
+                        "rev": "abcdef",
+                        "submodules": False,
+                        "sha256": "sha256-example",
+                    },
+                },
+            }
+        ),
+    )
+    editor = update.Editor("vim", tmp_path, "unused")
+
+    with pytest.raises(ValueError, match="Cannot parse unstable version"):
+        editor.get_current_plugins(update.FetchConfig(1, ""), str(tmp_path))
 
 
 def test_cache_keys_include_repo_and_selected_ref() -> None:
@@ -400,6 +485,98 @@ def test_cache_store_load_round_trips_plugins(
         tag="v1.2.3",
         license="MIT",
     )
+
+
+def test_cache_load_reads_realistic_tag_and_commit_entries(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    cache_file_name = "nixpkgs-plugin-update-test-cache.json"
+    cache_file = tmp_path / cache_file_name
+    cache_file.write_text(
+        json.dumps(
+            {
+                "https://github.com/owner/release@refs/tags/v2.4.0": {
+                    "name": "release",
+                    "commit": "release-commit",
+                    "has_submodules": False,
+                    "sha256": "sha256-release",
+                    "version": "2.4.0",
+                    "last_tag": None,
+                    "tag": "v2.4.0",
+                    "license": "Apache-2.0",
+                },
+                "https://github.com/owner/nightly@commit-head": {
+                    "name": "nightly",
+                    "commit": "commit-head",
+                    "has_submodules": True,
+                    "sha256": "sha256-nightly",
+                    "version": "1.9.0-unstable-2024-05-06",
+                    "last_tag": "v1.9.0",
+                    "tag": None,
+                    "license": None,
+                },
+            }
+        )
+    )
+
+    cache = update.Cache([], cache_file_name)
+
+    release = cache["https://github.com/owner/release@refs/tags/v2.4.0"]
+    nightly = cache["https://github.com/owner/nightly@commit-head"]
+    assert release == plugin(
+        name="release",
+        commit="release-commit",
+        has_submodules=False,
+        sha256="sha256-release",
+        version="2.4.0",
+        date=None,
+        last_tag=None,
+        tag="v2.4.0",
+        license="Apache-2.0",
+    )
+    assert nightly == plugin(
+        name="nightly",
+        commit="commit-head",
+        has_submodules=True,
+        sha256="sha256-nightly",
+        version="1.9.0-unstable-2024-05-06",
+        date=None,
+        last_tag="v1.9.0",
+        tag=None,
+        license=None,
+    )
+
+
+def test_prefetch_plugin_uses_real_github_repo_commit_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    head_date = BOUNDARY_DATE
+    repo = update.RepoGitHub("owner", "repo", "")
+    monkeypatch.setattr(repo, "get_latest_tag", Mock(return_value=None))
+    monkeypatch.setattr(repo, "latest_commit", Mock(return_value=("commit-head", head_date)))
+    monkeypatch.setattr(repo, "has_submodules", Mock(return_value=False))
+    monkeypatch.setattr(repo, "prefetch_github", Mock(return_value="sha256-github"))
+    monkeypatch.setattr(repo, "get_license_spdx_id", Mock(return_value="MIT"))
+
+    fetched, redirect = update.prefetch_plugin(
+        update.PluginDesc(repo, update.AUTO_BRANCH, None),
+        cache=FakeCache(),
+    )
+
+    assert redirect is None
+    assert fetched == plugin(
+        name="repo",
+        commit="commit-head",
+        has_submodules=False,
+        sha256="sha256-github",
+        version="0-unstable-2024-05-06",
+        date=head_date,
+        last_tag=None,
+        tag=None,
+        license="MIT",
+    )
+    repo.prefetch_github.assert_called_once_with("commit-head")
 
 
 def test_check_results_rewrites_redirected_plugin_name() -> None:

--- a/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/tests/test_targets.py
+++ b/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/tests/test_targets.py
@@ -1,0 +1,445 @@
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+import nixpkgs_plugin_update as update
+from helpers import FakeCache, FakeRepo, plugin, plugin_desc
+
+
+RELEASE_DATE = datetime(2024, 1, 15, tzinfo=timezone.utc)
+HEAD_DATE = datetime(2024, 2, 1, tzinfo=timezone.utc)
+BOUNDARY_DATE = datetime(2024, 5, 6, tzinfo=timezone.utc)
+
+
+def tag_ref(tag: str) -> str:
+    return f"{update.GIT_TAGS_PREFIX}{tag}"
+
+
+def test_auto_branch_without_current_plugin_prefers_release() -> None:
+    repo = FakeRepo(
+        latest_tag="v1.1.0",
+        refs={tag_ref("v1.1.0"): ("commit-release", RELEASE_DATE)},
+    )
+
+    assert update.select_plugin_target(plugin_desc(repo), None, "v1.1.0") == (
+        "commit-release",
+        RELEASE_DATE,
+        "1.1.0",
+        "v1.1.0",
+    )
+
+
+def test_commit_tracked_plugin_newer_than_release_stays_on_commit() -> None:
+    repo = FakeRepo(
+        latest_commit=("commit-head", HEAD_DATE),
+        refs={tag_ref("v1.1.0"): ("commit-release", RELEASE_DATE)},
+    )
+    current = plugin(
+        version="1.0.0-unstable-2024-01-20",
+        date=datetime(2024, 1, 20, tzinfo=timezone.utc),
+    )
+
+    assert update.select_plugin_target(plugin_desc(repo), current, "v1.1.0") == (
+        "commit-head",
+        HEAD_DATE,
+        "1.1.0-unstable-2024-02-01",
+        None,
+    )
+    assert repo.latest_commit_calls == 1
+    assert repo.resolve_ref_calls == [tag_ref("v1.1.0")]
+
+
+def test_commit_tracked_plugin_equal_to_release_switches_to_release() -> None:
+    repo = FakeRepo(
+        refs={tag_ref("v1.1.0"): ("commit-release", RELEASE_DATE)},
+    )
+    current = plugin(
+        version="1.0.0-unstable-2024-01-15",
+        date=RELEASE_DATE,
+    )
+
+    assert update.select_plugin_target(plugin_desc(repo), current, "v1.1.0") == (
+        "commit-release",
+        RELEASE_DATE,
+        "1.1.0",
+        "v1.1.0",
+    )
+
+
+def test_no_usable_release_falls_back_to_latest_commit() -> None:
+    repo = FakeRepo(latest_commit=("commit-head", HEAD_DATE))
+
+    assert update.select_plugin_target(plugin_desc(repo), None, "prerelease") == (
+        "commit-head",
+        HEAD_DATE,
+        "0-unstable-2024-02-01",
+        None,
+    )
+
+
+def test_explicit_branch_bypasses_release_heuristic() -> None:
+    branch_date = datetime(2024, 3, 1, tzinfo=timezone.utc)
+    repo = FakeRepo(refs={"main": ("commit-main", branch_date)})
+
+    assert update.select_plugin_target(plugin_desc(repo, "main"), None, "v1.1.0") == (
+        "commit-main",
+        branch_date,
+        "1.1.0-unstable-2024-03-01",
+        None,
+    )
+
+
+def test_cache_keys_include_repo_and_selected_ref() -> None:
+    current = plugin(tag="v1.2.3")
+    assert (
+        update.plugin_cache_key("https://example.com/repo", current)
+        == f"https://example.com/repo@{update.GIT_TAGS_PREFIX}v1.2.3"
+    )
+    assert (
+        update.target_cache_key("https://example.com/repo", "abcdef", None)
+        == "https://example.com/repo@abcdef"
+    )
+
+
+def test_cache_hit_replaces_metadata_without_mutating_cached_plugin(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    release_date = RELEASE_DATE
+    repo = FakeRepo(
+        latest_tag="v1.1.0",
+        refs={tag_ref("v1.1.0"): ("commit-release", release_date)},
+    )
+    desc = plugin_desc(repo)
+    cached = plugin(
+        name="old-name",
+        commit="commit-release",
+        version="old",
+        tag="v1.1.0",
+        license="MIT",
+    )
+    cache = update.Cache([(desc, cached)], "nixpkgs-plugin-update-test-cache.json")
+
+    fetched, _redirect = update.prefetch_plugin(desc, cache=cache)
+
+    assert fetched.name == "repo"
+    assert fetched.commit == "commit-release"
+    assert fetched.version == "1.1.0"
+    assert fetched.tag == "v1.1.0"
+    assert fetched.license == "MIT"
+    assert cached.name == "old-name"
+    assert cached.version == "old"
+    assert repo.prefetch_calls == []
+
+
+def test_cache_hit_fetches_license_once_when_cache_and_current_plugin_lack_it() -> None:
+    release_date = RELEASE_DATE
+    repo = FakeRepo(
+        latest_tag="v1.1.0",
+        refs={tag_ref("v1.1.0"): ("commit-release", release_date)},
+        license_spdx_id="Apache-2.0",
+    )
+    desc = plugin_desc(repo)
+    cached = plugin(commit="commit-release", version="old", tag="v1.1.0", license=None)
+    cache = FakeCache(
+        {update.target_cache_key(repo.uri, "commit-release", "v1.1.0"): cached}
+    )
+
+    fetched, _redirect = update.prefetch_plugin(desc, cache=cache)
+
+    assert fetched.license == "Apache-2.0"
+    assert repo.license_calls == 1
+    assert repo.prefetch_calls == []
+
+
+def test_prefetch_plugin_reuses_current_license_before_fetching_license() -> None:
+    head_date = datetime(2024, 2, 1, tzinfo=timezone.utc)
+    repo = FakeRepo(latest_commit=("commit-head", head_date))
+    current = plugin(license="Apache-2.0")
+
+    fetched, _redirect = update.prefetch_plugin(
+        plugin_desc(repo), current_plugin=current
+    )
+
+    assert fetched.license == "Apache-2.0"
+    assert repo.license_calls == 0
+    assert repo.prefetch_calls == ["commit-head"]
+    assert repo.prefetch_call_details == [("commit-head", None)]
+    assert repo.get_latest_tag_calls == 1
+    assert repo.latest_commit_calls == 1
+    assert repo.has_submodules_calls == 1
+
+
+def test_prefetch_plugin_cache_miss_fetches_selected_tag_ref() -> None:
+    release_date = RELEASE_DATE
+    repo = FakeRepo(
+        latest_tag="v1.1.0",
+        refs={tag_ref("v1.1.0"): ("commit-release", release_date)},
+        license_spdx_id="Apache-2.0",
+        has_submodules=True,
+    )
+    cache = FakeCache()
+
+    fetched, _redirect = update.prefetch_plugin(plugin_desc(repo), cache=cache)
+
+    assert fetched.commit == "commit-release"
+    assert fetched.tag == "v1.1.0"
+    assert fetched.has_submodules is True
+    assert fetched.sha256 == "sha256-prefetched"
+    assert fetched.license == "Apache-2.0"
+    assert repo.prefetch_call_details == [(tag_ref("v1.1.0"), None)]
+    assert repo.license_calls == 1
+
+
+def test_prefetch_stores_fetched_plugin_in_cache() -> None:
+    head_date = HEAD_DATE
+    repo = FakeRepo(latest_commit=("commit-head", head_date), license_spdx_id="MIT")
+    desc = plugin_desc(repo)
+    cache = FakeCache()
+
+    result_desc, result, redirect = update.prefetch(desc, cache)
+
+    assert result_desc is desc
+    assert isinstance(result, update.Plugin)
+    assert redirect is None
+    assert result.license == "MIT"
+    assert cache[update.target_cache_key(repo.uri, "commit-head", None)] is result
+    assert repo.get_latest_tag_calls == 1
+    assert repo.latest_commit_calls == 1
+    assert repo.has_submodules_calls == 1
+    assert repo.prefetch_call_details == [("commit-head", None)]
+    assert repo.license_calls == 1
+
+
+def test_prefetch_uses_current_plugin_metadata_and_real_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    head_date = HEAD_DATE
+    repo = FakeRepo(latest_commit=("commit-head", head_date), name="foo.nvim")
+    desc = plugin_desc(repo)
+    cache = update.Cache([], "nixpkgs-plugin-update-test-cache.json")
+    current_plugins = {
+        "foo-nvim": plugin(name="foo.nvim", license="Apache-2.0"),
+    }
+
+    result_desc, result, redirect = update.prefetch(desc, cache, current_plugins)
+
+    assert result_desc is desc
+    assert isinstance(result, update.Plugin)
+    assert redirect is None
+    assert result.name == "foo.nvim"
+    assert result.version == "0-unstable-2024-02-01"
+    assert result.license == "Apache-2.0"
+    assert cache[update.target_cache_key(repo.uri, "commit-head", None)] is result
+    assert repo.get_latest_tag_calls == 1
+    assert repo.latest_commit_calls == 1
+    assert repo.has_submodules_calls == 1
+    assert repo.prefetch_call_details == [("commit-head", None)]
+
+
+def test_get_update_counts_prefetches_and_stores_cache_once(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    release_date = RELEASE_DATE
+    head_date = HEAD_DATE
+    cached_repo = FakeRepo(
+        name="cached",
+        uri="https://example.com/owner/cached",
+        latest_tag="v1.1.0",
+        refs={f"{update.GIT_TAGS_PREFIX}v1.1.0": ("cached-release", release_date)},
+    )
+    missing_repo = FakeRepo(
+        name="missing",
+        uri="https://example.com/owner/missing",
+        latest_commit=("missing-head", head_date),
+        license_spdx_id="Apache-2.0",
+    )
+    kept_repo = FakeRepo(
+        name="kept",
+        uri="https://example.com/owner/kept",
+        latest_commit=("kept-head", head_date),
+    )
+    cached_desc = plugin_desc(cached_repo)
+    missing_desc = plugin_desc(missing_repo)
+    kept_desc = plugin_desc(kept_repo)
+    current_plugins = [
+        (cached_desc, plugin(name="cached", commit="cached-current", version="1.0.0")),
+        (
+            missing_desc,
+            plugin(name="missing", commit="missing-current", version="1.0.0"),
+        ),
+        (kept_desc, plugin(name="kept", commit="kept-current", version="1.0.0")),
+    ]
+
+    class CountingCache(FakeCache):
+        def __init__(self) -> None:
+            super().__init__(
+                {
+                    update.target_cache_key(
+                        cached_repo.uri,
+                        "cached-release",
+                        "v1.1.0",
+                    ): plugin(
+                        name="cached",
+                        commit="cached-release",
+                        version="1.1.0",
+                        tag="v1.1.0",
+                        license="MIT",
+                    ),
+                }
+            )
+            self.store_calls = 0
+
+        def store(self) -> None:
+            self.store_calls += 1
+
+    class CountingPool:
+        def __init__(self, processes: int) -> None:
+            self.processes = processes
+            pool_processes.append(processes)
+
+        def map(self, func, items):  # type: ignore[no-untyped-def]
+            mapped_items.extend(items)
+            return [func(item) for item in items]
+
+    cache = CountingCache()
+    generated_plugins: list[tuple[update.PluginDesc, update.Plugin]] = []
+    pool_processes: list[int] = []
+    mapped_items: list[update.PluginDesc] = []
+    editor = update.Editor("vim", tmp_path, "unused")
+    editor.nixpkgs = str(tmp_path)
+
+    monkeypatch.setattr(update, "Cache", Mock(return_value=cache))
+    monkeypatch.setattr(update, "Pool", CountingPool)
+    monkeypatch.setattr(
+        editor,
+        "get_current_plugins",
+        Mock(return_value=current_plugins),
+    )
+    monkeypatch.setattr(
+        editor,
+        "load_plugin_spec",
+        Mock(return_value=[cached_desc, missing_desc, kept_desc]),
+    )
+    monkeypatch.setattr(
+        editor,
+        "generate_nix",
+        Mock(side_effect=lambda plugins, _outfile: generated_plugins.extend(plugins)),
+    )
+
+    run_update = editor.get_update(
+        "plugin-names",
+        "generated.nix",
+        update.FetchConfig(2, ""),
+        ["cached", "missing"],
+    )
+    redirects, updated_plugins = run_update()
+
+    assert redirects == {}
+    assert updated_plugins == [
+        ("cached", "1.0.0", "1.1.0"),
+        ("missing", "1.0.0", "0-unstable-2024-02-01"),
+    ]
+    assert pool_processes == [2]
+    assert mapped_items == [cached_desc, missing_desc]
+    assert cache.store_calls == 1
+    assert [plugin.name for _desc, plugin in generated_plugins] == [
+        "cached",
+        "kept",
+        "missing",
+    ]
+    assert missing_repo.prefetch_call_details == [("missing-head", False)]
+    assert kept_repo.prefetch_calls == []
+
+
+def test_prefetch_returns_exception_when_selected_tag_cannot_be_resolved() -> None:
+    repo = FakeRepo(latest_tag="v9.9.9")
+    desc = plugin_desc(repo)
+
+    result_desc, result, redirect = update.prefetch(desc, FakeCache())
+
+    assert result_desc is desc
+    assert isinstance(result, AssertionError)
+    assert "refs/tags/v9.9.9" in str(result)
+    assert redirect is None
+
+
+def test_cache_store_load_round_trips_plugins(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    cache_file_name = "nixpkgs-plugin-update-test-cache.json"
+    current = plugin(
+        name="example-plugin",
+        commit="abcdef",
+        has_submodules=True,
+        sha256="sha256-example",
+        version="1.2.3",
+        last_tag=None,
+        tag="v1.2.3",
+        license="MIT",
+    )
+    desc = plugin_desc(FakeRepo(uri="https://example.com/owner/example-plugin"))
+
+    cache = update.Cache([(desc, current)], cache_file_name)
+    cache.store()
+    loaded_cache = update.Cache([], cache_file_name)
+
+    loaded = loaded_cache["https://example.com/owner/example-plugin@refs/tags/v1.2.3"]
+    assert loaded == plugin(
+        name="example-plugin",
+        commit="abcdef",
+        has_submodules=True,
+        sha256="sha256-example",
+        version="1.2.3",
+        date=None,
+        last_tag=None,
+        tag="v1.2.3",
+        license="MIT",
+    )
+
+
+def test_check_results_rewrites_redirected_plugin_name() -> None:
+    old_desc = plugin_desc(FakeRepo(name="old-repo"))
+    redirect = FakeRepo(name="new-repo", uri="https://example.com/owner/new-repo")
+    fetched = plugin(name="old-repo")
+
+    plugins, redirects = update.check_results([(old_desc, fetched, redirect)])
+
+    assert redirects == {old_desc: redirect}
+    new_desc, new_plugin = plugins[0]
+    assert new_desc.repo is redirect
+    assert new_desc.name == "new-repo"
+    assert new_plugin.name == "new-repo"
+
+
+def test_github_as_nix_uses_tag_when_available() -> None:
+    assert (
+        update.RepoGitHub("owner", "repo", "").as_nix(
+            plugin(commit="abcdef", sha256="sha256-example", tag="v1.2.3")
+        )
+        == """fetchFromGitHub {
+      owner = "owner";
+      repo = "repo";
+      tag = "v1.2.3";
+      hash = "sha256-example";
+    }"""
+    )
+
+
+def test_github_as_nix_uses_rev_and_submodules_without_tag() -> None:
+    assert (
+        update.RepoGitHub("owner", "repo", "").as_nix(
+            plugin(commit="abcdef", has_submodules=True, sha256="sha256-example")
+        )
+        == """fetchFromGitHub {
+      owner = "owner";
+      repo = "repo";
+      rev = "abcdef";
+      hash = "sha256-example";
+      fetchSubmodules = true;
+    }"""
+    )

--- a/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/tests/test_targets.py
+++ b/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/tests/test_targets.py
@@ -1,4 +1,5 @@
 import json
+import urllib.error
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import Mock
@@ -6,12 +7,27 @@ from unittest.mock import Mock
 import pytest
 
 import nixpkgs_plugin_update as update
-from helpers import FakeCache, FakeRepo, plugin, plugin_desc
+from helpers import (
+    BinaryResponse,
+    BoundaryRecorder,
+    FakeCache,
+    FakeRepo,
+    GITHUB_LICENSE_URL,
+    GITHUB_REPO_URL,
+    GITHUB_TAGS_ATOM_URL,
+    JsonResponse,
+    atom_feed,
+    plugin,
+    plugin_desc,
+)
 
 
 RELEASE_DATE = datetime(2024, 1, 15, tzinfo=timezone.utc)
 HEAD_DATE = datetime(2024, 2, 1, tzinfo=timezone.utc)
 BOUNDARY_DATE = datetime(2024, 5, 6, tzinfo=timezone.utc)
+GITHUB_REPO_GIT_URL = f"{GITHUB_REPO_URL}/"
+GITHUB_SUBMODULES_URL = f"{GITHUB_REPO_URL}/blob/HEAD/.gitmodules"
+GITHUB_TAG_TREE_URL = f"{GITHUB_REPO_URL}/tree/refs%2Ftags%2Fv1.2.3"
 
 
 def tag_ref(tag: str) -> str:
@@ -240,8 +256,10 @@ def test_cache_hit_fetches_license_once_when_cache_and_current_plugin_lack_it() 
 
 
 def test_prefetch_plugin_reuses_current_license_before_fetching_license() -> None:
-    head_date = datetime(2024, 2, 1, tzinfo=timezone.utc)
-    repo = FakeRepo(latest_commit=("commit-head", head_date))
+    head_date = HEAD_DATE
+    repo = FakeRepo(
+        latest_commit=("commit-head", head_date),
+    )
     current = plugin(license="Apache-2.0")
 
     fetched, _redirect = update.prefetch_plugin(
@@ -249,12 +267,8 @@ def test_prefetch_plugin_reuses_current_license_before_fetching_license() -> Non
     )
 
     assert fetched.license == "Apache-2.0"
+    assert repo.prefetch_call_details == [("commit-head", False)]
     assert repo.license_calls == 0
-    assert repo.prefetch_calls == ["commit-head"]
-    assert repo.prefetch_call_details == [("commit-head", None)]
-    assert repo.get_latest_tag_calls == 1
-    assert repo.latest_commit_calls == 1
-    assert repo.has_submodules_calls == 1
 
 
 def test_prefetch_plugin_cache_miss_fetches_selected_tag_ref() -> None:
@@ -274,7 +288,7 @@ def test_prefetch_plugin_cache_miss_fetches_selected_tag_ref() -> None:
     assert fetched.has_submodules is True
     assert fetched.sha256 == "sha256-prefetched"
     assert fetched.license == "Apache-2.0"
-    assert repo.prefetch_call_details == [(tag_ref("v1.1.0"), None)]
+    assert repo.prefetch_call_details == [(tag_ref("v1.1.0"), True)]
     assert repo.license_calls == 1
 
 
@@ -291,10 +305,7 @@ def test_prefetch_stores_fetched_plugin_in_cache() -> None:
     assert redirect is None
     assert result.license == "MIT"
     assert cache[update.target_cache_key(repo.uri, "commit-head", None)] is result
-    assert repo.get_latest_tag_calls == 1
-    assert repo.latest_commit_calls == 1
-    assert repo.has_submodules_calls == 1
-    assert repo.prefetch_call_details == [("commit-head", None)]
+    assert repo.prefetch_call_details == [("commit-head", False)]
     assert repo.license_calls == 1
 
 
@@ -319,10 +330,8 @@ def test_prefetch_uses_current_plugin_metadata_and_real_cache(
     assert result.version == "0-unstable-2024-02-01"
     assert result.license == "Apache-2.0"
     assert cache[update.target_cache_key(repo.uri, "commit-head", None)] is result
-    assert repo.get_latest_tag_calls == 1
-    assert repo.latest_commit_calls == 1
-    assert repo.has_submodules_calls == 1
-    assert repo.prefetch_call_details == [("commit-head", None)]
+    assert repo.prefetch_call_details == [("commit-head", False)]
+    assert repo.license_calls == 0
 
 
 def test_get_update_counts_prefetches_and_stores_cache_once(
@@ -548,16 +557,98 @@ def test_cache_load_reads_realistic_tag_and_commit_entries(
     )
 
 
-def test_prefetch_plugin_uses_real_github_repo_commit_path(
+@pytest.mark.parametrize(
+    (
+        "has_submodules",
+        "license_spdx_id",
+        "expected_sha256",
+        "expected_prefetch_cmd",
+    ),
+    [
+        (
+            False,
+            "MIT",
+            "sha256-github",
+            (
+                "nix-prefetch-github",
+                "owner",
+                "repo",
+                "--rev",
+                tag_ref("v1.2.3"),
+                "--json",
+            ),
+        ),
+        (
+            True,
+            "Apache-2.0",
+            "sha256-git",
+            (
+                "nix-prefetch-git",
+                "--quiet",
+                "--fetch-submodules",
+                GITHUB_REPO_GIT_URL,
+                tag_ref("v1.2.3"),
+            ),
+        ),
+    ],
+)
+def test_prefetch_plugin_real_github_cache_miss_counts_boundary_calls(
     monkeypatch: pytest.MonkeyPatch,
+    has_submodules: bool,
+    license_spdx_id: str,
+    expected_sha256: str,
+    expected_prefetch_cmd: tuple[str, ...],
 ) -> None:
-    head_date = BOUNDARY_DATE
     repo = update.RepoGitHub("owner", "repo", "")
-    monkeypatch.setattr(repo, "get_latest_tag", Mock(return_value=None))
-    monkeypatch.setattr(repo, "latest_commit", Mock(return_value=("commit-head", head_date)))
-    monkeypatch.setattr(repo, "has_submodules", Mock(return_value=False))
-    monkeypatch.setattr(repo, "prefetch_github", Mock(return_value="sha256-github"))
-    monkeypatch.setattr(repo, "get_license_spdx_id", Mock(return_value="MIT"))
+    repo.token = ""
+    recorder = BoundaryRecorder()
+
+    def fake_urlopen(request, timeout: int):  # type: ignore[no-untyped-def]
+        recorder.record_urlopen(request, timeout)
+        assert timeout == 10
+        if request.full_url == GITHUB_TAGS_ATOM_URL:
+            return BinaryResponse(atom_feed("v1.2.3"), request.full_url)
+        if request.full_url == GITHUB_TAG_TREE_URL:
+            return BinaryResponse(url=request.full_url)
+        if request.full_url == GITHUB_SUBMODULES_URL:
+            if not has_submodules:
+                raise urllib.error.HTTPError(request.full_url, 404, "", {}, None)
+            return BinaryResponse(url=request.full_url)
+        if request.full_url == GITHUB_LICENSE_URL:
+            return JsonResponse({"license": {"spdx_id": license_spdx_id}})
+        raise AssertionError(f"unexpected request: {request.full_url}")
+
+    def fake_check_output(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        recorder.record_check_output(cmd, kwargs)
+        if tuple(cmd) == (
+            "nix-prefetch-git",
+            "--quiet",
+            GITHUB_REPO_GIT_URL,
+            tag_ref("v1.2.3"),
+        ):
+            assert kwargs == {}
+            return json.dumps(
+                {
+                    "rev": "release-commit",
+                    "date": "2024-05-06T00:00:00+0000",
+                    "sha256": "sha256-resolve-only",
+                }
+            ).encode()
+        if tuple(cmd) == expected_prefetch_cmd:
+            assert kwargs == {}
+            if has_submodules:
+                return json.dumps(
+                    {
+                        "rev": "release-commit",
+                        "date": "2024-05-06T00:00:00+0000",
+                        "sha256": expected_sha256,
+                    }
+                ).encode()
+            return json.dumps({"hash": expected_sha256}).encode()
+        raise AssertionError(f"unexpected subprocess call: {cmd!r}")
+
+    monkeypatch.setattr(update.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(update.subprocess, "check_output", fake_check_output)
 
     fetched, redirect = update.prefetch_plugin(
         update.PluginDesc(repo, update.AUTO_BRANCH, None),
@@ -567,16 +658,123 @@ def test_prefetch_plugin_uses_real_github_repo_commit_path(
     assert redirect is None
     assert fetched == plugin(
         name="repo",
-        commit="commit-head",
+        commit="release-commit",
+        has_submodules=has_submodules,
+        sha256=expected_sha256,
+        version="1.2.3",
+        date=BOUNDARY_DATE,
+        last_tag="v1.2.3",
+        tag="v1.2.3",
+        license=license_spdx_id,
+    )
+    urlopen_calls = [call for call in recorder.calls if call[0] == "urlopen"]
+    check_output_calls = [call for call in recorder.calls if call[0] == "check_output"]
+    resolve_cmd = (
+        "nix-prefetch-git",
+        "--quiet",
+        GITHUB_REPO_GIT_URL,
+        tag_ref("v1.2.3"),
+    )
+
+    assert urlopen_calls.count(("urlopen", GITHUB_TAGS_ATOM_URL, {"timeout": 10})) == 1
+    assert urlopen_calls.count(("urlopen", GITHUB_TAG_TREE_URL, {"timeout": 10})) == 1
+    assert (
+        urlopen_calls.count(("urlopen", GITHUB_SUBMODULES_URL, {"timeout": 10})) == 1
+    )
+    assert urlopen_calls.count(("urlopen", GITHUB_LICENSE_URL, {"timeout": 10})) == 1
+    assert check_output_calls == [
+        ("check_output", resolve_cmd, {}),
+        ("check_output", expected_prefetch_cmd, {}),
+    ]
+
+
+@pytest.mark.parametrize(
+    (
+        "latest_tag",
+        "resolved",
+        "expected_commit",
+        "expected_version",
+        "expected_tag",
+        "expected_prefetch_ref",
+    ),
+    [
+        (
+            None,
+            None,
+            "commit-head",
+            "0-unstable-2024-05-06",
+            None,
+            "commit-head",
+        ),
+        (
+            "v1.2.3",
+            ("release-commit", BOUNDARY_DATE),
+            "release-commit",
+            "1.2.3",
+            "v1.2.3",
+            tag_ref("v1.2.3"),
+        ),
+    ],
+)
+def test_prefetch_plugin_uses_real_github_repo_path_without_duplicate_submodule_check(
+    monkeypatch: pytest.MonkeyPatch,
+    latest_tag: str | None,
+    resolved: tuple[str, datetime] | None,
+    expected_commit: str,
+    expected_version: str,
+    expected_tag: str | None,
+    expected_prefetch_ref: str,
+) -> None:
+    repo = update.RepoGitHub("owner", "repo", "")
+    get_latest_tag = Mock(
+        return_value=latest_tag
+    )
+    latest_commit = Mock(side_effect=AssertionError("unexpected latest_commit"))
+    if latest_tag is None:
+        latest_commit = Mock(return_value=("commit-head", BOUNDARY_DATE))
+    resolve_ref = Mock(
+        return_value=resolved
+    )
+    has_submodules = Mock(return_value=False)
+    prefetch_github = Mock(return_value="sha256-github")
+    base_prefetch = Mock(side_effect=AssertionError("unexpected git prefetch"))
+    get_license_spdx_id = Mock(return_value="MIT")
+    monkeypatch.setattr(repo, "get_latest_tag", get_latest_tag)
+    monkeypatch.setattr(repo, "latest_commit", latest_commit)
+    monkeypatch.setattr(repo, "resolve_ref", resolve_ref)
+    monkeypatch.setattr(repo, "has_submodules", has_submodules)
+    monkeypatch.setattr(repo, "prefetch_github", prefetch_github)
+    monkeypatch.setattr(update.Repo, "prefetch", base_prefetch)
+    monkeypatch.setattr(repo, "get_license_spdx_id", get_license_spdx_id)
+
+    fetched, redirect = update.prefetch_plugin(
+        update.PluginDesc(repo, update.AUTO_BRANCH, None),
+        cache=FakeCache(),
+    )
+
+    assert redirect is None
+    assert fetched == plugin(
+        name="repo",
+        commit=expected_commit,
         has_submodules=False,
         sha256="sha256-github",
-        version="0-unstable-2024-05-06",
-        date=head_date,
-        last_tag=None,
-        tag=None,
+        version=expected_version,
+        date=BOUNDARY_DATE,
+        last_tag=latest_tag,
+        tag=expected_tag,
         license="MIT",
     )
-    repo.prefetch_github.assert_called_once_with("commit-head")
+    get_latest_tag.assert_called_once_with()
+    if latest_tag is None:
+        latest_commit.assert_called_once_with()
+        resolve_ref.assert_not_called()
+    else:
+        latest_commit.assert_not_called()
+        resolve_ref.assert_called_once_with(tag_ref("v1.2.3"))
+    has_submodules.assert_called_once_with()
+    prefetch_github.assert_called_once_with(expected_prefetch_ref)
+    base_prefetch.assert_not_called()
+    get_license_spdx_id.assert_called_once_with()
 
 
 def test_check_results_rewrites_redirected_plugin_name() -> None:


### PR DESCRIPTION
Find myself afraid to touch a lot of the script due to the various permutations of implicit behavior and edge cases. I know @PerchunPak has similar opinions on the current state of the script design. Wanted to add some tests to make side effects of changes more obvious and easier to refactor / break up the updater into more maintainable code. 

This enables pytest for `nixpkgs-plugin-update` and adds coverage for:

  - GitHub metadata fetching and fallback paths
  - tag selection behavior
  - target selection behavior
  - cache handling
  - redirect handling
  - license metadata reuse
  - submodule-aware prefetching

  While adding tests and running recent Vim plugin updates, a few small fixes fell out:

  - fall back from GitHub GraphQL to Atom/`git ls-remote` when needed
  - preserve slash-containing tags from GitHub Atom feeds
  - avoid duplicate submodule checks during prefetch
  - keep unstable version prefixes from moving backward when staying on a newer HEAD commit

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
