### PR TITLE
sambaFull: fix samba-tool missing cryptography module

### DIFF
--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -279,6 +279,9 @@ stdenv.mkDerivation (finalAttrs: {
     python3Packages.dnspython
     python3Packages.markdown
     tdb
+  ]
+  ++ lib.optionals enableDomainController [
+    python3Packages.cryptography
   ];
 
   strictDeps = true;
@@ -341,6 +344,13 @@ stdenv.mkDerivation (finalAttrs: {
     version = testers.testVersion {
       command = "${finalAttrs.finalPackage}/bin/smbd -V";
       package = finalAttrs.finalPackage;
+    };
+  }
+  // lib.optionalAttrs enableDomainController {
+    versionSambaTool = testers.testVersion {
+      command = "${lib.getExe' finalAttrs.finalPackage "samba-tool"} --version";
+      package = finalAttrs.finalPackage;
+      version = finalAttrs.version;
     };
   };
 


### PR DESCRIPTION
samba-tool (from `sambaFull`) depends on `cryptography` python module so add it to `pythonPath` if `enableDomainController` and also check with `passthru.tests.versionSambaTool` test.

<details><summary>uncaught exception - No module named 'cryptography'</summary>
<p>
<pre>
ERROR(<class 'ModuleNotFoundError'>): uncaught exception - No module named 'cryptography'
  File "/nix/store/ba8slvlhqqy9havanhyqqkr13mblkaca-samba-4.23.5/lib/python3.13/site-packages/samba/netcmd/main.py", line 89, in samba_tool
    ret = cmd._run(*argv)
  File "/nix/store/ba8slvlhqqy9havanhyqqkr13mblkaca-samba-4.23.5/lib/python3.13/site-packages/samba/netcmd/__init__.py", line 474, in _run
    cmd = self.subcommands[cmd_name]
          ~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/nix/store/ba8slvlhqqy9havanhyqqkr13mblkaca-samba-4.23.5/lib/python3.13/site-packages/samba/netcmd/main.py", line 36, in __getitem__
    self[attr] = getattr(__import__('samba.netcmd.%s' % package,
                         ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                    fromlist=[cmd]), cmd)()
                                    ^^^^^^^^^^^^^^^
  File "/nix/store/ba8slvlhqqy9havanhyqqkr13mblkaca-samba-4.23.5/lib/python3.13/site-packages/samba/netcmd/delegation.py", line 23, in <module>
    from samba import provision
  File "/nix/store/ba8slvlhqqy9havanhyqqkr13mblkaca-samba-4.23.5/lib/python3.13/site-packages/samba/provision/__init__.py", line 76, in <module>
    from samba.gkdi import (
    ...<2 lines>...
    )
  File "/nix/store/ba8slvlhqqy9havanhyqqkr13mblkaca-samba-4.23.5/lib/python3.13/site-packages/samba/gkdi.py", line 25, in <module>
    from cryptography.hazmat.primitives import hashes
</pre>
</p>
</details> 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
