### PR TITLE
rubyPackages: fix json-schema and dip regressions

### DIFF
--- a/pkgs/development/ruby-modules/with-packages/Gemfile
+++ b/pkgs/development/ruby-modules/with-packages/Gemfile
@@ -52,7 +52,12 @@ gem 'curses'
 gem 'daemons'
 gem 'dep-selector-libgecode'
 gem 'digest-sha3'
-gem 'dip'
+# Because standard dependency resolution depends on dip = 8.1.0
+#   and Nixpkgs checks depend on dip >= 8.2.5,
+#   an unpinned dip cannot be used.
+# So, because Gemfile depends on preventing version regressions,
+#   explicit minimum bounds are required.
+gem 'dip', '>= 8.2.5'
 gem 'domain_name'
 gem 'do_sqlite3'
 gem 'erb-formatter'
@@ -95,6 +100,12 @@ gem 'jekyll-favicon'
 gem 'jekyll-spaceship'
 gem 'jekyll-webmention_io'
 gem 'jmespath'
+# Because standard dependency resolution depends on json-schema = 5.1.0
+#   and Nixpkgs checks depend on json-schema >= 5.2.2,
+#   an unpinned json-schema cannot be used.
+# So, because Gemfile depends on preventing version regressions,
+#   explicit minimum bounds are required.
+gem 'json-schema', '>= 5.2.2'
 gem 'jwt'
 gem 'kramdown-rfc2629'
 gem 'libxml-ruby'

--- a/pkgs/top-level/ruby-packages.nix
+++ b/pkgs/top-level/ruby-packages.nix
@@ -13,10 +13,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1yfl7blz9zlww0al921kmyqsmsx8gdphqjnszp5fgpzi8nr1fpg1";
+      sha256 = "0g5kbrqvhwlliyrzd2bhc3kdiqm58df0x3w716bs0ygwyjil1gyk";
       type = "gem";
     };
-    version = "7.2.3";
+    version = "7.2.3.1";
   };
   actionmailbox = {
     dependencies = [
@@ -31,10 +31,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0pjdrdlv14mzq24qx95hpxhfza0k72qc3qymaa6x1wihqfkz1fqn";
+      sha256 = "0hf59r6sk0qb5va0ga549rbadcb5n1a2ry8nlkszzcksr6039rx4";
       type = "gem";
     };
-    version = "7.2.3";
+    version = "7.2.3.1";
   };
   actionmailer = {
     dependencies = [
@@ -49,10 +49,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1f4axhrdhk9z3hjv6xzxqyj7c3y17mn7kz1li1fv5lm6aaw4dmk8";
+      sha256 = "0rq4aan18y6gwziabnj1q1486349k1v1i5m7ysv206pqqpavcy7m";
       type = "gem";
     };
-    version = "7.2.3";
+    version = "7.2.3.1";
   };
   actionpack = {
     dependencies = [
@@ -72,10 +72,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1kq7fbgb5yfsjd1na2ghc7assk18ca24kbvsx90p0xwm8v3f851a";
+      sha256 = "1jp4w493wvfh9246wxk7g00m1a3vmzkvs0rznq62fwvjjdzzwsmn";
       type = "gem";
     };
-    version = "7.2.3";
+    version = "7.2.3.1";
   };
   actiontext = {
     dependencies = [
@@ -90,10 +90,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0ds0m7qp55qkprhdkzpxrvbfiam95s58xj7555hf5d5pnzpxkzx6";
+      sha256 = "1qs350j3zm7sd6xxn61d93mv3lx1ravbjqja12c7nd7a0zs1h52v";
       type = "gem";
     };
-    version = "7.2.3";
+    version = "7.2.3.1";
   };
   actionview = {
     dependencies = [
@@ -108,10 +108,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1cpc91crvavdgvc3jqj1nqr9q6s581bm64894pbh8f5l85x7shhz";
+      sha256 = "0z7zy6ibfpsdj9jbdm54bx3ws4dszcq7qa564jn645rr8dlbh6fy";
       type = "gem";
     };
-    version = "7.2.3";
+    version = "7.2.3.1";
   };
   activejob = {
     dependencies = [
@@ -122,10 +122,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1c7zwmhkg9fpkl2isiggs9b2xbf8jf0hhbvmjfgbcrz25m3n8jg4";
+      sha256 = "1n3fiwm1x3dxwj36n9pspd2bgffyw28ys9yd36hjvf3iwdy25i0b";
       type = "gem";
     };
-    version = "7.2.3";
+    version = "7.2.3.1";
   };
   activemodel = {
     dependencies = [ "activesupport" ];
@@ -133,10 +133,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1nrr8w3hxkssgx13bcph8lb876hg57w01fbapy7fj4ijp6p6dbxv";
+      sha256 = "1l60a6mqx1wgp15ki1cp68djci0czgrikpydii5bd877hndqdq9r";
       type = "gem";
     };
-    version = "7.2.3";
+    version = "7.2.3.1";
   };
   activerecord = {
     dependencies = [
@@ -148,10 +148,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1mx087zngip62400z44p969l6fja1fjxliq6kym6npzbii3vgb3g";
+      sha256 = "0pd0f1hy6rvyanmrklqir33xq0jb2my4jajz7hc38nysfpi175dq";
       type = "gem";
     };
-    version = "7.2.3";
+    version = "7.2.3.1";
   };
   activestorage = {
     dependencies = [
@@ -165,10 +165,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0bya6k7i8s6538fa4j2c0a0xrf6kggg8mhrwnkkqj356zaxj452c";
+      sha256 = "1azzbpfp726yigwzmj8g2jji149wisnwrgb86zix6mk25sj4w8hb";
       type = "gem";
     };
-    version = "7.2.3";
+    version = "7.2.3.1";
   };
   activesupport = {
     dependencies = [
@@ -188,10 +188,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "043vbilaw855c91n5l7g0k0wxj63kngj911685qy74xc1mvwjxan";
+      sha256 = "0d6bhg9cim83g8cypjd7cms45ng4p9ga69v26i3vp823d98yvsqi";
       type = "gem";
     };
-    version = "7.2.3";
+    version = "7.2.3.1";
   };
   addressable = {
     dependencies = [ "public_suffix" ];
@@ -199,10 +199,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0cl2qpvwiffym62z991ynks7imsm87qmgxf0yfsmlwzkgi9qcaa6";
+      sha256 = "1by7h2lwziiblizpd5yx87jsq8ppdhzvwf08ga34wzqgcv1nmpvz";
       type = "gem";
     };
-    version = "2.8.7";
+    version = "2.9.0";
   };
   algoliasearch = {
     dependencies = [
@@ -223,10 +223,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "14ims9zfal4gs2wpx2m5rd8zsrl2k794d359shkrsgg3fhr2a22l";
+      sha256 = "0n36cqp65cq259n86wsbyf18iirsjq4ycj0k4x7gncldxb0a17mc";
       type = "gem";
     };
-    version = "1.5.0";
+    version = "1.6.0";
   };
   ast = {
     groups = [ "default" ];
@@ -247,10 +247,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "05zqwiz0qp7rifiiidz5qzzc0gmwwyacydqpv1y42z9kx2qv514m";
+      sha256 = "1yklm8rdvxl63mqyk8z74idvsqaj9i2i2flsm73px88bqx937jmh";
       type = "gem";
     };
