### PR TITLE
ubootNanoPCT4: fix build

### DIFF
--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -364,14 +364,7 @@ in
       '';
     };
 
-  ubootNanoPCT4 = buildUBoot rec {
-    rkbin = fetchFromGitHub {
-      owner = "armbian";
-      repo = "rkbin";
-      rev = "3bd0321cae5ef881a6005fb470009ad5a5d1462d";
-      sha256 = "09r4dzxsbs3pff4sh70qnyp30s3rc7pkc46v1m3152s7jqjasp31";
-    };
-
+  ubootNanoPCT4 = buildUBoot {
     defconfig = "nanopc-t4-rk3399_defconfig";
 
     extraMeta = {
@@ -383,10 +376,6 @@ in
       "u-boot.itb"
       "idbloader.img"
     ];
-    postBuild = ''
-      ./tools/mkimage -n rk3399 -T rksd -d ${rkbin}/rk33/rk3399_ddr_800MHz_v1.24.bin idbloader.img
-      cat ${rkbin}/rk33/rk3399_miniloader_v1.19.bin >> idbloader.img
-    '';
   };
 
   ubootNanoPCT6 = buildUBoot {


### PR DESCRIPTION
Fix U-Boot for the FriendlyElec NanoPC-T4 single-board computer (Rockchip RK3399).

The previous derivation manually assembled `idbloader.img` from an old Armbian `rkbin` snapshot and Rockchip miniloader binaries. With the current U-Boot package, the `nanopc-t4-rk3399_defconfig` build already produces `idbloader.img` when BL31 is provided through `armTrustedFirmwareRK3399`, so this keeps the package on the standard `buildUBoot` path and removes the stale `rkbin` override and custom `postBuild`.

I booted a NixOS image using this U-Boot on a FriendlyElec NanoPC-T4 and successfully ran `nix run nixpkgs#fastfetch` on the board.

<img width="774" height="391" alt="nanopctc-fastfetch" src="https://github.com/user-attachments/assets/71c75692-2956-4131-8826-b9ca610d718e" />

cc @lopsided98

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
