### PR TITLE
gpu-burn: support multiple capabilities

### DIFF
--- a/pkgs/by-name/gp/gpu-burn/0001-Emit-compare.fatbin-and-make-arch-compute_X-conditio.patch
+++ b/pkgs/by-name/gp/gpu-burn/0001-Emit-compare.fatbin-and-make-arch-compute_X-conditio.patch
@@ -1,0 +1,121 @@
+From b8dc3f753bd2aefb192f95688dc12797bc041627 Mon Sep 17 00:00:00 2001
+From: Connor Baker <ConnorBaker01@gmail.com>
+Date: Tue, 19 May 2026 20:16:28 -0700
+Subject: [PATCH] Emit compare.fatbin and make -arch=compute_X conditional
+
+cuModuleLoad accepts cubin/fatbin/PTX interchangeably, so the C++ side
+just needs the filename swap.  The benefit is that callers wanting to
+target multiple architectures (or to opt into architecture-conditional
+sm_90a / family-specific compute_100f features) can now append -gencode
+flags via NVCCFLAGS; -ptx output is a single-arch text format with no
+way to multiplex more than one architecture into one file.
+
+To let those callers fully control which architectures end up in the
+fatbin, guard the default -arch=compute_$(COMPUTE) entry behind a non-
+empty check.  'make COMPUTE=' now skips it; default 'make' and
+'make COMPUTE=86' behave exactly as before.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+---
+ Dockerfile       |  2 +-
+ Makefile         | 10 ++++++----
+ README.md        |  8 ++++++++
+ gpu-burn.8       |  2 +-
+ gpu_burn-drv.cpp |  2 +-
+ 5 files changed, 17 insertions(+), 7 deletions(-)
+
+diff --git a/Dockerfile b/Dockerfile
+index 08e5202..1c46976 100644
+--- a/Dockerfile
++++ b/Dockerfile
+@@ -12,7 +12,7 @@ RUN make
+ FROM nvidia/cuda:${CUDA_VERSION}-runtime-${IMAGE_DISTRO}
+ 
+ COPY --from=builder /build/gpu_burn /app/
+-COPY --from=builder /build/compare.ptx /app/
++COPY --from=builder /build/compare.fatbin /app/
+ 
+ WORKDIR /app
+ 
+diff --git a/Makefile b/Makefile
+index ec54a19..d23425a 100644
+--- a/Makefile
++++ b/Makefile
+@@ -32,23 +32,25 @@ IMAGE_DISTRO ?= ubi8
+ 
+ override NVCCFLAGS ?=
+ override NVCCFLAGS += -I${CUDAPATH}/include
++ifneq ($(strip $(COMPUTE)),)
+ override NVCCFLAGS += -arch=compute_$(subst .,,${COMPUTE})
++endif
+ 
+ IMAGE_NAME ?= gpu-burn
+ 
+ .PHONY: clean
+ 
+-gpu_burn: gpu_burn-drv.o compare.ptx
++gpu_burn: gpu_burn-drv.o compare.fatbin
+ 	g++ -o $@ $< -O3 ${LDFLAGS}
+ 
+ %.o: %.cpp
+ 	g++ ${CFLAGS} -c $<
+ 
+-%.ptx: %.cu
+-	PATH="${PATH}:${CCPATH}:." ${NVCC} ${NVCCFLAGS} -ptx $< -o $@
++%.fatbin: %.cu
++	PATH="${PATH}:${CCPATH}:." ${NVCC} ${NVCCFLAGS} -fatbin $< -o $@
+ 
+ clean:
+-	$(RM) *.ptx *.o gpu_burn
++	$(RM) *.fatbin *.o gpu_burn
+ 
+ image:
+ 	docker build --build-arg CUDA_VERSION=${CUDA_VERSION} --build-arg IMAGE_DISTRO=${IMAGE_DISTRO} -t ${IMAGE_NAME} .
+diff --git a/README.md b/README.md
+index ca95342..1b050bf 100644
+--- a/README.md
++++ b/README.md
+@@ -37,6 +37,14 @@ To override this with a different value:
+ 
+ `make COMPUTE=<compute capability value>`
+ 
++`COMPUTE` selects a single virtual architecture for the default `-arch`
++flag.  For a fat binary targeting multiple architectures, or to opt into
++architecture-conditional (`sm_90a`) or family-specific (`compute_100f`)
++features, set `COMPUTE=` to suppress the default and drive the build
++entirely from `-gencode` flags via `NVCCFLAGS`:
++
++`make COMPUTE= NVCCFLAGS='-gencode=arch=compute_86,code=sm_86 -gencode=arch=compute_90,code=sm_90'`
++
+ CFLAGS can be added when invoking make to add to the default
+ list of compiler flags:
+ 
+diff --git a/gpu-burn.8 b/gpu-burn.8
+index bf071a4..b1c46c4 100644
+--- a/gpu-burn.8
++++ b/gpu-burn.8
+@@ -19,7 +19,7 @@ GPU Burn
+ .br
+ \fB\-i\fR N    Execute only on GPU N
+ .br
+-\fB\-c\fR FILE Use FILE as compare kernel.  Default is compare.ptx
++\fB\-c\fR FILE Use FILE as compare kernel.  Default is compare.fatbin
+ .br
+ \fB\-stts\fR T Set timeout threshold to T seconds for using SIGTERM to abort child processes before using SIGKILL.  Default is 30
+ .br
+diff --git a/gpu_burn-drv.cpp b/gpu_burn-drv.cpp
+index eae3532..a66ec9a 100644
+--- a/gpu_burn-drv.cpp
++++ b/gpu_burn-drv.cpp
+@@ -30,7 +30,7 @@
+ // Matrices are SIZE*SIZE..  POT should be efficiently implemented in CUBLAS
+ #define SIZE 8192ul
+ #define USEMEM 0.9 // Try to allocate 90% of memory
+-#define COMPARE_KERNEL "compare.ptx"
++#define COMPARE_KERNEL "compare.fatbin"
+ 
+ // Used to report op/s, measured through Visual Profiler, CUBLAS from CUDA 7.5
+ // (Seems that they indeed take the naive dim^3 approach)
+-- 
+2.43.0
+