-    version = "4.3.3";
+    version = "4.3.6";
   };
   atomos = {
     groups = [ "default" ];
@@ -343,18 +343,18 @@
     version = "3.3.0";
   };
   byebug = {
+    dependencies = [ "reline" ];
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "07hsr9zzl2mvf5gk65va4smdizlk9rsiz8wwxik0p96cj79518fl";
+      sha256 = "0pg05blj56sxdxq9d54386y9rlvj36vl95x21x9clh8rfpz3w9nj";
       type = "gem";
     };
-    version = "12.0.0";
+    version = "13.0.0";
   };
   cairo = {
     dependencies = [
-      "native-package-installer"
       "pkg-config"
       "red-colors"
     ];
@@ -362,10 +362,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "02rd8zfzkq4nfv84y6jqmplc3ysygwladsnw1hfl44pgk9ync1ws";
+      sha256 = "08x6f2idyfnylq0b66mqi8lf5mjvff2y2q02n5hq0x4i3ha5cwz5";
       type = "gem";
     };
-    version = "1.18.4";
+    version = "1.18.5";
   };
   cairo-gobject = {
     dependencies = [
@@ -376,10 +376,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0zgkcidh80kgz110l6qmmh0bcwy6hd0sm15h9qbx8qcf3apblv3x";
+      sha256 = "1hxblh0k3h2ar4y47lify1fwjskmisvac24v72xwgn3q7znvds36";
       type = "gem";
     };
-    version = "4.3.3";
+    version = "4.3.6";
   };
   camping = {
     dependencies = [
@@ -394,16 +394,6 @@
       type = "gem";
     };
     version = "2.1.532";
-  };
-  certified = {
-    groups = [ "default" ];
-    platforms = [ ];
-    source = {
-      remotes = [ "https://rubygems.org" ];
-      sha256 = "1706p6p0a8adyvd943af2a3093xakvislgffw3v9dvp7j07dyk5a";
-      type = "gem";
-    };
-    version = "1.0.0";
   };
   cf-uaa-lib = {
     dependencies = [
@@ -436,10 +426,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1la4h74fxbx0dlb7mh3mkyh0vns25l3q87221vm7fg9pcx9qfy91";
+      sha256 = "0kixnv0f2l5ffr1yv4cbby2ycabqcq925yjkms3qniy8gdb0jkfc";
       type = "gem";
     };
-    version = "4.28.0";
+    version = "4.31.0";
   };
   CFPropertyList = {
     groups = [ "default" ];
@@ -456,10 +446,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1njrjznc2j5xqqw71sp9130b9hyv59h2gfrf6yaf4in1n9dzd6gy";
+      sha256 = "1s8qdw1nfh3njd47q154njlfyc2llcgi4ik13vz39adqd7yclgz9";
       type = "gem";
     };
-    version = "0.5.0";
+    version = "0.5.1";
   };
   charlock_holmes = {
     groups = [ "default" ];
@@ -497,10 +487,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1kzjd69njp32rpshms4c7dk3rxzkjqwdnv1pgcrag6404pkqfx5b";
+      sha256 = "1p2abxshwvj3khg7k3cfg3kcghqj9jfz6yh9nmz48q4vbhp23v9g";
       type = "gem";
     };
-    version = "1.3.3";
+    version = "1.5.2";
   };
   cld3 = {
     groups = [ "default" ];
@@ -830,10 +820,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "03n8gqzxnbkvfz875cdci4gdfc6pbdv1vjw8sy6m75l26ykimbav";
+      sha256 = "1yvl90g6619ykjk2nmmm8fdk9jchyh7kwwifw6xjqqzn3c95pjkx";
       type = "gem";
     };
-    version = "0.6.0";
+    version = "0.6.2";
   };
   cocoapods-wholemodule = {
     groups = [ "default" ];
@@ -914,20 +904,20 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1ipbrgvf0pp6zxdk5ascp6i29aybz2bx9wdrlchjmpx6mhvkwfw1";
+      sha256 = "1aymcakhzl83k77g2f2krz07bg1cbafbcd2ghvwr4lky3rz86mkb";
       type = "gem";
     };
-    version = "1.3.5";
+    version = "1.3.6";
   };
   connection_pool = {
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "02p7l47gvchbvnbag6kb4x2hg8n28r25ybslyvrr2q214wir5qg9";
+      sha256 = "02ifws3c4x7b54fv17sm4cca18d2pfw1saxpdji2lbd1f6xgbzrk";
       type = "gem";
     };
-    version = "2.5.4";
+    version = "3.0.2";
   };
   cookiejar = {
     groups = [ "default" ];
@@ -975,20 +965,20 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1ixcdcdiw13r5lgi313ysvpa8ijw55b592wanpnjns5xa2ncrsv4";
+      sha256 = "0n7d97d8b69qri4wazjqpiggqf441gzbgva21dqk2nr6wlm4v9vs";
       type = "gem";
     };
-    version = "1.2.2";
+    version = "1.3.5";
   };
   curses = {
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0z5zfxp10p7p2jwxbygkii8bffdl117qirh9qrl8xrvz5r21kll6";
+      sha256 = "1qkq83izdj0lzqwwf8c53b6dzcfcx47mzh5902yg9l1sabyjgkr6";
       type = "gem";
     };
-    version = "1.5.3";
+    version = "1.6.0";
   };
   daemons = {
     groups = [ "default" ];
@@ -1016,24 +1006,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1rbfqkzr6i8b6538z16chvrkgywf5p5vafsgmnbmvrmh0ingsx2y";
+      sha256 = "1h0db8r2v5llxdbzkzyllkfniqw9gm092qn7cbaib73v9lw0c3bm";
       type = "gem";
     };
-    version = "3.5.0";
-  };
-  debug = {
-    dependencies = [
-      "irb"
-      "reline"
-    ];
-    groups = [ "default" ];
-    platforms = [ ];
-    source = {
-      remotes = [ "https://rubygems.org" ];
-      sha256 = "sha256-LgsKxhGfIgem+Kx9SnPKjrTkQPZNoKMTbDA0MUbpUrY=";
-      type = "gem";
-    };
-    version = "1.11.1";
+    version = "3.5.1";
   };
   dentaku = {
     dependencies = [ "concurrent-ruby" ];
@@ -1096,10 +1072,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0b3p0mjz6l4dya5k8z0nsq186r1yvkbkrwaqgrg23lr96l24r381";
+      sha256 = "17938isqjcqd6bg8mr6hwdpdaf35im6s3vpimdbkk4ainz5s7mzc";
       type = "gem";
     };
-    version = "8.2.5";
+    version = "8.2.6";
   };
   dnsruby = {
     dependencies = [
@@ -1152,10 +1128,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1hwjsddv666wpp42bip3fqx7c5qq6s8lwf74dj71yn7d1h37c4cy";
+      sha256 = "17b1zr9kih0i3wb7h4yq9i8vi6hjfq07857j437a8z7a44qvhxg3";
       type = "gem";
     };
-    version = "3.1.8";
+    version = "3.2.0";
   };
   drb = {
     groups = [ "default" ];
@@ -1228,10 +1204,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0y95ynlfngs0s5x1w6mwralszhbi9d75lcdbdkqk75wcklzqjc17";
+      sha256 = "1ncmbdjf2bwmk0jf5cxywns9zbxyfiy4h4p3pzi7yddyjhv81qrq";
       type = "gem";
     };
-    version = "6.0.0";
+    version = "6.0.4";
   };
   erb-formatter = {
     dependencies = [ "syntax_tree" ];
@@ -1291,20 +1267,20 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1fvxb016l7kkbmx7alw49b8d48f0cm7j8dkzbzj0al89nw2nixmx";
+      sha256 = "0ddab9a8ry37nb9jl3h8kc9w5dbg15g6gd23h2dpsw8rlvnxin1j";
       type = "gem";
     };
