### PR TITLE
lib.extendMkDerivation: performance cleanups

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -858,24 +858,22 @@ rec {
       inheritFunctionArgs ? true,
       transformDrv ? id,
     }:
-    setFunctionArgs
+    {
       # Adds the fixed-point style support
-      (
+      __functor =
+        self:
         fpargs:
         transformDrv (
           constructDrv (extendsWithExclusion excludeDrvArgNames extendDrvArgs (toFunction fpargs))
-        )
-      )
-      # Add __functionArgs
-      (
-        removeAttrs (
-          # Inherit the __functionArgs from the base build helper
-          optionalAttrs inheritFunctionArgs (removeAttrs (functionArgs constructDrv) excludeDrvArgNames)
-          # Recover the __functionArgs from the derived build helper
-          // functionArgs (extendDrvArgs { })
-        ) excludeFunctionArgNames
-      )
-    // {
+        );
+
+      __functionArgs = removeAttrs (
+        # Inherit the __functionArgs from the base build helper
+        optionalAttrs inheritFunctionArgs (removeAttrs (functionArgs constructDrv) excludeDrvArgNames)
+        # Recover the __functionArgs from the derived build helper
+        // functionArgs (extendDrvArgs { })
+      ) excludeFunctionArgNames;
+
       inherit
         # Expose to the result build helper.
         constructDrv

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -30,7 +30,6 @@ let
     flatten
     deepSeq
     extends
-    toFunction
     id
     ;
   inherit (lib.strings) levenshtein levenshteinAtMost;
@@ -842,14 +841,6 @@ rec {
     :::
   */
   extendMkDerivation =
-    let
-      extendsWithExclusion =
-        excludedNames: g: f: final:
-        let
-          previous = f final;
-        in
-        removeAttrs previous excludedNames // g final previous;
-    in
     {
       constructDrv,
       excludeDrvArgNames ? [ ],
@@ -861,10 +852,15 @@ rec {
     {
       # Adds the fixed-point style support
       __functor =
-        self:
-        fpargs:
+        self: fpargs:
         transformDrv (
-          constructDrv (extendsWithExclusion excludeDrvArgNames extendDrvArgs (toFunction fpargs))
+          constructDrv (
+            final:
+            let
+              previous = if isFunction fpargs then fpargs final else fpargs;
+            in
+            removeAttrs previous excludeDrvArgNames // extendDrvArgs final previous
+          )
         );
 
       __functionArgs = removeAttrs (


### PR DESCRIPTION
Profiler sent me to extendMkDerivation as a performance hotspot.

Stats diff for firefox:
```json
{
  "attrset": {
    "lookups": "-0%",
    "merges": "-0.38%",
    "mergeCopies": "-0.03%"
  },
  "list": {
    "concats": null
  },
  "parser": {
    "expressions": null
  },
  "memory": {
    "envs": "-1.1%",
    "list": null,
    "sets": "-0.02%",
    "symbols": "-0.01%",
    "values": false,
    "total": "-0.11%"
  },
  "speed": {
    "primops": "+0.14%",
    "functionCalls": "-1.88%",
    "thunksMade": "-0.2%",
    "thunksAvoided": "-0.78%"
  }
}
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
