### PR TITLE
Contracts for file backups

### DIFF
--- a/nixos/modules/services/backup/borgbackup.nix
+++ b/nixos/modules/services/backup/borgbackup.nix
@@ -220,10 +220,9 @@ let
           )}
       '';
 
-  # Returns a singleton list, due to usage of lib.optional
   mkBorgWrapper =
     name: cfg:
-    lib.optional (cfg.wrapper != "" && cfg.wrapper != null) (mkWrapperDrv {
+    mkWrapperDrv {
       original = lib.getExe config.services.borgbackup.package;
       name = cfg.wrapper;
       set = {
@@ -232,7 +231,58 @@ let
       // (mkPassEnv cfg)
       // cfg.environment;
       extraArgs = cfg.extraArgs or null;
-    });
+    };
+
+  mkBackupContractScript =
+    name: backup:
+    let
+      script = mkBorgWrapper name backup;
+    in
+    # I chose to base the contract script on the existing script
+    # to avoid duplicating the environment variables logic.
+    # Similarly, I based the backup command on the systemd service
+    # because it already handled giving the source directories.
+    # I prioritized a small diff size.
+    pkgs.writeShellApplication {
+      name = "borgbackup-${name}";
+      text = ''
+        usage() {
+          echo "$0 snapshots"
+          echo "$0 backup"
+          echo "$0 restore <snapshot>"
+          echo "$0 exec <arg> [<arg>...]"
+        }
+
+        if [ -z "''${1:-}" ]; then
+          usage
+          exit 0
+        fi
+
+        if [ "$1" = "restore" ]; then
+          shift
+          snapshot="$1"
+
+          echo "Will restore snapshot '$snapshot'"
+
+          (cd / && exec ${script}/bin/borg-job-${name} extract "::$snapshot")
+        elif [ "$1" = "backup" ]; then
+          shift
+
+          systemctl start --wait borgbackup-job-${name}
+        elif [ "$1" = "snapshots" ]; then
+          shift
+
+          ${script}/bin/borg-job-${name} list --short
+        elif [ "$1" = "exec" ]; then
+          shift
+
+          exec ${script}/bin/borg-job-${name} "$@"
+        else
+          usage
+          exit 1
+        fi
+      '';
+    };
 
   # Paths listed in ReadWritePaths must exist before service is started
   mkTmpfiles =
@@ -423,7 +473,11 @@ in
 
             paths = lib.mkOption {
               type = with lib.types; nullOr (coercedTo str lib.singleton (listOf str));
-              default = null;
+              default =
+                if config.fileBackupContract == null then
+                  null
+                else
+                  config.fileBackupContract.input.sourceDirectories;
               description = ''
                 Path(s) to back up.
                 Mutually exclusive with {option}`dumpCommand`.
@@ -518,7 +572,8 @@ in
                 User or group need read permission
                 for the specified {option}`paths`.
               '';
-              default = "root";
+              default =
+                if config.fileBackupContract == null then "root" else config.fileBackupContract.input.user;
             };
 
             group = lib.mkOption {
@@ -603,7 +658,9 @@ in
                 Can not be set when {option}`createCommand` is set to
                 `import-tar`.
               '';
-              default = [ ];
+              default = lib.optionals (config.fileBackupContract == null) (
+                map (n: "sh:**/${n}") config.fileBackupContract.input.excludePatterns
+              );
               example = [
                 "/home/*/.cache"
                 "/nix"
@@ -830,6 +887,79 @@ in
               default = [ ];
               example = [ "--cleanup-commits" ];
             };
+
+            fileBackupContract = lib.mkOption {
+              description = "Provider of the fileBackup contract.";
+              default = null;
+              type = lib.types.nullOr (
+                lib.types.submodule {
+                  options = {
+                    input = {
+                      user = lib.mkOption {
+                        description = ''
+                          As which user the backup should run.
+                        '';
+                        type = lib.types.str;
+                        example = "vaultwarden";
+                      };
+
+                      sourceDirectories = lib.mkOption {
+                        description = ''
+                          Directories to backup.
+                        '';
+                        type = lib.types.nonEmptyListOf lib.types.str;
+                        example = [
+                          "/var/lib/vaultwarden"
+                        ];
+                      };
+
+                      excludePatterns = lib.mkOption {
+                        description = ''
+                          File patterns to exclude.
+                        '';
+                        type = lib.types.listOf lib.types.str;
+                        default = [ ];
+                      };
+                    };
+                    output = {
+                      script = lib.mkOption {
+                        description = ''
+                          Script that provide the following commands
+                          and runs with the necessary environment variables:
+
+                          - Listing snapshots:
+
+                            ```bash
+                            <script> snaphots
+                            ```
+
+                          - Restore a snapshot:
+
+                            ```bash
+                            <script> restore <snapshot>
+                            ```
+
+                          - Take a backup:
+
+                            ```bash
+                            <script> backup
+                            ```
+
+                          - Pass a custom command to the underlying provider:
+
+                            ```bash
+                            <script> exec <arg> [<arg> ...]
+                            ```
+                        '';
+                        type = lib.types.package;
+                        default = mkBackupContractScript name config;
+                        defaultText = "/path/to/script";
+                      };
+                    };
+                  };
+                }
+              );
+            };
           };
         }
       )