-    version = "1.3.1";
+    version = "1.4.2";
   };
   execjs = {
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "03a590q16nhqvfms0lh42mp6a1i41w41qpdnf39zjbq5y3l8pjvb";
+      sha256 = "1wbkbskyaz1vh4yq0zmf39lnm1q79n9yn508q4q8xsv7hh1axq5b";
       type = "gem";
     };
-    version = "2.10.0";
+    version = "2.10.1";
   };
   faraday = {
     dependencies = [
@@ -1316,10 +1292,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "077n5ss3z3ds4vj54w201kd12smai853dp9c9n7ii7g3q7nwwg54";
+      sha256 = "1b930ag8nh99v8n9645ac1wcah9fx0mclbp323q4i1ly9acvkk3k";
       type = "gem";
     };
-    version = "2.14.1";
+    version = "2.14.2";
   };
   faraday-net_http = {
     dependencies = [ "net-http" ];
@@ -1327,20 +1303,20 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0v4hfmc7d4lrqqj2wl366rm9551gd08zkv2ppwwnjlnkc217aizi";
+      sha256 = "1hgflj9qj8imf8yhbbn0aiyjija9j37yxvk9lx2z64lkxkn3pccx";
       type = "gem";
     };
-    version = "3.4.2";
+    version = "3.4.3";
   };
   ffi = {
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "19kdyjg3kv7x0ad4xsd4swy5izsbb1vl1rpb6qqcqisr5s23awi9";
+      sha256 = "1kqasqvy8d7r09ri4n6bkdwbk63j7afd9ilsw34nzlgh0qp69ldw";
       type = "gem";
     };
-    version = "1.17.2";
+    version = "1.17.4";
   };
   ffi-compiler = {
     dependencies = [
@@ -1351,10 +1327,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1844j58cdg2q6g0rqfwg4rrambnhf059h4yg9rfmrbrcs60kskx9";
+      sha256 = "0vhjv98f9rjdzdxfsyyk19sfb45dcxc57ynsdmvn8vzdkifrvmm9";
       type = "gem";
     };
-    version = "1.3.2";
+    version = "1.4.2";
   };
   ffi-rzmq-core = {
     dependencies = [ "ffi" ];
@@ -1416,10 +1392,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1zj8llzc119zafbmfa4ai3z5s7c4vp9akfs0f9l2piyvcarmlkyx";
+      sha256 = "05x2pvzdzwh5g7z1s5592k3dg3bfidfamc7zxqngj50w4bmlyblc";
       type = "gem";
     };
-    version = "1.2.0";
+    version = "1.3.0";
   };
   formatador = {
     dependencies = [ "reline" ];
@@ -1437,10 +1413,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1b5g1i3xdvmxxpq4qp0z4v78ivqnazz26w110fh4cvzsdayz8zgi";
+      sha256 = "0f78rjpnhm4lgp1qzadnr6kr02b6afh1lvy7w607k4qjk3641kgi";
       type = "gem";
     };
-    version = "1.3.3";
+    version = "1.4.0";
   };
   forwardable-extended = {
     groups = [ "default" ];
@@ -1483,10 +1459,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0byw9rjlirk3dlw3p2mla7x3bajxgfccjlb9ja9jj1wadwb9j00p";
+      sha256 = "12wfqjmxkdkn0bs7gqn04ac5ip0awx8jxvmmrykny8p19lrfsrw5";
       type = "gem";
     };
-    version = "4.3.3";
+    version = "4.3.6";
   };
   gdk_pixbuf2 = {
     dependencies = [
@@ -1497,10 +1473,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1z2ab23i4d47z4yd4fidpj41ixj2nvl9gmply9npn0zn1a1zai4x";
+      sha256 = "1ihv48n5vq7xrxwspm2icx9rszgygkhkcg6w4lv0cygay695nmn2";
       type = "gem";
     };
-    version = "4.3.3";
+    version = "4.3.6";
   };
   gemoji = {
     groups = [ "default" ];
@@ -1524,10 +1500,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0aji3873pxn6gc5qkvnv5y9025mqk0p6h22yrpyz2b3yx9qpzv03";
+      sha256 = "0x1wpyy5mgn0523f4pyv7lpxs8b4s6pfvyi24nymd7vym9cjr85d";
       type = "gem";
     };
-    version = "3.5.1";
+    version = "3.5.2";
   };
   gh_inspector = {
     groups = [ "default" ];
@@ -1548,10 +1524,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0jyqidl7clwyj0i2dcc971fzb188snpqyhak6k8ykgjxgnjl7a0w";
+      sha256 = "19fmvs919hnr5i9xwq9fw4vgnym3j37ngnbz1zfb8921c6qpvlsi";
       type = "gem";
     };
-    version = "4.3.3";
+    version = "4.3.6";
   };
   git = {
     dependencies = [
@@ -1564,10 +1540,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1x1y2v3ig9j7gi8f4c58ppj38dpz8skvd8ph20sfajq1bv8rzqbk";
+      sha256 = "01r9a8wbqwzg5ca7qvq8rvgcp98wc7i36333vjgdv35vfdjp1c53";
       type = "gem";
     };
-    version = "4.0.6";
+    version = "4.3.2";
   };
   github-pages = {
     dependencies = [
@@ -1662,10 +1638,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0dd66xccm6zg2szhcn740nvk3bhzknw169knr992qlf43hvsz2qa";
+      sha256 = "1k71h37jv0hn61sw9nrmph6mlw1y2d4bibk43163ndj7v1vfq76j";
       type = "gem";
     };
-    version = "4.3.3";
+    version = "4.3.6";
   };
   globalid = {
     dependencies = [ "activesupport" ];
@@ -1684,10 +1660,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "12bbrykgky90hgcy186k4nzxjrk7wc68mpsd334mpyqn1ixpvgg4";
+      sha256 = "0sw7fny16rhvdbbnk80vikl081jkbmmyg2r3b3i47hmyamjzc2bg";
       type = "gem";
     };
-    version = "4.3.3";
+    version = "4.3.6";
   };
   gpgme = {
     dependencies = [ "mini_portile2" ];
@@ -1695,10 +1671,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0d6whkyc63056nkaxsr86ygi9razbzr50qgbbla161bj525l0hlj";
+      sha256 = "1amb4f0hgwdlz9dzblfpsidays3mb4cg65plwr0m6x1vp0pgvsqs";
       type = "gem";
     };
-    version = "2.0.25";
+    version = "2.0.26";
   };
   gtk3 = {
     dependencies = [
@@ -1709,10 +1685,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1x8cdc91x8k9m0xlz195yfc3xn65g24cyq3lcjipn9h3hs4d9yq1";
+      sha256 = "16cwls02xpdy7ra5cz8jqpfhdk6zwryjhw4ipvmr0chv0la23vdd";
       type = "gem";
     };
-    version = "4.3.3";
+    version = "4.3.6";
   };
   haml = {
     dependencies = [
@@ -1724,20 +1700,21 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1ah31ir512j1427dw4c6f00qp33nl47x102y5wc3qlyzvmc7id65";
+      sha256 = "0nnmzj6g2wynxbrp9j885zab4nkzfryhl2bv6cj1gazyyxqjpzc7";
       type = "gem";
     };
-    version = "7.0.2";
+    version = "7.2.0";
   };
   hashie = {
+    dependencies = [ "logger" ];
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1nh3arcrbz1rc1cr59qm53sdhqm137b258y8rcb4cvd3y98lwv4x";
+      sha256 = "0w1qrab701d3a63aj2qavwc2fpcqmkzzh1w2x93c88zkjqc4frn2";
       type = "gem";
     };
