### PR TITLE
import-npm-lock: fixes to correctly package Git dependencies

### DIFF
--- a/pkgs/build-support/node/import-npm-lock/default.nix
+++ b/pkgs/build-support/node/import-npm-lock/default.nix
@@ -52,17 +52,19 @@ let
                 }
                 // fetcherOpts
               ))
-            else if lib.hasPrefix "git" module.resolved then
+            else if lib.strings.hasPrefix "git" module.resolved then
               let
+                # `fetchGit` will add the `git+` prefix back.
+                schemeWithoutPrefix = lib.strings.removePrefix "git+" scheme;
                 url = elemAt mUrl 1;
-                urlParts = lib.splitString "#" url;
+                urlParts = lib.strings.splitString "#" url;
                 commit = if builtins.length urlParts == 2 then elemAt urlParts 1 else null;
               in
               (fetchGit (
                 {
-                  url = "${scheme}://${elemAt urlParts 0}";
+                  url = "${schemeWithoutPrefix}://${elemAt urlParts 0}";
                 }
-                // lib.optionalAttrs (commit != null) {
+                // lib.attrsets.optionalAttrs (commit != null) {
                   rev = commit;
                 }
                 // fetcherOpts
@@ -185,6 +187,9 @@ lib.fix (self: {
       packageLock ? importJSON (npmRoot + "/package-lock.json"),
       nodejs,
       derivationArgs ? { },
+      # The following arguments are just forwarded to `importNpmLock`
+      fetcherOpts ? { },
+      packageSourceOverrides ? { },
     }:
     let
       # Backwards compatibility: if derivationArgs contains passAsFile,
@@ -199,7 +204,13 @@ lib.fix (self: {
         dontUnpack = true;
 
         npmDeps = self.importNpmLock {
-          inherit npmRoot package packageLock;
+          inherit
+            npmRoot
+            package
+            packageLock
+            fetcherOpts
+            packageSourceOverrides
+            ;
         };
 
         package = toJSON package;

--- a/pkgs/build-support/node/import-npm-lock/hooks/canonicalize-symlinks.js
+++ b/pkgs/build-support/node/import-npm-lock/hooks/canonicalize-symlinks.js
@@ -6,38 +6,42 @@ const path = require("path");
 // npm writes the symlinks relative to the build directory.
 //
 // This makes relocating node_modules tricky when refering to the store.
-// This script walks node_modules and canonicalizes symlinks.
+// This script walks node_modules and replaces symlinks to targets outside the
+// node_modules directory with copies.
 
-async function canonicalize(storePrefix, root) {
-  console.log(storePrefix, root)
-  const entries = await fs.promises.readdir(root);
-  const paths = entries.map((entry) => path.join(root, entry));
+async function canonicalize(storePrefix, dir, root = path.resolve(dir)) {
+  console.log(storePrefix, dir);
+  const entries = await fs.promises.readdir(dir);
+  const paths = entries.map((entry) => path.join(dir, entry));
 
   const stats = await Promise.all(
     paths.map(async (path) => {
-      return {
-        path: path,
-        stat: await fs.promises.lstat(path),
-      };
-    })
+      return { path: path, stat: await fs.promises.lstat(path) };
+    }),
   );
 
   const symlinks = stats.filter((stat) => stat.stat.isSymbolicLink());
-  const dirs = stats.filter((stat) => stat.stat.isDirectory());
+  const subdirs = stats.filter((stat) => stat.stat.isDirectory());
 
-  // Canonicalize symlinks to their real path
+  // Replace symlinks outside the root directory with a copy of their target.
   await Promise.all(
     symlinks.map(async (stat) => {
       const target = await fs.promises.realpath(stat.path);
-      if (target.startsWith(storePrefix)) {
+      // We assume that symlinks within the root can remain without issue.
+      if (!target.startsWith(root + "/")) {
         await fs.promises.unlink(stat.path);
-        await fs.promises.symlink(target, stat.path);
+        await fs.promises.cp(target, stat.path, {
+          errorOnExist: true,
+          recursive: true,
+        });
       }
-    })
+    }),
   );
 
-  // Recurse into directories
-  await Promise.all(dirs.map((dir) => canonicalize(storePrefix, dir.path)));
+  // Recurse into directories.
+  await Promise.all(
+    subdirs.map((subdir) => canonicalize(storePrefix, subdir.path, root)),
+  );
 }
 
 async function main() {


### PR DESCRIPTION
When trying to use `importNpmLock.buildNodeModules` with an NPM dependency from a (public) GitHub repository, I ran into a few issues.

1.  I needed to pass `allRefs = true;` to the fetcher, but `buildNodeModules` does not expose `fetcherOpts` (unlike `importNpmLock`).
2.  My `package-lock.json` file contains a URL along the lines of `git+https://...`,  but `fetchGit` adds an extra `git+`, causing it to break. We therefore need to remove the `git+` prefix.
3.  The resulting `node_modules` directory contained a symbolic link to the built dependency, outside the `node_modules` directory. This meant that node.js would not honor the dependency's transient dependencies, as after following the symlink, it was not within the `node_modules` confines.

This therefore includes patches for all of the above:

1.  Add `fetcherOpts` and `packageSourceOverrides` to `buildNodeModules`.
2.  Remove the `git+` prefix when calling `fetchGit`.
3.  Replace symlinks with copies where necessary.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
