### PR TITLE
plezy: 2.0.0 -> 2.1.0

### DIFF
--- a/pkgs/by-name/pl/plezy/git-hashes.json
+++ b/pkgs/by-name/pl/plezy/git-hashes.json
@@ -3,7 +3,7 @@
   "auto_updater_macos": "sha256-787cMkeT2BlfwVcy4y46XkWioNqLKJgQ/CCxQvERa+A=",
   "auto_updater_platform_interface": "sha256-787cMkeT2BlfwVcy4y46XkWioNqLKJgQ/CCxQvERa+A=",
   "auto_updater_windows": "sha256-787cMkeT2BlfwVcy4y46XkWioNqLKJgQ/CCxQvERa+A=",
-  "background_downloader": "sha256-U41AQVdXceT5ZBgvBR90h3JAAU2BLpguglcVBTrTww4=",
+  "background_downloader": "sha256-hW3fD7X1l6dPITPchE9lzpFwsIZ597JsgsBeAyQPjI0=",
   "material_symbols_icons": "sha256-XRB6AZ4Q33sQKVZFA8lgdXCW/bx55h/RpmuItmFYVJM=",
   "os_media_controls": "sha256-0Bghn1s28+xlcfSLyVA7B60atJkkdqcFKseSubPtzkQ=",
   "wakelock_plus": "sha256-89xs0sLNuoCqApFqwEY+SEk2DUqjHf8JsSd7dfxX3P0="

--- a/pkgs/by-name/pl/plezy/package.nix
+++ b/pkgs/by-name/pl/plezy/package.nix
@@ -25,13 +25,13 @@
 
 let
   pname = "plezy";
-  version = "2.0.0";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "edde746";
     repo = "plezy";
     tag = version;
-    hash = "sha256-Pi5M74CI6J31Pzaf7wnUFFTpbOSwOTWdKUoYuXt8+Zs=";
+    hash = "sha256-l09xiSTyV8MNE9ZI69nM+DTpumQ0ZOaRjhLlq4rXX0w=";
   };
 
   simdutf = fetchurl {
@@ -139,7 +139,7 @@ let
 
     src = fetchurl {
       url = "https://github.com/edde746/plezy/releases/download/${version}/plezy-macos.dmg";
-      hash = "sha256-zkctxQIgpU9dGhv8SdVy2S4eFUQ7GgeaWzwSEvFrWWc=";
+      hash = "sha256-khmDHKsW8zs7ehIj86EgqortRKKDUoOfPsX7VpvnfNY=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/pl/plezy/pubspec.lock.json
+++ b/pkgs/by-name/pl/plezy/pubspec.lock.json
@@ -108,8 +108,8 @@
       "dependency": "direct main",
       "description": {
         "path": ".",
-        "ref": "1f42690",
-        "resolved-ref": "1f426908b0d9e1083de35b3dd353c3434ad32ef2",
+        "ref": "4c965996210e408465e3c8b66e63ab4a659a62f9",
+        "resolved-ref": "4c965996210e408465e3c8b66e63ab4a659a62f9",
         "url": "https://github.com/edde746/background_downloader"
       },
       "source": "git",
@@ -629,6 +629,16 @@
       "source": "hosted",
       "version": "2.1.3"
     },
+    "globbing": {
+      "dependency": "transitive",
+      "description": {
+        "name": "globbing",
+        "sha256": "4f89cfaf6fa74c9c1740a96259da06bd45411ede56744e28017cc534a12b6e2d",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.0"
+    },
     "graphs": {
       "dependency": "transitive",
       "description": {
@@ -708,6 +718,16 @@
       },
       "source": "hosted",
       "version": "0.1.0"
+    },
+    "injector": {
+      "dependency": "transitive",
+      "description": {
+        "name": "injector",
+        "sha256": "ed389bed5b48a699d5b9561c985023d0d5cc88dd5ff2237aadcce5a5ab433e4e",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.0.0"
     },
     "intl": {
       "dependency": "direct main",
@@ -1101,6 +1121,16 @@
       "source": "hosted",
       "version": "5.0.5"
     },
+    "properties": {
+      "dependency": "transitive",
+      "description": {
+        "name": "properties",
+        "sha256": "333f427dd4ed07bdbe8c75b9ff864a1e70b5d7a8426a2e8bdd457b65ae5ac598",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.1"
+    },
     "provider": {
       "dependency": "direct main",
       "description": {
@@ -1260,6 +1290,16 @@
       },
       "source": "hosted",
       "version": "9.16.0"
+    },
+    "sentry_dart_plugin": {
+      "dependency": "direct dev",
+      "description": {
+        "name": "sentry_dart_plugin",
+        "sha256": "2c5f263f8d5aea3cf387a7e03f77e355d35c71bd9a429474d633fbc085b86ceb",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.3.0"
     },
     "sentry_flutter": {
       "dependency": "direct main",
@@ -1506,6 +1546,26 @@
       },
       "source": "hosted",
       "version": "1.4.1"
+    },
+    "string_similarity": {
+      "dependency": "direct main",
+      "description": {
+        "name": "string_similarity",
+        "sha256": "3ee1fc76e0c800aeb3dce197e28ed8541b622224d09b10c34a022803066a7c50",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.2.0"
+    },
+    "system_info2": {
+      "dependency": "transitive",
+      "description": {
+        "name": "system_info2",
+        "sha256": "b937736ecfa63c45b10dde1ceb6bb30e5c0c340e14c441df024150679d65ac43",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.1.0"
     },
     "term_glyph": {
       "dependency": "transitive",
@@ -1799,7 +1859,7 @@
       "version": "1.1.0"
     },
     "xml": {
-      "dependency": "transitive",
+      "dependency": "direct main",
       "description": {
         "name": "xml",
         "sha256": "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025",

--- a/pkgs/by-name/pl/plezy/replace-sentry-fork.patch
+++ b/pkgs/by-name/pl/plezy/replace-sentry-fork.patch
@@ -3,7 +3,7 @@
 @@ -56,11 +56,7 @@
      git:
        url: https://github.com/edde746/background_downloader
-       ref: 1f42690
+       ref: 4c965996210e408465e3c8b66e63ab4a659a62f9
 -  sentry_flutter:
 -    git:
 -      url: https://github.com/edde746/sentry-dart

--- a/pkgs/by-name/pl/plezy/update.sh
+++ b/pkgs/by-name/pl/plezy/update.sh
@@ -35,7 +35,7 @@ patch -d "$workdir" -p1 < "$ROOT/replace-sentry-fork.patch"
 
 export PUB_CACHE="$workdir/.pub-cache"
 flutter --no-version-check config --no-analytics >/dev/null
-flutter --no-version-check pub --directory "$workdir" get
+(cd "$workdir" && flutter --no-version-check pub get)
 
 yq eval --output-format=json --prettyPrint "$workdir/pubspec.lock" > "$ROOT/pubspec.lock.json"
 


### PR DESCRIPTION
https://github.com/edde746/plezy/releases/tag/2.1.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