-    version = "5.0.0";
+    version = "5.1.0";
   };
   highline = {
     dependencies = [ "reline" ];
@@ -1836,10 +1813,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "06dvmngd4hwrr6k774i1h6c50h2l8nww9f1id0wvrvi72l6yd99q";
+      sha256 = "1aga7z4p0dka4zcqw9i05wa4ab1q7h7cgnj328ldqqfycjz84jxs";
       type = "gem";
     };
-    version = "1.1.0";
+    version = "1.1.6";
   };
   http-form_data = {
     groups = [ "default" ];
@@ -1856,10 +1833,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1gj4fmls0mf52dlr928gaq0c0cb0m3aqa9kaa6l0ikl2zbqk42as";
+      sha256 = "0yh924g697spcv4hfigyxgidhyy6a7b9007rnac57airbcadzs4s";
       type = "gem";
     };
-    version = "0.8.0";
+    version = "0.8.1";
   };
   httpclient = {
     dependencies = [ "mutex_m" ];
@@ -1878,20 +1855,20 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "03sx3ahz1v5kbqjwxj48msw3maplpp2iyzs22l4jrzrqh4zmgfnf";
+      sha256 = "1994i044vdmzzkyr76g8rpl1fq1532wf0sb21xg5r1ilj5iphmr8";
       type = "gem";
     };
-    version = "1.14.7";
+    version = "1.14.8";
   };
   iconv = {
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1s10cwzm54vps35bqadgyksc7i0zkdaxjry8kkz6w65aag7dkmwa";
+      sha256 = "039md3wq0hb6zigqgb8y2p9h0dqdz5ig47ndyhc3mvfic3hbkhka";
       type = "gem";
     };
-    version = "1.1.0";
+    version = "1.1.1";
   };
   idn-ruby = {
     groups = [ "default" ];
@@ -1923,14 +1900,15 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1jszj95hazqqpnrjjzr326nn1j32xmsc9xvd97mbcrrgdc54858y";
+      sha256 = "1k0lk3pwadm2myvpg893n8jshmrf2sigrd4ki15lymy7gixaxqyn";
       type = "gem";
     };
-    version = "0.8.1";
+    version = "0.8.2";
   };
   irb = {
     dependencies = [
       "pp"
+      "prism"
       "rdoc"
       "reline"
     ];
@@ -1938,20 +1916,20 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1aja320qnimlnfc80wf2i2x8i99kl5sdzfacsfzzfzzs3vzysja3";
+      sha256 = "1qs8a9vprg7s8krgq4s0pygr91hclqqyz98ik15p0m1sf2h5956y";
       type = "gem";
     };
-    version = "1.15.3";
+    version = "1.18.0";
   };
   jaro_winkler = {
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "14xkw4lb6wwvbcwqkf6ds116sridk9c8yz6y3caw07vzpwdvcmn0";
+      sha256 = "1nja0hjdn9kil7m0y8c0km0haz6ln25alp66q4kpvgq5rnjhbald";
       type = "gem";
     };
-    version = "1.6.1";
+    version = "1.7.0";
   };
   jbuilder = {
     dependencies = [
@@ -1962,10 +1940,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0hmvz9lhx37x43gnms17hfczjwfj7i9xfvzxnh611vv0zxv67cjf";
+      sha256 = "12gq2xc2bs4lhmbh7mc0yljih14g6k2avhzbrfr8rn3xni2wsdpy";
       type = "gem";
     };
-    version = "2.14.1";
+    version = "2.15.0";
   };
   jekyll = {
     dependencies = [
@@ -2526,10 +2504,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "098m3q2jrx4xbf0knrbmflsynmmb5x9q9b0bzpmj7jmm1cr30mna";
+      sha256 = "0n9ch455pnvl9vxs2f3j77bpdmxg5g3mn3vyr9wxa0a87raii2i1";
       type = "gem";
     };
-    version = "2.16.0";
+    version = "2.19.5";
   };
   json-schema = {
     dependencies = [
@@ -2572,10 +2550,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0dfm4bhl4fzn076igh0bmh2v1vphcrxdv6ldc46hdd3bkbqr2sdg";
+      sha256 = "1mqps8z4ly74hpksfajcfamqk1wb79biy187pn10knmi6zzb26al";
       type = "gem";
     };
-    version = "3.1.2";
+    version = "3.2.0";
   };
   keystone-engine = {
     dependencies = [ "ffi" ];
@@ -2613,7 +2591,6 @@
   kramdown-rfc2629 = {
     dependencies = [
       "base64"
-      "certified"
       "differ"
       "json_pure"
       "kramdown"
@@ -2628,10 +2605,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1w44r4c1y69fzfbyw2bl8z5bs7jxsy288saijvl97vq8a33iq4cx";
+      sha256 = "1rrmg49sdbiqddm7na6b0acry5p80p6b8wba839v9y9zqy0625wk";
       type = "gem";
     };
-    version = "1.7.29";
+    version = "1.7.39";
   };
   language_server-protocol = {
     groups = [ "default" ];
@@ -2663,10 +2640,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "16jfgrgb3ys7lk4b7m6s5kg3jdd5w976k6hmf1fmbpw254ahgg7i";
+      sha256 = "1i6sm561mc70p7ykczg6gcmw6znn1h8w3zcm14fmkvld066lbnd9";
       type = "gem";
     };
-    version = "5.0.5";
+    version = "6.0.0";
   };
   link-header-parser = {
     groups = [ "default" ];
@@ -2700,6 +2677,7 @@
   };
   listen = {
     dependencies = [
+      "logger"
       "rb-fsevent"
       "rb-inotify"
     ];
@@ -2707,10 +2685,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0rwwsmvq79qwzl6324yc53py02kbrcww35si720490z5w0j497nv";
+      sha256 = "1ln9c0vx165hkfbn2817qw4m6i77xcxh6q0r5v6fqfhlcbdq5qf6";
       type = "gem";
     };
-    version = "3.9.0";
+    version = "3.10.0";
   };
   llhttp-ffi = {
     dependencies = [
@@ -2727,14 +2705,15 @@
     version = "0.5.1";
   };
   locale = {
+    dependencies = [ "fiddle" ];
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "107pm4ccmla23z963kyjldgngfigvchnv85wr6m69viyxxrrjbsj";
+      sha256 = "1x1fnf4knvyzb9br6ja7b1nvy0860nax0i8rx4ljrnvbmbl06s0w";
       type = "gem";
     };
-    version = "2.1.4";
+    version = "2.1.5";
   };
   logger = {
     groups = [ "default" ];
@@ -2755,10 +2734,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0dx316q03x6rpdbl610rdaj2vfd5s8fanixk21j4gv3h5f230nk5";
+      sha256 = "011fdngxzr1p9dq2hxqz7qq1glj2g44xnhaadjqlf48cplywfdnl";
       type = "gem";
     };
-    version = "2.24.1";
+    version = "2.25.1";
   };
   mab = {
     groups = [ "default" ];
@@ -2803,10 +2782,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1vhb1sbzlq42k2pzd9v0w5ws4kjx184y8h4d63296bn57jiwzkzx";
+      sha256 = "17w53z6vka8ddmxvi936biqv443d5yg0503wj7xfmy9j1qvfjy0n";
       type = "gem";
     };
