### PR TITLE
aop: init at 0.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4542,6 +4542,12 @@
     githubId = 53847249;
     name = "Casey Avila";
   };
+  castorNova2 = {
+    email = "solemnsquire@gmail.com";
+    github = "castorNova2";
+    githubId = 84083897;
+    name = "Nidhish Chauhan";
+  };
   catap = {
     email = "kirill@korins.ky";
     github = "catap";

--- a/pkgs/by-name/ao/aop/package.nix
+++ b/pkgs/by-name/ao/aop/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  ncurses,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "aop";
+  version = "0.6";
+
+  src = fetchurl {
+    url = "https://raffi.at/code/aop/aop-${finalAttrs.version}.tar.gz";
+    hash = "sha256-aKi2uPCCFrMYldU299xL6xN6eH/RcJbaLUb9hjSX9lo=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  buildInputs = [ ncurses ];
+
+  postPatch = ''
+    substituteInPlace aop.c \
+        --replace-fail "/usr/local/share/aop" \
+                        "$out/share/aop"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 aop $out/bin/aop
+
+    install -d $out/share/aop
+
+    install -m644 *.txt $out/share/aop/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "64-line ncurses based arcade game";
+    homepage = "https://raffi.at/view/code/aop";
+    mainProgram = "aop";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ castorNova2 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Part of https://github.com/NixOS/nixpkgs/issues/380688.

Add [aop](https://raffi.at/view/code/aop) which is a tiny ncurses based arcade game written in 64 lines of C.

- Patched the hardcoded <mark>/usr/local/share/aop</mark> path for Nix compatibility.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
