### PR TITLE
msedit: 1.2.1 -> 2.0.0

### DIFF
--- a/pkgs/by-name/ms/msedit/package.nix
+++ b/pkgs/by-name/ms/msedit/package.nix
@@ -4,25 +4,44 @@
   rustPlatform,
   fetchFromGitHub,
   versionCheckHook,
+  desktopToDarwinBundle,
+  copyDesktopItems,
+  iconConvTools,
+  installShellFiles,
   nix-update-script,
   icu,
 }:
+let
+  # Needs a hardcoded SONAME for some reason.
+  icuMaj = lib.versions.major icu.version;
+
+  # The library path needed to run properly
+  rpathAppend = lib.makeLibraryPath [ icu ];
+in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "msedit";
-  version = "1.2.1";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "edit";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Sb73awgdajBKKW0QIpmKF6g9mIIS/1f0a6D/jQulnUM=";
+    hash = "sha256-9HoK5i0IimujfTQxDplBNJRO7qmD/S+SnLLnR95RHiQ=";
   };
 
-  cargoHash = "sha256-U8U70nzTmpY6r8J661EJ4CGjx6vWrGovu5m25dvz5sY=";
+  __structuredAttrs = true;
+
+  cargoHash = "sha256-r7AR6Mf13UUeooPV5/8gyp7HvmOeSaOJNotWWqU10SQ=";
 
   # Requires nightly features
   env = {
-    RUSTC_BOOTSTRAP = 1;
+    EDIT_CFG_ICUI18N_SONAME = "libicui18n.so.${icuMaj}";
+    EDIT_CFG_ICUUC_SONAME = "libicuuc.so.${icuMaj}";
+    EDIT_CFG_ICU_RENAMING_VERSION = icuMaj;
+
+    # For checkPhase to work
+    LD_LIBRARY_PATH = rpathAppend;
+
     # Without -headerpad, the following error occurs on x86_64-darwin
     # error: install_name_tool: changing install names or rpaths can't be redone for: ... because larger updated load commands do not fit (the program must be relinked, and you may need to use -headerpad or -headerpad_max_install_names)
     NIX_LDFLAGS = toString (
@@ -32,26 +51,40 @@ rustPlatform.buildRustPackage (finalAttrs: {
     );
   };
 
+  nativeBuildInputs = [
+    copyDesktopItems
+    iconConvTools
+    installShellFiles
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    desktopToDarwinBundle
+  ];
+
   buildInputs = [
     icu
   ];
 
+  desktopItems = [
+    "assets/com.microsoft.edit.desktop"
+  ];
+
   # https://github.com/microsoft/edit/blob/f8bea2be191d00baa2a4551817541ea3f8c5b03e/src/icu.rs#L834
   # Required for Ctrl+F searching to work
-  postFixup =
-    let
-      rpathAppend = lib.makeLibraryPath [ icu ];
-    in
-    lib.optionalString stdenv.hostPlatform.isElf ''
-      patchelf $out/bin/edit \
-        --add-rpath ${rpathAppend}
-    ''
-    + lib.optionalString stdenv.hostPlatform.isDarwin ''
-      ${stdenv.cc.targetPrefix}install_name_tool -add_rpath ${rpathAppend} $out/bin/edit
-    '';
+  postFixup = ''
+    icoFileToHiColorTheme assets/edit.ico edit "$out"
+    install -Dm444 assets/edit.svg "$out/share/icons/hicolor/scalable/apps/edit.svg"
 
-  # Disabled for now, microsoft/edit#194
-  doInstallCheck = false;
+    installManPage assets/manpage/edit.1
+  ''
+  + lib.optionalString stdenv.hostPlatform.isElf ''
+    patchelf $out/bin/edit \
+      --add-rpath ${rpathAppend}
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    ${stdenv.cc.targetPrefix}install_name_tool -add_rpath ${rpathAppend} $out/bin/edit
+  '';
+
+  doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgram = "${placeholder "out"}/bin/edit";
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

No longer requires nightly features. But now the build system is super jank, so instead of just letting it searching via rpath or LD_LIBRARY the SONAME as it did before, the SONAME must be hardcoded at build-time.

Also adds a desktop file, icons, and a manpage.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
