### PR TITLE
pokerth: 2.0.0 and more

### DIFF
--- a/pkgs/by-name/po/pokerth/package.nix
+++ b/pkgs/by-name/po/pokerth/package.nix
@@ -91,7 +91,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Poker game ${target}";
     mainProgram = "pokerth";
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ obadz ];
+    maintainers = with lib.maintainers; [
+      obadz
+      philocalyst
+    ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/po/pokerth/package.nix
+++ b/pkgs/by-name/po/pokerth/package.nix
@@ -1,100 +1,141 @@
 {
   lib,
   stdenv,
-  qt5,
+  qt6,
   fetchFromGitHub,
-  fetchpatch,
-  SDL,
-  SDL_mixer,
-  boost181,
-  curl,
-  gsasl,
-  libgcrypt,
-  libircclient,
-  protobuf_21,
-  sqlite,
-  tinyxml,
+  cmake,
+  makeWrapper,
+  boost,
+  protobuf,
+  openssl,
+  libiconv,
   target ? "client",
 }:
 
 let
-  boost = boost181;
-  protobuf = protobuf_21;
+  isClient = target == "client";
+  isServer = target == "server";
 in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pokerth-${target}";
-  version = "1.1.2";
+  version = "2.0.7";
 
   src = fetchFromGitHub {
     owner = "pokerth";
     repo = "pokerth";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-j4E3VMpaPqX7+hE3wYRZZUeRD//F+K2Gp8oPmJqX5FQ=";
+    hash = "sha256-Dhm0qmNdABL2n6cOhTl8KRb/C6g9s9vHhBFv8rI0shA=";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "pokerth-1.1.2.patch";
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/pokerth-1.1.2.patch?h=pokerth&id=7734029cf9c6ef58f42ed873e1b9c3c19eb1df3b";
-      hash = "sha256-we2UOCFF5J/Wlji/rJeCHDu/dNsUU+R+bTw83AmvDxs=";
-    })
-    (fetchpatch {
-      name = "pokerth-1.1.2.patch.2019";
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/pokerth-1.1.2.patch.2019?h=pokerth&id=7734029cf9c6ef58f42ed873e1b9c3c19eb1df3b";
-      hash = "sha256-m6uFPmPC3T9kV7EI1p33vQSi0d/w+YCH0dKjviAphMY=";
-    })
-    (fetchpatch {
-      name = "pokerth-1.1.2.patch.2020";
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/pokerth-1.1.2.patch.2020?h=pokerth&id=7734029cf9c6ef58f42ed873e1b9c3c19eb1df3b";
-      hash = "sha256-I2qrgLGSMvFDHyUZFWGPGnuecZ914NBf2uGK02X/wOg=";
-    })
-  ];
+  postPatch =
+    lib.optionalString stdenv.hostPlatform.isDarwin ''
+      # nixpkgs protobuf propagates abseil properly; skip explicit
+      # find_package which would also require unavailable utf8_range
+      substituteInPlace CMakeLists.txt \
+        --replace-fail 'elseif(APPLE)' 'elseif(FALSE)'
 