@@ -961,7 +1091,9 @@ in
       environment.systemPackages = [
         config.services.borgbackup.package
       ]
-      ++ (lib.flatten (lib.mapAttrsToList mkBorgWrapper jobs));
+      ++ (lib.mapAttrsToList mkBorgWrapper (
+        lib.filterAttrs (_: cfg: cfg.wrapper != "" && cfg.wrapper != null) jobs
+      ));
     }
   );
 }

--- a/nixos/modules/services/backup/restic.nix
+++ b/nixos/modules/services/backup/restic.nix
@@ -8,6 +8,78 @@
 let
   # Type for a valid systemd unit option. Needed for correctly passing "timerConfig" to "systemd.timers"
   inherit (utils.systemdUtils.unitOptions) unitOption;
+
+  mkScript =
+    name: backup:
+    let
+      extraOptions = lib.concatMapStrings (arg: " -o ${arg}") backup.extraOptions;
+      resticCmd = "${lib.getExe backup.package}${extraOptions}";
+    in
+    pkgs.writeShellScriptBin "restic-${name}" ''
+      set -a  # automatically export variables
+      ${lib.optionalString (backup.environmentFile != null) "source ${backup.environmentFile}"}
+      # set same environment variables as the systemd service
+      ${lib.pipe config.systemd.services."restic-backups-${name}".environment [
+        (lib.filterAttrs (n: v: v != null && n != "PATH"))
+        (lib.mapAttrs (_: v: "${v}"))
+        lib.toShellVars
+      ]}
+      PATH=${config.systemd.services."restic-backups-${name}".environment.PATH}:$PATH
+
+      exec ${resticCmd} "$@"
+    '';
+
+  mkBackupContractScript =
+    name: backup:
+    let
+      script = mkScript name backup;
+    in
+    # I chose to base the contract script on the existing script
+    # to avoid duplicating the environment variables logic.
+    # Similarly, I based the backup command on the systemd service
+    # because it already handled giving the source directories.
+    # I prioritized a small diff size.
+    pkgs.writeShellApplication {
+      name = "restic-${name}";
+      text = ''
+        usage() {
+          echo "$0 snapshots"
+          echo "$0 backup"
+          echo "$0 restore <snapshot>"
+          echo "$0 exec <arg> [<arg>...]"
+        }
+
+        if [ -z "''${1:-}" ]; then
+          usage
+          exit 0
+        fi
+
+        if [ "$1" = "restore" ]; then
+          shift
+          snapshot="$1"
+
+          echo "Will restore snapshot '$snapshot'"
+
+          exec ${lib.getExe script} restore "$snapshot" --target /
+        elif [ "$1" = "backup" ]; then
+          shift
+
+          systemctl start --wait restic-backups-${name}
+        elif [ "$1" = "snapshots" ]; then
+          shift
+
+          ${lib.getExe script} snapshots --json \
+            | ${pkgs.jq}/bin/jq '.[].id'
+        elif [ "$1" = "exec" ]; then
+          shift
+
+          exec ${lib.getExe script} "$@"
+        else
+          usage
+          exit 1
+        fi
+      '';
+    };
 in
 {
   options.services.restic.backups = lib.mkOption {
@@ -16,7 +88,7 @@ in
     '';
     type = lib.types.attrsOf (
       lib.types.submodule (
-        { name, ... }:
+        { name, config, ... }:
         {
           options = {
             passwordFile = lib.mkOption {
@@ -134,12 +206,19 @@ in
               # This is nullable for legacy reasons only. We should consider making it a pure listOf
               # after some time has passed since this comment was added.
               type = lib.types.nullOr (lib.types.listOf lib.types.str);
-              default = [ ];
+              default =
+                if config.fileBackupContract == null then
+                  [ ]
+                else
+                  config.fileBackupContract.input.sourceDirectories;
               description = ''
                 Which paths to backup, in addition to ones specified via
                 `dynamicFilesFrom`.  If null or an empty array and
                 `dynamicFilesFrom` is also null, no backup command will be run.
                  This can be used to create a prune-only job.
+
+                If using the `fileBackupContract`, this option is set through
+                the `sourceDirectories` option of the contract.
               '';
               example = [
                 "/var/lib/postgresql"
@@ -164,7 +243,8 @@ in
 
             exclude = lib.mkOption {
               type = lib.types.listOf lib.types.str;
-              default = [ ];
+              default =
+                if config.fileBackupContract == null then [ ] else config.fileBackupContract.input.excludePatterns;
               description = ''
                 Patterns to exclude when backing up. See
                 https://restic.readthedocs.io/en/latest/040_backup.html#excluding-files for
@@ -197,9 +277,13 @@ in
 
             user = lib.mkOption {
               type = lib.types.str;
-              default = "root";
+              default =
+                if config.fileBackupContract == null then "root" else config.fileBackupContract.input.user;
               description = ''
                 As which user the backup should run.
+
+                If using the `fileBackupContract`, this option is set through
+                the `user` option of the contract.
               '';
               example = "postgresql";
             };
@@ -254,7 +338,7 @@ in
 
             runCheck = lib.mkOption {
               type = lib.types.bool;
-              default = builtins.length config.services.restic.backups.${name}.checkOpts > 0;
+              default = builtins.length config.checkOpts > 0;
               defaultText = lib.literalExpression "builtins.length config.services.backups.${name}.checkOpts > 0";
               description = "Whether to run the `check` command with the provided `checkOpts` options.";
               example = true;
@@ -317,6 +401,79 @@ in
                 Controls the frequency of progress reporting.
               '';
               example = 0.1;
+            };
+
+            fileBackupContract = lib.mkOption {
+              description = "Provider of the fileBackup contract.";
+              default = null;
+              type = lib.types.nullOr (
+                lib.types.submodule {
+                  options = {
+                    input = {
+                      user = lib.mkOption {
+                        description = ''
+                          As which user the backup should run.
+                        '';
+                        type = lib.types.str;
+                        example = "vaultwarden";
+                      };
+
+                      sourceDirectories = lib.mkOption {
+                        description = ''
+                          Directories to backup.
+                        '';
+                        type = lib.types.nonEmptyListOf lib.types.str;
+                        example = [
+                          "/var/lib/vaultwarden"
+                        ];
+                      };
+
+                      excludePatterns = lib.mkOption {
+                        description = ''
+                          File patterns to exclude.
+                        '';
+                        type = lib.types.listOf lib.types.str;
+                        default = [ ];
+                      };
+                    };
+                    output = {
+                      script = lib.mkOption {
+                        description = ''
+                          Script that provide the following commands
+                          and runs with the necessary environment variables:
+
+                          - Listing snapshots:
+
+                            ```bash
+                            <script> snaphots
+                            ```
+
+                          - Restore a snapshot:
+
+                            ```bash
+                            <script> restore <snapshot>
+                            ```
+
+                          - Take a backup:
+
+                            ```bash
+                            <script> backup
+                            ```
+
+                          - Pass a custom command to the underlying provider:
+
+                            ```bash
+                            <script> exec <arg> [<arg> ...]
+                            ```
+                        '';
+                        type = lib.types.package;
+                        default = mkBackupContractScript name config;
+                        defaultText = "/path/to/script";
+                      };
+                    };
+                  };
+                }
+              );
             };
           };
         }
@@ -500,6 +657,7 @@ in
         }
       )
     ) config.services.restic.backups;
+
     systemd.timers = lib.mapAttrs' (
       name: backup:
       lib.nameValuePair "restic-backups-${name}" {
@@ -510,25 +668,8 @@ in
     ) (lib.filterAttrs (_: backup: backup.timerConfig != null) config.services.restic.backups);
 
     # generate wrapper scripts, as described in the createWrapper option
-    environment.systemPackages = lib.mapAttrsToList (
-      name: backup:
-      let
-        extraOptions = lib.concatMapStrings (arg: " -o ${arg}") backup.extraOptions;
-        resticCmd = "${lib.getExe backup.package}${extraOptions}";
-      in
-      pkgs.writeShellScriptBin "restic-${name}" ''
-        set -a  # automatically export variables
-        ${lib.optionalString (backup.environmentFile != null) "source ${backup.environmentFile}"}
-        # set same environment variables as the systemd service
-        ${lib.pipe config.systemd.services."restic-backups-${name}".environment [
-          (lib.filterAttrs (n: v: v != null && n != "PATH"))
-          (lib.mapAttrs (_: v: "${v}"))
-          lib.toShellVars
-        ]}
-        PATH=${config.systemd.services."restic-backups-${name}".environment.PATH}:$PATH
-
-        exec ${resticCmd} "$@"
-      ''
-    ) (lib.filterAttrs (_: v: v.createWrapper) config.services.restic.backups);
+    environment.systemPackages = (
+      lib.mapAttrsToList mkScript (lib.filterAttrs (_: v: v.createWrapper) config.services.restic.backups)
+    );
   };
 }

--- a/nixos/modules/services/home-automation/home-assistant.nix
+++ b/nixos/modules/services/home-automation/home-assistant.nix
@@ -814,6 +814,29 @@ in
           "template"
         ]
     );
