### PR TITLE
luaPackages.osenv: init at 1.1.2

### DIFF
--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -5065,6 +5065,41 @@ final: prev: {
     }
   ) { };
 
+  osenv = callPackage (
+    {
+      buildLuarocksPackage,
+      fetchurl,
+      fetchzip,
+      luaOlder,
+    }:
+    buildLuarocksPackage {
+      pname = "osenv";
+      version = "1.1.2-1";
+      knownRockspec =
+        (fetchurl {
+          url = "mirror://luarocks/osenv-1.1.2-1.rockspec";
+          sha256 = "1sss100xvwzxlblsbyhqxszgy9b1q1j07cvykd4khiy31pdsa1c1";
+        }).outPath;
+      src = fetchzip {
+        url = "https://github.com/BirdeeHub/lua-osenv/archive/v1.1.2.zip";
+        sha256 = "0rd795hplg52wllx39iykg3hjyrg48kfx4dvcc4zzna912qzsbca";
+      };
+
+      disabled = luaOlder "5.1";
+
+      meta = {
+        homepage = "https://github.com/BirdeeHub/lua-osenv";
+        license.fullName = "MIT";
+        maintainers = [ lib.maintainers.birdee ];
+        description = "Manage lua process environment, vim.env polyfill with extra features";
+        longDescription = ''
+          os.getenv gets values from the process environment.
+          But how do you set them?
+          require('osenv').MY_VAR = "MY_VALUE"'';
+      };
+    }
+  ) { };
+
   papis-nvim = callPackage (
     {
       buildLuarocksPackage,

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -1010,6 +1010,19 @@ in
     '';
   };
 
+  osenv = prev.osenv.overrideAttrs (old: {
+    # compiled C module needs to be built before checks can be ran
+    checkPhase = ''
+      runHook preCheck
+      runHook postCheck
+    '';
+    installCheckPhase = ''
+      runHook preInstallCheck
+      luarocks test
+      runHook postInstallCheck
+    '';
+  });
+
   plenary-nvim = prev.plenary-nvim.overrideAttrs {
     postPatch = ''
       sed -Ei lua/plenary/curl.lua \


### PR DESCRIPTION
A `vim.env` polyfill with extra features, single C file lua module, supporting linux, mac, and windows.

Because there is no builtin `os.setenv`, nor one to get the whole env (without pulling `luaposix` or `luv`), and to make a `vim.env` polyfill you would otherwise have to wrap one of those.

https://github.com/BirdeeHub/lua-osenv

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
