### PR TITLE
vimPlugins.{BufOnly-vim, caw-vim, colorizer, Colour-Sampler-Pack, ...}: override license

### DIFF
--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -3752,6 +3752,12 @@ assertNoAdditions {
     dependencies = [ self.plenary-nvim ];
   };
 
+  PreserveNoEOL = super.PreserveNoEOL.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.vim;
+    };
+  });
+
   Preview-nvim = super.Preview-nvim.overrideAttrs {
     runtimeDeps = [
       md-tui

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -445,6 +445,12 @@ assertNoAdditions {
     nvimSkipModules = [ "bufferline.commands" ];
   };
 
+  BufOnly-vim = super.BufOnly-vim.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.vim;
+    };
+  });
+
   bufresize-nvim = super.bufresize-nvim.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.mit;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -2954,8 +2954,11 @@ assertNoAdditions {
     dependencies = [ self.plenary-nvim ];
   };
 
-  NotebookNavigator-nvim = super.NotebookNavigator-nvim.overrideAttrs {
-  };
+  NotebookNavigator-nvim = super.NotebookNavigator-nvim.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
 
   NrrwRgn = super.NrrwRgn.overrideAttrs (old: {
     meta = old.meta // {

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -1826,6 +1826,12 @@ assertNoAdditions {
     doInstallCheck = true;
   };
 
+  Improved-AnsiEsc = super.Improved-AnsiEsc.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.vim;
+    };
+  });
+
   indent-blankline-nvim = super.indent-blankline-nvim.overrideAttrs {
     # Meta file
     nvimSkipModules = "ibl.config.types";

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -363,6 +363,12 @@ assertNoAdditions {
     };
   });
 
+  bclose-vim = super.bclose-vim.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.cc-by-sa-30;
+    };
+  });
+
   bitbake = super.bitbake.overrideAttrs (old: {
     sourceRoot = "source/contrib/vim";
     meta = old.meta // {

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -3898,6 +3898,12 @@ assertNoAdditions {
     ];
   };
 
+  Rename = super.Rename.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.vim;
+    };
+  });
+
   renamer-nvim = super.renamer-nvim.overrideAttrs {
     dependencies = [ self.plenary-nvim ];
   };

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -910,6 +910,12 @@ assertNoAdditions {
     ];
   };
 
+  Colour-Sampler-Pack = super.Colour-Sampler-Pack.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.publicDomain;
+    };
+  });
+
   command-t = super.command-t.overrideAttrs {
     nativeBuildInputs = [
       getconf

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -3800,6 +3800,12 @@ assertNoAdditions {
     nvimSkipModules = "pywal.feline";
   };
 
+  QFEnter = super.QFEnter.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
+
   qmk-nvim = super.qmk-nvim.overrideAttrs {
     dependencies = [ self.plenary-nvim ];
     nvimSkipModules = [

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5557,6 +5557,12 @@ assertNoAdditions {
     };
   });
 
+  VimOrganizer = super.VimOrganizer.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.vim;
+    };
+  });
+
   vimoutliner = super.vimoutliner.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.gpl3Only;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -6004,6 +6004,12 @@ assertNoAdditions {
     ];
   };
 
+  whitespace-nvim = super.whitespace-nvim.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
+
   wiki-vim = super.wiki-vim.overrideAttrs {
     checkInputs = [
       # Optional picker integration

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -2667,9 +2667,12 @@ assertNoAdditions {
     dependencies = [ self.neco-syntax ];
   };
 
-  ncm2-ultisnips = super.ncm2-ultisnips.overrideAttrs {
+  ncm2-ultisnips = super.ncm2-ultisnips.overrideAttrs (old: {
     dependencies = [ self.ultisnips ];
-  };
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
 
   neco-ghc = super.neco-ghc.overrideAttrs (old: {
     meta = old.meta // {

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5722,6 +5722,7 @@ assertNoAdditions {
     dependencies = [ self.vim-textobj-user ];
     meta = old.meta // {
       maintainers = with lib.maintainers; [ workflow ];
+      license = lib.licenses.mit;
     };
   });
 

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5486,6 +5486,12 @@ assertNoAdditions {
     };
   });
 
+  vim-operator-replace = super.vim-operator-replace.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
+
   vim-operator-surround = super.vim-operator-surround.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.mit;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -2628,6 +2628,12 @@ assertNoAdditions {
     dependencies = [ self.nvim-yarp ];
   };
 
+  ncm2-dictionary = super.ncm2-dictionary.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
+
   ncm2-jedi = super.ncm2-jedi.overrideAttrs {
     dependencies = with self; [
       nvim-yarp

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5933,9 +5933,12 @@ assertNoAdditions {
     };
   });
 
-  vimshell-vim = super.vimshell-vim.overrideAttrs {
+  vimshell-vim = super.vimshell-vim.overrideAttrs (old: {
     dependencies = [ self.vimproc-vim ];
-  };
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
 
   vimtex = super.vimtex.overrideAttrs {
     checkInputs = with self; [

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -4398,6 +4398,12 @@ assertNoAdditions {
     };
   });
 
+  tabpagebuffer-vim = super.tabpagebuffer-vim.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
+
   tabular = super.tabular.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.bsd3;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -2900,13 +2900,16 @@ assertNoAdditions {
     ];
   };
 
-  neotest-mocha = super.neotest-mocha.overrideAttrs {
+  neotest-mocha = super.neotest-mocha.overrideAttrs (old: {
     dependencies = with self; [
       neotest
       nvim-nio
       plenary-nvim
     ];
-  };
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
 
   neotest-pest = super.neotest-pest.overrideAttrs {
     dependencies = with self; [

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5542,6 +5542,12 @@ assertNoAdditions {
     };
   });
 
+  vim-prettyprint = super.vim-prettyprint.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.zlib;
+    };
+  });
+
   vim-projectionist = super.vim-projectionist.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.vim;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -4644,6 +4644,12 @@ assertNoAdditions {
     dependencies = [ self.nvzone-volt ];
   };
 
+  timestamp-vim = super.timestamp-vim.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.publicDomain;
+    };
+  });
+
   tinted-vim = super.tinted-vim.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.mit;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5344,6 +5344,7 @@ assertNoAdditions {
       '';
 
     meta = old.meta // {
+      license = lib.licenses.vim;
       platforms = lib.platforms.all;
     };
   });

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5830,6 +5830,16 @@ assertNoAdditions {
     };
   });
 
+  vim-tmux = super.vim-tmux.overrideAttrs (old: {
+    meta = old.meta // {
+      # original code publicDomain, MIT after fork
+      license = with lib.licenses; [
+        mit
+        publicDomain
+      ];
+    };
+  });
+
   vim-tpipeline = super.vim-tpipeline.overrideAttrs {
     # Requires global variable
     nvimSkipModules = "tpipeline.main";

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -3865,6 +3865,12 @@ assertNoAdditions {
     ];
   };
 
+  pgsql-vim = super.pgsql-vim.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.vim;
+    };
+  });
+
   plantuml-nvim = super.plantuml-nvim.overrideAttrs {
     dependencies = [ self.LibDeflate-nvim ];
   };

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5474,6 +5474,12 @@ assertNoAdditions {
     };
   });
 
+  vim-opencl = super.vim-opencl.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.gpl3;
+    };
+  });
+
   vim-openscad = super.vim-openscad.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.publicDomain;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -1910,6 +1910,12 @@ assertNoAdditions {
     };
   });
 
+  iosvkem = super.iosvkem.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.publicDomain;
+    };
+  });
+
   iswap-nvim = super.iswap-nvim.overrideAttrs {
     dependencies = [ self.nvim-treesitter-legacy ];
   };

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5212,6 +5212,12 @@ assertNoAdditions {
     };
   });
 
