### PR TITLE
onnxruntime: add CoreML support on Darwin

### DIFF
--- a/pkgs/by-name/on/onnxruntime/package.nix
+++ b/pkgs/by-name/on/onnxruntime/package.nix
@@ -25,6 +25,7 @@
   cudaSupport ? config.cudaSupport,
   ncclSupport ? cudaSupport && cudaPackages.nccl.meta.available,
   rocmSupport ? config.rocmSupport,
+  coremlSupport ? stdenv.hostPlatform.isDarwin,
   withFullProtobuf ? false,
   cudaPackages ? { },
   rocmPackages,
@@ -78,6 +79,30 @@ let
     repo = "dlpack";
     rev = "5c210da409e7f1e51ddf445134a4376fdbd70d7d";
     hash = "sha256-YqgzCyNywixebpHGx16tUuczmFS5pjCz5WjR89mv9eI=";
+  };
+
+  coremltools-src = fetchFromGitHub {
+    name = "coremltools-src";
+    owner = "apple";
+    repo = "coremltools";
+    tag = "7.1";
+    hash = "sha256-kajQFHpl+4UK6fp+rM8TP0GiqIFYXPVFc2x1p19rBSw=";
+  };
+
+  fp16-src = fetchFromGitHub {
+    name = "fp16-src";
+    owner = "Maratyszcza";
+    repo = "FP16";
+    rev = "0a92994d729ff76a58f692d3028ca1b64b145d91";
+    hash = "sha256-m2d9bqZoGWzuUPGkd29MsrdscnJRtuIkLIMp3fMmtRY=";
+  };
+
+  psimd-src = fetchFromGitHub {
+    name = "psimd-src";
+    owner = "Maratyszcza";
+    repo = "psimd";
+    rev = "072586a71b55b7f8c584153d223e95687148a900";
+    hash = "sha256-lV+VZi2b4SQlRYrhKx9Dxc6HlDEFz3newvcBjTekupo=";
   };
 
   isCudaJetson = cudaSupport && cudaPackages.flags.isJetsonBuild;
@@ -263,6 +288,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "onnxruntime_USE_CUDA" cudaSupport)
     (lib.cmakeBool "onnxruntime_USE_NCCL" (cudaSupport && ncclSupport))
     (lib.cmakeBool "onnxruntime_USE_MIGRAPHX" rocmSupport)
+    (lib.cmakeBool "onnxruntime_USE_COREML" coremlSupport)
     (lib.cmakeBool "onnxruntime_ENABLE_LTO" (!cudaSupport || cudaPackages.cudaOlder "12.8"))
   ]
   ++ lib.optionals pythonSupport [
@@ -284,6 +310,12 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     # Incompatible with packaged version, far too slow to build vendored version
     (lib.cmakeBool "onnxruntime_USE_COMPOSABLE_KERNEL" false)
     (lib.cmakeBool "onnxruntime_USE_COMPOSABLE_KERNEL_CK_TILE" false)
+  ]
+  ++ lib.optionals coremlSupport [
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_COREMLTOOLS" "${coremltools-src}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_FP16" "${fp16-src}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_PSIMD" "${psimd-src}")
+    (lib.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.5") # needed for psimd
   ];
 
   env =
@@ -314,6 +346,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     !(
       cudaSupport
       || rocmSupport
+      || coremlSupport
       # cross-compiled test binaries can't execute on the build platform
       || (effectiveStdenv.hostPlatform != effectiveStdenv.buildPlatform)
       || builtins.elem effectiveStdenv.buildPlatform.system [
@@ -337,7 +370,8 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     install -m644 -Dt $out/include \
       ../include/onnxruntime/core/framework/provider_options.h \
       ../include/onnxruntime/core/providers/cpu/cpu_provider_factory.h \
-      ../include/onnxruntime/core/session/onnxruntime_*.h
+      ../include/onnxruntime/core/session/onnxruntime_*.h \
+      ../include/onnxruntime/core/providers/coreml/coreml_provider_factory.h
   '';
 
   # See comments in `cudaPackages.nccl`

--- a/pkgs/by-name/sh/sherpa-onnx/package.nix
+++ b/pkgs/by-name/sh/sherpa-onnx/package.nix
@@ -191,6 +191,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
+  preCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    export DYLD_FALLBACK_LIBRARY_PATH=${lib.getLib onnxruntime}/lib
+  '';
+
   # Use ctest directly because the default `make check` target includes clang-tidy.
   checkPhase = ''
     runHook preCheck
@@ -202,6 +206,10 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $python
     cp -r ../sherpa-onnx/python/sherpa_onnx $python/
     rm $out/lib/_sherpa_onnx*.so
+    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+      install_name_tool -add_rpath ${lib.getLib onnxruntime}/lib \
+        $python/sherpa_onnx/lib/_sherpa_onnx*.so
+    ''}
   '';
 
   passthru = {


### PR DESCRIPTION
Add optional CoreML execution provider for macOS builds. Fetches coremltools, FP16, and psimd as external sources via CMake's FetchContent. Tests are disabled when CoreML is enabled.

I also fixed packages:
- sherpa-onnx
- python313Packages.sherpa-onnx
- python314Packages.sherpa-onnx


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
