### PR TITLE
sjmcl: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18933,6 +18933,12 @@
     githubId = 93703653;
     name = "Marko Müller";
   };
+  mx6436 = {
+    email = "mx6436@foxmail.com";
+    github = "mx6436";
+    githubId = 96968598;
+    name = "Ming Xin";
+  };
   mxkrsv = {
     email = "mxkrsv@disroot.org";
     github = "mxkrsv";

--- a/pkgs/by-name/sj/sjmcl-unwrapped/package.nix
+++ b/pkgs/by-name/sj/sjmcl-unwrapped/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenv,
+  cargo-tauri,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  nodejs,
+  npmHooks,
+  pkg-config,
+  rustPlatform,
+  webkitgtk_4_1,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "sjmcl-unwrapped";
+  version = "1.1.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "UNIkeEN";
+    repo = "SJMCL";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-cwZRQjSo5lzSjX2lpLhcSuvdiTLhMTcXQhnk340+0yY=";
+  };
+
+  npmDeps = fetchNpmDeps {
+    name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
+    inherit (finalAttrs) src;
+    hash = "sha256-r4W4gjx0Y8o7iR1ififDATgZmpXhNRksgkCLd8iOJXI=";
+  };
+
+  cargoHash = "sha256-jUebQ3uIoe7mT8fRqEsofq1sxT8EBRB3CUJ2Ac6XEt8=";
+  cargoRoot = "src-tauri";
+
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+  cargoTestFlags = [
+    # skip doctests (doc examples are not compilable code)
+    "--lib"
+    "--bins"
+    "--tests"
+  ];
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    nodejs
+    npmHooks.npmConfigHook
+    pkg-config
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    webkitgtk_4_1
+  ];
+
+  meta = {
+    description = "Open source Minecraft launcher designed by SJTU Minecraft Club";
+    homepage = "https://mc.sjtu.cn/sjmcl";
+    changelog = "https://github.com/UNIkeEN/SJMCL/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ mx6436 ];
+    mainProgram = "SJMCL";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})

--- a/pkgs/by-name/sj/sjmcl/package.nix
+++ b/pkgs/by-name/sj/sjmcl/package.nix
@@ -1,0 +1,126 @@
+{
+  addDriverRunpath,
+  alsa-lib,
+  desktop-file-utils,
+  flite,
+  gamemode,
+  glfw3-minecraft,
+  glib-networking,
+  jdk17,
+  jdk21,
+  jdk25,
+  jdk8,
+  lib,
+  libGL,
+  libjack2,
+  libpulseaudio,
+  libusb1,
+  libx11,
+  libxcursor,
+  libxext,
+  libxrandr,
+  libxxf86vm,
+  openal,
+  pciutils,
+  pipewire,
+  sjmcl-unwrapped,
+  stdenv,
+  symlinkJoin,
+  udev,
+  vulkan-loader,
+  wrapGAppsHook3,
+  xrandr,
+
+  additionalLibs ? [ ],
+  additionalPrograms ? [ ],
+  jdks ? [
+    jdk25
+    jdk21
+    jdk17
+    jdk8
+  ],
+}:
+
+let
+
+  runtimeLibs = [
+    # openal
+    alsa-lib
+    libjack2
+    libpulseaudio
+    openal
+    pipewire
+
+    # glfw
+    glfw3-minecraft
+    libGL
+    libx11
+    libxcursor
+    libxext
+    libxrandr
+    libxxf86vm
+
+    addDriverRunpath.driverLink
+    flite # narrator support
+    gamemode.lib # gamemode support
+    glib-networking # Tauri
+    (lib.getLib stdenv.cc.cc) # lwjgl
+    libusb1 # controller support
+    udev # oshi
+    vulkan-loader # VulkanMod's lwjgl
+  ]
+  ++ additionalLibs;
+
+  runtimePrograms = [
+    desktop-file-utils # Tauri
+    pciutils # need lspci
+    xrandr # needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
+  ]
+  ++ additionalPrograms;
+
+in
+
+symlinkJoin {
+  pname = "sjmcl";
+  inherit (sjmcl-unwrapped) version;
+
+  paths = [ sjmcl-unwrapped ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    wrapGAppsHook3
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    glib-networking
+  ];
+
+  postBuild = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : ${lib.makeBinPath jdks}
+      ${lib.optionalString stdenv.hostPlatform.isLinux ''
+        --set-default APPIMAGE SJMCL
+        --set LD_LIBRARY_PATH ${lib.makeLibraryPath runtimeLibs}
+        --prefix PATH : ${lib.makeBinPath runtimePrograms}
+      ''}
+    )
+
+    glibPostInstallHook
+    gappsWrapperArgsHook
+    wrapGAppsHook
+  '';
+
+  meta = {
+    inherit (sjmcl-unwrapped.meta)
+      description
+      homepage
+      changelog
+      license
+      maintainers
+      mainProgram
+      platforms
+      ;
+  };
+}


### PR DESCRIPTION
adds [sjmcl](https://github.com/UNIkeEN/SJMCL), a cross-platform minecraft launcher built on the Tauri framework

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
