### PR TITLE
stdenv.mkDerivation: add attributePositionInformation

### DIFF
--- a/ci/eval/compare/maintainers.nix
+++ b/ci/eval/compare/maintainers.nix
@@ -54,12 +54,15 @@ let
     drv:
     (lib.unique (
       map (pos: lib.removePrefix nixpkgsRoot pos.file) (
+        let
+          info = drv.attributePositionInformation;
+        in
         lib.filter (x: x != null) [
-          (drv.meta.maintainersPosition or null)
-          (drv.meta.teamsPosition or null)
-          (lib.unsafeGetAttrPos "src" drv)
-          (lib.unsafeGetAttrPos "pname" drv)
-          (lib.unsafeGetAttrPos "version" drv)
+          (info.meta.maintainers.__pos or null)
+          (info.meta.teams.__pos or null)
+          (info.src.__pos or null)
+          (info.pname.__pos or null)
+          (info.version.__pos or null)
         ]
         ++ lib.optionals (drv ? meta.position) [
           # Use ".meta.position" for cases when most of the package is

--- a/ci/eval/compare/test.nix
+++ b/ci/eval/compare/test.nix
@@ -19,7 +19,7 @@ let
       (lib.imap0 (i: p: {
         path = p;
         update = _: {
-          meta.maintainersPosition.file = lib.concatStringsSep "/" p;
+          attributePositionInformation.meta.maintainers.__pos.file = lib.concatStringsSep "/" p;
           meta.nonTeamMaintainers = [ { githubId = i; } ];
           meta.teams =
             if githubTeams then [ { githubId = i + 100; } ] else [ { members = [ { githubId = i + 100; } ]; } ];

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -406,6 +406,9 @@
   "sec-allow-insecure": [
     "index.html#sec-allow-insecure"
   ],
+  "sec-attribute-position-information": [
+    "index.html#sec-attribute-position-information"
+  ],
   "sec-build-helper-extendMkDerivation": [
     "index.html#sec-build-helper-extendMkDerivation"
   ],

--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -45,6 +45,9 @@
   Package-URLs allow reliably identifying and locating software packages.
   Maintainers of derivations using the adapted fetchers should rely on the `drv.src.meta.identifiers.v1.purl` default identifier and can enhance their `drv.meta.identifiers.v1.purls` list once they would like to have additional identifiers.
   Maintainers using `fetchurl` for `drv.src` are urged to adapt their `drv.meta.identifiers.purlParts` for proper identification.
+- `mkDerivation` now adds an `attributePositionInformation` attribute to
+  all derivations it procudes, providing a way for downstream tooling to obtain
+  derivation position information.
 
 ## Nixpkgs Library {#sec-nixpkgs-release-26.11-lib}
 

--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -588,6 +588,21 @@ Unlike the `pkg` binding in the above example, the `finalAttrs` parameter always
 
 See also the section about [`passthru.tests`](#var-passthru-tests).
 
+### Attribute position information {#sec-attribute-position-information}
+
+Since `mkDerivation` modifies various attributes passed to it, a naive `builtins.unsafeGetAttrPos` call on any of its output attributes would be useless.
+As such, an `attributePositionInformation` attribute is passed along with the derivation attrs, containing information about original locations of attributes.
+This is intended for CI and tooling like [nixpkgs-vet](https://github.com/nixos/nixpkgs-vet).
+
+The structure of the attribute mirrors the structure of `mkDerivation` arguments, except each argument becomes and attrset containing a `__pos` argument, the format of which matches the output of `builtins.unsafeGetAttrPos`.
+Arguments which were originally attrsets (e.g. `meta`, `passthru`) are recursed into according to the algorithm above.
+
+For example:
+
+* `package.attributePositionInformation.patches.__pos` contains the position where the `patches` were originally defined
+* `package.attributePositionInformation.meta.__pos` contains the position where the `meta` was originally defined
+* `package.attributePositionInformation.meta.maintainers.__pos` contains the position where `meta.maintianers` was originally defined.
+
 ## Phases {#sec-stdenv-phases}
 
 `stdenv.mkDerivation` sets the Nix [derivation](https://nixos.org/manual/nix/stable/expressions/derivations.html#derivations)'s builder to a script that loads the stdenv `setup.sh` bash library and calls `genericBuild`. Most packaging functions rely on this default builder.

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -389,6 +389,7 @@ let
       isGutenprint = bool;
 
       # Used for the original location of the maintainer and team attributes to assist with pings.
+      # Deprecated, use `attributePositionInformation.meta.{maintainers,teams}.__pos`
       maintainersPosition = any;
       teamsPosition = any;
 

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -1073,7 +1073,7 @@ let
               mapAttrs (
                 name: value:
                 {
-                  __pos = builtins.unsafeGetAttrPos name a;
+                  __pos = unsafeGetAttrPos name a;
                 }
                 // optionalAttrs (isAttrs value) (value.attributePositionInformation or (process value))
               ) a;

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -37,6 +37,7 @@ let
     mapAttrs
     mapNullable
     optional
+    optionalAttrs
     optionalString
     optionals
     remove
@@ -1062,6 +1063,22 @@ let
 
         inherit passthru overrideAttrs;
         inherit meta;
+
+        # Pass through attribute position information for our input attrs.
+        # The reason this is here and not in meta is to avoid polluting `nix-env --meta` even more.
+        attributePositionInformation =
+          let
+            process =
+              a:
+              mapAttrs (
+                name: value:
+                {
+                  __pos = builtins.unsafeGetAttrPos name a;
+                }
+                // optionalAttrs (isAttrs value) (value.attributePositionInformation or (process value))
+              ) a;
+          in
+          attrs.attributePositionInformation or (process attrs);
       }
       //
         # Pass through extra attributes that are not inputs, but


### PR DESCRIPTION
Adds a new attribute, `attributePositionInformation`, to all derivations produced by `stdenv.mkDerivation`.

This is useful because `mkDerivation` overrides or just inherits many attributes, thus breaking `builtins.unsafeGetAttrPos`.

This also now replaces `meta.maintainersPosition` and `meta.teamsPosition`, which were ad-hoc attributes used for the same purpose in the CI.

This should not cause any mass-rebuilds, because the attribute is not passed to the builder.

This contribution was not assisted by any automated tooling.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
