### PR TITLE
jcs-canonicalize: init at 0.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -501,6 +501,12 @@
     githubId = 13504599;
     name = "Adam Boseley";
   };
+  abstracts33d = {
+    email = "abstract.s33d@gmail.com";
+    github = "abstracts33d";
+    githubId = 16547134;
+    name = "Manuel Wegria";
+  };
   abueide = {
     email = "andrea@abueide.com";
     github = "abueide";

--- a/pkgs/by-name/jc/jcs-canonicalize/package.nix
+++ b/pkgs/by-name/jc/jcs-canonicalize/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  runCommand,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "jcs-canonicalize";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "arcanesys";
+    repo = "jcs-canonicalize";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Cqgjnx519cjGgTdamkzpWw+QWsiZOoiFDp4f3l2e4cw=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  cargoHash = "sha256-yPYBBSQm87WdK8Wf1VNYzBVR2yET6hvhcnYd1qDRQek=";
+
+  passthru.tests = {
+    basic =
+      runCommand "jcs-canonicalize-test"
+        {
+          nativeBuildInputs = [ finalAttrs.finalPackage ];
+        }
+        ''
+          # Key sorting: input keys reordered to lexicographic.
+          actual=$(echo '{"b":2,"a":1}' | jcs-canonicalize)
+          expected='{"a":1,"b":2}'
+          if [ "$actual" != "$expected" ]; then
+            echo "FAIL: key sorting"
+            echo "  expected: $expected"
+            echo "  got:      $actual"
+            exit 1
+          fi
+
+          # Idempotence: canonicalizing canonical output yields same bytes.
+          canonical=$(echo '{"x":[3,1,2]}' | jcs-canonicalize)
+          re_canonical=$(echo "$canonical" | jcs-canonicalize)
+          if [ "$canonical" != "$re_canonical" ]; then
+            echo "FAIL: canonicalization is not idempotent"
+            echo "  first:  $canonical"
+            echo "  second: $re_canonical"
+            exit 1
+          fi
+
+          # Invalid JSON exits non-zero.
+          if echo 'not json' | jcs-canonicalize 2>/dev/null; then
+            echo "FAIL: invalid JSON should exit non-zero"
+            exit 1
+          fi
+
+          touch $out
+        '';
+  };
+
+  meta = {
+    description = "RFC 8785 JSON canonicalizer with SHA-256-over-canonical-bytes helper";
+    longDescription = ''
+      A CLI tool and Rust library that produces RFC 8785 canonical JSON: the
+      same input value yields the same byte sequence regardless of key order,
+      whitespace, or number formatting. That deterministic property is what
+      lets cryptographic signatures over JSON verify reliably across
+      implementations and across time.
+
+      The library exposes `canonicalize` (string in, JCS string out) and
+      `sha256_jcs_hex` (any Serialize value in, lowercase-hex SHA-256 over
+      canonical bytes out). The CLI reads JSON from stdin and writes
+      canonical JSON to stdout.
+
+      Ships an RFC 8785 Appendix E conformance test suite and a golden-file
+      drift test so consumers can rely on the byte sequence not changing
+      across releases.
+    '';
+    homepage = "https://github.com/arcanesys/jcs-canonicalize";
+    changelog = "https://github.com/arcanesys/jcs-canonicalize/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ abstracts33d ];
+    mainProgram = "jcs-canonicalize";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/jc/jcs-canonicalize/package.nix
+++ b/pkgs/by-name/jc/jcs-canonicalize/package.nix
@@ -72,9 +72,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
       canonical bytes out). The CLI reads JSON from stdin and writes
       canonical JSON to stdout.
 
-      Ships an RFC 8785 Appendix E conformance test suite and a golden-file
-      drift test so consumers can rely on the byte sequence not changing
-      across releases.
+      Tested against the cyberphone/json-canonicalization reference corpus
+      plus a golden-file drift test so consumers can rely on the byte
+      sequence not changing across releases.
     '';
     homepage = "https://github.com/arcanesys/jcs-canonicalize";
     changelog = "https://github.com/arcanesys/jcs-canonicalize/releases/tag/v${finalAttrs.version}";


### PR DESCRIPTION
RFC 8785 JSON canonicalizer (JCS) with a SHA-256-over-canonical-bytes helper. CLI plus Rust library.

Produces deterministic byte sequences for cryptographic signing of JSON artifacts: signed audit trails, JWS detached signatures, supply-chain attestations (sigstore / in-toto adjacent), content-addressed JSON stores, and cross-language signature workflows.

- Upstream: https://github.com/arcanesys/jcs-canonicalize
- crates.io: https://crates.io/crates/jcs-canonicalize
- RFC 8785: https://datatracker.ietf.org/doc/html/rfc8785

This package is a thin CLI on top of the [`serde_jcs`](https://crates.io/crates/serde_jcs) library (the most-downloaded RFC 8785 implementation on crates.io; already a transitive dependency in nixpkgs). The upstream test suite asserts byte-identity against the [cyberphone/json-canonicalization](https://github.com/cyberphone/json-canonicalization) reference corpus — the de facto cross-implementation conformance benchmark used by the Go, Java, JavaScript, Python, and .NET reference implementations — plus targeted edge cases for non-BMP UTF-16 key sort, ECMAScript `Number.toString` boundaries, C0-control escaping, and NaN/Infinity rejection. Release tags are GPG-signed. Upstream CI runs `cargo fmt --check`, `cargo clippy -D warnings`, and `cargo test --locked` on every push, PR, and release tag.

### Things done

- [x] Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] [`./ci/nixpkgs-vet.sh master`](https://github.com/NixOS/nixpkgs-vet) passes (`Validated successfully`).
- [x] `nix fmt` reports no changes.
- [x] `nix-build -A jcs-canonicalize` succeeds.
- [x] `passthru.tests.basic` succeeds (`nix-build -A jcs-canonicalize.tests.basic`).
- [x] Smoke test of the installed binary:
  ```
  $ echo '{"b":2,"a":1}' | ./result/bin/jcs-canonicalize
  {"a":1,"b":2}
  $ echo '{"x":[3,1,2],"a":{"z":1,"a":2}}' | ./result/bin/jcs-canonicalize
  {"a":{"a":2,"z":1},"x":[3,1,2]}
  ```
- [x] Maintainer addition is in a separate commit (`maintainers: add abstracts33d`) ahead of the package commit (`jcs-canonicalize: init at 0.2.1`), per `CONTRIBUTING.md`.
- [x] Fits CONTRIBUTING.md.