-    version = "1.1.0";
+    version = "1.2.1";
   };
   markaby = {
     dependencies = [ "builder" ];
@@ -2868,10 +2847,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0a27k4jcrx7pvb0p59fn1frh14iy087c2aygrdkmgwsrbshvqxpj";
+      sha256 = "1k28j6ww8rf43r5i8278jvm2cq3pnzsvqm7yqpb4p93kadjlq726";
       type = "gem";
     };
-    version = "3.2025.0924";
+    version = "3.2026.0414";
   };
   mini_magick = {
     dependencies = [ "logger" ];
@@ -2924,10 +2903,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "15jskd97qz3zsmyvfqb4shb557560qqdlfrc6jx0n8wf4za66spi";
+      sha256 = "1mbpz92ml19rcxxfjrj91gmkif9khb1xpzyw38f81rvglgw1ffrd";
       type = "gem";
     };
-    version = "5.26.1";
+    version = "5.27.0";
   };
   molinillo = {
     groups = [ "default" ];
@@ -2954,21 +2933,20 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "06sabsvnw0x1aqdcswc6bqrqz6705548bfd8z22jxgxfjrn1yn3n";
+      sha256 = "1040lr5y2phn7avdyam6zw6ikprlmk77biw3yhclsfwfh0qnl4p6";
       type = "gem";
     };
-    version = "1.17.0";
+    version = "1.21.1";
   };
   mustermann = {
-    dependencies = [ "ruby2_keywords" ];
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "08ma2fmxlm6i7lih4mc3har2fzsbj1pl4hhva65kljf6nfvdryl5";
+      sha256 = "163i29mdcr1h0nximk3d51a1fgp7vz3sfasn8p1rjm2d4g3p0qac";
       type = "gem";
     };
-    version = "3.0.4";
+    version = "3.1.1";
   };
   mutex_m = {
     groups = [ "default" ];
@@ -3037,10 +3015,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0vdlxiv9h9gzliz8722j6spw2nwl5z0rfz1i5b9mmsgrx5yc8hnz";
+      sha256 = "15k96fj6qwbaiv6g52l538ass95ds1qwgynqdridz29yqrkhpfi5";
       type = "gem";
     };
-    version = "0.8.0";
+    version = "0.9.1";
   };
   net-http-persistent = {
     dependencies = [ "connection_pool" ];
@@ -3048,10 +3026,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0pfxhhn1lqnxx8dj3ig3lgnhkxq5jsb0brg7w2wnrpwf8c23mfra";
+      sha256 = "1rk03449disq3azyiymv1c3qnpqr6cxawgq556rkf5b9klqyhggg";
       type = "gem";
     };
-    version = "4.0.6";
+    version = "4.0.8";
   };
   net-imap = {
     dependencies = [
@@ -3062,10 +3040,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0i24prs7yy1p1zdps2x1ksb7lmvbn2f0llxwdjdw3z2ksddx136b";
+      sha256 = "0ax0f0r97jm83q462vsrcbdxprs894fyyc44v62c48ihgb39hmcs";
       type = "gem";
     };
-    version = "0.5.12";
+    version = "0.6.4";
   };
   net-pop = {
     dependencies = [ "net-protocol" ];
@@ -3116,10 +3094,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1w1ypxa3n6mskkwb00b489314km19l61p5h3bar6zr8cng27c80p";
+      sha256 = "1m1d6rs40rjvdb6df34fi3za1c2ajdiydv4jzpjj03iq7hhrw0k5";
       type = "gem";
     };
-    version = "7.3.0";
+    version = "7.3.2";
   };
   netrc = {
     groups = [ "default" ];
@@ -3150,10 +3128,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1hcwwr2h8jnqqxmf8mfb52b0dchr7pm064ingflb78wa00qhgk6m";
+      sha256 = "1s30b7h7qpyim30m8060xs415mbr3ci7i5hdg09chh1aqfx2qcbq";
       type = "gem";
     };
-    version = "1.18.10";
+    version = "1.19.3";
   };
   observer = {
     groups = [ "default" ];
@@ -3201,15 +3179,25 @@
     };
     version = "1.7.4";
   };
+  open3 = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0lirpxrqk2bw02m3p4g8r50h37qkr0ssmh9q2hh52qsj2chpsbcf";
+      type = "gem";
+    };
+    version = "0.2.1";
+  };
   openssl = {
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0v0grpg9gi59zr3imxy1745k9rp3dd095mkir8gvxi69blhh2kkz";
+      sha256 = "0dfkwb2n4l7wrcal4f8niadvphhi181jdf7s48qw31r9iw9h4sfl";
       type = "gem";
     };
-    version = "3.3.2";
+    version = "3.3.3";
   };
   optimist = {
     groups = [ "default" ];
@@ -3273,10 +3261,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0rflz4di59qd2y8vxq8hr1kv3kyyvyd5aasa924riq4pw95kvac1";
+      sha256 = "050qsy2bcd04yi1w1g6mlibjr32mhh29swcm3rlnza3lwza9d64f";
       type = "gem";
     };
-    version = "2.1.0";
+    version = "2.2.1";
   };
   pango = {
     dependencies = [
@@ -3287,20 +3275,20 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1p9fqlvbq6bzs6ng46bbaswk57yjwccj5cjkqywn5s6d4gns83cq";
+      sha256 = "1p5ygivdz43ca96fap6k9ric7m72nm908cix2p0gl84blxav7sq4";
       type = "gem";
     };
-    version = "4.3.3";
+    version = "4.3.6";
   };
   parallel = {
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0c719bfgcszqvk9z47w2p8j2wkz5y35k48ywwas5yxbbh3hm3haa";
+      sha256 = "0w697335hi5dk5ay9kyn53399sy87y8v0y6ij93m5wmshhadxrik";
       type = "gem";
     };
-    version = "1.27.0";
+    version = "1.28.0";
   };
   parser = {
     dependencies = [
@@ -3311,10 +3299,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1mmb59323ldv6vxfmy98azgsla9k3di3fasvpb28hnn5bkx8fdff";
+      sha256 = "0m2xqvn1la62hji1mn04y59giikww95p2hs0r4y2rrz3mdxcwyni";
       type = "gem";
     };
-    version = "3.3.10.0";
+    version = "3.3.11.1";
   };
   paru = {
     dependencies = [ "csv" ];
@@ -3374,20 +3362,20 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0xf8i58shwvwlka4ld12nxcgqv0d5r1yizsvw74w5jaw83yllqaq";
+      sha256 = "16caca7lcz5pwl82snarqrayjj9j7abmxqw92267blhk7rbd120k";
       type = "gem";
     };
-    version = "1.6.2";
+    version = "1.6.3";
   };
   pkg-config = {
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0ynbh87awgjkz47krvcxx1va1cm7624ax21jrv6m072s1i0cb0rh";
+      sha256 = "0cy75ssbwjzi9z3zwfx2zq3b8xvpy9rbdf1rnhi3v612acfgiy9k";
       type = "gem";
     };
-    version = "1.6.4";
+    version = "1.6.5";
   };
   polyglot = {
     groups = [ "default" ];
@@ -3464,10 +3452,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0sqwckzzpj1mmmjnqcvqmq6adlxbhkf5ij3b6ir4i33ih4d2ih5z";
+      sha256 = "11ggfikcs1lv17nhmhqyyp6z8nq5pkfcj6a904047hljkxm0qlvv";
       type = "gem";
     };
-    version = "1.6.0";
+    version = "1.9.0";
   };
   process_executer = {
     dependencies = [ "track_open_instances" ];
@@ -3475,24 +3463,25 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "13iza6y7f0gqvb15lvvnqg68ndljlk17xgahw1x1s9b6jm4cz5ld";
+      sha256 = "0vxsqc3vfixrfha3132bbfdkncz7is7hrlqyg8724vl73g9rn5vc";
       type = "gem";
     };
