### PR TITLE
factor: refactor deploy to embed image + setting 0.101 as the default packages

### DIFF
--- a/pkgs/development/compilers/factor-lang/mk-factor-application.nix
+++ b/pkgs/development/compilers/factor-lang/mk-factor-application.nix
@@ -31,7 +31,7 @@ in
     extraPaths ? [ ],
     # Extra vocabularies needed by this application
     extraVocabs ? [ ],
-    deployScriptText ? ''
+    deployScriptText ? /* factor */ ''
       USING: command-line io io.backend io.pathnames kernel namespaces sequences
       tools.deploy tools.deploy.config tools.deploy.backend vocabs.loader ;
 
@@ -91,7 +91,7 @@ in
     buildInputs = (lib.optional enableUI gdk-pixbuf) ++ attrs.buildInputs or [ ];
 
     buildPhase =
-      attrs.buildPhase or ''
+      attrs.buildPhase or /* bash */ ''
         runHook preBuild
         vocabBaseName=$(basename "$vocabName")
         mkdir -p "$out/lib/factor" "$TMPDIR/.cache"
@@ -105,11 +105,11 @@ in
     __structuredAttrs = true;
 
     installPhase =
-      attrs.installPhase or (
-        ''
+      attrs.installPhase or
+        /* bash */ ''
           runHook preInstall
         ''
-        + (lib.optionalString finalAttrs.enableUI ''
+        + (lib.optionalString finalAttrs.enableUI /* bash */ ''
           # Set Gdk pixbuf loaders file to the one from the build dependencies here
           unset GDK_PIXBUF_MODULE_FILE
           # Defined in gdk-pixbuf setup hook
@@ -117,10 +117,10 @@ in
           appendToVar makeWrapperArgs --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
           appendToVar makeWrapperArgs --prefix LD_LIBRARY_PATH : /run/opengl-driver/lib
         '')
-        + (lib.optionalString (wrapped-factor.runtimeLibs != [ ])) ''
+        + (lib.optionalString (wrapped-factor.runtimeLibs != [ ])) /* bash */ ''
           appendToVar makeWrapperArgs --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath wrapped-factor.runtimeLibs}"
         ''
-        + ''
+        + /* bash */ ''
           mkdir -p "$out/bin"
           makeWrapper "$out/lib/factor/$vocabBaseName/$vocabBaseName" \
             "$out/bin/$binName" \

--- a/pkgs/development/compilers/factor-lang/mk-factor-application.nix
+++ b/pkgs/development/compilers/factor-lang/mk-factor-application.nix
@@ -105,30 +105,26 @@ in
     __structuredAttrs = true;
 
     installPhase =
-      attrs.installPhase or
-        /* bash */ ''
-          runHook preInstall
-        ''
-        + (lib.optionalString finalAttrs.enableUI /* bash */ ''
+      attrs.installPhase or /* bash */ ''
+        runHook preInstall
+        ${lib.optionalString finalAttrs.enableUI /* bash */ ''
           # Set Gdk pixbuf loaders file to the one from the build dependencies here
           unset GDK_PIXBUF_MODULE_FILE
           # Defined in gdk-pixbuf setup hook
           findGdkPixbufLoaders "${librsvg}"
           appendToVar makeWrapperArgs --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
           appendToVar makeWrapperArgs --prefix LD_LIBRARY_PATH : /run/opengl-driver/lib
-        '')
-        + (lib.optionalString (wrapped-factor.runtimeLibs != [ ])) /* bash */ ''
+        ''}
+        ${lib.optionalString (wrapped-factor.runtimeLibs != [ ]) /* bash */ ''
           appendToVar makeWrapperArgs --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath wrapped-factor.runtimeLibs}"
-        ''
-        + /* bash */ ''
-          mkdir -p "$out/bin"
-          makeWrapper "$out/lib/factor/$vocabBaseName/$vocabBaseName" \
-            "$out/bin/$binName" \
-            --prefix PATH : "${lib.makeBinPath runtimePaths}" \
-            "''${makeWrapperArgs[@]}"
-          runHook postInstall
-        ''
-      );
+        ''}
+        mkdir -p "$out/bin"
+        makeWrapper "$out/lib/factor/$vocabBaseName/$vocabBaseName" \
+          "$out/bin/$binName" \
+          --prefix PATH : "${lib.makeBinPath runtimePaths}" \
+          "''${makeWrapperArgs[@]}"
+        runHook postInstall
+      '';
 
     passthru = {
       vocab = finalAttrs.src;

--- a/pkgs/development/compilers/factor-lang/mk-factor-application.nix
+++ b/pkgs/development/compilers/factor-lang/mk-factor-application.nix
@@ -54,7 +54,7 @@ in
               first2 deploy-vocab
           ] [
               drop
-              "usage: deploy-me <PATH-TO-VOCAB> <TARGET-DIR>" print
+              "Usage: deploy-me <PATH-TO-VOCAB> <TARGET-DIR>" print
               nl
           ] if ;
 

