### PR TITLE
navidromePlugins.audiomuseai: init at 8

### DIFF
--- a/pkgs/by-name/na/navidrome/plugins/audiomuseai/package.nix
+++ b/pkgs/by-name/na/navidrome/plugins/audiomuseai/package.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  pkgs,
+  buildNavidromePlugin,
+}:
+buildNavidromePlugin rec {
+  pname = "audiomuseai";
+  version = "8";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "NeptuneHub";
+    repo = "AudioMuse-AI-NV-plugin";
+    tag = "v${version}";
+    hash = "sha256-WyobjyadD9IcY6mFYhCmuQgLbnoHpDoiLfINNfKmQM8=";
+  };
+
+  vendorHash = "sha256-mXes+doBSa5kcfHp1cuzTz30wnyyPN7NLC0iOSL8FDo=";
+
+  meta = {
+    description = "Navidrome plugin that integrates core AudioMuse-AI features into the Navidrome frontend.";
+    homepage = "https://github.com/NeptuneHub/AudioMuse-AI-NV-plugin";
+    license = lib.licenses.agpl3Only;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+  };
+}


### PR DESCRIPTION
Created [AudioMuse-AI](https://github.com/NeptuneHub/AudioMuse-AI) plugin for the new navidrome plugin system introduced in #424464. 072d267c95e9ba6d51ff648867c7dcb40ae7f9a8 was taken as a template for this change.

(I did not add myself to maintainers because the other plugins also had no maintainer set hence I assumed it is not needed in this case)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
