### PR TITLE
pipekit: init at 6.65.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13479,6 +13479,12 @@
     githubId = 5352661;
     name = "James Cleverley-Prance";
   };
+  jpz13 = {
+    email = "jp@pipekit.io";
+    github = "JPZ13";
+    githubId = 6625432;
+    name = "J.P. Zivalich";
+  };
   jqueiroz = {
     email = "nixos@johnjq.com";
     github = "jqueiroz";

--- a/pkgs/by-name/pi/pipekit/package.nix
+++ b/pkgs/by-name/pi/pipekit/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+let
+  sources = {
+    "x86_64-linux" = {
+      suffix = "linux_amd64";
+      hash = "sha256-3TTVSCZcsUVfNzC9hWn0OLytMAOxL39f5IlqCReCw7g=";
+    };
+    "aarch64-linux" = {
+      suffix = "linux_arm64";
+      hash = "sha256-pHygFgvMdyh8NQeGwZ1iNkaU1q+pcxvn5/CaoO/amIc=";
+    };
+  };
+  inherit (stdenvNoCC.hostPlatform) system;
+  source = sources.${system} or (throw "pipekit: no prebuilt binary for ${system}");
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "pipekit";
+  version = "6.65.5";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchurl {
+    url = "https://github.com/pipekit/cli/releases/download/v${finalAttrs.version}/cli_${finalAttrs.version}_${source.suffix}.tar.gz";
+    inherit (source) hash;
+  };
+
+  sourceRoot = ".";
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 pipekit -t $out/bin
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI for Pipekit. Observability, governance, and scale for Argo Workflows";
+    homepage = "https://pipekit.io";
+    changelog = "https://github.com/pipekit/cli/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.unfree;
+    mainProgram = "pipekit";
+    maintainers = with lib.maintainers; [ jpz13 ];
+    platforms = builtins.attrNames sources;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
Hi nixpkgs maintainers. We're heavy users of NixOS at [Pipekit](https://pipekit.io/), and we'd like to include our CLI as a nix package

This PR contains:
- Initial packaging of the [Pipekit CLI](https://pipekit.io/) — a workflow orchestration platform for [Argo Workflows](https://argoproj.github.io/workflows/). 
  - Distributed as prebuilt tarballs from <https://github.com/pipekit/cli/releases>. 
  - Proprietary binary, so the derivation is marked `unfree` with `sourceProvenance = [ binaryNativeCode ]`, following the same pattern used by `slack`, `zoom-us`, `_1password-cli`, and `snyk`.
  - Supports `x86_64-linux`, `aarch64-linux`. `passthru.updateScript = nix-update-script { }` so subsequent version bumps can be driven by `nix-update`.

I am Pipekit's CLI release owner and will maintain this package going forward. If we hand off the ownership to someone else, I'll update the maintainer declaration to include them

## Things done

- Built on platform:
  - [x] x86_64-linux — `./result/bin/pipekit version` prints `Pipekit CLI: v6.65.5`.
  - [x] aarch64-linux
  - darwin support dropped for now. See comment below
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

## Automation/AI disclosure

The derivation and the `maintainers/maintainer-list.nix` entry were drafted with the assistance of Claude Code (Anthropic Claude Opus 4.7). I reviewed every line, verified the build locally on `x86_64-linux` and `aarch64-linux`, and verified the darwin SRI hashes by fetching each release tarball as a fixed-output derivation. The commit carries an `Assisted-by:` trailer per CONTRIBUTING.md §10.

I've also automated the binary generation to be a part of our CLI pipeline using Goreleaser. It stages the release to [this repo](https://github.com/pipekit/pipekit-nix).

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test