### PR TITLE
nixos/{ly,plasma-login-manager}: use absolute pam module paths

### DIFF
--- a/nixos/modules/services/display-managers/ly.nix
+++ b/nixos/modules/services/display-managers/ly.nix
@@ -113,12 +113,12 @@ in
             {
               name = "nologin";
               control = "requisite";
-              modulePath = "pam_nologin.so";
+              modulePath = "${config.security.pam.package}/lib/security/pam_nologin.so";
             }
             {
               name = "ly-normal-user";
               control = "required";
-              modulePath = "pam_succeed_if.so";
+              modulePath = "${config.security.pam.package}/lib/security/pam_succeed_if.so";
               settings.quiet = true;
               args = lib.mkBefore [
                 "uid"
@@ -129,7 +129,7 @@ in
             {
               name = "permit";
               control = "required";
-              modulePath = "pam_permit.so";
+              modulePath = "${config.security.pam.package}/lib/security/pam_permit.so";
             }
           ];
 

--- a/nixos/modules/services/display-managers/plasma-login-manager.nix
+++ b/nixos/modules/services/display-managers/plasma-login-manager.nix
@@ -125,12 +125,12 @@ in
             {
               name = "nologin";
               control = "requisite";
-              modulePath = "pam_nologin.so";
+              modulePath = "${config.security.pam.package}/lib/security/pam_nologin.so";
             }
             {
               name = "permit";
               control = "required";
-              modulePath = "pam_permit.so";
+              modulePath = "${config.security.pam.package}/lib/security/pam_permit.so";
             }
           ];
 
@@ -166,7 +166,7 @@ in
               # Load environment from /etc/environment and ~/.pam_environment
               name = "env";
               control = "required";
-              modulePath = "pam_env.so";
+              modulePath = "${config.security.pam.package}/lib/security/pam_env.so";
               settings.conffile = "/etc/pam/environment";
               settings.readenv = 0;
             }
@@ -174,7 +174,7 @@ in
               # Always let the greeter start without authentication
               name = "permit";
               control = "required";
-              modulePath = "pam_permit.so";
+              modulePath = "${config.security.pam.package}/lib/security/pam_permit.so";
             }
           ];
 
@@ -183,7 +183,7 @@ in
               # No action required for account management
               name = "permit";
               control = "required";
-              modulePath = "pam_permit.so";
+              modulePath = "${config.security.pam.package}/lib/security/pam_permit.so";
             }
           ];
 
@@ -192,7 +192,7 @@ in
               # Can't change password
               name = "deny";
               control = "required";
-              modulePath = "pam_deny.so";
+              modulePath = "${config.security.pam.package}/lib/security/pam_deny.so";
             }
           ];
 
@@ -201,7 +201,7 @@ in
               # Setup session
               name = "unix";
               control = "required";
-              modulePath = "pam_unix.so";
+              modulePath = "${config.security.pam.package}/lib/security/pam_unix.so";
             }
             {
               name = "systemd";


### PR DESCRIPTION
closes #513970
fixes https://github.com/NixOS/nixpkgs/commit/4b864991aa141958fc701e4925527fbf45ff1bf0

Tested with:
```diff
diff --git a/nixos/tests/ly.nix b/nixos/tests/ly.nix
index 2d9303308001..74a3e43a0161 100644
--- a/nixos/tests/ly.nix
+++ b/nixos/tests/ly.nix
@@ -3,6 +3,7 @@
 let
   machineBase = {
     imports = [ ./common/user-account.nix ];
+    security.apparmor.enable = true;
     services.displayManager.ly = {
       enable = true;
       settings = {
diff --git a/nixos/tests/plasma6.nix b/nixos/tests/plasma6.nix
index 330dea78edcf..d535f50a4fdc 100644
--- a/nixos/tests/plasma6.nix
+++ b/nixos/tests/plasma6.nix
@@ -13,6 +13,7 @@
       imports = [ ./common/user-account.nix ];
       services.xserver.enable = true;
       services.displayManager.plasma-login-manager.enable = true;
+      security.apparmor.enable = true;
       # FIXME: this should be testing Wayland
       services.displayManager.defaultSession = "plasmax11";
       services.desktopManager.plasma6.enable = true;
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