+  vim-fold-cycle = super.vim-fold-cycle.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.wtfpl;
+    };
+  });
+
   vim-fugitive = super.vim-fugitive.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.vim;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5490,12 +5490,15 @@ assertNoAdditions {
     };
   });
 
-  vim-snipmate = super.vim-snipmate.overrideAttrs {
+  vim-snipmate = super.vim-snipmate.overrideAttrs (old: {
     dependencies = with self; [
       vim-addon-mw-utils
       tlib_vim
     ];
-  };
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
 
   vim-speeddating = super.vim-speeddating.overrideAttrs (old: {
     dependencies = [ self.vim-repeat ];

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -3970,6 +3970,12 @@ assertNoAdditions {
     };
   });
 
+  quickfixstatus = super.quickfixstatus.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.vim;
+    };
+  });
+
   rainbow-delimiters-nvim = super.rainbow-delimiters-nvim.overrideAttrs (old: {
     nvimSkipModules = [
       # rainbow-delimiters.types.lua

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -6170,6 +6170,12 @@ assertNoAdditions {
     ];
   };
 
+  zoomwintab-vim = super.zoomwintab-vim.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.vim;
+    };
+  });
+
   zotcite = super.zotcite.overrideAttrs {
     dependencies = with self; [
       plenary-nvim

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -543,7 +543,7 @@ assertNoAdditions {
     ];
   };
 
-  clang_complete = super.clang_complete.overrideAttrs {
+  clang_complete = super.clang_complete.overrideAttrs (old: {
     # In addition to the arguments you pass to your compiler, you also need to
     # specify the path of the C++ std header (if you are using C++).
     # These usually implicitly set by cc-wrapper around clang (pkgs/build-support/cc-wrapper).
@@ -559,7 +559,14 @@ assertNoAdditions {
             substituteInPlace "$out"/plugin/libclang.py \
               --replace-fail "/usr/lib/clang" "${llvmPackages.clang.cc}/lib/clang"
     '';
-  };
+    meta = old.meta // {
+      # Docs say bsd3, except some LLVM project files under ncsa.
+      license = with lib.licenses; [
+        bsd3
+        ncsa
+      ];
+    };
+  });
 
   clangd_extensions-nvim = super.clangd_extensions-nvim.overrideAttrs (old: {
     meta = old.meta // {

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5498,6 +5498,12 @@ assertNoAdditions {
     };
   });
 
+  vim-operator-user = super.vim-operator-user.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
+
   vim-orgmode = super.vim-orgmode.overrideAttrs (old: {
     meta = old.meta // {
       # Source is AGPL-3.0-only; bundled docs are GFDL-1.3-or-later.

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5680,6 +5680,16 @@ assertNoAdditions {
         };
       });
 
+  vim-sile = super.vim-sile.overrideAttrs (old: {
+    meta = old.meta // {
+      license = with lib.licenses; [
+        bsd0
+        cc0
+        gpl2Plus
+      ];
+    };
+  });
+
   vim-sleuth = super.vim-sleuth.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.vim;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -487,6 +487,12 @@ assertNoAdditions {
     ];
   };
 
+  caw-vim = super.caw-vim.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.bsd3;
+    };
+  });
+
   ccc-nvim = super.ccc-nvim.overrideAttrs {
     # ccc auto-discover requires all pass
     # but there's a bootstrap module that hangs forever if we dont stop on first success

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5548,6 +5548,12 @@ assertNoAdditions {
     };
   });
 
+  vim-printer = super.vim-printer.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
+
   vim-projectionist = super.vim-projectionist.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.vim;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -1801,6 +1801,12 @@ assertNoAdditions {
     ];
   };
 
+  hoon-vim = super.hoon-vim.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.publicDomain;
+    };
+  });
+
   hop-nvim = super.hop-nvim.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.bsd3;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -2293,9 +2293,12 @@ assertNoAdditions {
     };
   });
 
-  litee-symboltree-nvim = super.litee-symboltree-nvim.overrideAttrs {
+  litee-symboltree-nvim = super.litee-symboltree-nvim.overrideAttrs (old: {
     dependencies = [ self.litee-nvim ];
-  };
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
 
   live-preview-nvim = super.live-preview-nvim.overrideAttrs (old: {
     checkInputs = with self; [

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -3925,6 +3925,15 @@ assertNoAdditions {
     ];
   };
 
+  psc-ide-vim = super.psc-ide-vim.overrideAttrs (old: {
+    meta = old.meta // {
+      license = with lib.licenses; [
+        mit
+        wtfpl
+      ];
+    };
+  });
+
   python-mode = super.python-mode.overrideAttrs (old: {
     postPatch = (old.postPatch or "") + ''
       # NOTE: Fix broken symlink - the pytoolconfig directory was moved to src/

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -1434,6 +1434,13 @@ assertNoAdditions {
     dependencies = [ self.nui-nvim ];
   };
 
+  fastfold = super.fastfold.overrideAttrs (old: {
+    meta = old.meta // {
+      # This plugin is under the license "Rien à Branler", which is a French translation of the WTFPL license.
+      license = lib.licenses.wtfpl;
+    };
+  });
+
   faust-nvim = super.faust-nvim.overrideAttrs {
     dependencies = with self; [
       luasnip

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5560,6 +5560,12 @@ assertNoAdditions {
     };
   });
 
+  vim-prosession = super.vim-prosession.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.vim;
+    };
+  });
+
   vim-ps1 = super.vim-ps1.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.asl20;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -1920,6 +1920,12 @@ assertNoAdditions {
     dependencies = [ self.nvim-treesitter-legacy ];
   };
 
+  jdaddy-vim = super.jdaddy-vim.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.vim;
+    };
+  });
+
   jdd-nvim = super.jdd-nvim.overrideAttrs {
     dependencies = [ self.plenary-nvim ];
   };

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5726,6 +5726,12 @@ assertNoAdditions {
     };
   });
 
+  vim-textobj-function = super.vim-textobj-function.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
+
   vim-textobj-line = super.vim-textobj-line.overrideAttrs (old: {
     dependencies = [ self.vim-textobj-user ];
     meta = old.meta // {

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5712,6 +5712,12 @@ assertNoAdditions {
     };
   });
 
+  vim-textobj-comment = super.vim-textobj-comment.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.vim;
+    };
+  });
+
   vim-textobj-entire = super.vim-textobj-entire.overrideAttrs (old: {
     dependencies = [ self.vim-textobj-user ];
     meta = old.meta // {

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5144,6 +5144,12 @@ assertNoAdditions {
     };
   });
 
+  vim-emoji = super.vim-emoji.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
+
   vim-endwise = super.vim-endwise.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.vim;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -2829,13 +2829,19 @@ assertNoAdditions {
     ];
   };
 
