### PR TITLE
word-search-generator: init at 3.2.4

### DIFF
--- a/pkgs/by-name/wo/word-search-generator/package.nix
+++ b/pkgs/by-name/wo/word-search-generator/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "word-search-generator";
+  version = "3.2.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "thelabcat";
+    repo = "word-search-generator";
+    rev = "v${version}";
+    hash = "sha256-sImBEPJBXTA+l8+dRKOtPf8THm/sX7mp9J3fsIIYhYY=";
+  };
+
+  build-system = with python3.pkgs; [
+    hatchling
+  ];
+
+  dependencies = with python3.pkgs; [
+    numpy
+    pyside6
+    tkinter
+  ];
+
+  meta = {
+    description = "Create your own word search puzzles automatically from a list of words";
+    homepage = "https://github.com/thelabcat/word-search-generator";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ chkno ];
+    mainProgram = "wordsearchgen";
+  };
+
+  __structuredAttrs = true;
+}


### PR DESCRIPTION
New package

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
