### PR TITLE
swagger-typescript-api: 13.9.1 -> 13.9.3

### DIFF
--- a/pkgs/by-name/sw/swagger-typescript-api/package.nix
+++ b/pkgs/by-name/sw/swagger-typescript-api/package.nix
@@ -9,10 +9,11 @@
 }:
 let
   pname = "swagger-typescript-api";
-  version = "13.9.1";
+  version = "13.9.3";
 
   node-modules-hash = {
-    "x86_64-linux" = "sha256-QxnqTaV5oN5WoYvLzTckWrYAZVAUxTSLYHVTmmqhmgM=";
+    "x86_64-linux" = "sha256-0jTq1Ds8CNDGOaXZlBgtl5IspoLTGzfXwOhR9MwhoYQ=";
+    "aarch64-linux" = "sha256-7hR5cS8fFN1Eb82eKF+B24FdznfQn5roRqGe9dHk5H4=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -22,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "acacode";
     repo = "swagger-typescript-api";
     rev = "v${version}";
-    hash = "sha256-PnQ2aTj8oVUqoqM9voupfBqPu7MZSVflUtuGrXznifo=";
+    hash = "sha256-Xy67aqkZAB54dz9yabJHvOLilb2C/oe8ZCprnqfBBj4=";
   };
 
   node_modules = stdenv.mkDerivation {
@@ -40,15 +41,15 @@ stdenv.mkDerivation (finalAttrs: {
     ];
 
     dontConfigure = true;
-    # Prevent patchShebangs from rewriting node_modules/.bin shebangs to store
-    # paths, which would make this fixed-output derivation's output hash unstable.
-    dontPatchShebangs = true;
+    # Skip fixup, would embed store paths or modify binaries,
+    # making this fixed-output derivation's output hash unstable.
+    dontFixup = true;
 
     buildPhase = ''
       runHook preBuild
 
       export BUN_INSTALL_CACHE_DIR=$(mktemp -d)
-      bun install --no-progress --frozen-lockfile --no-cache
+      bun install --no-progress --frozen-lockfile
 
       runHook postBuild
     '';
@@ -64,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     outputHash =
       node-modules-hash.${stdenv.hostPlatform.system}
-        or (throw "${finalAttrs.pname}: Platform ${stdenv.hostPlatform.system} is not packaged yet. Supported platforms: x86_64-linux.");
+        or (throw "${finalAttrs.pname}: Platform ${stdenv.hostPlatform.system} is not packaged yet. Supported platforms: x86_64-linux, aarch64-linux.");
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/acacode/swagger-typescript-api/compare/v13.9.1...v13.9.3

Add `aarch64-linux` support.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
