### PR TITLE
ralphex: init at 1.3.2

### DIFF
--- a/pkgs/by-name/ra/ralphex/package.nix
+++ b/pkgs/by-name/ra/ralphex/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  git,
+  installShellFiles,
+  writableTmpDirAsHomeHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "ralphex";
+  version = "1.3.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "umputun";
+    repo = "ralphex";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-4+U2m6dPH4u5RCt1eIeR1PMU90hDD13mmu+2bXnF7D0=";
+  };
+
+  vendorHash = null;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.revision=${finalAttrs.version}"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  nativeCheckInputs = [
+    git
+    writableTmpDirAsHomeHook
+  ];
+
+  __darwinAllowLocalNetworking = true;
+
+  postInstall = ''
+    installShellCompletion completions/*
+  '';
+
+  meta = {
+    description = "Extended Ralph loop for autonomous AI-driven plan execution";
+    homepage = "https://ralphex.com/";
+    license = lib.licenses.mit;
+    mainProgram = "ralphex";
+    maintainers = [ lib.maintainers.sikmir ];
+  };
+})


### PR DESCRIPTION
**[ralphex](https://github.com/umputun/ralphex)** is an autonomous orchestrator of coding agents — the extended ralph loop.

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
