### PR TITLE
chevron: init at 0.5.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18349,6 +18349,11 @@
     githubId = 2597803;
     name = "Matthias Meschede";
   };
+  mmichie = {
+    github = "mmichie";
+    githubId = 12953;
+    name = "Matt Michie";
+  };
   mmilata = {
     email = "martin@martinmilata.cz";
     github = "mmilata";

--- a/pkgs/by-name/ch/chevron/package.nix
+++ b/pkgs/by-name/ch/chevron/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  libgit2,
+  openssl,
+  stdenv,
+  apple-sdk_15,
+  libiconv,
+  nix-update-script,
+  testers,
+  chevron,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "chevron";
+  version = "0.5.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "shiprock";
+    repo = "chevron";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+2vf/OIAClDilqIkkTXcwmi8UDYIK+sMqC0ZHNOnlUA=";
+  };
+
+  cargoHash = "sha256-0MElTChJ3agjj97cJWwS87Zch5yhpItCOku/6g6PbUw=";
+
+  # Link the system libgit2 rather than the vendored copy chevron's
+  # default features pull in.
+  buildNoDefaultFeatures = true;
+  buildFeatures = [
+    "banner"
+    "weather"
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    libgit2
+    openssl
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    apple-sdk_15
+    libiconv
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion { package = chevron; };
+  };
+
+  meta = {
+    description = "Configurable powerline prompt segments and tmux window titles for zsh, bash, and fish";
+    homepage = "https://github.com/shiprock/chevron";
+    changelog = "https://github.com/shiprock/chevron/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mmichie ];
+    mainProgram = "chevron";
+  };
+})


### PR DESCRIPTION
Initial packaging of [chevron](https://github.com/shiprock/chevron) v0.5.1 ([crates.io](https://crates.io/crates/chevron/0.5.1)).

Chevron is a fast, single-binary CLI that renders powerline-styled terminal segments for shell prompts (zsh, bash, fish via `chevron init <shell>`, or as Starship custom modules) and tmux window titles. It uses libgit2 directly via the `git2` crate rather than shelling out to git so prompts redraw in sub-millisecond time. Subcommands include `path`, `git`, `tmux-title`, `prompt`, `init`, `health`, and `weather`.

Built from the v0.5.1 release tag via `fetchFromGitHub`; full unit + integration test suite (283 lib + 42 CLI tests) runs and passes during `cargoCheckHook` on both tested platforms below. The package uses `buildNoDefaultFeatures = true` plus the `banner` and `weather` features so the system `libgit2` is linked instead of the vendored copy that ships in chevron's default feature set — matches the nixpkgs convention used by `cargo-release`, `debase`, and other git2-using Rust packages. Upstream (which I author) added the `vendored-libgit2` feature gate in 0.5.1 specifically so distro packagers can opt out cleanly.

## `nixpkgs-review` result

```
Commit: 5b17b005643fbe8e3206dcc680904709d23137a0

aarch64-darwin
  1 package built:
    - chevron
```

## Things done

- Built on platform:
  - [x] x86_64-linux (native on a separate Ubuntu host; binary dynamically links nixpkgs libgit2 1.9.3)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin (binary dynamically links nixpkgs libgit2 1.9.3)
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests` (`testers.testVersion`).
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

## Automation/AI disclosure

Per the [automation/AI policy]: the packaging scaffolding (`package.nix`, maintainer entry) and this PR body were drafted with Claude Code (Claude Opus 4.7) under my review. I'm the upstream author of chevron itself, built `nix-build -A chevron` on aarch64-darwin and a native build on x86_64-linux (Ubuntu, fresh clone of this branch), ran `nixpkgs-review rev HEAD` against a clean nixpkgs checkout (report above), verified `./result/bin/chevron` runs correctly and links the nixpkgs libgit2 (not vendored) on both platforms, and reviewed the final diff. The commit carries the required `Assisted-by: Claude Code:claude-opus-4.7` trailer.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test