### PR TITLE
python3Packages.orbax-checkpoint: 0.11.39 -> 0.11.40

### DIFF
--- a/pkgs/development/python-modules/orbax-checkpoint/default.nix
+++ b/pkgs/development/python-modules/orbax-checkpoint/default.nix
@@ -15,6 +15,7 @@
   jax,
   msgpack,
   numpy,
+  prometheus-client,
   protobuf,
   psutil,
   pyyaml,
@@ -24,21 +25,24 @@
   uvloop,
 
   # tests
+  aiosqlite,
   chex,
   fastapi,
   google-cloud-logging,
+  greenlet,
   httpx,
   mock,
   optax,
   portpicker,
   pytestCheckHook,
   safetensors,
+  sqlalchemy,
   torch,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "orbax-checkpoint";
-  version = "0.11.39";
+  version = "0.11.40";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -46,7 +50,7 @@ buildPythonPackage (finalAttrs: {
     owner = "google";
     repo = "orbax";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-KrehggcpKqMd51SdEo3uzYyvH8M15tmECHzvGLBhD/4=";
+    hash = "sha256-Z1T1mt12kdY6EMY+95m12kW9nHcGj77f87i4PY9ibBU=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/checkpoint";
@@ -61,6 +65,7 @@ buildPythonPackage (finalAttrs: {
     jax
     msgpack
     numpy
+    prometheus-client
     protobuf
     psutil
     pyyaml
@@ -73,19 +78,28 @@ buildPythonPackage (finalAttrs: {
   ++ etils.optional-dependencies.epy;
 
   nativeCheckInputs = [
+    aiosqlite
     chex
     fastapi
     google-cloud-logging
+    greenlet
     httpx
     mock
     optax
     portpicker
     pytestCheckHook
     safetensors
+    sqlalchemy
     torch
   ];
 
   disabledTests = [
+    # ValueError: Distributed system is not available; please initialize it via `jax.distributed.initialize()` at the start of your program.
+    "NumpyHandlerTest"
+    "SerializationTest"
+    "SingleReplicaArrayHandlerTest"
+    "UtilsTest"
+
     # Flaky
     # AssertionError: 2 not greater than 2.0046136379241943
     "test_async_mkdir_parallel"
@@ -108,6 +122,7 @@ buildPythonPackage (finalAttrs: {
 
     # ValueError: cannot reshape array of size 1 into shape (0,2)
     "test_get_leaf_memory_per_device"
+    "test_memory_size"
     "test_number_of_broadcasts"
     "test_tree_memory_per_device"
   ]
@@ -144,6 +159,7 @@ buildPythonPackage (finalAttrs: {
 
     # ValueError: Distributed system is not available; please initialize it via `jax.distributed.initialize()` at the start of your program.
     "orbax/checkpoint/_src/handlers/array_checkpoint_handler_test.py"
+    "orbax/checkpoint/experimental/v1/_src/layout/safetensors_layout_multiprocess_test.py"
 
     # import file mismatch:
     # imported module 'registry_test' has this __file__ attribute:
@@ -153,6 +169,13 @@ buildPythonPackage (finalAttrs: {
     # HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file module
     "orbax/checkpoint/experimental/v1/_src/serialization/registry_test.py"
 
+    # import file mismatch:
+    # imported module 'serialization_test' has this __file__ attribute:
+    #   /build/source/checkpoint/orbax/checkpoint/_src/serialization/serialization_test.py
+    # which is not the same as the test file we want to collect:
+    #   /build/source/checkpoint/orbax/checkpoint/experimental/v1/_src/metadata/serialization_test.py
+    "orbax/checkpoint/experimental/v1/_src/metadata/serialization_test.py"
+
     # E   FileNotFoundError: [Errno 2] No such file or directory:
     # '/build/absl_testing/DefaultSnapshotTest/runTest/root/path/to/source/data.txt'
     "orbax/checkpoint/_src/path/snapshot/snapshot_test.py"
@@ -161,15 +184,19 @@ buildPythonPackage (finalAttrs: {
     "orbax/checkpoint/_src/multihost/multihost_test.py"
 
     # Circular dependency flax
+    "orbax/checkpoint/_src/checkpointers/async_checkpointer_test.py"
+    "orbax/checkpoint/_src/checkpointers/checkpointer_test.py"
     "orbax/checkpoint/_src/handlers/pytree_checkpoint_handler_test.py"
     "orbax/checkpoint/_src/metadata/empty_values_test.py"
     "orbax/checkpoint/_src/metadata/tree_rich_types_test.py"
     "orbax/checkpoint/_src/metadata/tree_test.py"
+    "orbax/checkpoint/_src/serialization/local_type_handlers_test.py"
     "orbax/checkpoint/_src/testing/test_tree_utils.py"
     "orbax/checkpoint/_src/tree/parts_of_test.py"
     "orbax/checkpoint/_src/tree/structure_utils_test.py"
     "orbax/checkpoint/_src/tree/utils_test.py"
     "orbax/checkpoint/checkpoint_manager_test.py"
+    "orbax/checkpoint/experimental/v1/_src/handlers/pytree_handler_test.py"
     "orbax/checkpoint/single_host_test.py"
     "orbax/checkpoint/transform_utils_test.py"
     "orbax/checkpoint/_src/handlers/standard_checkpoint_handler_test.py"

--- a/pkgs/development/python-modules/tensorstore/default.nix
+++ b/pkgs/development/python-modules/tensorstore/default.nix
@@ -17,28 +17,29 @@ let
     "aarch64-darwin" = "macosx_11_0_arm64";
   };
   hashes = {
-    "311-x86_64-linux" = "sha256-gwcu4OVR1tylguFUtkyLgGbSduwHWXhOMUnCghKmHxg=";
-    "312-x86_64-linux" = "sha256-YI9xeOxuTko8JlRbCkT0S/g0ONBL8tlgzQ52meqpnvY=";
-    "313-x86_64-linux" = "sha256-yfLcM0LkaGr5j24lncn7N38b9le2ScJHv2ZHu+T5gJA=";
-    "314-x86_64-linux" = "sha256-evlCImnCv83s+d1VMJBgZlq5wtf2yJI3ftMsAyQA/uo=";
-    "311-aarch64-linux" = "sha256-xCMLj9KXleiORB90nYgZc+yo2t8zxSYrNng5+4iR95s=";
-    "312-aarch64-linux" = "sha256-3r1DUELAC+aLofs89ZMlp7q7P0o89HRMh93jRoAsu7Q=";
-    "313-aarch64-linux" = "sha256-lNj8nfFyGwKHBGrKcgn9UECInK1CAue3Oh/bd82bccY=";
-    "314-aarch64-linux" = "sha256-hHmCZSJz+3staUt4kgV0eq8+UK5kc4xct7XrA9hqmUc=";
-    "311-aarch64-darwin" = "sha256-XhUtM0vzT7q9/o5bw1uH0fmUcGWST/g8KeZZMIs26Ug=";
-    "312-aarch64-darwin" = "sha256-EIwOhnqiyH1JgsxjJaLeDE9b1jwr6hitsZOjcMQFlM4=";
-    "313-aarch64-darwin" = "sha256-Kc9DNhU68TasisUo4u1G3xk2ftrn4U43vKGot8SEjvI=";
-    "314-aarch64-darwin" = "sha256-l3VtLLo8XOIeFWAsKvWgJSHMDs2n+fttGNovO9UYJ/Q=";
+    "311-x86_64-linux" = "sha256-iudEUatcyKDNnlGSat8E9N/b2K1awxrHHxyqe9+ygo0=";
+    "312-x86_64-linux" = "sha256-ZMgDlVjVYHtzkDlI/OBYclcx30EMXBls9Ys/xiIjlbU=";
+    "313-x86_64-linux" = "sha256-jqU6hR6oaq09mcFKeQyFRo1jJL4Ux6whHx8CZej6twc=";
+    "314-x86_64-linux" = "sha256-fJEIrmwprckLcsome6K1dzhsXkEOovjofqvOXr2tMn4=";
+    "311-aarch64-linux" = "sha256-NDUvi6bl77pf6xiRfWjaGpK7/4DmTD/QbT0a9LNDgho=";
+    "312-aarch64-linux" = "sha256-Os4Azy5F3F1k/joQwsvvYTQ5FWg4CKEKPggSM1ZqcjE=";
+    "313-aarch64-linux" = "sha256-UK+wbFelCQkQFa9qhdpvSDp/WtA3IoTdldVRPYdzNuQ=";
+    "314-aarch64-linux" = "sha256-Gy/11VNqipsVlsUbkHXMnUC0xOpObMA8BIARHb5dlW0=";
+    "311-aarch64-darwin" = "sha256-NA/pcfGAjXBg8ic7ju41J4C8tl5QNfeBY/qbiTCqeVo=";
+    "312-aarch64-darwin" = "sha256-RHfqvibi9RMfGxo0RM2RZ/5p+rwpV56rglnSGDmbnms=";
+    "313-aarch64-darwin" = "sha256-AoRVzM3AXDHxlASM9FmiZmmybTjwUWyvkhPnIZse55o=";
+    "314-aarch64-darwin" = "sha256-19AXdZhfyqKw8QA0l2apU8UIbpLnRr85XpNhUdTY+aw=";
   };
 in
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "tensorstore";
-  version = "0.1.79";
+  version = "0.1.84";
   format = "wheel";
+  __structuredAttrs = true;
 
   # The source build involves some wonky Bazel stuff.
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     format = "wheel";
     python = "cp${pythonVersionNoDot}";
     abi = "cp${pythonVersionNoDot}";
@@ -61,9 +62,9 @@ buildPythonPackage rec {
   meta = {
     description = "Library for reading and writing large multi-dimensional arrays";
     homepage = "https://google.github.io/tensorstore";
-    changelog = "https://github.com/google/tensorstore/releases/tag/v${version}";
+    changelog = "https://github.com/google/tensorstore/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
     maintainers = with lib.maintainers; [ samuela ];
   };
-}
+})


### PR DESCRIPTION
## Things done

- **python3Packages.tensorstore: 0.1.79 -> 0.1.84**
- **python3Packages.orbax-checkpoint: 0.11.39 -> 0.11.40**
  - Diff: https://github.com/google/orbax/compare/v0.11.39...v0.11.40
  - Changelog: https://github.com/google/orbax/blob/v0.11.40/checkpoint/CHANGELOG.md

cc @fabaff

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test