### PR TITLE
wealthfolio-server: init at 3.5.2, nixos/wealthfolio: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16408,6 +16408,12 @@
     githubId = 115777584;
     name = "Lutz Berger";
   };
+  luuumine = {
+    email = "nix@luuumine.com";
+    github = "luuumine";
+    githubId = 55056797;
+    name = "Romain Delhommais";
+  };
   lux = {
     email = "lux@lux.name";
     github = "luxzeitlos";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1805,6 +1805,7 @@
   ./services/web-apps/umami.nix
   ./services/web-apps/vikunja.nix
   ./services/web-apps/wakapi.nix
+  ./services/web-apps/wealthfolio.nix
   ./services/web-apps/weblate.nix
   ./services/web-apps/websurfx.nix
   ./services/web-apps/whitebophir.nix

--- a/nixos/modules/services/web-apps/wealthfolio.nix
+++ b/nixos/modules/services/web-apps/wealthfolio.nix
@@ -1,0 +1,184 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.wealthfolio;
+in
+{
+  options.services.wealthfolio = {
+    enable = lib.mkEnableOption "Wealthfolio personal investment tracker";
+    package = lib.mkPackageOption pkgs "wealthfolio-server" { };
+
+    address = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      description = "The IP address the Wealthfolio server binds to.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 8088;
+      description = "The port the Wealthfolio server listens on.";
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether to automatically open the specified port in the system firewall.";
+    };
+
+    secretKeyFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = lib.literalExpression "config.age.secrets.wealthfolio-key.path";
+      description = ''
+        Path to a file containing the 32-byte secret key used for encrypting sensitive data
+        at rest (broker credentials, API keys) and signing JWT tokens.
+
+        Generate with: `openssl rand -base64 32`.
+
+        Note: Losing this key means losing access to all stored encrypted secrets.
+        There is no recovery.
+      '';
+    };
+
+    authPasswordHashFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = lib.literalExpression "config.age.secrets.wealthfolio-hash.path";
+      description = ''
+        Path to a file containing the Argon2id PHC string defining the login password.
+        Required for web access unless `authRequired` is false.
+
+        Generate with: `printf 'your-password' | argon2 yoursalt16chars! -id -e`
+      '';
+    };
+
+    authRequired = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Whether to require internal authentication.
+
+        Security Note: The server panics at startup if the listener is bound to a
+        non-loopback address and authentication is disabled. Set this to `false`
+        only if a reverse proxy handles authentication for you.
+      '';
+    };
+
+    corsAllowOrigins = lib.mkOption {
+      type = lib.types.str;
+      default = "*";
+      example = "https://wealthfolio.example.com";
+      description = ''
+        Comma-separated list of allowed CORS origins.
+
+        Security Note: The server panics at startup if `*` is used while authentication
+        is enabled, as this is a CSRF vector. Set explicit origins matching your
+        deployment URL (scheme + host + port).
+      '';
+    };
+
+    authTokenTtlMinutes = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 60;
+      description = "JWT access token lifetime in minutes. (e.g., 1440 for 24h, 10080 for 7d).";
+    };
+
+    cookieSecure = lib.mkOption {
+      type = lib.types.enum [
+        "auto"
+        "true"
+        "false"
+      ];
+      default = "auto";
+      description = ''
+        Controls the Secure attribute on the authentication session cookie.
+        - auto: Sets Secure based on HTTPS protocol.
+        - true: Always sets Secure (Use behind a reverse proxy that terminates HTTPS).
+        - false: Never sets Secure (Not recommended).
+      '';
+    };
+
+    requestTimeoutMs = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 300000;
+      description = "HTTP request timeout in milliseconds. Default (5m) accommodates large broker syncs.";
+    };
+
+    logFormat = lib.mkOption {
+      type = lib.types.enum [
+        "text"
+        "json"
+      ];
+      default = "text";
+      description = "Log output format. `json` is recommended if shipping to log aggregators.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    networking.firewall.allowedTCPPorts = lib.optional cfg.openFirewall cfg.port;
+
+    assertions = [
+      {
+        assertion = cfg.secretKeyFile != null;
+        message = "services.wealthfolio: secretKeyFile must be provided.";
+      }
+      {
+        assertion = cfg.authRequired -> cfg.authPasswordHashFile != null;
+        message = "services.wealthfolio: authPasswordHashFile must be provided when authRequired is true.";
+      }
+      {
+        assertion = cfg.authRequired -> cfg.corsAllowOrigins != "*";
+        message = "services.wealthfolio: corsAllowOrigins cannot be '*' when authRequired is true. Provide an explicit domain.";
+      }
+    ];
+
+    systemd.services.wealthfolio = {
+      description = "Wealthfolio server service daemon.";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      environment = {
+        WF_LISTEN_ADDR = "${cfg.address}:${toString cfg.port}";
+        WF_DB_PATH = "/var/lib/wealthfolio/wealthfolio.db";
+        WF_AUTH_REQUIRED = lib.boolToString cfg.authRequired;
+        WF_CORS_ALLOW_ORIGINS = cfg.corsAllowOrigins;
+        WF_AUTH_TOKEN_TTL_MINUTES = toString cfg.authTokenTtlMinutes;
+        WF_COOKIE_SECURE = cfg.cookieSecure;
+        WF_REQUEST_TIMEOUT_MS = toString cfg.requestTimeoutMs;
+        WF_LOG_FORMAT = cfg.logFormat;
+      };
+
+      script = ''
+        ${lib.optionalString (
+          cfg.secretKeyFile != null
+        ) "export WF_SECRET_KEY=$(<\"$CREDENTIALS_DIRECTORY/secret_key\")"}
+        ${lib.optionalString (
+          cfg.authPasswordHashFile != null
+        ) "export WF_AUTH_PASSWORD_HASH=$(<\"$CREDENTIALS_DIRECTORY/auth_hash\")"}
+
+        exec ${lib.getExe cfg.package}
+      '';
+
+      serviceConfig = {
+        LoadCredential =
+          lib.optional (cfg.secretKeyFile != null) "secret_key:${cfg.secretKeyFile}"
+          ++ lib.optional (cfg.authPasswordHashFile != null) "auth_hash:${cfg.authPasswordHashFile}";
+
+        DynamicUser = true;
+        StateDirectory = "wealthfolio";
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+      };
+    };
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [ luuumine ];
+  };
+}