-  neotest-foundry = super.neotest-foundry.overrideAttrs {
+  neotest-foundry = super.neotest-foundry.overrideAttrs (old: {
     dependencies = with self; [
       neotest
       nvim-nio
       plenary-nvim
     ];
-  };
+    meta = old.meta // {
+      license = with lib.licenses; [
+        asl20
+        mit
+      ];
+    };
+  });
 
   neotest-go = super.neotest-go.overrideAttrs {
     dependencies = with self; [

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5830,12 +5830,15 @@ assertNoAdditions {
     buildInputs = [ xkb-switch ];
   };
 
-  vim-yapf = super.vim-yapf.overrideAttrs {
+  vim-yapf = super.vim-yapf.overrideAttrs (old: {
     buildPhase = ''
       substituteInPlace ftplugin/python_yapf.vim \
         --replace-fail '"yapf"' '"${python3.pkgs.yapf}/bin/yapf"'
     '';
-  };
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
 
   vim-zettel = super.vim-zettel.overrideAttrs {
     dependencies = with self; [

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -2421,6 +2421,12 @@ assertNoAdditions {
     dependencies = [ self.plenary-nvim ];
   };
 
+  mark-radar-nvim = super.mark-radar-nvim.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
+
   markdoc-nvim = super.markdoc-nvim.overrideAttrs {
     dependencies = with self; [
       nvim-treesitter-parsers.markdown

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5536,6 +5536,12 @@ assertNoAdditions {
     dependencies = [ self.denops-vim ];
   };
 
+  vim-pony = super.vim-pony.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.vim;
+    };
+  });
+
   vim-projectionist = super.vim-projectionist.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.vim;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5789,6 +5789,12 @@ assertNoAdditions {
     };
   });
 
+  vim-visualstar = super.vim-visualstar.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.zlib;
+    };
+  });
+
   vim-waikiki = super.vim-waikiki.overrideAttrs (old: {
     meta = old.meta // {
       # README-only CC-BY-SA-4.0 notice; GitHub detection missed it.

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5186,6 +5186,12 @@ assertNoAdditions {
     };
   });
 
+  vim-figlet = super.vim-figlet.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.vim;
+    };
+  });
+
   vim-fireplace = super.vim-fireplace.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.vim;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -2687,6 +2687,12 @@ assertNoAdditions {
     ];
   };
 
+  neocomplete-vim = super.neocomplete-vim.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
+
   neoconf-nvim = super.neoconf-nvim.overrideAttrs {
     dependencies = [ self.nvim-lspconfig ];
 

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -4831,6 +4831,12 @@ assertNoAdditions {
     };
   });
 
+  verilog_systemverilog-vim = super.verilog_systemverilog-vim.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.vim;
+    };
+  });
+
   vim-abolish = super.vim-abolish.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.vim;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -2599,6 +2599,12 @@ assertNoAdditions {
     ];
   };
 
+  moonscript-vim = super.moonscript-vim.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.wtfpl;
+    };
+  });
+
   mru = super.mru.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.mit;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5965,6 +5965,12 @@ assertNoAdditions {
     };
   });
 
+  vissort-vim = super.vissort-vim.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.vim;
+    };
+  });
+
   vs-tasks-nvim = super.vs-tasks-nvim.overrideAttrs {
     checkInputs = [
       # Optional telescope integration

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5353,6 +5353,12 @@ assertNoAdditions {
     buildInputs = [ vim ];
   };
 
+  vim-hybrid = super.vim-hybrid.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
+
   vim-hypr-nav = super.vim-hypr-nav.overrideAttrs {
     runtimeDeps = [ jq ];
   };

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5419,6 +5419,12 @@ assertNoAdditions {
     };
   });
 
+  vim-lion = super.vim-lion.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.vim;
+    };
+  });
+
   vim-llvm = super.vim-llvm.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.WITH lib.licenses.asl20 lib.licenses.llvm-exception;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -4004,6 +4004,12 @@ assertNoAdditions {
     };
   });
 
+  readline-vim = super.readline-vim.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.vim;
+    };
+  });
+
   Recover-vim = super.Recover-vim.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.vim;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -4303,6 +4303,12 @@ assertNoAdditions {
     };
   });
 
+  starrynight = super.starrynight.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.vim;
+    };
+  });
+
   startup-nvim = super.startup-nvim.overrideAttrs {
     dependencies = [ self.plenary-nvim ];
   };

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5168,6 +5168,12 @@ assertNoAdditions {
     };
   });
 
+  vim-erlang-runtime = super.vim-erlang-runtime.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.vim;
+    };
+  });
+
   vim-erlang-tags = super.vim-erlang-tags.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.asl20;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -2981,13 +2981,16 @@ assertNoAdditions {
     ];
   };
 
-  neotest-testthat = super.neotest-testthat.overrideAttrs {
+  neotest-testthat = super.neotest-testthat.overrideAttrs (old: {
     dependencies = with self; [
       neotest
       nvim-nio
       plenary-nvim
     ];
-  };
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
 
   neotest-vitest = super.neotest-vitest.overrideAttrs {
     dependencies = with self; [

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -4857,9 +4857,12 @@ assertNoAdditions {
     ];
   };
 
-  vim-addon-async = super.vim-addon-async.overrideAttrs {
+  vim-addon-async = super.vim-addon-async.overrideAttrs (old: {
     dependencies = [ self.vim-addon-signs ];
-  };
+    meta = old.meta // {
+      license = lib.licenses.vim;
+    };
+  });
 
   vim-addon-background-cmd = super.vim-addon-background-cmd.overrideAttrs {
     dependencies = [ self.vim-addon-mw-utils ];

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -2051,6 +2051,12 @@ assertNoAdditions {
     };
   });
 
+  last256 = super.last256.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
+
   lazy-lsp-nvim = super.lazy-lsp-nvim.overrideAttrs {
     dependencies = [ self.nvim-lspconfig ];
   };

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5700,6 +5700,12 @@ assertNoAdditions {
   vim-tabby = super.vim-tabby.overrideAttrs {
   };
 
+  vim-tabpagecd = super.vim-tabpagecd.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
+
   vim-tbone = super.vim-tbone.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.vim;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -2210,6 +2210,12 @@ assertNoAdditions {
     };
   });
 
+  lexima-vim = super.lexima-vim.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
+
   lf-nvim = super.lf-nvim.overrideAttrs {
     dependencies = [ self.toggleterm-nvim ];
   };

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -1629,6 +1629,12 @@ assertNoAdditions {
     dependencies = [ self.plenary-nvim ];
   };
 
+  gitv = super.gitv.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.vim;
+    };
+  });
+
   go-nvim = super.go-nvim.overrideAttrs {
     dependencies = with self; [
       nvim-treesitter

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5218,6 +5218,12 @@ assertNoAdditions {
     };
   });
 
+  vim-ft-diff_fold = super.vim-ft-diff_fold.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.zlib;
+    };
+  });
+
   vim-fugitive = super.vim-fugitive.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.vim;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -2344,6 +2344,12 @@ assertNoAdditions {
     };
   });
 
+  lsp-rooter-nvim = super.lsp-rooter-nvim.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.wtfpl;
+    };
+  });
+
   lsp_extensions-nvim = super.lsp_extensions-nvim.overrideAttrs {
     dependencies = [ self.plenary-nvim ];
   };

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5066,6 +5066,13 @@ assertNoAdditions {
     };
   });
 
+  vim-CtrlXA = super.vim-CtrlXA.overrideAttrs (old: {
+    meta = old.meta // {
+      # This plugin is under the license "Rien à Branler", which is a French translation of the WTFPL license.
+      license = lib.licenses.wtfpl;
+    };
+  });
+
   vim-dadbod = super.vim-dadbod.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.vim;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5592,6 +5592,12 @@ assertNoAdditions {
     };
   });
 
+  vim-protobuf = super.vim-protobuf.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.bsd3;
+    };
+  });
+
   vim-ps1 = super.vim-ps1.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.asl20;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5736,6 +5736,7 @@ assertNoAdditions {
     dependencies = [ self.vim-textobj-user ];
     meta = old.meta // {
       maintainers = with lib.maintainers; [ llakala ];
+      license = lib.licenses.mit;
     };
   });
 

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5446,6 +5446,12 @@ assertNoAdditions {
     passthru.python3Dependencies = [ python3.pkgs.mwclient ];
   };
 