--- a/pkgs/development/compilers/factor-lang/mk-factor-application.nix
+++ b/pkgs/development/compilers/factor-lang/mk-factor-application.nix
@@ -5,6 +5,7 @@
   makeBinaryWrapper,
   factor-lang,
   factor-no-gui,
+  factor-unwrapped,
   librsvg,
   gdk-pixbuf,
 }@initAttrs:
@@ -33,7 +34,8 @@ in
     extraVocabs ? [ ],
     deployScriptText ? /* factor */ ''
       USING: command-line io io.backend io.pathnames kernel namespaces sequences
-      tools.deploy tools.deploy.config tools.deploy.backend vocabs.loader ;
+      tools.deploy tools.deploy.config tools.deploy.config.editor
+      tools.deploy.backend vocabs.loader ;
 
       IN: deploy-me
 
@@ -44,18 +46,20 @@ in
               file-name dup reload deploy
           ] bi ;
 
-      : deploy-vocab ( path/vocab path/target -- )
-          normalize-path deploy-directory set
-          f open-directory-after-deploy? set
-          load-and-deploy ;
+      : deploy-vocab ( path/vocab executable -- )
+          swap normalize-path
+          [ parent-directory add-vocab-root ]
+          [ file-name dup reload ] bi
+          [ deployed-image-name ] keep
+          [ deploy-config ] keep swap
+          make-deploy-image-executable drop ;
 
       : deploy-me ( -- )
           command-line get dup length 2 = [
               first2 deploy-vocab
           ] [
               drop
-              "Usage: deploy-me <PATH-TO-VOCAB> <TARGET-DIR>" print
-              nl
+              "Usage: deploy-me <PATH-TO-VOCAB> <EXECUTABLE-PATH>" print nl
           ] if ;
 
       MAIN: deploy-me
@@ -93,12 +97,11 @@ in
     buildPhase =
       attrs.buildPhase or /* bash */ ''
         runHook preBuild
-        vocabBaseName=$(basename "$vocabName")
-        mkdir -p "$out/lib/factor" "$TMPDIR/.cache"
-        export XDG_CACHE_HOME="$TMPDIR/.cache"
 
-        factor "${deployScript}" "./$vocabName" "$out/lib/factor"
-        cp "$TMPDIR/factor-temp"/*.image "$out/lib/factor/$vocabBaseName"
+        vocabBaseName=$(basename "$vocabName")
+        export XDG_CACHE_HOME="$TMPDIR/.cache"
+        mkdir -p "$out/bin" "$XDG_CACHE_HOME"
+
         runHook postBuild
       '';
 
@@ -107,6 +110,7 @@ in
     installPhase =
       attrs.installPhase or /* bash */ ''
         runHook preInstall
+
         ${lib.optionalString finalAttrs.enableUI /* bash */ ''
           # Set Gdk pixbuf loaders file to the one from the build dependencies here
           unset GDK_PIXBUF_MODULE_FILE
@@ -118,12 +122,26 @@ in
         ${lib.optionalString (wrapped-factor.runtimeLibs != [ ]) /* bash */ ''
           appendToVar makeWrapperArgs --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath wrapped-factor.runtimeLibs}"
         ''}
+
         mkdir -p "$out/bin"
-        makeWrapper "$out/lib/factor/$vocabBaseName/$vocabBaseName" \
-          "$out/bin/$binName" \
+
+        # Stage copy of the raw VM binary into the output directory with correct
+        # permissions for embed-image to modify in place
+        install -m755 "${lib.getLib factor-unwrapped}/lib/factor/factor" "$out/bin/$binName"
+
+        wrapProgram "$out/bin/$binName" \
           --prefix PATH : "${lib.makeBinPath runtimePaths}" \
           "''${makeWrapperArgs[@]}"
+
         runHook postInstall
