### PR TITLE
[25.11] radicle-node{,-unstable}: 1.8.0 -> 1.9.0

### DIFF
--- a/pkgs/by-name/ra/radicle-desktop/package.nix
+++ b/pkgs/by-name/ra/radicle-desktop/package.nix
@@ -20,6 +20,7 @@
   wrapGAppsHook4,
   rustfmt,
   clippy,
+  writableTmpDirAsHomeHook,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -96,12 +97,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
     radicle-node
     rustfmt
     clippy
+    writableTmpDirAsHomeHook
   ];
 
   checkPhase = ''
     runHook preCheck
 
-    export RAD_HOME="$PWD/_rad-home"
     export RAD_PASSPHRASE=""
     rad auth --alias test
     bins="tests/tmp/bin/heartwood/$HW_RELEASE"

--- a/pkgs/by-name/ra/radicle-node/package.nix
+++ b/pkgs/by-name/ra/radicle-node/package.nix
@@ -15,9 +15,9 @@
   xdg-utils,
   versionCheckHook,
 
-  version ? "1.8.0",
-  srcHash ? "sha256-QjAdZO5PwJ6FuThzQYnkF+hAeArltXxhEnzIcAePwzA=",
-  cargoHash ? "sha256-m8CqRTJD/1bOqTB2SoUjglZsOWGfv/nBNTOQftNvIqE=",
+  version ? "1.9.0",
+  srcHash ? "sha256-ECged52tJaBSW2ua3MPDEBdGKPJ50Q347evd5wdbbU0=",
+  cargoHash ? "sha256-Vb86Zx851Mrn9yaNuIQHEuVr7PrD7plPZhPGFJOLKRg=",
   updateScript ? ./update.sh,
 }:
 

--- a/pkgs/by-name/ra/radicle-node/unstable.nix
+++ b/pkgs/by-name/ra/radicle-node/unstable.nix
@@ -1,8 +1,8 @@
 { radicle-node }:
 
 radicle-node.override {
-  version = "1.9.0-rc.1";
-  srcHash = "sha256-CM1BdpdnAyAelrPAJjvsD7qOfHkV3EEmF4pTNOFvQik=";
-  cargoHash = "sha256-N28PQpuTcDAszWF0TPY/H5uzWfQZSuxn0XVYLeKNmn0=";
+  version = "1.9.0-rc.3";
+  srcHash = "sha256-NUxrNv0NbqZqE0zx8L+PS32jFeb/upoGtZorEcL4O1c=";
+  cargoHash = "sha256-WUOfZ41ImJQhX5Jqj6z8v28oapG/sP4zBe8inkfDlbA=";
   updateScript = ./update-unstable.sh;
 }

--- a/pkgs/by-name/ra/radicle-node/unstable.nix
+++ b/pkgs/by-name/ra/radicle-node/unstable.nix
@@ -1,8 +1,8 @@
 { radicle-node }:
 
 radicle-node.override {
-  version = "1.8.0";
-  srcHash = "sha256-QjAdZO5PwJ6FuThzQYnkF+hAeArltXxhEnzIcAePwzA=";
-  cargoHash = "sha256-m8CqRTJD/1bOqTB2SoUjglZsOWGfv/nBNTOQftNvIqE=";
+  version = "1.9.0-rc.1";
+  srcHash = "sha256-CM1BdpdnAyAelrPAJjvsD7qOfHkV3EEmF4pTNOFvQik=";
+  cargoHash = "sha256-N28PQpuTcDAszWF0TPY/H5uzWfQZSuxn0XVYLeKNmn0=";
   updateScript = ./update-unstable.sh;
 }

--- a/pkgs/by-name/ra/radicle-node/unstable.nix
+++ b/pkgs/by-name/ra/radicle-node/unstable.nix
@@ -1,8 +1,8 @@
 { radicle-node }:
 
 radicle-node.override {
-  version = "1.9.0-rc.3";
-  srcHash = "sha256-NUxrNv0NbqZqE0zx8L+PS32jFeb/upoGtZorEcL4O1c=";
-  cargoHash = "sha256-WUOfZ41ImJQhX5Jqj6z8v28oapG/sP4zBe8inkfDlbA=";
+  version = "1.9.0";
+  srcHash = "sha256-ECged52tJaBSW2ua3MPDEBdGKPJ50Q347evd5wdbbU0=";
+  cargoHash = "sha256-Vb86Zx851Mrn9yaNuIQHEuVr7PrD7plPZhPGFJOLKRg=";
   updateScript = ./update-unstable.sh;
 }


### PR DESCRIPTION
Backport of #514081, #517645, and #521635

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
