### PR TITLE
netboxPlugins.netbox-qrcode: 0.0.20 -> 0.0.21 and configure nix-update-script to ignore broken release .0.0.14

### DIFF
--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-qrcode/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-qrcode/package.nix
@@ -15,6 +15,8 @@
   django,
   netaddr,
   netbox,
+
+  nix-update-script,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -48,6 +50,13 @@ buildPythonPackage (finalAttrs: {
   '';
 
   pythonImportsCheck = [ "netbox_qrcode" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^v(\\d+\\.\\d+\\.\\d+)$"
+    ];
+  };
 
   meta = {
     description = "Netbox plugin for generate QR codes for objects: Rack, Device, Cable";

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-qrcode/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-qrcode/package.nix
@@ -21,14 +21,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "netbox-qrcode";
-  version = "0.0.20";
+  version = "0.0.21";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "netbox-community";
     repo = "netbox-qrcode";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-7dPMpuJ2nuj9rRmVrfthD+xrEHoUaLFqDJWC6cGGCwY=";
+    hash = "sha256-A4qjpbfTULzS0UchUN9eX8jZmwoX/ej/18L/YAB8dKA=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
fixes https://github.com/netbox-community/netbox-qrcode/issues/136
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
