### PR TITLE
spidermonkey_140: 140.9.0 -> 140.11.0

### DIFF
--- a/pkgs/development/interpreters/spidermonkey/140.nix
+++ b/pkgs/development/interpreters/spidermonkey/140.nix
@@ -1,4 +1,4 @@
 import ./common.nix {
-  version = "140.9.0";
-  hash = "sha512-vAP9KnPQCoi9Cjye6u/mGP+zQib7e8L6xKAiRv8p/gOEI793U4Jz7m+sJfsePk+pi7UiAmrjQnoK1fQdLsa6mA==";
+  version = "140.11.0";
+  hash = "sha512-0GrbPvTeEyTj1hhy1w3jGrCKwBPzOQNUm+0oxuvMW03ulLs2OIKCwZNdd9GlZAefOtvwjWu4AoSomcuz2GEwDA==";
 }


### PR DESCRIPTION
https://www.firefox.com/en-US/firefox/140.11.0/releasenotes/




## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