+      '';
+
+    # strip & patchelf in base fixupPhase rewrite the the ELF — *including*
+    # appended sections like the magic footer bits Factor writes — so the
+    # deploy script must be be run after
+    postFixup =
+      attrs.postFixup or /* bash */ ''
+        factor "${deployScript}" "./$vocabName" "$out/bin/.$binName-wrapped"
       '';
 
     passthru = {

--- a/pkgs/development/compilers/factor-lang/test/hello-world/default.nix
+++ b/pkgs/development/compilers/factor-lang/test/hello-world/default.nix
@@ -1,0 +1,33 @@
+# Builds a basic hello-world Factor application using buildFactorApplication &
+# verifies source-to-binary that the resulting app prints "Hello, $NAME"
+# depending on `--name` flag.
+{
+  lib,
+  runCommandLocal,
+  buildFactorApplication,
+}:
+
+let
+  app = buildFactorApplication {
+    pname = "hello";
+    version = "test";
+    src = ./extra;
+    vocabName = "hello";
+
+    doInstallCheck = true;
+    installCheckPhase = "";
+  };
+in
+runCommandLocal "assert-factor-hello-world"
+  {
+    env.expected = "Hello, Nixpkgs";
+  }
+  ''
+    echo "App path: ${app}" >&2
+    output="$(${lib.getExe app} --name "Nixpkgs")"
+    if [ "$output" != "$expected" ]; then
+      echo "FAIL: expected “$expected”; got “$output”" >&2
+      exit 1
+    fi
+    touch "$out"
+  ''

--- a/pkgs/development/compilers/factor-lang/test/hello-world/extra/hello/author.txt
+++ b/pkgs/development/compilers/factor-lang/test/hello-world/extra/hello/author.txt
@@ -1,0 +1,1 @@
+toastal

--- a/pkgs/development/compilers/factor-lang/test/hello-world/extra/hello/hello.factor
+++ b/pkgs/development/compilers/factor-lang/test/hello-world/extra/hello/hello.factor
@@ -1,0 +1,16 @@
+! SPDX-License-Identifier: 0BSD
+USING: command-line combinators io kernel namespaces sequences ;
+
+IN: hello
+
+: greet ( name -- )
+    "Hello, " prepend print ;
+
+: main ( -- )
+    command-line get {
+        { [ dup empty? ] [ drop "world" ] }
+        { [ dup first "--name" = not ] [ drop "world" ] }
+        [ second ]
+    } cond greet ;
+
+MAIN: main

--- a/pkgs/development/compilers/factor-lang/wrapper.nix
+++ b/pkgs/development/compilers/factor-lang/wrapper.nix
@@ -2,6 +2,8 @@
   lib,
   stdenv,
   makeWrapper,
+  runCommandLocal,
+  buildFactorApplication,
   buildEnv,
   copyDesktopItems,
   makeDesktopItem,
@@ -220,6 +222,11 @@ stdenv.mkDerivation (finalAttrs: {
       extraVocabs
       vocabTree
       ;
+    tests = {
+      hello-world = import ./test/hello-world {
+        inherit lib runCommandLocal buildFactorApplication;
+      };
+    };
   };
 
   meta = factor-unwrapped.meta // {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5934,7 +5934,7 @@ with pkgs;
       stdenv = clangStdenv;
     };
   };
-  factorPackages = factorPackages-0_100;
+  factorPackages = factorPackages-0_101;
 
   factor-lang-0_99 = factorPackages-0_99.factor-lang;
   factor-lang-0_100 = factorPackages-0_100.factor-lang;

--- a/pkgs/top-level/factor-packages.nix
+++ b/pkgs/top-level/factor-packages.nix
@@ -20,15 +20,20 @@ let
 
       inherit factor-unwrapped;
 
-      factor-lang = callPackage ../development/compilers/factor-lang/wrapper.nix { };
+      factor-lang = callPackage ../development/compilers/factor-lang/wrapper.nix {
+        inherit (self) buildFactorApplication;
+      };
       factor-no-gui = callPackage ../development/compilers/factor-lang/wrapper.nix {
+        inherit (self) buildFactorApplication;
         guiSupport = false;
       };
       factor-minimal = callPackage ../development/compilers/factor-lang/wrapper.nix {
+        inherit (self) buildFactorApplication;
         enableDefaults = false;
         guiSupport = false;
       };
       factor-minimal-gui = callPackage ../development/compilers/factor-lang/wrapper.nix {
+        inherit (self) buildFactorApplication;
         enableDefaults = false;
       };
 


### PR DESCRIPTION
0.101 is the default `factor-lang`, but not the default Factor package set. I needed 0.101 vocabularies & my environment showed I was using, but was surprised to see the 0.100 vocabularies being unexpectedly referenced.

```console
$ factor -version
Factor 0.101 x86.64 (2298, -, Dec  9 2025 04:49:49)
[Clang (GCC Clang 21.1.8)] on linux
```

To investigate, I created a basic `hello.factor` program that took argument flags to test the basic feature set & debug the factor deployment (where I used AI (DeepSeek) to help walk thru that code since I am still learning Factor).

There are a number of issues:

1. In 0.101, the `unix` vocab changed & started appending an `out` extension breaking expected output locations (which embedding directly into an image avoids)
2. ~~The C bin wrapper is better for this application since we just need to set env vars (no need for Bash’s overhead)~~ (standalone: #527895)
3. The old wrapper adding the `factor -i=*.image`  made it hard to make bins with their own flags (hence testing `hello --name …`)
4. Stripping in the fixup phase culls the magic Factor footer?


This approach copies a base image, embeds the application into that copy postFixup (avoid stripping the image) without needing a separate image.

I have been using this patchset for a few days on a binary I made which worked.
<!--
^ Please summarize the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.