### PR TITLE
python3Packages.tpm2-pytss: fix build with cryptography 47

### DIFF
--- a/pkgs/development/python-modules/tpm2-pytss/default.nix
+++ b/pkgs/development/python-modules/tpm2-pytss/default.nix
@@ -45,6 +45,13 @@ buildPythonPackage rec {
       url = "https://github.com/tpm2-software/tpm2-pytss/commit/6ab4c74e6fb3da7cd38e97c1f8e92532312f8439.patch";
       hash = "sha256-01Qe4qpD2IINc5Z120iVdPitiLBwdr8KNBjLFnGgE7E=";
     })
+    # support cryptography >= 47.0.0, which made __deepcopy__ an abstract
+    # method on the private-key base classes
+    # https://github.com/tpm2-software/tpm2-pytss/pull/689
+    (fetchpatch {
+      url = "https://github.com/tpm2-software/tpm2-pytss/commit/5d15cad4bde28902a4becb8e2a8e915aba8abbd0.patch";
+      hash = "sha256-b2zVD7KJGVzJ765HO8LFAe9MyQmjOTpERmEqUrIg3oM=";
+    })
     # Properly restore environment variables upon exit from
     # FAPIConfig context. Accepted into upstream, not yet released.
     (fetchpatch2 {


### PR DESCRIPTION
cryptography 47.0.0 made `__deepcopy__` an abstract method on the `RSAPrivateKey` and `EllipticCurvePrivateKey` base classes, which tpm2-pytss subclasses. tpm2-pytss 2.3.0 only implements `__copy__`, so its tpm_rsa_private_key / tpm_ecc_private_key classes can no longer be instantiated, failing 33 tests in the check phase.

Backported a minimal upstream fix, which adds `__deepcopy__` delegating to `__copy__`. It's the first commit in this PR:

- https://github.com/tpm2-software/tpm2-pytss/pull/689

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
