### PR TITLE
zbctl: 8.4.19 -> 8.5.25

### DIFF
--- a/pkgs/by-name/zb/zbctl/package.nix
+++ b/pkgs/by-name/zb/zbctl/package.nix
@@ -6,18 +6,18 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "zbctl";
-  version = "8.4.19";
+  version = "8.5.25";
 
   src =
     if stdenvNoCC.hostPlatform.system == "x86_64-darwin" then
       fetchurl {
         url = "https://github.com/camunda/zeebe/releases/download/${finalAttrs.version}/zbctl.darwin";
-        hash = "sha256-RuZX9TWuXBxxegLw0La0l9/6zh96V/2trJvZUoCvTKk=";
+        hash = "sha256-MMal+M7cJSeysr5j3LVSc3CoByHUoq5h6XzJSKknCWE=";
       }
     else if stdenvNoCC.hostPlatform.system == "x86_64-linux" then
       fetchurl {
         url = "https://github.com/camunda/zeebe/releases/download/${finalAttrs.version}/zbctl";
-        hash = "sha256-NTJqmcOzpOzHjrtOHBU2J3u0f7sESBeZMbb8kx3zR38=";
+        hash = "sha256-EzPIKBgs0zkoLbGQPxKIeRbNCQvfiVthb3IKBZZItlQ=";
       }
     else
       throw "Unsupported platform ${stdenvNoCC.hostPlatform.system}";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/camunda/camunda/releases/tag/8.5.25
https://github.com/camunda/camunda/compare/8.4.19...8.5.25

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
