### PR TITLE
apfel-llm: 1.0.5 -> 1.3.6

### DIFF
--- a/pkgs/by-name/ap/apfel-llm/package.nix
+++ b/pkgs/by-name/ap/apfel-llm/package.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "apfel-llm";
-  version = "1.0.5";
+  version = "1.3.6";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   # Building from source requires swift 6.3.0 while nixpkgs only has 5.10.1
   src = fetchurl {
     url = "https://github.com/Arthur-Ficial/apfel/releases/download/v${finalAttrs.version}/apfel-${finalAttrs.version}-arm64-macos.tar.gz";
-    hash = "sha256-etEOYkYVPm08SRE3nuKcDigS7lCkUUgMacOl/sLv/1A=";
+    hash = "sha256-PMQpc/GBj2vV2WCL0ZWnw9u8CyfYnITEZDH0RH26m8I=";
   };
 
   sourceRoot = ".";


### PR DESCRIPTION
Bumps apfel-llm to 1.3.6.

Release: https://github.com/Arthur-Ficial/apfel/releases/tag/v1.3.6

This PR was opened automatically by `scripts/publish-nixpkgs-bump.sh` as a step of the apfel release flow. The package's `passthru.updateScript` (`nix-update-script`) would produce the same diff.