### PR TITLE
osu-lazer{,-bin}: 2026.429.0 -> 2026.518.0

### DIFF
--- a/pkgs/by-name/os/osu-lazer-bin/package.nix
+++ b/pkgs/by-name/os/osu-lazer-bin/package.nix
@@ -10,23 +10,23 @@
 
 let
   pname = "osu-lazer-bin";
-  version = "2026.429.0";
+  version = "2026.518.0";
 
   src =
     {
       aarch64-darwin = fetchzip {
         url = "https://github.com/ppy/osu/releases/download/${version}-lazer/osu.app.Apple.Silicon.zip";
-        hash = "sha256-So87dCg3exApEEnzj0tMi30+OFHhcPHlb3M2uwEyZgU=";
+        hash = "sha256-T/uoriXCXfK+HnLqMZ3xQ79qmlT5rVaoeEi5Wgu1Oc4=";
         stripRoot = false;
       };
       x86_64-darwin = fetchzip {
         url = "https://github.com/ppy/osu/releases/download/${version}-lazer/osu.app.Intel.zip";
-        hash = "sha256-n2XkyzBsgiY65yrd5Jd0zvByaJ0EZ3C4URTb2Z6n5Fc=";
+        hash = "sha256-G/l2WSgl7GcIMHmb86K4qzryMirebe5dmnMrsSlYNfY=";
         stripRoot = false;
       };
       x86_64-linux = fetchurl {
         url = "https://github.com/ppy/osu/releases/download/${version}-lazer/osu.AppImage";
-        hash = "sha256-3yBDCMffgWQKmBHETYl7IrvT5BOE6vN+sH8dGg+w//s=";
+        hash = "sha256-4LLNjrKEBS77LIbq+O6Xpxj6CvufGDApNqs61HN2JmA=";
       };
     }
     .${stdenvNoCC.system} or (throw "osu-lazer-bin: ${stdenvNoCC.system} is unsupported.");

--- a/pkgs/by-name/os/osu-lazer/deps.json
+++ b/pkgs/by-name/os/osu-lazer/deps.json
@@ -16,8 +16,8 @@
   },
   {
     "pname": "DiscordRichPresence",
-    "version": "1.6.1.70",
-    "hash": "sha256-uXTNIWfZU7Gf/JpXQ5ufKA3SQdXYSkg3yLm5yCrBDd8="
+    "version": "1.5.0.51",
+    "hash": "sha256-ZfyXXsJ7c8u0EAfKjquv/pAL3ZajKLnVIJWADQYJ6wI="
   },
   {
     "pname": "FFmpeg.AutoGen",
@@ -616,8 +616,8 @@
   },
   {
     "pname": "ppy.osu.Framework",
-    "version": "2026.428.0",
-    "hash": "sha256-mlf9kFMjtBLx+9VV7Z08VaQicnH4Z8EV3CHzH60+JAQ="
+    "version": "2026.513.0",
+    "hash": "sha256-9mrCn7mBxDYUAhD4cJSDRanPD1fghDlmJEu3rqExJbY="
   },
   {
     "pname": "ppy.osu.Framework.NativeLibs",
@@ -631,8 +631,8 @@
   },
   {
     "pname": "ppy.osu.Game.Resources",
-    "version": "2026.427.0",
-    "hash": "sha256-vrPesDiu08qqdcm06Lzs0iKY2rH/pOfkVXvvr7rMsQY="
+    "version": "2026.516.0",
+    "hash": "sha256-jMm4uJBhaqfi8QKayMWlN4IDn8mR+gtHDGRZgzbYFtI="
   },
   {
     "pname": "ppy.osuTK.NS20",
@@ -646,8 +646,8 @@
   },
   {
     "pname": "ppy.SDL3-CS",
-    "version": "2026.302.0",
-    "hash": "sha256-7e+HN9StGkK4je1QITNT2Fsk/wrPVDEXb97xjlZx6yY="
+    "version": "2026.512.0",
+    "hash": "sha256-JWa1njiqY0Cz1bME5uQ4jSxfY9VCThNcmMttMXKGH5Y="
   },
   {
     "pname": "ppy.Veldrid",
@@ -956,8 +956,8 @@
   },
   {
     "pname": "SharpCompress",
-    "version": "0.47.0",
-    "hash": "sha256-eeTuwUXeH9gw54bczkwrYCze2bHX22Rclx8QZm4zoxY="
+    "version": "0.48.0",
+    "hash": "sha256-2MXainbTJeuBwRA6eJU+AlUT8ireNrWxHYNCMkFG8Lc="
   },
   {
     "pname": "SharpFNT",

--- a/pkgs/by-name/os/osu-lazer/package.nix
+++ b/pkgs/by-name/os/osu-lazer/package.nix
@@ -22,13 +22,13 @@
 
 buildDotnetModule rec {
   pname = "osu-lazer";
-  version = "2026.429.0";
+  version = "2026.518.0";
 
   src = fetchFromGitHub {
     owner = "ppy";
     repo = "osu";
     tag = "${version}-lazer";
-    hash = "sha256-QmdgcK65TD+VM6wx5Py1Kyp0MhRe1lr0V4nwTMkvtuA=";
+    hash = "sha256-ELtK5itKM7QIdVWzy3bHurp76AJvXA1a15OkYJgFcvU=";
   };
 
   projectFile = "osu.Desktop/osu.Desktop.csproj";


### PR DESCRIPTION
Release: https://github.com/ppy/osu/releases/tag/2026.518.0-lazer

Changelog: https://osu.ppy.sh/home/changelog/lazer/2026.518.0

Closes https://github.com/NixOS/nixpkgs/issues/522051

> From https://github.com/NixOS/nixpkgs/issues/522051: Uses SDL3 on linux by default now, might need some more changes other than just running the update script. Can be turned off using OSU_SDL3=0 as per note in the changelog.

Thanks @cggjaicf, this is good to know (I should switch to reading the forum changelogs rather than the GitHub releases as that stopped including more technical changes there).

I think we can stick to upstream's default by not setting a default `OSU_SDL3`. We are only setting `SDL_VIDEODRIVER` to `wayland` currently. This update works well for me on X11 AMD GPU, but testing reports on different setups would be welcome from everyone.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
