### PR TITLE
cataclysm-dda: cleanup and version bump

### DIFF
--- a/pkgs/games/cataclysm-dda/common.nix
+++ b/pkgs/games/cataclysm-dda/common.nix
@@ -1,7 +1,6 @@
 {
   lib,
   stdenv,
-  runtimeShell,
   pkg-config,
   gettext,
   ncurses,
@@ -19,54 +18,32 @@
 
 let
   inherit (lib) optionals optionalString;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cataclysm-dda";
 
-  commonDeps = [
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
     gettext
     zlib
-  ];
-
-  cursesDeps = commonDeps ++ [ ncurses ];
-
-  tilesDeps = commonDeps ++ [
+  ]
+  ++ lib.optionals tiles [
     SDL2
     SDL2_image
     SDL2_mixer
     SDL2_ttf
     libx11
     freetype
-  ];
-
-  patchDesktopFile = ''
-    substituteInPlace $out/share/applications/org.cataclysmdda.CataclysmDDA.desktop \
-      --replace-fail "Exec=cataclysm-tiles" "Exec=$out/bin/cataclysm-tiles"
-  '';
-
-  installMacOSAppLauncher = ''
-    app=$out/Applications/Cataclysm.app
-    install -D -m 444 build-data/osx/Info.plist -t $app/Contents
-    install -D -m 444 build-data/osx/AppIcon.icns -t $app/Contents/Resources
-    mkdir $app/Contents/MacOS
-    launcher=$app/Contents/MacOS/Cataclysm.sh
-    cat << EOF > $launcher
-    #!${runtimeShell}
-    $out/bin/cataclysm-tiles
-    EOF
-    chmod 555 $launcher
-  '';
-in
-
-stdenv.mkDerivation {
-  pname = "cataclysm-dda";
-
-  nativeBuildInputs = [ pkg-config ];
-
-  buildInputs = if tiles then tilesDeps else cursesDeps;
+  ]
+  ++ lib.optional (!tiles) ncurses;
 
   postPatch = ''
     patchShebangs lang/compile_mo.sh
+    substituteInPlace data/fontdata.json \
+      --replace-fail 'data/font/' 'font/'
   '';
 
-  # remove once on O.I/ahead of upstream commit 15b3cb0
   env.NIX_CFLAGS_COMPILE = optionalString stdenv.hostPlatform.isDarwin "-Wno-missing-noreturn";
 
   makeFlags = [
@@ -87,9 +64,22 @@ stdenv.mkDerivation {
     "OSX_MIN=${stdenv.hostPlatform.darwinMinVersion}"
   ];
 
-  postInstall = optionalString tiles (
-    if !stdenv.hostPlatform.isDarwin then patchDesktopFile else installMacOSAppLauncher
-  );
+  postInstall =
+    optionalString tiles ''
+      install -Dm644 data/xdg/org.cataclysmdda.CataclysmDDA.svg \
+        $out/share/icons/hicolor/scalable/apps/org.cataclysmdda.CataclysmDDA.svg
+
+      install -Dm644 data/xdg/org.cataclysmdda.CataclysmDDA.appdata.xml \
+        $out/share/metainfo/org.cataclysmdda.CataclysmDDA.appdata.xml
+    ''
+    + optionalString (tiles && stdenv.hostPlatform.isDarwin) ''
+      app=$out/Applications/Cataclysm.app
+
+      install -Dm444 build-data/osx/Info.plist -t $app/Contents
+      install -Dm444 build-data/osx/AppIcon.icns -t $app/Contents/Resources
+      install -Dm555 build-data/osx/Cataclysm.sh $app/Contents/MacOS/Cataclysm.sh
+      ln -sf $out/bin/cataclysm-tiles $app/Contents/Resources/cataclysm-tiles
+    '';
 
   dontStrip = debug;
   enableParallelBuilding = true;
@@ -100,7 +90,7 @@ stdenv.mkDerivation {
   };
 
   meta = {
-    description = "Free, post apocalyptic, zombie infested rogue-like";
+    description = "Free post-apocalyptic zombie-infested roguelike";
     mainProgram = "cataclysm-tiles";
     longDescription = ''
       Cataclysm: Dark Days Ahead is a roguelike set in a post-apocalyptic world.
@@ -133,4 +123,4 @@ stdenv.mkDerivation {
     ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/games/cataclysm-dda/common.nix
+++ b/pkgs/games/cataclysm-dda/common.nix
@@ -120,6 +120,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       mnacamura
       DeeUnderscore
+      philocalyst
     ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/games/cataclysm-dda/locale-path.patch
+++ b/pkgs/games/cataclysm-dda/locale-path.patch
@@ -6,8 +6,8 @@ diff --git a/src/translations.cpp b/src/translations.cpp
  #endif
 
 -#if !defined(__ANDROID__) && ((defined(__linux__) || defined(CATA_IS_ON_BSD) || (defined(MACOSX) && !defined(TILES))))
-     if( !PATH_INFO::base_path().empty() ) {
-         loc_dir = PATH_INFO::base_path() + "share/locale";
+     if( !PATH_INFO::base_path().get_logical_root_path().empty() ) {
+         loc_dir = ( PATH_INFO::base_path() / "share" / "locale" ).generic_u8string();
      } else {
          loc_dir = PATH_INFO::langdir();
      }

--- a/pkgs/games/cataclysm-dda/stable.nix
+++ b/pkgs/games/cataclysm-dda/stable.nix
@@ -1,10 +1,7 @@
 {
-  lib,
   callPackage,
   fetchFromGitHub,
-  fetchpatch,
   pkgs,
-  wrapCDDA,
   attachPkgs,
   tiles ? true,
   debug ? false,
@@ -17,14 +14,14 @@ let
   };
 
   self = common.overrideAttrs (common: rec {
-    version = "0.H-2025-07-10-0402";
+    # 0.I is the latest stable release tag (https://github.com/CleverRaven/Cataclysm-DDA/releases/tag/0.I)
+    version = "0.I-2026-06-11-1250";
 
     src = fetchFromGitHub {
       owner = "CleverRaven";
       repo = "Cataclysm-DDA";
-      # Head of 0.H-branch
       tag = "cdda-${version}";
-      sha256 = "sha256-r4cl8cij68WmQRfg+DHQIeDBIwhgwSre6kAUYZaCPR8=";
+      hash = "sha256-DpB9OlSpg0t4L1JdMMPeQC+cLd0zs/ZkCdXSFGWgRhA=";
     };
 
     patches = [

--- a/pkgs/games/cataclysm-dda/wrapper.nix
+++ b/pkgs/games/cataclysm-dda/wrapper.nix
@@ -39,7 +39,7 @@ else
           mv "''${1}.bk" "$1"
           sed -i "$1" -e "s,${builtins.storeDir}/.\+\(/bin/cataclysm-tiles\),$out\1,"
       }
-      for script in "$out/share/applications/cataclysm-dda.desktop" \
+      for script in "$out/share/applications/org.cataclysmdda.CataclysmDDA.desktop" \
                     "$out/Applications/Cataclysm.app/Contents/MacOS/Cataclysm.sh"
       do
           if [ -e "$script" ]; then


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- Got cataclysm building on its latest release with really clean darwin bundling
- nix update script with version regex to hopefully keep up with releases (there seem to be a lot)
- general refactor to support modern finalattrs pattern

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
