### PR TITLE
kallisto: fix build with gcc 15

### DIFF
--- a/pkgs/by-name/ka/kallisto/bifrost-fix-datastorage-sz_link-typo.patch
+++ b/pkgs/by-name/ka/kallisto/bifrost-fix-datastorage-sz_link-typo.patch
@@ -1,0 +1,26 @@
+diff --git a/ext/bifrost/src/DataStorage.hpp b/ext/bifrost/src/DataStorage.hpp
+index 016775f..deb849d 100644
+--- a/ext/bifrost/src/DataStorage.hpp
++++ b/ext/bifrost/src/DataStorage.hpp
+@@ -67,6 +67,8 @@ class DataStorage {
+ 
+         inline size_t getNbColors() const { return color_names.size(); }
+ 
++        inline vector<string> const& getColorNames() const { return color_names; }
++
+         size_t getUnitigColorsSize(const size_t nb_threads = 1) const;
+ 
+         uint64_t getHash(const UnitigColorMap<U>& um) const;
+diff --git a/ext/bifrost/src/DataStorage.tcc b/ext/bifrost/src/DataStorage.tcc
+index 02929d9..10b844e 100644
+--- a/ext/bifrost/src/DataStorage.tcc
++++ b/ext/bifrost/src/DataStorage.tcc
+@@ -78,7 +78,7 @@ DataStorage<U>::DataStorage(const DataStorage& o) : color_sets(nullptr), shared_
+ 
+         unitig_cs_link = new atomic<uint64_t>[sz_link];
+ 
+-        for (size_t i = 0; i != sz_link; ++i) unitig_cs_link[i] = o.sz_link[i].load();
++        for (size_t i = 0; i != sz_link; ++i) unitig_cs_link[i] = o.unitig_cs_link[i].load();
+     }
+ 
+     if ((o.data != nullptr) && (o.sz_cs != 0)){

--- a/pkgs/by-name/ka/kallisto/package.nix
+++ b/pkgs/by-name/ka/kallisto/package.nix
@@ -18,8 +18,13 @@ stdenv.mkDerivation (finalAttrs: {
     repo = "kallisto";
     owner = "pachterlab";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-hfdeztEyHvuOnLS71oSv8sPqFe2UCX5KlANqrT/Gfx8=";
+    hash = "sha256-hfdeztEyHvuOnLS71oSv8sPqFe2UCX5KlANqrT/Gfx8=";
   };
+
+  patches = [
+    # https://github.com/pmelsted/bifrost/pull/18
+    ./bifrost-fix-datastorage-sz_link-typo.patch
+  ];
 
   postPatch = ''
     substituteInPlace CMakeLists.txt ext/bifrost/CMakeLists.txt \


### PR DESCRIPTION
Vendor the patch from https://github.com/pmelsted/bifrost/pull/18
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/327021777)](https://hydra.nixos.org/build/327021777)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