-    version = "4.0.0";
+    version = "4.0.4";
   };
   pry = {
     dependencies = [
       "coderay"
       "method_source"
+      "reline"
     ];
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0ssv704qg75mwlyagdfr9xxbzn1ziyqgzm0x474jkynk8234pm8j";
+      sha256 = "0kh5nv8v74k1ccy6gc7nd04aaf1cjkbk7g8pwy2izvcqaq36jv6p";
       type = "gem";
     };
-    version = "0.15.2";
+    version = "0.16.0";
   };
   pry-byebug = {
     dependencies = [
@@ -3503,10 +3492,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0wpa3jd46h44rjz3hjwl5c0zfx3jav4a64nm8h0g1iwv61yvn2hb";
+      sha256 = "1dyi2dr5zp08s4bp9ik44v84wc0kdvinmcy7six0lfd8x150jkjr";
       type = "gem";
     };
-    version = "3.11.0";
+    version = "3.12.0";
   };
   pry-doc = {
     dependencies = [
@@ -3517,10 +3506,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0qq58vsmmvi9i4d15pav46ca5pd85qx3fxv17pq7ia5lqgxcrc8r";
+      sha256 = "13id4bmq39fm8176b7a9mz0cira5qfa4zr24chf48m1b0vn9znka";
       type = "gem";
     };
-    version = "1.6.0";
+    version = "1.7.0";
   };
   psych = {
     dependencies = [
@@ -3531,10 +3520,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0vii1xc7x81hicdbp7dlllhmbw5w3jy20shj696n0vfbbnm2hhw1";
+      sha256 = "0x0r3gc66abv8i4dw0x0370b5hrshjfp6kpp7wbp178cy775fypb";
       type = "gem";
     };
-    version = "5.2.6";
+    version = "5.3.1";
   };
   public_suffix = {
     groups = [ "default" ];
@@ -3552,10 +3541,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1pa9zpr51kqnsq549p6apvnr95s9flx6bnwqii24s8jg2b5i0p74";
+      sha256 = "0z6k79ns8wgz12k3m2r0jc9ddiq6zh8imr4azg0ihmv50w6fb53v";
       type = "gem";
     };
-    version = "7.1.0";
+    version = "8.0.1";
   };
   pwntools = {
     dependencies = [
@@ -3593,10 +3582,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1xmnrk076sqymilydqgyzhkma3hgqhcv8xhy7ks479l2a3vvcx2x";
+      sha256 = "1hhjy9gcp52dzij05gmidqac8g28ski5xm67prwmdqmjfcgqxmsy";
       type = "gem";
     };
-    version = "3.2.4";
+    version = "3.2.6";
   };
   rack-protection = {
     dependencies = [
@@ -3622,10 +3611,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1sg4laz2qmllxh1c5sqlj9n1r7scdn08p3m4b0zmhjvyx9yw0v8b";
+      sha256 = "1s7zcxlmg88a6dam4aqbgk9xkpy6dkdfqmmcszkkliy3q3w38m2r";
       type = "gem";
     };
-    version = "2.1.1";
+    version = "2.1.2";
   };
   rack-test = {
     dependencies = [ "rack" ];
@@ -3644,10 +3633,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "13brkq5xkj6lcdxj3f0k7v28hgrqhqxjlhd4y2vlicy5slgijdzp";
+      sha256 = "0s48d2a0z5f0cg4npvzznf933vipi6j7gmk16yc913kpadkw4ybc";
       type = "gem";
     };
-    version = "2.2.1";
+    version = "2.3.1";
   };
   rails = {
     dependencies = [
@@ -3668,10 +3657,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1zwvc2fa0hm27ygfz1yc2bs52h4wzj1nhpv6cip6g28i2gmi564s";
+      sha256 = "155skqkjrckvzj1qy37lrnafrillc47qhf3l80g3zvw100ba1h4n";
       type = "gem";
     };
-    version = "7.2.3";
+    version = "7.2.3.1";
   };
   rails-dom-testing = {
     dependencies = [
@@ -3697,10 +3686,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0q55i6mpad20m2x1lg5pkqfpbmmapk0sjsrvr1sqgnj2hb5f5z1m";
+      sha256 = "128y5g3fyi8fds41jasrr4va1jrs7hcamzklk1523k7rxb64bc98";
       type = "gem";
     };
-    version = "1.6.2";
+    version = "1.7.0";
   };
   railties = {
     dependencies = [
@@ -3718,10 +3707,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "08h44mkf91861agp7xw778gqpf5mppydsfgphgkj7wp6pyk11c3f";
+      sha256 = "0np1m8xqb4wbzwpg66yjnqjban0di92lbjzcrgnwwhq2w4z3k8xf";
       type = "gem";
     };
-    version = "7.2.3";
+    version = "7.2.3.1";
   };
   rainbow = {
     groups = [ "default" ];
@@ -3738,10 +3727,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "175iisqb211n0qbfyqd8jz2g01q6xj038zjf4q0nm8k6kz88k7lc";
+      sha256 = "009p524zl0p0kfa65nii8wdmaigkmawv9pbvlcffky7islmmp0nb";
       type = "gem";
     };
-    version = "13.3.1";
+    version = "13.4.2";
   };
   rb-fsevent = {
     groups = [ "default" ];
@@ -3786,15 +3775,19 @@
     version = "7.1.2";
   };
   rbs = {
-    dependencies = [ "logger" ];
+    dependencies = [
+      "logger"
+      "prism"
+      "tsort"
+    ];
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1c0r26dhdr4jiklc0g7wjmr5q56dp7hwcfa8z75khkp8mrhazfpa";
+      sha256 = "09ggg2zk0qrh0mc3fa23xjbn2gzqxd0jfqj6qm6460ydcqg6fxdg";
       type = "gem";
     };
-    version = "3.9.5";
+    version = "4.0.2";
   };
   rchardet = {
     groups = [ "default" ];
@@ -3816,10 +3809,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "06j83bdhsmq10083ahz3h125pnycx965cfpmg606l8lbrmrsrgr8";
+      sha256 = "14iiyb4yi1chdzrynrk74xbhmikml3ixgdayjma3p700singfl46";
       type = "gem";
     };
-    version = "6.15.1";
+    version = "7.2.0";
   };
   re2 = {
     dependencies = [ "mini_portile2" ];
@@ -3827,10 +3820,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1q86axcrrl9sh7wgnc70mb8kcyg2qjb67a2wm2qhfh9jqx12k4xg";
+      sha256 = "11d3yfzjajc5a2xwqx5ilhhaz6lrvjcm91xrz74sijf47f7kg68a";
       type = "gem";
     };
-    version = "2.21.0";
+    version = "2.27.0";
   };
   red-colors = {
     dependencies = [
@@ -3873,10 +3866,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0wx0v68lh924x544mkpydcrkkbr7i386xvkpyxgsf5j55j3d4f8y";
+      sha256 = "18xy2nd8mcb186gqd11sy3vfwkq5n85mq26v7l325jkdiwgvyr8c";
       type = "gem";
     };
-    version = "0.26.1";
+    version = "0.29.0";
   };
   redis-rack = {
     dependencies = [
@@ -3908,10 +3901,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "192mzi0wgwl024pwpbfa6c2a2xlvbh3mjd75a0sakdvkl60z64ya";
+      sha256 = "1fwfw26a32rps78920nn29shqg2zmqv72i89j1fap41isshida9m";
       type = "gem";
     };
-    version = "2.11.3";
+    version = "2.12.0";
   };
   reline = {
     dependencies = [ "io-console" ];
@@ -3946,10 +3939,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "195c7yra7amggqj7rir0yr09r4v29c2hgkbkb21mj0jsfs3868mb";
+      sha256 = "1bxqlpwnixn8x4bnna958w6m6qkdkbnd23b9j6ib3nrrrs9bp3l1";
       type = "gem";
     };
