### PR TITLE
ungoogled-chromium: 148.0.7778.167-1 -> 148.0.7778.178-1

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -828,7 +828,7 @@
     }
   },
   "ungoogled-chromium": {
-    "version": "148.0.7778.167",
+    "version": "148.0.7778.178",
     "deps": {
       "depot_tools": {
         "rev": "41c40cfaec7ee3bf0423c59925d8b23982a601f1",
@@ -840,16 +840,16 @@
         "hash": "sha256-BTPD8WM1pVAMkFDlHekMdWFGyf63KdhKkKwsqikqoBQ="
       },
       "ungoogled-patches": {
-        "rev": "148.0.7778.167-1",
-        "hash": "sha256-07mzJHDgWiEQm/8pPDDzT8r+6/bh95yBrZMm2jDqCus="
+        "rev": "148.0.7778.178-1",
+        "hash": "sha256-s4zTU4rQUcrfpg7CWFdvEn3JYNqhHGsAFcYmQGS64fc="
       },
       "npmHash": "sha256-JuVcY8iFRDWcPcP4Pg+qm5rnTXkiVfNsqSkXbDWqsE8="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "65db666ac2cf205fcc36db8bb5b9cd87f94808ac",
-        "hash": "sha256-Vda6y35lHYP3xK9FT5FdsnfTtL0MiY2m/auSq6NyL0U=",
+        "rev": "d096af1c9e98c45c3596e59620622b1a049bfecb",
+        "hash": "sha256-XRalekzeALnDh9KiGqhYdhXvkGkjO3TOIZeqwpPLO+U=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -919,8 +919,8 @@
       },
       "src/third_party/angle": {
         "url": "https://chromium.googlesource.com/angle/angle.git",
-        "rev": "6c71c70ec7e838c5f1712974086c8bc33d07de14",
-        "hash": "sha256-35Zu8jSopO47pH1rNLtSq5I8QRsOkMMvTgtmD13Yw/Y="
+        "rev": "50fd896fb21cca91f325812d01d1e971593efc73",
+        "hash": "sha256-HcfKm7UQmg3wMDOytmaYzm7Z7gRdOrRoqAKaE0ZdI4E="
       },
       "src/third_party/angle/third_party/glmark2/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glmark2/glmark2",
@@ -1219,8 +1219,8 @@
       },
       "src/third_party/icu": {
         "url": "https://chromium.googlesource.com/chromium/deps/icu.git",
-        "rev": "ff7995a708a10ab44db101358083c7f74752da9f",
-        "hash": "sha256-yQ55MGzqkVkp/arTlmKqySBvQFtaPaBk9UUAFE0imhE="
+        "rev": "3859e64eed5d34544b27fbcab0ac1685ce83df3c",
+        "hash": "sha256-rNErsn11FZUh8GXAl7jK+NyLHIKrQR3LuoM1qFFGtmM="
       },
       "src/third_party/nlohmann_json/src": {
         "url": "https://chromium.googlesource.com/external/github.com/nlohmann/json.git",
@@ -1649,8 +1649,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "e38030f4228c8d1405fe105fc5feaa5173559e25",
-        "hash": "sha256-VsJpsCfDGF6rlfYQXccgF+F/pBhY/ybUa9N5HnHJ2lU="
+        "rev": "ad6e4525c418a92147c8247ef9d144ce4c242a38",
+        "hash": "sha256-+cQdsWTgIohd3yOCsNCprSr4Ctes77fWGdmPxN2tQlM="
       }
     }
   }

--- a/pkgs/applications/networking/browsers/chromium/ungoogled-flags.toml
+++ b/pkgs/applications/networking/browsers/chromium/ungoogled-flags.toml
@@ -15,3 +15,5 @@ safe_browsing_mode=0
 treat_warnings_as_errors=false
 use_official_google_api_keys=false
 use_unofficial_version_number=false
+v8_drumbrake_bounds_checks=true
+v8_enable_drumbrake=true


### PR DESCRIPTION
Same underlying changes as #522088

https://chromereleases.googleblog.com/2026/05/stable-channel-update-for-desktop_0841193308.html

This update includes 16 security fixes.

CVEs:
CVE-2026-9111 CVE-2026-9110 CVE-2026-9112 CVE-2026-9113 CVE-2026-9114
CVE-2026-9115 CVE-2026-9116 CVE-2026-9117 CVE-2026-9118 CVE-2026-9119
CVE-2026-9120 CVE-2026-9126 CVE-2026-9121 CVE-2026-9122 CVE-2026-9123
CVE-2026-9124

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
