### PR TITLE
open-stage-control-headless: init at 1.30.3

### DIFF
--- a/pkgs/by-name/op/open-stage-control-headless/package.nix
+++ b/pkgs/by-name/op/open-stage-control-headless/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  unzip,
+  makeWrapper,
+  nodejs,
+  python3,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "open-stage-control-headless";
+  version = "1.30.3";
+
+  src = fetchzip {
+    url = "https://openstagecontrol.ammd.net/packages/open-stage-control_${finalAttrs.version}_node.zip";
+    hash = "sha256-ef9433pG+eMFc+7pReE2qA3hK27y5KyiRTPQ2h6Ir8A=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [
+    python3.pkgs.python-rtmidi
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/lib/open-stage-control"
+    cp -r ./source/* "$out/lib/open-stage-control/"
+
+    mkdir -p "$out/bin"
+    makeWrapper ${nodejs}/bin/node "$out/bin/open-stage-control" \
+      --prefix PYTHONPATH : "$PYTHONPATH" \
+      --prefix PATH : ${lib.makeBinPath [ python3 ]} \
+      --add-flags "$out/lib/open-stage-control"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Libre and modular OSC / MIDI controller";
+    homepage = "https://openstagecontrol.ammd.net/";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ eymeric ];
+    platforms = nodejs.meta.platforms;
+    mainProgram = "open-stage-control";
+  };
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1682,7 +1682,7 @@ mapAliases {
   onscripter-en = throw "onscripter-en has been removed due to lack of maintenance in both upstream and Nixpkgs; onscripter is available instead"; # Added 2025-10-17
   onthespot = throw "onethespot has been removed due to lack of upstream maintenance"; # Added 2025-09-26
   opae = throw "opae has been removed because it has been marked as broken since June 2023."; # Added 2025-10-11
-  open-stage-control = throw "'open-stage-control' has been removed due to being broken for more than a year; see RFC 180"; # Added 2026-05-04
+  open-stage-control = throw "'open-stage-control' has been removed due to being broken for more than a year; see RFC 180. Consider using open-stage-control-headless instead."; # Added 2026-05-04
   open-timeline-io = warnAlias "'open-timeline-io' has been renamed to 'opentimelineio'" opentimelineio; # Added 2025-08-10
   openafs_1_8 = throw "'openafs_1_8' has been renamed to/replaced by 'openafs'"; # Converted to throw 2025-10-27
   openai = throw "'openai' has been removed, since upstream removed the legacy CLI in v2.35.0; use 'python3Packages.openai' instead"; # Added 2026-06-10


### PR DESCRIPTION
To address #516266.
However, packaging open-stage-control directly from the source is pretty hard because package.json depends on deps like : 
`    "bonjour": "git+https://framagit.org/jean-emmanuel/bonjour.git",`
Which itself depends on another Framagit dep, which breaks the npm fetcher and makes some transitive npm deps not available at run time.
That's why I chose simply to package the node version, which is available prebuilt in Framagit releases.

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
