### PR TITLE
mcat-unwrapped: 0.4.6 -> 0.6.1

### DIFF
--- a/pkgs/by-name/mc/mcat-unwrapped/package.nix
+++ b/pkgs/by-name/mc/mcat-unwrapped/package.nix
@@ -9,19 +9,24 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "mcat-unwrapped";
-  version = "0.4.6";
+  version = "0.6.1";
 
   src = fetchFromGitHub {
     owner = "Skardyy";
     repo = "mcat";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-8NWWEV/1Kk3s/Ip6Mtt2uSX8lhsaVFmkldBG1qyCTrM=";
+    hash = "sha256-zedVMX3JV0jHSUzSY3x9Olimy4Y6GrNVGRSc6Eev9ow=";
   };
 
-  cargoHash = "sha256-VrJMM++giBJQt+8YBPu370AScLTOgaLZNiRP3wk9nt8=";
+  cargoHash = "sha256-szqXS2CRfHoCtt6Lq1DuVb199mIuf7HUPiN7fj5BGtc=";
 
   nativeBuildInputs = [
     installShellFiles
+  ];
+
+  checkFlags = [
+    # Requires network access: the test embeds a remote URL in the SVG.
+    "--skip=stdin_svg_output_is_image"
   ];
 
   postInstall =


### PR DESCRIPTION

## Releases: 
- https://github.com/Skardyy/mcat/releases/tag/v0.5.0
- https://github.com/Skardyy/mcat/releases/tag/v0.5.1
- https://github.com/Skardyy/mcat/releases/tag/v0.5.2
- https://github.com/Skardyy/mcat/releases/tag/v0.5.4
- https://github.com/Skardyy/mcat/releases/tag/v0.5.5
- https://github.com/Skardyy/mcat/releases/tag/v0.5.6
- https://github.com/Skardyy/mcat/releases/tag/v0.6.0
- https://github.com/Skardyy/mcat/releases/tag/v0.6.1
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->


[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
