### PR TITLE
python3Packages.langchain-google-genai: disable tests failing w/ google-genai >= 1.74

### DIFF
--- a/pkgs/development/python-modules/langchain-google-genai/default.nix
+++ b/pkgs/development/python-modules/langchain-google-genai/default.nix
@@ -72,7 +72,8 @@ buildPythonPackage (finalAttrs: {
 
   disabledTestPaths = [
     # AssertionError: assert {'google_maps...s': None, ...} == {'google_maps...a'...
-    "tests/unit_tests/test_chat_models.py::test_response_to_result_grounding_metadata[raw_response0-expected_grounding_metadata0]"
+    # https://github.com/langchain-ai/langchain-google/issues/1791
+    "tests/unit_tests/test_chat_models.py::test_response_to_result_grounding_metadata"
   ];
 
   pythonImportsCheck = [ "langchain_google_genai" ];


### PR DESCRIPTION
Fixes failure with google-genai >= 1.74, unblocks the update in #515940

> FAILED tests/unit_tests/test_chat_models.py::test_response_to_result_grounding_metadata[raw_response2-expected_grounding_metadata2] - AssertionError: assert {'google_maps...images'], ...} == {'google_maps...im...

`test_response_to_result_grounding_metadata` already failed with a different set of data (it's too sensitive to a specific output format), so disabled the test for all cases.

Filed https://github.com/langchain-ai/langchain-google/issues/1791

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
