### PR TITLE
uutils-procps: 0.0.1-unstable-2026-05-13 -> 0.0.1-unstable-2026-05-17

### DIFF
--- a/pkgs/by-name/uu/uutils-procps/package.nix
+++ b/pkgs/by-name/uu/uutils-procps/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "uutils-procps";
-  version = "0.0.1-unstable-2026-05-13";
+  version = "0.0.1-unstable-2026-05-17";
 
   src = fetchFromGitHub {
     owner = "uutils";
     repo = "procps";
-    rev = "c0b901770156504d1a2021794d5375b7f35a2112";
-    hash = "sha256-1aB/xFZaB9mvjYsHud0wajpdXKVKFLIFfeb9vpJebFQ=";
+    rev = "d688aee40781bcefb669979cfe858761c4fab240";
+    hash = "sha256-z40wxe2iDArGdEqKiDm2a459DmWFF/vIO7zvwKxeuFo=";
   };
 
-  cargoHash = "sha256-fv7bgnbuhE2XKxb7ZKL2Vjt+mmrdqK6bSVKRBdTgoRE=";
+  cargoHash = "sha256-uPq4IoVBb9qRYxD8nBLWpu62kdJpEc/XjlnvUzlzoR8=";
 
   cargoBuildFlags = [ "--workspace" ];
 
@@ -49,6 +49,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--skip=test_pgrep::test_pidfile"
     # pgrep: pattern that searches for process name longer than 15 characters will result in zero matches
     "--skip=test_pgrep::test_pool_workqueue_release"
+    # can't fetch user info in sandbox
+    "--skip=test_w::test_option_short"
   ];
 
   passthru.updateScript = nix-update-script {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
