### PR TITLE
oxidized: 0.36.0 -> 0.37.0

### DIFF
--- a/pkgs/by-name/ox/oxidized/Gemfile
+++ b/pkgs/by-name/ox/oxidized/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'oxidized', '0.36.0'
+gem 'oxidized', '0.37.0'
 gem 'oxidized-web', '0.18.1'
 gem 'oxidized-script', '0.7.0'
 gem 'psych', '~> 5.0'

--- a/pkgs/by-name/ox/oxidized/Gemfile.lock
+++ b/pkgs/by-name/ox/oxidized/Gemfile.lock
@@ -30,7 +30,7 @@ GEM
     net-ssh (7.3.2)
     net-telnet (0.2.0)
     nio4r (2.7.5)
-    oxidized (0.36.0)
+    oxidized (0.37.0)
       asetus (~> 0.4)
       bcrypt_pbkdf (~> 1.0)
       ed25519 (~> 1.2)
@@ -103,7 +103,7 @@ PLATFORMS
 
 DEPENDENCIES
   net-scp (~> 4.1)
-  oxidized (= 0.36.0)
+  oxidized (= 0.37.0)
   oxidized-script (= 0.7.0)
   oxidized-web (= 0.18.1)
   psych (~> 5.0)

--- a/pkgs/by-name/ox/oxidized/gemset.nix
+++ b/pkgs/by-name/ox/oxidized/gemset.nix
@@ -241,10 +241,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0g2a60bwpjidwkksai6l2ndnq3qbvqj33jv53c800m7m4hgr5r0n";
+      sha256 = "0apg5psqdkc0h71qpgiq52qnifr41g57agvgyxiq10335gh6c2v0";
       type = "gem";
     };
-    version = "0.36.0";
+    version = "0.37.0";
   };
   oxidized-script = {
     dependencies = [


### PR DESCRIPTION
Changelog : https://github.com/ytti/oxidized/releases/tag/0.37.0
Diff : https://github.com/ytti/oxidized/compare/0.36.0...0.37.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
