### PR TITLE
python3Packages.pytorch-lightning: fix hash

### DIFF
--- a/pkgs/development/python-modules/lightning/default.nix
+++ b/pkgs/development/python-modules/lightning/default.nix
@@ -12,6 +12,7 @@
 buildPythonPackage {
   pname = "lightning";
   pyproject = true;
+  __structuredAttrs = true;
 
   inherit (pytorch-lightning)
     version

--- a/pkgs/development/python-modules/pytorch-lightning/default.nix
+++ b/pkgs/development/python-modules/pytorch-lightning/default.nix
@@ -26,6 +26,7 @@ buildPythonPackage (finalAttrs: {
   pname = "pytorch-lightning";
   version = "2.6.4";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "Lightning-AI";

--- a/pkgs/development/python-modules/pytorch-lightning/default.nix
+++ b/pkgs/development/python-modules/pytorch-lightning/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage (finalAttrs: {
     owner = "Lightning-AI";
     repo = "pytorch-lightning";
     tag = finalAttrs.version;
-    hash = "sha256-zOSV2X3yZy0uh1lJ2yNl/hHBvfIDcIrATHtiRwThsQA=";
+    hash = "sha256-Qysnr76OCO9eZzhQW5EoGT2hUAYGw/qY+j6dF8XCXC4=";
   };
 
   env.PACKAGE_NAME = "pytorch";


### PR DESCRIPTION
## Things done

Upstream keeps force-pushing times.
Summoning @dotlambda to eventually merge this PR and yell at them.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