+  vim-merginal = super.vim-merginal.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.vim;
+    };
+  });
+
   vim-metamath = super.vim-metamath.overrideAttrs {
     preInstall = "cd vim";
   };

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5312,6 +5312,12 @@ assertNoAdditions {
     };
   });
 
+  vim-habamax = super.vim-habamax.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.vim;
+    };
+  });
+
   vim-hcl = super.vim-hcl.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.vim;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -3680,6 +3680,12 @@ assertNoAdditions {
     nvimSkipModules = "omni-lightline";
   };
 
+  omnisharp-extended-lsp-nvim = super.omnisharp-extended-lsp-nvim.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
+
   one-nvim = super.one-nvim.overrideAttrs (old: {
     # E5108: /lua/one-nvim.lua:14: Unknown option 't_Co'
     # https://github.com/Th3Whit3Wolf/one-nvim/issues/23

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -922,6 +922,12 @@ assertNoAdditions {
     ];
   };
 
+  colorizer = super.colorizer.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.vim;
+    };
+  });
+
   Colour-Sampler-Pack = super.Colour-Sampler-Pack.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.publicDomain;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5156,6 +5156,12 @@ assertNoAdditions {
     };
   });
 
+  vim-erlang-compiler = super.vim-erlang-compiler.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.vim;
+    };
+  });
+
   vim-erlang-omnicomplete = super.vim-erlang-omnicomplete.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.vim;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -2293,6 +2293,12 @@ assertNoAdditions {
     };
   });
 
+  litee-nvim = super.litee-nvim.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
+
   litee-symboltree-nvim = super.litee-symboltree-nvim.overrideAttrs (old: {
     dependencies = [ self.litee-nvim ];
     meta = old.meta // {

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -4674,6 +4674,12 @@ assertNoAdditions {
     ];
   };
 
+  todo-txt-vim = super.todo-txt-vim.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.vim;
+    };
+  });
+
   tokyonight-nvim = super.tokyonight-nvim.overrideAttrs {
     checkInputs = [ self.fzf-lua ];
     nvimSkipModules = [

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -6115,6 +6115,12 @@ assertNoAdditions {
     };
   });
 
+  zeavim-vim = super.zeavim-vim.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.publicDomain;
+    };
+  });
+
   zenbones-nvim = super.zenbones-nvim.overrideAttrs {
     checkInputs = with self; [
       # Optional lush-nvim integration

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -2286,9 +2286,12 @@ assertNoAdditions {
     };
   });
 
-  litee-filetree-nvim = super.litee-filetree-nvim.overrideAttrs {
+  litee-filetree-nvim = super.litee-filetree-nvim.overrideAttrs (old: {
     dependencies = [ self.litee-nvim ];
-  };
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
 
   litee-symboltree-nvim = super.litee-symboltree-nvim.overrideAttrs {
     dependencies = [ self.litee-nvim ];

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -4392,6 +4392,12 @@ assertNoAdditions {
     ];
   };
 
+  tabmerge = super.tabmerge.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.vim;
+    };
+  });
+
   tabular = super.tabular.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.bsd3;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5971,6 +5971,12 @@ assertNoAdditions {
     };
   });
 
+  vivify-vim = super.vivify-vim.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.gpl3;
+    };
+  });
+
   vs-tasks-nvim = super.vs-tasks-nvim.overrideAttrs {
     checkInputs = [
       # Optional telescope integration

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5641,6 +5641,12 @@ assertNoAdditions {
     };
   });
 
+  vim-smalls = super.vim-smalls.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.cc-by-30;
+    };
+  });
+
   vim-snipmate = super.vim-snipmate.overrideAttrs (old: {
     dependencies = with self; [
       vim-addon-mw-utils

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5908,7 +5908,7 @@ assertNoAdditions {
     };
   });
 
-  vimproc-vim = super.vimproc-vim.overrideAttrs {
+  vimproc-vim = super.vimproc-vim.overrideAttrs (old: {
     buildInputs = [ which ];
 
     # TODO: revisit
@@ -5919,7 +5919,11 @@ assertNoAdditions {
         --replace-fail vimproc_linux32.so vimproc_unix.so
       make -f make_unix.mak
     '';
-  };
+
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
 
   vimsence = super.vimsence.overrideAttrs (old: {
     meta = old.meta // {

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5462,6 +5462,12 @@ assertNoAdditions {
     };
   });
 
+  vim-niceblock = super.vim-niceblock.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
+
   vim-obsession = super.vim-obsession.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.vim;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -2279,9 +2279,12 @@ assertNoAdditions {
     ];
   };
 
-  litee-calltree-nvim = super.litee-calltree-nvim.overrideAttrs {
+  litee-calltree-nvim = super.litee-calltree-nvim.overrideAttrs (old: {
     dependencies = [ self.litee-nvim ];
-  };
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
 
   litee-filetree-nvim = super.litee-filetree-nvim.overrideAttrs {
     dependencies = [ self.litee-nvim ];

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -2220,9 +2220,12 @@ assertNoAdditions {
     dependencies = [ self.toggleterm-nvim ];
   };
 
-  lf-vim = super.lf-vim.overrideAttrs {
+  lf-vim = super.lf-vim.overrideAttrs (old: {
     dependencies = [ self.vim-floaterm ];
-  };
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
 
   lh-brackets = super.lh-brackets.overrideAttrs (old: {
     meta = old.meta // {

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5088,6 +5088,12 @@ assertNoAdditions {
     };
   });
 
+  vim-diminactive = super.vim-diminactive.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.publicDomain;
+    };
+  });
+
   vim-dirvish = super.vim-dirvish.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.gpl3Plus;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5758,6 +5758,12 @@ assertNoAdditions {
     nvimSkipModules = "tpipeline.main";
   };
 
+  vim-twiggy = super.vim-twiggy.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.vim;
+    };
+  });
+
   vim-ultest = super.vim-ultest.overrideAttrs {
     # NOTE: vim-ultest is no longer maintained.
     # If using Neovim, you can switch to using neotest (https://github.com/nvim-neotest/neotest) instead.

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5641,6 +5641,13 @@ assertNoAdditions {
     };
   });
 
+  vim-sentence-chopper = super.vim-sentence-chopper.overrideAttrs (old: {
+    meta = old.meta // {
+      # This plugin is under the license "Rien à Branler", which is a French translation of the WTFPL license.
+      license = lib.licenses.wtfpl;
+    };
+  });
+
   vim-sexp-mappings-for-regular-people =
     super.vim-sexp-mappings-for-regular-people.overrideAttrs
       (old: {

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -1943,6 +1943,12 @@ assertNoAdditions {
     dependencies = [ self.lush-nvim ];
   };
 
+  jellybeans-vim = super.jellybeans-vim.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
+
   jinja-vim = super.jinja-vim.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.mit;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5120,6 +5120,12 @@ assertNoAdditions {
     };
   });
 
+  vim-dirdiff = super.vim-dirdiff.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.bsd3;
+    };
+  });
+
   vim-dirvish = super.vim-dirvish.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.gpl3Plus;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -1707,6 +1707,12 @@ assertNoAdditions {
     };
   });
 
