### PR TITLE
phpantom-lsp: 0.7.0 -> 0.8.0

### DIFF
--- a/pkgs/by-name/ph/phpantom-lsp/package.nix
+++ b/pkgs/by-name/ph/phpantom-lsp/package.nix
@@ -11,14 +11,14 @@ let
   stubsSrc = fetchFromGitHub {
     owner = "JetBrains";
     repo = "phpstorm-stubs";
-    rev = "3327932472f512d2eb9e122b19702b335083fd9d";
-    hash = "sha256-WN5DAvaw4FfHBl2AqSo1OcEthUm3lOpikdB78qy3cyY=";
+    rev = "517b9ad1adaf2c5453c00ec2fbb02d192a4a9b6c";
+    hash = "sha256-IDWAuy301avfTF/E7Mby2JQQtIr/gnN5flZ3uctUpus=";
   };
 in
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "phpantom-lsp";
-  version = "0.7.0";
+  version = "0.8.0";
 
   __structuredAttrs = true;
 
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "AJenbo";
     repo = "phpantom_lsp";
     tag = finalAttrs.version;
-    hash = "sha256-ZmtOdoxXkwn2IDg7RyQ9KG0RNz5mrGDMcESfcOSR3Ig=";
+    hash = "sha256-00NAiPm3qqxyS1u1GPpJlgnBlUjDx9VmjK6oOwH8kcU=";
   };
 
   postPatch = ''
@@ -38,7 +38,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       > stubs/jetbrains/phpstorm-stubs/.commit
   '';
 
-  cargoHash = "sha256-pXP4qItYgmUXVx9XwMdS6WLVc5lP7P4VX9+0TbhYrUc=";
+  cargoHash = "sha256-FyMI8Kb3QUD8Jui9k7vayMcQC+KWL8sZi3A05NPbXsg=";
 
   checkFlags = [
     "--test"


### PR DESCRIPTION
Updated since Rust 1.95 is merged now

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
