### PR TITLE
iqmol: init at 3.2.2

### DIFF
--- a/pkgs/by-name/iq/iqmol/package.nix
+++ b/pkgs/by-name/iq/iqmol/package.nix
@@ -1,0 +1,108 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  gfortran,
+  pkg-config,
+  boost,
+  libarchive,
+  libGLU,
+  libsForQt5,
+  libssh2,
+  openbabel,
+  openmesh,
+  yaml-cpp,
+  zlib,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "iqmol";
+  version = "3.2.2";
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "nutjunkie";
+    repo = "IQmol3";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-AJ5pAYHeATBZISNLmWuqbdxrrM7wuCvIN4uAXgEomGU=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    gfortran
+    pkg-config
+    libsForQt5.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    boost
+    libarchive
+    libGLU
+    libsForQt5.qtbase
+    libsForQt5.libqglviewer
+    libssh2
+    openbabel
+    openmesh
+    yaml-cpp
+    zlib
+  ];
+
+  postPatch =
+    let
+      openbabelLibVersion = builtins.concatStringsSep "." (
+        lib.take 3 (builtins.splitVersion openbabel.version)
+      );
+    in
+    ''
+      substituteInPlace CMakeLists.txt \
+        --replace-fail "-static-libgcc -static-libstdc++" "" \
+        --replace-fail "/usr/include/openbabel3" "${openbabel}/include/openbabel3" \
+        --replace-fail '   ''${ARCHIVE_LIBRARY}' "   LibArchive::LibArchive"
+
+      substituteInPlace src/Math/CMakeLists.txt \
+        --replace-fail "QGLViewer" "QGLViewer-qt5"
+
+      substituteInPlace src/Main/IQmolApplication.C \
+        --replace-fail "/usr/lib/openbabel/3.1.1" "${openbabel}/lib/openbabel/${openbabelLibVersion}" \
+        --replace-fail "/usr/share/openbabel" "${openbabel}/share/openbabel"
+
+      substituteInPlace src/Util/Preferences.C \
+        --replace-fail "/usr/share/iqmol" "$out/share/iqmol"
+    '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 IQmol $out/bin/iqmol
+
+    mkdir -p $out/share/iqmol
+    cd ..
+    cp -r share/* $out/share/iqmol/
+
+    install -Dm644 doc/IQmolUserGuide.pdf $out/share/doc/iqmol/IQmolUserGuide.pdf
+    install -Dm644 share/man/man7/iqmol.7.gz $out/share/man/man7/iqmol.7.gz
+    install -Dm644 resources/IQmol.png $out/share/icons/hicolor/512x512/apps/iqmol.png
+    install -Dm644 resources/IQmol.appdata.xml $out/share/metainfo/iqmol.appdata.xml
+    mkdir -p $out/share/applications
+
+    substitute resources/iqmol.desktop $out/share/applications/iqmol.desktop \
+      --replace-fail "/usr/local/bin/iqmol" "iqmol" \
+      --replace-fail "/usr/share/icons/hicolor/512x512/apps/iqmol.png" "iqmol"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Molecular builder and visualization package";
+    homepage = "https://iqmol.org/";
+    changelog = "https://github.com/nutjunkie/IQmol3/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ usu171 ];
+    mainProgram = "iqmol";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
[iqmol](https://github.com/nutjunkie/IQmol3) is a molecular builder and visualization package
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
