### PR TITLE
sqld: 0.24.32 -> 0.24.33

### DIFF
--- a/pkgs/by-name/sq/sqld/package.nix
+++ b/pkgs/by-name/sq/sqld/package.nix
@@ -16,31 +16,23 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sqld";
-  version = "0.24.32";
+  version = "0.24.33";
 
   src = fetchFromGitHub {
     owner = "tursodatabase";
     repo = "libsql";
     tag = "libsql-server-v${finalAttrs.version}";
-    hash = "sha256-CiTJ9jLANBrncz/O/0k2/UI/qGCTGWLZuLQdncunlX8";
+    hash = "sha256-ufpYZdw/96QIQ43ex4FTA/aulouZPDkbmSt7X4YnEzo=";
   };
 
-  patches = [
-    # https://github.com/tursodatabase/libsql/pull/1981
-    # A CMakeLists.txt broke builds by forcing the '-msse4.2' and '-maes' x86-specific compile flags,
-    # when compiling with Clang, regardless of the host platform's architecture.
-    (fetchpatch {
-      url = "https://github.com/tursodatabase/libsql/commit/5ce88e8cf9476ea64453bf1532d75c8faf037aad.patch";
-      hash = "sha256-5M6XNp0EpCZMZb7NC7TBGBVdZLkC74vwqEnVTCZ7n5U=";
-    })
-  ];
+  patches = [ ];
 
   cargoBuildFlags = [
     "--bin"
     "sqld"
   ];
 
-  cargoHash = "sha256-4Ma/17t+EmmjiYICBLhJifQez0dnwtjhlkmoQrAIG+s";
+  cargoHash = "sha256-n2STJfX1sEeSbr3v9xst3S7UgLrUIdqfokqlHLWCVzY=";
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
Update to 0.24.33

remove outdated patch

## Things done

- Built on platform:
  - [] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
