### PR TITLE
truenas-incus-ctl: init at 0.7.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30482,6 +30482,12 @@
     githubId = 7040031;
     name = "Yannik Sander";
   };
+  ysnt-yes = {
+    name = "Yes";
+    github = "ysnt-yes";
+    githubId = 85800291;
+    email = "yes@ysnt.live";
+  };
   yuannan = {
     email = "brandon@emergence.ltd";
     github = "yuannan";

--- a/pkgs/by-name/tr/truenas-incus-ctl/package.nix
+++ b/pkgs/by-name/tr/truenas-incus-ctl/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "truenas-incus-ctl";
+  version = "0.7.7";
+
+  src = fetchFromGitHub {
+    owner = "truenas";
+    repo = "truenas_incus_ctl";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-F9bTh++yt6heYmkjYSOGXsIyS4s5yIIBS4F44JmIhwc=";
+  };
+
+  vendorHash = "sha256-4mm28T6nWTe3UvwGJ1S7s09ZSRZjm6TGcTD13vazUa4=";
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "A CLI tool for managing Incus volumes on TrueNAS";
+    homepage = "https://github.com/truenas/truenas_incus_ctl";
+    changelog = "https://github.com/truenas/truenas_incus_ctl/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ ysnt-yes ];
+    mainProgram = "truenas_incus_ctl";
+  };
+})


### PR DESCRIPTION
I added a new package (truenas-incus-ctl) which is needed by the truenas storage driver in incus. The driver needs a few packages, but this was the only one not already in nixpkgs. I have also added myself as a maintainer for this package build.
[Here's their page for the program](https://github.com/truenas/truenas_incus_ctl/tree/master)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
