### PR TITLE
Update supabase py 2.31.0

### DIFF
--- a/pkgs/development/python-modules/postgrest/default.nix
+++ b/pkgs/development/python-modules/postgrest/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "postgrest";
-  version = "2.29.0";
+  version = "2.31.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "supabase";
     repo = "supabase-py";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-LaSlAYFvx/HHdfmc9J+KScVQ9JFGS98Yfihzn8F7t3g=";
+    hash = "sha256-cdsxB42X9nJeDElOI20jaWRKOrpNYwY2sB4vty8yYUM=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/src/postgrest";

--- a/pkgs/development/python-modules/realtime/default.nix
+++ b/pkgs/development/python-modules/realtime/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "realtime";
-  version = "2.29.0";
+  version = "2.31.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "supabase";
     repo = "supabase-py";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-LaSlAYFvx/HHdfmc9J+KScVQ9JFGS98Yfihzn8F7t3g=";
+    hash = "sha256-cdsxB42X9nJeDElOI20jaWRKOrpNYwY2sB4vty8yYUM=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/src/realtime";

--- a/pkgs/development/python-modules/storage3/default.nix
+++ b/pkgs/development/python-modules/storage3/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "storage3";
-  version = "2.29.0";
+  version = "2.31.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "supabase";
     repo = "supabase-py";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-LaSlAYFvx/HHdfmc9J+KScVQ9JFGS98Yfihzn8F7t3g=";
+    hash = "sha256-cdsxB42X9nJeDElOI20jaWRKOrpNYwY2sB4vty8yYUM=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/src/storage";

--- a/pkgs/development/python-modules/supabase-auth/default.nix
+++ b/pkgs/development/python-modules/supabase-auth/default.nix
@@ -14,14 +14,14 @@
 }:
 buildPythonPackage (finalAttrs: {
   pname = "supabase-auth";
-  version = "2.29.0";
+  version = "2.31.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "supabase";
     repo = "supabase-py";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-LaSlAYFvx/HHdfmc9J+KScVQ9JFGS98Yfihzn8F7t3g=";
+    hash = "sha256-cdsxB42X9nJeDElOI20jaWRKOrpNYwY2sB4vty8yYUM=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/src/auth";

--- a/pkgs/development/python-modules/supabase-functions/default.nix
+++ b/pkgs/development/python-modules/supabase-functions/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "supabase-functions";
-  version = "2.29.0";
+  version = "2.31.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "supabase";
     repo = "supabase-py";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-LaSlAYFvx/HHdfmc9J+KScVQ9JFGS98Yfihzn8F7t3g=";
+    hash = "sha256-cdsxB42X9nJeDElOI20jaWRKOrpNYwY2sB4vty8yYUM=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/src/functions";

--- a/pkgs/development/python-modules/supabase/default.nix
+++ b/pkgs/development/python-modules/supabase/default.nix
@@ -18,14 +18,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "supabase";
-  version = "2.29.0";
+  version = "2.31.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "supabase";
     repo = "supabase-py";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-LaSlAYFvx/HHdfmc9J+KScVQ9JFGS98Yfihzn8F7t3g=";
+    hash = "sha256-cdsxB42X9nJeDElOI20jaWRKOrpNYwY2sB4vty8yYUM=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/src/supabase";


### PR DESCRIPTION
Updates the Supabase Python client stack to **v2.31.0**

Changelog:
- https://github.com/supabase/supabase-py/blob/v2.31.0/CHANGELOG.md
- https://github.com/supabase/supabase-py/releases/tag/v2.31.0

## Things done

- Built on platform:
  - [x] x86_64-linux (NixOS)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.

  Commands run:
  - `nix build -L .#python3Packages.postgrest`
  - `nix build -L .#python3Packages.supabase`
  - `nix build -L .#python3Packages.realtime`
  - `nix build -L .#python3Packages.storage3`
  - `nix build -L .#python3Packages.supabase-auth`
  - `nix build -L .#python3Packages.supabase-functions`

- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.