### PR TITLE
ethercat: add myself as maintainer, fix license, add kernel modules

### DIFF
--- a/pkgs/by-name/et/ethercat/kernel-module.nix
+++ b/pkgs/by-name/et/ethercat/kernel-module.nix
@@ -1,0 +1,70 @@
+ethercat:
+{
+  lib,
+  stdenv,
+  kernelModuleMakeFlags,
+  kernel,
+}:
+let
+  # Aside from a generic drivers there are special drivers for specific NICs
+  # (for example r8139, r8169, e100, e1000, e1000e) which are only available
+  # for these kernel versions
+  extraSupportedKernel = lib.elem (lib.versions.majorMinor kernel.version) [
+    "5.10"
+    "5.14"
+    "5.15"
+    "6.1"
+    "6.4"
+    "6.12"
+  ];
+in
+stdenv.mkDerivation {
+  pname = "ethercat";
+  version = "${kernel.version}-${ethercat.version}";
+
+  __structuredAttrs = true;
+
+  enableParallelBuilding = true;
+
+  inherit (ethercat) src;
+
+  nativeBuildInputs = kernel.moduleBuildDependencies ++ ethercat.nativeBuildInputs;
+
+  configureFlags = [
+    "--with-linux-dir=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "--enable-userlib=no"
+    "--enable-tool=no"
+    "--enable-kernel=yes"
+    "--enable-ccat=yes"
+  ]
+  ++ lib.optionals extraSupportedKernel [
+    "--enable-e100=yes"
+    "--enable-e1000=yes"
+    "--enable-e1000e=yes"
+    "--enable-r8169=yes"
+    "--enable-igb=yes"
+  ]
+  ++ lib.optionals (extraSupportedKernel && lib.versionAtLeast kernel.version "5.14") [
+    "--enable-igc=yes"
+  ];
+
+  makeFlags = kernelModuleMakeFlags ++ [
+    "INSTALL_MOD_PATH=${placeholder "out"}"
+  ];
+
+  buildFlags = [ "modules" ];
+
+  installTargets = [ "modules_install" ];
+
+  meta = {
+    description = ethercat.meta.description + " - kernel modules";
+
+    inherit (ethercat.meta)
+      homepage
+      changelog
+      license
+      maintainers
+      platforms
+      ;
+  };
+}

--- a/pkgs/by-name/et/ethercat/package.nix
+++ b/pkgs/by-name/et/ethercat/package.nix
@@ -35,8 +35,14 @@ stdenv.mkDerivation (finalAttrs: {
     description = "IgH EtherCAT Master for Linux";
     homepage = "https://etherlab.org/ethercat";
     changelog = "https://gitlab.com/etherlab.org/ethercat/-/blob/${finalAttrs.version}/NEWS";
-    license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ stv0g ];
+    license = with lib.licenses; [
+      gpl2Only
+      lgpl21Only
+    ];
+    maintainers = with lib.maintainers; [
+      ninelore
+      stv0g
+    ];
     platforms = [ "x86_64-linux" ];
   };
 })

--- a/pkgs/by-name/et/ethercat/package.nix
+++ b/pkgs/by-name/et/ethercat/package.nix
@@ -29,7 +29,10 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-kernel=no"
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru = {
+    kernelModule = import ./kernel-module.nix finalAttrs.finalPackage;
+    updateScript = gitUpdater { };
+  };
 
   meta = {
     description = "IgH EtherCAT Master for Linux";

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -332,6 +332,8 @@ in
           inherit kernel;
         };
 
+        ethercat = callPackage pkgs.ethercat.kernelModule { };
+
         evdi = callPackage ../os-specific/linux/evdi { };
 
         fanout = callPackage ../os-specific/linux/fanout { };


### PR DESCRIPTION
I implemented this similar to bcachefs to keep it version-synced with the existing userspace package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
