### PR TITLE
python3Packages.pytensor: 3.1.3 -> 3.2.3; python3Packages.pymc: 6.1.0 -> 6.2.0

### DIFF
--- a/pkgs/development/python-modules/pymc/default.nix
+++ b/pkgs/development/python-modules/pymc/default.nix
@@ -22,7 +22,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pymc";
-  version = "6.1.0";
+  version = "6.2.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -30,7 +30,7 @@ buildPythonPackage (finalAttrs: {
     owner = "pymc-devs";
     repo = "pymc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-veJ42myRo23JXh33qC1OXxiGVI0VAARuYKVs7ObFr+Q=";
+    hash = "sha256-90Ui3hiLzU0apYq6YNuAYbqd2JOZ3J7XMh+Lu+C729w=";
   };
 
   build-system = [
@@ -38,6 +38,10 @@ buildPythonPackage (finalAttrs: {
     versioneer
   ];
 
+  pythonRelaxDeps = [
+    "cachetools"
+    "pytensor"
+  ];
   dependencies = [
     arviz
     cachetools

--- a/pkgs/development/python-modules/pytensor/default.nix
+++ b/pkgs/development/python-modules/pytensor/default.nix
@@ -33,7 +33,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pytensor";
-  version = "3.1.3";
+  version = "3.2.3";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -44,7 +44,7 @@ buildPythonPackage (finalAttrs: {
     postFetch = ''
       sed -i 's/git_refnames = "[^"]*"/git_refnames = " (tag: ${finalAttrs.src.tag})"/' $out/pytensor/_version.py
     '';
-    hash = "sha256-9Apjyg+wmAWrK7hMSF54b1u/3TT0GGitDlyF6rQA4OY=";
+    hash = "sha256-SyBI0EZoCKl1DcM2M6Jh/VKwJTlSyLCB2v2rq/7T/u4=";
   };
 
   # DeprecationWarning: scipy.linalg: the `lwork` keyword is deprecated and no longer in use as of
@@ -179,13 +179,6 @@ buildPythonPackage (finalAttrs: {
     # Don't run the most compute-intense tests
     "tests/scan/"
     "tests/tensor/"
-
-    # The IndexedElemwise fusion is intentionally disabled on the 3.0.x line
-    # (it can trigger a RecursionError, see the comment in
-    # pytensor/tensor/rewriting/indexed_elemwise.py), but these tests still
-    # assert that the fusion produces an IndexedElemwise node. Upstream test bug.
-    "tests/link/numba/test_indexed_elemwise.py"
-    "tests/benchmarks/test_gather_fusion.py"
   ];
 
   passthru.updateScript = nix-update-script {

--- a/pkgs/development/python-modules/pytensor/default.nix
+++ b/pkgs/development/python-modules/pytensor/default.nix
@@ -60,6 +60,9 @@ buildPythonPackage (finalAttrs: {
     versioneer
   ];
 
+  pythonRelaxDeps = [
+    "numba"
+  ];
   dependencies = [
     cons
     etuples


### PR DESCRIPTION
## Things done

- **python3Packages.pytensor: relax numba**
- **python3Packages.pytensor: 3.1.3 -> 3.2.3**
  - Diff: https://github.com/pymc-devs/pytensor/compare/rel-3.1.3...rel-3.2.3
  - Changelog: https://github.com/pymc-devs/pytensor/releases/tag/rel-3.2.3
- **python3Packages.pymc: 6.1.0 -> 6.2.0**
  - Diff: https://github.com/pymc-devs/pymc/compare/v6.1.0...v6.2.0
  - Changelog: https://github.com/pymc-devs/pymc/releases/tag/v6.2.0

cc @nidabdella

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test