### PR TITLE
bambu-studio: make this package functional/usable again (various fixes)

### DIFF
--- a/pkgs/by-name/ba/bambu-studio/package.nix
+++ b/pkgs/by-name/ba/bambu-studio/package.nix
@@ -168,19 +168,19 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   cmakeFlags = [
-    "-DSLIC3R_STATIC=0"
-    "-DSLIC3R_FHS=1"
-    "-DSLIC3R_GTK=3"
+    (lib.cmakeBool "SLIC3R_STATIC" false)
+    (lib.cmakeBool "SLIC3R_FHS" true)
+    (lib.cmakeFeature "SLIC3R_GTK" "3")
 
     # Skips installing ffmpeg, since we BYO.
-    "-DFLATPAK=1"
+    (lib.cmakeBool "FLATPAK" true)
 
-    # BambuStudio-specific
-    "-DBBL_RELEASE_TO_PUBLIC=1"
-    "-DBBL_INTERNAL_TESTING=0"
-    "-DDEP_WX_GTK3=ON"
-    "-DSLIC3R_BUILD_TESTS=0"
-    "-DCMAKE_CXX_FLAGS=-DBOOST_LOG_DYN_LINK"
+    # Substituted into `#define BBL_x @value@`; must be integer literals.
+    (lib.cmakeFeature "BBL_RELEASE_TO_PUBLIC" "1")
+    (lib.cmakeFeature "BBL_INTERNAL_TESTING" "0")
+    (lib.cmakeBool "DEP_WX_GTK3" true)
+    (lib.cmakeBool "SLIC3R_BUILD_TESTS" false)
+    (lib.cmakeFeature "CMAKE_CXX_FLAGS" "-DBOOST_LOG_DYN_LINK")
   ];
 
   preFixup = ''

--- a/pkgs/by-name/ba/bambu-studio/package.nix
+++ b/pkgs/by-name/ba/bambu-studio/package.nix
@@ -1,7 +1,6 @@
 {
   stdenv,
   lib,
-  binutils,
   fetchFromGitHub,
   cmake,
   ninja,
@@ -35,7 +34,6 @@
   openvdb,
   openexr,
   opencv,
-  pcre,
   systemd,
   onetbb,
   webkitgtk_4_1,
@@ -85,7 +83,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    binutils
     boost183
     cereal
     cgal_5
@@ -112,7 +109,6 @@ stdenv.mkDerivation (finalAttrs: {
     opencascade-occt_7_6
     openexr
     openvdb
-    pcre
     onetbb
     webkitgtk_4_1
     wxGTK'

--- a/pkgs/by-name/ba/bambu-studio/package.nix
+++ b/pkgs/by-name/ba/bambu-studio/package.nix
@@ -8,6 +8,7 @@
   pkg-config,
   wrapGAppsHook3,
   boost183,
+  cacert,
   cereal,
   cgal_5,
   curl,
@@ -15,7 +16,6 @@
   eigen,
   expat,
   ffmpeg,
-  gcc-unwrapped,
   glew,
   glfw,
   glib,
@@ -26,7 +26,10 @@
   gtk3,
   hicolor-icon-theme,
   libpng,
+  libsecret,
+  makeFontsConf,
   mpfr,
+  nanum,
   nlopt,
   opencascade-occt_7_6,
   openvdb,
@@ -39,6 +42,9 @@
   wxwidgets_3_1,
   libx11,
   withSystemd ? stdenv.hostPlatform.isLinux,
+  # 3D viewport blank on NVIDIA proprietary GL; routes through Mesa + zink.
+  # https://github.com/NixOS/nixpkgs/issues/498311
+  withNvidiaGLWorkaround ? false,
 }:
 let
   wxGTK' =
@@ -48,11 +54,17 @@ let
       withWebKit = true;
     }).overrideAttrs
       (old: {
+        buildInputs = old.buildInputs ++ [ libsecret ];
         configureFlags = old.configureFlags ++ [
           # Disable noisy debug dialogs
           "--enable-debug=no"
+          "--enable-secretstore"
         ];
       });
+
+  fontsConf = makeFontsConf { fontDirectories = [ nanum ]; };
+
+  caBundle = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "bambu-studio";
@@ -82,7 +94,6 @@ stdenv.mkDerivation (finalAttrs: {
     eigen
     expat
     ffmpeg
-    gcc-unwrapped
     glew
     glfw
     glib
@@ -95,6 +106,7 @@ stdenv.mkDerivation (finalAttrs: {
     gtk3
     hicolor-icon-theme
     libpng
+    libsecret
     mpfr
     nlopt
     opencascade-occt_7_6
@@ -178,6 +190,25 @@ stdenv.mkDerivation (finalAttrs: {
       # Fixes intermittent crash
       # The upstream setup links in glew statically
       --prefix LD_PRELOAD : "${glew.out}/lib/libGLEW.so"
+
+      # plugin libcurl + main HTTPS need explicit CA bundle.
+      # https://github.com/NixOS/nixpkgs/issues/498307
+      --set-default SSL_CERT_FILE ${caBundle}
+      --set-default CURL_CA_BUNDLE ${caBundle}
+
+      # WebKit OAuth callback fails with DMA-BUF compositing.
+      # https://github.com/NixOS/nixpkgs/issues/498307
+      --set WEBKIT_DISABLE_COMPOSITING_MODE 1
+      --set WEBKIT_DISABLE_DMABUF_RENDERER 1
+
+      --set FONTCONFIG_FILE "${fontsConf}"
+
+      ${lib.optionalString withNvidiaGLWorkaround ''
+        --set __GLX_VENDOR_LIBRARY_NAME mesa
+        --set __EGL_VENDOR_LIBRARY_FILENAMES /run/opengl-driver/share/glvnd/egl_vendor.d/50_mesa.json
+        --set MESA_LOADER_DRIVER_OVERRIDE zink
+        --set GALLIUM_DRIVER zink
+      ''}
     )
   '';
 


### PR DESCRIPTION
This PR fixes various issues regarding bambustudio (which is currently in a broken, unusable state). As a maintainer of this package who recently joined before any of these issues were created, I didn't get pinged, so I didn't even know these issues existed. But I've reviewed all of the fixable issues and bundled them into this PR. If there is any breakage feels free to ping me, I will jump right in.

Fixes #440951
Fixes #498307
Fixes #498311 (Via opt in option called `withNvidiaGLWorkaround`)

The cloud login issue was such a pain. Without GDB I would never have known how to fix it (dual-loaded `libstdc++`). 😆

Tested (should be stable for people who actually want to use this package):
- viewport functional
- completed auth flow and state persisted
- no crashes

Related: https://github.com/NixOS/nixpkgs/pull/521817#issuecomment-4489406343 / https://discourse.nixos.org/t/bambu-studio-any-working-method/62272
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