--- a/pkgs/by-name/we/wealthfolio-server/package.nix
+++ b/pkgs/by-name/we/wealthfolio-server/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  fetchPnpmDeps,
+  stdenv,
+  pnpm_10,
+  pnpmConfigHook,
+  nodejs,
+  makeWrapper,
+}:
+
+rustPlatform.buildRustPackage (
+  finalAttrs:
+  let
+    frontendPname = "wealthfolio-frontend";
+
+    frontend = stdenv.mkDerivation {
+      pname = frontendPname;
+      inherit (finalAttrs) version src;
+
+      __structuredAttrs = true;
+      strictDeps = true;
+
+      pnpmDeps = fetchPnpmDeps {
+        pname = frontendPname;
+        inherit (finalAttrs) version src;
+
+        pnpm = pnpm_10;
+        fetcherVersion = 3;
+        hash = "sha256-Pt8eDb7tCTM1YD/7I8Ot9+fNzsvpcPfhWsniRD5OjcU=";
+      };
+
+      nativeBuildInputs = [
+        nodejs
+        pnpm_10
+        pnpmConfigHook
+      ];
+
+      buildPhase = ''
+        export BUILD_TARGET=web
+        pnpm --filter frontend... build
+      '';
+
+      installPhase = ''
+        mkdir -p $out
+        cp -R dist/* $out/
+      '';
+
+      inherit (finalAttrs) meta;
+    };
+  in
+  {
+    __structuredAttrs = true;
+
+    pname = "wealthfolio-server";
+    version = "3.5.2";
+
+    src = fetchFromGitHub {
+      owner = "wealthfolio";
+      repo = "wealthfolio";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-WU87VmnbzUno1CmIVwBLYjmTZybM4qSuRmBH/2n/Tfo=";
+    };
+
+    cargoRoot = ".";
+    buildAndTestSubdir = "apps/server";
+    cargoHash = "sha256-KoS2EouZ0Uf3cijUUOpwYBYEjEB5VxIArU1CuCji2+I=";
+
+    nativeBuildInputs = [ makeWrapper ];
+
+    postInstall = ''
+      mkdir -p $out/share/wealthfolio/dist
+
+      cp -R ${frontend}/* $out/share/wealthfolio/dist/
+
+      wrapProgram $out/bin/wealthfolio-server \
+        --set WF_STATIC_DIR "$out/share/wealthfolio/dist"
+    '';
+
+    meta = {
+      description = "Self-hosted web app for Wealthfolio";
+      homepage = "https://wealthfolio.app/";
+      changelog = "https://github.com/wealthfolio/wealthfolio/tag/${finalAttrs.src.tag}";
+      mainProgram = "wealthfolio-server";
+      license = lib.licenses.agpl3Only;
+      maintainers = with lib.maintainers; [ luuumine ];
+      platforms = lib.platforms.linux;
+    };
+  }
+)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This pull request adds [wealthfolio-server](https://wealthfolio.app/docs/guide/self-hosting/), the self-hosted server for [wealthfolio](https://wealthfolio.app/docs/guide/self-hosting/), at its version 3.5.2.
The wealthfolio client is already available as a [package](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/we/wealthfolio/package.nix). The self-hosted server comes comes with a web-app allowing users to access their data over the web instead of needing a local app.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files (wealthfolio-server).
- [X] Tested the module (service starts, web ui accessible, assertions pass).
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [X] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Everything should work correctly. This is my first contribution to nixpkgs so please tell me if I need to add more tests or assertions or documentation. I'd be happy to fix any issue you might find.

cc: @kilianar as the maintainer of the original wealthfolio (the client) package.