### PR TITLE
partydeck: init at 0.8.6

### DIFF
--- a/pkgs/by-name/ga/gamescope-kbm/package.nix
+++ b/pkgs/by-name/ga/gamescope-kbm/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  fetchFromGitHub,
+  gamescope,
+}:
+
+gamescope.overrideAttrs (
+  _finalAttrs: previousAttrs: {
+    pname = "gamescope-kbm";
+    version = "0-unstable-2026-03-11";
+
+    __structuredAttrs = true;
+
+    # This fork is pinned to a PartyDeck commit and does not follow
+    # ValveSoftware/gamescope releases.
+    # nixpkgs-update: no auto update
+    src = fetchFromGitHub {
+      owner = "partydeck";
+      repo = "gamescope";
+      rev = "074c4f6f6f07d473af995717cc647e43efef741c";
+      fetchSubmodules = true;
+      hash = "sha256-IHxM1j2HMf5hC2GjTq4fI3qs3ev/AFwP2CPcyF6203o=";
+    };
+
+    mesonFlags = previousAttrs.mesonFlags ++ [
+      (lib.mesonOption "benchmark" "disabled")
+      (lib.mesonOption "input_emulation" "disabled")
+    ];
+
+    # Reuse upstream gamescope fixups, but apply them to the renamed binary.
+    postInstall = ''
+      mv $out/bin/gamescope $out/bin/gamescope-kbm
+    ''
+    +
+      builtins.replaceStrings [ "$out/bin/gamescope" ] [ "$out/bin/gamescope-kbm" ]
+        previousAttrs.postInstall;
+
+    # Do not inherit gamescope's update script for ValveSoftware/gamescope.
+    passthru = { };
+
+    meta = previousAttrs.meta // {
+      description = "Gamescope fork with keyboard and mouse device filtering support";
+      homepage = "https://github.com/partydeck/gamescope";
+      mainProgram = "gamescope-kbm";
+      maintainers = [ lib.maintainers.imalison ];
+    };
+  }
+)

--- a/pkgs/by-name/pa/partydeck/package.nix
+++ b/pkgs/by-name/pa/partydeck/package.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  pkg-config,
+
+  bubblewrap,
+  fontconfig,
+  fuse-overlayfs,
+  gamescope-kbm,
+  libGL,
+  libx11,
+  libxcursor,
+  libxi,
+  libxkbcommon,
+  libxrandr,
+  openssl,
+  umu-launcher,
+  util-linux,
+  wayland,
+  xdg-utils,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "partydeck";
+  version = "0.8.6";
+
+  src = fetchFromGitHub {
+    owner = "partydeck";
+    repo = "partydeck";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-BLgaQxmnLaKWo/RFOCpdjwfoYnyHXxoJy1ImJU/8ceI=";
+  };
+
+  cargoHash = "sha256-pPbMKyp3e3umhVwZ7Aj3T9RUPPTdZlGYgWUjUdy2YB8=";
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    fontconfig
+    libGL
+    libx11
+    libxcursor
+    libxi
+    libxkbcommon
+    libxrandr
+    openssl
+    wayland
+  ];
+
+  runtimePath = [
+    bubblewrap
+    fuse-overlayfs
+    gamescope-kbm
+    umu-launcher
+    util-linux
+    xdg-utils
+  ];
+
+  prePatch = ''
+    substituteInPlace Cargo.toml \
+      --replace-fail 'version = "0.8.5"' 'version = "${finalAttrs.version}"'
+  '';
+
+  postPatch = ''
+    substituteInPlace src/paths.rs \
+      --replace-fail 'PathBuf::from("/usr/share/partydeck")' \
+                     'PathBuf::from("${placeholder "out"}/share/partydeck")'
+  '';
+
+  postInstall = ''
+    install -Dm644 res/*.js -t $out/share/partydeck
+    install -Dm644 res/*.png -t $out/share/partydeck
+    install -Dm755 res/GamingModeLauncher.sh -t $out/share/partydeck
+  '';
+
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    wrapProgram $out/bin/partydeck \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath finalAttrs.buildInputs}:/run/opengl-driver/lib" \
+      --prefix PATH : "${lib.makeBinPath finalAttrs.runtimePath}"
+  '';
+
+  meta = {
+    description = "Split-screen game launcher for Linux and SteamOS";
+    homepage = "https://github.com/partydeck/partydeck";
+    changelog = "https://github.com/partydeck/partydeck/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    mainProgram = "partydeck";
+    maintainers = [ lib.maintainers.imalison ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Things done

- Added `gamescope-kbm`, the PartyDeck gamescope fork with keyboard and mouse device filtering support.
- Added `partydeck` 0.8.6 and wrapped its runtime dependencies.
- Wrapped PartyDeck with `gamescope-kbm` in `PATH`; stock `gamescope` is intentionally not included in the wrapper closure.
- Patched the upstream v0.8.6 `Cargo.toml` package version from `0.8.5` to `0.8.6`; `Cargo.lock` is left unchanged so cargo vendor validation matches upstream.

## Testing

- `nixfmt pkgs/by-name/ga/gamescope-kbm/package.nix pkgs/by-name/pa/partydeck/package.nix`
- `deadnix pkgs/by-name/ga/gamescope-kbm/package.nix pkgs/by-name/pa/partydeck/package.nix`
- `statix check pkgs/by-name/ga/gamescope-kbm/package.nix pkgs/by-name/pa/partydeck/package.nix`
- `git diff --check origin/master...HEAD`
- `nix eval --impure --expr 'let pkgs = import ./. {}; in { partydeck = pkgs.partydeck.name; gamescopeKbm = pkgs.gamescope-kbm.name; hasFork = builtins.elem pkgs.gamescope-kbm pkgs.partydeck.runtimePath; hasStockGamescope = builtins.elem pkgs.gamescope pkgs.partydeck.runtimePath; }'`
- `nix-instantiate -A gamescope-kbm`
- `nix-instantiate -A partydeck`
- `nix-build -A partydeck`
- `nixpkgs-review rev HEAD -b master --no-shell --print-result`

`nixpkgs-review` result on `x86_64-linux`: 2 packages built: `gamescope-kbm`, `partydeck`.
