### PR TITLE
qbz: wrap pactl and pw-metadata into PATH

### DIFF
--- a/pkgs/by-name/qb/qbz/package.nix
+++ b/pkgs/by-name/qb/qbz/package.nix
@@ -14,7 +14,9 @@
   nodejs,
   npmHooks,
   openssl,
+  pipewire, # pw-metadata for bit-perfect sample rate queries
   pkg-config,
+  pulseaudio, # pactl for PipeWire device enumeration and sink routing
   rustPlatform,
   webkitgtk_4_1,
   wrapGAppsHook3,
@@ -66,6 +68,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   postInstall = ''
     gappsWrapperArgs+=(
+      --prefix PATH : ${
+        lib.makeBinPath [
+          pulseaudio
+          pipewire
+        ]
+      }
       --prefix LD_LIBRARY_PATH : ${
         lib.makeLibraryPath [
           libappindicator


### PR DESCRIPTION
qbz's PipeWire audio backend shells out to external CLI tools at runtime:
- `pactl` (from `pulseaudio`) for device enumeration, default sink detection, and sink routing
- `pw-metadata` (from `pipewire`) for sample rate queries used in bit-perfect playback mode

Without these on PATH, the PipeWire backend fails to start playback:
```
Failed to load devices for PipeWire: Failed to run pactl: No such file or directory (os error 2)
```

This wraps both into qbz's PATH via `gappsWrapperArgs`, matching the existing pattern used for `LD_LIBRARY_PATH`.

Relevant source references: [`crates/qbz-audio/src/pipewire_backend.rs`](https://github.com/vicrodh/qbz/blob/main/crates/qbz-audio/src/pipewire_backend.rs) and [`crates/qbz-audio/src/backend.rs`](https://github.com/vicrodh/qbz/blob/main/crates/qbz-audio/src/backend.rs).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test