### PR TITLE
protobuf: 34.1 -> 35.0

### DIFF
--- a/pkgs/development/libraries/protobuf/35.nix
+++ b/pkgs/development/libraries/protobuf/35.nix
@@ -1,0 +1,9 @@
+{ callPackage, ... }@args:
+
+callPackage ./generic.nix (
+  {
+    version = "35.0";
+    hash = "sha256-J0NA19W44CzgSjKv3A+1An6vDRTDjaWMhDzQGEOtrCk=";
+  }
+  // args
+)

--- a/pkgs/development/libraries/protobuf/generic.nix
+++ b/pkgs/development/libraries/protobuf/generic.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
         hash = "sha256-rIP+Ft/SWVwh9Oy8y8GSUBgP6CtLCLvGmr6nOqmyHhY=";
       })
     ]
-    ++ lib.optionals (lib.versionAtLeast version "30") [
+    ++ lib.optionals ((lib.versionAtLeast version "30") && (lib.versionOlder version "35")) [
       # workaround nvcc bug in message_lite.h
       # https://github.com/protocolbuffers/protobuf/issues/21542
       # Caused by: https://github.com/protocolbuffers/protobuf/commit/8f7aab29b21afb89ea0d6e2efeafd17ca71486a9
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
         hash = "sha256-2/vc4anc+kH7otfLHfBtW8dRowPyObiXZn0+HtQktak=";
       })
     ]
-    ++ lib.optionals (lib.versionAtLeast version "33") [
+    ++ lib.optionals ((lib.versionAtLeast version "33") && (lib.versionOlder version "35")) [
       # Fix protoc plugins crashing on big-endian platforms
       # https://github.com/protocolbuffers/protobuf/pull/25363
       (fetchpatch {

--- a/pkgs/development/libraries/protobuf/generic.nix
+++ b/pkgs/development/libraries/protobuf/generic.nix
@@ -28,6 +28,7 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "protobuf";
   inherit version;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "protocolbuffers";

--- a/pkgs/development/python-modules/protobuf/7.nix
+++ b/pkgs/development/python-modules/protobuf/7.nix
@@ -9,12 +9,12 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "protobuf";
-  version = "7.34.1";
+  version = "7.35.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    hash = "sha256-nOQiRecEzFAnvnl8HbHrkxhNRNHN1xgR+y2bJa1UEoA=";
+    hash = "sha256-ou/YRgX0HlWfGIGwkStECZ0KKsm/RrNHSCPxD7OTsOY=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7081,10 +7081,11 @@ with pkgs;
 
   # this version should align with the static protobuf version linked into python3.pkgs.tensorflow
   # $ nix-shell -I nixpkgs=$(git rev-parse --show-toplevel) -p python3.pkgs.tensorflow --run "python3 -c 'import google.protobuf; print(google.protobuf.__version__)'"
-  protobuf = protobuf_34;
+  protobuf = protobuf_35;
 
   inherit
     ({
+      protobuf_35 = callPackage ../development/libraries/protobuf/35.nix { };
       protobuf_34 = callPackage ../development/libraries/protobuf/34.nix { };
       protobuf_33 = callPackage ../development/libraries/protobuf/33.nix { };
       protobuf_32 = callPackage ../development/libraries/protobuf/32.nix { };
@@ -7103,6 +7104,7 @@ with pkgs;
         abseil-cpp = abseil-cpp_202103;
       };
     })
+    protobuf_35
     protobuf_34
     protobuf_33
     protobuf_32


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/protocolbuffers/protobuf/compare/v34.1...v35.0
Changelog: https://github.com/protocolbuffers/protobuf/releases/

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
