### PR TITLE
python3Packages.torch-cluster: init at 2.6.3-unstable-2026-03-26

### DIFF
--- a/pkgs/development/python-modules/torch-cluster/default.nix
+++ b/pkgs/development/python-modules/torch-cluster/default.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+  torch,
+
+  # buildInputs
+  pybind11,
+
+  # dependencies
+  scipy,
+
+  # tests
+  pytestCheckHook,
+
+  # passthru
+  nix-update-script,
+}:
+
+buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
+  pname = "torch-cluster";
+  version = "2.6.3-unstable-2026-03-26";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  # Last stable release is from 2023
+  # Development is still active, but nothing was properly tagged on GitHub or Pypi
+  # See: https://github.com/rusty1s/pytorch_cluster/issues/270
+  src = fetchFromGitHub {
+    owner = "rusty1s";
+    repo = "pytorch_cluster";
+    rev = "af7b9f0af6b74be1594eb3d0a1685470cbb21265";
+    hash = "sha256-2SXkk7m+feqk7uDir3Ov31TujyIUrRSEwONaiaq3Vvs=";
+  };
+
+  build-system = [
+    setuptools
+    torch
+  ];
+
+  buildInputs = [
+    pybind11
+  ];
+
+  dependencies = [
+    scipy
+  ];
+
+  pythonImportsCheck = [ "torch_cluster" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  # Otherwise python imports torch_cluster from /build/source instead of $out/..., which fails when
+  # trying to load the inexistant .so artifacts.
+  preCheck = ''
+    rm -rf torch_cluster
+  '';
+
+  disabledTests = lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+    # aarch64-linux fails cpuinfo test, because /sys/devices/system/cpu/ does not exist in the sandbox:
+    # RuntimeError: Failed to initialize cpuinfo!
+    "test_fps"
+    "test_nearest"
+  ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = "PyTorch Extension Library of Optimized Graph Cluster Algorithms";
+    homepage = "https://github.com/rusty1s/pytorch_cluster";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19740,6 +19740,8 @@ self: super: with self; {
 
   torch-c-dlpack-ext = callPackage ../development/python-modules/torch-c-dlpack-ext { };
 
+  torch-cluster = callPackage ../development/python-modules/torch-cluster { };
+
   torch-einops-utils = callPackage ../development/python-modules/torch-einops-utils { };
 
   torch-geometric = callPackage ../development/python-modules/torch-geometric { };


### PR DESCRIPTION
## Things done

Add [torch-cluster](https://github.com/rusty1s/pytorch_cluster), a PyTorch Extension Library of Optimized Graph Cluster Algorithms.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
