### PR TITLE
nixos/ydotool: autoload uinput kernel module

### DIFF
--- a/nixos/modules/programs/ydotool.nix
+++ b/nixos/modules/programs/ydotool.nix
@@ -33,6 +33,12 @@ in
     lib.mkIf cfg.enable {
       users.groups."${config.programs.ydotool.group}" = { };
 
+      # ydotoold opens /dev/uinput at startup but has ProtectKernelModules=true,
+      # so it cannot autoload the uinput module itself. Load it at boot so the
+      # device node exists when the service starts. Same pattern as
+      # hardware.steam-hardware (#70499).
+      boot.kernelModules = [ "uinput" ];
+
       systemd.services.ydotoold = {
         description = "ydotoold - backend for ydotool";
         wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/programs/ydotool.nix
+++ b/nixos/modules/programs/ydotool.nix
@@ -33,11 +33,7 @@ in
     lib.mkIf cfg.enable {
       users.groups."${config.programs.ydotool.group}" = { };
 
-      # ydotoold opens /dev/uinput at startup but has ProtectKernelModules=true,
-      # so it cannot autoload the uinput module itself. Load it at boot so the
-      # device node exists when the service starts. Same pattern as
-      # hardware.steam-hardware (#70499).
-      boot.kernelModules = [ "uinput" ];
+      hardware.uinput.enable = true;
 
       systemd.services.ydotoold = {
         description = "ydotoold - backend for ydotool";


### PR DESCRIPTION
## Description of changes

`programs.ydotool` enables a hardened systemd service whose `ExecStart` opens `/dev/uinput` as its first action. Because the service has `ProtectKernelModules = true`, it cannot autoload the `uinput` module itself. On systems where `uinput` is not autoloaded (default on many configurations), enabling `programs.ydotool` starts the service successfully but every `ydotool` invocation fails because the device node is absent.

This PR loads `uinput` at boot via `boot.kernelModules` so the device node exists when the service starts. Same one-line pattern previously applied to `hardware.steam-hardware` in #70499 for the identical autoload case.

## Reproducer (before fix)

On a hermetic NixOS VM with:

```nix
programs.ydotool.enable = true;
```

and `uinput` *not* otherwise in `boot.kernelModules`:

```
$ systemctl status ydotoold
... Active: active (running)
$ ydotool key 28:1 28:0
ydotool: client.c:200: uinput_emit: Assertion `fd > 0' failed.
$ journalctl -u ydotoold | grep uinput
... open(/dev/uinput): No such file or directory
```

After this PR, `boot.kernelModules` includes `"uinput"`, the device node is present, and `ydotool` works as documented.

## Things done

- [x] Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = relaxed` set in `nix.conf`? (N/A — Linux-only module)
- [x] Tested, as applicable:
  - [x] NixOS configuration with `programs.ydotool.enable = true`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` in a clone of nixpkgs (N/A — module-only change)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`) (N/A — module-only)
- [ ] 25.11 Release Notes (or backporting 25.05 Release notes) (no behavior change beyond enabling existing intent)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)

## Backport

May want to backport to `release-25.11` given the same out-of-the-box failure mode is present there. Happy to file the backport if maintainers agree.

## Related

- #70499 — equivalent `boot.kernelModules = [ "uinput" ]` line added to `hardware.steam-hardware` for the same reason
- Cross-references the recurring "ydotool service started but doesn't work" pattern that surfaces in several user reports