### PR TITLE
python3Packages.wagtail: 7.3 -> 7.4

### DIFF
--- a/pkgs/development/python-modules/django-modelcluster/default.nix
+++ b/pkgs/development/python-modules/django-modelcluster/default.nix
@@ -20,14 +20,14 @@
 
 buildPythonPackage rec {
   pname = "django-modelcluster";
-  version = "6.4.1";
+  version = "6.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "wagtail";
     repo = "django-modelcluster";
     tag = "v${version}";
-    hash = "sha256-LVCYjbKN53740hr5Tl0JRbx17g35fnauZHIKQNkb5Kc=";
+    hash = "sha256-jIEiwWuC+sudUHsHuG975nxrlC2yKZN/QjdvMKEeL6s=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/wagtail-localize/default.nix
+++ b/pkgs/development/python-modules/wagtail-localize/default.nix
@@ -25,14 +25,14 @@
 
 buildPythonPackage rec {
   pname = "wagtail-localize";
-  version = "1.13";
+  version = "1.13.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     repo = "wagtail-localize";
     owner = "wagtail";
     tag = "v${version}";
-    hash = "sha256-JhLfrK4CBdTR85JuAjf9vGByQVgCIYT3IrM6AYxxNTE=";
+    hash = "sha256-iJwX/N8/aaAjinU1htVasp88fuuZCOomVPgJ1Ymxre4=";
   };
 
   build-system = [ flit-core ];
@@ -56,11 +56,11 @@ buildPythonPackage rec {
     google-cloud-translate
   ];
 
+  # See https://github.com/wagtail/wagtail-localize/issues/922
+  patches = [ ./failing-test.patch ];
+
   checkPhase = ''
     runHook preCheck
-
-    # test_translate_html fails with later Beautifulsoup releases
-    rm wagtail_localize/machine_translators/tests/test_dummy_translator.py
 
     ${python.interpreter} testmanage.py test
 

--- a/pkgs/development/python-modules/wagtail-localize/failing-test.patch
+++ b/pkgs/development/python-modules/wagtail-localize/failing-test.patch
@@ -1,0 +1,19 @@
+diff --git a/wagtail_localize/tests/test_edit_translation.py b/wagtail_localize/tests/test_edit_translation.py
+index 4bbe5a1..033b6bf 100644
+--- a/wagtail_localize/tests/test_edit_translation.py
++++ b/wagtail_localize/tests/test_edit_translation.py
+@@ -1,5 +1,6 @@
+ import json
+ import tempfile
++import unittest
+ import uuid
+ 
+ from unittest.mock import patch
+@@ -1718,6 +1719,7 @@ def test_cant_edit_snippet_translation_without_perms(self):
+             "Sorry, you do not have permission to access this area.\n\n\n\n\n",
+         )
+ 
++    @unittest.skip
+     def test_edit_nested_snippet_translation(self):
+         for permission in Permission.objects.filter(
+             content_type=ContentType.objects.get_for_model(Header)

--- a/pkgs/development/python-modules/wagtail/default.nix
+++ b/pkgs/development/python-modules/wagtail/default.nix
@@ -37,14 +37,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "wagtail";
-  version = "7.3";
+  version = "7.4.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "wagtail";
     repo = "wagtail";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-o/4jn32ffR3BPVNwtFKJ6PowXYi7SpjBqghdeZIl5tM=";
+    hash = "sha256-+Ar8lg340rafaRNgcohEBuloU/dJC+ODTzAMmrPS/PU=";
   };
 
   nativeBuildInputs = [
@@ -54,7 +54,7 @@ buildPythonPackage (finalAttrs: {
 
   npmDeps = fetchNpmDeps {
     inherit (finalAttrs) src;
-    hash = "sha256-Uc16K1RZUCnr4qRe2u4yB44F+zYFBxMpEQCz5992RMA=";
+    hash = "sha256-Z2VOMqsNIBybJpfYxAq2dkmS2vwd8Yuhu7MCFyqNxdI=";
   };
 
   preBuild = ''


### PR DESCRIPTION
* https://github.com/wagtail/django-modelcluster/releases/tag/v6.5
* https://github.com/wagtail/wagtail-localize/releases/tag/v1.13.1
* https://github.com/wagtail/wagtail/releases

Fixes https://github.com/NixOS/nixpkgs/issues/519386, https://github.com/NixOS/nixpkgs/issues/519382, https://github.com/NixOS/nixpkgs/issues/519367, https://github.com/NixOS/nixpkgs/issues/519360, https://github.com/NixOS/nixpkgs/issues/497291 and https://github.com/NixOS/nixpkgs/issues/497641 .

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
