### PR TITLE
nixos/tests/systemd-xdg-autostart: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15828,6 +15828,12 @@
     githubId = 36448130;
     name = "Michael Brantley";
   };
+  limwa = {
+    name = "André Lima";
+    github = "limwa";
+    githubId = 13498603;
+    email = "me@limwa.pt";
+  };
   linbreux = {
     email = "linbreux@gmail.com";
     github = "linbreux";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1714,6 +1714,7 @@ in
   systemd-user-tmpfiles-rules = runTest ./systemd-user-tmpfiles-rules.nix;
   systemd-userdbd = runTest ./systemd-userdbd.nix;
   systemd-varlink = runTest ./systemd-varlink.nix;
+  systemd-xdg-autostart = import ./systemd-xdg-autostart.nix { inherit runTest; };
   systemtap = handleTest ./systemtap.nix { };
   szurubooru = handleTest ./szurubooru.nix { };
   taler = handleTest ./taler { };

--- a/nixos/tests/systemd-xdg-autostart.nix
+++ b/nixos/tests/systemd-xdg-autostart.nix
@@ -1,0 +1,275 @@
+{ runTest }:
+
+let
+  # Module to provide common configuration for all test configurations
+  node-common = { lib, ... }: {
+    imports = [
+      ./common/user-account.nix
+    ];
+
+    # Start a user session without a graphical environment
+    users.users.alice.linger = lib.mkForce true;
+
+    # Most tests need `xdg.autostart.enable = true;` so set it by default
+    xdg.autostart.enable = lib.mkDefault true;
+
+    # Add a target to run the autostart items
+    # From nixos/modules/services/x11/desktop-managers/none.nix
+    systemd.user.targets.run-xdg-autostart = {
+      description = "Run XDG autostart files";
+      requires = [
+        "xdg-desktop-autostart.target"
+        "graphical-session.target"
+      ];
+      before = [
+        "xdg-desktop-autostart.target"
+        "graphical-session.target"
+      ];
+      bindsTo = [ "graphical-session.target" ];
+    };
+  };
+
+  # Module to provide the test library for all test configurations
+  node-inject-test-lib = { lib, pkgs, ... }: {
+    _module.args.testLib =
+      let
+        makeAutostartItem =
+          {
+            name,
+            exec,
+          }:
+          pkgs.makeDesktopItem {
+            inherit exec;
+
+            name = "${name}-autostart-item";
+            desktopName = "XDG Autostart for ${name}";
+            terminal = false;
+            categories = [ "Utility" ];
+            destination = "/etc/xdg/autostart";
+          };
+
+        createFooFilePackage = pkgs.writeShellApplication {
+          runtimeInputs = [ pkgs.coreutils ];
+          name = "create-foo-file";
+          text = ''
+            touch "/tmp/$(whoami)-foo-file"
+          '';
+
+          passthru.autostartItems = {
+            relative = makeAutostartItem {
+              name = "create-foo-file-relative-autostart-item";
+              exec = createFooFilePackage.meta.mainProgram;
+            };
+
+            absolute = makeAutostartItem {
+              name = "create-foo-file-absolute-autostart-item";
+              exec = lib.getExe createFooFilePackage;
+            };
+          };
+        };
+      in
+      {
+        inherit
+          makeAutostartItem
+          createFooFilePackage
+          ;
+      };
+  };
+
+  common = {
+    nodeDefaults = {
+      imports = [
+        node-common
+        node-inject-test-lib
+      ];
+    };
+  };
+
+  makeTestScript =
+    script:
+    ''
+      from test_driver.errors import RequestedAssertionFailed
+
+
+      def escape_unit_id(unit_id: str) -> str:
+        return unit_id.replace("\\", "\\\\\\") if unit_id.startswith('"') and unit_id.endswith('"') else unit_id
+
+
+      def wait_for_autostart(machine: QemuMachine, user: str, timeout: int = 900):
+        """
+        Starts the run-xdg-autostart.target and waits for all of the weak
+        dependencies of the xdg-desktop-autostart.target to exit.
+        """
+
+        with machine.nested(f"waiting for autostart units to finish for user {user}"):
+          machine.wait_for_unit("multi-user.target")
+
+          machine.systemctl("start run-xdg-autostart.target", user=user)
+
+          autostart_info = machine.get_unit_info("xdg-desktop-autostart.target", user=user)
+          autostart_wants = autostart_info.get("Wants", "").split()
+
+          for unit_id in autostart_wants:
+            escaped_unit_id = escape_unit_id(unit_id)
+
+            unit_type = machine.get_unit_property(escaped_unit_id, "Type", user)
+            if unit_type != "exec":
+              raise RequestedAssertionFailed(f"Autostart unit {unit_id} is not an exec unit")
+
+            def check_exited(_last_try: bool) -> bool:
+              state = machine.get_unit_info(escaped_unit_id, user)
+              finished = state["ActiveState"] == "inactive" and "ExecMainExitTimestamp" in state
+
+              if finished and state["Result"] != "success":
+                raise RequestedAssertionFailed(f"unit {unit_id} failed with exit code {state['ExecMainStatus']}")
+
+              return finished
+
+            with machine.nested(f"waiting for unit {unit_id} to exit for user {user}"):
+              retry(check_exited, timeout)
+
+
+    ''
+    + script;
+
+in
+{
+  # Basic test to check if the autostart service is generated and executed.
+  # `Exec` uses an absolute path.
+  basic = runTest (
+    { lib, ... }:
+    {
+      name = "systemd-xdg-autostart-basic";
+      meta.maintainers = [ lib.maintainers.limwa ];
+
+      imports = [
+        common
+      ];
+
+      nodes.machine =
+        { testLib, ... }:
+        {
+          environment.systemPackages = [
+            testLib.createFooFilePackage.autostartItems.absolute
+          ];
+        };
+
+      testScript = makeTestScript ''
+        start_all()
+
+        machine.wait_for_unit("multi-user.target")
+        machine.fail("test -f /tmp/alice-foo-file")
+
+        wait_for_autostart(machine, user="alice")
+        machine.succeed("test -f /tmp/alice-foo-file")
+      '';
+    }
+  );
+
+  # Tests that the autostart desktop entry is not executed if
+  # `xdg.autostart.enable = false`.
+  disabled = runTest (
+    { lib, ... }:
+    {
+      name = "systemd-xdg-autostart-disabled";
+      meta.maintainers = [ lib.maintainers.limwa ];
+
+      imports = [
+        common
+      ];
+
+      nodes.machine =
+        { testLib, ... }:
+        {
+          xdg.autostart.enable = false;
+
+          environment.systemPackages = [
+            testLib.createFooFilePackage.autostartItems.absolute
+          ];
+        };
+
+      testScript = makeTestScript ''
+        start_all()
+
+        machine.wait_for_unit("multi-user.target")
+        machine.fail("test -f /tmp/alice-foo-file")
+
+        wait_for_autostart(machine, user="alice")
+        machine.fail("test -f /tmp/alice-foo-file")
+      '';
+    }
+  );
+
+  # Test to check if the autostart service can execute commands in the
+  # system environment. `Exec` uses the name of a command.
+  in-system-environment = runTest (
+    { lib, ... }:
+    {
+      name = "systemd-xdg-autostart-in-system-environment";
+      meta.maintainers = [ lib.maintainers.limwa ];
+
+      imports = [
+        common
+      ];
+
+      nodes.machine =
+        { testLib, ... }:
+        {
+          environment.systemPackages = [
+            testLib.createFooFilePackage
+            testLib.createFooFilePackage.autostartItems.relative
+          ];
+        };
+
+      testScript = makeTestScript ''
+        start_all()
+
+        machine.wait_for_unit("multi-user.target")
+        machine.fail("test -f /tmp/alice-foo-file")
+
+        wait_for_autostart(machine, user="alice")
+        machine.succeed("test -f /tmp/alice-foo-file")
+      '';
+    }
+  );
+
+  # Test to check if the autostart service can execute commands in the
+  # user environment. `Exec` uses the name of a command.
+  in-user-environment = runTest (
+    { lib, ... }:
+    {
+      name = "systemd-xdg-autostart-in-user-environment";
+      meta.maintainers = [ lib.maintainers.limwa ];
+
+      imports = [
+        common
+      ];
+
+      nodes.machine =
+        { testLib, ... }:
+        {
+          environment.systemPackages = [
+            testLib.createFooFilePackage.autostartItems.relative
+          ];
+
+          users.users.alice.packages = [ testLib.createFooFilePackage ];
+          users.users.bob.linger = true;
+        };
+
+      testScript = makeTestScript ''
+        start_all()
+
+        machine.wait_for_unit("multi-user.target")
+        machine.fail("test -f /tmp/alice-foo-file")
+        machine.fail("test -f /tmp/bob-foo-file")
+
+        wait_for_autostart(machine, user="alice")
+        machine.succeed("test -f /tmp/alice-foo-file")
+        machine.fail("test -f /tmp/bob-foo-file")
+
+        wait_for_autostart(machine, user="bob")
+        machine.fail("test -f /tmp/bob-foo-file")
+      '';
+    }
+  );
+}

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -785,6 +785,12 @@ stdenv.mkDerivation (finalAttrs: {
           ;
       }
       // {
+        inherit (prefixTests "systemd-xdg-autostart")
+          systemd-xdg-autostart-basic
+          systemd-xdg-autostart-in-system-environment
+          ;
+      }
+      // {
         inherit (nixosTests)
           simple-vm
           fsck-systemd-stage-1


### PR DESCRIPTION
Adds 4 new tests to prevent future regressions in systemd's xdg autostart functionalities.

### AI policy

Codex GPT-5.4 was used to understand how to use systemd to execute desktop entries in `etc/xdg/autostart` without requiring a graphical session. It pointed me to [nixos/modules/services/x11/desktop-managers/none.nix](https://github.com/NixOS/nixpkgs/blob/5acfd691d8e5d7216624f0681ba1ea057051c2cc/nixos/modules/services/x11/desktop-managers/none.nix) and `users.users.alice.linger`. The relevant commit has the appropriate `Assisted-by` trailer.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
