### PR TITLE
treewide: don't pass `--version` to `versionCheckHook`

### DIFF
--- a/pkgs/applications/blockchains/groestlcoin/default.nix
+++ b/pkgs/applications/blockchains/groestlcoin/default.nix
@@ -116,7 +116,6 @@ stdenv.mkDerivation (finalAttrs: {
     versionCheckHook
   ];
   versionCheckProgram = "${placeholder "out"}/bin/groestlcoin-cli";
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   meta = {

--- a/pkgs/applications/networking/cluster/rke2/builder.nix
+++ b/pkgs/applications/networking/cluster/rke2/builder.nix
@@ -137,7 +137,6 @@ buildGoModule (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
 
   passthru = {
     inherit updateScript;

--- a/pkgs/applications/networking/firehol/iprange.nix
+++ b/pkgs/applications/networking/firehol/iprange.nix
@@ -25,8 +25,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   doInstallCheck = true;
 
-  versionCheckProgramArg = [ "--version" ];
-
   meta = {
     description = "Manage IP ranges";
     homepage = "https://github.com/firehol/iprange";

--- a/pkgs/by-name/ag/age/package.nix
+++ b/pkgs/by-name/ag/age/package.nix
@@ -42,7 +42,6 @@ buildGoModule (finalAttrs: {
   '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   # plugin test is flaky, see https://github.com/FiloSottile/age/issues/517

--- a/pkgs/by-name/am/amp-cli/package.nix
+++ b/pkgs/by-name/am/amp-cli/package.nix
@@ -69,7 +69,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     versionCheckHook
   ];
   versionCheckProgram = "${placeholder "out"}/bin/amp";
-  versionCheckProgramArg = "--version";
   versionCheckKeepEnvironment = [ "HOME" ];
 
   passthru = {

--- a/pkgs/by-name/ar/argonaut/package.nix
+++ b/pkgs/by-name/ar/argonaut/package.nix
@@ -33,7 +33,6 @@ buildGoModule (finalAttrs: {
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   postInstall = ''

--- a/pkgs/by-name/bi/biwascheme/package.nix
+++ b/pkgs/by-name/bi/biwascheme/package.nix
@@ -28,7 +28,6 @@ buildNpmPackage (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/bo/bombardier/package.nix
+++ b/pkgs/by-name/bo/bombardier/package.nix
@@ -35,7 +35,6 @@ buildGoModule (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
 
   passthru.tests = {
     updateScript = nix-update-script { };

--- a/pkgs/by-name/br/brioche/package.nix
+++ b/pkgs/by-name/br/brioche/package.nix
@@ -48,7 +48,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   passthru.updateScript = _experimental-update-script-combinators.sequence [

--- a/pkgs/by-name/br/brutus/package.nix
+++ b/pkgs/by-name/br/brutus/package.nix
@@ -29,8 +29,6 @@ buildGoModule (finalAttrs: {
 
   doInstallCheck = true;
 
-  versionCheckProgramArg = [ "--version" ];
-
   meta = {
     description = "Credential testing tool for multiple services";
     homepage = "https://github.com/praetorian-inc/brutus";

--- a/pkgs/by-name/ca/cadabra2/package.nix
+++ b/pkgs/by-name/ca/cadabra2/package.nix
@@ -117,7 +117,6 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
 
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
   #doInstallCheck = !enableBuildAsCppLibrary;
   doInstallCheck = false; # FIXME: remove this line and uncomment the above after next release
 

--- a/pkgs/by-name/ca/cargo-bundle/package.nix
+++ b/pkgs/by-name/ca/cargo-bundle/package.nix
@@ -47,7 +47,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/ca/cargo-component/package.nix
+++ b/pkgs/by-name/ca/cargo-component/package.nix
@@ -34,7 +34,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/ca/cargo-local-registry/package.nix
+++ b/pkgs/by-name/ca/cargo-local-registry/package.nix
@@ -41,7 +41,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/ca/cargo-play/package.nix
+++ b/pkgs/by-name/ca/cargo-play/package.nix
@@ -27,7 +27,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/ca/cargo-sbom/package.nix
+++ b/pkgs/by-name/ca/cargo-sbom/package.nix
@@ -21,7 +21,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-a0tGBTCLvYUObFeZwSxEqRPpMkEZdsO4kHnExUMrNWk=";
 
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
 

--- a/pkgs/by-name/ca/cargo-shuttle/package.nix
+++ b/pkgs/by-name/ca/cargo-shuttle/package.nix
@@ -41,7 +41,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/ca/cargo-tarpaulin/package.nix
+++ b/pkgs/by-name/ca/cargo-tarpaulin/package.nix
@@ -37,7 +37,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/ca/cargo-zigbuild/package.nix
+++ b/pkgs/by-name/ca/cargo-zigbuild/package.nix
@@ -30,7 +30,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/ci/circt/package.nix
+++ b/pkgs/by-name/ci/circt/package.nix
@@ -133,7 +133,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   doInstallCheck = true;
   versionCheckProgram = "${placeholder "out"}/bin/firtool";
-  versionCheckProgramArg = "--version";
 
   outputs = [
     "out"

--- a/pkgs/by-name/cl/claude-code/package.nix
+++ b/pkgs/by-name/cl/claude-code/package.nix
@@ -84,7 +84,6 @@ stdenv.mkDerivation (finalAttrs: {
     versionCheckHook
   ];
   versionCheckKeepEnvironment = [ "HOME" ];
-  versionCheckProgramArg = "--version";
 
   passthru.updateScript = ./update.sh;
 

--- a/pkgs/by-name/co/concurrently/package.nix
+++ b/pkgs/by-name/co/concurrently/package.nix
@@ -74,7 +74,6 @@ stdenv.mkDerivation (finalAttrs: {
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/co/conmon/package.nix
+++ b/pkgs/by-name/co/conmon/package.nix
@@ -62,7 +62,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
 
   meta = {
     changelog = "https://github.com/containers/conmon/releases/tag/${finalAttrs.src.tag}";

--- a/pkgs/by-name/cr/crun/package.nix
+++ b/pkgs/by-name/cr/crun/package.nix
@@ -118,7 +118,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
 
   meta = {
     changelog = "https://github.com/containers/crun/releases/tag/${finalAttrs.version}";

--- a/pkgs/by-name/cr/cryptomator-cli/package.nix
+++ b/pkgs/by-name/cr/cryptomator-cli/package.nix
@@ -80,7 +80,6 @@ maven.buildMavenPackage rec {
   '';
 
   doInstallCheck = true;
-  versionCheckProgramArg = "--version";
   nativeInstallCheckInputs = [
     versionCheckHook
   ];

--- a/pkgs/by-name/do/docuum/package.nix
+++ b/pkgs/by-name/do/docuum/package.nix
@@ -26,7 +26,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/dt/dtop/package.nix
+++ b/pkgs/by-name/dt/dtop/package.nix
@@ -20,7 +20,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-4F5eCt8AaVtGJRe7uBMHqdM3g1mLlWDXIpZCojRUjjc=";
 
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/du/dum/package.nix
+++ b/pkgs/by-name/du/dum/package.nix
@@ -21,7 +21,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/fb/fblog/package.nix
+++ b/pkgs/by-name/fb/fblog/package.nix
@@ -21,7 +21,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/fc/fclones/package.nix
+++ b/pkgs/by-name/fc/fclones/package.nix
@@ -43,7 +43,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   passthru = {

--- a/pkgs/by-name/fl/flow/package.nix
+++ b/pkgs/by-name/fl/flow/package.nix
@@ -72,7 +72,6 @@ stdenv.mkDerivation (finalAttrs: {
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   meta = {

--- a/pkgs/by-name/fu/fut/package.nix
+++ b/pkgs/by-name/fu/fut/package.nix
@@ -35,7 +35,6 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   passthru.updateScript = nix-update-script { extraArgs = [ "--use-github-releases" ]; };

--- a/pkgs/by-name/gh/ghgrab/package.nix
+++ b/pkgs/by-name/gh/ghgrab/package.nix
@@ -20,7 +20,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-6B9rVTqA2IoYCYOKy1Dc0f+3YZUJFeFQfEXF1OXZmEQ=";
 
   doInstallCheck = true;
-  versionCheckProgramArg = "--version";
   nativeInstallCheckInputs = [ versionCheckHook ];
 
   meta = {

--- a/pkgs/by-name/gi/git-branchless/package.nix
+++ b/pkgs/by-name/gi/git-branchless/package.nix
@@ -69,7 +69,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   meta = {

--- a/pkgs/by-name/gi/git-pages-cli/package.nix
+++ b/pkgs/by-name/gi/git-pages-cli/package.nix
@@ -28,7 +28,6 @@ buildGoModule (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
 
   passthru.updateScript = nix-update-script {
     extraArgs = [

--- a/pkgs/by-name/gi/git-xet/package.nix
+++ b/pkgs/by-name/gi/git-xet/package.nix
@@ -42,7 +42,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/gi/gitlab-duo/package.nix
+++ b/pkgs/by-name/gi/gitlab-duo/package.nix
@@ -66,7 +66,6 @@ buildNpmPackage (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
 
   passthru.updateScript = ./update.sh;
 

--- a/pkgs/by-name/gi/gittype/package.nix
+++ b/pkgs/by-name/gi/gittype/package.nix
@@ -51,7 +51,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   __structuredAttrs = true;

--- a/pkgs/by-name/go/goose-cli/package.nix
+++ b/pkgs/by-name/go/goose-cli/package.nix
@@ -174,7 +174,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/go/goupile/package.nix
+++ b/pkgs/by-name/go/goupile/package.nix
@@ -64,7 +64,6 @@ stdenv'.mkDerivation (finalAttrs: {
   '';
 
   doInstallCheck = true;
-  versionCheckProgramArg = "--version";
   nativeInstallCheckInputs = [ versionCheckHook ];
 
   passthru = {

--- a/pkgs/by-name/go/govulncheck/package.nix
+++ b/pkgs/by-name/go/govulncheck/package.nix
@@ -42,8 +42,6 @@ buildGoLatestModule (finalAttrs: {
 
   doInstallCheck = true;
 
-  versionCheckProgramArg = [ "--version" ];
-
   meta = {
     homepage = "https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck";
     downloadPage = "https://github.com/golang/vuln";

--- a/pkgs/by-name/ht/http-nu/package.nix
+++ b/pkgs/by-name/ht/http-nu/package.nix
@@ -32,7 +32,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/in/infat/package.nix
+++ b/pkgs/by-name/in/infat/package.nix
@@ -19,7 +19,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-8WE9TiZX1QWenjEQF/uhzJ8Gqbggt8B9EZ+1tzWq72Q=";
 
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/ja/jarl/package.nix
+++ b/pkgs/by-name/ja/jarl/package.nix
@@ -41,7 +41,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   postInstall = ''

--- a/pkgs/by-name/js/json-tui/package.nix
+++ b/pkgs/by-name/js/json-tui/package.nix
@@ -54,7 +54,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   doInstallCheck = true;
-  versionCheckProgramArg = "--version";
   nativeInstallCheckInputs = [ versionCheckHook ];
 
   meta = {

--- a/pkgs/by-name/ki/kickstart/package.nix
+++ b/pkgs/by-name/ki/kickstart/package.nix
@@ -30,7 +30,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   passthru = {

--- a/pkgs/by-name/ki/kilocode-cli/package.nix
+++ b/pkgs/by-name/ki/kilocode-cli/package.nix
@@ -117,7 +117,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
-  versionCheckProgramArg = "--version";
 
   passthru = {
     updateScript = nix-update-script { extraArgs = [ "--version-regex=^cli-v(.+)$" ]; };

--- a/pkgs/by-name/le/leo-lang/package.nix
+++ b/pkgs/by-name/le/leo-lang/package.nix
@@ -32,7 +32,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgram = "${placeholder "out"}/bin/leo";
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/le/lexy/package.nix
+++ b/pkgs/by-name/le/lexy/package.nix
@@ -44,7 +44,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
-  versionCheckProgramArg = "--version";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/lu/lurk/package.nix
+++ b/pkgs/by-name/lu/lurk/package.nix
@@ -28,7 +28,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
-  versionCheckProgramArg = "--version";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/ma/macism/package.nix
+++ b/pkgs/by-name/ma/macism/package.nix
@@ -46,7 +46,6 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   meta = {

--- a/pkgs/by-name/ma/matcha/package.nix
+++ b/pkgs/by-name/ma/matcha/package.nix
@@ -47,7 +47,6 @@ buildGoModule (finalAttrs: {
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
-  versionCheckProgramArg = "--version";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/me/meshtasticd/package.nix
+++ b/pkgs/by-name/me/meshtasticd/package.nix
@@ -134,7 +134,6 @@ stdenv.mkDerivation (finalAttrs: {
     udevCheckHook
     versionCheckHook
   ];
-  versionCheckProgramArg = "--version";
   preVersionCheck = ''
     version="${lib.versions.major finalAttrs.version}.${lib.versions.minor finalAttrs.version}.${lib.versions.patch finalAttrs.version}"
   '';

--- a/pkgs/by-name/mk/mklittlefs/package.nix
+++ b/pkgs/by-name/mk/mklittlefs/package.nix
@@ -59,7 +59,6 @@ stdenv.mkDerivation (finalAttrs: {
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   passthru = {

--- a/pkgs/by-name/ne/neowall/package.nix
+++ b/pkgs/by-name/ne/neowall/package.nix
@@ -50,7 +50,6 @@ stdenv.mkDerivation (finalAttrs: {
     versionCheckHook
   ];
   doInstallCheck = true;
-  versionCheckProgramArg = "--version";
 
   meta = {
     changelog = "https://github.com/1ay1/neowall/releases/tag/${finalAttrs.src.tag}";

--- a/pkgs/by-name/nu/numr/package.nix
+++ b/pkgs/by-name/nu/numr/package.nix
@@ -33,7 +33,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   env.OPENSSL_NO_VENDOR = true;
 
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/nx/nxv/package.nix
+++ b/pkgs/by-name/nx/nxv/package.nix
@@ -25,7 +25,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/ob/obfs4/package.nix
+++ b/pkgs/by-name/ob/obfs4/package.nix
@@ -40,7 +40,6 @@ buildGoModule (finalAttrs: {
   '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   passthru.updateScript = nix-update-script {

--- a/pkgs/by-name/od/odiff/package.nix
+++ b/pkgs/by-name/od/odiff/package.nix
@@ -36,7 +36,6 @@ stdenv.mkDerivation (finalAttrs: {
   doInstallCheck = true;
 
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
 
   meta = {
     homepage = "https://github.com/dmtrKovalenko/odiff";

--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -157,7 +157,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     "HOME"
     "OPENCODE_DISABLE_MODELS_FETCH"
   ];
-  versionCheckProgramArg = "--version";
 
   passthru = {
     jsonschema = {

--- a/pkgs/by-name/ox/oxwm/package.nix
+++ b/pkgs/by-name/ox/oxwm/package.nix
@@ -49,7 +49,6 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = false;
 
   doInstallCheck = true;
-  versionCheckProgramArg = "--version";
   versionCheckKeepEnvironment = [ "HOME" ];
   nativeInstallCheckInputs = [
     writableTmpDirAsHomeHook

--- a/pkgs/by-name/pg/pgformatter/package.nix
+++ b/pkgs/by-name/pg/pgformatter/package.nix
@@ -44,7 +44,6 @@ perlPackages.buildPerlPackage rec {
   '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/pi/pi-coding-agent/package.nix
+++ b/pkgs/by-name/pi/pi-coding-agent/package.nix
@@ -86,7 +86,6 @@ buildNpmPackage (finalAttrs: {
   ];
   versionCheckKeepEnvironment = [ "HOME" ];
   versionCheckProgram = "${placeholder "out"}/bin/pi";
-  versionCheckProgramArg = "--version";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/pr/pretty-php/package.nix
+++ b/pkgs/by-name/pr/pretty-php/package.nix
@@ -22,7 +22,6 @@ php.buildComposerProject2 (finalAttrs: {
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckKeepEnvironment = [ "HOME" ];
-  versionCheckProgramArg = "--version";
 
   meta = {
     description = "Opinionated PHP code formatter";

--- a/pkgs/by-name/pr/prometheus-node-cert-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-node-cert-exporter/package.nix
@@ -36,7 +36,6 @@ buildGoModule (finalAttrs: {
   ];
 
   doInstallCheck = true;
-  versionCheckProgramArg = "--version";
   nativeInstallCheckInputs = [ versionCheckHook ];
 
   passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };

--- a/pkgs/by-name/py/pyrefly/package.nix
+++ b/pkgs/by-name/py/pyrefly/package.nix
@@ -30,7 +30,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   buildInputs = [ rust-jemalloc-sys ];
 
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   patches = [

--- a/pkgs/by-name/ra/radicle-httpd/package.nix
+++ b/pkgs/by-name/ra/radicle-httpd/package.nix
@@ -63,7 +63,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   passthru = {

--- a/pkgs/by-name/re/reaction/package.nix
+++ b/pkgs/by-name/re/reaction/package.nix
@@ -60,7 +60,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   passthru = {

--- a/pkgs/by-name/re/resterm/package.nix
+++ b/pkgs/by-name/re/resterm/package.nix
@@ -39,7 +39,6 @@ buildGoModule (finalAttrs: {
     versionCheckHook
   ];
   doInstallCheck = true;
-  versionCheckProgramArg = "--version";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/ru/rumqttd/package.nix
+++ b/pkgs/by-name/ru/rumqttd/package.nix
@@ -26,7 +26,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = [ "--version" ];
 
   passthru.updateScript = nix-update-script {
     extraArgs = [ "--version-regex=^rumqttd\\-(.+)$" ];

--- a/pkgs/by-name/ru/rust-petname/package.nix
+++ b/pkgs/by-name/ru/rust-petname/package.nix
@@ -20,7 +20,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/ru/rusthound-ce/package.nix
+++ b/pkgs/by-name/ru/rusthound-ce/package.nix
@@ -29,7 +29,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/se/sentry-cli/package.nix
+++ b/pkgs/by-name/se/sentry-cli/package.nix
@@ -66,7 +66,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/sh/shaderc/package.nix
+++ b/pkgs/by-name/sh/shaderc/package.nix
@@ -68,7 +68,6 @@ stdenv.mkDerivation (finalAttrs: {
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   passthru.tests.pkg-config = testers.hasPkgConfigModules {

--- a/pkgs/by-name/sh/shfmt/package.nix
+++ b/pkgs/by-name/sh/shfmt/package.nix
@@ -46,7 +46,6 @@ buildGoModule (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
 
   meta = {
     homepage = "https://github.com/mvdan/sh";

--- a/pkgs/by-name/sh/shore/package.nix
+++ b/pkgs/by-name/sh/shore/package.nix
@@ -33,7 +33,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
-  versionCheckProgramArg = "--version";
 
   meta = {
     description = "CLI-based frontend for inference providers with vim inspired keybindings";

--- a/pkgs/by-name/so/socks-to-http-proxy/package.nix
+++ b/pkgs/by-name/so/socks-to-http-proxy/package.nix
@@ -36,7 +36,6 @@ rustPlatform.buildRustPackage {
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
-  versionCheckProgramArg = "--version";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/sp/sprite/package.nix
+++ b/pkgs/by-name/sp/sprite/package.nix
@@ -39,7 +39,6 @@ stdenv.mkDerivation (finalAttrs: {
     versionCheckHook
     writableTmpDirAsHomeHook
   ];
-  versionCheckProgramArg = "--version";
   versionCheckKeepEnvironment = "HOME";
   doInstallCheck = true;
 

--- a/pkgs/by-name/sq/sqlfluff/package.nix
+++ b/pkgs/by-name/sq/sqlfluff/package.nix
@@ -47,8 +47,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     versionCheckHook
   ];
 
-  versionCheckProgramArg = "--version";
-
   disabledTestPaths = [
     # Don't run the plugin related tests
     "plugins/sqlfluff-plugin-example/test/rules/rule_test_cases_test.py"

--- a/pkgs/by-name/st/stax/package.nix
+++ b/pkgs/by-name/st/stax/package.nix
@@ -24,7 +24,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   doInstallCheck = true;
   doCheck = false;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
 
   meta = {
     description = "Stacked-branch workflow for Git with an interactive TUI, smart PRs, and safe undo";

--- a/pkgs/by-name/st/stremio-linux-shell/package.nix
+++ b/pkgs/by-name/st/stremio-linux-shell/package.nix
@@ -122,7 +122,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   passthru = {

--- a/pkgs/by-name/st/stylance-cli/package.nix
+++ b/pkgs/by-name/st/stylance-cli/package.nix
@@ -20,7 +20,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
-  versionCheckProgramArg = "--version";
 
   meta = {
     description = "Library and cli tool for working with scoped CSS in rust";

--- a/pkgs/by-name/ta/tailsnitch/package.nix
+++ b/pkgs/by-name/ta/tailsnitch/package.nix
@@ -27,7 +27,6 @@ buildGoModule (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
 
   meta = {
     homepage = "https://github.com/Adversis/tailsnitch";

--- a/pkgs/by-name/tc/tclint/package.nix
+++ b/pkgs/by-name/tc/tclint/package.nix
@@ -53,7 +53,6 @@ pythonPackages.buildPythonApplication (finalAttrs: {
     pythonPackages.pytestCheckHook
     versionCheckHook
   ];
-  versionCheckProgramArg = "--version";
 
   disabledTestPaths = [
     # Fails to find lsprotocol in the sandbox, even when added to nativeCheckInputs

--- a/pkgs/by-name/te/temporal/package.nix
+++ b/pkgs/by-name/te/temporal/package.nix
@@ -58,7 +58,6 @@ buildGoModule (finalAttrs: {
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   passthru.tests = {

--- a/pkgs/by-name/te/terragrunt/package.nix
+++ b/pkgs/by-name/te/terragrunt/package.nix
@@ -41,7 +41,6 @@ buildGoModule (finalAttrs: {
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   meta = {

--- a/pkgs/by-name/tg/tgeraser/package.nix
+++ b/pkgs/by-name/tg/tgeraser/package.nix
@@ -30,8 +30,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   nativeCheckInputs = [ versionCheckHook ];
 
-  versionCheckProgramArg = "--version";
-
   meta = {
     description = "Tool to delete all your messages from Telegram";
     longDescription = ''

--- a/pkgs/by-name/ti/timr-tui/package.nix
+++ b/pkgs/by-name/ti/timr-tui/package.nix
@@ -47,7 +47,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
-  versionCheckProgramArg = "--version";
   # Error: Operation not permitted (os error 1)
   versionCheckKeepEnvironment = lib.optionals stdenv.hostPlatform.isDarwin [ "HOME" ];
   doInstallCheck = true;

--- a/pkgs/by-name/tu/tuios/package.nix
+++ b/pkgs/by-name/tu/tuios/package.nix
@@ -34,7 +34,6 @@ buildGoModule (finalAttrs: {
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
-  versionCheckProgramArg = "--version";
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd ${finalAttrs.meta.mainProgram} \

--- a/pkgs/by-name/ur/urx/package.nix
+++ b/pkgs/by-name/ur/urx/package.nix
@@ -36,8 +36,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doInstallCheck = true;
 
-  versionCheckProgramArg = [ "--version" ];
-
   meta = {
     description = "Extracts URLs from OSINT Archives for Security Insights";
     homepage = "https://github.com/hahwul/urx";

--- a/pkgs/by-name/vc/vcmi/package.nix
+++ b/pkgs/by-name/vc/vcmi/package.nix
@@ -98,7 +98,6 @@ stdenv.mkDerivation (finalAttrs: {
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgram = "${placeholder "out"}/bin/vcmiclient";
-  versionCheckProgramArg = "--version";
   versionCheckKeepEnvironment = [
     "XDG_CACHE_HOME"
     "XDG_CONFIG_HOME"

--- a/pkgs/by-name/ve/versatiles/package.nix
+++ b/pkgs/by-name/ve/versatiles/package.nix
@@ -55,7 +55,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   meta = {

--- a/pkgs/by-name/ve/versitygw/package.nix
+++ b/pkgs/by-name/ve/versitygw/package.nix
@@ -33,8 +33,6 @@ buildGoModule (finalAttrs: {
 
   nativeInstallCheckInputs = [ versionCheckHook ];
 
-  versionCheckProgramArg = "--version";
-
   passthru = {
     updateScript = nix-update-script { };
   };

--- a/pkgs/by-name/wa/wallrizz/package.nix
+++ b/pkgs/by-name/wa/wallrizz/package.nix
@@ -60,7 +60,6 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   doInstallCheck = true;
-  versionCheckProgramArg = "--version";
   nativeInstallCheckInputs = [
     versionCheckHook
   ];

--- a/pkgs/by-name/ze/zensical/package.nix
+++ b/pkgs/by-name/ze/zensical/package.nix
@@ -41,7 +41,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
   ];
 
   nativeCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
 
   meta = {
     description = "Static site generator for documentation";

--- a/pkgs/by-name/ze/zerofs/package.nix
+++ b/pkgs/by-name/ze/zerofs/package.nix
@@ -31,7 +31,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/development/php-packages/phan/default.nix
+++ b/pkgs/development/php-packages/phan/default.nix
@@ -22,7 +22,6 @@
     composerStrictValidation = false;
     doInstallCheck = true;
     nativeInstallCheckInputs = [ versionCheckHook ];
-    versionCheckProgramArg = "--version";
 
     meta = {
       description = "Static analyzer for PHP";

--- a/pkgs/development/php-packages/php-parallel-lint/default.nix
+++ b/pkgs/development/php-packages/php-parallel-lint/default.nix
@@ -21,7 +21,6 @@ php.buildComposerProject2 (finalAttrs: {
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
-  versionCheckProgramArg = "--version";
 
   meta = {
     description = "Tool to check syntax of PHP files faster than serial check with fancier output";

--- a/pkgs/development/python-modules/atopile/default.nix
+++ b/pkgs/development/python-modules/atopile/default.nix
@@ -147,7 +147,6 @@ buildPythonPackage (finalAttrs: {
     hypothesis
     versionCheckHook
   ];
-  versionCheckProgramArg = "--version";
 
   preCheck = ''
     # do not report worker logs to filee

--- a/pkgs/development/python-modules/jupyter-book/default.nix
+++ b/pkgs/development/python-modules/jupyter-book/default.nix
@@ -71,7 +71,6 @@ buildPythonPackage (finalAttrs: {
   nativeCheckInputs = [
     versionCheckHook
   ];
-  versionCheckProgramArg = "--version";
 
   meta = {
     description = "Build a book with Jupyter Notebooks and Sphinx";

--- a/pkgs/development/python-modules/reflex/default.nix
+++ b/pkgs/development/python-modules/reflex/default.nix
@@ -170,7 +170,6 @@ buildPythonPackage (finalAttrs: {
     versionCheckHook
     writableTmpDirAsHomeHook
   ];
-  versionCheckProgramArg = "--version";
 
   disabledTests = [
     # Touches network

--- a/pkgs/development/python-modules/xclim/default.nix
+++ b/pkgs/development/python-modules/xclim/default.nix
@@ -80,8 +80,6 @@ buildPythonPackage rec {
     versionCheckHook
   ];
 
-  versionCheckProgramArg = "--version";
-
   pythonImportsCheck = [
     "xclim"
     "xclim.ensembles"

--- a/pkgs/os-specific/linux/drbd/utils.nix
+++ b/pkgs/os-specific/linux/drbd/utils.nix
@@ -118,7 +118,6 @@ stdenv.mkDerivation (finalAttrs: {
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgram = [ "${placeholder "out"}/bin/drbdadm" ];
-  versionCheckProgramArg = "--version";
 
   passthru.tests.drbd = nixosTests.drbd;
 

--- a/pkgs/servers/nosql/mongodb/mongodb.nix
+++ b/pkgs/servers/nosql/mongodb/mongodb.nix
@@ -160,7 +160,6 @@ stdenv.mkDerivation (finalAttrs: {
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgram = "${placeholder "out"}/bin/mongo";
-  versionCheckProgramArg = "--version";
 
   installTargets = "install-devcore";
 


### PR DESCRIPTION
`--version` has been the default value of `versionCheckHookArg` and the recommendation is to not pass it unless it differs so remove the explicit `versionCheckProgramArg = "--version";` across all packages.

This was assisted with `OpenCode opencode/big-pickle` (as specified by the Git trailer) as a personal experiment with it performing a treewide trivial refactoring.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
