### PR TITLE
cryptop: migrate to pyproject

### DIFF
--- a/pkgs/by-name/cr/cryptop/package.nix
+++ b/pkgs/by-name/cr/cryptop/package.nix
@@ -6,14 +6,16 @@
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "cryptop";
   version = "0.2.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
     sha256 = "0akrrz735vjfrm78plwyg84vabj0x3qficq9xxmy9kr40fhdkzpb";
   };
 
-  propagatedBuildInputs = with python3Packages; [
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [
     setuptools
     requests
     requests-cache

--- a/pkgs/by-name/cr/cryptop/package.nix
+++ b/pkgs/by-name/cr/cryptop/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   python3Packages,
-  fetchPypi,
+  fetchFromGitHub,
 }:
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "cryptop";
@@ -9,9 +9,11 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pyproject = true;
   __structuredAttrs = true;
 
-  src = fetchPypi {
-    inherit (finalAttrs) pname version;
-    sha256 = "0akrrz735vjfrm78plwyg84vabj0x3qficq9xxmy9kr40fhdkzpb";
+  src = fetchFromGitHub {
+    owner = "huwwp";
+    repo = "cryptop";
+    tag = "v.${finalAttrs.version}";
+    hash = "sha256-lrHTtTQJ9Zuspt+LRT9WjmCruhwms6FUM3EFo6PZ26A=";
   };
 
   build-system = with python3Packages; [ setuptools ];
@@ -22,7 +24,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     requests-cache
   ];
 
-  # No tests in archive
+  # No tests
   doCheck = false;
 
   meta = {

--- a/pkgs/by-name/cr/cryptop/package.nix
+++ b/pkgs/by-name/cr/cryptop/package.nix
@@ -7,6 +7,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pname = "cryptop";
   version = "0.2.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
