### PR TITLE
_1password-gui: 8.12.12 -> 8.12.21

### DIFF
--- a/pkgs/by-name/_1/_1password-gui/sources.json
+++ b/pkgs/by-name/_1/_1password-gui/sources.json
@@ -1,28 +1,28 @@
 {
   "stable": {
     "linux": {
-      "version": "8.12.12",
+      "version": "8.12.21",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.12.12.x64.tar.gz",
-          "hash": "sha256-tdhuBJeCXbepDN6Z9Yqs6gE5lMUh72sOJuQSv4Qoj1M="
+          "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.12.21.x64.tar.gz",
+          "hash": "sha256-+TNkHD+CEODImJqxsvYO008UYqOAyrFpfXiaI5zYuDs="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.12.12.arm64.tar.gz",
-          "hash": "sha256-RNwZOqr29aLgNJYH/66TFEKCK3AVBhk+qnSax+Y7Dl4="
+          "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.12.21.arm64.tar.gz",
+          "hash": "sha256-zY2hwSANgpGLGh/qOXUbY2JlZnNpXByysAgZvnuS+Qc="
         }
       }
     },
     "darwin": {
-      "version": "8.12.12",
+      "version": "8.12.21",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.12.12-x86_64.zip",
-          "hash": "sha256-6vVMkra7T4kVRrVn8QexBMRkHDrUoZXP/eALyBPYPow="
+          "url": "https://downloads.1password.com/mac/1Password-8.12.21-x86_64.zip",
+          "hash": "sha256-3CX1Qv2lYTy23XXRaAblOE+mp5YoX4qtV0SXV4hP8xI="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.12.12-aarch64.zip",
-          "hash": "sha256-IqMw4dgMhHkzjMVbmZy/h3li74JZxbY8D4COeMEg+1o="
+          "url": "https://downloads.1password.com/mac/1Password-8.12.21-aarch64.zip",
+          "hash": "sha256-dwE97R0ZXn5kH9GGlyE+Zizb2T5GasgpGW+5zUFog8U="
         }
       }
     }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