--- a/pkgs/by-name/gp/gpu-burn/package.nix
+++ b/pkgs/by-name/gp/gpu-burn/package.nix
@@ -7,7 +7,7 @@
   nix-update-script,
 }:
 let
-  inherit (lib.lists) last map optionals;
+  inherit (lib.lists) optionals;
   inherit (lib.trivial) boolToString;
   inherit (config) cudaSupport;
   inherit (cudaPackages)
@@ -17,7 +17,7 @@ let
     cuda_nvcc
     libcublas
     ;
-  inherit (cudaPackages.flags) cudaCapabilities dropDots isJetsonBuild;
+  inherit (cudaPackages.flags) gencodeString isJetsonBuild;
 in
 backendStdenv.mkDerivation {
   pname = "gpu-burn";
@@ -32,11 +32,14 @@ backendStdenv.mkDerivation {
     hash = "sha256-zaGzwpdvF9dw3RypBO+g6FhjOFN8/F9+yI1+lLxLjgs=";
   };
 
+  # TODO: drop once https://github.com/wilicc/gpu-burn/pull/148 lands.
+  patches = [ ./0001-Emit-compare.fatbin-and-make-arch-compute_X-conditio.patch ];
+
   postPatch = ''
     substituteInPlace gpu_burn-drv.cpp \
       --replace-fail \
-        '#define COMPARE_KERNEL "compare.ptx"' \
-        '#define COMPARE_KERNEL "${placeholder "out"}/share/compare.ptx"'
+        '#define COMPARE_KERNEL "compare.fatbin"' \
+        '#define COMPARE_KERNEL "${placeholder "out"}/share/compare.fatbin"'
     substituteInPlace Makefile \
       --replace-fail \
         '${"\${CUDAPATH}/bin/nvcc"}' \
@@ -58,15 +61,19 @@ backendStdenv.mkDerivation {
   makeFlags = [
     # NOTE: CUDAPATH assumes cuda_cudart is a single output containing all of lib, dev, and stubs.
     "CUDAPATH=${cuda_cudart}"
-    "COMPUTE=${last (map dropDots cudaCapabilities)}"
     "IS_JETSON=${boolToString isJetsonBuild}"
+    # Empty COMPUTE suppresses the Makefile's default -arch=compute_$(COMPUTE);
+    # gencodeString below is the single source of truth for architectures.
+    "COMPUTE="
   ];
+
+  env.NVCCFLAGS = gencodeString;
 
   installPhase = ''
     runHook preInstall
     mkdir -p $out/{bin,share}
     install -Dm755 gpu_burn $out/bin/
-    install -Dm644 compare.ptx $out/share/
+    install -Dm644 compare.fatbin $out/share/
     runHook postInstall
   '';
 


### PR DESCRIPTION
As title.

Patch is vendored from upstream PR: https://github.com/wilicc/gpu-burn/pull/148.

As a followup, it's concerning that NVCC throws a fatal error when specifying family feature sets with a baseline feature set. Perhaps that's by design? Either way, we shouldn't progress beyond eval if we can catch it there. Warrants further investigation.

```console
$ nix build -f . --arg config '{ allowUnfree = true; cudaSupport = true; cudaCapabilities = [ "11.0f" ]; cudaForwardCompat = false; }' --argstr system aarch64-linux cudaPackages_13_2.pkgs.gpu-burn
$ nix build -f . --arg config '{ allowUnfree = true; cudaSupport = true; cudaCapabilities = [ "11.0a" ]; cudaForwardCompat = false; }' --argstr system aarch64-linux cudaPackages_13_2.pkgs.gpu-burn
$ nix build -f . --arg config '{ allowUnfree = true; cudaSupport = true; cudaCapabilities = [ "11.0f" "11.0a" ]; cudaForwardCompat = false; }' --argstr system aarch64-linux cudaPackages_13_2.pkgs.gpu-burn
$ nix build -f . --arg config '{ allowUnfree = true; cudaSupport = true; cudaCapabilities = [ "11.0a" "11.0f" ]; cudaForwardCompat = false; }' --argstr system aarch64-linux cudaPackages_13_2.pkgs.gpu-burn
$ nix build -f . --arg config '{ allowUnfree = true; cudaSupport = true; cudaCapabilities = [ "11.0" "11.0a" ]; cudaForwardCompat = false; }' --argstr system aarch64-linux cudaPackages_13_2.pkgs.gpu-burn
$ nix build -f . --arg config '{ allowUnfree = true; cudaSupport = true; cudaCapabilities = [ "11.0" "11.0f" ]; cudaForwardCompat = false; }' --argstr system aarch64-linux cudaPackages_13_2.pkgs.gpu-burn
error: Cannot build '/nix/store/7l73rydzsjiwm3q820rnl49gwvq0v0yb-gpu-burn-0-unstable-2025-11-04.drv'.
       Reason: builder failed with exit code 2.
       Output paths:
         /nix/store/qcyxbw4wzvg568172072gx4vj155c9iy-gpu-burn-0-unstable-2025-11-04
       Last 25 log lines:
       > source: added removeStubsFromRunpathHookRegistration to prePhases
       > Sourcing fix-elf-files.sh
       > Running phase: removeStubsFromRunpathHookRegistration
       > removeStubsFromRunpathHookRegistration: discovered 'autoFixElfFiles addDriverRunpath' in postFixupHooks; this hook should be unnecessary when linking against stub files!
       > removeStubsFromRunpathHookRegistration: added removeStubsFromRunpath to postFixupHooks
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/h8xmclnv8zi78wx79miwsh12vydjs6lb-source
       > source root is source
       > Running phase: patchPhase
       > applying patch /nix/store/9p9a72xaki020dv2npiywpl2b8cj8zv3-0001-Emit-compare.fatbin-and-make-arch-compute_X-conditio.patch
       > patching file Dockerfile
       > patching file Makefile
       > patching file README.md
       > patching file gpu-burn.8
       > patching file gpu_burn-drv.cpp
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > Executing setupCUDAToolkitCompilers
       > no configure script, doing nothing
       > Running phase: buildPhase
       > build flags: SHELL=/nix/store/j927vicadxxmqjhkfkc2zcx7bhdyc7iw-bash-5.3p9/bin/bash CUDAPATH=/nix/store/i5pj44qbrargivqx3cl5i55gd0xgb771-cuda13.2-cuda_cudart-13.2.51 IS_JETSON=true COMPUTE=
       > g++ -O3 -Wno-unused-result -I/nix/store/i5pj44qbrargivqx3cl5i55gd0xgb771-cuda13.2-cuda_cudart-13.2.51/include -std=c++11 -DIS_JETSON=true -c gpu_burn-drv.cpp
       > PATH="/nix/store/rg2kcim8kk5igq2mb71cy951bmm7cm0x-cuda13.2-cuda_nvcc-13.2.51/bin:/nix/store/56dima09js5zsyxi3dhnkrhkffm3padq-patchelf-0.15.2/bin:/nix/store/waack2w5n0208w1qy7pxnwxbsq2n26vm-gcc-wrapper-15.2.0/bin:/nix/store/ss8q6dq4j6wq2nx1sja1w76xh36jdpnf-gcc-15.2.0/bin:/nix/store/aykwmpgd6gkncw8vkxx9m2sl43kw7fgc-glibc-2.42-51-bin/bin:/nix/store/f03gf7yy36rlr9n1wkblvikq12a3hg6c-coreutils-9.10/bin:/nix/store/l55jb1md1wniv3y2lxk3ygd3picxy6df-binutils-wrapper-2.44/bin:/nix/store/k1dwi3mlxm3vd32r4zg7qj9yi8d4symx-binutils-2.44/bin:/nix/store/f03gf7yy36rlr9n1wkblvikq12a3hg6c-coreutils-9.10/bin:/nix/store/y9vr3s3grrbzsqx5p17ykls2hpx941yx-findutils-4.10.0/bin:/nix/store/g3ajbl1clfw1x9xd819fs025chp09b0k-diffutils-3.12/bin:/nix/store/h6b6hd5zrd460779nvb6vphjw9x6lpdw-gnused-4.9/bin:/nix/store/cl5dx515i81xljb5197g2lswr74i07jn-gnugrep-3.12/bin:/nix/store/rzgfpccg7p882144kakc4b4mxv95zg3q-gawk-5.3.2/bin:/nix/store/492i29l9ipq710r3ngwmwgmgbsvj4l47-gnutar-1.35/bin:/nix/store/gr9irlci6q5grw5yghjm6g6xyp3rffhz-gzip-1.14/bin:/nix/store/psxpqil9qcv8k92yv7fds9crys7abjl9-bzip2-1.0.8-bin/bin:/nix/store/1h2wn0fqqdgi7svxd078yw9yg715p6sw-gnumake-4.4.1/bin:/nix/store/j927vicadxxmqjhkfkc2zcx7bhdyc7iw-bash-5.3p9/bin:/nix/store/f0y2psw43gfbawfhqlq2rfa718p7cylj-patch-2.8/bin:/nix/store/lm0qx39b4k0329wbrl15icqc6yn19yhf-xz-5.8.2-bin/bin:/nix/store/010a064xk008s2i1vr1pqannf15hiqxw-file-5.45/bin::." /nix/store/rg2kcim8kk5igq2mb71cy951bmm7cm0x-cuda13.2-cuda_nvcc-13.2.51/bin/nvcc -gencode=arch=compute_110,code=sm_110 -gencode=arch=compute_110f,code=sm_110f -I/nix/store/i5pj44qbrargivqx3cl5i55gd0xgb771-cuda13.2-cuda_cudart-13.2.51/include -fatbin compare.cu -o compare.fatbin
       > nvcc fatal   : The same GPU code (`sm_110f`) generated for non family-specific and family-specific GPU arch
       > make: *** [Makefile:50: compare.fatbin] Error 1
       For full logs, run:
         nix log /nix/store/7l73rydzsjiwm3q820rnl49gwvq0v0yb-gpu-burn-0-unstable-2025-11-04.drv
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
