### PR TITLE
lib.licenses: performance improvements

### DIFF
--- a/lib/licenses/helpers.nix
+++ b/lib/licenses/helpers.nix
@@ -11,10 +11,7 @@ let
       else
         throw "Unknown license operator"
     else if license.licenseType == "exception" then
-      AND evaluateSubProperty [
-        license.license
-        license.exception
-      ]
+      evaluateSubProperty license.license && evaluateSubProperty license.exception
     else if license.licenseType == "plus" then
       evaluateSubProperty license.license
     else

--- a/lib/licenses/helpers.nix
+++ b/lib/licenses/helpers.nix
@@ -1,4 +1,25 @@
 { lib }:
+
+let
+  handleComplexProperty =
+    evaluateSubProperty: AND: OR: license:
+    if license.licenseType == "compound" then
+      if license.operator == "OR" then
+        OR evaluateSubProperty license.licenses
+      else if license.operator == "AND" then
+        AND evaluateSubProperty license.licenses
+      else
+        throw "Unknown license operator"
+    else if license.licenseType == "exception" then
+      AND evaluateSubProperty [
+        license.license
+        license.exception
+      ]
+    else if license.licenseType == "plus" then
+      evaluateSubProperty license.license
+    else
+      throw "Unknown license type or legacy license";
+in
 rec {
   /**
     Evaluate a license expression for a given predicate.
@@ -25,27 +46,41 @@ rec {
     let
       OR = if permissive then lib.any else lib.all;
       AND = if permissive then lib.all else lib.any;
-      evaluateSubProperty = evaluateProperty predicate permissive;
+      evaluateComplexProperty = handleComplexProperty (evaluateProperty predicate permissive) AND OR;
     in
     license:
-    if license.licenseType == "simple" then
-      predicate license
-    else if license.licenseType == "compound" then
-      if license.operator == "OR" then
-        OR evaluateSubProperty license.licenses
-      else if license.operator == "AND" then
-        AND evaluateSubProperty license.licenses
-      else
-        throw "Unknown license operator"
-    else if license.licenseType == "exception" then
-      AND evaluateSubProperty [
-        license.license
-        license.exception
-      ]
-    else if license.licenseType == "plus" then
-      evaluateSubProperty license.license
-    else
-      throw "Unknown license type or legacy license";
+    if license.licenseType == "simple" then predicate license else evaluateComplexProperty license;
+
+  /**
+    Evaluate a license expression for a given property name. The property must
+    be defined as a boolean attribute of all licenses passed.
+
+    # Example
+
+    ```nix
+    evaluateNamedProperty "deprecated" true (with lib.licenses; AND [ ncsa (WITH asl20 llvm-exception) ])
+    ```
+    # Type
+
+    ```
+    evaluateProperty :: String -> Bool -> AttrSet -> Bool
+    ```
+
+    # Arguments
+
+    - [name] name of the attribute to check
+    - [permissive] whether to apply checks permissive or reciprocal
+    - [license] license expression to check
+  */
+  evaluateNamedProperty =
+    name: permissive:
+    let
+      OR = if permissive then lib.any else lib.all;
+      AND = if permissive then lib.all else lib.any;
+      evaluateComplexProperty = handleComplexProperty (evaluateNamedProperty name permissive) AND OR;
+    in
+    license:
+    if license.licenseType == "simple" then license.${name} else evaluateComplexProperty license;
 
   /**
     Check whether a license expression is free.
@@ -67,7 +102,7 @@ rec {
 
     - [license] License expression to check if free
   */
-  isFree = evaluateProperty (x: x.free) true;
+  isFree = evaluateNamedProperty "free" true;
 
   /**
     Check whether a license expression is redistributable.
@@ -89,7 +124,7 @@ rec {
 
     - [license] License expression to check if redistributable
   */
-  isRedistributable = evaluateProperty (x: x.redistributable) true;
+  isRedistributable = evaluateNamedProperty "redistributable" true;
 
   /**
     Check whether any of the given licenses is required in the license expression.

--- a/lib/licenses/helpers.nix
+++ b/lib/licenses/helpers.nix
@@ -25,24 +25,25 @@ rec {
     let
       OR = if permissive then lib.any else lib.all;
       AND = if permissive then lib.all else lib.any;
+      evaluateSubProperty = evaluateProperty predicate permissive;
     in
     license:
     if license.licenseType == "simple" then
       predicate license
     else if license.licenseType == "compound" then
       if license.operator == "OR" then
-        OR (x: evaluateProperty predicate permissive x) license.licenses
+        OR evaluateSubProperty license.licenses
       else if license.operator == "AND" then
-        AND (x: evaluateProperty predicate permissive x) license.licenses
+        AND evaluateSubProperty license.licenses
       else
         throw "Unknown license operator"
     else if license.licenseType == "exception" then
-      AND (x: evaluateProperty predicate permissive x) [
+      AND evaluateSubProperty [
         license.license
         license.exception
       ]
     else if license.licenseType == "plus" then
-      evaluateProperty predicate permissive license.license
+      evaluateSubProperty license.license
     else
       throw "Unknown license type or legacy license";
 

--- a/lib/licenses/helpers.nix
+++ b/lib/licenses/helpers.nix
@@ -1,6 +1,7 @@
 { lib }:
 
 let
+  inherit (lib) all any elem;
   handleComplexProperty =
     evaluateSubProperty: AND: OR: license:
     if license.licenseType == "compound" then
@@ -41,8 +42,8 @@ rec {
   evaluateProperty =
     predicate: permissive:
     let
-      OR = if permissive then lib.any else lib.all;
-      AND = if permissive then lib.all else lib.any;
+      OR = if permissive then any else all;
+      AND = if permissive then all else any;
       evaluateComplexProperty = handleComplexProperty (evaluateProperty predicate permissive) AND OR;
     in
     license:
@@ -72,8 +73,8 @@ rec {
   evaluateNamedProperty =
     name: permissive:
     let
-      OR = if permissive then lib.any else lib.all;
-      AND = if permissive then lib.all else lib.any;
+      OR = if permissive then any else all;
+      AND = if permissive then all else any;
       evaluateComplexProperty = handleComplexProperty (evaluateNamedProperty name permissive) AND OR;
     in
     license:
@@ -144,7 +145,7 @@ rec {
     - [licenses] List of licenses to look
     - [license] License expression to check
   */
-  containsLicenses = licenses: evaluateProperty (x: lib.lists.elem x licenses) false;
+  containsLicenses = licenses: evaluateProperty (x: elem x licenses) false;
 
   /**
     Convert a license expression to an SPDX license expression string.

--- a/lib/licenses/helpers.nix
+++ b/lib/licenses/helpers.nix
@@ -21,11 +21,12 @@ rec {
     - [license] license expression to check
   */
   evaluateProperty =
-    predicate: permissive: license:
+    predicate: permissive:
     let
       OR = if permissive then lib.any else lib.all;
       AND = if permissive then lib.all else lib.any;
     in
+    license:
     if license.licenseType == "simple" then
       predicate license
     else if license.licenseType == "compound" then


### PR DESCRIPTION
Patches from a few weeks ago that I forgot about, rebased on master. These are used in `checkMeta`  for checking unfree licenses, so improving their performance is meaningful.  Stats diff for pkgs.hello:
```json
{
  "attrset": {
    "lookups": "-0%",
    "merges": "-0.35%",
    "mergeCopies": "-0.01%"
  },
  "list": {
    "concats": null
  },
  "parser": {
    "expressions": "+0.03%"
  },
  "memory": {
    "envs": "-0.46%",
    "list": null,
    "sets": "-0.01%",
    "symbols": "+0.02%",
    "values": "-0.09%",
    "total": "-0.06%"
  },
  "speed": {
    "primops": null,
    "functionCalls": "-0.39%",
    "thunksMade": "-0.27%",
    "thunksAvoided": "-0.12%"
  }
}
```
Relatively minor, but wins are wins.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
