### PR TITLE
lib.fetchers: minor performance improvements

### DIFF
--- a/lib/fetchers.nix
+++ b/lib/fetchers.nix
@@ -202,9 +202,11 @@ rec {
     {
       hashTypes ? defaultHashTypes,
     }:
-    fetcher:
     let
       inherit (commonH hashTypes) hashSet;
+    in
+    fetcher:
+    let
       fArgs = functionArgs fetcher;
 
       normalize = normalizeHash {

--- a/lib/fetchers.nix
+++ b/lib/fetchers.nix
@@ -199,6 +199,12 @@ rec {
     and is implemented somewhat more efficiently.
   */
   withNormalizedHash =
+    let
+      removedAttributes = [
+        "outputHash"
+        "outputHashAlgo"
+      ];
+    in
     {
       hashTypes ? defaultHashTypes,
     }:
@@ -219,10 +225,7 @@ rec {
     assert intersectAttrs fArgs hashSet == { };
 
     setFunctionArgs (args: fetcher (normalize args)) (
-      removeAttrs fArgs [
-        "outputHash"
-        "outputHashAlgo"
-      ]
+      removeAttrs fArgs removedAttributes
       // {
         hash = fArgs.outputHash;
       }

--- a/lib/fetchers.nix
+++ b/lib/fetchers.nix
@@ -11,6 +11,19 @@ let
     sha256 = lib.fakeSha256;
     sha512 = lib.fakeSha512;
   };
+
+  inherit (lib)
+    concatMapStringsSep
+    head
+    tail
+    throwIf
+    ;
+  inherit (lib.attrsets)
+    attrsToList
+    intersectAttrs
+    removeAttrs
+    optionalAttrs
+    ;
 in
 rec {
 
@@ -94,19 +107,6 @@ rec {
       required ? true,
     }:
     let
-      inherit (lib)
-        concatMapStringsSep
-        head
-        tail
-        throwIf
-        ;
-      inherit (lib.attrsets)
-        attrsToList
-        intersectAttrs
-        removeAttrs
-        optionalAttrs
-        ;
-
       inherit (commonH hashTypes) hashNames hashSet;
     in
     args:

--- a/lib/fetchers.nix
+++ b/lib/fetchers.nix
@@ -3,7 +3,7 @@
 let
   commonH = hashTypes: rec {
     hashNames = [ "hash" ] ++ hashTypes;
-    hashSet = lib.genAttrs hashNames (lib.const { });
+    hashSet = genAttrs hashNames (const { });
   };
 
   fakeH = {
@@ -21,11 +21,12 @@ let
   inherit (lib.attrsets)
     attrsToList
     intersectAttrs
+    genAttrs
     removeAttrs
     optionalAttrs
     ;
 
-  inherit (lib.trivial) functionArgs setFunctionArgs;
+  inherit (lib.trivial) const functionArgs setFunctionArgs;
 in
 rec {
 

--- a/lib/fetchers.nix
+++ b/lib/fetchers.nix
@@ -24,6 +24,8 @@ let
     removeAttrs
     optionalAttrs
     ;
+
+  inherit (lib.trivial) functionArgs setFunctionArgs;
 in
 rec {
 
@@ -195,9 +197,6 @@ rec {
     }:
     fetcher:
     let
-      inherit (lib.attrsets) intersectAttrs removeAttrs;
-      inherit (lib.trivial) functionArgs setFunctionArgs;
-
       inherit (commonH hashTypes) hashSet;
       fArgs = functionArgs fetcher;
 

--- a/lib/fetchers.nix
+++ b/lib/fetchers.nix
@@ -113,7 +113,7 @@ rec {
       inherit (commonH hashTypes) hashNames hashSet;
     in
     args:
-    if args ? "outputHash" then
+    if args ? outputHash then
       args
     else
       let

--- a/lib/fetchers.nix
+++ b/lib/fetchers.nix
@@ -15,7 +15,7 @@ let
   inherit (lib)
     concatMapStringsSep
     head
-    tail
+    length
     throwIf
     ;
   inherit (lib.attrsets)
@@ -125,7 +125,7 @@ rec {
           in
           if hashesAsNVPairs == [ ] then
             throwIf required "fetcher called without `hash`" null
-          else if tail hashesAsNVPairs != [ ] then
+          else if length hashesAsNVPairs != 1 then
             throw "fetcher called with mutually-incompatible arguments: ${
               concatMapStringsSep ", " (a: a.name) hashesAsNVPairs
             }"

--- a/lib/fetchers.nix
+++ b/lib/fetchers.nix
@@ -16,6 +16,8 @@ let
     sha512 = lib.fakeSha512;
   };
 
+  defaultHashTypes = [ "sha256" ];
+
   inherit (lib)
     concatMapStringsSep
     head
@@ -110,7 +112,7 @@ rec {
   */
   normalizeHash =
     {
-      hashTypes ? [ "sha256" ],
+      hashTypes ? defaultHashTypes,
       required ? true,
     }:
     let
@@ -198,7 +200,7 @@ rec {
   */
   withNormalizedHash =
     {
-      hashTypes ? [ "sha256" ],
+      hashTypes ? defaultHashTypes,
     }:
     fetcher:
     let

--- a/lib/fetchers.nix
+++ b/lib/fetchers.nix
@@ -1,10 +1,14 @@
 # snippets that can be shared by multiple fetchers (pkgs/build-support)
 { lib }:
 let
-  commonH = hashTypes: rec {
-    hashNames = [ "hash" ] ++ hashTypes;
-    hashSet = genAttrs hashNames (const { });
-  };
+  commonH =
+    let
+      defaultHashNames = [ "hash" ];
+    in
+    hashTypes: rec {
+      hashNames = defaultHashNames ++ hashTypes;
+      hashSet = genAttrs hashNames (const { });
+    };
 
   fakeH = {
     hash = lib.fakeHash;


### PR DESCRIPTION
These functions aren't used very much, but they make the claim of being somewhat efficient, and my eyes started bleeding when I opened the file. Nothing major, just classical free wins.

Stats diff for firefox:
```json
{
  "attrset": {
    "lookups": "-0.07%",
    "merges": null,
    "mergeCopies": null
  },
  "list": {
    "concats": null
  },
  "parser": {
    "expressions": null
  },
  "memory": {
    "envs": "-0.01%",
    "list": "-0.02%",
    "sets": null,
    "symbols": "+0.01%",
    "values": false,
    "total": "-0%"
  },
  "speed": {
    "primops": null,
    "functionCalls": null,
    "thunksMade": "-0.02%",
    "thunksAvoided": "-0.01%"
  }
}
```
So indeed very minor, but a win is a win.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
