### PR TITLE
pixinsight: 1.9.3-20250402 -> 1.9.4-20260522

### DIFF
--- a/pkgs/by-name/pi/pixinsight/default.nix
+++ b/pkgs/by-name/pi/pixinsight/default.nix
@@ -10,12 +10,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pixinsight";
-  version = "1.9.3-20250402";
+  version = "1.9.4-20260512";
 
   src = requireFile {
     name = "PI-linux-x64-${finalAttrs.version}-c.tar.xz";
     url = "http://pixinsight.com";
-    hash = "sha256-MOAWH64A13vVLeNiBC9nO78P0ELmXXHR5ilh5uUhWhs=";
+    hash = "sha256-VRJjPsVpJIYzvCmnXaNA4Kx868T22AoPqZ+lJEGAQn4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/pi/pixinsight/default.nix
+++ b/pkgs/by-name/pi/pixinsight/default.nix
@@ -10,12 +10,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pixinsight";
-  version = "1.9.4-20260512";
+  version = "1.9.4-20260522";
 
   src = requireFile {
     name = "PI-linux-x64-${finalAttrs.version}-c.tar.xz";
     url = "http://pixinsight.com";
-    hash = "sha256-VRJjPsVpJIYzvCmnXaNA4Kx868T22AoPqZ+lJEGAQn4=";
+    hash = "sha256-+mMVAleBO5zVAOLfbvi2xedF5aTxzZoZl3UY6HzWW7I=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/pi/pixinsight/package.nix
+++ b/pkgs/by-name/pi/pixinsight/package.nix
@@ -62,6 +62,7 @@ buildFHSEnv {
 
       libGL
       libdrm
+      vulkan-loader
       qt6Packages.qtbase
       gtk3
       fontconfig
@@ -71,6 +72,7 @@ buildFHSEnv {
       libssh2
       libpsl
       libidn2
+      libnghttp2
 
       brotli
       libdeflate


### PR DESCRIPTION
Closes #522104

Updates Pixinsight to the latest version, see https://pixinsight.net/dev/index.php?ams/pixinsight-1-9-4-lockhart-released.15/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
