### PR TITLE
snmpen: 1.1.0 -> 1.1.3

### DIFF
--- a/pkgs/by-name/sn/snmpen/package.nix
+++ b/pkgs/by-name/sn/snmpen/package.nix
@@ -7,14 +7,14 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "snmpen";
-  version = "1.1.0";
+  version = "1.1.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "fabaff";
     repo = "snmpen";
     tag = finalAttrs.version;
-    hash = "sha256-PH1kUnDOiiE7ouEkhd1+TuIBziB2uxCVnmiEkCgQma0=";
+    hash = "sha256-XJP+f5Ahizxgk80B0896sbE6JeNB0Bm7aafwJsFaHYY=";
   };
 
   build-system = with python3.pkgs; [ hatchling ];
@@ -38,8 +38,8 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   meta = {
     description = "SNMP Enumeration tool";
-    homepage = "https://github.com/fabaff/snmpen";
-    changelog = "https://github.com/fabaff/snmpen/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    homepage = "https://github.com/affolter-engineering/snmpen";
+    changelog = "https://github.com/affolter-engineering/snmpen/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "snmpen";


### PR DESCRIPTION
Diff: https://github.com/fabaff/snmpen/compare/1.1.0...1.1.3

Changelog: https://github.com/affolter-engineering/snmpen/blob/refs/tags/1.1.3/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
