### PR TITLE
fwts: link against zlib

### DIFF
--- a/pkgs/os-specific/linux/fwts/default.nix
+++ b/pkgs/os-specific/linux/fwts/default.nix
@@ -14,6 +14,7 @@
   dmidecode,
   acpica-tools,
   libbsd,
+  zlib,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -44,6 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
     dmidecode
     acpica-tools
     libbsd
+    zlib
   ];
 
   postPatch = ''
@@ -55,6 +57,10 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace src/lib/src/fwts_devicetree.c \
                       src/devicetree/dt_base/dt_base.c \
       --replace-fail "dtc -I" "${dtc}/bin/dtc -I"
+
+    # libfwts uses gzopen/gzclose/gzgets but does not link zlib.
+    substituteInPlace src/lib/src/Makefile.am \
+      --replace-fail "-lm -lpthread -lbsd" "-lm -lpthread -lbsd -lz"
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327822166)](https://hydra.nixos.org/build/327822166)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

