### PR TITLE
x32edit, m32edit: fix source URLs after upstream website migration

### DIFF
--- a/pkgs/applications/audio/midas/m32edit.nix
+++ b/pkgs/applications/audio/midas/m32edit.nix
@@ -6,8 +6,8 @@ callPackage ./generic.nix (
     brand = "Midas";
     type = "M32";
     version = "4.4.1";
-    url = "https://cdn.mediavalet.com/aunsw/musictribe/Yd1JkAyxqUeqIxoRM0lWWw/uwBe453FiEKSpqZzdjvYpQ/Original/${type}-Edit_LINUX_${version}.tar.gz";
+    url = "https://cdn-media.empowertribe.com/9ba5bed1bc7a427cb96cef8aeb49f097/${type}-Edit_LINUX_${version}.tar.gz";
     hash = "sha256-cEva2Brxo7zm3qppO+BtYIlUqV9t69j+8f6g94C4i3c=";
-    homepage = "https://www.midasconsoles.com/series.html?category=R-MIDAS-M32SERIES";
+    homepage = "https://www.midasconsoles.com/en/products/0603-AEO";
   }
 )

--- a/pkgs/applications/audio/midas/x32edit.nix
+++ b/pkgs/applications/audio/midas/x32edit.nix
@@ -6,8 +6,8 @@ callPackage ./generic.nix (
     brand = "Behringer";
     type = "X32";
     version = "4.4.1";
-    url = "https://cdn.mediavalet.com/aunsw/musictribe/6-vOpP2lRkyNSDXgZEUbQA/FyIw4jc3bk60nseai05MBQ/Original/${type}-Edit_LINUX_${version}.tar.gz";
+    url = "https://cdn-media.empowertribe.com/23b991ede2e6473d916c7ac56f53d71d/${type}-Edit_LINUX_${version}.tar.gz";
     hash = "sha256-HrSPDWnWF2s1U8Khj6VnLptPdcMVyTivewWAIIdArMc=";
-    homepage = "https://www.behringer.com/product.html?modelCode=0603-ACE";
+    homepage = "https://www.behringer.com/en/products/0603-ACE";
   }
 )


### PR DESCRIPTION
## Summary

Music Tribe migrated from `cdn.mediavalet.com` to `cdn-media.empowertribe.com`, changing the download URL format from flat filenames to GUID-based paths. Homepage URLs changed from `/product?modelCode=P0xxx` to `/en/products/P0xxx`.

Versions and hashes are unchanged (4.4.1).

Resolves #521002.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