+
+    fileBackupContract.input = {
+      user = lib.mkOption {
+        description = ''
+          As which user the backup should run.
+        '';
+        type = lib.types.str;
+        default = "hass";
+      };
+
+      sourceDirectories = lib.mkOption {
+        description = ''
+          Directories to backup.
+        '';
+        type = lib.types.nonEmptyListOf lib.types.str;
+        default = [
+          cfg.configDir
+        ];
+        defaultText = [
+          "config.services.home-assistant.configDir"
+        ];
+      };
+    };
   };
 
   config = mkIf cfg.enable {

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -1188,6 +1188,41 @@ in
     };
 
     imaginary.enable = lib.mkEnableOption "Imaginary";
+
+    fileBackupContract.input = {
+      user = lib.mkOption {
+        description = ''
+          As which user the backup should run.
+        '';
+        type = lib.types.str;
+        default = "nextcloud";
+      };
+
+      sourceDirectories = lib.mkOption {
+        description = ''
+          Directories to backup.
+        '';
+        type = lib.types.nonEmptyListOf lib.types.str;
+        default = [
+          cfg.home
+          datadir
+        ];
+        defaultText = [
+          "config.services.nextcloud.home"
+          "config.services.nextcloud.datadir"
+        ];
+      };
+
+      excludePatterns = lib.mkOption {
+        description = ''
+          File patterns to exclude.
+        '';
+        type = lib.types.listOf lib.types.str;
+        default = [
+          "*.rnd"
+        ];
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable (

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -399,6 +399,7 @@ in
   containers-restart_networking = runTest ./containers-restart_networking.nix;
   containers-tmpfs = runTest ./containers-tmpfs.nix;
   containers-unified-hierarchy = runTest ./containers-unified-hierarchy.nix;
+  contracts = import ./contracts { inherit runTest; };
   convos = runTest ./convos.nix;
   coredns = runTest ./coredns.nix;
   corerad = runTest ./corerad.nix;

--- a/nixos/tests/contracts/default.nix
+++ b/nixos/tests/contracts/default.nix
@@ -10,5 +10,6 @@
 
        <contract name>-<provider name> = runTest ./<contract name>/<provider name>.nix
   */
+  fileBackup-borgbackup = runTest ./fileBackup/borgbackup.nix;
   fileBackup-restic = runTest ./fileBackup/restic.nix;
 }

--- a/nixos/tests/contracts/default.nix
+++ b/nixos/tests/contracts/default.nix
@@ -11,5 +11,6 @@
        <contract name>-<provider name> = runTest ./<contract name>/<provider name>.nix
   */
   fileBackup-borgbackup = runTest ./fileBackup/borgbackup.nix;
+  fileBackup-demo = runTest ./fileBackup/demo.nix;
   fileBackup-restic = runTest ./fileBackup/restic.nix;
 }

--- a/nixos/tests/contracts/default.nix
+++ b/nixos/tests/contracts/default.nix
@@ -10,4 +10,5 @@
 
        <contract name>-<provider name> = runTest ./<contract name>/<provider name>.nix
   */
+  fileBackup-restic = runTest ./fileBackup/restic.nix;
 }

