### PR TITLE
exegol: relax requests

### DIFF
--- a/pkgs/by-name/ex/exegol/package.nix
+++ b/pkgs/by-name/ex/exegol/package.nix
@@ -24,6 +24,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "requests"
     "rich"
     "supabase"
+    "cryptography"
   ];
 
   dependencies =


### PR DESCRIPTION
Exegol would not build because of this deps:
```
       > Successfully built exegol-5.1.10-py3-none-any.whl
       > Finished creating a wheel...
       > /build/source/dist /build/source
       > Unpacking to: unpacked/exegol-5.1.10...OK
       > Repacking wheel as ./exegol-5.1.10-py3-none-any.whl...OK
       > /build/source
       > Finished executing pypaBuildPhase
       > Running phase: pythonRuntimeDepsCheckHook
       > Executing pythonRuntimeDepsCheck
       > Checking runtime dependencies for exegol-5.1.10-py3-none-any.whl
       >   - cryptography~=46.0.3 not satisfied by version 48.0.0
       For full logs, run:
         nix log /nix/store/bv3i3lzc4nldib03q3ajabxg1xn2nhd1-exegol-5.1.10.drv
```

So I relaxed the deps

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
