### PR TITLE
john-data: init at 1.9.0-Jumbo-1-unstable-2026-06-07

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16633,6 +16633,12 @@
     githubId = 1433367;
     name = "Marc Fontaine";
   };
+  mag1cbyt3s = {
+    email = "ppeinecke@protonmail.com";
+    github = "Mag1cByt3s";
+    githubId = 48777549;
+    name = "MagicBytes";
+  };
   magicquark = {
     name = "magicquark";
     github = "magicquark";

--- a/pkgs/by-name/jo/john-data/package.nix
+++ b/pkgs/by-name/jo/john-data/package.nix
@@ -1,0 +1,192 @@
+{
+  lib,
+  stdenvNoCC,
+  john,
+  python3Packages,
+  perl,
+  perlPackages,
+  makeWrapper,
+}:
+
+let
+  # Perl modules the .pl helpers need at runtime. Kept in a binding so the same
+  # list feeds both propagatedBuildInputs and the PERL5LIB the wrappers bake in.
+  # The latter is built explicitly with makeFullPerlPath because strictDeps keeps
+  # propagated host deps out of the build-time $PERL5LIB.
+  perlModules = with perlPackages; [
+    # For pass_gen.pl and netntlm.pl
+    DigestMD4
+    GetoptLong
+    # For 7z2john.pl
+    CompressRawLzma
+    # For sha-dump.pl
+    perlldap
+  ];
+in
+# The interpreted *2john conversion scripts shipped with John the Ripper, split
+# out of the core `john` package (which only carries the binary and the compiled
+# C helpers). This mirrors the john / john-data split done by Debian and Kali and
+# keeps the large python/perl runtime closure these scripts need out of `john`.
+stdenvNoCC.mkDerivation {
+  pname = "john-data";
+  inherit (john) version src;
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    python3Packages.wrapPython
+    perl
+    makeWrapper
+  ];
+
+  propagatedBuildInputs =
+    (with python3Packages; [
+      # For pcap2john.py and radius2john.py
+      dpkt
+      scapy
+      # For krb2john.py
+      lxml
+      # For pdf2john.py
+      pyhanko
+      # For pem2john.py and pfx2john.py
+      asn1crypto
+      # For fvde2john.py (also needs pytsk3, not packaged in nixpkgs)
+      cryptography
+      # For DPAPImk2john.py, keplr2john.py, telegram2john.py, zed2john.py
+      pycryptodome
+      # For ccache2john.py, kirbi2john.py
+      pyasn1
+      # For coinomi2john.py and multibit2john.py — they import generated
+      # `protobuf.coinomi_pb2` / `protobuf.wallet_pb2` modules from the bundled
+      # run/protobuf/ tree installed below; the runtime needs google.protobuf
+      # (provided by python3Packages.protobuf).
+      protobuf
+      # For cardano2john.py
+      cbor2
+      # For ejabberd2john.py
+      parsimonious
+      # For 1password2john.py, bitwarden2john.py, ethereum2john.py,
+      # padlock2john.py and electrum2john.py
+      simplejson
+      # For sspr2john.py
+      ldap3
+      # For office2john.py — upstream PR #5931 dropped the bundled olefile copy,
+      # so it is now an external dependency.
+      olefile
+      # For pcap2john.py (the DNS/TACACS+ code path)
+      dnspython
+      # For bitwarden2john.py
+      plyvel
+      # For keplr2john.py (it reads Chrome LevelDB via the bundled
+      # ccl_chrome_indexeddb tree installed below)
+      scrypt
+    ])
+    ++ perlModules;
+  # Not packaged in nixpkgs, so the corresponding scripts cannot run:
+  #   bitcoin2john.py -> bsddb3
+  #   fvde2john.py    -> pytsk3
+  #   pse2john.py     -> pysap
+  #   itunes_backup2john.pl, lion2john-alt.pl -> Data::Plist
+  #   sha-test.pl     -> SHA (legacy module; a dev test script, not a converter)
+  # defusedexpat (signal2john.py, sspr2john.py) is also unpackaged, but those
+  # scripts fall back to the stdlib expat, so they still work.
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  postPatch = ''
+    # Rewrite the bundled john.conf .include paths to absolute store paths so
+    # rulestack.pl (via jtrconf.pm) can resolve them.
+    sed -ri -e '/^\.include/ {
+      s!\$JOHN!'"$out"'/etc/john!
+      s!^(\.include\s*)<([^./]+\.conf)>!\1"'"$out"'/etc/john/\2"!
+    }' run/*.conf
+    # atmail2john.pl: portable shebang.
+    substituteInPlace run/atmail2john.pl \
+      --replace-fail '#!/usr/bin/perl' '#!/usr/bin/env perl'
+    # leet.pl: pin perl directly so the `-l` flag survives patchShebangs
+    # (env can't pass multi-word args reliably).
+    substituteInPlace run/leet.pl \
+      --replace-fail '#! /usr/bin/perl -l' '#!${perl}/bin/perl -l'
+    # jtrconf.pm looks for john.conf next to itself; point it at $out/etc/john.
+    # Also stop it from prepending './' to .include paths we've rewritten to
+    # absolute store paths.
+    substituteInPlace run/jtrconf.pm \
+      --replace-fail "dirname(__FILE__).'/'" "'$out/etc/john/'" \
+      --replace-fail "\$dirname = './';" "\$dirname = substr(\$inc_name, 0, 1) eq '/' ? ''' : './';"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/bin" "$out/etc/john" "$out/share/john/rules" "$out/${perlPackages.perl.libPrefix}"
+
+    # The interpreted *2john conversion scripts. pkcs12kdf.py has no shebang and
+    # is imported by zed2john.py; it is copied as a plain module (not wrapped).
+    # aix2john.pl, pdf2john.pl and radius2john.pl are skipped — they are
+    # superseded by the equivalent aix2john.py / pdf2john.py / radius2john.py.
+    find -L run -mindepth 1 -maxdepth 1 -type f -executable \
+      \( -name '*.py' -o -name '*.pl' \) \
+      ! -name 'aix2john.pl' ! -name 'pdf2john.pl' ! -name 'radius2john.pl' \
+      -exec cp -d {} "$out/bin" \;
+
+    # config + rules so rulestack.pl can resolve john.conf's rule includes.
+    cp -t "$out/etc/john" run/*.conf
+    cp -t "$out/share/john/rules" run/rules/*.rule
+    # john.conf has `.include <rules/foo.rule>` resolved against $out/etc/john;
+    # the actual rule files live under share/john.
+    ln -s "$out/share/john/rules" "$out/etc/john/rules"
+
+    # Perl helper modules used by the .pl scripts (ExifTool.pm, PDF.pm, … and
+    # jtrconf.pm).
+    cp -t "$out/${perlPackages.perl.libPrefix}" run/lib/* run/jtrconf.pm
+
+    # Bundled support trees the scripts import/read relative to their own
+    # location (sys.argv[0] / sys.path). The wrapped scripts live in $out/bin,
+    # so these must sit alongside them:
+    #   protobuf/            -> coinomi2john.py, multibit2john.py (from protobuf.*_pb2)
+    #   ccl_chrome_indexeddb/ -> keplr2john.py (from ccl_chrome_indexeddb import …)
+    #   bip-0039/            -> tezos2john.py (BIP-39 wordlist data dir)
+    cp -r run/protobuf run/ccl_chrome_indexeddb run/bip-0039 "$out/bin/"
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapPythonPrograms
+
+    for i in "$out"/bin/*.pl; do
+      wrapProgram "$i" \
+        --prefix PATH : "${lib.makeBinPath [ perl ]}" \
+        --prefix PERL5LIB : "${perlPackages.makeFullPerlPath perlModules}:$out/${perlPackages.perl.libPrefix}"
+    done
+
+    # The bundled protobuf/*_pb2.py modules were generated against an older
+    # protoc; force the pure-Python implementation so they load against the
+    # current python3Packages.protobuf.
+    for i in "$out"/bin/coinomi2john.py "$out"/bin/multibit2john.py; do
+      wrapProgram "$i" --set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION python
+    done
+  '';
+
+  meta = {
+    description = "Conversion scripts and data files for John the Ripper";
+    longDescription = ''
+      The architecture-independent *2john conversion scripts that ship with John
+      the Ripper (jumbo), packaged separately from the core `john` package. These
+      Python and Perl helpers extract crackable hashes from a wide range of file
+      formats and applications (PDF, SSH keys, office documents, wallets, …) for
+      use with `john`. Split out so the core `john` package does not pull in the
+      large python/perl runtime closure they depend on.
+    '';
+    homepage = "https://github.com/openwall/john/";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [
+      mag1cbyt3s
+      cherrykitten
+      therealhammer
+    ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/by-name/jo/john/package.nix
+++ b/pkgs/by-name/jo/john/package.nix
@@ -4,24 +4,17 @@
   fetchFromGitHub,
   unstableGitUpdater,
   openssl,
-  nss,
-  nspr,
-  libkrb5,
   gmp,
   zlib,
   libpcap,
-  re2,
-  gcc,
-  python3Packages,
+  python3,
   perl,
-  perlPackages,
   withOpenCL ? true,
   opencl-headers,
   ocl-icd,
   # include non-free ClamAV unrar code
   enableUnfree ? false,
   replaceVars,
-  makeWrapper,
 }:
 
 stdenv.mkDerivation {
@@ -70,63 +63,37 @@ stdenv.mkDerivation {
 
   buildInputs = [
     openssl
-    nss
-    nspr
-    libkrb5
     gmp
     zlib
     libpcap
-    re2
   ]
   ++ lib.optionals withOpenCL [
     opencl-headers
     ocl-icd
   ];
   nativeBuildInputs = [
-    gcc
-    python3Packages.wrapPython
-    perl
-    makeWrapper
+    python3 # for opencl_generate_dynamic_loader.py
+    perl # detected by configure; gates the crypt(3) format
   ];
-  propagatedBuildInputs =
-    # For pcap2john.py
-    (with python3Packages; [
-      dpkt
-      scapy
-      lxml
-    ])
-    ++ (with perlPackages; [
-      # For pass_gen.pl
-      DigestMD4
-      DigestSHA1
-      GetoptLong
-      # For 7z2john.pl
-      CompressRawLzma
-      # For sha-dump.pl
-      perlldap
-    ]);
-  # TODO: Get dependencies for radius2john.pl and lion2john-alt.pl
 
   enableParallelBuilding = true;
 
   postInstall = ''
-    mkdir -p "$out/bin" "$out/etc/john" "$out/share/john" "$out/share/doc/john" "$out/share/john/rules" "$out/share/john/opencl" "$out/${perlPackages.perl.libPrefix}"
+    mkdir -p "$out/bin" "$out/etc/john" "$out/share/john" "$out/share/doc/john" "$out/share/john/rules" "$out/share/john/opencl"
+    # Install the john binary and the compiled C *2john helpers only. The
+    # interpreted *.py / *.pl conversion scripts are shipped separately in the
+    # `john-data` package, since they pull in a large python/perl closure.
     find -L ../run -mindepth 1 -maxdepth 1 -type f -executable \
+      ! -name '*.py' ! -name '*.pl' \
       -exec cp -d {} "$out/bin" \;
     cp -vt "$out/etc/john" ../run/*.conf
     cp -vt "$out/share/john" ../run/*.chr ../run/password.lst
     cp -vt "$out/share/john/rules" ../run/rules/*.rule
     cp -vt "$out/share/john/opencl" ../run/opencl/*.cl ../run/opencl/*.h
     cp -vLrt "$out/share/doc/john" ../doc/*
-    cp -vt "$out/${perlPackages.perl.libPrefix}" ../run/lib/*
-  '';
-
-  postFixup = ''
-    wrapPythonPrograms
-
-    for i in $out/bin/*.pl; do
-      wrapProgram "$i" --prefix PERL5LIB : "$PERL5LIB:$out/${perlPackages.perl.libPrefix}"
-    done
+    # john.conf has `.include <rules/foo.rule>` resolved against
+    # $out/etc/john; the actual rule files live under share/john.
+    ln -s "$out/share/john/rules" "$out/etc/john/rules"
   '';
 
   passthru.updateScript = unstableGitUpdater {
@@ -143,6 +110,7 @@ stdenv.mkDerivation {
     maintainers = with lib.maintainers; [
       cherrykitten
       therealhammer
+      mag1cbyt3s
     ];
     platforms = lib.platforms.unix;
   };


### PR DESCRIPTION
New package: **`john-data`** - the architecture-independent `*2john` conversion scripts that ship with John the Ripper (jumbo), split out of the core `john` package. Mirrors the `john` / `john-data` split done by Debian and [Kali](https://www.kali.org/tools/john/), and implements review feedback on #521623.

`john` keeps the binary and the compiled C helpers; `john-data` ships the interpreted Python/Perl `*2john` helpers (plus the config/rules data and bundled support trees they need) and the python/perl runtime closure they require. It reuses `john`'s `src`/`version` (single source of truth, so it stays in sync on updates) and only copies and wraps the scripts - there is no compilation.

Rebased onto current `master` after #530092; inherits `john`'s updated source (`1.9.0-Jumbo-1-unstable-2026-06-07`).

**Dependencies** were audited against the actual imports of every script at the pinned revision (upstream's `run/requirements.txt` is incomplete - e.g. it omits `dnspython`/`plyvel`/`scrypt`). Beyond the long-standing set this wires up `parsimonious`, `simplejson`, `ldap3`, `olefile` (upstream [PR #5931](https://github.com/openwall/john/pull/5931) dropped the bundled `olefile` copy), `dnspython`, `plyvel` and `scrypt`, and installs the bundled support trees scripts load relative to themselves: `protobuf/` (coinomi/multibit), `ccl_chrome_indexeddb/` (keplr - self-contained, bundles a pure-Python snappy), and `bip-0039/` (tezos wordlist data).

`aix2john.pl`, `pdf2john.pl` and `radius2john.pl` are skipped in favour of the equivalent `aix2john.py` / `pdf2john.py` / `radius2john.py`.

A handful of scripts remain non-functional only because their dependencies are not packaged in nixpkgs (`pysap` -> `pse2john.py`; `pytsk3` -> `fvde2john.py`; `bsddb3` -> `bitcoin2john.py`; `Data::Plist` -> `itunes_backup2john.pl`/`lion2john-alt.pl`; `SHA` -> `sha-test.pl`) - unchanged from the pre-split behaviour.

Related: #81418 (NixOS for pentesting).

> [!IMPORTANT]
> Stacked on #521623. The first commits here belong to that PR and drop out once it merges - **please merge #521623 first**, then this rebases onto `master`.

Verified: `nix-build -A john-data --no-out-link` succeeds (no compilation; scripts copied + wrapped); `nix-build -A john --no-out-link` still succeeds with no python/perl in its runtime closure. A run of every helper confirms only the unpackaged-dependency scripts above fail to load; everything else (including `pcap2john.py`, `keplr2john.py`, `bitwarden2john.py` and `tezos2john.py`) resolves its imports and data.

_Disclosure: this PR was prepared with AI assistance, per the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy); all changes were reviewed and verified by the maintainer._

## Things done

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Ran `nixpkgs-review` on this PR.
- [x] Fits `CONTRIBUTING.md`, `pkgs/README.md`, `maintainers/README.md` and other READMEs.
- [x] Follows the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy).
