### PR TITLE
tidekeeper-cli: init at v2026.5.17.4

### DIFF
--- a/pkgs/by-name/ti/tidekeeper-cli/package.nix
+++ b/pkgs/by-name/ti/tidekeeper-cli/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "tidekeeper-cli";
+  version = "v2026.5.17.4";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "OpenNerdz";
+    repo = "tidekeeper-cli";
+    rev = "v2026.5.16.7";
+    hash = "sha256-OXKnsIkQwJKSPSldUpR1q+iXbDVp8u5eb6I4BruSxPg=";
+  };
+  sourceRoot = "./source/TIDALDL-PY/";
+  propagatedBuildInputs = with python3Packages; [ aigpy ];
+  passthru.updateScript = nix-update-script { };
+
+  __structuredAttrs = true;
+
+  meta = {
+    homepage = "https://github.com/OpenNerdz/tidekeeper-cli";
+    description = "Fork of Tidal-DL; an application that lets you download videos and tracks from Tidal.";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.xeni ];
+    platforms = lib.platforms.all;
+    mainProgram = "tidekeeper-cli";
+  };
+})


### PR DESCRIPTION

Maintained command-line fork of [Tidal-Media-Downloader](https://github.com/yaronzz/Tidal-Media-Downloader) ; an application which allows users to download media from Tidal.


Due to the original [Tidal-dl](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/ti/tidal-dl/package.nix#L21) being broken for many users and seemingly unmaintained (last commit 7 months ago), I'd suggest dropping it from nixpkgs and to use this as the defacto replacement.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
