### PR TITLE
macaulay2: change issue, add note

### DIFF
--- a/pkgs/by-name/ma/macaulay2/package.nix
+++ b/pkgs/by-name/ma/macaulay2/package.nix
@@ -155,6 +155,7 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace Macaulay2/packages/DeterminantalRepresentations.m2 \
       --replace-fail "eps = 1e-15" "eps = 1e-14"
   ''
+  # TODO remove in v1.26.06 (see https://github.com/Macaulay2/M2/pull/4334)
   # ForeignFunctions.m2 uses `brew --prefix` to discover potential library paths,
   # which fails when Homebrew is not installed.
   # We patch it to return an empty path instead, which should be harmless
@@ -172,7 +173,7 @@ stdenv.mkDerivation (finalAttrs: {
   configureFlags = [
     "--disable-download"
     "--enable-shared"
-    "--with-issue=nixos"
+    "--with-issue=Nix"
     "--with-boost-libdir=${boost}/lib"
     "--with-system-libs"
     "CPPFLAGS=-I${lib.getDev cddlib}/include/cddlib"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
The configure script for Macaulay2 takes an `--issue` tag that is useful for identifying certain characteristics during the build and in the `M2` shell (via `version#issue`).  I had this as `nixos` (from the first build), but `Nix` is a more accurate descriptor (especially if Nix exceptions need to be carved out in upstream in the future).

I also added a note that a specific fix can be removed shortly in `v1.26.06` (see upstream [#4334](https://github.com/Macaulay2/M2/pull/4334)).

In summary, no major changes, but a couple of small ones.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
