### PR TITLE
vault-tasks: 0.13.0 -> 2.0.3

### DIFF
--- a/pkgs/by-name/va/vault-tasks/package.nix
+++ b/pkgs/by-name/va/vault-tasks/package.nix
@@ -5,29 +5,27 @@
   stdenv,
   buildPackages,
   installShellFiles,
+  versionCheckHook,
   nix-update-script,
 }:
-let
-  version = "0.13.0";
-in
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "vault-tasks";
-  inherit version;
+  version = "2.0.3";
   src = fetchFromGitHub {
     owner = "louis-thevenet";
     repo = "vault-tasks";
-    rev = "v${version}";
-    hash = "sha256-XWeY2l82n51O4/LKPOJZOXf7PCRPOUshFg832iDvmuA=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-EioDozhVgI6queKe0giINiaahvc91ANDgT0m8/oL9Kk=";
   };
 
-  cargoHash = "sha256-znc2oKpovsXyrUhKvBVMorv7yWM39xNgaNDiq/5I6Dg=";
+  cargoHash = "sha256-TlkuQiNjl+U7dmSHPWlsuThRnMfdLy2/4koK6wcFlT0=";
 
   nativeBuildInputs = [
     installShellFiles
   ];
 
   postInstall = ''
-    install -Dm444 desktop/vault-tasks.desktop -t $out/share/applications
+    install -Dm444 desktop/vault-tasks-tui.desktop -t $out/share/applications
   ''
   + (
     let
@@ -41,13 +39,16 @@ rustPlatform.buildRustPackage {
       # vault-tasks tries to load a config file from ~/.config/ before generating completions
       export HOME="$(mktemp -d)"
 
-      installShellCompletion --cmd vault-tasks \
-        --bash <(${vault-tasks}/bin/vault-tasks generate-completions bash) \
-        --fish <(${vault-tasks}/bin/vault-tasks generate-completions fish) \
-        --zsh <(${vault-tasks}/bin/vault-tasks generate-completions zsh)
+      installShellCompletion --cmd vault-tasks-tui \
+        --bash <(${vault-tasks}/bin/vault-tasks-tui generate-completions bash) \
+        --fish <(${vault-tasks}/bin/vault-tasks-tui generate-completions fish) \
+        --zsh <(${vault-tasks}/bin/vault-tasks-tui generate-completions zsh)
     ''
   );
 
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
   passthru.updateScript = nix-update-script { };
 
   meta = {
@@ -58,7 +59,7 @@ rustPlatform.buildRustPackage {
     '';
     homepage = "https://github.com/louis-thevenet/vault-tasks";
     license = lib.licenses.mit;
-    mainProgram = "vault-tasks";
+    mainProgram = "vault-tasks-tui";
     maintainers = with lib.maintainers; [ louis-thevenet ];
   };
-}
+})


### PR DESCRIPTION
## Releases
- https://github.com/louis-thevenet/vault-tasks/releases/tag/v1.0.0
- https://github.com/louis-thevenet/vault-tasks/releases/tag/v2.0.0
- https://github.com/louis-thevenet/vault-tasks/releases/tag/v2.0.1
- https://github.com/louis-thevenet/vault-tasks/releases/tag/v2.0.2
- https://github.com/louis-thevenet/vault-tasks/releases/tag/v2.0.3
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
