### PR TITLE
vinyl-cache: 9.0.0 -> 9.0.1

### DIFF
--- a/nixos/modules/services/web-servers/vinyl-cache/default.nix
+++ b/nixos/modules/services/web-servers/vinyl-cache/default.nix
@@ -18,12 +18,9 @@ let
   cfg = config.services.vinyl-cache;
 
   # Vinyl Cache has very strong opinions and very complicated code around handling
-  # the stateDir. After a lot of back and forth, we decided that we a)
-  # do not want a configurable option here, as most of the handling depends
-  # on the version and the compile time options. Putting everything into
-  # /var/run (RAM backed) is absolutely recommended by Vinyl Cache anyways.
-  # We do need to pay attention to the version-dependend variations, though!
-  stateDir = "/var/run/vinyld";
+  # the stateDir. After a lot of back and forth, we decided to set the stateDir
+  # at compile time and let the package expose the particular path as passthru.
+  stateDir = cfg.package.stateDir;
 
   # from --help:
   #   -a [<name>=]address[:port][,proto] # HTTP listen address and port
@@ -183,13 +180,13 @@ in
         after = [ "network.target" ];
         serviceConfig = {
           Type = "simple";
-          ExecStart = "${cfg.package}/bin/vinyld ${commandLineAddresses} -n ${stateDir} -F ${cfg.extraCommandLine} ${commandLine}";
+          ExecStart = "${cfg.package}/bin/vinyld ${commandLineAddresses} -F ${cfg.extraCommandLine} ${commandLine}";
           Restart = "always";
           RestartSec = "5s";
           User = "vinyl-cache";
           Group = "vinyl-cache";
           DynamicUser = true;
-          RuntimeDirectory = lib.removePrefix "/var/run/" stateDir;
+          RuntimeDirectory = lib.removePrefix "/run/" stateDir;
           AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
           NoNewPrivileges = true;
           LimitNOFILE = 131072;
@@ -220,6 +217,10 @@ in
           {
             assertion = cfg.package.pname == "vinyl-cache";
             message = "services.vinyl-cache only supports Vinyl Cache. Please use services.varnish.";
+          }
+          {
+            assertion = lib.strings.hasPrefix "/run/" stateDir;
+            message = "The vinyl-cache NixOS mosule only supports statedirs in /run/, but vinyl-cache package was compiled with ${stateDir}.";
           }
         ];
     })

--- a/pkgs/servers/vinyl-cache/0001-Makefile-do-not-create-VINYL_STATE_DIR.patch
+++ b/pkgs/servers/vinyl-cache/0001-Makefile-do-not-create-VINYL_STATE_DIR.patch
@@ -1,0 +1,26 @@
+From 51ee9140e547eccfae99c6ee0846b8d1023d463e Mon Sep 17 00:00:00 2001
+From: Oliver Schmidt <os@flyingcircus.io>
+Date: Tue, 19 May 2026 23:31:18 +0200
+Subject: [PATCH] Makefile: do not create VINYL_STATE_DIR
+
+In the nix expression, we continue to hardcode /var/run
+as a statedirectory. But trying to create that  top-level
+directory from within the build sandbox fails (and is
+a wrong move anyways).
+
+An upstream solution would need to be more nuanced though.
+
+diff --git a/Makefile.in b/Makefile.in
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -44,7 +44,6 @@ AM_DISTCHECK_CONFIGURE_FLAGS += --with-unwind
+ endif
+ 
+ install-data-local:
+-	$(install_sh) -d -m 0755 "${VINYL_STATE_DIR}"
+ 
+ distclean-local:
+ 	-find . '(' -name '*.gcda' -o -name '*.gcda' ')' -exec rm '{}' ';'
+-- 
+2.51.2
+

--- a/pkgs/servers/vinyl-cache/default.nix
+++ b/pkgs/servers/vinyl-cache/default.nix
@@ -127,7 +127,7 @@ in
 {
   # EOL 2027-03-16
   vinyl-cache_9 = generic {
-    version = "9.0.0";
-    hash = "sha256-l0DCEMKndifVD9CtbHWdw8oJT8tOZVW6VfynHPSDvRc=";
+    version = "9.0.1";
+    hash = "sha256-Lo7GfNIT6mhkx2OTnWSRICVVc0L60qX/2mx8W1m96xc=";
   };
 }

--- a/pkgs/servers/vinyl-cache/default.nix
+++ b/pkgs/servers/vinyl-cache/default.nix
@@ -19,6 +19,21 @@
 }:
 
 let
+  # Vinyl Cache has very strong opinions and very complicated code around handling
+  # the stateDir. After a lot of back and forth, we decided that we
+  # a) do not want a configurable option here, as most of the handling depends
+  # on the version and the compile time options.
+  # b) Vinyl Cache prefers RAM backed stateDirs due to shared memory usage.
+  # /var/run (RAM backed) is a very good fit as long as it is *not* mounted as
+  # `noexec`, which is currently not the case in NixOS but in other distros.
+  # https://code.vinyl-cache.org/vinyl-cache/vinyl-cache/issues/4477
+  # c) need to explicitly specify this at compile-time as upstream even changed
+  # defaults in a patch release.
+  # To handle potential version-dependent differences, the path is exposed to a
+  # module using the package via passthru.
+  stateDirPrefix = "/run";
+  # the actual subdirectory is created by vinyld itself within the prefix at runtime
+  stateDir = "${stateDirPrefix}/vinyld";
   generic =
     {
       version,
@@ -60,10 +75,12 @@ let
         "ac_cv_have_tcp_fastopen=yes"
         "ac_cv_have_tcp_keep=yes"
         "ac_cv_have_working_close_range=yes"
+
         "PYTHON=${buildPackages.python3.interpreter}"
+        "--with-statedir=${stateDirPrefix}"
       ];
 
-      buildFlags = [ "localstatedir=/var/run" ];
+      patches = [ ./0001-Makefile-do-not-create-VINYL_STATE_DIR.patch ];
 
       postPatch = ''
         substituteInPlace bin/vinyltest/vtest2/src/vtc_main.c --replace-fail /bin/rm "${coreutils}/bin/rm"
@@ -109,6 +126,8 @@ let
       passthru = {
         python = python3;
         tests = nixosTests."vinyl-cache_${lib.versions.major version}";
+        # pass-thru compile-time value for usage in module
+        inherit stateDir;
       };
 
       meta = {


### PR DESCRIPTION
Supersedes #521779.

fixes VSV00019 and reworks the stateDir to deal with upstream changes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
