### PR TITLE
 python314Packages.django-valkey: fix python version conditions in optional dependencies, cleanup;  python314Packages.django-vcache: 1.0.0 -> 2.1.1;  python314Packages.django-vtasks: 1.0.3 -> 2.1.1

### DIFF
--- a/pkgs/development/python-modules/django-valkey/default.nix
+++ b/pkgs/development/python-modules/django-valkey/default.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   buildPythonPackage,
   hatchling,
+  pythonOlder,
 
   # propagated
   backports-zstd,
@@ -47,8 +48,8 @@ buildPythonPackage rec {
     lz4 = [ lz4 ];
     msgpack = [ msgpack ];
     msgspec = [ msgspec ];
-    pyzstd = [ backports-zstd ];
-    zstd = [ backports-zstd ];
+    pyzstd = lib.optionals (pythonOlder "3.14") [ backports-zstd ];
+    zstd = lib.optionals (pythonOlder "3.14") [ backports-zstd ];
   };
 
   pythonImportsCheck = [ "django_valkey" ];
@@ -82,11 +83,11 @@ buildPythonPackage rec {
 
   __darwinAllowLocalNetworking = true;
 
-  meta = with lib; {
+  meta = {
     description = "Valkey backend for django";
     homepage = "https://github.com/django-commons/django-valkey";
     changelog = "https://github.com/django-commons/django-valkey/releases/tag/${version}";
-    license = licenses.bsd3;
+    license = lib.licenses.bsd3;
     maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/django-vcache/default.nix
+++ b/pkgs/development/python-modules/django-vcache/default.nix
@@ -1,27 +1,30 @@
 {
   lib,
   buildPythonPackage,
-  croniter,
   django,
   fetchFromGitLab,
   hatchling,
   ormsgpack,
-  prometheus-client,
   pythonOlder,
-  valkey,
-  zstd,
+  pyzstd,
+  rustPlatform,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "django-vcache";
-  version = "1.0.0";
+  version = "2.1.1";
   pyproject = true;
 
   src = fetchFromGitLab {
     owner = "glitchtip";
     repo = "django-vcache";
-    tag = "v${version}";
-    hash = "sha256-bOHEw4nl82tFjHiJdmyW0LleKMpjUh8uu4crGp6IsWY=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-EUTZ7dUpjwZ7cU4Hgud40PKfryX5gNyAgaRBGEdy9WE=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) src;
+    hash = "sha256-fj0Ukfo9+Aq8D+spqB5OzL8QkPqpHqr2AaCgYqDCjzw=";
   };
 
   build-system = [ hatchling ];
@@ -29,16 +32,13 @@ buildPythonPackage rec {
   dependencies = [
     django
     ormsgpack
-    croniter
-    valkey
   ]
-  ++ valkey.optional-dependencies.libvalkey
-  ++ lib.optional (pythonOlder "3.14") zstd;
+  ++ lib.optional (pythonOlder "3.14") pyzstd;
 
-  optional-dependencies = {
-    metrics = [ prometheus-client ];
-    valkey = [ valkey ] ++ valkey.optional-dependencies.libvalkey;
-  };
+  nativeBuildInputs = [
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+  ];
 
   pythonImportsCheck = [ "django_vcache" ];
 
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     description = "Specialized, lightweight Django cache backend for Valkey";
     homepage = "https://gitlab.com/glitchtip/django-vcache/";
     changelog = "https://gitlab.com/glitchtip/django-vcache/-/blob/main/CHANGELOG.md#${
-      lib.replaceString "." "" version
+      lib.replaceString "." "" finalAttrs.version
     }";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
@@ -57,4 +57,4 @@ buildPythonPackage rec {
       felbinger
     ];
   };
-}
+})

--- a/pkgs/development/python-modules/django-vtasks/default.nix
+++ b/pkgs/development/python-modules/django-vtasks/default.nix
@@ -4,6 +4,7 @@
   croniter,
   dj-database-url,
   django-valkey,
+  django-vcache,
   django,
   fetchFromGitLab,
   hatchling,
@@ -16,21 +17,20 @@
   pytest-django,
   pytestCheckHook,
   pythonOlder,
+  pyzstd,
   redisTestHook,
-  valkey,
-  zstandard,
 }:
 
 buildPythonPackage rec {
   pname = "django-vtasks";
-  version = "1.0.3";
+  version = "2.1.1";
   pyproject = true;
 
   src = fetchFromGitLab {
     owner = "glitchtip";
     repo = "django-vtasks";
     tag = "v${version}";
-    hash = "sha256-75W63HsLBT4EPQCiAXjd9qr6n07/2e5GCUNWeDzXUq0=";
+    hash = "sha256-f9x6atPMYgQQ/jpCJdDj33l+mhyei+6IWi4bqqVWxU8=";
   };
 
   postPatch = ''
@@ -47,12 +47,11 @@ buildPythonPackage rec {
     django
     orjson
     croniter
-  ]
-  ++ lib.optional (pythonOlder "3.14") zstandard;
+  ];
 
   optional-dependencies = {
     metrics = [ prometheus-client ];
-    valkey = [ valkey ] ++ valkey.optional-dependencies.libvalkey;
+    valkey = [ django-vcache ] ++ lib.optional (pythonOlder "3.14") pyzstd;
   };
 
   pythonImportsCheck = [ "django_vtasks" ];
@@ -67,6 +66,7 @@ buildPythonPackage rec {
 
     dj-database-url
     django-valkey
+    django-vcache
     postgresql
     postgresqlTestHook
     psycopg


### PR DESCRIPTION
Fixes GlitchTip throwing many errors.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
