### PR TITLE
angle: fix issue with string interpolation of pkg-config file

### DIFF
--- a/pkgs/by-name/an/angle/package.nix
+++ b/pkgs/by-name/an/angle/package.nix
@@ -146,18 +146,18 @@ stdenv.mkDerivation (finalAttrs: {
 
     mkdir -p $out/lib/pkgconfig
 
-    cat > $out/lib/pkgconfig/angle.pc <<EOF
-    prefix=${placeholder "out"}
-    exec_prefix=''${prefix}
-    libdir=''${prefix}/lib
-    includedir=''${prefix}/include
+    cat <<EOF > $out/lib/pkgconfig/angle.pc
+    prefix=$out
+    exec_prefix=$out
+    libdir=$out/lib
+    includedir=$out/include
 
     Name: angle
     Description: ${finalAttrs.meta.description}
 
     URL: ${finalAttrs.meta.homepage}
     Version: ${lib.versions.major finalAttrs.version}
-    Libs: -L''${libdir} -l${
+    Libs: -L$out/lib -l${
       lib.concatStringsSep " -l" [
         "EGL"
         "EGL_vulkan_secondaries"
@@ -169,7 +169,7 @@ stdenv.mkDerivation (finalAttrs: {
         "feature_support"
       ]
     }
-    Cflags: -I''${includedir}
+    Cflags: -I$out/include
     EOF
 
     runHook postInstall


### PR DESCRIPTION
Made sure that every path is "hard-coded" in the generated `$out/lib/pkgconfig/angle.pc` instead of relying on file variables. It seems to fix the issue pointed out on #522377.

Took some inspiration from the following file:
https://github.com/NixOS/nixpkgs/blob/22b5577ab32f946edde57fb119c503e13634f2b4/pkgs/by-name/ra/raygui/package.nix#L19-L38

Fixes #522377

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
