### PR TITLE
rusty-diceware: 0.5.8 -> 0.5.10

### DIFF
--- a/pkgs/by-name/ru/rusty-diceware/package.nix
+++ b/pkgs/by-name/ru/rusty-diceware/package.nix
@@ -1,30 +1,33 @@
 {
-  fetchFromGitLab,
   lib,
   rustPlatform,
+  fetchFromCodeberg,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rusty-diceware";
-  version = "0.5.8";
+  version = "0.5.10";
 
-  src = fetchFromGitLab {
-    owner = "yuvallanger";
+  __structuredAttrs = true;
+
+  src = fetchFromCodeberg {
+    owner = "kakafarm";
     repo = "rusty-diceware";
-    rev = "diceware-v${finalAttrs.version}";
-    hash = "sha256-GDWvHHl4EztTaR0jI4XL1I9qE2KSL+q9C8IvLWQF4Ys=";
+    rev = "53975f17f5f575720d724035bd715dd2dd75986d";
+    hash = "sha256-uSbJFZ0wqo1RbRP9BWiT4cDg9CV/aSYz432a/qUk7qw=";
   };
 
-  cargoHash = "sha256-f+jvrokt5kuHYKKfluu4OvI7dzp9rFPlTo4KC4jKb0o=";
-
-  doCheck = true;
+  cargoHash = "sha256-TCNHtDz7dgUx5lBwwIs67mnQcAZ5Xknc6otpl8zRaVc=";
 
   meta = {
     description = "Commandline diceware, with or without dice, written in Rustlang";
-    homepage = "https://gitlab.com/yuvallanger/rusty-diceware";
-    changelog = "https://gitlab.com/yuvallanger/rusty-diceware/-/blob/v${finalAttrs.version}/CHANGELOG.md?ref_type=heads";
+    homepage = "https://codeberg.org/kakafarm/rusty-diceware";
+    changelog = "https://codeberg.org/kakafarm/rusty-diceware/src/branch/master/CHANGELOG.md";
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ cherrykitten ];
+    maintainers = with lib.maintainers; [
+      cherrykitten
+      kybe236
+    ];
     mainProgram = "diceware";
   };
 })


### PR DESCRIPTION
Also gonna fix r-ryantm [trying to update it to `0.5.10`](https://nixpkgs-update-logs.nix-community.org/rusty-diceware/2026-05-19.log)

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