-    version = "3.0.0";
+    version = "3.0.2";
   };
   rexml = {
     groups = [ "default" ];
@@ -3970,10 +3963,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0r8gndcl5xz4zibslgch12w5101wjq03i851h2657jvv07fr7183";
+      sha256 = "1dz0znrnzzc6p1f58gw9ghlismd8307iiqj5ssx6n1y61q5lb90q";
       type = "gem";
     };
-    version = "6.1.4";
+    version = "7.0.0";
   };
   rmate = {
     groups = [ "default" ];
@@ -4054,20 +4047,20 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "071bqrk2rblk3zq3jk1xxx0dr92y0szi5pxdm8waimxici706y89";
+      sha256 = "0iqxmw0knjiz5nf6pgr8ihs6cjzh89f0ppj3fqiz8cvms79x6sh8";
       type = "gem";
     };
-    version = "3.13.7";
+    version = "3.13.8";
   };
   rspec-support = {
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1cmgz34hwj5s3jwxhyl8mszs24nci12ffbrmr5jb1si74iqf739f";
+      sha256 = "0z64h5rznm2zv21vjdjshz4v0h7bxvg02yc6g7yzxakj11byah06";
       type = "gem";
     };
-    version = "3.13.6";
+    version = "3.13.7";
   };
   rubocop = {
     dependencies = [
@@ -4086,10 +4079,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1x5bv4yrm02ma8qy5127arz3zx0y7cjmw7mrnffijp6gxw7z71b4";
+      sha256 = "0pxzipl8a1bv62jdfykh7j4ymdr4aiffjvwsny6drwv886jwx4jn";
       type = "gem";
     };
-    version = "1.80.2";
+    version = "1.84.2";
   };
   rubocop-ast = {
     dependencies = [
@@ -4100,10 +4093,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0xifbp09jfl1hdy9wwgq9dq2l7mf8y2ycm5d1zgcqvks7yzrppr2";
+      sha256 = "0dahfpnzz63hyqxa03x8rypnrxzwyvh4i5a8ri34bzpnf3pg64j4";
       type = "gem";
     };
-    version = "1.48.0";
+    version = "1.49.1";
   };
   rubocop-performance = {
     dependencies = [
@@ -4115,10 +4108,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1h9flnqk2f3llwf8g0mk0fvzzznfj7hsil3qg88m803pi9b06zbg";
+      sha256 = "0d0qyyw1332afi9glwfjkb4bd62gzlibar6j55cghv8rzwvbj6fd";
       type = "gem";
     };
-    version = "1.25.0";
+    version = "1.26.1";
   };
   ruby-graphviz = {
     dependencies = [ "rexml" ];
@@ -4165,10 +4158,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "10b93m34plp7rssbvdcci2k1zqlranmrpgmygsch6c6fh1n8pll0";
+      sha256 = "0aa1mg6bdl23wgrxd98wycq3963jfpnh9z0yh976p9q03h01r81k";
       type = "gem";
     };
-    version = "0.26.3";
+    version = "0.26.9";
   };
   ruby-lxc = {
     groups = [ "default" ];
@@ -4219,48 +4212,21 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0n3pgw1jkkivgkn08qpc4fb1kiivhbshkj0lhrms4sy3fahlgigk";
+      sha256 = "0x2k5x272m2zs0vmznl2jac14bj9a2g0365xxcnr2s9rq41fr1g6";
       type = "gem";
     };
-    version = "2.2.5";
-  };
-  ruby2_keywords = {
-    groups = [ "default" ];
-    platforms = [ ];
-    source = {
-      remotes = [ "https://rubygems.org" ];
-      sha256 = "1vz322p8n39hz3b4a9gkmz9y7a5jaz41zrm2ywf31dvkqm03glgz";
-      type = "gem";
-    };
-    version = "0.0.5";
+    version = "2.3.0";
   };
   ruby2ruby = {
-    dependencies = [
-      "ruby_parser"
-      "sexp_processor"
-    ];
+    dependencies = [ "sexp_processor" ];
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0cs7z80wnr3spia7mdfqq2gn87sljl9hw08cxqsz0yiin8i1xd16";
+      sha256 = "000szrcq2pw3m26fpgfm4zdgxr7csn46gjmfl7szcb10wphbmz8i";
       type = "gem";
     };
-    version = "2.5.2";
-  };
-  ruby_parser = {
-    dependencies = [
-      "racc"
-      "sexp_processor"
-    ];
-    groups = [ "default" ];
-    platforms = [ ];
-    source = {
-      remotes = [ "https://rubygems.org" ];
-      sha256 = "1v3g9nc7k154ii99zm0vxxb4jmkjyqy1v08g51jpsa7cbaz1m4wx";
-      type = "gem";
-    };
-    version = "3.21.1";
+    version = "2.6.1";
   };
   rubyserial = {
     dependencies = [ "ffi" ];
@@ -4368,15 +4334,19 @@
     version = "3.1.0";
   };
   seccomp-tools = {
-    dependencies = [ "os" ];
+    dependencies = [
+      "logger"
+      "os"
+      "racc"
+    ];
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0v5zyby5glih0prddxm8wp6gn2glrnvf7y4r64k4iqfpdazdpsa3";
+      sha256 = "1w12yvg1zdd6kkmgcwnblnj5s8jr4qzjh7nfffbibxi066nb8vn2";
       type = "gem";
     };
-    version = "1.6.1";
+    version = "1.6.2";
   };
   securerandom = {
     groups = [ "default" ];
@@ -4394,10 +4364,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "03vbqblwfcx4smgp040mph7az861hpnygm3yk1y8ygp5gbzc2qqw";
+      sha256 = "1yvwyfi2gxlr1rnqk2ymxpb49qk18hxshbpjvk55agz78pancib4";
       type = "gem";
     };
-    version = "0.26.6";
+    version = "0.28.1";
   };
   sequel = {
     dependencies = [ "bigdecimal" ];
@@ -4405,10 +4375,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0irbjils48r7w14jacka3l96jzh534d98vb88yj1qc9nl43r3r2g";
+      sha256 = "0gph3g9nj4cff57z6w925nlgd8wvc0mbp7xj4mf7zah4jadq288m";
       type = "gem";
     };
-    version = "5.98.0";
+    version = "5.104.0";
   };
   sequel_pg = {
     dependencies = [
@@ -4419,20 +4389,20 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1c5r1scy8dwfd8r1i37gqqrg84irs180ml8734lqrldzgyxjkxmg";
+      sha256 = "1ww2i94r8cz40b0nljgy554b60885gqxr58z3nrhlb7aqq4lsf6g";
       type = "gem";
     };
-    version = "1.17.2";
+    version = "1.19.0";
   };
   sexp_processor = {
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1l0sdr7fbr3s864z4f4irza3nh4h353j1lhm2fygf02b2902l3dg";
+      sha256 = "03igwdnh4nw1swacv7w7ql92wpx0nwv9hxg8bi35sg9mk2x4haxf";
       type = "gem";
     };
