### PR TITLE
chromium,chromedriver: 148.0.7778.167 -> 148.0.7778.178

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,10 +1,10 @@
 {
   "chromium": {
-    "version": "148.0.7778.167",
+    "version": "148.0.7778.178",
     "chromedriver": {
-      "version": "148.0.7778.168",
-      "hash_darwin": "sha256-F24gaQI0JZkStM71KJDEn8EKBTw1UifMxYXDdUIVup4=",
-      "hash_darwin_aarch64": "sha256-WpAiIz3nXxJLkxAP5JSn6rSxDW0vvl7EHeJA5MD+nss="
+      "version": "148.0.7778.179",
+      "hash_darwin": "sha256-jDw+ON0X8rePW1HLBZ5FVKMibImBuW/Tp0EDZ/UjJlw=",
+      "hash_darwin_aarch64": "sha256-hNaaKMVy8sKNU444Uf78YI3ayUATrTBAr6/7Z3jewv0="
     },
     "deps": {
       "depot_tools": {
@@ -21,8 +21,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "65db666ac2cf205fcc36db8bb5b9cd87f94808ac",
-        "hash": "sha256-Vda6y35lHYP3xK9FT5FdsnfTtL0MiY2m/auSq6NyL0U=",
+        "rev": "d096af1c9e98c45c3596e59620622b1a049bfecb",
+        "hash": "sha256-XRalekzeALnDh9KiGqhYdhXvkGkjO3TOIZeqwpPLO+U=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -92,8 +92,8 @@
       },
       "src/third_party/angle": {
         "url": "https://chromium.googlesource.com/angle/angle.git",
-        "rev": "6c71c70ec7e838c5f1712974086c8bc33d07de14",
-        "hash": "sha256-35Zu8jSopO47pH1rNLtSq5I8QRsOkMMvTgtmD13Yw/Y="
+        "rev": "50fd896fb21cca91f325812d01d1e971593efc73",
+        "hash": "sha256-HcfKm7UQmg3wMDOytmaYzm7Z7gRdOrRoqAKaE0ZdI4E="
       },
       "src/third_party/angle/third_party/glmark2/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glmark2/glmark2",
@@ -392,8 +392,8 @@
       },
       "src/third_party/icu": {
         "url": "https://chromium.googlesource.com/chromium/deps/icu.git",
-        "rev": "ff7995a708a10ab44db101358083c7f74752da9f",
-        "hash": "sha256-yQ55MGzqkVkp/arTlmKqySBvQFtaPaBk9UUAFE0imhE="
+        "rev": "3859e64eed5d34544b27fbcab0ac1685ce83df3c",
+        "hash": "sha256-rNErsn11FZUh8GXAl7jK+NyLHIKrQR3LuoM1qFFGtmM="
       },
       "src/third_party/nlohmann_json/src": {
         "url": "https://chromium.googlesource.com/external/github.com/nlohmann/json.git",
@@ -822,8 +822,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "e38030f4228c8d1405fe105fc5feaa5173559e25",
-        "hash": "sha256-VsJpsCfDGF6rlfYQXccgF+F/pBhY/ybUa9N5HnHJ2lU="
+        "rev": "ad6e4525c418a92147c8247ef9d144ce4c242a38",
+        "hash": "sha256-+cQdsWTgIohd3yOCsNCprSr4Ctes77fWGdmPxN2tQlM="
       }
     }
   },


### PR DESCRIPTION
https://chromereleases.googleblog.com/2026/05/stable-channel-update-for-desktop_0841193308.html

This update includes 16 security fixes.

CVEs:
CVE-2026-9111 CVE-2026-9110 CVE-2026-9112 CVE-2026-9113 CVE-2026-9114
CVE-2026-9115 CVE-2026-9116 CVE-2026-9117 CVE-2026-9118 CVE-2026-9119
CVE-2026-9120 CVE-2026-9126 CVE-2026-9121 CVE-2026-9122 CVE-2026-9123
CVE-2026-9124

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