--- a/nixos/tests/contracts/default.nix
+++ b/nixos/tests/contracts/default.nix
@@ -1,0 +1,13 @@
+{ runTest }:
+{
+  /*
+    Tests for contract providers should be added here.
+
+    Each contract has its generic test in a separate folder <contract name>/genericTest.nix.
+
+    To prove a provider implements a contract correctly, add a file under <contract name>/<provider name>.nix
+    which implements the generic test at <contract name>/default.nix. Then, add a line here in the form
+
+       <contract name>-<provider name> = runTest ./<contract name>/<provider name>.nix
+  */
+}

--- a/nixos/tests/contracts/fileBackup/borgbackup.nix
+++ b/nixos/tests/contracts/fileBackup/borgbackup.nix
@@ -1,0 +1,34 @@
+args@{ lib, pkgs, ... }:
+let
+  genericTest = import ./genericTest.nix args;
+in
+genericTest {
+  providerName = "borgbackup";
+  maintainers = [ lib.maintainers.ibizaman ];
+
+  providerRoot = [
+    "services"
+    "borgbackup"
+    "jobs"
+    "mytest"
+    "fileBackupContract"
+  ];
+
+  imports = [
+    ../../../modules/services/backup/borgbackup.nix
+    (
+      { config, ... }:
+      {
+        # systemd.tmpfiles.rules = [
+        #   "d /opt/repos/mytest 0750 ${config.test.input.user} root - -"
+        # ];
+
+        services.borgbackup.jobs.mytest = {
+          doInit = true;
+          encryption.passphrase = "${pkgs.writeText "passphrase" "mypassphrase"}";
+          repo = "/opt/repos/mytest";
+        };
+      }
+    )
+  ];
+}

