### PR TITLE
build-support/vm: fix unpopulated `debsGrouped` after structuredAttrs refactor

### DIFF
--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -731,7 +731,7 @@ let
             ;
 
           debsFlat = lib.flatten debs;
-          debsGrouped = debs;
+          debsGrouped = map toString debs;
 
           preVM = createEmptyImage { inherit size fullName; };
 

--- a/pkgs/build-support/vm/test.nix
+++ b/pkgs/build-support/vm/test.nix
@@ -2,12 +2,12 @@
   hello,
   patchelf,
   pcmanfm,
+  runCommand,
   stdenv,
   vmTools,
 }:
 let
   inherit (vmTools)
-    buildRPM
     diskImages
     makeImageTestScript
     runInLinuxImage
@@ -44,6 +44,23 @@ in
       # goes out-of-memory with many cores
       enableParallelBuilding = false;
     })
+  );
+
+  # Sanity check to ensure the dpkg --install commands have run
+  checkPerlInstalledInDebian = runInLinuxImage (
+    runCommand "check-perl"
+      {
+        diskImage = diskImages.debian13x86_64;
+        diskImageFormat = "qcow2";
+        memSize = 512;
+      }
+      ''
+        echo Check if perl is present
+        perl -v
+        echo Check if perl is installed
+        dpkg -l | grep 'ii *perl'
+        mkdir $out
+      ''
   );
 
   # RPM-based distros


### PR DESCRIPTION
debsGrouped is a nested array, like `[ [ drv1 drv2 ] [ drv3 ] ... ]`. this doesn't map to any bash item, so it lives only in the json attrs.

the old code which uses `${debsGrouped[@]}` was referring to an unset variable... but the default bash behavior is to treat that as an empty array even with `set -u` so the loop was just doing nothing.

verify by building a vm (e.g.
`tests.vmTools.buildPatchelfInDebian.diskImage`) and checking the nix-log before and after for `INSTALLING COMPONENT` messages.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. (`nix-build -A vmTools.tests`)
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
