### PR TITLE
rpi-imager: 2.0.6 -> 2.0.9

### DIFF
--- a/pkgs/by-name/rp/rpi-imager/package.nix
+++ b/pkgs/by-name/rp/rpi-imager/package.nix
@@ -7,6 +7,7 @@
   gnutls,
   libarchive,
   libtasn1,
+  libusb1,
   liburing,
   nix-update-script,
   pkg-config,
@@ -22,13 +23,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rpi-imager";
-  version = "2.0.6";
+  version = "2.0.9";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "rpi-imager";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-YbPGxc6EWE3B+7MWgtwTDRdjin9FM7KpWfw38FqKXYA=";
+    hash = "sha256-hoypze5EyJKRVQNI8x5sh3LqVyK8tEze1/vxogrqckA=";
   };
 
   patches = [ ./remove-vendoring.patch ];
@@ -72,6 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
     gnutls
     libarchive
     libtasn1
+    libusb1
     qt6.qtbase
     qt6.qtdeclarative
     qt6.qtsvg
@@ -124,6 +126,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "rpi-imager";
     maintainers = with lib.maintainers; [
       anthonyroussel
+      agustinmista
     ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     # could not find xz

--- a/pkgs/by-name/rp/rpi-imager/remove-vendoring.patch
+++ b/pkgs/by-name/rp/rpi-imager/remove-vendoring.patch
@@ -1,8 +1,8 @@
-diff --git i/src/CMakeLists.txt w/src/CMakeLists.txt
-index de474c4d..36b6cf2c 100644
---- i/src/CMakeLists.txt
-+++ w/src/CMakeLists.txt
-@@ -129,26 +129,37 @@ set(BUILD_SHARED_LIBS OFF)
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 19f931b..ca78f8f 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -158,26 +158,40 @@ set(BUILD_SHARED_LIBS OFF)
  include(FetchContent)
  
  # Bundled liblzma
@@ -15,6 +15,9 @@ index de474c4d..36b6cf2c 100644
 +find_package(zstd ${ZSTD_VERSION})
 +if(NOT zstd_FOUND)
  include(dependencies/zstd.cmake)
++else()
++set(ZSTD_LIBRARIES zstd::libzstd_shared)
++set(ZSTD_INCLUDE_DIR ${zstd_INCLUDE_DIR})
 +endif()
  
  # Remote nghttp2
@@ -42,11 +45,25 @@ index de474c4d..36b6cf2c 100644
      # In version 8.15.0, libcurl dropped support for Secure Transport, because it
      # does not implement TLS 1.3. Unfortunately, there was no replacement Network.framework implementation,
      # so on macOS we're forced to use the macOS SDK version of libcurl, including libcurl's own OpenSSL-analogue.
-@@ -506,7 +517,6 @@ else()
+@@ -193,7 +207,13 @@ endif()
+ 
+ 
+ # Bundled libusb (for rpiboot Compute Module support)
++find_package(PkgConfig REQUIRED)
++pkg_check_modules(LIBUSB libusb-1.0)
++if(NOT LIBUSB_FOUND)
+ include(dependencies/libusb.cmake)
++else()
++set(LIBUSB_INCLUDE_DIR ${LIBUSB_INCLUDE_DIRS})
++endif()
+ 
+ # Add dependencies
+ if (APPLE)
+@@ -553,7 +573,6 @@ else()
      include(linux/PlatformPackaging.cmake)
  endif()
  
--add_dependencies(${PROJECT_NAME} zlibstatic yescrypt)
- include_directories(${CURL_INCLUDE_DIR} ${LibArchive_INCLUDE_DIR} ${LIBLZMA_INCLUDE_DIRS} ${LIBDRM_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS} ${ZSTD_INCLUDE_DIR} ${YESCRYPT_INCLUDE_DIR})
+-add_dependencies(${PROJECT_NAME} zlibstatic yescrypt usb-1.0-static)
+ include_directories(${CURL_INCLUDE_DIR} ${LibArchive_INCLUDE_DIR} ${LIBLZMA_INCLUDE_DIRS} ${LIBDRM_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS} ${ZSTD_INCLUDE_DIR} ${YESCRYPT_INCLUDE_DIR} ${LIBUSB_INCLUDE_DIR})
  
  # Link different Qt components based on build type


### PR DESCRIPTION
This version fixes a bug on the "Erase" operation that would lead to corrupted SD cards. See:

https://github.com/raspberrypi/rpi-imager/issues/1372#issuecomment-4489785655

It includes some minor changes to account for the new dependency on `libusb1` and a missing symbol `ZSTD_getFrameContentSize` when linking against `zstd`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
