### PR TITLE
rclip: 2.1.6 -> 3.0.10

### DIFF
--- a/pkgs/by-name/rc/rclip/package.nix
+++ b/pkgs/by-name/rc/rclip/package.nix
@@ -6,58 +6,55 @@
 }:
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "rclip";
-  version = "2.1.6";
+  version = "3.0.10";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "yurijmikhalevich";
     repo = "rclip";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-95OiG3I9S9eJHMYkRd9Y52XnCROFV98fvmUs4SRBF4s=";
+    hash = "sha256-FRsdZ0sM8Ato+v7239bZygZ98eYOQqiD0vLXa/+ybIg=";
   };
 
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.11.12,<0.12.0" uv_build
+  '';
+
   build-system = with python3Packages; [
-    poetry-core
+    uv-build
   ];
 
   dependencies = with python3Packages; [
+    ftfy
+    huggingface-hub
     numpy
-    open-clip-torch
+    onnxruntime
     pillow
     pillow-heif
+    regex
     requests
-    torch
-    torchvision
     tqdm
     rawpy
   ];
 
   pythonRelaxDeps = [
     "numpy"
-    "open_clip_torch"
     "pillow"
     "rawpy"
-    "torch"
-    "torchvision"
   ];
 
   pythonImportsCheck = [ "rclip" ];
 
   nativeCheckInputs = [
     versionCheckHook
+    python3Packages.jinja2
   ]
   ++ (with python3Packages; [ pytestCheckHook ]);
 
   disabledTestPaths = [
     # requires network
     "tests/e2e/test_rclip.py"
-  ];
-
-  disabledTests = [
-    # requires network
-    "test_text_model_produces_the_same_vector_as_the_main_model"
-    "test_loads_text_model_when_text_processing_only_requested_and_checkpoint_exists"
-    "test_loads_full_model_when_text_processing_only_requested_and_checkpoint_doesnt_exist"
   ];
 
   meta = {


### PR DESCRIPTION
Diff: https://github.com/yurijmikhalevich/rclip/compare/v2.1.6...v3.0.9

Changelog: https://github.com/yurijmikhalevich/rclip/releases/tag/v3.0.9

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Build system was changed from poetry to uv-build. Onnxruntime is now used as the backend, instead of  torch. (https://github.com/yurijmikhalevich/rclip/pull/249)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