+  gv-vim = super.gv-vim.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
+
   gx-nvim = super.gx-nvim.overrideAttrs {
     runtimeDeps = [
       xdg-utils

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -5837,6 +5837,13 @@ assertNoAdditions {
     '';
   };
 
+  vim-watchdogs = super.vim-watchdogs.overrideAttrs (old: {
+    meta = old.meta // {
+      # Plugin file licenses it under Perl terms (artistic1).
+      license = lib.licenses.artistic1;
+    };
+  });
+
   vim-wordy = super.vim-wordy.overrideAttrs (old: {
     meta = old.meta // {
       license = lib.licenses.mit;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -1868,6 +1868,12 @@ assertNoAdditions {
     };
   });
 
+  incsearch-easymotion-vim = super.incsearch-easymotion-vim.overrideAttrs (old: {
+    meta = old.meta // {
+      license = lib.licenses.mit;
+    };
+  });
+
   indent-blankline-nvim = super.indent-blankline-nvim.overrideAttrs {
     # Meta file
     nvimSkipModules = "ibl.config.types";


### PR DESCRIPTION
### Main body of the PR

The PR name didn't fit all the modified plugins. If you have a better PR name, please propose.

This PR sets the correct license for arround 25% of the 338 vimPlugins that are set as Unfree.

Close #521202

This PR shouldn't cause any rebuild.

Any help is welcome for this PR, as it is a big one and an important one (licensing issues could lead to legal problems)
### ~~Draft~~
~~This PR is for the moment only a draft. List of things I must do:~~ This PR is now ready for reviews
* [x] check for duplicates. For some reason, my script made duplicate changes (ex: `caw`and `caw-vim`. `BufOnly` and `BufOnly-vim`) which is really odd as I got the list of packages with a `nix eval`
Edit: this is what causes the build failures (an old build failure. Not the current tarball)
* [x] Sanity check each license at least one time
* [x] check linting. probably broken after so much commits
* [x] Discard, resolve or open an issue for each of the [oddities](#oddities). Edit: most of them were solved. Some of them stay unsolved, I don't think it is worth it to open issues.

### Sources
I logged each link, which I used to affirm the new license:
* ~~BufOnly: license vim found in https://github.com/vim-scripts/BufOnly.vim/blob/master/plugin/BufOnly.vim~~ Edit: removed duplicate
* BufOnly-vim: license vim found in https://github.com/vim-scripts/BufOnly.vim/blob/master/plugin/BufOnly.vim
* Colour-Sampler-Pack: license publicDomain found in https://github.com/vim-scripts/Colour-Sampler-Pack/blob/master/plugin/mimicpak.vim
* Improved-AnsiEsc: license vim found in https://github.com/vim-scripts/Improved-AnsiEsc/blob/master/doc/AnsiEsc.txt
* NotebookNavigator-nvim: license mit found in https://github.com/GCBallesteros/NotebookNavigator.nvim/blob/main/doc/NotebookNavigator.txt
* PreserveNoEOL: license vim found in https://github.com/vim-scripts/PreserveNoEOL/blob/master/noeol
* QFEnter: license mit found in https://github.com/yssl/QFEnter/blob/master/plugin/QFEnter.vim
* Rename: license vim found in https://github.com/vim-scripts/Rename/blob/master/plugin/Rename.vim
* ReplaceWithRegister: license vim found in https://github.com/vim-scripts/ReplaceWithRegister/blob/master/plugin/ReplaceWithRegister.vim
* VimOrganizer: license vim found in https://github.com/hsitz/VimOrganizer/blob/master/syntax/org.vim
* bclose-vim: license cc-by-sa-30 found in https://github.com/rbgrouleff/bclose.vim/
* ~~caw: license bsd2 found in https://github.com/tyru/caw.vim/blob/master/doc/caw.txt~~ Edit: removed duplicate
* caw-vim: license ~~bsd2~~ bsd3 found in https://github.com/tyru/caw.vim/blob/master/doc/caw.txt
* colorizer: license vim found in https://github.com/lilydjwg/colorizer/blob/master/plugin/colorizer.vim
* colorsamplerpack: license publicDomain found in https://github.com/vim-scripts/Colour-Sampler-Pack/blob/master/plugin/mimicpak.vim
* gitv: license vim found in https://github.com/gregsexton/gitv/blob/master/doc/gitv.txt
* gv-vim: license mit found in https://github.com/junegunn/gv.vim/blob/master/plugin/gv.vim
* hoon-vim: license publicDomain found in https://github.com/urbit/hoon.vim/blob/master/indent/hoon.vim
* incsearch-easymotion-vim: license mit found in https://github.com/haya14busa/incsearch-easymotion.vim/blob/master/plugin/incsearch/easymotion.vim
* iosvkem: license publicDomain found in https://github.com/neutaaaaan/iosvkem/blob/master/colors/Iosvkem.vim
* jdaddy-vim: license vim found in https://github.com/vim-scripts/jdaddy.vim/blob/master/doc/jdaddy.txt
* jellybeans-vim: license mit found in https://github.com/nanotech/jellybeans.vim/blob/master/colors/jellybeans.vim
* lexima-vim: license mit found in https://github.com/cohama/lexima.vim/blob/master/doc/lexima.txt
* lf-vim: license mit found in https://github.com/ptzz/lf.vim/blob/master/plugin/lf.vim
* litee-calltree-nvim: license mit found in https://github.com/ldelossa/litee-calltree.nvim/blob/main/doc/litee-calltree.txt
* litee-filetree-nvim: license mit found in https://github.com/ldelossa/litee-filetree.nvim/blob/main/doc/litee-filetree.txt
* litee-nvim: license mit found in https://github.com/ldelossa/litee.nvim/blob/main/doc/litee.txt
* litee-symboltree-nvim: license mit found in https://github.com/ldelossa/litee-symboltree.nvim/blob/main/doc/litee-symboltree.txt
* lsp-rooter-nvim: license wtfpl found in https://github.com/ahmedkhalf/lsp-rooter.nvim/blob/main/COPYING
* mark-radar-nvim: license mit found in https://github.com/winston0410/mark-radar.nvim/blob/master/LICENSE
* moonscript-vim: license wtfpl found in https://github.com/leafo/moonscript-vim/blob/master/ftdetect/moon.vim
* ncm2-dictionary: license mit found in https://github.com/yuki-yano/ncm2-dictionary/blob/master/ncm2-plugin/ncm2_dictionary.vim
* ~~neocomplete: license mit found in https://github.com/Shougo/neocomplete.vim/blob/master/plugin/neocomplete.vim~~ Edit: removed duplicate
* neocomplete-vim: license mit found in https://github.com/Shougo/neocomplete.vim/blob/master/doc/neocomplete.txt
* neotest-mocha: license mit found in https://github.com/adrigzr/neotest-mocha/blob/main/package.json
* neotest-vitest: license mit found in https://github.com/marilari88/neotest-vitest/blob/main/spec/package.json
* omnisharp-extended-lsp-nvim: license mit found in https://github.com/Hoffs/omnisharp-extended-lsp.nvim/blob/main/lua/omnisharp_extended/log.lua
* pgsql-vim: license vim found in https://github.com/lifepillar/pgsql.vim/blob/master/syntax/pgsql.vim
* ~~prettyprint: license zlib found in https://github.com/thinca/vim-prettyprint/blob/master/plugin/prettyprint.vim~~ Edit: removed duplicate
* quickfixstatus: license vim found in https://github.com/dannyob/quickfixstatus/blob/master/plugin/quickfixstatus.vim
* readline-vim: license vim found in https://github.com/ryvnf/readline.vim/blob/main/doc/readline.txt
* vim-snipmate: license mit found in https://github.com/garbas/vim-snipmate/blob/master/doc/SnipMate.txt
* starrynight: license vim found in https://github.com/josegamez82/starrynight/blob/master/colors/starrynight.vim
* tabmerge: license vim found in https://github.com/vim-scripts/Tabmerge/blob/master/plugin/Tabmerge.vim
* ~~tabpagebuffer: license mit found in https://github.com/Shougo/tabpagebuffer.vim/blob/master/doc/tabpagebuffer.txt~~ Edit: removed duplicate
* tabpagebuffer-vim: license mit found in https://github.com/Shougo/tabpagebuffer.vim/blob/master/doc/tabpagebuffer.txt
* ~~tabpagecd: license mit found in https://github.com/kana/vim-tabpagecd/blob/master/doc/tabpagecd.txt~~ Edit: removed duplicate
* timestamp-vim: license publicDomain found in https://github.com/vim-scripts/timestamp.vim/blob/master/plugin/timestamp.vim
* todo-txt-vim: license vim found in https://github.com/freitass/todo.txt-vim/blob/master/ftplugin/todo.vim
* verilog_systemverilog-vim: license vim found in https://github.com/vhda/verilog_systemverilog.vim/blob/master/doc/verilog_systemverilog.txt
* vim-diminactive: license publicDomain found in https://github.com/blueyed/vim-diminactive/blob/master/plugin/diminactive.vim
* vim-emoji: license mit found in https://github.com/junegunn/vim-emoji/blob/master/autoload/emoji.vim
* vim-erlang-compiler: license vim found in https://github.com/vim-erlang/vim-erlang-compiler/blob/master/compiler/erlang.vim
* vim-erlang-runtime: license vim found in https://github.com/vim-erlang/vim-erlang-runtime/blob/master/ftplugin/erlang.vim
* ~~vim-extradite: license vim found in https://github.com/int3/vim-extradite/blob/master/doc/extradite.txt~~ Edit: removed duplicate. vim-extradite is under vim and publicDomain. See below
* vim-figlet: license vim found in https://github.com/fadein/vim-FIGlet/blob/master/plugin/FIGlet.vim
* vim-fold-cycle: license wtfpl found in https://github.com/arecarn/vim-fold-cycle/blob/master/plugin/fold_cycle.vim
* vim-ft-diff_fold: license zlib found in https://github.com/thinca/vim-ft-diff_fold/blob/master/ftplugin/diff_fold.vim
* vim-habamax: license vim found in https://github.com/habamax/vim-habamax/blob/master/colors/habamax.vim
* vim-hexokinase: license vim found in https://github.com/RRethy/vim-hexokinase/blob/master/doc/hexokinase.txt
* vim-hybrid: license mit found in https://github.com/w0ng/vim-hybrid/blob/master/colors/hybrid.vim
* vim-lion: license vim found in https://github.com/tommcdo/vim-lion/blob/master/doc/lion.txt
* vim-merginal: license vim found in https://github.com/idanarye/vim-merginal/blob/develop/doc/merginal.txt
* vim-niceblock: license mit found in https://github.com/kana/vim-niceblock/blob/master/doc/niceblock.txt
* vim-opencl: license gpl3 found in https://github.com/petRUShka/vim-opencl/blob/master/syntax_checkers/opencl/clcc.vim
* vim-operator-replace: license mit found in https://github.com/kana/vim-operator-replace/blob/master/doc/operator-replace.txt
* vim-operator-user: license mit found in https://github.com/kana/vim-operator-user/blob/master/doc/operator-user.txt
* vim-pony: license vim found in https://github.com/jmcomets/vim-pony/blob/master/plugin/pony.vim
* vim-prettyprint: license zlib found in https://github.com/thinca/vim-prettyprint/blob/master/doc/prettyprint.txt
* vim-printer: license mit found in https://github.com/meain/vim-printer/blob/master/plugin/vim-printer.vim
* vim-prosession: license vim found in https://github.com/dhruvasagar/vim-prosession/blob/master/doc/prosession.txt
* vim-smalls: license cc-by-30 found in https://github.com/t9md/vim-smalls/blob/master/doc/smalls.txt
* vim-tabpagecd: license mit found in https://github.com/kana/vim-tabpagecd/blob/master/doc/tabpagecd.txt
* vim-textobj-comment: license vim found in https://github.com/glts/vim-textobj-comment/blob/master/doc/textobj-comment.txt
* vim-textobj-entire: license mit found in https://github.com/kana/vim-textobj-entire/blob/master/doc/textobj-entire.txt
* vim-textobj-function: license mit found in https://github.com/kana/vim-textobj-function/blob/master/doc/textobj-function.txt
* vim-textobj-line: license mit found in https://github.com/kana/vim-textobj-line/blob/master/doc/textobj-line.txt
* vim-twiggy: license vim found in https://github.com/sodapopcan/vim-twiggy/blob/master/autoload/twiggy.vim
* vim-visualstar: license zlib found in https://github.com/thinca/vim-visualstar/blob/master/doc/visualstar.txt
* vim-yapf: license mit found in https://github.com/simonrw/vim-yapf/blob/master/doc/yapf.txt
* vimproc: license mit found in https://github.com/Shougo/vimproc.vim/blob/master/doc/vimproc.txt
* vimshell: license mit found in https://github.com/Shougo/vimshell.vim/blob/master/doc/vimshell.txt
* vissort-vim: license vim found in https://github.com/navicore/vissort.vim/blob/master/doc/vissort.txt
* vivify-vim: license gpl3 found in https://github.com/jannis-baum/vivify.vim/blob/main/LICENSE
* whitespace-nvim: license mit found in https://github.com/johnfrankmorgan/whitespace.nvim/blob/master/LICENSE
* zeavim-vim: license publicDomain found in https://github.com/KabbAmine/zeavim.vim/blob/master/doc/zeavim.txt
* zoomwintab-vim: license vim found in https://github.com/troydm/zoomwintab.vim/blob/master/doc/zoomwintab.txt


* fastfold: license "Rien à Branler" (translation of the wtfpl) found in https://github.com/Konfekt/FastFold/blob/master/plugin/fastfold.vim
* vim-CtrlXA: license "Rien à Branler" (translation of the wtfpl) found in https://github.com/Konfekt/vim-CtrlXA/blob/master/plugin/CtrlXA.vim
* vim-sentence-chopper: license "Rien à Branler" (translation of the wtfpl) found in https://github.com/Konfekt/vim-sentence-chopper/blob/master/plugin/sentences.vim
* vim-sile: 
   * license bsd0 found in https://github.com/sile-typesetter/vim-sile/blob/master/LICENSES/0BSD.txt
   * license cc0 found in https://github.com/sile-typesetter/vim-sile/blob/master/LICENSES/CC0-1.0.txt
   * license gpl2Plus found in https://github.com/sile-typesetter/vim-sile/blob/master/LICENSES/GPL-2.0-or-later.txt
 * ~~vim-extradite~~:
   * license vim found in https://github.com/int3/vim-extradite/blob/master/doc/extradite.txt
   * license publicDomain found in https://github.com/int3/vim-extradite/blob/master/plugin/extradite.vim
   * REMOVED from PR due to failling CI
 * neotest-foundry:
   * license asl20 found in https://github.com/llllvvuu/neotest-foundry/blob/main/spec/lib/forge-std/LICENSE-APACHE
   * license mit found in https://github.com/llllvvuu/neotest-foundry/blob/main/spec/lib/forge-std/LICENSE-MIT
 * psc-ide-vim:
   * license wtfpl found in https://github.com/FrigoEU/psc-ide-vim/blob/master/syntax_checkers/purescript/pscide.vim
   * license mit found in https://github.com/FrigoEU/psc-ide-vim/blob/master/autoload/purescript/job.vim


Thanks to @ShadowRZ 
* vim-addon-sync: license vim found in https://github.com/MarcWeber/vim-addon-async/blob/master/C/async_helper.rb
* vim-watchdogs: license artistic1 found in https://github.com/osyo-manga/vim-watchdogs/blob/master/bin/vimparse.pl
* ncm2-ultisnips: license mit found in https://github.com/ncm2/ncm2-ultisnips/blob/master/pythonx/ncm2_lsp_snippet/LICENSE
* last256: license mit found in https://github.com/sk1418/last256/blob/master/colors/last256.vim
* vim-protobuf: license bsd3 found in https://github.com/uarun/vim-protobuf/blob/master/syntax/proto.vim
* vim-dirdiff: license bsd3 found in https://github.com/will133/vim-dirdiff/blob/master/doc/dirdiff.txt
* clang_complete: 
   * license bsd3 found in https://github.com/xavierd/clang_complete/blob/master/doc/clang_complete.txt
   * The file above also licenses two of the plugin's file under LLVM's ncsa (https://releases.llvm.org/7.0.0/LICENSE.TXT)
* vim-tmux:
  * license publicDomain applies to all original commits of [zaiste/tmux.vim](https://github.com/zaiste/tmux.vim) found in https://github.com/zaiste/tmux.vim
  * license mit applies to all commits after the fork. See https://github.com/tmux-plugins/vim-tmux/
### Oddities

As said before, most of them are solved. Few remain unsolved, I don't think it's worth opening more issues

I found a few oddities during the few hours it took. Some will be solved in this PR. For some, I will create dedicated issues: 
* Some plugins stated a license but didn't gave the name nor I recognized it.
   * [csapprox](https://github.com/godlygeek/csapprox/blob/master/plugin/CSApprox.vim) Edit: My search engine show me it is really close to the [bsd-3-Clause](https://opensource.org/license/BSD-3-clause) but the wording is different at some points
   * [a-vim](https://github.com/vim-scripts/a.vim/blob/master/plugin/a.vim)
   * [align](https://github.com/vim-scripts/Align/blob/master/plugin/AlignMapsPlugin.vim)
   * [clang_complete](https://github.com/xavierd/clang_complete/blob/master/doc/clang_complete.txt). It uses the llvm-exception with bsd3-clause. But this exception is [for use with asl20](https://spdx.org/licenses/LLVM-exception.html)
   * [errormaker-vim](https://github.com/vim-scripts/errormarker.vim/blob/master/plugin/errormarker.vim)
   * [last256](https://github.com/sk1418/last256/blob/master/colors/last256.vim) Edit: solved
   * [ncm2-ultisnips](https://github.com/ncm2/ncm2-ultisnips/blob/master/pythonx/ncm2_lsp_snippet/LICENSE) Edit: solved
   * [taglist-vim](https://github.com/vim-scripts/taglist.vim/blob/master/doc/taglist.txt)
   * [vim-watchdogs](https://github.com/osyo-manga/vim-watchdogs/blob/master/bin/vimparse.pl) Edit: solved.
* ~~vim-ReplaceWithRegister and vim-ReplaceWithSameIndentRegister have their license overridden, [but it doesn't show them](https://search.nixos.org/packages?channel=25.11&query=vim-Replace)~~ Edit: nixos-unstable solved this. I saw this one on nixos-25.11
```nix
  vim-ReplaceWithRegister = super.vim-ReplaceWithRegister.overrideAttrs (old: {
    meta = old.meta // {
      license = lib.licenses.vim;
    };
  });

  vim-ReplaceWithSameIndentRegister = super.vim-ReplaceWithSameIndentRegister.overrideAttrs (old: {
    meta = old.meta // {
      license = lib.licenses.vim;
    };
  });
```
* Some have a GPL license but don't say which version
  * [YankRing-vim](https://github.com/vim-scripts/YankRing.vim/blob/master/plugin/yankring.vim)
  * [cmdalias-vim](https://github.com/vim-scripts/cmdalias.vim/blob/master/plugin/cmdalias.vim) Edit: see discussion in the comments
* Some stated a copyright but no license:
  * [acp](https://github.com/eikenb/acp/blob/master/doc/acp.txt)
* Some collections have a lot of different licenses
  * awesome-vim-colorschemes : some themes don't have licenses. Some do and a lot of different ones.
  * same with vim-colorschemes
  * [vim-polyglot](https://github.com/vim-polyglot/vim-polyglot/) is itself under mit but reunites a lot of other licensed packages
* Some are under multiple licenses ~~(this might be an easy fix, but i still separated them to do it later manually)~~ Edit: I handled them
  * [vim-sile](https://github.com/sile-typesetter/vim-sile/blob/master/LICENSES/) is under 0bsd (~~not in nixpkgs~~ bsd0 in nixpkgs), CC0-1.0 and gpl2-Plus
  * vim-extradite is both under [the Vim license](https://github.com/int3/vim-extradite/blob/master/doc/extradite.txt) and [the public domain](https://github.com/int3/vim-extradite/blob/master/plugin/extradite.vim)
  * neotest-foundry is both under [apach 2.0](https://github.com/llllvvuu/neotest-foundry/blob/main/spec/lib/forge-std/LICENSE-APACHE) and [mit](https://github.com/llllvvuu/neotest-foundry/blob/main/spec/lib/forge-std/LICENSE-MIT)
  * psc-ide-vim is both under [wtfpl](https://github.com/FrigoEU/psc-ide-vim/blob/master/syntax_checkers/purescript/pscide.vim) and [mit](https://github.com/FrigoEU/psc-ide-vim/blob/master/autoload/purescript/job.vim)
* Some are under licenses that aren't in nixpkgs
  * [copilot-vim](https://github.com/github/copilot.vim/blob/release/LICENSE.md) are under GitHub's ToS
  * [FastFold](https://github.com/Konfekt/FastFold/blob/master/plugin/fastfold.vim) [vim-CtrlXA](https://github.com/Konfekt/vim-CtrlXA/blob/master/plugin/CtrlXA.vim), [vim-sentence-chopper](https://github.com/Konfekt/vim-sentence-chopper/blob/master/plugin/sentences.vim) are under "Rien à Branler". ~~It isn't a direct translation of [wtfpl](https://en.wikipedia.org/wiki/WTFPL) but closely follows the spirit~~ Edit: Yes, it is a direct translation. I had only read the title (it's an expression that means the same thing in french but is not a direct translation) and didn't see that the body text was in fact a direct translation. I'm marking them as WTFPL with a small comment.
  * [vim-highlightedyank](https://github.com/machakann/vim-highlightedyank/blob/master/doc/highlightedyank.txt), [vim-swap](https://github.com/machakann/vim-swap/blob/master/doc/swap.txt) and [vim-sandwich](https://github.com/machakann/vim-sandwich/blob/master/doc/sandwich.txt) use NYSL. Edit: It seems that the only one using this license is the author of this plugin. The license not being in [spdx](https://spdx.org/licenses/), I do not see the point adding it to nixpkgs.
  * [vim-scouter](https://github.com/thinca/vim-scouter/blob/master/doc/scouter.txt) is under creative commons japan 2.1. Edit: [CC-BY-2.1-JP](https://creativecommons.org/licenses/by/2.1/jp/deed.en) is not in [spdx](https://spdx.org/licenses/). There is the similar [CC-BY-SA-2.1-JP](https://spdx.org/licenses/CC-BY-SA-2.1-JP.html), but it is not the same.
* Some have standart license but modified them
  * [nvim-remote-containers](https://github.com/jamestthompson3/nvim-remote-containers/blob/master/LICENSE) has a mit license + a special clause about the military and intelligence agencies
  * [vim-dirdiff](https://github.com/will133/vim-dirdiff/blob/master/doc/dirdiff.txt) has ~~a bsd-like license~~ Edit: bsd3
* Some `nix eval nixpkgs#vimPlugins.PACKAGE.meta.license` have incomplete returns
  * `nix eval nixpkgs#vimPlugins.orgmode.meta.license` returns only `{ fullName = "MIT"; }`
  It should return `{ deprecated = false; free = true; fullName = "MIT License"; licenseType = "simple"; redistributable = true; shortName = "mit"; spdxId = "MIT"; url = "https://spdx.org/licenses/MIT.html"; }`
  * Same issue with telescope-nvim: `{"fullName":"MIT"}` Edit: See issue #522196
* [vim-addon-async](https://github.com/MarcWeber/vim-addon-async/blob/master/C/async_helper.rb) says it has somewhere a license, but can't find it. Solved.
* ~~vim-automkdir's,vim-hoogle's and vim-ipython's homepages crashed my browser. I must manually recheck them.~~ Edit: checked
* Some tell us to check the source for license, but the source doesn't have one or are unclear about the source
  * [vim-docbk](https://github.com/jhradilek/vim-docbk/)
  * [vim-snippets](https://github.com/jhradilek/vim-snippets/)
  * [vim-osc52](https://github.com/fcpg/vim-osc52/)
* Some have licensing for only one file
  * [vim-jinja](https://github.com/lepture/vim-jinja/blob/master/syntax/html.vim)
  * [vim-ocaml](https://github.com/ocaml/vim-ocaml/blob/master/doc/opam.txt)
  * [vim-plugin-AnsiEsc](https://github.com/powerman/vim-plugin-AnsiEsc/blob/master/doc/AnsiEsc.txt)
* Some have contradictory licensing
  * ~~[vim-protobuf](https://github.com/uarun/vim-protobuf/blob/master/syntax/proto.vim)~~ Edit: solved. The propretary Google's all rights reserved applies only to the protocol and not the plugin itself
* Some have license that apply only after a specific commit
   * [vim-tmux](https://github.com/tmux-plugins/vim-tmux/) Edit: solved

### AI/Automation
#### Automation
The following script was used:
```zsh
#!/run/current-system/sw/bin/zsh

setopt NO_GLOB

# those file won't be commited. Only usefull for the script and to anote some information for the PR
rm ./PR.md && touch ./PR.md
rm ./errors.md && touch ./errors.md


#list=( $(nix --log-format raw search nixpkgs vimPlugins | awk 'match($0, /\.([^. ]+) \(/, m) { print m[1] }') )

list=("${(@f)$(nix --log-format raw search nixpkgs vimPlugins \
  | sed -r 's/\x1B\[[0-9;]*[mK]//g' \
  | awk 'match($0, /\.([^. ]+) \(/, m) { print m[1] }')}")
# each item ends with invisible char ^[[0m we must remove it with sed


# get array of nixpkgs licenses
license_array=$(nix eval nixpkgs#lib.licenses --apply builtins.attrNames --json)
licenseArray=("${(@f)$(jq -r '.[]' <<< "$license_array")}") # nix array -> zsh array

placeholder="
  HEREISTHEPACKAGE = super.HEREISTHEPACKAGE.overrideAttrs (old: {
    meta = old.meta // {
      license = lib.licenses.HEREISTHELICENSE;
    };
  });

"

# removes last element (vimPluginsUpdater)
list=("${list[@]:0:-1}")

for item in "${list[@]}"; do
  itemPath="nixpkgs/nixos-unstable#vimPlugins.$item"
  echo "$itemPath"
  echo $(nix eval --json "$itemPath.meta.license")
  type=$(nix eval --json "$itemPath.meta.license" | jq -r 'type') # checks the type -> if it object -> multiple license don't check
  echo "$type"
  if [[ "$type" == "object" ]] ; then # some json might be type array (when multiple licenses) we suppose those cases already resolved
    checkLicense=$(nix eval --raw "$itemPath.meta.license.shortName")
    if [[ "$checkLicense" == "unfree" ]]; then # checks if it has only one license and then checks if it is unfree
      homepage=$(nix eval --raw "$itemPath.meta.homepage")
      qutebrowser $homepage # the nix eval is computationaly heavy for each item...
      read "?Enter new license: (empty to keep old license) (vim, mit, gpl*Only, gpl*Plus, bsd*)" licenseInput
      echo "This was the input:\n$licenseInput"
      if [[ "$licenseInput" != "" ]]; then # do it only if license is not empty
        echo "We must change the license"
        # search if inputed license is inside licenseArray
        isInIt=0
        for x in "${licenseArray[@]}"; do
          if [[ "$licenseInput" == "$x" ]]; then
            isInIt=1
            break
          fi
        done

          if (( isInIt )); then
            # we annote in a text file where we found the license (must copy path manually) -> for futur PR
            link="$(cliphist list | head -1 | cut -f2-)"
            echo "source for the change of license: $link"
            echo "* $item: license $licenseInput found in $link\n" >> ./PR.md
            # we need to override the license
            # we check if the package has already been overwritten
            line=$(rg -n -m 1 "$item" ./nixpkgs/pkgs/applications/editors/vim/plugins/overrides.nix | cut -d: -f1) # it should return either 1 to ... or nothing. So 0 shouldn't be an edge case
            line=${line:-0} # solves the case where line is empty

            if [[ "$line" != "0" ]]; then
              echo "$item is already in overrides.nix. Going to the line"
              kitty nvim ./nixpkgs/pkgs/applications/editors/vim/plugins/overrides.nix +$line # opens the override at the good line
            else
              adaptedPlaceholder=${placeholder//HEREISTHEPACKAGE/$item} # replace HEREISTHEPACKAGE by the package name
              adaptedPlaceholder=${adaptedPlaceholder//HEREISTHELICENSE/$licenseInput} # replace HEREISTHELICENSE by the license
              echo "You must copy\n$adaptedPlaceholder\n into overrides.nix"
              echo "$adaptedPlaceholder" | tee >(wl-copy) | cliphist store # copy it to my clipboard to me to paste it in the file
              kitty nvim ./nixpkgs/pkgs/applications/editors/vim/plugins/overrides.nix # maybe i could find where the override should alphabetically find itselfs, but I feel too lazy
            fi
            
            git -C ./nixpkgs/ add pkgs/applications/editors/vim/plugins/overrides.nix
            git -C ./nixpkgs/ commit -m "vimPlugins.$item: override license to $licenseInput"
          else
            echo "* $item: license $licenseInput (from $link) is invalid. Please check it manually later\n" >> ./errors.md
          fi
      else
        echo "No change of license for $item"
      fi
    fi
  fi
done
```

It works like this:
1. Get list of vimPlugins
2. For each plugin
  2.1. If the license is not unfree abort (I observed that most if not all licensing problems come with Unfree packages as `vimPluginsUpdater` relies on GitHub's sometimes faulty api to get licenses and defaults to unfree)
  2.2 Opens my browser on the homepage of the plugin
  2.3 I manually search for a license. If I found one I copy the link to it.
  2.4 I close my browser
  2.5 I input in the terminal the shortName of the new license (or nothing if it doesn't change)
  2.6 If the plugin is already overwritten in overrides.nix opens neovim at the correct line (this part is broken)
  2.7. If the plugin is not in overrides.nix, copies into my clipboard the code to override the license.
  2.8 I find the correct place and paste it.
  2.9. The scripts stages and commits the changes
#### AI

None of the commits were done by AI. 
This PR wasn't written by AI.

ChatGPT (the free tier) did debug for me one or two bugs in the script before I used it and to teach me some zsh/bash quirks I didn't knew.
I also used ChatGPT to explain to me how to use the git rebase interactive tool. I learned with him. And I did alone use it to fix some commits.

I'm new to the  [automation/AI policy]. It doesn't seem to me I need to use `Assissted-by: ChatGPT` as (I repeat) it didn't touch the commits. But if I'm wrong, feel free to correct me.
### Pings

Two plugins had maintainers:
* for `vim-textobj-entire` @workflow 
* for `vim-textobj-line` @llakala 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