-  postPatch = ''
-    for f in *.pro; do
-      substituteInPlace $f \
-        --replace '$$'{PREFIX}/include/libircclient ${libircclient.dev}/include/libircclient \
-        --replace 'LIB_DIRS =' 'LIB_DIRS = ${boost.out}/lib' \
-        --replace /opt/gsasl ${gsasl}
-    done
-  '';
+      # Boost lexical_cast + enums fails under Apple Clang due to strict
+      # constexpr rules. Cast GameState to int before lexical_cast.
+      substituteInPlace src/engine/log.cpp \
+        --replace-fail \
+          'boost::lexical_cast<string>(currentRound)' \
+          'boost::lexical_cast<string>(static_cast<int>(currentRound))'
+      substituteInPlace src/gui/qt/gametable/log/guilog.cpp \
+        --replace-fail \
+          'boost::lexical_cast<std::string>(GAME_STATE_PREFLOP)' \
+          'boost::lexical_cast<std::string>(static_cast<int>(GAME_STATE_PREFLOP))'
+    ''
+    + lib.optionalString (stdenv.hostPlatform.isDarwin && isServer) ''
+      # Server compiles convhelper.cpp which uses iconv (not in glibc on macOS)
+      substituteInPlace src/CMakeLists.txt \
+        --replace-fail \
+          'target_link_libraries(pokerth_dedicated_server PRIVATE Qt6::Xml Qt6::Sql)' \
+          'target_link_libraries(pokerth_dedicated_server PRIVATE "-liconv" Qt6::Xml Qt6::Sql)'
+    '';
 
   nativeBuildInputs = [
-    qt5.qmake
-    qt5.wrapQtAppsHook
+    cmake
+    qt6.wrapQtAppsHook
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin && isClient) [
+    makeWrapper
+  ];
+
+  # On macOS, QT_PLUGIN_PATH is not read by Qt6! only
+  # QT_QPA_PLATFORM_PLUGIN_PATH works for platform plugin discovery.
+  # Adding qtbase/bin to PATH also enables the PATH-based plugin path
+  # derivation from the nixpkgs qtbase patch.
+  qtWrapperArgs = lib.optionals stdenv.hostPlatform.isDarwin [
+    "--prefix QT_QPA_PLATFORM_PLUGIN_PATH : ${qt6.qtbase}/lib/qt-6/plugins/platforms"
+    "--prefix PATH : ${qt6.qtbase}/bin"
   ];
 
   buildInputs = [
-    SDL
-    SDL_mixer
     boost
-    curl
-    gsasl
-    libgcrypt
-    libircclient
+    openssl
     protobuf
-    qt5.qtbase
-    sqlite
-    tinyxml
+    qt6.qtbase
+    qt6.qtdeclarative
+    qt6.qtmultimedia
+    qt6.qtsvg
+    qt6.qtwebsockets
+    qt6.qttools
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin && isServer) [
+    libiconv # server compiles convhelper.cpp which needs iconv
   ];
 
-  qmakeFlags = [
-    "CONFIG+=${target}"
-    "pokerth.pro"
-  ];
+  buildFlags = [ (if isClient then "pokerth_client" else "pokerth_dedicated_server") ];
 
-  env.NIX_CFLAGS_COMPILE = "-I${lib.getDev SDL}/include/SDL";
+  installPhase = ''
+    runHook preInstall
+    cmake --install . --component ${if isClient then "pokerth_client" else "pokerth_dedicated_server"}
+    runHook postInstall
+  '';
+
+  postInstall = lib.optionalString (stdenv.hostPlatform.isDarwin && isClient) ''
+    appName="PokerTH"
+    appBundle="$out/Applications/$appName.app"
+    appContents="$appBundle/Contents"
+    appMacOS="$appContents/MacOS"
+    appResources="$appContents/Resources"
+
+    mkdir -p "$appMacOS" "$appResources"
+
+    # Extract Info.plist template from upstream build_macos.sh
+    awk '/<<EOF$/{found=1; next} /^EOF$/{found=0; next} found' "$src/build_macos.sh" > "$appContents/Info.plist"
+
+    substituteInPlace "$appContents/Info.plist" \
+      --replace-fail '$APP_NAME' "$appName" \
+      --replace-fail '2.0.7' '${finalAttrs.version}'
+
+    # Move the cmake-installed binary into the app bundle
+    mv "$out/bin/pokerth_client" "$appMacOS/$appName"
+
+    # pokerth.icns is tracked in git at repo root
+    cp "$src/pokerth.icns" "$appResources/"
+
+    # Data directory (gfx, sounds, fonts, stylesheets, translations) — already
+    # installed to $out/share/pokerth/data by cmake.  Symlink into the bundle so
+    # the macOS code path (../Resources/data/) in qthelper.cpp finds it.
+    ln -s "$out/share/pokerth/data" "$appResources/data"
+
+    # CLI entry points both pointing to the app bundle binary
+    makeWrapper "$appMacOS/$appName" "$out/bin/pokerth_client"
+    makeWrapper "$appMacOS/$appName" "$out/bin/pokerth"
+  '';
 
   meta = {
     homepage = "https://www.pokerth.net";
     description = "Poker game ${target}";
-    mainProgram = "pokerth";
-    license = lib.licenses.gpl3;
+    mainProgram = if isClient then "pokerth_client" else "pokerth_dedicated_server";
+    license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [
       obadz
       philocalyst
     ];
     platforms = lib.platforms.all;
+    changelog = "https://github.com/pokerth/pokerth/blob/v${finalAttrs.version}/ChangeLog";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- Full darwin build!
- Please let me know if the commit is too dense, it was hard to pull it apart
- Bumped to version 2 which means qt6 and all other good things
- small license change
- added some meta fields that are nice!

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
