### PR TITLE
obelisk: migrate to by-name, modernize derivation

### DIFF
--- a/pkgs/by-name/ob/obelisk/package.nix
+++ b/pkgs/by-name/ob/obelisk/package.nix
@@ -4,14 +4,15 @@
   ocamlPackages,
 }:
 
-ocamlPackages.buildDunePackage rec {
+ocamlPackages.buildDunePackage (finalAttrs: {
   pname = "obelisk";
   version = "0.8.1";
+
   src = fetchFromGitHub {
     owner = "Lelio-Brun";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-JJ8k9/6awKZH87T9Ut8x/hlshiUI6sy2fZtY6x2dIIk=";
+    repo = "obelisk";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JJ8k9/6awKZH87T9Ut8x/hlshiUI6sy2fZtY6x2dIIk=";
   };
 
   strictDeps = true;
@@ -26,4 +27,4 @@ ocamlPackages.buildDunePackage rec {
     maintainers = [ lib.maintainers.vbgl ];
     homepage = "https://github.com/Lelio-Brun/Obelisk";
   };
-}
+})

--- a/pkgs/by-name/ob/obelisk/package.nix
+++ b/pkgs/by-name/ob/obelisk/package.nix
@@ -2,7 +2,6 @@
   lib,
   fetchFromGitHub,
   ocamlPackages,
-  menhir,
 }:
 
 ocamlPackages.buildDunePackage rec {
@@ -17,7 +16,7 @@ ocamlPackages.buildDunePackage rec {
 
   strictDeps = true;
 
-  nativeBuildInputs = [ menhir ];
+  nativeBuildInputs = with ocamlPackages; [ menhir ];
   buildInputs = with ocamlPackages; [ re ];
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5750,8 +5750,6 @@ with pkgs;
     sdk = true;
   };
 
-  obelisk = callPackage ../development/tools/ocaml/obelisk { menhir = ocamlPackages.menhir; };
-
   openai = with python3Packages; toPythonApplication openai;
 
   openai-whisper = with python3.pkgs; toPythonApplication openai-whisper;


### PR DESCRIPTION
This PR moves obelisk to pkgs/by-name/ob/obelisk/package.nix, updates it to the modern buildDunePackage (finalAttrs: { … }) style, and switches the fetcher to use tag and hash. The old menhir override in all-packages.nix is removed, with dependencies now scoped cleanly via with ocamlPackages; [ menhir ].
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
