### PR TITLE
ggz_base_libs: fix build with gcc 15

### DIFF
--- a/pkgs/by-name/gg/ggz_base_libs/package.nix
+++ b/pkgs/by-name/gg/ggz_base_libs/package.nix
@@ -14,8 +14,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://mirrors.ibiblio.org/pub/mirrors/ggzgamingzone/ggz/snapshots/ggz-base-libs-snapshot-${finalAttrs.version}.tar.gz";
-    sha256 = "1cw1vg0fbj36zyggnzidx9cbjwfc1yr4zqmsipxnvns7xa2awbdk";
+    hash = "sha256-sy2uhOpH2237jbriT7IPzHG5WOotfvue/2bI5cDbgbM=";
   };
+
+  postPatch = ''
+    substituteInPlace configure \
+      --replace-fail "/usr/local/ssl/include" "${openssl.dev}/include" \
+      --replace-fail "/usr/local/ssl/lib" "${lib.getLib openssl}/lib"
+  '';
 
   nativeBuildInputs = [ intltool ];
   buildInputs = [
@@ -24,11 +30,11 @@ stdenv.mkDerivation (finalAttrs: {
     libgcrypt
   ];
 
-  patchPhase = ''
-    substituteInPlace configure \
-      --replace "/usr/local/ssl/include" "${openssl.dev}/include" \
-      --replace "/usr/local/ssl/lib" "${lib.getLib openssl}/lib"
-  '';
+  # gcc 15 errors on incompatible-pointer-types (ggz_tls_openssl.c OPENSSL_sk_* casts) and implicit-function-declaration (configure C99 VLA probe).
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-Wno-error=incompatible-pointer-types"
+    "-Wno-error=implicit-function-declaration"
+  ];
 
   configureFlags = [
     "--with-tls"


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/326977461)](https://hydra.nixos.org/build/326977461)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

