### PR TITLE
tetro-tui: init at 3.5.2

### DIFF
--- a/pkgs/by-name/te/tetro-tui/package.nix
+++ b/pkgs/by-name/te/tetro-tui/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tetro-tui";
+  version = "3.5.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Strophox";
+    repo = "tetro-tui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9UHP3mo7sEjVPtBdLgbJpW3RlyXA8zAbY20CgBVdptg=";
+  };
+
+  cargoHash = "sha256-fBbHwCnlUuas+g1dFIRmOZM+hD32tp/++k1KNEFzphY=";
+
+  meta = {
+    description = "Terminal-based but modern tetromino-stacking game that is very customizable and cross-platform";
+    homepage = "https://github.com/Strophox/tetro-tui";
+    changelog = "https://github.com/Strophox/tetro-tui/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kybe236 ];
+    mainProgram = "tetro-tui";
+  };
+})


### PR DESCRIPTION
supersedes/closes: #493620
supersedes/closes: #497257

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
