### PR TITLE
cargo-auditable: 0.7.2 -> 0.7.5

### DIFF
--- a/pkgs/by-name/ca/cargo-auditable/builder.nix
+++ b/pkgs/by-name/ca/cargo-auditable/builder.nix
@@ -21,6 +21,8 @@ lib.extendMkDerivation {
     {
       inherit auditable pname;
 
+      __structuredAttrs = true;
+
       src = fetchFromGitHub {
         owner = "rust-secure-code";
         repo = "cargo-auditable";

--- a/pkgs/by-name/ca/cargo-auditable/builder.nix
+++ b/pkgs/by-name/ca/cargo-auditable/builder.nix
@@ -16,6 +16,7 @@ lib.extendMkDerivation {
       auditable ? true,
       hash ? "",
       cargoHash ? "",
+      passthru ? { },
       ...
     }:
     {
@@ -47,7 +48,9 @@ lib.extendMkDerivation {
         installManPage cargo-auditable/cargo-auditable.1
       '';
 
-      passthru.bootstrap = auditable-bootstrap;
+      passthru = passthru // {
+        bootstrap = auditable-bootstrap;
+      };
 
       meta = {
         description = "Tool to make production Rust binaries auditable";

--- a/pkgs/by-name/ca/cargo-auditable/package.nix
+++ b/pkgs/by-name/ca/cargo-auditable/package.nix
@@ -2,6 +2,7 @@
   buildPackages,
   callPackage,
   makeRustPlatform,
+  nix-update-script,
 }:
 let
   # Need to use the build platform rustc and Cargo so that
@@ -32,4 +33,5 @@ in
 auditableBuilder {
   inherit version hash cargoHash;
   auditable = true;
+  passthru.updateScript = nix-update-script { };
 }

--- a/pkgs/by-name/ca/cargo-auditable/package.nix
+++ b/pkgs/by-name/ca/cargo-auditable/package.nix
@@ -18,9 +18,9 @@ let
     auditable-bootstrap = bootstrap;
   };
 
-  version = "0.7.2";
-  hash = "sha256-hR6PjTOps8JSM7UbfGlCoZmmwtWExVqYwh4lxDiFWdc=";
-  cargoHash = "sha256-JEfnUJ9J6Xak3AOCwQCnu+v+3Wl3QbXX20qVFWB6040=";
+  version = "0.7.5";
+  hash = "sha256-0VONJCv/msLcGenItWMLJ7DH79RTD6vsU9gX/nphh1g=";
+  cargoHash = "sha256-/iAYib+xDQSJ8B559/V7b994ErSUGsPSDx64jFF5B6I=";
 
   # cargo-auditable cannot be built with cargo-auditable until cargo-auditable is built
   bootstrap = auditableBuilder {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
