### PR TITLE
pijuice: fix build

### DIFF
--- a/pkgs/development/python-modules/pijuice/default.nix
+++ b/pkgs/development/python-modules/pijuice/default.nix
@@ -43,18 +43,14 @@ buildPythonPackage rec {
 
   # Remove the following files from the package:
   #
-  # pijuice_cli - A precompiled ELF binary that is a setuid wrapper for calling
-  #               pijuice_cli.py
-  #
-  # pijuiceboot - a precompiled ELF binary for flashing firmware. Not needed for
-  #               the python library.
+  # pijuiceboot{32,64} - precompiled ELF binaries for flashing firmware.
+  #                      Not needed for the python library.
   #
   # pijuice_sys.py - A program that acts as a system daemon for monitoring the
   #                  pijuice.
-  preFixup = ''
-    rm $out/bin/pijuice_cli
+  postFixup = ''
     rm $out/bin/pijuice_sys.py
-    rm $out/bin/pijuiceboot
+    rm $out/bin/pijuiceboot{32,64}
     mv $out/bin/pijuice_cli.py $out/bin/pijuice_cli
   '';
 


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/516381
- https://nfd.1l.is/?selected=python313Packages.pijuice

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
