### PR TITLE
nocturne: init at 1.1.1

### DIFF
--- a/pkgs/by-name/no/nocturne/package.nix
+++ b/pkgs/by-name/no/nocturne/package.nix
@@ -1,0 +1,96 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  blueprint-compiler,
+  wrapGAppsHook4,
+  gettext,
+  desktop-file-utils,
+  appstream,
+  glib,
+  glib-networking,
+  pkg-config,
+  cmake,
+  gtk4,
+  python3,
+  python3Packages,
+  libadwaita,
+  gobject-introspection,
+  libsecret,
+  gst_all_1,
+  xdg-user-dirs,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nocturne";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "Jeffser";
+    repo = "Nocturne";
+    tag = finalAttrs.version;
+    hash = "sha256-7B9wtuxfsF6brtLkIEeWII4IvXwdJHnZ1Wr3uLfoqHU=";
+  };
+
+  __structuredAttrs = true;
+
+  dontUseCmakeConfigure = true;
+
+  strictDeps = true;
+  nativeBuildInputs = [
+    meson
+    ninja
+    blueprint-compiler
+    gobject-introspection
+    wrapGAppsHook4
+    gettext # for msgfmt
+    desktop-file-utils # for desktop-file-validate
+    appstream
+    glib
+    pkg-config
+    cmake
+    gtk4
+    python3
+  ];
+
+  buildInputs = [
+    gtk4
+    libadwaita
+    libsecret
+    python3
+    glib-networking
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+  ];
+
+  pythonDependencies = [
+    python3Packages.pygobject3
+    python3Packages.tinytag
+    python3Packages.requests
+    python3Packages.syncedlyrics
+    python3Packages.pycairo
+    python3Packages.colorthief
+    python3Packages.favicon
+    python3Packages.mpris-server
+    python3Packages.pillow
+  ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : ${lib.makeBinPath [ xdg-user-dirs ]}
+      --prefix PYTHONPATH : ${python3.pkgs.makePythonPath finalAttrs.pythonDependencies}
+    )
+  '';
+
+  meta = {
+    description = "Adwaita Music Player and Library Manager";
+    homepage = "https://jeffser.com/nocturne/";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ pbsds ];
+    mainProgram = "nocturne";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/development/python-modules/mpris-server/default.nix
+++ b/pkgs/development/python-modules/mpris-server/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  emoji,
+  pydbus,
+  pygobject3,
+  unidecode,
+  setuptools,
+  strenum,
+}:
+buildPythonPackage rec {
+  pname = "mpris-server";
+  version = "0.9.6";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "mpris_server";
+    inherit version;
+    hash = "sha256-T0ZeDQiYIAhKR8aw3iv3rtwzc+R0PTQuIh6+Hi4rIHQ=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    emoji
+    pydbus
+    pygobject3
+    strenum
+    unidecode
+  ];
+
+  pythonImportsCheck = [ "mpris_server" ];
+
+  # upstream has no tests
+  doCheck = false;
+
+  meta = {
+    description = "Publish a MediaPlayer2 MPRIS device to D-Bus";
+    homepage = "https://pypi.org/project/mpris-server/";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ quadradical ];
+  };
+}

--- a/pkgs/development/python-modules/mpris-server/default.nix
+++ b/pkgs/development/python-modules/mpris-server/default.nix
@@ -9,16 +9,23 @@
   setuptools,
   strenum,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "mpris-server";
   version = "0.9.6";
   pyproject = true;
 
   src = fetchPypi {
     pname = "mpris_server";
-    inherit version;
+    inherit (finalAttrs) version;
     hash = "sha256-T0ZeDQiYIAhKR8aw3iv3rtwzc+R0PTQuIh6+Hi4rIHQ=";
   };
+
+  postPatch = ''
+    substituteInPlace mpris_server/__init__.py \
+      --replace-fail \
+        "__version__: Final[str] = '0.9.0'" \
+        "__version__: Final[str] = '${finalAttrs.version}'"
+  '';
 
   build-system = [ setuptools ];
 
@@ -39,6 +46,6 @@ buildPythonPackage rec {
     description = "Publish a MediaPlayer2 MPRIS device to D-Bus";
     homepage = "https://pypi.org/project/mpris-server/";
     license = lib.licenses.agpl3Only;
-    maintainers = with lib.maintainers; [ quadradical ];
+    maintainers = with lib.maintainers; [ pbsds ];
   };
-}
+})

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -346,7 +346,6 @@ mapAliases {
   monarchmoney = throw "'monarchmoney' has been renamed to/replaced by 'monarchmoneycommunity'"; # Added 2026-03-05
   monkeytype = throw "'monkeytype' has been removed as it was unmaintained upstream"; # Added 2026-04-19
   moretools = "'moretools' has been removed because it is unmaintained"; # Added 2026-01-19
-  mpris-server = throw "mpris-server was removed because it is unused"; # added 2025-10-31
   msldap-bad = throw "'msldap-bad' has been renamed to/replaced by 'badldap'"; # added 2025-11-06
   mullvad-closest = throw "'mullvad-closest' has been removed as it was unmaintained. Consider using 'mullvad-compass' instead."; # Added 2026-01-13
   multi_key_dict = throw "'multi_key_dict' has been renamed to/replaced by 'multi-key-dict'"; # Converted to throw 2025-10-29

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10397,6 +10397,8 @@ self: super: with self; {
 
   mpris-api = callPackage ../development/python-modules/mpris-api { };
 
+  mpris-server = callPackage ../development/python-modules/mpris-server { };
+
   mprisify = callPackage ../development/python-modules/mprisify { };
 
   mpv = callPackage ../development/python-modules/mpv { inherit (pkgs) mpv; };


### PR DESCRIPTION
* **Revert "python3Packages.mpris-server: drop"**
* **python3Packages.mpris-server: adopt, fixup**
* **nocturne: init at 1.1.1**


<img width="2120" height="1460" alt="image" src="https://github.com/user-attachments/assets/d6fe07e6-d077-4990-9615-8c6e57bf4e44" />


Tried to package this earlier, but i was blocked waiting for the gnome updates in staging-next

homepages:

* https://jeffser.com/nocturne/
* https://github.com/Jeffser/Nocturne

announcements:

* https://thisweek.gnome.org//posts/2026/05/twig-248/
* https://www.phoronix.com/news/Nocturne-1.0-GNOME-Music

prior art:

* https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=nocturne
* closes https://github.com/NixOS/nixpkgs/pull/509384
* https://forge.kruemmelspalter.org/communix/nur-packages/src/branch/main/pkgs/nocturne/default.nix


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
