### PR TITLE
fail2ban: switch to pyproject

### DIFF
--- a/pkgs/by-name/fa/fail2ban/package.nix
+++ b/pkgs/by-name/fa/fail2ban/package.nix
@@ -13,6 +13,9 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   version = "1.1.0";
   pyproject = true;
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   src = fetchFromGitHub {
     owner = "fail2ban";
     repo = "fail2ban";

--- a/pkgs/by-name/fa/fail2ban/package.nix
+++ b/pkgs/by-name/fa/fail2ban/package.nix
@@ -112,6 +112,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   meta = {
     homepage = "https://www.fail2ban.org/";
     description = "Program that scans log files for repeated failing login attempts and bans IP addresses";
+    changelog = "https://github.com/fail2ban/fail2ban/blob/${finalAttrs.src.tag}/ChangeLog";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
       Deric-W

--- a/pkgs/by-name/fa/fail2ban/package.nix
+++ b/pkgs/by-name/fa/fail2ban/package.nix
@@ -11,12 +11,12 @@
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "fail2ban";
   version = "1.1.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "fail2ban";
     repo = "fail2ban";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-0xPNhbu6/p/cbHOr5Y+PXbMbt5q/S13S5100ZZSdylE=";
   };
 
@@ -35,16 +35,16 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     (builtins.any lib.id)
   ]) [ "doc" ];
 
+  build-system = [ python3.pkgs.setuptools ];
+
   nativeBuildInputs = [ installShellFiles ];
 
-  pythonPath =
+  dependencies =
     with python3.pkgs;
-    lib.optionals stdenv.hostPlatform.isLinux [
+    [ distutils ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
       systemd-python
       pyinotify
-
-      # https://github.com/fail2ban/fail2ban/issues/3787, remove it in the next release
-      setuptools
     ];
 
   preConfigure = ''


### PR DESCRIPTION
Related to #515974

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
