### PR TITLE
xrootd: 5.9.1 -> 6.0.2

### DIFF
--- a/pkgs/by-name/xr/xrootd/package.nix
+++ b/pkgs/by-name/xr/xrootd/package.nix
@@ -109,6 +109,13 @@ stdenv.mkDerivation (finalAttrs: {
   + lib.optionalString stdenv.hostPlatform.isLinux ''
     mkdir -p "$out/lib/systemd/system"
     install -m 644 -t "$out/lib/systemd/system" ../systemd/*.service ../systemd/*.socket
+  ''
+  # Install missing private headers needed by Python bindings
+  + ''
+    mkdir -p $dev/include/xrootd/private/XrdCks
+    cp ../src/XrdCks/XrdCksXAttr.hh $dev/include/xrootd/private/XrdCks/
+    mkdir -p $dev/include/xrootd/private/XrdOuc
+    cp ../src/XrdOuc/XrdOucXAttr.hh $dev/include/xrootd/private/XrdOuc/
   '';
 
   cmakeFlags = [

--- a/pkgs/by-name/xr/xrootd/package.nix
+++ b/pkgs/by-name/xr/xrootd/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   callPackage,
   fetchFromGitHub,
-  davix,
   cmake,
   gtest,
   makeWrapper,
@@ -15,6 +14,7 @@
   libuuid,
   libxcrypt,
   libxml2,
+  libzip,
   openssl,
   readline,
   scitokens-cpp,
@@ -30,14 +30,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xrootd";
-  version = "5.9.1";
+  version = "6.0.2";
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "xrootd";
     repo = "xrootd";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-XClMtQfCGWpLtILGQyYCsKMcOlhLHC5i7UabzXH/imc=";
+    hash = "sha256-RSODctDfDkdY1YnxFINGwbpNxEkNCYjW1QEDk9VAYFw=";
   };
 
   postPatch = ''
@@ -65,12 +68,12 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    davix
     curl
     libkrb5
     libuuid
     libxcrypt
     libxml2
+    libzip
     openssl
     readline
     scitokens-cpp
@@ -86,17 +89,15 @@ stdenv.mkDerivation (finalAttrs: {
     voms # only available on Linux due to gsoap failing to build on Darwin
   ];
 
-  # https://github.com/xrootd/xrootd/blob/master/packaging/rhel/xrootd.spec.in#L665-L675=
+  # https://github.com/xrootd/xrootd/blob/v6.0.2/config/
   postInstall = ''
-    mkdir -p "$out/lib/tmpfiles.d"
-    install -m 644 -T ../packaging/rhel/xrootd.tmpfiles "$out/lib/tmpfiles.d/xrootd.conf"
     mkdir -p "$out/etc/xrootd"
-    install -m 644 -t "$out/etc/xrootd" ../packaging/common/*.cfg
-    install -m 644 -t "$out/etc/xrootd" ../packaging/common/client.conf
+    install -m 644 -t "$out/etc/xrootd" ../config/*.cfg
+    install -m 644 -t "$out/etc/xrootd" ../config/client.conf
     mkdir -p "$out/etc/xrootd/client.plugins.d"
-    install -m 644 -t "$out/etc/xrootd/client.plugins.d" ../packaging/common/client-plugin.conf.example
+    install -m 644 -t "$out/etc/xrootd/client.plugins.d" ../config/client-plugin.conf.example
     mkdir -p "$out/etc/logrotate.d"
-    install -m 644 -T ../packaging/common/xrootd.logrotate "$out/etc/logrotate.d/xrootd"
+    install -m 644 -T ../config/xrootd.logrotate "$out/etc/logrotate.d/xrootd"
   ''
   # Leaving those in bin/ leads to a cyclic reference between $dev and $bin
   # This happens since https://github.com/xrootd/xrootd/commit/fe268eb622e2192d54a4230cea54c41660bd5788
@@ -107,13 +108,12 @@ stdenv.mkDerivation (finalAttrs: {
   ''
   + lib.optionalString stdenv.hostPlatform.isLinux ''
     mkdir -p "$out/lib/systemd/system"
-    install -m 644 -t "$out/lib/systemd/system" ../packaging/common/*.service ../packaging/common/*.socket
+    install -m 644 -t "$out/lib/systemd/system" ../systemd/*.service ../systemd/*.socket
   '';
 
   cmakeFlags = [
     (lib.cmakeFeature "XRootD_VERSION_STRING" finalAttrs.version)
     (lib.cmakeBool "FORCE_ENABLED" true)
-    (lib.cmakeBool "ENABLE_DAVIX" true)
     (lib.cmakeBool "ENABLE_FUSE" (!stdenv.hostPlatform.isDarwin)) # XRootD doesn't support MacFUSE
     (lib.cmakeBool "ENABLE_MACAROONS" false)
     (lib.cmakeBool "ENABLE_PYTHON" false) # built separately

--- a/pkgs/development/python-modules/xrootd/default.nix
+++ b/pkgs/development/python-modules/xrootd/default.nix
@@ -12,7 +12,11 @@ buildPythonPackage rec {
 
   inherit (xrootd) version src;
 
-  sourceRoot = "${src.name}/bindings/python";
+  sourceRoot = "${src.name}/python";
+
+  env.CMAKE_ARGS = lib.toString [
+    (lib.cmakeFeature "XRootD_INCLUDE_DIR" "${lib.getDev xrootd}/include/xrootd;${src}/src")
+  ];
 
   build-system = [
     cmake


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/xrootd/xrootd/releases/tag/v6.0.2
https://github.com/xrootd/xrootd/compare/v5.9.1...v6.0.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
