### PR TITLE
flightgear: flightgear: 2024.1.5 -> 2024.1.6-rc1; modernization

### DIFF
--- a/pkgs/by-name/fl/flightgear/openscenegraph-flightgear.nix
+++ b/pkgs/by-name/fl/flightgear/openscenegraph-flightgear.nix
@@ -32,9 +32,8 @@ stdenv.mkDerivation {
   src = fetchFromGitLab {
     owner = "flightgear";
     repo = "openscenegraph";
-    # release/2024-build as of 2025-08-08
-    rev = "a4ea8ec535cc969e31e2026b13be147dcb978689";
-    sha256 = "sha256-wnxm4G40j2e6Paqx0vfAR4s4L7esfCHcgxUJWNxk1SM=";
+    rev = "b5895abe0d94a57839929d38b5681dc8e796a8a0";
+    hash = "sha256-FaTn+QZa1qAU9DNhBjQvBLu/Z9q2liatBbsxY8a0hUI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/fl/flightgear/openscenegraph-flightgear.nix
+++ b/pkgs/by-name/fl/flightgear/openscenegraph-flightgear.nix
@@ -83,13 +83,19 @@ stdenv.mkDerivation {
   ++ lib.optional stdenv.hostPlatform.isDarwin (lib.cmakeFeature "OSG_WINDOWING_SYSTEM" "Cocoa");
 
   meta = {
-    description = "3D graphics toolkit";
-    homepage = "http://www.openscenegraph.org/";
+    description = "3D graphics toolkit (FlightGear fork)";
+    homepage = "https://gitlab.com/flightgear/openscenegraph";
+    changelog = "https://gitlab.com/flightgear/openscenegraph/-/commits/release/2024-build";
     maintainers = with lib.maintainers; [
       aanderse
       raskin
     ];
     platforms = with lib.platforms; linux ++ darwin;
-    license = "OpenSceneGraph Public License - free LGPL-based license";
+
+    # This is a fork of openscenegraph, mirrored licenses
+    license = with lib.licenses; [
+      lgpl21Only
+      wxWindowsException31
+    ];
   };
 }

--- a/pkgs/by-name/fl/flightgear/package.nix
+++ b/pkgs/by-name/fl/flightgear/package.nix
@@ -39,13 +39,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "flightgear";
-  version = "2024.1.5";
+  version = "2024.1.6-rc1";
 
   src = fetchFromGitLab {
     owner = "flightgear";
     repo = "flightgear";
     tag = finalAttrs.version;
-    hash = "sha256-sORiO0SDChIVWIhGKelm7IE/cZ40gMqlZ1OoZZna7kI=";
+    hash = "sha256-YYWDLCZ+2g4sWrSZJ+EvFCPH/IIYWD0wKzcslqw9VSs=";
   };
 
   nativeBuildInputs = [
@@ -118,7 +118,7 @@ stdenv.mkDerivation (finalAttrs: {
         owner = "flightgear";
         repo = "fgdata";
         tag = finalAttrs.version;
-        hash = "sha256-8B5wSYjkWuPEySpqBiprZ+jrHy01HA9+iX70wNAn81s=";
+        hash = "sha256-B7WCEMrHtSW4Yk2HM+ZjgKt5GeQrSmvxKITqAYXKSuw=";
       };
 
       dontUnpack = true;

--- a/pkgs/by-name/fl/flightgear/package.nix
+++ b/pkgs/by-name/fl/flightgear/package.nix
@@ -135,6 +135,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       raskin
       kirillrdy
+      philocalyst
     ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     hydraPlatforms = [ ]; # disabled from hydra because it's so big

--- a/pkgs/by-name/fl/flightgear/package.nix
+++ b/pkgs/by-name/fl/flightgear/package.nix
@@ -131,7 +131,9 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    description = "Flight simulator";
+    description = "A free and highly sophisticated flight simulator";
+    homepage = "https://www.flightgear.org/";
+    changelog = "https://www.flightgear.org/download/releases/2024-1-5"; # TODO: Use finalattrs when back on stable tracking
     maintainers = with lib.maintainers; [
       raskin
       kirillrdy

--- a/pkgs/by-name/fl/flightgear/package.nix
+++ b/pkgs/by-name/fl/flightgear/package.nix
@@ -35,36 +35,16 @@
 }:
 
 let
-  version = "2024.1.5";
-  data = stdenv.mkDerivation rec {
-    pname = "flightgear-data";
-    inherit version;
-
-    src = fetchFromGitLab {
-      owner = "flightgear";
-      repo = "fgdata";
-      tag = version;
-      hash = "sha256-8B5wSYjkWuPEySpqBiprZ+jrHy01HA9+iX70wNAn81s=";
-    };
-
-    dontUnpack = true;
-
-    installPhase = ''
-      mkdir -p "$out/share/FlightGear"
-      cp ${src}/* -a "$out/share/FlightGear/"
-    '';
-  };
   openscenegraph = callPackage ./openscenegraph-flightgear.nix { };
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "flightgear";
-  # inheriting data for `nix-prefetch-url -A pkgs.flightgear.data.src`
-  inherit version data;
+  version = "2024.1.5";
 
   src = fetchFromGitLab {
     owner = "flightgear";
     repo = "flightgear";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-sORiO0SDChIVWIhGKelm7IE/cZ40gMqlZ1OoZZna7kI=";
   };
 
@@ -111,7 +91,7 @@ stdenv.mkDerivation rec {
     lib.cmakeFeature "CMAKE_OSX_DEPLOYMENT_TARGET" "11.0"
   );
 
-  qtWrapperArgs = [ "--set FG_ROOT ${data}/share/FlightGear" ];
+  qtWrapperArgs = [ "--set FG_ROOT ${finalAttrs.passthru.data}/share/FlightGear" ];
 
   postInstall = ''
     # Remove redundant AppImage artifacts
@@ -127,7 +107,28 @@ stdenv.mkDerivation rec {
     ln -s "$out/Applications/FlightGear.app/Contents/MacOS/FlightGear" "$out/bin/fgfs"
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+
+    data = stdenv.mkDerivation {
+      pname = "flightgear-data";
+      inherit (finalAttrs) version;
+
+      src = fetchFromGitLab {
+        owner = "flightgear";
+        repo = "fgdata";
+        tag = finalAttrs.version;
+        hash = "sha256-8B5wSYjkWuPEySpqBiprZ+jrHy01HA9+iX70wNAn81s=";
+      };
+
+      dontUnpack = true;
+
+      installPhase = ''
+        mkdir -p "$out/share/FlightGear"
+        cp -a "$src"/* "$out/share/FlightGear/"
+      '';
+    };
+  };
 
   meta = {
     description = "Flight simulator";
@@ -140,4 +141,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Plus;
     mainProgram = "fgfs";
   };
-}
+})

--- a/pkgs/by-name/si/simgear/package.nix
+++ b/pkgs/by-name/si/simgear/package.nix
@@ -27,18 +27,16 @@
   curl,
   c-ares,
 }:
-let
-  version = "2024.1.5";
-in
+
 stdenv.mkDerivation (finalAttrs: {
   pname = "simgear";
-  inherit version;
+  version = "2024.1.6-rc1";
 
   src = fetchFromGitLab {
     owner = "flightgear";
     repo = "simgear";
     tag = finalAttrs.version;
-    hash = "sha256-WONlVdfDWIcoj/UfcFA4Vw5edlgr0vlT/fjIPDti7fk=";
+    hash = "sha256-uj8yVJNjAsrO0ydL5xMVtRRqx+5mXZ60qrPW2BAHl0g=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- Bumped things to their latest versions (Flightgear seems to be on life-support so these little changes are nice to have while its in this state)
- Moved to latest nixpkgs patterns, for minimal let blocks and no rec
- Also holds changes to simgear
- Apologies if the diffs are annoying to read here the structure changes make it difficult

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