-    version = "4.17.4";
+    version = "4.17.5";
   };
   simplecov = {
     dependencies = [
@@ -4539,23 +4509,24 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1ndib94d181y5gd7qg515ralb02zri91vd3q94k21fgc4r897cd4";
+      sha256 = "1l6dvcyids2kra4sm6mkjwnsv45893hl22pvqa5b4z5gsqj04p4k";
       type = "gem";
     };
-    version = "0.4.0";
+    version = "0.5.1";
   };
   snmp = {
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "005yjb33hyz7cqrki1h6x67wdza29gjskbmdk0iw8m0hj76aql7c";
+      sha256 = "1fikr2yjkbxi6hh97706ilpqrm6xxp89d3vxc1krhzlv91q4yb74";
       type = "gem";
     };
-    version = "1.3.3";
+    version = "1.3.4";
   };
   solargraph = {
     dependencies = [
+      "ast"
       "backport"
       "benchmark"
       "diff-lcs"
@@ -4564,6 +4535,7 @@
       "kramdown-parser-gfm"
       "logger"
       "observer"
+      "open3"
       "ostruct"
       "parser"
       "prism"
@@ -4580,10 +4552,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0k52l72bv513sgzpc88shh2xfcns3z7kv8m71r1n7fjajzna18w7";
+      sha256 = "0rvj8smqbz9pnncr4j7x4zi5gjs1rww56wlxnrxdq0r8j5ryd738";
       type = "gem";
     };
-    version = "0.57.0";
+    version = "0.59.1";
   };
   sqlite3 = {
     dependencies = [ "mini_portile2" ];
@@ -4591,10 +4563,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1q92qa2yzxx01kr26q8zp22d4lxfizdwbkq0xw3jk6f01vxh7d48";
+      sha256 = "15swvvy6nk3zlv4k693dfcaah8lana180v4fan4v51kqq6wwaqb1";
       type = "gem";
     };
-    version = "2.8.0";
+    version = "2.9.4";
   };
   standard = {
     dependencies = [
@@ -4608,10 +4580,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1wpshw7v55hrh4izmaqp9f9vncj6hsf3syzkjc1ncvf2zahrh3bd";
+      sha256 = "0001x9klgvq3kj140fr3916sidpf1xplig03iwy0i4wq7pw0hjvs";
       type = "gem";
     };
-    version = "1.51.1";
+    version = "1.54.0";
   };
   standard-custom = {
     dependencies = [
@@ -4636,20 +4608,20 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "125pjbfasldlmhk2zwhh4gry4fclcbplnhyxj6da3ck1w38bf5zd";
+      sha256 = "1wp3i2f6w6vgxh5b9iq3458c4xmmviyfdrc03nar50j4pqqksj29";
       type = "gem";
     };
-    version = "1.8.0";
+    version = "1.9.0";
   };
   stringio = {
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1v74k5yw7ndikr53wgbjn6j51p83qnzqbn9z4b53r102jcx3ri4r";
+      sha256 = "1q92y9627yisykyscv0bdsrrgyaajc2qr56dwlzx7ysgigjv4z63";
       type = "gem";
     };
-    version = "3.1.8";
+    version = "3.2.0";
   };
   syntax_tree = {
     dependencies = [ "prettier_print" ];
@@ -4737,40 +4709,41 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0gcarlmpfbmqnjvwfz44gdjhcmm634di7plcx2zdgwdhrhifhqw7";
+      sha256 = "0wsy88vg2mazl039392hqrcwvs5nb9kq8jhhrrclir2px1gybag3";
       type = "gem";
     };
-    version = "1.4.0";
+    version = "1.5.0";
   };
   thrift = {
+    dependencies = [ "logger" ];
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0y2xpdpj8rm9xgx2w9l8liwb6hqcwqxnmhnhkvw15y4saabs2i3s";
+      sha256 = "0bsr123m2857gknrdc4yy6j1whgrj1y7q2nzln5k3fdpc1x6kspp";
       type = "gem";
     };
-    version = "0.22.0";
+    version = "0.23.0";
   };
   tilt = {
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0w27v04d7rnxjr3f65w1m7xyvr6ch6szjj2v5wv1wz6z5ax9pa9m";
+      sha256 = "1cvaikq1dcbfl008i16c1pi1gmdax7vfkvmhch64jdkakyk9nnqd";
       type = "gem";
     };
-    version = "2.6.1";
+    version = "2.7.0";
   };
   timeout = {
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1nqf9rg974k4bjji7aggalg8pfvbkd9hys4hv5y450jb21qgkxph";
+      sha256 = "1jxcji88mh6xsqz0mfzwnxczpg7cyniph7wpavnavfz7lxl77xbq";
       type = "gem";
     };
-    version = "0.4.4";
+    version = "0.6.1";
   };
   tiny_tds = {
     dependencies = [ "bigdecimal" ];
@@ -4778,10 +4751,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0rm9bjby47pd2y9125c9k11gc8avbc79b7l1cmn1h2rqpy80m1si";
+      sha256 = "121ncml1z2yajpqskqa050rx76gd5avsb9j791kscbsbrisi8gml";
       type = "gem";
     };
-    version = "3.3.0";
+    version = "3.4.0";
   };
   track_open_instances = {
     groups = [ "default" ];
@@ -4914,10 +4887,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1995yfjbvjlwrslq48gzzc9j0blkdzlbda9h90pjbm0yvzax55s9";
+      sha256 = "03zqn207zypycbz5m9mn7ym763wgpk7hcqbkpx02wrbm1wank7ji";
       type = "gem";
     };
-    version = "4.1.0";
+    version = "4.2.0";
   };
   unicode-name = {
     dependencies = [ "unicode-types" ];
@@ -5000,10 +4973,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "12d9n8hll67j737ym2zw4v23cn4vxyfkb6vyv1rzpwv6y6a3qbdl";
+      sha256 = "0ca1hr2rxrfw7s613rp4r4bxb454i3ylzniv9b9gxpklqigs3d5y";
       type = "gem";
     };
-    version = "1.9.1";
+    version = "1.9.2";
   };
   websocket-driver = {
     dependencies = [
@@ -5072,10 +5045,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "14k9lb9a60r9z2zcqg08by9iljrrgjxdkbd91gw17rkqkqwi1sd6";
+      sha256 = "08aq3im74b20ixmhkpi2dlgsc59231grnzljcahz4pa8y2l371yg";
       type = "gem";
     };
-    version = "0.9.37";
+    version = "0.9.43";
   };
   yard-activesupport-concern = {
     dependencies = [ "yard" ];
@@ -5104,10 +5077,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "119ypabas886gd0n9kiid3q41w76gz60s8qmiak6pljpkd56ps5j";
+      sha256 = "1ma94h606cgxri15j2yqd2dn0vw44rzs6papdv8qrmjli7rf118w";
       type = "gem";
     };
-    version = "2.7.3";
+    version = "2.8.1";
   };
   zookeeper = {
     groups = [ "default" ];


### PR DESCRIPTION
This pull request updates the `Gemfile` in `pkgs/development/ruby-modules/with-packages` to set explicit minimum version constraints for two gems. These changes are made to prevent version regressions and ensure compatibility with Nixpkgs checks, which require newer versions than the standard dependency resolution would provide.

Dependency version constraints:

* Set an explicit minimum version for the `dip` gem to `>= 8.2.5` to resolve conflicts between standard dependency resolution (which uses `dip = 8.1.0`) and Nixpkgs checks (which require `dip >= 8.2.5`).
* Set an explicit minimum version for the `json-schema` gem to `>= 5.2.2` to resolve conflicts between standard dependency resolution (which uses `json-schema = 5.1.0`) and Nixpkgs checks (which require `json-schema >= 5.2.2`).
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