--- a/nixos/tests/contracts/fileBackup/borgbackup.nix
+++ b/nixos/tests/contracts/fileBackup/borgbackup.nix
@@ -19,12 +19,9 @@ genericTest {
     (
       { config, ... }:
       {
-        # systemd.tmpfiles.rules = [
-        #   "d /opt/repos/mytest 0750 ${config.test.input.user} root - -"
-        # ];
-
         services.borgbackup.jobs.mytest = {
           doInit = true;
+          encryption.mode = "repokey";
           encryption.passphrase = "${pkgs.writeText "passphrase" "mypassphrase"}";
           repo = "/opt/repos/mytest";
         };

--- a/nixos/tests/contracts/fileBackup/demo.nix
+++ b/nixos/tests/contracts/fileBackup/demo.nix
@@ -1,0 +1,110 @@
+{
+  lib,
+  pkgs,
+  ...
+}:
+let
+  mkResticConfig = name: input: {
+    initialize = true;
+    repository = "/opt/restic-repos/${name}";
+    passwordFile = "${pkgs.writeText "password" "restic-${name}-password"}";
+
+    # fileBackup contract wiring
+    fileBackupContract.input = input;
+  };
+
+  mkBorgBackupConfig = name: input: {
+    doInit = true;
+    repo = "/opt/borgbackup-repos/${name}";
+    encryption.mode = "repokey";
+    encryption.passphrase = "${pkgs.writeText "password" "borgbackup-${name}-password"}";
+    environment.BORG_BASE_DIR = "/opt/borgbackup/${name}";
+    readWritePaths = [ "/opt/borgbackup/${name}" ];
+
+    # fileBackup contract wiring
+    fileBackupContract.input = input;
+  };
+in
+{
+  name = "contract_fileBackup_demo";
+  meta.maintainers = [ lib.maintainers.ibizaman ];
+
+  nodes.machine =
+    { config, ... }:
+    {
+      services.nextcloud = {
+        enable = true;
+        hostName = "nextcloud.example.com";
+        database.createLocally = true;
+        config = {
+          adminpassFile = "${pkgs.writeText "password" "nextcloud-password"}";
+          dbtype = "sqlite";
+        };
+      };
+
+      services.home-assistant = {
+        enable = true;
+      };
+
+      systemd.tmpfiles.rules =
+        let
+          homeAssistantUser = config.services.restic.backups."home-assistant".fileBackupContract.input.user;
+          nextcloudUser = config.services.restic.backups."nextcloud".fileBackupContract.input.user;
+        in
+        [
+          # # Repo directories for restic
+          "d /opt/restic-repos/home-assistant 0750 ${homeAssistantUser} root - -"
+          "d /opt/restic-repos/nextcloud 0750 ${nextcloudUser} root - -"
+
+          # Repo directories for borgbackup
+          "d /opt/borgbackup-repos/home-assistant 0750 ${homeAssistantUser} root - -"
+          "d /opt/borgbackup-repos/nextcloud 0750 ${nextcloudUser} root - -"
+
+          # State directories for borgbackup
+          "d /opt/borgbackup/home-assistant 0750 ${homeAssistantUser} root - -"
+          "d /opt/borgbackup/nextcloud 0750 ${nextcloudUser} root - -"
+        ];
+
+      services.restic.backups."home-assistant" =
+        mkResticConfig "home-assistant" config.services.home-assistant.fileBackupContract.input;
+
+      services.borgbackup.jobs."home-assistant" =
+        mkBorgBackupConfig "home-assistant" config.services.home-assistant.fileBackupContract.input;
+
+      services.restic.backups."nextcloud" =
+        mkResticConfig "nextcloud" config.services.nextcloud.fileBackupContract.input;
+
+      services.borgbackup.jobs."nextcloud" =
+        mkBorgBackupConfig "nextcloud" config.services.nextcloud.fileBackupContract.input;
+
+      environment.systemPackages = [
+        # fileBackup contract wiring
+        config.services.restic.backups."home-assistant".fileBackupContract.output.script
+        config.services.borgbackup.jobs."home-assistant".fileBackupContract.output.script
+        config.services.restic.backups."nextcloud".fileBackupContract.output.script
+        config.services.borgbackup.jobs."nextcloud".fileBackupContract.output.script
+      ];
+    };
+
+  testScript = ''
+    machine.start()
+
+    with subtest("home-assistant"):
+        machine.wait_for_unit("home-assistant.service")
+
+        machine.succeed("restic-home-assistant backup")
+        print(machine.succeed("restic-home-assistant snapshots"))
+
+        machine.succeed("borgbackup-home-assistant backup")
+        print(machine.succeed("borgbackup-home-assistant snapshots"))
+
+    with subtest("nextcloud"):
+        machine.wait_for_unit("phpfpm-nextcloud.service")
+
+        machine.succeed("restic-nextcloud backup")
+        print(machine.succeed("restic-nextcloud snapshots"))
+
+        machine.succeed("borgbackup-nextcloud backup")
+        print(machine.succeed("borgbackup-nextcloud snapshots"))
+  '';
+}

--- a/nixos/tests/contracts/fileBackup/genericTest.nix
+++ b/nixos/tests/contracts/fileBackup/genericTest.nix
@@ -1,0 +1,244 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+{
+  providerName,
+  providerRoot,
+  imports ? [ ],
+  maintainers ? [ ],
+}:
+let
+  inherit (lib) mkOption types;
+
+  contractWiringModule =
+    { config, ... }:
+    {
+      test.output = (lib.getAttrFromPath providerRoot config).output;
+
+      imports = imports ++ [
+        (lib.setAttrByPath providerRoot {
+          input = config.test.input;
+        })
+      ];
+    };
+in
+{
+  name = "contracts_fileBackup_${providerName}";
+  meta.maintainers = [ lib.maintainers.ibizaman ] ++ maintainers;
+
+  nodes.machine =
+    { config, ... }:
+    {
+      options = {
+        test = {
+          input = {
+            user = mkOption {
+              type = types.str;
+            };
+
+            sourceDirectories = mkOption {
+              type = types.nonEmptyListOf types.str;
+            };
+
+            excludePatterns = mkOption {
+              type = types.listOf types.str;
+            };
+          };
+
+          output = {
+            script = mkOption {
+              type = types.package;
+            };
+
+            # Helper option to serialize path to binary to JSON.
+            bin = mkOption {
+              type = types.str;
+              internal = true;
+              default = lib.getExe config.test.output.script;
+            };
+          };
+        };
+
+        jsonTestConfig = mkOption {
+          type = types.path;
+          default = pkgs.writeText "config.json" (builtins.toJSON config.test);
+        };
+      };
+
+      config = {
+        specialisation.root.configuration =
+          { config, ... }:
+          {
+            imports = [ contractWiringModule ];
+
+            test.input = {
+              user = "root";
+              sourceDirectories = [
+                "/opt/files/A"
+                "/opt/files/B"
+              ];
+              excludePatterns = [
+                "_exclude"
+              ];
+            };
+          };
+
+        specialisation.user.configuration =
+          { config, ... }:
+          {
+            imports = [ contractWiringModule ];
+
+            test.input = {
+              user = "me";
+              sourceDirectories = [
+                "/opt/files/A"
+                "/opt/files/B"
+              ];
+              excludePatterns = [
+                "_exclude"
+              ];
+            };
+            users.users.${config.test.input.user} = {
+              isSystemUser = true;
+              group = config.test.input.user;
+              home = "/home/${config.test.input.user}";
+              createHome = true;
+            };
+            users.groups.${config.test.input.user} = { };
+          };
+      };
+    };
+
+  extraPythonPackages = p: [ p.dictdiffer ];
+
+  testScript =
+    { nodes, ... }:
+    let
+      specialisations = "${nodes.machine.system.build.toplevel}/specialisation";
+    in
+    ''
+      from datetime import datetime, timedelta
+      from dictdiffer import diff
+      import json
+      import re
+
+      def list_files(dir):
+          files_and_content = {}
+
+          files = machine.succeed(f"""find {dir} -type f""").split("\n")[:-1]
+
+          for f in files:
+              content = machine.succeed(f"""cat {f}""").strip()
+              files_and_content[f] = content
+
+          return files_and_content
+
+      def assert_files(dir, files):
+          result = list(diff(list_files(dir), files))
+          if len(result) > 0:
+              raise Exception("Unexpected files:", result)
+
+      def run_test_with_config(file):
+          config = json.loads(machine.succeed(f"cat {file}"))
+          script = config["output"]["bin"]
+          user = config["input"]["user"]
+          sourceDirectories = config["input"]["sourceDirectories"]
+
+          with subtest("Create initial content"):
+              for path in sourceDirectories:
+                  machine.succeed(f"""
+                      mkdir -p {path}
+                      echo repo_fileA_1 > {path}/fileA
+                      echo repo_fileB_1 > {path}/fileB
+                      touch {path}/_exclude
+
+                      chown {user}: -R {path}
+                      chmod go-rwx -R {path}
+                  """)
+
+              for path in sourceDirectories:
+                  assert_files(path, {
+                      f'{path}/fileA': 'repo_fileA_1',
+                      f'{path}/fileB': 'repo_fileB_1',
+                      f'{path}/_exclude': "",
+                  })
+
+          with subtest("First backup in repo"):
+              machine.succeed(f"{script} backup")
+
+          with subtest("One snapshot"):
+              out = machine.succeed(f"{script} snapshots").splitlines()
+              print(f"Found snapshots:\n{out}")
+              if len(out) != 1:
+                raise Exception(f"Unexpected snapshots:\n{out}")
+
+          # To accomodate for snapshot orchestrators which keep only a given amount
+          # of snapshots per unit of time, we set the time to now + 2h.
+          new_date = (datetime.now() + timedelta(hours=2)).strftime("%Y-%m-%d %H:%M:%S")
+          machine.succeed(f"timedatectl set-time '{new_date}'")
+
+          with subtest("New content"):
+              for path in sourceDirectories:
+                  machine.succeed(f"""
+                    echo repo_fileA_2 > {path}/fileA
+                    echo repo_fileB_2 > {path}/fileB
+                    """)
+
+                  assert_files(path, {
+                      f'{path}/fileA': 'repo_fileA_2',
+                      f'{path}/fileB': 'repo_fileB_2',
+                      f'{path}/_exclude': "",
+                  })
+
+          with subtest("Second backup in repo"):
+              machine.succeed(f"{script} backup")
+
+          with subtest("two snapshots"):
+              out = machine.succeed(f"{script} snapshots").splitlines()
+              print("Found snapshots:")
+              for i, s in enumerate(out):
+                  print(f" {i+1}: {s}")
+              if len(out) != 2:
+                  raise Exception(f"Unexpected snapshots:\n{out}")
+
+          firstSnapshot = re.split("[ \t+]", out[0], maxsplit=1)[0]
+          secondSnapshot = re.split("[ \t+]", out[1], maxsplit=1)[0]
+
+          with subtest("Delete content"):
+              for path in sourceDirectories:
+                  machine.succeed(f"""rm -r {path}/*""")
+
+                  assert_files(path, {})
+
+          with subtest("Restore second backup"):
+              machine.succeed(f"{script} restore {secondSnapshot}")
+
+              for path in sourceDirectories:
+                  assert_files(path, {
+                      f'{path}/fileA': 'repo_fileA_2',
+                      f'{path}/fileB': 'repo_fileB_2',
+                  })
+
+          with subtest("Restore first backup"):
+              machine.succeed(f"{script} restore {firstSnapshot}")
+
+              for path in sourceDirectories:
+                  assert_files(path, {
+                      f'{path}/fileA': 'repo_fileA_1',
+                      f'{path}/fileB': 'repo_fileB_1',
+                  })
+
+          machine.succeed("rm -r /opt")
+
+      with subtest("Test 1 - user=root"):
+          machine.succeed("${specialisations}/root/bin/switch-to-configuration test")
+          run_test_with_config("${nodes.machine.specialisation.root.configuration.jsonTestConfig}")
+
+      with subtest("Test 2 - user=me"):
+          machine.succeed("${specialisations}/user/bin/switch-to-configuration test")
+          run_test_with_config("${nodes.machine.specialisation.user.configuration.jsonTestConfig}")
+    '';
+}

--- a/nixos/tests/contracts/fileBackup/restic.nix
+++ b/nixos/tests/contracts/fileBackup/restic.nix
@@ -1,0 +1,34 @@
+args@{ lib, pkgs, ... }:
+let
+  genericTest = import ./genericTest.nix args;
+in
+genericTest {
+  providerName = "restic";
+  maintainers = [ lib.maintainers.ibizaman ];
+
+  providerRoot = [
+    "services"
+    "restic"
+    "backups"
+    "mytest"
+    "fileBackupContract"
+  ];
+
+  imports = [
+    ../../../modules/services/backup/restic.nix
+    (
+      { config, ... }:
+      {
+        systemd.tmpfiles.rules = [
+          "d /opt/repos/mytest 0750 ${config.test.input.user} root - -"
+        ];
+
+        services.restic.backups.mytest = {
+          initialize = true;
+          passwordFile = "${pkgs.writeText "passphrase" "mypassphrase"}";
+          repository = "/opt/repos/mytest";
+        };
+      }
+    )
+  ];
+}


### PR DESCRIPTION
**Converting back the PR to draft because I got some sizable amount of changes I want to make and you should know that before continuing.**

This PR follows the [RFC 189](https://github.com/NixOS/rfcs/pull/189) to implement a contract for file backups.

File backups means specifically backing up files on a filesystem. Backing up a database using a dump command or taking snapshots of a snapshottable filesystem (e.g. ZFS) are out of scope. Separate contracts will be made for those as seen fit.

# Previous work

This PR supersedes https://github.com/NixOS/nixpkgs/pull/495303 which was introducing a contract for secrets. I am of the opinion that PR, although having similar goals, was doomed to fail from the start because:

1. It touches a subject that has a lot of bagage in nixpkgs - secrets. Although the contract was technically forward compatible with the Vars initiative, I fully understand it still looked like a competitor.
2. The intended providers for the contract - sops-nix, agenix, etc. - live outside of the nixpkgs repo, making it hard to give concrete usage examples.
3. The contract was not fully backwards compatible as it was changing the type of an existing option in the consumers.

This contract does not suffer from the issues.

Two other prior PRs exist that introduced contracts by the wrong end. They started by adding a complex mechanism without a concrete use case and it made it hard to distinguish between intrinsic complexity and accidental complexity. This PR does not suffer from this issue either as it introduces no such mechanism and focuses on the essence of the contract. The PRs are linked at the end of the PR description.

There is also the PR https://github.com/NixOS/nixpkgs/pull/506343 which goes very far, a bit like a research project, and sees what pushing the contracts mechanism can lead to. It answers to the questions like does this work with modular services and others with success. The implementation might change in the future but the answers are there.

Finally, I do use this contract, although with a different naming convention, in my project and it works great for about 10 services https://shb.skarabox.com/contracts-backup.html. The options I chose are the minimal necessary ones to satisfy all those services.

# Contract

This PR creates a standardized option submodule that allows maintainers of a service to codify how their service should be backed up. The submodule provides the following option:

```nix
{
  input = {
    user = mkOption {
      type = types.str;
    };

    sourceDirectories = mkOption {
      type = types.nonEmptyListOf types.str;
    };

    excludePatterns = mkOption {
      type = types.listOf types.str;
      default = [ ];
    };
  };

  output = {
    script = mkOption {
      type = types.package;
    };
  };
}
```

The `input.user` option defines which Unix user the backup service should run under to have the correct permission to backup the wanted files.

The `input.sourceDirectories` option defines which directories to back up.

The `input.excludePatterns` option defines which patterns to exclude from the backup. For example, setting `[ "_exclude" "*.rnd" ]` would exclude the file whose name exactly matches `_exclude` and all files ending in `.rnd`. Note that uniformizing the handling of this option across all providers is important although must still be further expanded in this PR (I'm happy to get suggestions here, TBH I didn’t want to spend too much time making this option perfect before getting more feedback on the PR). The generic test is used to enforce all providers implement this option as expected. See the `Provider` section below for the generic test.

The `output.script` option must be a package whose goal is to provide a uniformized helper on the command line:

```bash
# List snapshots. Must output 1 snapshot by line.
# No format is imposed on what the snapshot should look like
# but copying it verbatim in the restore command must restore that snapshot.
$ <script> snaphots

# Restore a snapshot:
$ <script> restore <snapshot>

# Take a backup:
$ <script> backup

# Pass a custom command to the underlying provider:
$ <script> exec <arg> [<arg> ...]
```

These exact same commands must be understood by all providers. These are enforced by the generic tests, see the `Provider` section below for the generic test.

The user may expose the package provided under the `output.script` option in any way they see fit, including adding them in the `environment.systemPackages` option.

This package, although not strictly necessary from a user perspective, is necessary to make the tests generic as it can then trigger a backup or restore a snapshot ion a standard way for each test. After writing those tests I realized extracting this script was super nice and thus why it appeared as an option here instead of staying internal in the tests.

# Consumer

A service that wants to be backed up, also called a consumer of the file backup contract, must declare and define at least the `input.user` and `input.sourceDirectories` options and optionally the `input.excludePatterns` option. Although the usefulness is limited, the `output.script` option may be referenced by the service. A minimal example is:

```nix
{
  options.services.vaultwarden.fileBackupContract.input = {
    user = mkOption {
      type = types.str;
      default = "vaultwarden";
    };

    sourceDirectories = mkOption {
      type = types.nonEmptyListOf types.str;
      default = [ cfg.dataDir ];
      defaultText = [ "config.services.vaultwarden.dataDir" ];
    };
  };
}
```

The `nextcloud` and `home-assistant` modules are modified to implement this contract. You will notice the implementation is fully backwards compatible and is quite minimal.

# Provider

The `restic`  and `borgbackup` modules are modified to implement this contract. Although the diff here is bigger than for the consumers, the diff is merely a massaging of the options of the contract to match those of the existing `restic` and `borgbackup` providers. Most of the diff is related to the implementation of the script that goes into the `output.script` option. The modifications are fully backwards compatible.

A service that can back up files which wants to become a provider of this contract must:

1. Implement all the options of the contract:

```nix
{
  input = {
    user = mkOption {
      type = types.str;
    };

    sourceDirectories = mkOption {
      type = types.nonEmptyListOf types.str;
    };

    excludePatterns = mkOption {
      type = types.listOf types.str;
      default = [ ];
    };
  };

  output = {
    script = mkOption {
      type = types.package;
      default = pkgs.writeShellApplication { ... };
    };
  };
}
```

Each option must be handled the same way by all providers. This is enforced by making the provider pass the NixOS VM generic test described hereunder.

5. Pass the generic test. 

The goal of the generic test is to make sure each provider behaves in the same uniformized way, making them interchangeable.

A provider wanting to implement this contract must add a file at

```
nixos/tests/contracts/fileBackup/<provider name>.nix
```

which imports the generic test function
```
genericTest = import ./genericTest.nix args;
```
and uses it to define a test. A line referencing this new file must be added to `nixos/tests/contracts/default.nix`. The test can then be run with `nix-build -A nixosTests.contracts.fileBackup-<provider name>`.

All generic test functions (for this contract and others) accept one `attrset` as argument which must define the following attributes:

- `providerName (str)`
- `providerRoot (listOf str)` this is the path in the option tree to the provider option implementing the `fileBackupContract`. It is a list because the generic test uses `setAttrByPath` and `getAttrFromPath` to respectively set the `input` and get the `output` of the contract.
- `maintainers` to know who to ping in case of an issue.
- `imports` which is a list of modules which is used both to import the actual provider module to be tested but also to setup any required options needed to initialize the provider, would this be necessary.

Furthermore, the generic test function defines the `test.input` and `test.output` options which follows exactly the same definition as the contract. These can be used in the modules in the `imports` if required by the provider.

# Usage

To make this PR more concrete, a demo file has been added at `nixos/tests/contracts/fileBackup/demo.nix` with a NixOS VM test which shows how the end user would use the `fileBackup` contract.

The demo shows the `restic` and `borgbackup` services using the file backup contract to backup both `nextcloud` and `home-assistant`. This demo file could be moved to the manual instead of living as a NixOS VM test but I wanted to showcase this is actually evaluating and building correctly.

```nix
{
  services.restic.backups."home-assistant" = {
    // Here goes "normal" Restic options
    initialize = true;
    repository = "/opt/restic-repos/${name}";
    passwordFile = "${pkgs.writeText "password" "restic-${name}-password"}";

    pruneOpts = [
      "--keep-daily 7"
      "--keep-weekly 5"
      "--keep-monthly 12"
      "--keep-yearly 75"
    ];

    // Contract option
    fileBackupContract.input = config.services.home-assistant.fileBackupContract.input;
  };
}
```

# Out of Scope

## Options Machinery

All in all, this PR does not do anything magic as far as the module system is concerned and that is its primary goal, keep it simple.

Clearly, the options for the contract are repeated in various places. It is quite evident that it would be beneficial in the long run to somehow define the options once in a source of truth location and be able to reuse them when needed. After all, the diff in the consumers repeat a lot of stuff.

I specifically want to _not_ include this consideration in this PR. The goal here is to focus on the contract itself. What it means to have a file backup contract, what options should go in there, etc. Attempts were made to introduce the machinery to avoid repeating the options in other PRs but these did not receive a lot of attention. If you have ideas though, feel free to comment on those PRs:

- https://github.com/NixOS/nixpkgs/pull/432529 implementation using dependent types
- https://github.com/NixOS/nixpkgs/pull/485453 implementation using functions

## Service Orchestration

Or is it out of scope? Should we stop a service before backing up the files? Should the contract include a "hook" option that triggers a dump of a consumer service's files?

## Streaming Backup

I do have an implementation ready for this but it should probably go into its own follow-up PR.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- [x] nix-build -A nixosTests.restic
- [x] nix-build -A nixosTests.borgbackup
- [x] nix-build -A nixosTests.contracts.fileBackup-restic
- [x] nix-build -A nixosTests.contracts.fileBackup-borgbackup
- [x] nix-build -A nixosTests.contracts.fileBackup-demo
- [x] (cd nixos/; nix-build release.nix -A manual.x86_64-linux)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
