### PR TITLE
hyperglot: 0.7.3 -> 0.8.1

### DIFF
--- a/pkgs/development/python-modules/hyperglot/default.nix
+++ b/pkgs/development/python-modules/hyperglot/default.nix
@@ -1,23 +1,27 @@
 {
   lib,
   nix-update-script,
-  fetchPypi,
+  fetchFromGitHub,
   buildPythonApplication,
   setuptools,
+  pytestCheckHook,
   click,
   fonttools,
   uharfbuzz,
   pyyaml,
   colorlog,
+  packaging,
 }:
 buildPythonApplication rec {
   pname = "hyperglot";
-  version = "0.7.3";
+  version = "0.8.1";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-Pd9Yxmv9a1T2xV03q2U1m1laHE3WifHwmnGBfTTCSxM=";
+  src = fetchFromGitHub {
+    owner = "rosettatype";
+    repo = "hyperglot";
+    tag = version;
+    hash = "sha256-fiiDYggMBwd7nTHeQLWnSc3BNDyU+JUgAIk8pHLntUY=";
   };
 
   dependencies = [
@@ -26,10 +30,12 @@ buildPythonApplication rec {
     uharfbuzz
     pyyaml
     colorlog
+    packaging
   ];
 
   build-system = [ setuptools ];
 
+  nativeCheckInputs = [ pytestCheckHook ];
   pythonImportsCheck = [ "hyperglot" ];
 
   passthru.updateScript = nix-update-script { };
@@ -38,7 +44,7 @@ buildPythonApplication rec {
     description = "Database and tools for detecting language support in fonts";
     homepage = "https://hyperglot.rosettatype.com";
     changelog = "https://github.com/rosettatype/hyperglot/blob/${version}/CHANGELOG.md";
-    license = lib.licenses.gpl3Only;
+    license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ imatpot ];
     mainProgram = "hyperglot";
   };


### PR DESCRIPTION
Replaces https://github.com/NixOS/nixpkgs/pull/522383

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
