### PR TITLE
python3Packages.weasyprint: 68.0 -> 68.1-unstable-2026-05-18

### DIFF
--- a/pkgs/development/python-modules/weasyprint/default.nix
+++ b/pkgs/development/python-modules/weasyprint/default.nix
@@ -7,7 +7,9 @@
   fontconfig,
   glib,
   harfbuzz,
+  makeFontsConf,
   pango,
+  twemoji-color-font,
 
   # build-system
   flit-core,
@@ -32,7 +34,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "weasyprint";
-  version = "68.0";
+  version = "68.1-unstable-2026-05-18";
   pyproject = true;
 
   __darwinAllowLocalNetworking = true;
@@ -40,8 +42,10 @@ buildPythonPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "Kozea";
     repo = "WeasyPrint";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-kAJgSQz1RKrPwzO7I5xHXyXcXYJtvca9izjrAgTy3ek=";
+    # Includes upstream's Ghostscript 10.07-compatible rasterization tests.
+    # Drop the pin when the next WeasyPrint release is packaged.
+    rev = "2cb9b3d2378c67e2bfde646344ca4c2cb7c0f25f";
+    hash = "sha256-zQ8gvYy72ROMwprT5dWA3N1vC7y+6ZKNwKESwtPS21w=";
   };
 
   patches = [
@@ -99,19 +103,28 @@ buildPythonPackage (finalAttrs: {
     "test_woff_simple"
     # AssertionError
     "test_2d_transform"
-    # Reported upstream: https://github.com/Kozea/WeasyPrint/issues/2666
-    "test_text_stroke"
   ];
 
   env.FONTCONFIG_FILE = "${fontconfig.out}/etc/fonts/fonts.conf";
 
+  # Test include some emoji characters that require a custom fontconfig configuration to be found.
+  preCheck = ''
+    export FONTCONFIG_FILE=${makeFontsConf { fontDirectories = [ twemoji-color-font ]; }}
+  '';
+
   # Set env variable explicitly for Darwin, but allow overriding when invoking directly
   makeWrapperArgs = [ "--set-default FONTCONFIG_FILE ${finalAttrs.env.FONTCONFIG_FILE}" ];
+
+  # Upstream still reports the last release version from weasyprint.__version__.
+  # Remove when the next release is packaged.
+  preVersionCheck = ''
+    version=68.1
+  '';
 
   pythonImportsCheck = [ "weasyprint" ];
 
   meta = {
-    changelog = "https://github.com/Kozea/WeasyPrint/releases/tag/${finalAttrs.src.tag}";
+    changelog = "https://github.com/Kozea/WeasyPrint/commits/${finalAttrs.src.rev}";
     description = "Converts web documents to PDF";
     homepage = "https://weasyprint.org/";
     license = lib.licenses.bsd3;


### PR DESCRIPTION
Changelog:
https://github.com/Kozea/WeasyPrint/compare/v68.0...2cb9b3d2378c67e2bfde646344ca4c2cb7c0f25f

Pin to upstream main to pick up Ghostscript 10.07-compatible rasterization test expectations.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
