### PR TITLE
casacore,casacpp: fix build on darwin

### DIFF
--- a/pkgs/by-name/ca/casacore/package.nix
+++ b/pkgs/by-name/ca/casacore/package.nix
@@ -101,6 +101,10 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "PORTABLE" true)
     (lib.cmakeBool "USE_PCH" false)
     (lib.cmakeBool "BUILD_FFTPACK_DEPRECATED" true) # Needed for casacpp
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # Upstream probes this flag, but it fails on darwin, so pass it explicitly
+    (lib.cmakeFeature "CMAKE_Fortran_FLAGS" "-fallow-argument-mismatch")
   ];
 
   meta = {

--- a/pkgs/by-name/ca/casacpp/Fix-Vi2DataProvider-move-semantics.patch
+++ b/pkgs/by-name/ca/casacpp/Fix-Vi2DataProvider-move-semantics.patch
@@ -1,0 +1,58 @@
+From 7d946685a48be3a0c854793950b7d0dd95125041 Mon Sep 17 00:00:00 2001
+From: Kiran Shila <me@kiranshila.com>
+Date: Wed, 20 May 2026 15:11:25 +0800
+Subject: Fix Vi2DataProvider move semantics
+
+---
+ msvis/MSVis/statistics/Vi2DataProvider.h | 18 ++++++++----------
+ 1 file changed, 8 insertions(+), 10 deletions(-)
+
+diff --git a/msvis/MSVis/statistics/Vi2DataProvider.h b/msvis/MSVis/statistics/Vi2DataProvider.h
+index 4570d13..cb76a2e 100644
+--- a/msvis/MSVis/statistics/Vi2DataProvider.h
++++ b/msvis/MSVis/statistics/Vi2DataProvider.h
+@@ -121,7 +121,7 @@ public:
+ 	}
+ 
+ 	Vi2DataProvider(Vi2DataProvider&& other)
+-		: vi2(other.vi2)
++		: vi2(std::move(other.vi2))
+ 		, mergedColumns(other.mergedColumns)
+ 		, datasetIndex(other.datasetIndex)
+ 		, datasetChunkOrigin(other.datasetChunkOrigin)
+@@ -130,14 +130,13 @@ public:
+ 		, component(other.component)
+ 		, use_data_weights(other.use_data_weights)
+ 		, omit_flagged_data(other.omit_flagged_data)
+-		, data_iterator(other.data_iterator)
+-		, weights_iterator(other.weights_iterator)
+-		, mask_iterator(other.mask_iterator) {
+-		other.vi2 = nullptr;
++		, data_iterator(std::move(other.data_iterator))
++		, weights_iterator(std::move(other.weights_iterator))
++		, mask_iterator(std::move(other.mask_iterator)) {
+ 	}
+ 
+ 	Vi2DataProvider& operator=(Vi2DataProvider&& other) {
+-		vi2 = other.vi2;
++		vi2 = std::move(other.vi2);
+ 		mergedColumns = other.mergedColumns;
+ 		datasetIndex = other.datasetIndex;
+ 		datasetChunkOrigin = other.datasetChunkOrigin;
+@@ -146,10 +145,9 @@ public:
+ 		component = other.component;
+ 		const_cast<casacore::Bool&> (use_data_weights) = other.use_data_weights;
+ 		const_cast<casacore::Bool&> (omit_flagged_data) = other.omit_flagged_data;
+-		data_iterator = other.data_iterator;
+-		weights_iterator = other.weights_iterator;
+-		mask_iterator = other.mask_iterator;
+-		other.vi2 = nullptr;
++		data_iterator = std::move(other.data_iterator);
++		weights_iterator = std::move(other.weights_iterator);
++		mask_iterator = std::move(other.mask_iterator);
+ 		return *this;
+ 	}
+ 
+-- 
+2.53.0
+

--- a/pkgs/by-name/ca/casacpp/Link-synthesis-target-with-LAPACK-BLAS-libraries.patch
+++ b/pkgs/by-name/ca/casacpp/Link-synthesis-target-with-LAPACK-BLAS-libraries.patch
@@ -1,0 +1,28 @@
+From 71a658844e69e3993ab2fe712e0063a67daa00e0 Mon Sep 17 00:00:00 2001
+From: Moraxyc <i@qaq.li>
+Date: Wed, 20 May 2026 15:13:10 +0800
+Subject: Link synthesis target with LAPACK/BLAS libraries
+
+---
+ synthesis/CMakeLists.txt | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/synthesis/CMakeLists.txt b/synthesis/CMakeLists.txt
+index e2250f0..59b55dc 100644
+--- a/synthesis/CMakeLists.txt
++++ b/synthesis/CMakeLists.txt
+@@ -42,6 +42,11 @@ target_link_libraries(casacpp_synthesis PUBLIC PkgConfig::CASACORE)
+ # Libsakura dependency
+ target_link_libraries(casacpp_synthesis PUBLIC PkgConfig::SAKURA)
+ 
++# LAPACK / BLAS dependency
++find_package(BLAS REQUIRED)
++find_package(LAPACK REQUIRED)
++target_link_libraries(casacpp_synthesis PRIVATE LAPACK::LAPACK)
++
+ # Optional HPG dependency
+ if(DEFINED hpg_FOUND AND ${hpg_FOUND})
+ 	target_link_libraries(casacpp_synthesis PUBLIC hpg::hpg)
+-- 
+2.53.0
+

--- a/pkgs/by-name/ca/casacpp/package.nix
+++ b/pkgs/by-name/ca/casacpp/package.nix
@@ -58,6 +58,11 @@ stdenv.mkDerivation (finalAttrs: {
     # leaving it empty, and remove hardcoded absolute cmake build paths from
     # Cflags (which would embed /nix/store paths from the build environment).
     ./casacpp-pkgconfig.patch
+
+    # TODO: remove this once the upstream resolves this issue
+    #   error: call to implicitly-deleted copy constructor of 'std::unique_ptr<vi::VisibilityIterator2>'
+    #   error: object of type 'std::unique_ptr<vi::VisibilityIterator2>' cannot be assigned because its copy assignment operator is implicitly deleted
+    ./Fix-Vi2DataProvider-move-semantics.patch
   ];
 
   postPatch = ''

--- a/pkgs/by-name/ca/casacpp/package.nix
+++ b/pkgs/by-name/ca/casacpp/package.nix
@@ -17,11 +17,13 @@
   protobuf,
   gsl,
   libxml2,
-  libxslt,
   fftw,
   fftwFloat,
-  sqlite,
+  blas,
+  lapack,
+  libxslt,
   openssl,
+  sqlite,
   mpi,
   mpiSupport ? false,
 }:
@@ -63,6 +65,10 @@ stdenv.mkDerivation (finalAttrs: {
     #   error: call to implicitly-deleted copy constructor of 'std::unique_ptr<vi::VisibilityIterator2>'
     #   error: object of type 'std::unique_ptr<vi::VisibilityIterator2>' cannot be assigned because its copy assignment operator is implicitly deleted
     ./Fix-Vi2DataProvider-move-semantics.patch
+
+    # fix missing LAPACK symbols
+    #   ld: symbol(s) not found, dgetrf_ dgetri_ dposv_ dpotri_
+    ./Link-synthesis-target-with-LAPACK-BLAS-libraries.patch
   ];
 
   postPatch = ''
@@ -88,9 +94,11 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional mpiSupport mpi;
 
   buildInputs = [
+    blas
     libxslt
-    sqlite
     openssl
+    sqlite
+    lapack
   ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
ZHF: https://github.com/NixOS/nixpkgs/issues/516381
Hydra: https://hydra.nixos.org/build/328368134 https://hydra.nixos.org/build/328368140

- casacore:
https://github.com/casacore/casacore/blob/aaf72eb7edd5a5fecefa78ca04713233b7b6ffd6/scimath_f/CMakeLists.txt#L32-L45
On darwin, `FORTRAN_HAS_ALLOW_ARGUMENT_MISMATCH` unexpectedly fails, likely because extra diagnostics are emitted (perhaps due to flags inserted by nix wrapper).

- casacpp
1. Vi2DataProvider move semantics
https://open-bitbucket.nrao.edu/projects/CASA/repos/casa6/browse/casatools/src/code/msvis/MSVis/statistics/Vi2DataProvider.h#124
https://open-bitbucket.nrao.edu/projects/CASA/repos/casa6/browse/casatools/src/code/msvis/MSVis/statistics/Vi2DataProvider.h#133-136
2. Link synthesis target with LAPACK/BLAS libraries
Otherwise `ld: symbol(s) not found` occured on darwin.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
