### PR TITLE
btest: 0.6.2 -> 0.6.3

### DIFF
--- a/pkgs/by-name/bt/btest/package.nix
+++ b/pkgs/by-name/bt/btest/package.nix
@@ -10,22 +10,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "btest";
-  version = "0.6.2";
+  version = "0.6.3";
 
   src = fetchFromGitHub {
     owner = "manawenuz";
     repo = "btest-rs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ltePF8HX46FDbdyq30u19FNVpIwPxhOo8AgNvKRzKHE=";
+    hash = "sha256-bS70knj5xUMj0zCoKUJLJDXMPOErH+yoyISlhbyhFIU=";
   };
 
-  cargoHash = "sha256-8AO7eTzZMzvNWcls3VXP0kPun/D5gsA1ih0FOqZ57R0=";
-
-  postPatch = ''
-    # https://github.com/manawenuz/btest-rs/pull/1
-    substituteInPlace Cargo.toml \
-      --replace-fail "0.6.0" "${finalAttrs.version}"
-  '';
+  cargoHash = "sha256-ydHr+4yKCzWbznwF6oWjn8S0dTkJqbV01j4p3ksT+60=";
 
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
updat to 0.6.3

remove outdated substitution

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
