### PR TITLE
nixos/pangolin: render default settings in option search, disable sign up per default

### DIFF
--- a/nixos/modules/services/networking/pangolin.nix
+++ b/nixos/modules/services/networking/pangolin.nix
@@ -9,7 +9,7 @@
 let
   cfg = config.services.pangolin;
   format = pkgs.formats.yaml { };
-  finalSettings = lib.attrsets.recursiveUpdate pangolinConf cfg.settings;
+  finalSettings = lib.attrsets.recursiveUpdate options.services.pangolin.settings.default cfg.settings;
   cfgFile = format.generate "config.yml" finalSettings;
   # override the type to allow for optionality
   nullOrOpt = t: lib.types.nullOr t // { _optional = true; };
@@ -33,25 +33,6 @@ let
       fi
     '';
   };
-
-  pangolinConf = {
-    app.dashboard_url = "https://${cfg.dashboardDomain}";
-    domains.domain1 = {
-      base_domain = cfg.baseDomain;
-      prefer_wildcard_cert = false;
-    };
-    server = {
-      external_port = 3000;
-      internal_port = 3001;
-      next_port = 3002;
-      integration_port = 3003;
-      # needs to be set, otherwise this fails silently
-      # see https://github.com/fosrl/newt/issues/37
-      internal_hostname = "localhost";
-    };
-    gerbil.base_endpoint = cfg.dashboardDomain;
-    flags.enable_integration_api = false;
-  };
 in
 {
   options.services = {
@@ -61,7 +42,44 @@ in
 
       settings = lib.mkOption {
         inherit (format) type;
-        default = { };
+        default = {
+          app.dashboard_url = "https://${cfg.dashboardDomain}";
+          domains.domain1 = {
+            base_domain = cfg.baseDomain;
+            prefer_wildcard_cert = false;
+          };
+          server = {
+            external_port = 3000;
+            internal_port = 3001;
+            next_port = 3002;
+            integration_port = 3003;
+            # needs to be set, otherwise this fails silently
+            # see https://github.com/fosrl/newt/issues/37
+            internal_hostname = "localhost";
+          };
+          gerbil.base_endpoint = cfg.dashboardDomain;
+          flags.enable_integration_api = false;
+        };
+        defaultText = lib.literalExpression ''
+          {
+            app.dashboard_url = "https://''${config.services.pangolin.dashboardDomain}";
+            domains.domain1 = {
+              base_domain = cfg.baseDomain;
+              prefer_wildcard_cert = false;
+            };
+            server = {
+              external_port = 3000;
+              internal_port = 3001;
+              next_port = 3002;
+              integration_port = 3003;
+              # needs to be set, otherwise this fails silently
+              # see https://github.com/fosrl/newt/issues/37
+              internal_hostname = "localhost";
+            };
+            gerbil.base_endpoint = config.services.pangolin.dashboardDomain;
+            flags.disable_signup_without_invite = true;
+          }
+        '';
         description = ''
           Additional attributes to be merged with the configuration options and written to Pangolin's {file}`config.yml` file.
         '';

--- a/nixos/modules/services/networking/pangolin.nix
+++ b/nixos/modules/services/networking/pangolin.nix
@@ -58,7 +58,10 @@ in
             internal_hostname = "localhost";
           };
           gerbil.base_endpoint = cfg.dashboardDomain;
-          flags.enable_integration_api = false;
+          flags = {
+            disable_signup_without_invite = true;
+            enable_integration_api = false;
+          };
         };
         defaultText = lib.literalExpression ''
           {
@@ -77,7 +80,10 @@ in
               internal_hostname = "localhost";
             };
             gerbil.base_endpoint = config.services.pangolin.dashboardDomain;
-            flags.disable_signup_without_invite = true;
+            flags = {
+              disable_signup_without_invite = true;
+              enable_integration_api = false;
+            };
           }
         '';
         description = ''


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
