### PR TITLE
endcord: init at 1.4.2

### DIFF
--- a/pkgs/by-name/en/endcord/package.nix
+++ b/pkgs/by-name/en/endcord/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  python313Packages,
+  fetchFromGitHub,
+  makeWrapper,
+}:
+python313Packages.buildPythonApplication (finalAttrs: {
+  pname = "endcord";
+  version = "1.4.2";
+  src = fetchFromGitHub {
+    owner = "sparklost";
+    repo = "endcord";
+    tag = "${finalAttrs.version}";
+    sha256 = "sha256-YY9NRK5ZXH5Ry7FCGQ158AySRcPwr+jNh2QrcP1YlV4=";
+  };
+  propagatedBuildInputs = with python313Packages; [
+    filetype
+    numpy
+    orjson
+    protobuf
+    pycryptodome
+    pysocks
+    python-socks
+    qrcode
+    soundcard
+    soundfile
+    urllib3
+    websocket-client
+    emoji
+    pynacl
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  pythonRelaxDeps = true;
+  pyproject = true;
+  build-system = with python313Packages; [
+    setuptools
+    wheel
+    cython
+  ];
+  postInstall = ''
+    install -Dm644 $src/main.py "$out/${python313Packages.python.sitePackages}/main.py"
+    cp -r $src/endcord "$out/${python313Packages.python.sitePackages}/endcord"
+    makeWrapper ${python313Packages.python.interpreter} $out/bin/endcord \
+      --add-flags "$out/${python313Packages.python.sitePackages}/main.py" \
+      --prefix PYTHONPATH : "$out/${python313Packages.python.sitePackages}:${python313Packages.makePythonPath finalAttrs.propagatedBuildInputs}"
+  '';
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Feature rich Discord TUI client.";
+    homepage = "https://github.com/sparklost/endcord";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ Simon-Weij ];
+    platforms = lib.platforms.linux;
+    mainProgram = "endcord";
+  };
+})


### PR DESCRIPTION
https://github.com/sparklost/endcord

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
