### PR TITLE
libnatspec: 0.3.0 -> 0.3.3

### DIFF
--- a/pkgs/by-name/li/libnatspec/package.nix
+++ b/pkgs/by-name/li/libnatspec/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   autoreconfHook,
   popt,
   libiconv,
@@ -9,11 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libnatspec";
-  version = "0.3.0";
+  version = "0.3.3";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/natspec/libnatspec-${finalAttrs.version}.tar.bz2";
-    sha256 = "0wffxjlc8svilwmrcg3crddpfrpv35mzzjgchf8ygqsvwbrbb3b7";
+  src = fetchFromGitHub {
+    owner = "Etersoft";
+    repo = "libnatspec";
+    rev = "0.3.3-alt1";
+    hash = "sha256-lg3kjrvv7G+nX6xlR7TQKvXqQJFcQTHarSpD0qYLZsw=";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
@@ -27,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   propagatedBuildInputs = [ libiconv ];
 
   meta = {
-    homepage = "https://natspec.sourceforge.net/";
+    homepage = "https://github.com/Etersoft/libnatspec";
     description = "Library intended to smooth national specificities in using of programs";
     mainProgram = "natspec";
     platforms = lib.platforms.unix;


### PR DESCRIPTION
Update to 0.3.3

Change repo to GitHub (which is linked from the previous sourceforge page)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
