### PR TITLE
[do not merge] mono: build from bootstrapped sources

### DIFF
--- a/pkgs/development/compilers/mono/6.nix
+++ b/pkgs/development/compilers/mono/6.nix
@@ -2,6 +2,7 @@
   callPackage,
   fetchurl,
   fetchpatch,
+  monoBootstrap,
 }:
 
 callPackage ./generic.nix rec {
@@ -18,4 +19,9 @@ callPackage ./generic.nix rec {
       hash = "sha256-qyc3t1OyDzWBSnNW+W2YpdgFfTBs1Ew13jwdGKs09u0=";
     })
   ];
+  bootstrapMono = monoBootstrap.mono-6_12_0;
+  # mono 6.14.1 inherits the same recursive `(cd ../<peer>; make ...)`
+  # pattern in mcs/class libraries that races under `-j` (see
+  # mono_bootstrap_logs.md Run 1b/1c). Keep serial like the chain.
+  enableParallelBuilding = false;
 }

--- a/pkgs/development/compilers/mono/bootstrap/default.nix
+++ b/pkgs/development/compilers/mono/bootstrap/default.nix
@@ -1,0 +1,1944 @@
+{
+  lib,
+  newScope,
+  fetchgit,
+  fetchurl,
+  cmake,
+  python3,
+  bash,
+  libgdiplus,
+  libx11,
+  unixodbc,
+}:
+
+lib.makeScope newScope (
+  self:
+  let
+    baseCflags = lib.concatStringsSep " " [
+      "-O2"
+      "-g"
+      "-DARG_MAX=500"
+      "-Wno-error=implicit-function-declaration"
+      "-Wno-error=incompatible-pointer-types"
+      "-Wno-error=implicit-int"
+      "-Wno-error=return-mismatch"
+    ];
+    baseCflagsWithIntConversion = "${baseCflags} -Wno-error=int-conversion";
+    fetchMonoExternal =
+      name: rev: hash:
+      fetchgit {
+        url = "https://github.com/mono/${name}.git";
+        inherit rev hash;
+      };
+    guixMonoPatchRev = "09be58292f6c8795d7e9723a58d9b32c8177cf34";
+    fetchGuixMonoPatch =
+      name: hash:
+      fetchurl {
+        url = "https://codeberg.org/guix/guix/raw/commit/${guixMonoPatchRev}/gnu/packages/patches/${name}";
+        inherit hash;
+      };
+    guixPatches = {
+      "corefx-mono-5.4.0-patches.patch" =
+        fetchGuixMonoPatch "corefx-mono-5.4.0-patches.patch" "sha256-jaltVGiBt7eNXh0KjerMcuq3L8CRKZaHY8rRpGQXcLg=";
+      "corefx-mono-pre-5.8.0-patches.patch" =
+        fetchGuixMonoPatch "corefx-mono-pre-5.8.0-patches.patch" "sha256-f1r7ktS3e0bCTwW3t2V4ioF59/+aunyYsSswsFdJMrg=";
+      "mono-1.2.6-bootstrap.patch" =
+        fetchGuixMonoPatch "mono-1.2.6-bootstrap.patch" "sha256-ILvVFM0DnwGUELRbDORwHmLPSBEA6ndSuR75sPvmnLo=";
+      "mono-1.9.1-add-MONO_CREATE_IMAGE_VERSION.patch" =
+        fetchGuixMonoPatch "mono-1.9.1-add-MONO_CREATE_IMAGE_VERSION.patch" "sha256-XLeFscltiit0QDOwgB0jYuZjcO23XXaPwjYSChse/NI=";
+      "mono-1.9.1-fixes.patch" =
+        fetchGuixMonoPatch "mono-1.9.1-fixes.patch" "sha256-yA34QM3iSzZmVPl0SG9AJdmWsfx12sYfE3vHrmyJXU8=";
+      "mono-2.4.2.3-fixes.patch" =
+        fetchGuixMonoPatch "mono-2.4.2.3-fixes.patch" "sha256-LCJyNTUfppiOxvrLzRJyyjjtYfwd20AkBPGX+GlCdOc=";
+      "mono-2.6.4-fixes.patch" =
+        fetchGuixMonoPatch "mono-2.6.4-fixes.patch" "sha256-w62DG4rtYLgKhYSr97fPc28dC3+K/+lcig5OAkOXJpw=";
+      "mono-4.9.0-fix-runtimemetadataversion.patch" =
+        fetchGuixMonoPatch "mono-4.9.0-fix-runtimemetadataversion.patch" "sha256-cm3YJKs+RI1AVrZ+HfBiD9SlYjwc7kniRKTD3gT67VI=";
+      "mono-5.4.0-patches.patch" =
+        fetchGuixMonoPatch "mono-5.4.0-patches.patch" "sha256-yCZ/f1f2/58T1Gbe5VhL5ysKTJ1uP2JMe8wO+m8HIGg=";
+      "mono-5.8.0-patches.patch" =
+        fetchGuixMonoPatch "mono-5.8.0-patches.patch" "sha256-3LEvgLPbfm5KDjyXo1AY7/vVNRFcYde0w7kRxHGohxs=";
+      "mono-6.12.0-fix-AssemblyResolver.patch" =
+        fetchGuixMonoPatch "mono-6.12.0-fix-AssemblyResolver.patch" "sha256-sLwbs4KOarG6vfQzpG6QWgOZcu6hdl3L9FGDP2V5ups=";
+      "mono-6.12.0-fix-ConditionParser.patch" =
+        fetchGuixMonoPatch "mono-6.12.0-fix-ConditionParser.patch" "sha256-pTXuDLgChoSDjPI+MuzPXjkCeAY9gMsM0petuW9Qobc=";
+      "mono-mcs-patches-from-5.10.0.patch" =
+        fetchGuixMonoPatch "mono-mcs-patches-from-5.10.0.patch" "sha256-UdciaWIr/gTmGpiABW4yzXyBIXbW3xAahA4q7h5KWC4=";
+      "pnet-fix-line-number-info.patch" =
+        fetchGuixMonoPatch "pnet-fix-line-number-info.patch" "sha256-998Gz5sQahG/licd1p0iuDT8B0ArF0aMH404J+ozdMs=";
+      "pnet-fix-off-by-one.patch" =
+        fetchGuixMonoPatch "pnet-fix-off-by-one.patch" "sha256-RAyyRNv3T85E/JjsodF1WMKFqnZHt+QIrsCTVvfQ8xY=";
+      "pnet-newer-libgc-fix.patch" =
+        fetchGuixMonoPatch "pnet-newer-libgc-fix.patch" "sha256-XCzWEtYJk/IK+nYgR2vz2mxHV68VttO3i45dYOHM9n4=";
+      "pnet-newer-texinfo-fix.patch" =
+        fetchGuixMonoPatch "pnet-newer-texinfo-fix.patch" "sha256-yaqKIte5TW9JzlZ2vSH/nN65jTapwV1nJGwZLA7atPA=";
+    };
+    mkMono = args: self.callPackage ./mono.nix ({ cflags = baseCflags; } // args);
+    copyExternalRepos =
+      repos:
+      lib.concatStringsSep "\n" (
+        lib.mapAttrsToList (name: src: ''
+          rm -rf external/${name}
+          cp -R ${src} external/${name}
+          chmod -R u+w external/${name}
+        '') repos
+      );
+  in
+  {
+    treecc = self.callPackage ./treecc.nix { };
+    pnet = self.callPackage ./pnet.nix {
+      inherit (self) treecc;
+      inherit guixPatches;
+    };
+    pnetlib = self.callPackage ./pnetlib.nix {
+      inherit (self) pnet treecc;
+    };
+
+    mono-1_2_6 = mkMono {
+      version = "1.2.6";
+      src = fetchurl {
+        url = "http://download.mono-project.com/sources/mono/mono-1.2.6.tar.bz2";
+        hash = "sha256-JMxPOWysMFPHuj/mi8G4A1nXXcT1SoXzmnPKvD0/Vg8=";
+      };
+      patches = [ guixPatches."mono-1.2.6-bootstrap.patch" ];
+      bootstrapCompiler = self.pnet;
+      bootstrapRuntime = self.pnet;
+      bootstrapLibraries = self.pnetlib;
+      configureFlags = [ "--with-gc=boehm" ];
+      makeFlags = [
+        "EXTERNAL_MCS=${lib.getBin self.pnet}/bin/cscc"
+        "EXTERNAL_RUNTIME=${lib.getBin self.pnet}/bin/ilrun"
+        "V=1"
+      ];
+      enableParallelBuilding = true;
+      doCheck = false;
+    };
+
+    mono-1_9_1 = mkMono {
+      version = "1.9.1";
+      src = fetchgit {
+        url = "https://gitlab.winehq.org/mono/mono.git";
+        rev = "fa2352e7bba168ce21f63ccdb59cce70e69b0b98";
+        hash = "sha256-mq8RXKWSGJQfJHoC/VK44tPz5Qy0uV51mlQJBtsfNmg=";
+      };
+      patches = [
+        guixPatches."mono-1.9.1-fixes.patch"
+        guixPatches."mono-1.9.1-add-MONO_CREATE_IMAGE_VERSION.patch"
+      ];
+      bootstrapCompiler = self.mono-1_2_6;
+      bootstrapRuntime = self.mono-1_2_6;
+      configureFlags = [ "--with-gc=boehm" ];
+      makeFlags = [
+        "NO_SIGN_ASSEMBLY=yes"
+        "V=1"
+      ];
+      enableParallelBuilding = true;
+      doCheck = false;
+      extraPostPatch = ''
+        patchShebangs mcs/tools
+      '';
+      extraPreConfigure = ''
+        export MONO_CREATE_IMAGE_VERSION=v1.1.4322
+      '';
+      extraPostConfigure = ''
+        if [ -f mcs/class/IBM.Data.DB2/Makefile ]; then
+          substituteInPlace mcs/class/IBM.Data.DB2/Makefile \
+            --replace-fail "LIB_MCS_FLAGS =" "LIB_MCS_FLAGS = /delaysign+ "
+        fi
+        if [ -f mcs/class/FirebirdSql.Data.Firebird/Assembly/AssemblyInfo.cs ]; then
+          substituteInPlace mcs/class/FirebirdSql.Data.Firebird/Assembly/AssemblyInfo.cs \
+            --replace-fail "AssemblyDelaySign(false)" "AssemblyDelaySign(true)"
+        fi
+      '';
+      extraPreInstall = ''
+        find . -type f -name '*.mdb' -delete
+      '';
+    };
+
+    mono-2_4_2 = mkMono {
+      version = "2.4.2.3";
+      src = fetchgit {
+        url = "https://gitlab.winehq.org/mono/mono.git";
+        rev = "f79a3230c2f0a8d80b36cdbe067c53e36374a017";
+        hash = "sha256-qt2pkQH1+J3vjoEslJK2YarE0lACwQYGzIWllk+Y2VY=";
+      };
+      patches = [ guixPatches."mono-2.4.2.3-fixes.patch" ];
+      bootstrapCompiler = self.mono-1_9_1;
+      bootstrapRuntime = self.mono-1_9_1;
+      cflags = baseCflagsWithIntConversion;
+      configureFlags = [ "--with-gc=boehm" ];
+      makeFlags = [ "V=1" ];
+      enableParallelBuilding = true;
+      doCheck = false;
+      extraPostPatch = ''
+        mkdir -p m4
+        if [ -f mono/mini/Makefile.am ]; then
+          substituteInPlace mono/mini/Makefile.am \
+            --replace-fail '`date`' 'Tue Jan  1 12:00:00 AM UTC 1980'
+        fi
+        if [ -f eglib/autogen.sh ]; then
+          patchShebangs eglib/autogen.sh
+        fi
+        if [ -d mcs/tools ]; then
+          patchShebangs mcs/tools
+        fi
+      '';
+    };
+
+    mono-2_6_4 = mkMono {
+      version = "2.6.4";
+      src = fetchgit {
+        url = "https://gitlab.winehq.org/mono/mono.git";
+        rev = "680b5eb2d695de54fe4eb3210c07722ef60e5a4b";
+        hash = "sha256-BTFSMl5jy9+47Rcs1IdGrTsS9UARLkK1qxJBXAg/J50=";
+      };
+      patches = [ guixPatches."mono-2.6.4-fixes.patch" ];
+      bootstrapCompiler = self.mono-2_4_2;
+      bootstrapRuntime = self.mono-2_4_2;
+      cflags = baseCflagsWithIntConversion;
+      configureFlags = [ "--with-gc=boehm" ];
+      makeFlags = [ "V=1" ];
+      enableParallelBuilding = true;
+      doCheck = false;
+      patchReflectionFormatStrings = false;
+      extraPostPatch = ''
+        mkdir -p m4
+        if [ -f mono/mini/Makefile.am ]; then
+          substituteInPlace mono/mini/Makefile.am \
+            --replace-fail '`date`' 'Tue Jan  1 12:00:00 AM UTC 1980'
+        fi
+        if [ -f eglib/autogen.sh ]; then
+          patchShebangs eglib/autogen.sh
+        fi
+        if [ -d mcs/tools ]; then
+          patchShebangs mcs/tools
+        fi
+      '';
+    };
+
+    mono-2_11_4 = mkMono {
+      version = "2.11.4";
+      src = fetchgit {
+        url = "https://gitlab.winehq.org/mono/mono.git";
+        rev = "417ec7840f3f9195b03115f0c8c25aaa646a5b04";
+        hash = "sha256-/WZAUoVQqJuy86bv+Q1Z5Ebsm1BPQoCuq3JtJaKLS3g=";
+        fetchSubmodules = false;
+      };
+      # Adapted from Guix: the generic isinf fix is handled in mono.nix, and
+      # this adds a GCC keyword compatibility fix not present in Guix.
+      patches = [ ./patches/mono-2.11.4-fixes.patch ];
+      bootstrapCompiler = self.mono-2_6_4;
+      bootstrapRuntime = self.mono-2_6_4;
+      cflags = baseCflagsWithIntConversion;
+      configureFlags = [ "--with-gc=boehm" ];
+      makeFlags = [ "V=1" ];
+      enableParallelBuilding = true;
+      doCheck = false;
+      patchReflectionFormatStrings = false;
+      extraPostPatch = ''
+        mkdir -p m4 external
+        ${copyExternalRepos {
+          aspnetwebstack =
+            fetchMonoExternal "aspnetwebstack" "1836deff6a2683b8a5b7dd78f2b591a10b47573e"
+              "sha256-k5Ahwb24b3H+MjTLR4HlSEseMYYJ5KwkpV6aiWIhGG8=";
+          cecil =
+            fetchMonoExternal "cecil" "54e0a50464edbc254b39ea3c885ee91ada730705"
+              "sha256-04s++I2Y/hWtk4/SP8f/PJurzm2clmTQQJgEVdz6+gA=";
+          entityframework =
+            fetchMonoExternal "entityframework" "9baca562ee3a747a41870f45e749e4436b6aca26"
+              "sha256-qpWdUFSZjukn4O4keb5XxCPfEfwQ/StwmSuv6RcBE1E=";
+          "Newtonsoft.Json" =
+            fetchMonoExternal "Newtonsoft.Json" "471c3e0803a9f40a0acc8aeceb31de6ff93a52c4"
+              "sha256-Gp1UpraahcFFXQanzr4Y1U7bsLFLTUAehd5MDEt79jU=";
+        }}
+        find external -type f \( -name '*.dll' -o -name '*.DLL' -o -name '*.exe' -o -name '*.EXE' -o -name '*.so' \) -delete
+        if [ -f mono/mini/Makefile.am ]; then
+          substituteInPlace mono/mini/Makefile.am \
+            --replace-fail '`date`' 'Tue Jan  1 12:00:00 AM UTC 1980'
+        fi
+        if [ -f eglib/autogen.sh ]; then
+          patchShebangs eglib/autogen.sh
+        fi
+        if [ -d mcs/tools ]; then
+          patchShebangs mcs/tools
+        fi
+      '';
+    };
+
+    mono-3_0_12 = mkMono {
+      version = "3.0.12";
+      src = fetchgit {
+        url = "https://gitlab.winehq.org/mono/mono.git";
+        rev = "d6c5db881b26fd0f8ef64a65eba00e72fda552a2";
+        hash = "sha256-kobOKOxHJknsa3vU/YhwKbJGcStayZdXX2bO6BgcDoQ=";
+        fetchSubmodules = false;
+      };
+      bootstrapCompiler = self.mono-2_11_4;
+      bootstrapRuntime = self.mono-2_11_4;
+      cflags = baseCflagsWithIntConversion;
+      configureFlags = [ "--with-gc=boehm" ];
+      makeFlags = [ "V=1" ];
+      enableParallelBuilding = true;
+      doCheck = false;
+      patchReflectionFormatStrings = false;
+      extraPostPatch = ''
+        mkdir -p m4 external
+        for dir in mono/metadata mono/mini; do
+          if [ ! -f "$dir/Makefile.am" ] && [ -f "$dir/Makefile.am.in" ]; then
+            cp "$dir/Makefile.am.in" "$dir/Makefile.am"
+          fi
+        done
+        substituteInPlace mono/mini/method-to-ir.c \
+          --replace-fail 'create_magic_tls_access (MonoCompile *cfg, MonoClassField *tls_field, MonoInst **cached_tls_addr, MonoInst *thread_local)' \
+                         'create_magic_tls_access (MonoCompile *cfg, MonoClassField *tls_field, MonoInst **cached_tls_addr, MonoInst *tls_ins)' \
+          --replace-fail 'thread_local->dreg' 'tls_ins->dreg'
+        ${copyExternalRepos {
+          aspnetwebstack =
+            fetchMonoExternal "aspnetwebstack" "e77b12e6cc5ed260a98447f609e887337e44e299"
+              "sha256-AbtgeY4xkkTJP03O0FBFZNQ6sWjEiKDduNWRjAkZemY=";
+          cecil =
+            fetchMonoExternal "cecil" "54e0a50464edbc254b39ea3c885ee91ada730705"
+              "sha256-04s++I2Y/hWtk4/SP8f/PJurzm2clmTQQJgEVdz6+gA=";
+          entityframework =
+            fetchMonoExternal "entityframework" "a5faddeca2bee08636f1b7b3af8389bd4119f4cd"
+              "sha256-R6UsW6tu+hnwVL9tIJAZOCNenRWj+r+uSK1xbNy/BSw=";
+          ikvm =
+            fetchMonoExternal "ikvm-fork" "10b8312c8024111780ee382688cd4c8754b1f1ac"
+              "sha256-1SaAUfNNvnN1G+j0TRLg7Fc2PFQh8bcFwXm7J19yvAg=";
+          "Lucene.Net" =
+            fetchMonoExternal "Lucene.Net" "88fb67b07621dfed054d8d75fd50672fb26349df"
+              "sha256-E40lPQIUkY4cXBj5sO0CsQNlndm0b6vKy+lOeL7D3eU=";
+          "Newtonsoft.Json" =
+            fetchMonoExternal "Newtonsoft.Json" "471c3e0803a9f40a0acc8aeceb31de6ff93a52c4"
+              "sha256-Gp1UpraahcFFXQanzr4Y1U7bsLFLTUAehd5MDEt79jU=";
+          rx =
+            fetchMonoExternal "rx" "17e8477b2cb8dd018d49a567526fe99fd2897857"
+              "sha256-BG6pz7a0J7Wl3HYYoMlfQeWiWdtrO+PcNKpW4CTx3js=";
+        }}
+        find external -type f \( -name '*.dll' -o -name '*.DLL' -o -name '*.exe' -o -name '*.EXE' -o -name '*.so' \) -delete
+        if [ -f eglib/autogen.sh ]; then
+          patchShebangs eglib/autogen.sh
+        fi
+        if [ -d mcs/tools ]; then
+          patchShebangs mcs/tools
+        fi
+      '';
+    };
+
+    mono-3_12_1 = mkMono {
+      version = "3.12.1";
+      src = fetchgit {
+        url = "https://gitlab.winehq.org/mono/mono.git";
+        rev = "4cb3f77b4bbf703b1cda59db2f5aee206e35d31a";
+        hash = "sha256-DvgCxlDOL8u8kcAQdD3y84w9fF2Mna3ORjMYyJzNXQc=";
+        fetchSubmodules = false;
+      };
+      bootstrapCompiler = self.mono-3_0_12;
+      bootstrapRuntime = self.mono-3_0_12;
+      cflags = baseCflagsWithIntConversion;
+      configureFlags = [ "--with-gc=boehm" ];
+      makeFlags = [
+        "SKIP_AOT=1"
+        "V=1"
+      ];
+      # mcs/ class-library Makefile uses recursive sub-make to build dependent
+      # libraries (System → System.Xml etc.); under `-j` two sub-makes can
+      # enter the same dir and race on the .dll write. Force serial.
+      enableParallelBuilding = false;
+      doCheck = false;
+      patchReflectionFormatStrings = false;
+      extraPostPatch = ''
+        mkdir -p m4 external
+        for dir in mono/metadata mono/mini; do
+          if [ ! -f "$dir/Makefile.am" ] && [ -f "$dir/Makefile.am.in" ]; then
+            cp "$dir/Makefile.am.in" "$dir/Makefile.am"
+          fi
+        done
+        substituteInPlace mono/mini/method-to-ir.c \
+          --replace-fail 'create_magic_tls_access (MonoCompile *cfg, MonoClassField *tls_field, MonoInst **cached_tls_addr, MonoInst *thread_local)' \
+                         'create_magic_tls_access (MonoCompile *cfg, MonoClassField *tls_field, MonoInst **cached_tls_addr, MonoInst *tls_ins)' \
+          --replace-fail 'thread_local->dreg' 'tls_ins->dreg'
+        ${copyExternalRepos {
+          aspnetwebstack =
+            fetchMonoExternal "aspnetwebstack" "e77b12e6cc5ed260a98447f609e887337e44e299"
+              "sha256-AbtgeY4xkkTJP03O0FBFZNQ6sWjEiKDduNWRjAkZemY=";
+          cecil =
+            fetchMonoExternal "cecil" "33d50b874fd527118bc361d83de3d494e8bb55e1"
+              "sha256-C3qp7SgHNmy4hLgDKOvZoFMgmaFWF+enN2JFk06gkNw=";
+          entityframework =
+            fetchMonoExternal "entityframework" "a5faddeca2bee08636f1b7b3af8389bd4119f4cd"
+              "sha256-R6UsW6tu+hnwVL9tIJAZOCNenRWj+r+uSK1xbNy/BSw=";
+          ikdasm =
+            fetchMonoExternal "ikdasm" "7ded4decb9c39446be634d42a575fda9bc3d945c"
+              "sha256-1IQEYkkgcESxlJH/KnDZBX19LAd8iCClLXnX/qNbdTg=";
+          ikvm =
+            fetchMonoExternal "ikvm-fork" "22534de2098acbcf208f6b06836d122dab799e4b"
+              "sha256-FCUDNPsGv+ZNsunsGva5E64WlJ25J70G1SQVpovnfsc=";
+          "Lucene.Net" =
+            fetchMonoExternal "Lucene.Net" "88fb67b07621dfed054d8d75fd50672fb26349df"
+              "sha256-E40lPQIUkY4cXBj5sO0CsQNlndm0b6vKy+lOeL7D3eU=";
+          "Newtonsoft.Json" =
+            fetchMonoExternal "Newtonsoft.Json" "471c3e0803a9f40a0acc8aeceb31de6ff93a52c4"
+              "sha256-Gp1UpraahcFFXQanzr4Y1U7bsLFLTUAehd5MDEt79jU=";
+          rx =
+            fetchMonoExternal "rx" "00c1aadf149334c694d2a5096983a84cf46221b8"
+              "sha256-uE7E8XNEKeWll5rruFHQh+MKPHv4KhqEfGRNmzGoqlk=";
+        }}
+        find external -type f \( -name '*.dll' -o -name '*.DLL' -o -name '*.exe' -o -name '*.EXE' -o -name '*.so' \) -delete
+        if [ -f eglib/autogen.sh ]; then
+          patchShebangs eglib/autogen.sh
+        fi
+        if [ -d mcs/tools ]; then
+          patchShebangs mcs/tools
+        fi
+      '';
+      extraPreConfigure = ''
+        export TZ=
+      '';
+    };
+
+    mono-4_9_0 = mkMono {
+      version = "4.9.0";
+      src = fetchgit {
+        url = "https://gitlab.winehq.org/mono/mono.git";
+        rev = "5a3736606e6243d2c84d4df2cf35c284214b8cc4";
+        hash = "sha256-A8av5X1bt86xl8coXesM34XhvXMbvN8giXFxrCaeE28=";
+        fetchSubmodules = false;
+      };
+      patches = [ guixPatches."mono-4.9.0-fix-runtimemetadataversion.patch" ];
+      bootstrapCompiler = self.mono-3_12_1;
+      bootstrapRuntime = self.mono-3_12_1;
+      cflags = baseCflagsWithIntConversion;
+      configureFlags = [
+        "--with-sgen=yes"
+        "--disable-boehm"
+        "--with-csc=mcs"
+      ];
+      makeFlags = [ "V=1" ];
+      enableParallelBuilding = false;
+      doCheck = false;
+      patchReflectionFormatStrings = false;
+      extraPostPatch = ''
+        mkdir -p m4 external
+        if [ ! -f mono/mini/Makefile.am ] && [ -f mono/mini/Makefile.am.in ]; then
+          cp mono/mini/Makefile.am.in mono/mini/Makefile.am
+        fi
+        substituteInPlace mono/mini/main.c \
+          --replace-fail "mono_build_date = build_date;" "(void) build_date;"
+        ${copyExternalRepos {
+          aspnetwebstack =
+            fetchMonoExternal "aspnetwebstack" "e77b12e6cc5ed260a98447f609e887337e44e299"
+              "sha256-AbtgeY4xkkTJP03O0FBFZNQ6sWjEiKDduNWRjAkZemY=";
+          boringssl =
+            fetchMonoExternal "boringssl" "c06ac6b33d3e7442ad878488b9d1100127eff998"
+              "sha256-7DdPAcy0IZDTwbIab18Osfd8xsD4c8acNDHBnUO8/6A=";
+          buildtools =
+            fetchMonoExternal "buildtools" "9b6ee8686be55a983d886938165b6206cda50772"
+              "sha256-rTuCKcxXN+S+n5Ci3GB8S8t58SEGdlWtl7GyrbgeXGo=";
+          cecil =
+            fetchMonoExternal "cecil" "2b39856e80d8513f70bc3241ed05325b0de679ae"
+              "sha256-tXVsJ/HKcoDTQ+JDAs7q/jHccnsD6bhZ3tAuk8Xoam8=";
+          cecil-legacy =
+            fetchMonoExternal "cecil" "33d50b874fd527118bc361d83de3d494e8bb55e1"
+              "sha256-C3qp7SgHNmy4hLgDKOvZoFMgmaFWF+enN2JFk06gkNw=";
+          entityframework =
+            fetchMonoExternal "entityframework" "a5faddeca2bee08636f1b7b3af8389bd4119f4cd"
+              "sha256-R6UsW6tu+hnwVL9tIJAZOCNenRWj+r+uSK1xbNy/BSw=";
+          ikdasm =
+            fetchMonoExternal "ikdasm" "e4deabf61c11999f200dcea6f6d6b42474cc2131"
+              "sha256-VkGCK6bMkCrchC9ezt1mowQzeWxbjTSkOPTY48FxK7s=";
+          ikvm =
+            fetchMonoExternal "ikvm-fork" "367864ef810859ae3ce652864233b35f2dd5fdbe"
+              "sha256-/ZbBnNCGSGng+9XgELJ7HgBRd5j62xHWr0ATVddM6UU=";
+          "Lucene.Net.Light" =
+            fetchMonoExternal "Lucene.Net.Light" "85978b7eb94738f516824341213d5e94060f5284"
+              "sha256-MXonEg7tutx2hgLoN4S0GxM2hQooMgel20CNKkpEITQ=";
+          "Newtonsoft.Json" =
+            fetchMonoExternal "Newtonsoft.Json" "471c3e0803a9f40a0acc8aeceb31de6ff93a52c4"
+              "sha256-Gp1UpraahcFFXQanzr4Y1U7bsLFLTUAehd5MDEt79jU=";
+          nuget-buildtasks = fetchgit {
+            url = "https://github.com/mono/NuGet.BuildTasks.git";
+            rev = "04bdab55d8de9edcf628694cfd2001561e8f8e60";
+            hash = "sha256-5RycEC928dM5HODnYMpGgU78m2WEUEd5eVO32b3qdNo=";
+          };
+          nunit-lite = fetchgit {
+            url = "https://github.com/mono/NUnitLite.git";
+            rev = "4bc79a6da1f0ee538560b7e4d0caff46d3c86e4f";
+            hash = "sha256-WBzxIgdE00xTVtTmJFd7WYqnf+SG/7IgsvkQLpe6riA=";
+          };
+          rx =
+            fetchMonoExternal "rx" "b29a4b0fda609e0af33ff54ed13652b6ccf0e05e"
+              "sha256-O/oioCocqVIG9xUl3wn4WZw1/2W1RgNQE5vNpSvkMtg=";
+        }}
+        find external -type f \( -name '*.dll' -o -name '*.DLL' -o -name '*.exe' -o -name '*.EXE' -o -name '*.so' \) -delete
+        substituteInPlace tools/monograph/Makefile.am \
+          --replace-fail "/mono/metadata/libmonoruntimesgen-static.la" \
+                         "/mono/metadata/libmonoruntimesgen-static.la \$(top_builddir)/mono/sgen/libmonosgen-static.la"
+        substituteInPlace mcs/class/reference-assemblies/Makefile \
+          --replace-fail "../../../external/binary-reference-assemblies/v" "${self.mono-3_12_1}/lib/mono/"
+        substituteInPlace mcs/class/Microsoft.Build.Tasks/Makefile \
+          --replace-fail "include ../../build/library.make" $'include ../../build/library.make\nrun-test-recursive:\n\t@echo skipping tests'
+        if [ -f eglib/autogen.sh ]; then
+          patchShebangs eglib/autogen.sh
+        fi
+        if [ -d mcs/tools ]; then
+          patchShebangs mcs/tools
+        fi
+      '';
+      extraPreConfigure = ''
+        export TZ=
+      '';
+    };
+
+    mono-5_0_1 = mkMono {
+      version = "5.0.1";
+      src = fetchgit {
+        url = "https://gitlab.winehq.org/mono/mono.git";
+        rev = "cf6c12e5759720b714e7aaee9156d61ba27c1f7b";
+        hash = "sha256-xaIj0nf8RWJdWvICwzIXQETE4jpucHy45h1dSVtb6Rc=";
+        fetchSubmodules = false;
+      };
+      bootstrapCompiler = self.mono-4_9_0;
+      bootstrapRuntime = self.mono-4_9_0;
+      cflags = baseCflagsWithIntConversion;
+      configureFlags = [
+        "--with-sgen=yes"
+        "--disable-boehm"
+        "--with-csc=mcs"
+      ];
+      makeFlags = [
+        "SKIP_AOT=1"
+        "V=1"
+      ];
+      enableParallelBuilding = false;
+      doCheck = false;
+      patchReflectionFormatStrings = false;
+      cmakeForConfigure = cmake;
+      extraPostPatch = ''
+                mkdir -p m4 external
+                if [ ! -f mono/mini/Makefile.am ] && [ -f mono/mini/Makefile.am.in ]; then
+                  cp mono/mini/Makefile.am.in mono/mini/Makefile.am
+                fi
+                substituteInPlace mono/mini/main.c \
+                  --replace-fail "mono_build_date = build_date;" "(void) build_date;"
+                substituteInPlace mono/utils/mono-dl.h \
+                  --replace-fail 'MonoDl*     mono_dl_open       (const char *name, int flags, char **error_msg) MONO_LLVM_INTERNAL;' \
+                                 'MONO_API MonoDl* mono_dl_open (const char *name, int flags, char **error_msg);'
+                substituteInPlace mono/metadata/metadata-internals.h \
+                  --replace-fail 'void
+        mono_loader_register_module (const char *name, MonoDl *module);' \
+                                 'MONO_API void
+        mono_loader_register_module (const char *name, MonoDl *module);'
+                substituteInPlace mono/btls/Makefile.am \
+                  --replace-fail '-D SRC_DIR:PATH=$(abs_top_srcdir)/mono/btls -D BTLS_CFLAGS:STRING="$(BTLS_CFLAGS)"' \
+                                 '-D SRC_DIR:PATH=$(abs_top_srcdir)/mono/btls -D BTLS_CFLAGS:STRING="$(BTLS_CFLAGS)" -D CMAKE_POLICY_VERSION_MINIMUM=3.5'
+                ${copyExternalRepos {
+                  aspnetwebstack =
+                    fetchMonoExternal "aspnetwebstack" "e77b12e6cc5ed260a98447f609e887337e44e299"
+                      "sha256-AbtgeY4xkkTJP03O0FBFZNQ6sWjEiKDduNWRjAkZemY=";
+                  binary-reference-assemblies =
+                    fetchMonoExternal "reference-assemblies" "febc100f0313f0dc9d75dd1bcea45e87134b5b55"
+                      "sha256-xBsqhdTezq77xduh3o5w0xPvBIjE3yZEHgJTUUNI8lI=";
+                  bockbuild =
+                    fetchMonoExternal "bockbuild" "512ba41a94bec35ff0c395eb71a180fda23da95c"
+                      "sha256-b6lWIAoL0Yon4qP4b0c7eDGA7+qf+K4P2KhvjRQFoJo=";
+                  boringssl =
+                    fetchMonoExternal "boringssl" "c06ac6b33d3e7442ad878488b9d1100127eff998"
+                      "sha256-7DdPAcy0IZDTwbIab18Osfd8xsD4c8acNDHBnUO8/6A=";
+                  buildtools =
+                    fetchMonoExternal "buildtools" "9b6ee8686be55a983d886938165b6206cda50772"
+                      "sha256-rTuCKcxXN+S+n5Ci3GB8S8t58SEGdlWtl7GyrbgeXGo=";
+                  cecil =
+                    fetchMonoExternal "cecil" "7801534de1bfed97c844821c3244e05fc7ffcfb8"
+                      "sha256-69SIRUEf2nEdIwumFSfVoRP0yHfOdErfosOeUuf3rjY=";
+                  cecil-legacy =
+                    fetchMonoExternal "cecil" "33d50b874fd527118bc361d83de3d494e8bb55e1"
+                      "sha256-C3qp7SgHNmy4hLgDKOvZoFMgmaFWF+enN2JFk06gkNw=";
+                  corefx =
+                    fetchMonoExternal "corefx" "bd96ae5f1485ae8541fe476dfd944efde76bcd9c"
+                      "sha256-8asdv2eWYRV6dK3cVXSYNDR2iXRyC2W/I4rXRgqjoUg=";
+                  corert =
+                    fetchMonoExternal "corert" "d87c966d80c1274373ddafe3375bf1730cd430ed"
+                      "sha256-zuP6KNlkysNc7hLlAyHEYVspyEyhm+RgeKLaePQsGx0=";
+                  ikdasm =
+                    fetchMonoExternal "ikdasm" "e4deabf61c11999f200dcea6f6d6b42474cc2131"
+                      "sha256-VkGCK6bMkCrchC9ezt1mowQzeWxbjTSkOPTY48FxK7s=";
+                  ikvm =
+                    fetchMonoExternal "ikvm-fork" "367864ef810859ae3ce652864233b35f2dd5fdbe"
+                      "sha256-/ZbBnNCGSGng+9XgELJ7HgBRd5j62xHWr0ATVddM6UU=";
+                  linker =
+                    fetchMonoExternal "linker" "e4d9784ac37b9ebf4757175c92bc7a3ec9fd867a"
+                      "sha256-dEvHWOP0ZGk17UJQa2gFhoG2eFyz2SbEZ143TFNeRz0=";
+                  "Lucene.Net.Light" =
+                    fetchMonoExternal "Lucene.Net.Light" "85978b7eb94738f516824341213d5e94060f5284"
+                      "sha256-MXonEg7tutx2hgLoN4S0GxM2hQooMgel20CNKkpEITQ=";
+                  "Newtonsoft.Json" =
+                    fetchMonoExternal "Newtonsoft.Json" "471c3e0803a9f40a0acc8aeceb31de6ff93a52c4"
+                      "sha256-Gp1UpraahcFFXQanzr4Y1U7bsLFLTUAehd5MDEt79jU=";
+                  nuget-buildtasks = fetchgit {
+                    url = "https://github.com/mono/NuGet.BuildTasks.git";
+                    rev = "8d307472ea214f2b59636431f771894dbcba7258";
+                    hash = "sha256-UtIWVbfCnSP+JaVwCV/V9dININNREhaTWGeiDqTNLsA=";
+                  };
+                  nunit-lite = fetchgit {
+                    url = "https://github.com/mono/NUnitLite.git";
+                    rev = "690603bea98aae69fca9a65130d88591bc6cabee";
+                    hash = "sha256-jD9bxexVanJ+BxQtO135BJE+bTOGc89ean7oL7UvBLk=";
+                  };
+                  rx =
+                    fetchMonoExternal "rx" "b29a4b0fda609e0af33ff54ed13652b6ccf0e05e"
+                      "sha256-O/oioCocqVIG9xUl3wn4WZw1/2W1RgNQE5vNpSvkMtg=";
+                }}
+                find external -type f \( -name '*.dll' -o -name '*.DLL' -o -name '*.exe' -o -name '*.EXE' -o -name '*.so' \) -delete
+                substituteInPlace tools/monograph/Makefile.am \
+                  --replace-fail "/mono/metadata/libmonoruntimesgen-static.la" \
+                                 "/mono/metadata/libmonoruntimesgen-static.la \$(top_builddir)/mono/sgen/libmonosgen-static.la"
+                substituteInPlace mcs/class/Microsoft.Build.Tasks/Makefile \
+                  --replace-fail "include ../../build/library.make" $'include ../../build/library.make\nrun-test-recursive:\n\t@echo skipping tests'
+                substituteInPlace mcs/packages/Makefile \
+                  --replace-fail "install-local:" $'install-local:\n\techo "Skipping blob install"\n\nunused0:'
+                if [ -f eglib/autogen.sh ]; then
+                  patchShebangs eglib/autogen.sh
+                fi
+                if [ -d mcs/tools ]; then
+                  patchShebangs mcs/tools
+                fi
+      '';
+      extraPreConfigure = ''
+        export TZ=
+      '';
+      extraPostBuild = ''
+        pushd external/binary-reference-assemblies
+        for makefile in $(find . -name Makefile); do
+          substituteInPlace "$makefile" \
+            --replace-quiet "CSC_COMMON_ARGS := " "CSC_COMMON_ARGS := -delaysign+ " \
+            --replace-quiet "IBM.Data.DB2_REFS := " "IBM.Data.DB2_REFS := System.Xml " \
+            --replace-quiet "Mono.Data.Sqlite_REFS := " "Mono.Data.Sqlite_REFS := System.Xml " \
+            --replace-quiet "System.Data.DataSetExtensions_REFS := " "System.Data.DataSetExtensions_REFS := System.Xml " \
+            --replace-quiet "System.Data.OracleClient_REFS := " "System.Data.OracleClient_REFS := System.Xml " \
+            --replace-quiet "System.IdentityModel_REFS := " "System.IdentityModel_REFS := System.Configuration " \
+            --replace-quiet "System.Design_REFS := " "System.Design_REFS := Accessibility " \
+            --replace-quiet "System.Web.Extensions.Design_REFS := " "System.Web.Extensions.Design_REFS := System.Windows.Forms System.Web " \
+            --replace-quiet "System.ServiceModel.Routing_REFS := " "System.ServiceModel.Routing_REFS := System.Xml " \
+            --replace-quiet "System.Web.Abstractions_REFS := " "System.Web.Abstractions_REFS := System " \
+            --replace-quiet "System.Reactive.Windows.Forms_REFS := " "System.Reactive.Windows.Forms_REFS := System " \
+            --replace-quiet "System.Windows.Forms.DataVisualization_REFS := " "System.Windows.Forms.DataVisualization_REFS := Accessibility " \
+            --replace-quiet "Facades/System.ServiceModel.Primitives_REFS := " "Facades/System.ServiceModel.Primitives_REFS := System.Xml " \
+            --replace-quiet "Facades/System.Dynamic.Runtime_REFS := " "Facades/System.Dynamic.Runtime_REFS := System " \
+            --replace-quiet "Facades/System.Xml.XDocument_REFS := " "Facades/System.Xml.XDocument_REFS := System.Xml " \
+            --replace-quiet "Facades/System.Runtime.Serialization.Xml_REFS := " "Facades/System.Runtime.Serialization.Xml_REFS := System.Xml "
+        done
+        make -j"$NIX_BUILD_CORES" V=1 SKIP_AOT=1 \
+          CSC="MONO_PATH=$PWD/../../mcs/class/lib/build $PWD/../../runtime/mono-wrapper $PWD/../../mcs/class/lib/build/mcs.exe"
+        unset makefile
+        popd
+      '';
+    };
+
+    mono-5_1_0 = mkMono {
+      version = "5.1.0";
+      src = fetchgit {
+        url = "https://gitlab.winehq.org/mono/mono.git";
+        rev = "6fafd08b507c56f11a2eb6570703a39e5bdc0a81";
+        hash = "sha256-ZYq+IyWp2l67xXdkM/CBwKcQc0TJ0rZchfAVrywguOs=";
+        fetchSubmodules = false;
+      };
+      bootstrapCompiler = self.mono-5_0_1;
+      bootstrapRuntime = self.mono-5_0_1;
+      cflags = baseCflagsWithIntConversion;
+      configureFlags = [
+        "--with-sgen=yes"
+        "--disable-boehm"
+        "--with-csc=mcs"
+      ];
+      makeFlags = [
+        "SKIP_AOT=1"
+        "V=1"
+      ];
+      enableParallelBuilding = false;
+      doCheck = false;
+      patchReflectionFormatStrings = false;
+      cmakeForConfigure = cmake;
+      extraPostPatch = ''
+                mkdir -p m4 external
+                if [ ! -f mono/mini/Makefile.am ] && [ -f mono/mini/Makefile.am.in ]; then
+                  cp mono/mini/Makefile.am.in mono/mini/Makefile.am
+                fi
+                substituteInPlace mono/mini/main.c \
+                  --replace-fail "mono_build_date = build_date;" "(void) build_date;"
+                substituteInPlace mono/utils/mono-dl.h \
+                  --replace-fail 'MonoDl*     mono_dl_open       (const char *name, int flags, char **error_msg) MONO_LLVM_INTERNAL;' \
+                                 'MONO_API MonoDl* mono_dl_open (const char *name, int flags, char **error_msg);'
+                substituteInPlace mono/metadata/metadata-internals.h \
+                  --replace-fail 'void
+        mono_loader_register_module (const char *name, MonoDl *module);' \
+                                 'MONO_API void
+        mono_loader_register_module (const char *name, MonoDl *module);'
+                substituteInPlace mono/btls/Makefile.am \
+                  --replace-fail '-D SRC_DIR:PATH=$(abs_top_srcdir)/mono/btls -D BTLS_CFLAGS:STRING="$(BTLS_CFLAGS)"' \
+                                 '-D SRC_DIR:PATH=$(abs_top_srcdir)/mono/btls -D BTLS_CFLAGS:STRING="$(BTLS_CFLAGS)" -D CMAKE_POLICY_VERSION_MINIMUM=3.5'
+                ${copyExternalRepos {
+                  aspnetwebstack =
+                    fetchMonoExternal "aspnetwebstack" "e77b12e6cc5ed260a98447f609e887337e44e299"
+                      "sha256-AbtgeY4xkkTJP03O0FBFZNQ6sWjEiKDduNWRjAkZemY=";
+                  binary-reference-assemblies =
+                    fetchMonoExternal "reference-assemblies" "febc100f0313f0dc9d75dd1bcea45e87134b5b55"
+                      "sha256-xBsqhdTezq77xduh3o5w0xPvBIjE3yZEHgJTUUNI8lI=";
+                  bockbuild =
+                    fetchMonoExternal "bockbuild" "fd1d6c404d763c98b6f0e64e98ab65f92e808245"
+                      "sha256-YPkncwENMgwE1/TbiieYjsmkwFqXSTcuBcIXOQxKVlA=";
+                  boringssl =
+                    fetchMonoExternal "boringssl" "c06ac6b33d3e7442ad878488b9d1100127eff998"
+                      "sha256-7DdPAcy0IZDTwbIab18Osfd8xsD4c8acNDHBnUO8/6A=";
+                  buildtools =
+                    fetchMonoExternal "buildtools" "b5cc6e6ab5f71f6c0be7b730058b426e92528479"
+                      "sha256-BlhZn9MA+U9aF4xyU9bWjJgI6sguWjBhSxJhcgktslE=";
+                  cecil =
+                    fetchMonoExternal "cecil" "44bc86223530a07fa74ab87007cf264e53d63400"
+                      "sha256-jyBaeyueHq8c3M1Zyk9gTMLu1ZFQw+GnDT6BQyJSumo=";
+                  cecil-legacy =
+                    fetchMonoExternal "cecil" "33d50b874fd527118bc361d83de3d494e8bb55e1"
+                      "sha256-C3qp7SgHNmy4hLgDKOvZoFMgmaFWF+enN2JFk06gkNw=";
+                  corefx =
+                    fetchMonoExternal "corefx" "63c51e726292149b4868db71baa883e5ad173766"
+                      "sha256-6VmwciurTpaLqsRganxCMPjIHcNOW9sEf2YOpPLKBpA=";
+                  corert =
+                    fetchMonoExternal "corert" "31eda261991f9f6c1add1686b6d3799f835b2978"
+                      "sha256-+yOaNaRAo+hp18AN5/4WzcexhMOwOTREpx0ckCppF2g=";
+                  ikdasm =
+                    fetchMonoExternal "ikdasm" "88b67c42ca8b7d58141c176b46749819bfcef166"
+                      "sha256-XHG6u9szp9YokE72T2xCYobYJ+cKx4AsICYD9GALCyw=";
+                  ikvm =
+                    fetchMonoExternal "ikvm-fork" "7c1e61bec8c069b2cc9e214c3094b147d76bbf82"
+                      "sha256-1v0Jn0GWmBou8aBRhv6hAQba7k3mBB0/aROaI0kurG4=";
+                  linker = fetchgit {
+                    url = "https://github.com/mono/linker.git";
+                    rev = "1bdcf6b7bfbe3b03fdaa76f6124d0d7374f08615";
+                    hash = "sha256-cwg7Q+FF1Q48mYjunTfSiZkg62PwP7z9AOizxxrSpvc=";
+                    fetchSubmodules = false;
+                  };
+                  "Lucene.Net.Light" =
+                    fetchMonoExternal "Lucene.Net.Light" "85978b7eb94738f516824341213d5e94060f5284"
+                      "sha256-MXonEg7tutx2hgLoN4S0GxM2hQooMgel20CNKkpEITQ=";
+                  "Newtonsoft.Json" =
+                    fetchMonoExternal "Newtonsoft.Json" "471c3e0803a9f40a0acc8aeceb31de6ff93a52c4"
+                      "sha256-Gp1UpraahcFFXQanzr4Y1U7bsLFLTUAehd5MDEt79jU=";
+                  nuget-buildtasks = fetchgit {
+                    url = "https://github.com/mono/NuGet.BuildTasks.git";
+                    rev = "04bdab55d8de9edcf628694cfd2001561e8f8e60";
+                    hash = "sha256-5RycEC928dM5HODnYMpGgU78m2WEUEd5eVO32b3qdNo=";
+                  };
+                  nunit-lite = fetchgit {
+                    url = "https://github.com/mono/NUnitLite.git";
+                    rev = "690603bea98aae69fca9a65130d88591bc6cabee";
+                    hash = "sha256-jD9bxexVanJ+BxQtO135BJE+bTOGc89ean7oL7UvBLk=";
+                  };
+                  rx =
+                    fetchMonoExternal "rx" "b29a4b0fda609e0af33ff54ed13652b6ccf0e05e"
+                      "sha256-O/oioCocqVIG9xUl3wn4WZw1/2W1RgNQE5vNpSvkMtg=";
+                }}
+                find external -type f \( -name '*.dll' -o -name '*.DLL' -o -name '*.exe' -o -name '*.EXE' -o -name '*.so' \) -delete
+                substituteInPlace tools/monograph/Makefile.am \
+                  --replace-fail "/mono/metadata/libmonoruntimesgen-static.la" \
+                                 "/mono/metadata/libmonoruntimesgen-static.la \$(top_builddir)/mono/sgen/libmonosgen-static.la"
+                substituteInPlace mcs/class/Microsoft.Build.Tasks/Makefile \
+                  --replace-fail "include ../../build/library.make" $'include ../../build/library.make\nrun-test-recursive:\n\t@echo skipping tests'
+                substituteInPlace mcs/packages/Makefile \
+                  --replace-fail "install-local:" $'install-local:\n\techo "Skipping blob install"\n\nunused0:'
+                if [ -f eglib/autogen.sh ]; then
+                  patchShebangs eglib/autogen.sh
+                fi
+                if [ -d mcs/tools ]; then
+                  patchShebangs mcs/tools
+                fi
+      '';
+      extraPreConfigure = ''
+        export TZ=
+      '';
+      extraPostBuild = ''
+        pushd external/binary-reference-assemblies
+        for makefile in $(find . -name Makefile); do
+          substituteInPlace "$makefile" \
+            --replace-quiet "CSC_COMMON_ARGS := " "CSC_COMMON_ARGS := -delaysign+ " \
+            --replace-quiet "IBM.Data.DB2_REFS := " "IBM.Data.DB2_REFS := System.Xml " \
+            --replace-quiet "Mono.Data.Sqlite_REFS := " "Mono.Data.Sqlite_REFS := System.Xml " \
+            --replace-quiet "System.Data.DataSetExtensions_REFS := " "System.Data.DataSetExtensions_REFS := System.Xml " \
+            --replace-quiet "System.Data.OracleClient_REFS := " "System.Data.OracleClient_REFS := System.Xml " \
+            --replace-quiet "System.IdentityModel_REFS := " "System.IdentityModel_REFS := System.Configuration " \
+            --replace-quiet "System.Design_REFS := " "System.Design_REFS := Accessibility " \
+            --replace-quiet "System.Web.Extensions.Design_REFS := " "System.Web.Extensions.Design_REFS := System.Windows.Forms System.Web " \
+            --replace-quiet "System.ServiceModel.Routing_REFS := " "System.ServiceModel.Routing_REFS := System.Xml " \
+            --replace-quiet "System.Web.Abstractions_REFS := " "System.Web.Abstractions_REFS := System " \
+            --replace-quiet "System.Reactive.Windows.Forms_REFS := " "System.Reactive.Windows.Forms_REFS := System " \
+            --replace-quiet "System.Windows.Forms.DataVisualization_REFS := " "System.Windows.Forms.DataVisualization_REFS := Accessibility " \
+            --replace-quiet "Facades/System.ServiceModel.Primitives_REFS := " "Facades/System.ServiceModel.Primitives_REFS := System.Xml " \
+            --replace-quiet "Facades/System.Dynamic.Runtime_REFS := " "Facades/System.Dynamic.Runtime_REFS := System " \
+            --replace-quiet "Facades/System.Xml.XDocument_REFS := " "Facades/System.Xml.XDocument_REFS := System.Xml " \
+            --replace-quiet "Facades/System.Runtime.Serialization.Xml_REFS := " "Facades/System.Runtime.Serialization.Xml_REFS := System.Xml "
+        done
+        make -j"$NIX_BUILD_CORES" V=1 SKIP_AOT=1 \
+          CSC="MONO_PATH=$PWD/../../mcs/class/lib/build $PWD/../../runtime/mono-wrapper $PWD/../../mcs/class/lib/build/mcs.exe"
+        unset makefile
+        popd
+        make -C mcs/tools/resx2sr SKIP_AOT=1 V=1
+      '';
+      extraPostInstall = ''
+                make -C mcs/tools/resx2sr install SKIP_AOT=1 V=1
+                cat > "$out/bin/resx2sr" <<EOF
+        #!/bin/sh
+        exec "$out/bin/mono" "$out/lib/mono/4.5/resx2sr.exe" "\$@"
+        EOF
+                chmod +x "$out/bin/resx2sr"
+      '';
+    };
+
+    mono-5_2_0 = mkMono {
+      version = "5.2.0.224";
+      src = fetchgit {
+        url = "https://gitlab.winehq.org/mono/mono.git";
+        rev = "mono-5.2.0.224";
+        hash = "sha256-yi3G2gHDYTFwOGR7tmkvVzLOsPcY7rdfAT3eKT12T38=";
+        fetchSubmodules = false;
+      };
+      bootstrapCompiler = self.mono-5_1_0;
+      bootstrapRuntime = self.mono-5_1_0;
+      cflags = baseCflagsWithIntConversion;
+      configureFlags = [
+        "--with-sgen=yes"
+        "--disable-boehm"
+        "--with-csc=mcs"
+      ];
+      makeFlags = [
+        "SKIP_AOT=1"
+        "V=1"
+      ];
+      enableParallelBuilding = false;
+      doCheck = false;
+      patchReflectionFormatStrings = false;
+      cmakeForConfigure = cmake;
+      extraPostPatch = ''
+                mkdir -p m4 external
+                if [ ! -f mono/mini/Makefile.am ] && [ -f mono/mini/Makefile.am.in ]; then
+                  cp mono/mini/Makefile.am.in mono/mini/Makefile.am
+                fi
+                substituteInPlace mono/mini/main.c \
+                  --replace-fail "mono_build_date = build_date;" "(void) build_date;"
+                substituteInPlace mono/utils/mono-dl.h \
+                  --replace-fail 'MonoDl*     mono_dl_open       (const char *name, int flags, char **error_msg) MONO_LLVM_INTERNAL;' \
+                                 'MONO_API MonoDl* mono_dl_open (const char *name, int flags, char **error_msg);'
+                substituteInPlace mono/metadata/metadata-internals.h \
+                  --replace-fail 'void
+        mono_loader_register_module (const char *name, MonoDl *module);' \
+                                 'MONO_API void
+        mono_loader_register_module (const char *name, MonoDl *module);'
+                substituteInPlace mono/btls/Makefile.am \
+                  --replace-fail '-D SRC_DIR:PATH=$(abs_top_srcdir)/mono/btls -D BTLS_CFLAGS:STRING="$(BTLS_CFLAGS)"' \
+                                 '-D SRC_DIR:PATH=$(abs_top_srcdir)/mono/btls -D BTLS_CFLAGS:STRING="$(BTLS_CFLAGS)" -D CMAKE_POLICY_VERSION_MINIMUM=3.5'
+                ${copyExternalRepos {
+                  aspnetwebstack =
+                    fetchMonoExternal "aspnetwebstack" "e77b12e6cc5ed260a98447f609e887337e44e299"
+                      "sha256-AbtgeY4xkkTJP03O0FBFZNQ6sWjEiKDduNWRjAkZemY=";
+                  binary-reference-assemblies =
+                    fetchMonoExternal "reference-assemblies" "142cbeb62ffabf1dd9c1414d8dd76f93bcbed0c2"
+                      "sha256-qSkuxIUiAsEJhRtJGZTy2funTlk+3bp/qSasBxMqbfI=";
+                  bockbuild =
+                    fetchMonoExternal "bockbuild" "45aa142fa322f5b41051e7f40008f03346a1e119"
+                      "sha256-QCjblbeteVx+6A8+r5x9Agd2wOk3qCTODEVgOOB/VOo=";
+                  boringssl =
+                    fetchMonoExternal "boringssl" "3e0770e18835714708860ba9fe1af04a932971ff"
+                      "sha256-3rxa7em96fHVzPIjNHOQano8P1XRKGuymKKokOgDKo0=";
+                  buildtools =
+                    fetchMonoExternal "buildtools" "b5cc6e6ab5f71f6c0be7b730058b426e92528479"
+                      "sha256-BlhZn9MA+U9aF4xyU9bWjJgI6sguWjBhSxJhcgktslE=";
+                  cecil =
+                    fetchMonoExternal "cecil" "362e2bb00fa693d04c2d140a4cd313eb82c78d95"
+                      "sha256-bbP73NVPfjDBv2TqUjcoqYA/x3jLmNUjUjI3aulWai8=";
+                  cecil-legacy =
+                    fetchMonoExternal "cecil" "33d50b874fd527118bc361d83de3d494e8bb55e1"
+                      "sha256-C3qp7SgHNmy4hLgDKOvZoFMgmaFWF+enN2JFk06gkNw=";
+                  corefx =
+                    fetchMonoExternal "corefx" "78360b22e71b70de1d8cc9588cb4ef0040449c31"
+                      "sha256-p2LmU+A+6EpXr5+JGuO4pDSyTOvIqOUaC/hk5Z36OvM=";
+                  corert =
+                    fetchMonoExternal "corert" "ed6296dfbb88d66f08601c013caee30c88c41afa"
+                      "sha256-ubc4xwV8vez024UHE8xlZaDueTQV9/Ama38RgqMKOJ0=";
+                  ikdasm =
+                    fetchMonoExternal "ikdasm" "88b67c42ca8b7d58141c176b46749819bfcef166"
+                      "sha256-XHG6u9szp9YokE72T2xCYobYJ+cKx4AsICYD9GALCyw=";
+                  ikvm =
+                    fetchMonoExternal "ikvm-fork" "7c1e61bec8c069b2cc9e214c3094b147d76bbf82"
+                      "sha256-1v0Jn0GWmBou8aBRhv6hAQba7k3mBB0/aROaI0kurG4=";
+                  linker = fetchgit {
+                    url = "https://github.com/mono/linker.git";
+                    rev = "c7450ca2669becddffdea7dcdcc06692e57989e1";
+                    hash = "sha256-YdfCSdKcO2xhIHJPFYnLk+VObLrpAFOPCDdUDA3foW0=";
+                    fetchSubmodules = false;
+                  };
+                  "Lucene.Net.Light" =
+                    fetchMonoExternal "Lucene.Net.Light" "85978b7eb94738f516824341213d5e94060f5284"
+                      "sha256-MXonEg7tutx2hgLoN4S0GxM2hQooMgel20CNKkpEITQ=";
+                  "Newtonsoft.Json" =
+                    fetchMonoExternal "Newtonsoft.Json" "471c3e0803a9f40a0acc8aeceb31de6ff93a52c4"
+                      "sha256-Gp1UpraahcFFXQanzr4Y1U7bsLFLTUAehd5MDEt79jU=";
+                  nuget-buildtasks = fetchgit {
+                    url = "https://github.com/mono/NuGet.BuildTasks.git";
+                    rev = "8d307472ea214f2b59636431f771894dbcba7258";
+                    hash = "sha256-UtIWVbfCnSP+JaVwCV/V9dININNREhaTWGeiDqTNLsA=";
+                  };
+                  nunit-lite = fetchgit {
+                    url = "https://github.com/mono/NUnitLite.git";
+                    rev = "690603bea98aae69fca9a65130d88591bc6cabee";
+                    hash = "sha256-jD9bxexVanJ+BxQtO135BJE+bTOGc89ean7oL7UvBLk=";
+                  };
+                  rx =
+                    fetchMonoExternal "rx" "b29a4b0fda609e0af33ff54ed13652b6ccf0e05e"
+                      "sha256-O/oioCocqVIG9xUl3wn4WZw1/2W1RgNQE5vNpSvkMtg=";
+                }}
+                find external -type f \( -name '*.dll' -o -name '*.DLL' -o -name '*.exe' -o -name '*.EXE' -o -name '*.so' \) -delete
+                substituteInPlace tools/monograph/Makefile.am \
+                  --replace-fail "/mono/metadata/libmonoruntimesgen-static.la" \
+                                 "/mono/metadata/libmonoruntimesgen-static.la \$(top_builddir)/mono/sgen/libmonosgen-static.la"
+                substituteInPlace mcs/class/Microsoft.Build.Tasks/Makefile \
+                  --replace-fail "include ../../build/library.make" $'include ../../build/library.make\nrun-test-recursive:\n\t@echo skipping tests'
+                substituteInPlace mcs/packages/Makefile \
+                  --replace-fail "install-local:" $'install-local:\n\techo "Skipping blob install"\n\nunused0:'
+                if [ -f eglib/autogen.sh ]; then
+                  patchShebangs eglib/autogen.sh
+                fi
+                if [ -d mcs/tools ]; then
+                  patchShebangs mcs/tools
+                fi
+      '';
+      extraPreConfigure = ''
+        export TZ=
+      '';
+      extraPostBuild = ''
+        pushd external/binary-reference-assemblies
+        for makefile in $(find . -name Makefile); do
+          substituteInPlace "$makefile" \
+            --replace-quiet "CSC_COMMON_ARGS := " "CSC_COMMON_ARGS := -delaysign+ " \
+            --replace-quiet "IBM.Data.DB2_REFS := " "IBM.Data.DB2_REFS := System.Xml " \
+            --replace-quiet "Mono.Data.Sqlite_REFS := " "Mono.Data.Sqlite_REFS := System.Xml " \
+            --replace-quiet "System.Data.DataSetExtensions_REFS := " "System.Data.DataSetExtensions_REFS := System.Xml " \
+            --replace-quiet "System.Data.OracleClient_REFS := " "System.Data.OracleClient_REFS := System.Xml " \
+            --replace-quiet "System.IdentityModel_REFS := " "System.IdentityModel_REFS := System.Configuration " \
+            --replace-quiet "System.Design_REFS := " "System.Design_REFS := Accessibility " \
+            --replace-quiet "System.Web.Extensions.Design_REFS := " "System.Web.Extensions.Design_REFS := System.Windows.Forms System.Web " \
+            --replace-quiet "System.ServiceModel.Routing_REFS := " "System.ServiceModel.Routing_REFS := System.Xml " \
+            --replace-quiet "System.Web.Abstractions_REFS := " "System.Web.Abstractions_REFS := System " \
+            --replace-quiet "System.Reactive.Windows.Forms_REFS := " "System.Reactive.Windows.Forms_REFS := System " \
+            --replace-quiet "System.Windows.Forms.DataVisualization_REFS := " "System.Windows.Forms.DataVisualization_REFS := Accessibility " \
+            --replace-quiet "Facades/System.ServiceModel.Primitives_REFS := " "Facades/System.ServiceModel.Primitives_REFS := System.Xml " \
+            --replace-quiet "Facades/System.Dynamic.Runtime_REFS := " "Facades/System.Dynamic.Runtime_REFS := System " \
+            --replace-quiet "Facades/System.Xml.XDocument_REFS := " "Facades/System.Xml.XDocument_REFS := System.Xml " \
+            --replace-quiet "Facades/System.Runtime.Serialization.Xml_REFS := " "Facades/System.Runtime.Serialization.Xml_REFS := System.Xml "
+        done
+        make -j"$NIX_BUILD_CORES" V=1 SKIP_AOT=1 \
+          CSC="MONO_PATH=$PWD/../../mcs/class/lib/build $PWD/../../runtime/mono-wrapper $PWD/../../mcs/class/lib/build/mcs.exe"
+        unset makefile
+        popd
+        make -C mcs/tools/resx2sr SKIP_AOT=1 V=1
+      '';
+      extraPostInstall = ''
+                make -C mcs/tools/resx2sr install SKIP_AOT=1 V=1
+                cat > "$out/bin/resx2sr" <<EOF
+        #!/bin/sh
+        exec "$out/bin/mono" "$out/lib/mono/4.5/resx2sr.exe" "\$@"
+        EOF
+                chmod +x "$out/bin/resx2sr"
+      '';
+    };
+
+    mono-5_4_0 = mkMono {
+      version = "5.4.0.212";
+      src = fetchgit {
+        url = "https://gitlab.winehq.org/mono/mono.git";
+        rev = "mono-5.4.0.212";
+        hash = "sha256-XliVpsDekaVysu+mSo6K6NT0thgb3njkdAVTHn53oz8=";
+        fetchSubmodules = false;
+      };
+      patches = [ guixPatches."mono-5.4.0-patches.patch" ];
+      bootstrapCompiler = self.mono-5_2_0;
+      bootstrapRuntime = self.mono-5_2_0;
+      cflags = baseCflagsWithIntConversion;
+      configureFlags = [
+        "--with-sgen=yes"
+        "--disable-boehm"
+        "--with-csc=mcs"
+      ];
+      makeFlags = [
+        "SKIP_AOT=1"
+        "V=1"
+      ];
+      enableParallelBuilding = false;
+      doCheck = false;
+      patchReflectionFormatStrings = false;
+      cmakeForConfigure = cmake;
+      extraPostPatch = ''
+                mkdir -p m4 external
+                if [ ! -f mono/mini/Makefile.am ] && [ -f mono/mini/Makefile.am.in ]; then
+                  cp mono/mini/Makefile.am.in mono/mini/Makefile.am
+                fi
+                substituteInPlace mono/mini/main.c \
+                  --replace-fail "mono_build_date = build_date;" "(void) build_date;"
+                substituteInPlace mono/utils/mono-dl.h \
+                  --replace-fail 'MonoDl*     mono_dl_open       (const char *name, int flags, char **error_msg) MONO_LLVM_INTERNAL;' \
+                                 'MONO_API MonoDl* mono_dl_open (const char *name, int flags, char **error_msg);'
+                substituteInPlace mono/metadata/metadata-internals.h \
+                  --replace-fail 'void
+        mono_loader_register_module (const char *name, MonoDl *module);' \
+                                 'MONO_API void
+        mono_loader_register_module (const char *name, MonoDl *module);'
+                substituteInPlace mono/btls/Makefile.am \
+                  --replace-fail '-D SRC_DIR:PATH=$(abs_top_srcdir)/mono/btls -D BTLS_CFLAGS:STRING="$(BTLS_CFLAGS)"' \
+                                 '-D SRC_DIR:PATH=$(abs_top_srcdir)/mono/btls -D BTLS_CFLAGS:STRING="$(BTLS_CFLAGS)" -D CMAKE_POLICY_VERSION_MINIMUM=3.5'
+                ${copyExternalRepos {
+                  aspnetwebstack =
+                    fetchMonoExternal "aspnetwebstack" "e77b12e6cc5ed260a98447f609e887337e44e299"
+                      "sha256-AbtgeY4xkkTJP03O0FBFZNQ6sWjEiKDduNWRjAkZemY=";
+                  api-doc-tools = fetchgit {
+                    url = "https://github.com/mono/api-doc-tools.git";
+                    rev = "d03e819838c6241f92f90655cb448cc47c9e8791";
+                    hash = "sha256-0g2nzdFL/goqfS6+oESyMADzW0Bax/1iZ+PF4dKJM+Y=";
+                    fetchSubmodules = true;
+                  };
+                  api-snapshot =
+                    fetchMonoExternal "api-snapshot" "b09033be33ab25113743151c644c831158c54042"
+                      "sha256-k52pbX5MqVDdGf2OaUvM0Heaz810XjOiNSvmFRqOx3w=";
+                  binary-reference-assemblies =
+                    fetchMonoExternal "reference-assemblies" "142cbeb62ffabf1dd9c1414d8dd76f93bcbed0c2"
+                      "sha256-qSkuxIUiAsEJhRtJGZTy2funTlk+3bp/qSasBxMqbfI=";
+                  bockbuild =
+                    fetchMonoExternal "bockbuild" "0efdb371e6d79abc54c0e3bb3689fa1646f4394e"
+                      "sha256-O1vEgcU60kwahpjCFQqp8kWYCGYgmiBHFOsPxUUNGYM=";
+                  boringssl =
+                    fetchMonoExternal "boringssl" "3e0770e18835714708860ba9fe1af04a932971ff"
+                      "sha256-3rxa7em96fHVzPIjNHOQano8P1XRKGuymKKokOgDKo0=";
+                  cecil =
+                    fetchMonoExternal "cecil" "c0eb983dac62519d3ae93a689312076aacecb723"
+                      "sha256-s93gkWYHaB8Ycdti30hBA91HwYedV0fnBQAbpy6/Iwo=";
+                  cecil-legacy =
+                    fetchMonoExternal "cecil" "33d50b874fd527118bc361d83de3d494e8bb55e1"
+                      "sha256-C3qp7SgHNmy4hLgDKOvZoFMgmaFWF+enN2JFk06gkNw=";
+                  corefx =
+                    fetchMonoExternal "corefx" "9ad53d674e31327abcc60f35c14387700f50cc68"
+                      "sha256-vJhGhdy2WDUwvYoWzminCh9DRZvNsLU7yUpzJJ145Co=";
+                  corert =
+                    fetchMonoExternal "corert" "48dba73801e804e89f00311da99d873f9c550278"
+                      "sha256-c+tPJ1b9W9VvpTs5vgK5ihnXx4ldR+p7VBVzRpw8hP8=";
+                  ikdasm =
+                    fetchMonoExternal "ikdasm" "1d7d43603791e0236b56d076578657bee44fef6b"
+                      "sha256-Tw897/mXDgQqdckQ9C/FNqp9asR7SfOugriUpub0iM8=";
+                  ikvm =
+                    fetchMonoExternal "ikvm-fork" "847e05fced5c9a41ff0f24f1f9d40d5a8a5772c1"
+                      "sha256-8TqnNImacb6teF3HnnfjlRTm0p84kj42jsj9Skddibo=";
+                  linker = fetchgit {
+                    url = "https://github.com/mono/linker.git";
+                    rev = "99354bf5c13b8055209cb082cddc50c8047ab088";
+                    hash = "sha256-soYTaL3sn499xdoIrkTAuiBpKLYJQi7sdn0gh61U9Bc=";
+                    fetchSubmodules = false;
+                  };
+                  "Newtonsoft.Json" =
+                    fetchMonoExternal "Newtonsoft.Json" "471c3e0803a9f40a0acc8aeceb31de6ff93a52c4"
+                      "sha256-Gp1UpraahcFFXQanzr4Y1U7bsLFLTUAehd5MDEt79jU=";
+                  nuget-buildtasks = fetchgit {
+                    url = "https://github.com/mono/NuGet.BuildTasks.git";
+                    rev = "b58ba4282377bcefd48abdc2d62ce6330e079abe";
+                    hash = "sha256-d9PjUMACrDjE5RMegaaDlcii9PBWMfVP6lpObN0AXuk=";
+                  };
+                  nunit-lite = fetchgit {
+                    url = "https://github.com/mono/NUnitLite.git";
+                    rev = "690603bea98aae69fca9a65130d88591bc6cabee";
+                    hash = "sha256-jD9bxexVanJ+BxQtO135BJE+bTOGc89ean7oL7UvBLk=";
+                  };
+                  rx =
+                    fetchMonoExternal "rx" "b29a4b0fda609e0af33ff54ed13652b6ccf0e05e"
+                      "sha256-O/oioCocqVIG9xUl3wn4WZw1/2W1RgNQE5vNpSvkMtg=";
+                }}
+                patch -d external/corefx -p1 < ${guixPatches."corefx-mono-5.4.0-patches.patch"}
+                find external -type f \( -name '*.dll' -o -name '*.DLL' -o -name '*.exe' -o -name '*.EXE' -o -name '*.so' \) -delete
+                substituteInPlace tools/monograph/Makefile.am \
+                  --replace-fail "/mono/metadata/libmonoruntimesgen-static.la" \
+                                 "/mono/metadata/libmonoruntimesgen-static.la \$(top_builddir)/mono/sgen/libmonosgen-static.la"
+                substituteInPlace mcs/class/Microsoft.Build.Tasks/Makefile \
+                  --replace-fail "include ../../build/library.make" $'include ../../build/library.make\nrun-test-recursive:\n\t@echo skipping tests'
+                substituteInPlace mcs/packages/Makefile \
+                  --replace-fail "install-local:" $'install-local:\n\techo "Skipping blob install"\n\nunused0:'
+                if [ -f eglib/autogen.sh ]; then
+                  patchShebangs eglib/autogen.sh
+                fi
+                if [ -d mcs/tools ]; then
+                  patchShebangs mcs/tools
+                fi
+      '';
+      extraPreConfigure = ''
+        export TZ=
+      '';
+      extraPostBuild = ''
+        pushd external/binary-reference-assemblies
+        for makefile in $(find . -name Makefile); do
+          substituteInPlace "$makefile" \
+            --replace-quiet "CSC_COMMON_ARGS := " "CSC_COMMON_ARGS := -delaysign+ " \
+            --replace-quiet "IBM.Data.DB2_REFS := " "IBM.Data.DB2_REFS := System.Xml " \
+            --replace-quiet "Mono.Data.Sqlite_REFS := " "Mono.Data.Sqlite_REFS := System.Xml " \
+            --replace-quiet "System.Data.DataSetExtensions_REFS := " "System.Data.DataSetExtensions_REFS := System.Xml " \
+            --replace-quiet "System.Data.OracleClient_REFS := " "System.Data.OracleClient_REFS := System.Xml " \
+            --replace-quiet "System.IdentityModel_REFS := " "System.IdentityModel_REFS := System.Configuration " \
+            --replace-quiet "System.Design_REFS := " "System.Design_REFS := Accessibility " \
+            --replace-quiet "System.Web.Extensions.Design_REFS := " "System.Web.Extensions.Design_REFS := System.Windows.Forms System.Web " \
+            --replace-quiet "System.ServiceModel.Routing_REFS := " "System.ServiceModel.Routing_REFS := System.Xml " \
+            --replace-quiet "System.Web.Abstractions_REFS := " "System.Web.Abstractions_REFS := System " \
+            --replace-quiet "System.Reactive.Windows.Forms_REFS := " "System.Reactive.Windows.Forms_REFS := System " \
+            --replace-quiet "System.Windows.Forms.DataVisualization_REFS := " "System.Windows.Forms.DataVisualization_REFS := Accessibility " \
+            --replace-quiet "Facades/System.ServiceModel.Primitives_REFS := " "Facades/System.ServiceModel.Primitives_REFS := System.Xml " \
+            --replace-quiet "Facades/System.Dynamic.Runtime_REFS := " "Facades/System.Dynamic.Runtime_REFS := System " \
+            --replace-quiet "Facades/System.Xml.XDocument_REFS := " "Facades/System.Xml.XDocument_REFS := System.Xml " \
+            --replace-quiet "Facades/System.Runtime.Serialization.Xml_REFS := " "Facades/System.Runtime.Serialization.Xml_REFS := System.Xml "
+        done
+        make -j"$NIX_BUILD_CORES" V=1 SKIP_AOT=1 \
+          CSC="MONO_PATH=$PWD/../../mcs/class/lib/build $PWD/../../runtime/mono-wrapper $PWD/../../mcs/class/lib/build/mcs.exe"
+        unset makefile
+        popd
+        make -C mcs/tools/resx2sr SKIP_AOT=1 V=1
+      '';
+      extraPostInstall = ''
+                if grep -q "NO_INSTALL = yes" mcs/tools/resx2sr/Makefile; then
+                  substituteInPlace mcs/tools/resx2sr/Makefile \
+                    --replace-fail "NO_INSTALL = yes" "# NO_INSTALL disabled for bootstrapping"
+                fi
+                make -C mcs/tools/resx2sr install SKIP_AOT=1 V=1
+                cat > "$out/bin/resx2sr" <<EOF
+        #!/bin/sh
+        exec "$out/bin/mono" "$out/lib/mono/4.5/resx2sr.exe" "\$@"
+        EOF
+                chmod +x "$out/bin/resx2sr"
+      '';
+    };
+
+    mono-pre-5_8_0 = self.mono-5_4_0.override {
+      version = "5.4.0.201-0.d0f51b4e8340";
+      src = fetchgit {
+        url = "https://gitlab.winehq.org/mono/mono.git";
+        rev = "d0f51b4e834042cfa593748ada942033b458cc40";
+        hash = "sha256-o7BIrnczK83vb3qKJvKKBqeKR1i3rlljaS9ZG6bX5Ss=";
+        fetchSubmodules = false;
+      };
+      patches = [ guixPatches."mono-5.4.0-patches.patch" ];
+      bootstrapCompiler = self.mono-5_4_0;
+      bootstrapRuntime = self.mono-5_4_0;
+      extraPostPatch = ''
+        mkdir -p m4 external
+        if [ ! -f mono/mini/Makefile.am.in ] && [ -f mono/mini/Makefile.am ]; then
+          cp mono/mini/Makefile.am mono/mini/Makefile.am.in
+        fi
+        if [ ! -f mono/mini/Makefile.am ] && [ -f mono/mini/Makefile.am.in ]; then
+          cp mono/mini/Makefile.am.in mono/mini/Makefile.am
+        fi
+        if [ -f mono/mini/main.c ]; then
+          if grep -q "mono_build_date = build_date;" mono/mini/main.c; then
+            substituteInPlace mono/mini/main.c \
+              --replace-fail "mono_build_date = build_date;" "(void) build_date;"
+          fi
+          if grep -q '__DATE__' mono/mini/main.c; then
+            substituteInPlace mono/mini/main.c \
+              --replace-fail '__DATE__' '"Jan 01 1980"'
+          fi
+          if grep -q '__TIME__' mono/mini/main.c; then
+            substituteInPlace mono/mini/main.c \
+              --replace-fail '__TIME__' '"00:00:00"'
+          fi
+        fi
+        if [ -f mono/utils/mono-dl.c ] && grep -q "void\* mono_dl_open" mono/utils/mono-dl.c; then
+          substituteInPlace mono/utils/mono-dl.c \
+            --replace-fail "void* mono_dl_open" "__attribute__((visibility(\"default\"))) void* mono_dl_open"
+        fi
+        if [ -f mono/metadata/loader.c ] && grep -q "void mono_loader_register_module" mono/metadata/loader.c; then
+          substituteInPlace mono/metadata/loader.c \
+            --replace-fail "void mono_loader_register_module" "__attribute__((visibility(\"default\"))) void mono_loader_register_module"
+        fi
+        if [ -f mono/btls/Makefile.am ] && grep -q -- "-DENABLE_ASSEMBLER=1" mono/btls/Makefile.am; then
+          substituteInPlace mono/btls/Makefile.am \
+            --replace-fail "-DENABLE_ASSEMBLER=1" "-DENABLE_ASSEMBLER=1 -DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+        fi
+        if [ -f mono/btls/Makefile.am ] && grep -q "CMAKE_ARGS = " mono/btls/Makefile.am; then
+          substituteInPlace mono/btls/Makefile.am \
+            --replace-fail "CMAKE_ARGS = " "CMAKE_ARGS = -DCMAKE_POLICY_VERSION_MINIMUM=3.5 "
+        fi
+        ${copyExternalRepos {
+          api-doc-tools = fetchgit {
+            url = "https://github.com/mono/api-doc-tools.git";
+            rev = "d03e819838c6241f92f90655cb448cc47c9e8791";
+            hash = "sha256-0g2nzdFL/goqfS6+oESyMADzW0Bax/1iZ+PF4dKJM+Y=";
+            fetchSubmodules = true;
+          };
+          api-snapshot =
+            fetchMonoExternal "api-snapshot" "e790a9b77031ef1d8ebf093ef88840edea11ed73"
+              "sha256-2HRV5NpNelp3tZe3t+dG5TJ1ve16oR5iYLemhp24lrA=";
+          aspnetwebstack =
+            fetchMonoExternal "aspnetwebstack" "e77b12e6cc5ed260a98447f609e887337e44e299"
+              "sha256-AbtgeY4xkkTJP03O0FBFZNQ6sWjEiKDduNWRjAkZemY=";
+          binary-reference-assemblies =
+            fetchMonoExternal "reference-assemblies" "142cbeb62ffabf1dd9c1414d8dd76f93bcbed0c2"
+              "sha256-qSkuxIUiAsEJhRtJGZTy2funTlk+3bp/qSasBxMqbfI=";
+          bockbuild =
+            fetchMonoExternal "bockbuild" "b445017309aac741a26d8c51bb0636234084bf23"
+              "sha256-JZmUNfB640qhM6f9+crIK9cJtnyfKR68PhbI0Lba8Ms=";
+          boringssl =
+            fetchMonoExternal "boringssl" "3e0770e18835714708860ba9fe1af04a932971ff"
+              "sha256-3rxa7em96fHVzPIjNHOQano8P1XRKGuymKKokOgDKo0=";
+          cecil =
+            fetchMonoExternal "cecil" "c76ba7b410447fa37093150cb7bc772cba28a0ae"
+              "sha256-SH3TO51iedekeuOx9mZqD5NFKTnWP5Wk3R5LhWw+sXk=";
+          cecil-legacy =
+            fetchMonoExternal "cecil" "33d50b874fd527118bc361d83de3d494e8bb55e1"
+              "sha256-C3qp7SgHNmy4hLgDKOvZoFMgmaFWF+enN2JFk06gkNw=";
+          corefx =
+            fetchMonoExternal "corefx" "74ccd8aa00d7d271191ca3b9c4f818268dc36c28"
+              "sha256-0miVkvuGvXtU+bg9T0iJocoa56kiOdsXysLIfRsOpFo=";
+          corert =
+            fetchMonoExternal "corert" "48dba73801e804e89f00311da99d873f9c550278"
+              "sha256-c+tPJ1b9W9VvpTs5vgK5ihnXx4ldR+p7VBVzRpw8hP8=";
+          ikdasm =
+            fetchMonoExternal "ikdasm" "3aef9cdd6013fc0620a1817f0b11d8fb90ed2e0f"
+              "sha256-+2u7hdqXziXmeEpUVS+Ll7uGV4Un8phMCoehPkZUDB0=";
+          ikvm =
+            fetchMonoExternal "ikvm-fork" "847e05fced5c9a41ff0f24f1f9d40d5a8a5772c1"
+              "sha256-8TqnNImacb6teF3HnnfjlRTm0p84kj42jsj9Skddibo=";
+          linker = fetchgit {
+            url = "https://github.com/mono/linker.git";
+            rev = "21e445c26c69ac3a2e1441befa02d0bd105ff849";
+            hash = "sha256-jPt1/tGnT0XDdSgWEJMBgGJJRe2ySeQF0x6cp8GMo8M=";
+            fetchSubmodules = false;
+          };
+          "Newtonsoft.Json" =
+            fetchMonoExternal "Newtonsoft.Json" "471c3e0803a9f40a0acc8aeceb31de6ff93a52c4"
+              "sha256-Gp1UpraahcFFXQanzr4Y1U7bsLFLTUAehd5MDEt79jU=";
+          nuget-buildtasks = fetchgit {
+            url = "https://github.com/mono/NuGet.BuildTasks.git";
+            rev = "8d307472ea214f2b59636431f771894dbcba7258";
+            hash = "sha256-UtIWVbfCnSP+JaVwCV/V9dININNREhaTWGeiDqTNLsA=";
+          };
+          nunit-lite = fetchgit {
+            url = "https://github.com/mono/NUnitLite.git";
+            rev = "690603bea98aae69fca9a65130d88591bc6cabee";
+            hash = "sha256-jD9bxexVanJ+BxQtO135BJE+bTOGc89ean7oL7UvBLk=";
+          };
+          rx =
+            fetchMonoExternal "rx" "b29a4b0fda609e0af33ff54ed13652b6ccf0e05e"
+              "sha256-O/oioCocqVIG9xUl3wn4WZw1/2W1RgNQE5vNpSvkMtg=";
+        }}
+        patch -d external/corefx -p1 < ${guixPatches."corefx-mono-pre-5.8.0-patches.patch"}
+        find external -type f \( -name '*.dll' -o -name '*.DLL' -o -name '*.exe' -o -name '*.EXE' -o -name '*.so' \) -delete
+        substituteInPlace tools/monograph/Makefile.am \
+          --replace-fail "/mono/metadata/libmonoruntimesgen-static.la" \
+                         "/mono/metadata/libmonoruntimesgen-static.la \$(top_builddir)/mono/sgen/libmonosgen-static.la"
+        substituteInPlace mcs/class/Microsoft.Build.Tasks/Makefile \
+          --replace-fail "include ../../build/library.make" $'include ../../build/library.make\nrun-test-recursive:\n\t@echo skipping tests'
+        substituteInPlace mcs/packages/Makefile \
+          --replace-fail "install-local:" $'install-local:\n\techo "Skipping blob install"\n\nunused0:'
+        if [ -f eglib/autogen.sh ]; then
+          patchShebangs eglib/autogen.sh
+        fi
+        if [ -d mcs/tools ]; then
+          patchShebangs mcs/tools
+        fi
+      '';
+    };
+
+    mono-5_8_0 = self.mono-pre-5_8_0.override {
+      version = "5.8.0.129";
+      src = fetchgit {
+        url = "https://gitlab.winehq.org/mono/mono.git";
+        rev = "mono-5.8.0.129";
+        hash = "sha256-5hMPi1bIw3Xzr/MuyVTtYp0nsOyJY3DK4eR+P0bbYAQ=";
+        fetchSubmodules = false;
+      };
+      patches = [ guixPatches."mono-5.8.0-patches.patch" ];
+      bootstrapCompiler = self.mono-pre-5_8_0;
+      bootstrapRuntime = self.mono-pre-5_8_0;
+      extraPostPatch = ''
+        mkdir -p m4 external
+        if [ ! -f mono/mini/Makefile.am.in ] && [ -f mono/mini/Makefile.am ]; then
+          cp mono/mini/Makefile.am mono/mini/Makefile.am.in
+        fi
+        if [ ! -f mono/mini/Makefile.am ] && [ -f mono/mini/Makefile.am.in ]; then
+          cp mono/mini/Makefile.am.in mono/mini/Makefile.am
+        fi
+        if [ -f mono/mini/main.c ]; then
+          if grep -q "mono_build_date = build_date;" mono/mini/main.c; then
+            substituteInPlace mono/mini/main.c \
+              --replace-fail "mono_build_date = build_date;" "(void) build_date;"
+          fi
+          if grep -q '__DATE__' mono/mini/main.c; then
+            substituteInPlace mono/mini/main.c \
+              --replace-fail '__DATE__' '"Jan 01 1980"'
+          fi
+          if grep -q '__TIME__' mono/mini/main.c; then
+            substituteInPlace mono/mini/main.c \
+              --replace-fail '__TIME__' '"00:00:00"'
+          fi
+        fi
+        if [ -f mono/utils/mono-dl.c ] && grep -q "void\* mono_dl_open" mono/utils/mono-dl.c; then
+          substituteInPlace mono/utils/mono-dl.c \
+            --replace-fail "void* mono_dl_open" "__attribute__((visibility(\"default\"))) void* mono_dl_open"
+        fi
+        if [ -f mono/metadata/loader.c ] && grep -q "void mono_loader_register_module" mono/metadata/loader.c; then
+          substituteInPlace mono/metadata/loader.c \
+            --replace-fail "void mono_loader_register_module" "__attribute__((visibility(\"default\"))) void mono_loader_register_module"
+        fi
+        if [ -f mono/btls/Makefile.am ] && grep -q -- "-DENABLE_ASSEMBLER=1" mono/btls/Makefile.am; then
+          substituteInPlace mono/btls/Makefile.am \
+            --replace-fail "-DENABLE_ASSEMBLER=1" "-DENABLE_ASSEMBLER=1 -DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+        fi
+        if [ -f mono/btls/Makefile.am ] && grep -q "CMAKE_ARGS = " mono/btls/Makefile.am; then
+          substituteInPlace mono/btls/Makefile.am \
+            --replace-fail "CMAKE_ARGS = " "CMAKE_ARGS = -DCMAKE_POLICY_VERSION_MINIMUM=3.5 "
+        fi
+        ${copyExternalRepos {
+          api-doc-tools = fetchgit {
+            url = "https://github.com/mono/api-doc-tools.git";
+            rev = "d03e819838c6241f92f90655cb448cc47c9e8791";
+            hash = "sha256-0g2nzdFL/goqfS6+oESyMADzW0Bax/1iZ+PF4dKJM+Y=";
+            fetchSubmodules = true;
+          };
+          api-snapshot =
+            fetchMonoExternal "api-snapshot" "6668c80a9499218c0b8cc41f48a9e242587df756"
+              "sha256-7eiZxULDQQLnFXkEguAgGsWyx1yIDySOpJJkGBRffG0=";
+          aspnetwebstack =
+            fetchMonoExternal "aspnetwebstack" "e77b12e6cc5ed260a98447f609e887337e44e299"
+              "sha256-AbtgeY4xkkTJP03O0FBFZNQ6sWjEiKDduNWRjAkZemY=";
+          binary-reference-assemblies =
+            fetchMonoExternal "reference-assemblies" "e048fe4a88d237d105ae02fe0363a68296099362"
+              "sha256-iXjoopYNM10zzz6ud3TrdCEEFdjUUSc0esSRZPqIB0U=";
+          bockbuild =
+            fetchMonoExternal "bockbuild" "cb4545409dafe16dfe86c7d8e6548a69c369e2a2"
+              "sha256-pz8b77+Ouz+KUBZGrK0rx+WbchIhzvdJ4/eaFsx2bWs=";
+          boringssl =
+            fetchMonoExternal "boringssl" "3e0770e18835714708860ba9fe1af04a932971ff"
+              "sha256-3rxa7em96fHVzPIjNHOQano8P1XRKGuymKKokOgDKo0=";
+          cecil =
+            fetchMonoExternal "cecil" "76ffcdabae660e9586273c9b40db180a0dc8d4c8"
+              "sha256-5BZK/IY1KnMtdGn3KNnJ+sla7SIHmAqWrf0iEbPTazg=";
+          cecil-legacy =
+            fetchMonoExternal "cecil" "33d50b874fd527118bc361d83de3d494e8bb55e1"
+              "sha256-C3qp7SgHNmy4hLgDKOvZoFMgmaFWF+enN2JFk06gkNw=";
+          corefx =
+            fetchMonoExternal "corefx" "b965d1f8b5281712c4400ef28ed97670ffd4880d"
+              "sha256-WXPTNJ5+0JKPN+UY1zdWzDuZ6gyW4CsifmrIoRfIMGU=";
+          corert =
+            fetchMonoExternal "corert" "48dba73801e804e89f00311da99d873f9c550278"
+              "sha256-c+tPJ1b9W9VvpTs5vgK5ihnXx4ldR+p7VBVzRpw8hP8=";
+          ikdasm =
+            fetchMonoExternal "ikdasm" "465c0815558fd43c0110f8d00fc186ac0044ac6a"
+              "sha256-gpczTQGgto9ZLj8OqXIS1Kzrc8Oap4f0WZAA/Ng9OXY=";
+          ikvm =
+            fetchMonoExternal "ikvm-fork" "847e05fced5c9a41ff0f24f1f9d40d5a8a5772c1"
+              "sha256-8TqnNImacb6teF3HnnfjlRTm0p84kj42jsj9Skddibo=";
+          linker = fetchgit {
+            url = "https://github.com/mono/linker.git";
+            rev = "c62335c350f3902ff0459112f7efc8b926f4f15d";
+            hash = "sha256-HUk1OlkzruQDlyHMYtq8zlrEbzGbeU2h3Scm3nRIoQQ=";
+            fetchSubmodules = false;
+          };
+          "Newtonsoft.Json" =
+            fetchMonoExternal "Newtonsoft.Json" "471c3e0803a9f40a0acc8aeceb31de6ff93a52c4"
+              "sha256-Gp1UpraahcFFXQanzr4Y1U7bsLFLTUAehd5MDEt79jU=";
+          nuget-buildtasks = fetchgit {
+            url = "https://github.com/mono/NuGet.BuildTasks.git";
+            rev = "b2c30bc81b2a7733a4eeb252a55f6b4d50cfc3a1";
+            hash = "sha256-dL2D7QW8p5b8xXHlYrSovn6c7HI8tl5EcSJ4012Wagc=";
+          };
+          nunit-lite = fetchgit {
+            url = "https://github.com/mono/NUnitLite.git";
+            rev = "764656cdafdb3acd25df8cb52a4e0ea14760fccd";
+            hash = "sha256-eAOuYiwLj7Uv8Xr6K/ce+9NK5cbqWWIZ0tGEdMekh10=";
+          };
+          rx =
+            fetchMonoExternal "rx" "b29a4b0fda609e0af33ff54ed13652b6ccf0e05e"
+              "sha256-O/oioCocqVIG9xUl3wn4WZw1/2W1RgNQE5vNpSvkMtg=";
+        }}
+        find external -type f \( -name '*.dll' -o -name '*.DLL' -o -name '*.exe' -o -name '*.EXE' -o -name '*.so' \) -delete
+        substituteInPlace tools/monograph/Makefile.am \
+          --replace-fail "/mono/metadata/libmonoruntimesgen-static.la" \
+                         "/mono/metadata/libmonoruntimesgen-static.la \$(top_builddir)/mono/sgen/libmonosgen-static.la"
+        substituteInPlace mcs/class/Microsoft.Build.Tasks/Makefile \
+          --replace-fail "include ../../build/library.make" $'include ../../build/library.make\nrun-test-recursive:\n\t@echo skipping tests'
+        substituteInPlace mcs/packages/Makefile \
+          --replace-fail "install-local:" $'install-local:\n\techo "Skipping blob install"\n\nunused0:'
+        if [ -f eglib/autogen.sh ]; then
+          patchShebangs eglib/autogen.sh
+        fi
+        if [ -d mcs/tools ]; then
+          patchShebangs mcs/tools
+        fi
+      '';
+      extraPostBuild = ''
+        pushd external/binary-reference-assemblies
+        for makefile in $(find . -name Makefile); do
+          substituteInPlace "$makefile" \
+            --replace-quiet "CSC_COMMON_ARGS := " "CSC_COMMON_ARGS := -delaysign+ " \
+            --replace-quiet "IBM.Data.DB2_REFS := " "IBM.Data.DB2_REFS := System.Xml " \
+            --replace-quiet "Mono.Data.Sqlite_REFS := " "Mono.Data.Sqlite_REFS := System.Xml " \
+            --replace-quiet "System.Data.DataSetExtensions_REFS := " "System.Data.DataSetExtensions_REFS := System.Xml " \
+            --replace-quiet "System.Data.OracleClient_REFS := " "System.Data.OracleClient_REFS := System.Xml " \
+            --replace-quiet "System.IdentityModel_REFS := " "System.IdentityModel_REFS := System.Configuration " \
+            --replace-quiet "System.Design_REFS := " "System.Design_REFS := Accessibility " \
+            --replace-quiet "System.Web.Extensions.Design_REFS := " "System.Web.Extensions.Design_REFS := System.Windows.Forms System.Web " \
+            --replace-quiet "System.ServiceModel.Routing_REFS := " "System.ServiceModel.Routing_REFS := System.Xml " \
+            --replace-quiet "System.Web.Abstractions_REFS := " "System.Web.Abstractions_REFS := System " \
+            --replace-quiet "System.Reactive.Windows.Forms_REFS := " "System.Reactive.Windows.Forms_REFS := System " \
+            --replace-quiet "System.Windows.Forms.DataVisualization_REFS := " "System.Windows.Forms.DataVisualization_REFS := Accessibility " \
+            --replace-quiet "Facades/System.ServiceModel.Primitives_REFS := " "Facades/System.ServiceModel.Primitives_REFS := System.Xml " \
+            --replace-quiet "Facades/System.Dynamic.Runtime_REFS := " "Facades/System.Dynamic.Runtime_REFS := System " \
+            --replace-quiet "Facades/System.Xml.XDocument_REFS := " "Facades/System.Xml.XDocument_REFS := System.Xml " \
+            --replace-quiet "Facades/System.Runtime.Serialization.Xml_REFS := " "Facades/System.Runtime.Serialization.Xml_REFS := System.Xml " \
+            --replace-quiet "Facades/System.Data.Common_REFS := " "Facades/System.Data.Common_REFS := System System.Xml "
+        done
+        make -j"$NIX_BUILD_CORES" V=1 SKIP_AOT=1 \
+          CSC="MONO_PATH=$PWD/../../mcs/class/lib/build $PWD/../../runtime/mono-wrapper $PWD/../../mcs/class/lib/build/mcs.exe"
+        unset makefile
+        popd
+        make -C mcs/tools/resx2sr SKIP_AOT=1 V=1
+      '';
+    };
+
+    mono-pre-5_10_0 = self.mono-5_8_0.override {
+      version = "5.8.0.129-0.3e9d7d6e9cf8";
+      src = fetchgit {
+        url = "https://gitlab.winehq.org/mono/mono.git";
+        rev = "3e9d7d6e9cf8dc33eb29c497c350a1cd7df3a057";
+        hash = "sha256-SxKKZJtWuqLJQEdKgM2hGbAwP0u7JK/1WM8B+N8HEVU=";
+        fetchSubmodules = false;
+      };
+      patches = [ guixPatches."mono-mcs-patches-from-5.10.0.patch" ];
+      bootstrapCompiler = self.mono-5_8_0;
+      bootstrapRuntime = self.mono-5_8_0;
+      extraPostPatch = ''
+        mkdir -p m4 external
+        if [ ! -f mono/mini/Makefile.am.in ] && [ -f mono/mini/Makefile.am ]; then
+          cp mono/mini/Makefile.am mono/mini/Makefile.am.in
+        fi
+        if [ ! -f mono/mini/Makefile.am ] && [ -f mono/mini/Makefile.am.in ]; then
+          cp mono/mini/Makefile.am.in mono/mini/Makefile.am
+        fi
+        if [ -f mono/mini/main.c ]; then
+          if grep -q "mono_build_date = build_date;" mono/mini/main.c; then
+            substituteInPlace mono/mini/main.c \
+              --replace-fail "mono_build_date = build_date;" "(void) build_date;"
+          fi
+          if grep -q '__DATE__' mono/mini/main.c; then
+            substituteInPlace mono/mini/main.c \
+              --replace-fail '__DATE__' '"Jan 01 1980"'
+          fi
+          if grep -q '__TIME__' mono/mini/main.c; then
+            substituteInPlace mono/mini/main.c \
+              --replace-fail '__TIME__' '"00:00:00"'
+          fi
+        fi
+        if [ -f mono/utils/mono-dl.c ] && grep -q "void\* mono_dl_open" mono/utils/mono-dl.c; then
+          substituteInPlace mono/utils/mono-dl.c \
+            --replace-fail "void* mono_dl_open" "__attribute__((visibility(\"default\"))) void* mono_dl_open"
+        fi
+        if [ -f mono/metadata/loader.c ] && grep -q "void mono_loader_register_module" mono/metadata/loader.c; then
+          substituteInPlace mono/metadata/loader.c \
+            --replace-fail "void mono_loader_register_module" "__attribute__((visibility(\"default\"))) void mono_loader_register_module"
+        fi
+        if [ -f mono/btls/Makefile.am ] && grep -q -- "-DENABLE_ASSEMBLER=1" mono/btls/Makefile.am; then
+          substituteInPlace mono/btls/Makefile.am \
+            --replace-fail "-DENABLE_ASSEMBLER=1" "-DENABLE_ASSEMBLER=1 -DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+        fi
+        if [ -f mono/btls/Makefile.am ] && grep -q "CMAKE_ARGS = " mono/btls/Makefile.am; then
+          substituteInPlace mono/btls/Makefile.am \
+            --replace-fail "CMAKE_ARGS = " "CMAKE_ARGS = -DCMAKE_POLICY_VERSION_MINIMUM=3.5 "
+        fi
+        ${copyExternalRepos {
+          api-doc-tools = fetchgit {
+            url = "https://github.com/mono/api-doc-tools.git";
+            rev = "d03e819838c6241f92f90655cb448cc47c9e8791";
+            hash = "sha256-0g2nzdFL/goqfS6+oESyMADzW0Bax/1iZ+PF4dKJM+Y=";
+            fetchSubmodules = true;
+          };
+          api-snapshot =
+            fetchMonoExternal "api-snapshot" "627333cae84f02a36ee9ca605c96dac4557d9f35"
+              "sha256-tOHsAfozO7Oh0KoDqMoa0vUaKGiyFKe2R6Pz2PMyLF0=";
+          aspnetwebstack =
+            fetchMonoExternal "aspnetwebstack" "e77b12e6cc5ed260a98447f609e887337e44e299"
+              "sha256-AbtgeY4xkkTJP03O0FBFZNQ6sWjEiKDduNWRjAkZemY=";
+          binary-reference-assemblies =
+            fetchMonoExternal "reference-assemblies" "9c5cc7f051a0bba2e41341a5baebfc4d2c2133ef"
+              "sha256-4XFAVVqkthSbapIu68izRQ4vpZ9+Vy678w9Fu3GwbpE=";
+          bockbuild =
+            fetchMonoExternal "bockbuild" "29022af5d8a94651b2eece93f910559b254ec3f0"
+              "sha256-hB+vygiw8MG9ADurtHuMrRHe6ziA0iYG70bmWnVglFE=";
+          boringssl =
+            fetchMonoExternal "boringssl" "3e0770e18835714708860ba9fe1af04a932971ff"
+              "sha256-3rxa7em96fHVzPIjNHOQano8P1XRKGuymKKokOgDKo0=";
+          cecil =
+            fetchMonoExternal "cecil" "bc11f472954694ebd92ae4956f110c1036a7c2e0"
+              "sha256-zfJlCpTY4wUaLEb35DdpV9VMO57YVmXkRYFbdsu1Vog=";
+          cecil-legacy =
+            fetchMonoExternal "cecil" "33d50b874fd527118bc361d83de3d494e8bb55e1"
+              "sha256-C3qp7SgHNmy4hLgDKOvZoFMgmaFWF+enN2JFk06gkNw=";
+          corefx =
+            fetchMonoExternal "corefx" "cb1b049c95227465c1791b857cb5ba86385d9f29"
+              "sha256-o6y3M/eqVIU+qh8xRjlYj0I8umn4AfSC/sO4/qjEIN8=";
+          corert =
+            fetchMonoExternal "corert" "48dba73801e804e89f00311da99d873f9c550278"
+              "sha256-c+tPJ1b9W9VvpTs5vgK5ihnXx4ldR+p7VBVzRpw8hP8=";
+          ikdasm =
+            fetchMonoExternal "ikdasm" "465c0815558fd43c0110f8d00fc186ac0044ac6a"
+              "sha256-gpczTQGgto9ZLj8OqXIS1Kzrc8Oap4f0WZAA/Ng9OXY=";
+          ikvm =
+            fetchMonoExternal "ikvm-fork" "847e05fced5c9a41ff0f24f1f9d40d5a8a5772c1"
+              "sha256-8TqnNImacb6teF3HnnfjlRTm0p84kj42jsj9Skddibo=";
+          linker = fetchgit {
+            url = "https://github.com/mono/linker.git";
+            rev = "99354bf5c13b8055209cb082cddc50c8047ab088";
+            hash = "sha256-soYTaL3sn499xdoIrkTAuiBpKLYJQi7sdn0gh61U9Bc=";
+            fetchSubmodules = false;
+          };
+          "Newtonsoft.Json" =
+            fetchMonoExternal "Newtonsoft.Json" "471c3e0803a9f40a0acc8aeceb31de6ff93a52c4"
+              "sha256-Gp1UpraahcFFXQanzr4Y1U7bsLFLTUAehd5MDEt79jU=";
+          nuget-buildtasks = fetchgit {
+            url = "https://github.com/mono/NuGet.BuildTasks.git";
+            rev = "b58ba4282377bcefd48abdc2d62ce6330e079abe";
+            hash = "sha256-d9PjUMACrDjE5RMegaaDlcii9PBWMfVP6lpObN0AXuk=";
+          };
+          nunit-lite = fetchgit {
+            url = "https://github.com/mono/NUnitLite.git";
+            rev = "764656cdafdb3acd25df8cb52a4e0ea14760fccd";
+            hash = "sha256-eAOuYiwLj7Uv8Xr6K/ce+9NK5cbqWWIZ0tGEdMekh10=";
+          };
+          rx =
+            fetchMonoExternal "rx" "b29a4b0fda609e0af33ff54ed13652b6ccf0e05e"
+              "sha256-O/oioCocqVIG9xUl3wn4WZw1/2W1RgNQE5vNpSvkMtg=";
+        }}
+        find external -type f \( -name '*.dll' -o -name '*.DLL' -o -name '*.exe' -o -name '*.EXE' -o -name '*.so' \) -delete
+        substituteInPlace tools/monograph/Makefile.am \
+          --replace-fail "/mono/metadata/libmonoruntimesgen-static.la" \
+                         "/mono/metadata/libmonoruntimesgen-static.la \$(top_builddir)/mono/sgen/libmonosgen-static.la"
+        substituteInPlace mcs/class/Microsoft.Build.Tasks/Makefile \
+          --replace-fail "include ../../build/library.make" $'include ../../build/library.make\nrun-test-recursive:\n\t@echo skipping tests'
+        substituteInPlace mcs/packages/Makefile \
+          --replace-fail "install-local:" $'install-local:\n\techo "Skipping blob install"\n\nunused0:'
+        if [ -f eglib/autogen.sh ]; then
+          patchShebangs eglib/autogen.sh
+        fi
+        if [ -d mcs/tools ]; then
+          patchShebangs mcs/tools
+        fi
+      '';
+    };
+
+    mono-5_10_0 = self.mono-pre-5_10_0.override {
+      version = "5.10.0.179";
+      src = fetchgit {
+        url = "https://gitlab.winehq.org/mono/mono.git";
+        rev = "mono-5.10.0.179";
+        hash = "sha256-RpgBURkrelpNN90JJa1qjCEggK+pegOmzr8STkxYcf8=";
+        fetchSubmodules = false;
+      };
+      # Adapted from Guix: fragile nunit/csproj hunks are handled in
+      # extraPostPatch below so they tolerate source layout and line ending
+      # differences across this stage.
+      patches = [ ./patches/mono-5.10.0-later-mcs-changes.patch ];
+      bootstrapCompiler = self.mono-pre-5_10_0;
+      bootstrapRuntime = self.mono-pre-5_10_0;
+      extraNativeBuildInputs = [ python3 ];
+      extraPostPatch = ''
+        mkdir -p m4 external
+        for file in \
+          mcs/nunit24/ClientUtilities/util/AssemblyInfo.cs \
+          mcs/nunit24/ConsoleRunner/nunit-console/AssemblyInfo.cs \
+          mcs/nunit24/NUnitCore/core/AssemblyInfo.cs \
+          mcs/nunit24/NUnitCore/interfaces/AssemblyInfo.cs \
+          mcs/nunit24/NUnitExtensions/core/AssemblyInfo.cs \
+          mcs/nunit24/NUnitExtensions/framework/AssemblyInfo.cs \
+          mcs/nunit24/NUnitFramework/framework/AssemblyInfo.cs \
+          mcs/nunit24/NUnitMocks/mocks/AssemblyInfo.cs; do
+          if [ -f "$file" ]; then
+            perl -0pi -e 's/\r?\n\[assembly: AssemblyDelaySign\(false\)\]\r?\n\[assembly: AssemblyKeyFile\("\.\.\/\.\.\/nunit\.snk"\)\]\r?\n\[assembly: AssemblyKeyName\(""\)\]//g' "$file"
+          fi
+        done
+        if [ -f msvc/scripts/csproj.tmpl ] && ! grep -q "@METADATAVERSION@" msvc/scripts/csproj.tmpl; then
+          perl -0pi -e 's/(    \@NOSTDLIB\@\r?\n)/$1    \@METADATAVERSION\@\n/' msvc/scripts/csproj.tmpl
+        fi
+        if [ ! -f mono/mini/Makefile.am.in ] && [ -f mono/mini/Makefile.am ]; then
+          cp mono/mini/Makefile.am mono/mini/Makefile.am.in
+        fi
+        if [ ! -f mono/mini/Makefile.am ] && [ -f mono/mini/Makefile.am.in ]; then
+          cp mono/mini/Makefile.am.in mono/mini/Makefile.am
+        fi
+        if [ -f mono/mini/main.c ]; then
+          if grep -q "mono_build_date = build_date;" mono/mini/main.c; then
+            substituteInPlace mono/mini/main.c \
+              --replace-fail "mono_build_date = build_date;" "(void) build_date;"
+          fi
+          if grep -q '__DATE__' mono/mini/main.c; then
+            substituteInPlace mono/mini/main.c \
+              --replace-fail '__DATE__' '"Jan 01 1980"'
+          fi
+          if grep -q '__TIME__' mono/mini/main.c; then
+            substituteInPlace mono/mini/main.c \
+              --replace-fail '__TIME__' '"00:00:00"'
+          fi
+        fi
+        if [ -f mono/utils/mono-dl.c ] && grep -q "void\* mono_dl_open" mono/utils/mono-dl.c; then
+          substituteInPlace mono/utils/mono-dl.c \
+            --replace-fail "void* mono_dl_open" "__attribute__((visibility(\"default\"))) void* mono_dl_open"
+        fi
+        if [ -f mono/metadata/loader.c ] && grep -q "void mono_loader_register_module" mono/metadata/loader.c; then
+          substituteInPlace mono/metadata/loader.c \
+            --replace-fail "void mono_loader_register_module" "__attribute__((visibility(\"default\"))) void mono_loader_register_module"
+        fi
+        if [ -f mono/btls/Makefile.am ] && grep -q -- "-DENABLE_ASSEMBLER=1" mono/btls/Makefile.am; then
+          substituteInPlace mono/btls/Makefile.am \
+            --replace-fail "-DENABLE_ASSEMBLER=1" "-DENABLE_ASSEMBLER=1 -DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+        fi
+        if [ -f mono/btls/Makefile.am ] && grep -q "CMAKE_ARGS = " mono/btls/Makefile.am; then
+          substituteInPlace mono/btls/Makefile.am \
+            --replace-fail "CMAKE_ARGS = " "CMAKE_ARGS = -DCMAKE_POLICY_VERSION_MINIMUM=3.5 "
+        fi
+        ${copyExternalRepos {
+          api-doc-tools = fetchgit {
+            url = "https://github.com/mono/api-doc-tools.git";
+            rev = "d03e819838c6241f92f90655cb448cc47c9e8791";
+            hash = "sha256-0g2nzdFL/goqfS6+oESyMADzW0Bax/1iZ+PF4dKJM+Y=";
+            fetchSubmodules = true;
+          };
+          api-snapshot =
+            fetchMonoExternal "api-snapshot" "da8bb8c7b970383ce26c9b09ce3689d843a6222e"
+              "sha256-HPtR/d1cAWLQGvap9EhLW7a5DBwb6D3/ArDl6BPgfQI=";
+          aspnetwebstack =
+            fetchMonoExternal "aspnetwebstack" "e77b12e6cc5ed260a98447f609e887337e44e299"
+              "sha256-AbtgeY4xkkTJP03O0FBFZNQ6sWjEiKDduNWRjAkZemY=";
+          binary-reference-assemblies =
+            fetchMonoExternal "reference-assemblies" "e048fe4a88d237d105ae02fe0363a68296099362"
+              "sha256-iXjoopYNM10zzz6ud3TrdCEEFdjUUSc0esSRZPqIB0U=";
+          bockbuild =
+            fetchMonoExternal "bockbuild" "1908d43ec630544189bd11630a59ec4ef571db28"
+              "sha256-Y4XMhsvv+tqkzx/WQi0AwQH7FJQQW1TYX5Y3weKjI8A=";
+          boringssl =
+            fetchMonoExternal "boringssl" "3e0770e18835714708860ba9fe1af04a932971ff"
+              "sha256-3rxa7em96fHVzPIjNHOQano8P1XRKGuymKKokOgDKo0=";
+          cecil =
+            fetchMonoExternal "cecil" "dfee11e80d59e1a3d6d9c914c3f277c726bace52"
+              "sha256-CAg8a6nmXna2mpsowD+qflLgaaIfRHwxpcIjlHYqTvg=";
+          cecil-legacy =
+            fetchMonoExternal "cecil" "33d50b874fd527118bc361d83de3d494e8bb55e1"
+              "sha256-C3qp7SgHNmy4hLgDKOvZoFMgmaFWF+enN2JFk06gkNw=";
+          corefx =
+            fetchMonoExternal "corefx" "e327d2855ed74dac96f684797e4820345297a690"
+              "sha256-AKuIwhM60fkIqo3BWlrN/MA6sWcoSfdAhMTxj6y18YY=";
+          corert =
+            fetchMonoExternal "corert" "aa64b376c1a2238b1a768e158d1b11dac77d722a"
+              "sha256-7/H93nmli0alCl9r8v6/vqSRj89K8mZS98VnoBOp5L0=";
+          ikdasm =
+            fetchMonoExternal "ikdasm" "465c0815558fd43c0110f8d00fc186ac0044ac6a"
+              "sha256-gpczTQGgto9ZLj8OqXIS1Kzrc8Oap4f0WZAA/Ng9OXY=";
+          ikvm =
+            fetchMonoExternal "ikvm-fork" "847e05fced5c9a41ff0f24f1f9d40d5a8a5772c1"
+              "sha256-8TqnNImacb6teF3HnnfjlRTm0p84kj42jsj9Skddibo=";
+          linker = fetchgit {
+            url = "https://github.com/mono/linker.git";
+            rev = "84d37424cde6e66bbf997110a4dbdba7e60038e9";
+            hash = "sha256-GR8CJM/q/snp8n+Sopfy/ekili7WBZbn2k1/GRObzh0=";
+            fetchSubmodules = false;
+          };
+          "Newtonsoft.Json" =
+            fetchMonoExternal "Newtonsoft.Json" "471c3e0803a9f40a0acc8aeceb31de6ff93a52c4"
+              "sha256-Gp1UpraahcFFXQanzr4Y1U7bsLFLTUAehd5MDEt79jU=";
+          nuget-buildtasks = fetchgit {
+            url = "https://github.com/mono/NuGet.BuildTasks.git";
+            rev = "b2c30bc81b2a7733a4eeb252a55f6b4d50cfc3a1";
+            hash = "sha256-dL2D7QW8p5b8xXHlYrSovn6c7HI8tl5EcSJ4012Wagc=";
+          };
+          nunit-lite = fetchgit {
+            url = "https://github.com/mono/NUnitLite.git";
+            rev = "70bb70b0ffd0109aadaa6e4ea178972d4fb63ea3";
+            hash = "sha256-mMBn3mDiIa9G2cjlhKGdll9mRROXaYZd5Y0Bk4LNx1I=";
+          };
+          rx =
+            fetchMonoExternal "rx" "b29a4b0fda609e0af33ff54ed13652b6ccf0e05e"
+              "sha256-O/oioCocqVIG9xUl3wn4WZw1/2W1RgNQE5vNpSvkMtg=";
+        }}
+        find external -type f \( -name '*.dll' -o -name '*.DLL' -o -name '*.exe' -o -name '*.EXE' -o -name '*.so' \) -delete
+        substituteInPlace tools/monograph/Makefile.am \
+          --replace-fail "/mono/metadata/libmonoruntimesgen-static.la" \
+                         "/mono/metadata/libmonoruntimesgen-static.la \$(top_builddir)/mono/sgen/libmonosgen-static.la"
+        substituteInPlace mcs/class/Microsoft.Build.Tasks/Makefile \
+          --replace-fail "include ../../build/library.make" $'include ../../build/library.make\nrun-test-recursive:\n\t@echo skipping tests'
+        substituteInPlace mcs/packages/Makefile \
+          --replace-fail "install-local:" $'install-local:\n\techo "Skipping blob install"\n\nunused0:'
+        if [ -f eglib/autogen.sh ]; then
+          patchShebangs eglib/autogen.sh
+        fi
+        if [ -d mcs/tools ]; then
+          patchShebangs mcs/tools
+        fi
+      '';
+      extraPreBuild = ''
+        pushd external/binary-reference-assemblies
+        for makefile in $(find . -name Makefile); do
+          substituteInPlace "$makefile" \
+            --replace-quiet "CSC_COMMON_ARGS := " "CSC_COMMON_ARGS := -delaysign+ " \
+            --replace-quiet "IBM.Data.DB2_REFS := " "IBM.Data.DB2_REFS := System.Xml " \
+            --replace-quiet "Mono.Data.Sqlite_REFS := " "Mono.Data.Sqlite_REFS := System.Xml " \
+            --replace-quiet "System.Data.DataSetExtensions_REFS := " "System.Data.DataSetExtensions_REFS := System.Xml " \
+            --replace-quiet "System.Data.OracleClient_REFS := " "System.Data.OracleClient_REFS := System.Xml " \
+            --replace-quiet "System.IdentityModel_REFS := " "System.IdentityModel_REFS := System.Configuration " \
+            --replace-quiet "System.Design_REFS := " "System.Design_REFS := Accessibility " \
+            --replace-quiet "System.Web.Extensions.Design_REFS := " "System.Web.Extensions.Design_REFS := System.Windows.Forms System.Web " \
+            --replace-quiet "System.ServiceModel.Routing_REFS := " "System.ServiceModel.Routing_REFS := System.Xml " \
+            --replace-quiet "System.Web.Abstractions_REFS := " "System.Web.Abstractions_REFS := System " \
+            --replace-quiet "System.Reactive.Windows.Forms_REFS := " "System.Reactive.Windows.Forms_REFS := System " \
+            --replace-quiet "System.Windows.Forms.DataVisualization_REFS := " "System.Windows.Forms.DataVisualization_REFS := Accessibility " \
+            --replace-quiet "Facades/System.ServiceModel.Primitives_REFS := " "Facades/System.ServiceModel.Primitives_REFS := System.Xml " \
+            --replace-quiet "Facades/System.Dynamic.Runtime_REFS := " "Facades/System.Dynamic.Runtime_REFS := System " \
+            --replace-quiet "Facades/System.Xml.XDocument_REFS := " "Facades/System.Xml.XDocument_REFS := System.Xml " \
+            --replace-quiet "Facades/System.Runtime.Serialization.Xml_REFS := " "Facades/System.Runtime.Serialization.Xml_REFS := System.Xml " \
+            --replace-quiet "Facades/System.Data.Common_REFS := " "Facades/System.Data.Common_REFS := System System.Xml "
+        done
+        make -j"$NIX_BUILD_CORES" V=1 SKIP_AOT=1 CSC=mcs
+        unset makefile
+        popd
+      '';
+      extraPostBuild = ''
+        make -C mcs/tools/resx2sr SKIP_AOT=1 V=1
+      '';
+    };
+
+    mono-6_12_0 = self.mono-5_10_0.override {
+      version = "6.12.0.206";
+      src = fetchgit {
+        url = "https://gitlab.winehq.org/mono/mono.git";
+        rev = "mono-6.12.0.206";
+        hash = "sha256-c1NlEoa65yLQlKL/8MLXZtlovDkyllv72Yatt0bZibM=";
+        fetchSubmodules = false;
+      };
+      patches = [
+        guixPatches."mono-6.12.0-fix-ConditionParser.patch"
+        # Adapted from Guix: the SectionGroupInfo runpath hunk is omitted.
+        ./patches/mono-6.12.0-add-runpath.patch
+        guixPatches."mono-6.12.0-fix-AssemblyResolver.patch"
+      ];
+      bootstrapCompiler = self.mono-5_10_0;
+      bootstrapRuntime = self.mono-5_10_0;
+      extraNativeBuildInputs = [ python3 ];
+      extraBuildInputs = [
+        libgdiplus
+        unixodbc
+      ];
+      extraPostPatch = ''
+        mkdir -p m4 external
+        if [ -f mcs/build/common/basic-profile-check.cs ]; then
+          perl -0pi -e 's/min_mono_version = new Version \([0-9]+, [0-9]+\);/min_mono_version = new Version (0, 0);/g' \
+            mcs/build/common/basic-profile-check.cs
+        fi
+        if [ -f mono/mini/Makefile.am.in ]; then
+          substituteInPlace mono/mini/Makefile.am.in \
+            --replace-quiet "-langversion:8.0" ""
+        fi
+        if [ -f mono/tests/Makefile.am ]; then
+          perl -0pi -e 's/\t(dim-generic|dim-issue-18917|interface-2|delegate18|generic-unmanaged-constraint|async-generic-enum)\.cs[^\n]*\n//g' mono/tests/Makefile.am
+        fi
+        if [ -f runtime/Makefile.am ]; then
+          substituteInPlace runtime/Makefile.am \
+            --replace-quiet "	    fi; done; done;" "	    fi; done; done; ok=:;"
+        fi
+        if [ -f mcs/tools/Makefile ]; then
+          substituteInPlace mcs/tools/Makefile \
+            --replace-quiet "mono-helix-client" ""
+        fi
+        if [ -f mcs/tools/resx2sr/Makefile ]; then
+          substituteInPlace mcs/tools/resx2sr/Makefile \
+            --replace-quiet "NO_INSTALL = yes" "NO_INSTALL ="
+        fi
+        if [ ! -f mono/mini/Makefile.am.in ] && [ -f mono/mini/Makefile.am ]; then
+          cp mono/mini/Makefile.am mono/mini/Makefile.am.in
+        fi
+        if [ ! -f mono/mini/Makefile.am ] && [ -f mono/mini/Makefile.am.in ]; then
+          cp mono/mini/Makefile.am.in mono/mini/Makefile.am
+        fi
+        if [ -f mono/mini/main.c ]; then
+          if grep -q "mono_build_date = build_date;" mono/mini/main.c; then
+            substituteInPlace mono/mini/main.c \
+              --replace-fail "mono_build_date = build_date;" "(void) build_date;"
+          fi
+          if grep -q '__DATE__' mono/mini/main.c; then
+            substituteInPlace mono/mini/main.c \
+              --replace-fail '__DATE__' '"Jan 01 1980"'
+          fi
+          if grep -q '__TIME__' mono/mini/main.c; then
+            substituteInPlace mono/mini/main.c \
+              --replace-fail '__TIME__' '"00:00:00"'
+          fi
+        fi
+        if [ -f mono/utils/mono-dl.c ] && grep -q "void\* mono_dl_open" mono/utils/mono-dl.c; then
+          substituteInPlace mono/utils/mono-dl.c \
+            --replace-fail "void* mono_dl_open" "__attribute__((visibility(\"default\"))) void* mono_dl_open"
+        fi
+        if [ -f mono/metadata/loader.c ] && grep -q "void mono_loader_register_module" mono/metadata/loader.c; then
+          substituteInPlace mono/metadata/loader.c \
+            --replace-fail "void mono_loader_register_module" "__attribute__((visibility(\"default\"))) void mono_loader_register_module"
+        fi
+        if [ -f mono/btls/Makefile.am ] && grep -q -- "-DENABLE_ASSEMBLER=1" mono/btls/Makefile.am; then
+          substituteInPlace mono/btls/Makefile.am \
+            --replace-fail "-DENABLE_ASSEMBLER=1" "-DENABLE_ASSEMBLER=1 -DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+        fi
+        if [ -f mono/btls/Makefile.am ] && grep -q "CMAKE_ARGS = " mono/btls/Makefile.am; then
+          substituteInPlace mono/btls/Makefile.am \
+            --replace-fail "CMAKE_ARGS = " "CMAKE_ARGS = -DCMAKE_POLICY_VERSION_MINIMUM=3.5 "
+        fi
+        ${copyExternalRepos {
+          api-doc-tools = fetchgit {
+            url = "https://github.com/mono/api-doc-tools.git";
+            rev = "5da8127af9e68c9d58a90aa9de21f57491d81261";
+            hash = "sha256-5DFNne4mEMC4F9YPwymG36ChUQNmoiSaNWOr4mtvCGc=";
+            fetchSubmodules = true;
+          };
+          api-snapshot =
+            fetchMonoExternal "api-snapshot" "808e8a9e4be8d38e097d2b0919cac37bc195844a"
+              "sha256-KgAyyc/3njVRqtnByygPQc1tGhQ4pRhxrysRw9uLtcQ=";
+          aspnetwebstack =
+            fetchMonoExternal "aspnetwebstack" "e77b12e6cc5ed260a98447f609e887337e44e299"
+              "sha256-AbtgeY4xkkTJP03O0FBFZNQ6sWjEiKDduNWRjAkZemY=";
+          binary-reference-assemblies =
+            fetchMonoExternal "reference-assemblies" "e68046d5106aa0349c23f95821456955fc15b96b"
+              "sha256-IJGbH8cek+cfeELP+BQ2jklVXf5qoW48QRQ2TI74F9c=";
+          bockbuild =
+            fetchMonoExternal "bockbuild" "3bd44f6784b85b1ece8b00b13d12cf416f5a87e7"
+              "sha256-uku2DwztSEfVl/jXXZxjDxFhi3+66s0undRyRz1GbXw=";
+          boringssl =
+            fetchMonoExternal "boringssl" "296137cf989688b03ed89f72cd7bfd86d470441e"
+              "sha256-yiHa7/RnSVOdevvMKwdZ5+UO0SFynWACtNpv5rxq8IU=";
+          cecil =
+            fetchMonoExternal "cecil" "8021f3fbe75715a1762e725594d8c00cce3679d8"
+              "sha256-tVvPVO9gBzDsnrZKvNENVC1IdF8OTF/R78KDoRenKUg=";
+          cecil-legacy =
+            fetchMonoExternal "cecil" "33d50b874fd527118bc361d83de3d494e8bb55e1"
+              "sha256-C3qp7SgHNmy4hLgDKOvZoFMgmaFWF+enN2JFk06gkNw=";
+          corefx =
+            fetchMonoExternal "corefx" "c4eeab9fc2faa0195a812e552cd73ee298d39386"
+              "sha256-SONNnmv2GXEwZdk6l39FM6tFxk91oLVhpLi1ZtwFoww=";
+          corert =
+            fetchMonoExternal "corert" "11136ad55767485063226be08cfbd32ed574ca43"
+              "sha256-DkWrTC838hfZ8hjrP9KeoPNf3ZmVOc3tGWIE59xAGLw=";
+          helix-binaries =
+            fetchMonoExternal "helix-binaries" "64b3a67631ac8a08ff82d61087cfbfc664eb4af8"
+              "sha256-p7kZuUPBH+yhQNnKejOZk90LsPzTjAXDTX0N+ded07g=";
+          ikdasm =
+            fetchMonoExternal "ikdasm" "f0fd66ea063929ef5d51aafdb10832164835bb0f"
+              "sha256-IKx/rCeOKUBBDUgq+lRfdjFnGjNNGjBWggFAWeu+Iww=";
+          ikvm =
+            fetchMonoExternal "ikvm-fork" "08266ac8c0b620cc929ffaeb1f23ac37629ce825"
+              "sha256-W2Io+1u1DQ46oopwnU3FA/f6ZnIQe5z4wXz2bdEOG7w=";
+          illinker-test-assets =
+            fetchMonoExternal "illinker-test-assets" "ec9eb51af2eb07dbe50a2724db826bf3bfb930a6"
+              "sha256-9BVEq116ACIvKAHo6ZaZ4t2rAy9WgOfcp4TatyTBm6w=";
+          linker = fetchgit {
+            url = "https://github.com/mono/linker.git";
+            rev = "ed4a9413489aa29a70e41f94c3dac5621099f734";
+            hash = "sha256-4knV2QCSrPwb6GGsy+VIPxNlf1KBkPgZtFlZlSC7LZs=";
+            fetchSubmodules = false;
+          };
+          "Newtonsoft.Json" =
+            fetchMonoExternal "Newtonsoft.Json" "471c3e0803a9f40a0acc8aeceb31de6ff93a52c4"
+              "sha256-Gp1UpraahcFFXQanzr4Y1U7bsLFLTUAehd5MDEt79jU=";
+          nuget-buildtasks = fetchgit {
+            url = "https://github.com/mono/NuGet.BuildTasks.git";
+            rev = "99558479578b1d6af0f443bb411bc3520fcbae5c";
+            hash = "sha256-A1NHJ/P6gI9B+NKcRn0kisB6sY3RqJXi3Ossnb6pZJA=";
+          };
+          nunit-lite = fetchgit {
+            url = "https://github.com/mono/NUnitLite.git";
+            rev = "a977ca57572c545e108b56ef32aa3f7ff8287611";
+            hash = "sha256-UhOOVt5A8bQanj42UhB5KFHsOP4Tkrs4pV9dxK9r/As=";
+          };
+          rx =
+            fetchMonoExternal "rx" "b29a4b0fda609e0af33ff54ed13652b6ccf0e05e"
+              "sha256-O/oioCocqVIG9xUl3wn4WZw1/2W1RgNQE5vNpSvkMtg=";
+        }}
+        find external -type f \( -name '*.dll' -o -name '*.DLL' -o -name '*.exe' -o -name '*.EXE' -o -name '*.so' \) -delete
+        if [ -f tools/monograph/Makefile.am ]; then
+          substituteInPlace tools/monograph/Makefile.am \
+            --replace-quiet "/mono/metadata/libmonoruntimesgen-static.la" \
+                            "/mono/metadata/libmonoruntimesgen-static.la \$(top_builddir)/mono/sgen/libmonosgen-static.la"
+        fi
+        if [ -f mcs/class/Microsoft.Build.Tasks/Makefile ]; then
+          substituteInPlace mcs/class/Microsoft.Build.Tasks/Makefile \
+            --replace-quiet "include ../../build/library.make" $'include ../../build/library.make\nrun-test-recursive:\n\t@echo skipping tests'
+        fi
+        if [ -f mcs/packages/Makefile ]; then
+          substituteInPlace mcs/packages/Makefile \
+            --replace-quiet "install-local:" $'install-local:\n\techo "Skipping blob install"\n\nunused0:'
+        fi
+        if [ -f eglib/autogen.sh ]; then
+          patchShebangs eglib/autogen.sh
+        fi
+        if [ -d mcs/tools ]; then
+          patchShebangs mcs/tools
+        fi
+      '';
+      extraPreBuild = ''
+        pushd external/binary-reference-assemblies
+        for makefile in $(find . -name Makefile); do
+          substituteInPlace "$makefile" \
+            --replace-quiet "CSC_COMMON_ARGS := " "CSC_COMMON_ARGS := -delaysign+ " \
+            --replace-quiet "IBM.Data.DB2_REFS := " "IBM.Data.DB2_REFS := System.Xml " \
+            --replace-quiet "Mono.Data.Sqlite_REFS := " "Mono.Data.Sqlite_REFS := System.Xml " \
+            --replace-quiet "System.Data.DataSetExtensions_REFS := " "System.Data.DataSetExtensions_REFS := System.Xml " \
+            --replace-quiet "System.Data.OracleClient_REFS := " "System.Data.OracleClient_REFS := System.Xml " \
+            --replace-quiet "System.IdentityModel_REFS := " "System.IdentityModel_REFS := System.Configuration " \
+            --replace-quiet "System.Design_REFS := " "System.Design_REFS := Accessibility " \
+            --replace-quiet "System.Web.Extensions.Design_REFS := " "System.Web.Extensions.Design_REFS := System.Windows.Forms System.Web " \
+            --replace-quiet "System.ServiceModel.Routing_REFS := " "System.ServiceModel.Routing_REFS := System.Xml " \
+            --replace-quiet "System.Web.Abstractions_REFS := " "System.Web.Abstractions_REFS := System " \
+            --replace-quiet "System.Reactive.Windows.Forms_REFS := " "System.Reactive.Windows.Forms_REFS := System " \
+            --replace-quiet "System.Windows.Forms.DataVisualization_REFS := " "System.Windows.Forms.DataVisualization_REFS := Accessibility " \
+            --replace-quiet "Facades/System.ServiceModel.Primitives_REFS := " "Facades/System.ServiceModel.Primitives_REFS := System.Xml " \
+            --replace-quiet "Facades/System.Dynamic.Runtime_REFS := " "Facades/System.Dynamic.Runtime_REFS := System " \
+            --replace-quiet "Facades/System.Xml.XDocument_REFS := " "Facades/System.Xml.XDocument_REFS := System.Xml " \
+            --replace-quiet "Facades/System.Runtime.Serialization.Xml_REFS := " "Facades/System.Runtime.Serialization.Xml_REFS := System.Xml " \
+            --replace-quiet "Facades/System.Data.Common_REFS := " "Facades/System.Data.Common_REFS := System System.Xml "
+        done
+        if [ -f build/monodroid/Makefile ]; then
+          substituteInPlace build/monodroid/Makefile \
+            --replace-quiet "ECMA_KEY := ../../../../../mono/" "ECMA_KEY := ../../../../"
+        fi
+        make -j"$NIX_BUILD_CORES" V=1 SKIP_AOT=1 CSC=mcs
+        unset makefile
+        popd
+      '';
+      extraPostBuild = ''
+        make -C mcs/tools/resx2sr SKIP_AOT=1 V=1
+      '';
+      extraPostInstall = ''
+                gac="$out/lib/mono/gac"
+                while IFS= read -r name; do
+                  cat > "$name.config" <<EOF
+        <configuration><dllmap dll="libodbc.so.2" target="${unixodbc}/lib/libodbc.so.2"/></configuration>
+        EOF
+                done < <(find "$gac" -name 'System.Data.dll' -type f)
+                while IFS= read -r name; do
+                  cat > "$name.config" <<EOF
+        <configuration><dllmap dll="gdiplus" target="${libgdiplus}/lib/libgdiplus.so"/></configuration>
+        EOF
+                done < <(find "$gac" -name 'System.Drawing.dll' -type f)
+                while IFS= read -r name; do
+                  cat > "$name.config" <<EOF
+        <configuration><dllmap dll="libX11" target="${libx11.out}/lib/libX11.so.6"/></configuration>
+        EOF
+                done < <(find "$gac" -name 'System.Windows.Forms.dll' -type f)
+                if [ ! -x "$out/bin/resx2sr" ] && [ -f "$out/lib/mono/4.5/resx2sr.exe" ]; then
+                  cat > "$out/bin/resx2sr" <<EOF
+        #!${bash}/bin/sh
+        exec "$out/bin/mono" "$out/lib/mono/4.5/resx2sr.exe" "\$@"
+        EOF
+                  chmod +x "$out/bin/resx2sr"
+                fi
+      '';
+    };
+  }
+)

--- a/pkgs/development/compilers/mono/bootstrap/mono.nix
+++ b/pkgs/development/compilers/mono/bootstrap/mono.nix
@@ -1,0 +1,253 @@
+{
+  lib,
+  stdenv,
+  autoreconfHook,
+  automake,
+  autoconf,
+  bison,
+  pkg-config,
+  libtool,
+  cmakeForConfigure ? null,
+  glib,
+  boehmgc,
+  libx11,
+  zlib,
+  gettext,
+  which,
+  perl,
+  version,
+  src,
+  patches ? [ ],
+  bootstrapCompiler ? null,
+  bootstrapRuntime ? null,
+  bootstrapLibraries ? null,
+  cflags,
+  configureFlags ? [ ],
+  makeFlags ? [ ],
+  extraNativeBuildInputs ? [ ],
+  extraBuildInputs ? [ ],
+  enableParallelBuilding ? true,
+  doCheck ? false,
+  patchReflectionFormatStrings ? true,
+  extraPostPatch ? "",
+  extraPreConfigure ? "",
+  extraPostConfigure ? "",
+  extraPreBuild ? "",
+  extraPostBuild ? "",
+  extraPreInstall ? "",
+  extraPostInstall ? "",
+}:
+
+let
+  hasBootstrapCompiler = bootstrapCompiler != null;
+  hasBootstrapRuntime = bootstrapRuntime != null && bootstrapRuntime != bootstrapCompiler;
+  hasBootstrapLibraries = bootstrapLibraries != null;
+  hasCmakeForConfigure = cmakeForConfigure != null;
+  hasPerl = perl != null;
+in
+stdenv.mkDerivation {
+  pname = "mono-bootstrap";
+  inherit version src patches;
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    autoconf
+    automake
+    bison
+    libtool
+    pkg-config
+    which
+  ]
+  ++ lib.optional hasBootstrapCompiler bootstrapCompiler
+  ++ lib.optional hasBootstrapRuntime bootstrapRuntime
+  ++ lib.optional hasBootstrapLibraries bootstrapLibraries
+  ++ lib.optional hasCmakeForConfigure cmakeForConfigure
+  ++ lib.optional hasPerl perl
+  ++ extraNativeBuildInputs;
+
+  buildInputs = [
+    glib
+    boehmgc
+    libx11
+    zlib
+    gettext
+  ]
+  ++ extraBuildInputs;
+
+  inherit configureFlags enableParallelBuilding doCheck;
+  # mono's `make install` recursively descends profiles concurrently and
+  # races on `mkdir $out/lib/mono/<profile>` (see mcs/tools/tuner in 1.9.1).
+  # Keep build parallel; install serial.
+  enableParallelInstalling = false;
+
+  inherit makeFlags;
+
+  dontUseCmakeConfigure = true;
+
+  hardeningDisable = [ "format" ];
+
+  env.CFLAGS = cflags;
+
+  postPatch = ''
+    rm -f configure
+    rm -rf libgc
+    find . -type f \( -name '*.dll' -o -name '*.DLL' -o -name '*.exe' -o -name '*.EXE' -o -name '*.so' \) -delete
+
+    if [ -f Makefile.am ]; then
+      if grep -q " docs" Makefile.am; then
+        substituteInPlace Makefile.am --replace-fail " docs" ""
+      fi
+      if grep -q ' $(libgc_dir)' Makefile.am; then
+        substituteInPlace Makefile.am --replace-fail ' $(libgc_dir)' ""
+      fi
+      if grep -q " libgc" Makefile.am; then
+        substituteInPlace Makefile.am --replace-fail " libgc" ""
+      fi
+    fi
+
+    for f in configure.in configure.ac; do
+      if [ -f "$f" ]; then
+        if grep -q "int f = isinf (1);" "$f"; then
+          substituteInPlace "$f" --replace-fail "int f = isinf (1);" "int f = isinf (1.0);"
+        fi
+      fi
+    done
+
+    if [ -f mono/io-layer/processes.c ]; then
+      if grep -q '#ifdef HAVE_SYS_MKDEV_H' mono/io-layer/processes.c; then
+        substituteInPlace mono/io-layer/processes.c \
+          --replace-fail "#ifdef HAVE_SYS_MKDEV_H" "#if 1"
+      fi
+      if grep -q 'sys/mkdev.h' mono/io-layer/processes.c; then
+        substituteInPlace mono/io-layer/processes.c \
+          --replace-fail "sys/mkdev.h" "sys/sysmacros.h"
+      fi
+    fi
+    if [ -f mono/io-layer/sockets.c ] && grep -q "int ret, true = 1;" mono/io-layer/sockets.c; then
+      substituteInPlace mono/io-layer/sockets.c \
+        --replace-fail "int ret, true = 1;" "int ret, reuseaddr = 1;" \
+        --replace-fail "&true," "&reuseaddr,"
+    fi
+    if [ -f mono/metadata/threads-types.h ] && grep -q "MonoBoolean thread_local" mono/metadata/threads-types.h; then
+      substituteInPlace mono/metadata/threads-types.h \
+        --replace-fail "MonoBoolean thread_local" "MonoBoolean is_thread_local"
+    fi
+    if [ -f mono/metadata/threads.c ] && grep -q "MonoBoolean thread_local" mono/metadata/threads.c; then
+      substituteInPlace mono/metadata/threads.c \
+        --replace-fail "MonoBoolean thread_local" "MonoBoolean is_thread_local" \
+        --replace-fail "if (thread_local)" "if (is_thread_local)"
+    fi
+    ${lib.optionalString patchReflectionFormatStrings ''
+      if [ -f mono/metadata/reflection.c ]; then
+        substituteInPlace mono/metadata/reflection.c \
+          --replace-fail "g_string_printf (fullName, info->name);" "g_string_printf (fullName, \"%s\", info->name);" \
+          --replace-fail "g_print (obj->vtable->klass->name);" "g_print (\"%s\", obj->vtable->klass->name);"
+      fi
+    ''}
+    if [ -f mono/metadata/boehm-gc.c ]; then
+      if grep -q GC_set_finalizer_notify_proc mono/metadata/boehm-gc.c; then
+        substituteInPlace mono/metadata/boehm-gc.c \
+          --replace-fail GC_set_finalizer_notify_proc GC_set_await_finalize_proc
+      fi
+      if grep -q GC_toggleref_register_callback mono/metadata/boehm-gc.c; then
+        substituteInPlace mono/metadata/boehm-gc.c \
+          --replace-fail GC_toggleref_register_callback GC_set_toggleref_func
+      fi
+    fi
+    if [ -f mono/utils/mono-compiler.h ]; then
+      if grep -q "static __thread gpointer x MONO_TLS_FAST" mono/utils/mono-compiler.h; then
+        substituteInPlace mono/utils/mono-compiler.h \
+          --replace-fail "static __thread gpointer x MONO_TLS_FAST" "static __thread gpointer x __attribute__((used))"
+      fi
+      if grep -q "#define MONO_TLS_FAST " mono/utils/mono-compiler.h; then
+        substituteInPlace mono/utils/mono-compiler.h \
+          --replace-fail "#define MONO_TLS_FAST " "#define MONO_TLS_FAST __attribute__((used)) "
+      fi
+    fi
+    if [ -f mono/metadata/sgen-alloc.c ]; then
+      if grep -q "static __thread char \\*\\*tlab_next_addr" mono/metadata/sgen-alloc.c; then
+        substituteInPlace mono/metadata/sgen-alloc.c \
+          --replace-fail "static __thread char **tlab_next_addr" "static __thread char **tlab_next_addr __attribute__((used))"
+      fi
+    fi
+
+    if [ -f mcs/class/System/System.Text.RegularExpressions/BaseMachine.cs-2 ]; then
+      mv mcs/class/System/System.Text.RegularExpressions/BaseMachine.cs-2 \
+        mcs/class/System/System.Text.RegularExpressions/BaseMachine.cs
+    fi
+    if [ -f mono/metadata/security.c ]; then
+      if ! grep -q '#include <mono/metadata/assembly.h>' mono/metadata/security.c; then
+        substituteInPlace mono/metadata/security.c \
+          --replace-fail "#include <mono/metadata/image.h>" $'#include <mono/metadata/image.h>\n#include <mono/metadata/assembly.h>'
+      fi
+    fi
+    if [ -f mcs/jay/Makefile ]; then
+      substituteInPlace mcs/jay/Makefile \
+        --replace-fail 'LOCAL_CFLAGS = -DSKEL_DIRECTORY=\""$(prefix)/share/jay"\"' \
+                       'LOCAL_CFLAGS = -std=gnu89 -DSKEL_DIRECTORY=\""$(prefix)/share/jay"\"'
+    fi
+
+    if [ -d mcs/class/Managed.Windows.Forms ]; then
+      patchShebangs mcs/class/Managed.Windows.Forms/build-csproj*
+    fi
+    ${extraPostPatch}
+  '';
+
+  preConfigure = ''
+    export CFLAGS="${cflags}"
+    export HOME="$TMPDIR"
+    export SOURCE_DATE_EPOCH=315532800
+    ${lib.optionalString hasBootstrapLibraries ''
+      export CSCC_LIB_PATH="${bootstrapLibraries}/lib/cscc/lib"
+    ''}
+    ${extraPreConfigure}
+  '';
+
+  postConfigure = extraPostConfigure;
+
+  preBuild = extraPreBuild;
+
+  postBuild = extraPostBuild;
+
+  preInstall = extraPreInstall;
+
+  postInstall = ''
+    # Trim outputs not used by the next bootstrap stage:
+    # docs, locale, static archives, monodoc / lldb support.
+    # `rm -rf` is a no-op on missing paths; `find` only walks $out.
+    rm -rf "$out"/share/man "$out"/share/doc "$out"/share/gtk-doc \
+           "$out"/share/info "$out"/share/locale
+    rm -rf "$out"/lib/monodoc "$out"/lib/mono-source-libs \
+           "$out"/lib/mono/monodoc "$out"/lib/mono/lldb
+    find "$out"/lib -name '*.a' -delete
+    # `lib/mono/<ver>-api/` are reference assemblies for end users
+    # compiling against specific .NET framework versions. The next
+    # bootstrap stage builds its own from `external/binary-reference-
+    # assemblies`, so the previous stage's copies are dead weight
+    # (~10 MB per profile, ~12 profiles, ~110 MB per late stage).
+    if [ -d "$out/lib/mono" ]; then
+      find "$out/lib/mono" -mindepth 1 -maxdepth 1 -type d -name '*-api' \
+        -exec rm -rf {} +
+      # Some build-profile dirs (e.g. `lib/mono/4.0/`) are nothing but
+      # symlinks into the now-deleted `*-api/`. Drop the broken links.
+      find "$out/lib/mono" -type l ! -exec test -e {} \; -delete
+      # And drop the now-empty profile-dirs.
+      find "$out/lib/mono" -mindepth 1 -maxdepth 1 -type d -empty -delete
+    fi
+  ''
+  + extraPostInstall;
+
+  meta = {
+    description = "Mono bootstrap stage ${version}";
+    homepage = "https://www.mono-project.com/";
+    license = with lib.licenses; [
+      mit
+      gpl1Plus
+      lgpl2Plus
+      bsdOriginal
+    ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/development/compilers/mono/bootstrap/patches/mono-2.11.4-fixes.patch
+++ b/pkgs/development/compilers/mono/bootstrap/patches/mono-2.11.4-fixes.patch
@@ -1,0 +1,45 @@
+diff --git a/mono/io-layer/processes.c b/mono/io-layer/processes.c
+index 586b54715db..d27857aa092 100644
+--- a/mono/io-layer/processes.c
++++ b/mono/io-layer/processes.c
+@@ -18,6 +18,7 @@
+ #include <errno.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
++#include <sys/sysmacros.h>
+ #include <unistd.h>
+ #include <signal.h>
+ #include <sys/wait.h>
+diff --git a/mono/mini/method-to-ir.c b/mono/mini/method-to-ir.c
+index d82a375b6a2..80f1c26ccf6 100644
+--- a/mono/mini/method-to-ir.c
++++ b/mono/mini/method-to-ir.c
+@@ -5704,7 +5704,7 @@ mono_get_gsharedvt_type (MonoClass *klass)
+ }
+ 
+ static MonoInst*
+-create_magic_tls_access (MonoCompile *cfg, MonoClassField *tls_field, MonoInst **cached_tls_addr, MonoInst *thread_local)
++create_magic_tls_access (MonoCompile *cfg, MonoClassField *tls_field, MonoInst **cached_tls_addr, MonoInst *tls_ins)
+ {
+ 	MonoInst *load, *addr, *temp, *store, *thread_ins;
+ 	MonoClassField *offset_field;
+@@ -5716,7 +5716,7 @@ create_magic_tls_access (MonoCompile *cfg, MonoClassField *tls_field, MonoInst *
+ 	thread_ins = mono_get_thread_intrinsic (cfg);
+ 	offset_field = mono_class_get_field_from_name (tls_field->parent, "tls_offset");
+ 
+-	EMIT_NEW_LOAD_MEMBASE_TYPE (cfg, load, offset_field->type, thread_local->dreg, offset_field->offset);
++	EMIT_NEW_LOAD_MEMBASE_TYPE (cfg, load, offset_field->type, tls_ins->dreg, offset_field->offset);
+ 	if (thread_ins) {
+ 		MONO_ADD_INS (cfg->cbb, thread_ins);
+ 	} else {
+diff --git a/runtime/Makefile.am b/runtime/Makefile.am
+index 6957a287d38..2d071230a84 100644
+--- a/runtime/Makefile.am
++++ b/runtime/Makefile.am
+@@ -1,6 +1,3 @@
+-# hack to prevent 'check' from depending on 'all'
+-AUTOMAKE_OPTIONS = cygnus
+-
+ tmpinst = _tmpinst
+ 
+ noinst_SCRIPTS = mono-wrapper monodis-wrapper

--- a/pkgs/development/compilers/mono/bootstrap/patches/mono-5.10.0-later-mcs-changes.patch
+++ b/pkgs/development/compilers/mono/bootstrap/patches/mono-5.10.0-later-mcs-changes.patch
@@ -1,0 +1,4493 @@
+The result of cherry-picking every commit (except ones that seemed to not
+affect the compiler itself) from mono-5.10.0.179 to mono-6.12.0.206 that
+touched ./mcs/mcs.
+
+Mono seems to consistently, almost as a rule, depend on C# features before
+they implement them.  This is extremely awkward for building using previous
+versions, so hopefully this will allow us to jump straight to a high version.
+
+Includes the following commits, in order of most-recent to least-recent:
+
+b3911589b37
+6700dd220fe
+2a7dfb28e07
+eea6f11a3e6
+3fc047c6f3a
+ac6666f5b0b
+927b27bb9d8
+4ab24d4c059
+aa836b46a23
+ee7dccfb320
+23510f26915
+d9f26547d88
+9dc1c885a0f
+ef558ead89a
+2cb7909b13c
+0390ea2e78c
+b4f6659bdc0
+e92d6070eaf
+4c5b3fbd4f4
+e6507f2da8a
+656a4b1120c
+9bd2fa4cf33
+be2d1aeffe0
+454a76cfa4a
+60c1ee454d4
+53f1ef506ea
+d3487bfebb3
+92f6e5b1a81
+
+diff --git a/.gitignore b/.gitignore
+index c6ef19a849b..c37d4fce3f0 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -40,6 +40,7 @@ Ankh.NoLoad
+ *.gpState
+ .vscode/
+ *.exp
++.vs/
+ 
+ # Tooling
+ _ReSharper*/
+diff --git a/mcs/class/Commons.Xml.Relaxng/Makefile b/mcs/class/Commons.Xml.Relaxng/Makefile
+index 1febae4eb1e..f9b57fea265 100644
+--- a/mcs/class/Commons.Xml.Relaxng/Makefile
++++ b/mcs/class/Commons.Xml.Relaxng/Makefile
+@@ -22,7 +22,7 @@ EXTRA_DISTFILES = \
+ 	$(RESOURCE_FILES)
+ 
+ Commons.Xml.Relaxng.Rnc/RncParser.cs: Commons.Xml.Relaxng.Rnc/RncParser.jay $(topdir)/jay/skeleton.cs
+-	$(topdir)/jay/jay -ctv < $(topdir)/jay/skeleton.cs $(CURDIR)/Commons.Xml.Relaxng.Rnc/RncParser.jay > Commons.Xml.Relaxng.Rnc/RncParser.cs
++	$(topdir)/jay/jay -ctv -o Commons.Xml.Relaxng.Rnc/RncParser.cs $< < $(topdir)/jay/skeleton.cs
+ 
+ BUILT_SOURCES = Commons.Xml.Relaxng.Rnc/RncParser.cs
+ 
+diff --git a/mcs/class/Microsoft.Build/Makefile b/mcs/class/Microsoft.Build/Makefile
+index 2dcbefdf7f9..1a711069b0b 100644
+--- a/mcs/class/Microsoft.Build/Makefile
++++ b/mcs/class/Microsoft.Build/Makefile
+@@ -26,7 +26,7 @@ EXTRA_DISTFILES = \
+ EXPR_PARSER = Microsoft.Build.Internal/ExpressionParser
+ 
+ $(EXPR_PARSER).cs: $(EXPR_PARSER).jay $(topdir)/jay/skeleton.cs
+-	(cd Microsoft.Build.Internal; $(topdir)/../jay/jay -ctv < $(topdir)/../jay/skeleton.cs ExpressionParser.jay > ExpressionParser.cs)
++	(cd Microsoft.Build.Internal; $(topdir)/../jay/jay -ctv -o ExpressionParser.cs ExpressionParser.jay < $(topdir)/../jay/skeleton.cs )
+ 
+ BUILT_SOURCES = $(EXPR_PARSER).cs
+ 
+diff --git a/mcs/class/Mono.CSharp/Makefile b/mcs/class/Mono.CSharp/Makefile
+index 7b1986b78e5..3615532853d 100644
+--- a/mcs/class/Mono.CSharp/Makefile
++++ b/mcs/class/Mono.CSharp/Makefile
+@@ -24,7 +24,7 @@ LIB_MCS_FLAGS += $(REFERENCE_SOURCES_FLAGS)
+ BUILT_SOURCES = $(PROFILE)-parser.cs
+ 
+ $(PROFILE)-parser.cs: $(topdir)/mcs/cs-parser.jay $(topdir)/jay/skeleton.cs
+-	$(topdir)/jay/jay -c < $(topdir)/jay/skeleton.cs $< > $(PROFILE)-jay-tmp.out && mv $(PROFILE)-jay-tmp.out $@
++	$(topdir)/jay/jay -c -o $(PROFILE)-jay-tmp.out $< < $(topdir)/jay/skeleton.cs && mv $(PROFILE)-jay-tmp.out $@
+ 
+ include ../../build/library.make
+ 
+diff --git a/mcs/class/Mono.Xml.Ext/Makefile b/mcs/class/Mono.Xml.Ext/Makefile
+index dc49f816fee..16498215a38 100644
+--- a/mcs/class/Mono.Xml.Ext/Makefile
++++ b/mcs/class/Mono.Xml.Ext/Makefile
+@@ -29,13 +29,13 @@ Mono.Xml.XPath2/XQueryParser.jay: Mono.Xml.XPath2/ParserBase.jay $(SKELETON)
+ Mono.Xml.XPath2/XPath2Parser.cs: Mono.Xml.XPath2/XPath2Parser.jay
+ 	echo "#define XPATH2_PARSER" > $@
+ 	echo "#if NET_2_0" >> $@
+-	$(topdir)/jay/jay -ct < $(SKELETON) $(CURDIR)/$< >>$@
++	$(topdir)/jay/jay -ct $(CURDIR)/$< < $(SKELETON) >>$@
+ 	echo "#endif" >> $@
+ 
+ Mono.Xml.XPath2/XQueryParser.cs: Mono.Xml.XPath2/XQueryParser.jay $(SKELETON)
+ 	echo "#define XQUERY_PARSER" > $@
+ 	echo "#if NET_2_0" >> $@
+-	$(topdir)/jay/jay -ct < $(SKELETON) $(CURDIR)/$< >>$@
++	$(topdir)/jay/jay -ct $(CURDIR)/$< < $(SKELETON) >>$@
+ 	echo "#endif" >> $@
+ 
+ Mono.Xml.XPath2/XPath2Tokenizer.cs: Mono.Xml.XPath2/TokenizerBase.cs
+diff --git a/mcs/class/corlib/System/RuntimeArgumentHandle.cs b/mcs/class/corlib/System/RuntimeArgumentHandle.cs
+index 216c4ea3924..c10d3f174d1 100644
+--- a/mcs/class/corlib/System/RuntimeArgumentHandle.cs
++++ b/mcs/class/corlib/System/RuntimeArgumentHandle.cs
+@@ -31,13 +31,9 @@
+ // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ //
+ 
+-using System;
+-using System.Runtime.InteropServices;
+-
+ namespace System
+ {
+-	[ComVisible (true)]
+-	public struct RuntimeArgumentHandle
++	public ref struct RuntimeArgumentHandle
+ 	{
+ #pragma warning disable 649
+ 		internal IntPtr args;
+diff --git a/mcs/class/referencesource/mscorlib/system/typedreference.cs b/mcs/class/referencesource/mscorlib/system/typedreference.cs
+index 80bef5ab852..a30541f4399 100644
+--- a/mcs/class/referencesource/mscorlib/system/typedreference.cs
++++ b/mcs/class/referencesource/mscorlib/system/typedreference.cs
+@@ -19,7 +19,11 @@ namespace System {
+     [CLSCompliant(false)] 
+     [System.Runtime.InteropServices.ComVisible(true)]
+     [System.Runtime.Versioning.NonVersionable] // This only applies to field layout
+-    public struct TypedReference
++    public
++#if MONO
++    ref
++#endif
++    struct TypedReference
+     {
+ #if MONO
+ #pragma warning disable 169
+diff --git a/mcs/errors/cs0151-4.cs b/mcs/errors/cs0151-4.cs
+index 0e45b1a9049..c9e05589e4d 100644
+--- a/mcs/errors/cs0151-4.cs
++++ b/mcs/errors/cs0151-4.cs
+@@ -1,5 +1,6 @@
+ // CS0151: A switch expression of type `S1?' cannot be converted to an integral type, bool, char, string, enum or nullable type
+-// Line: 24
++// Line: 25
++// Compiler options: -langversion:5
+ 
+ using System;
+ 
+diff --git a/mcs/errors/cs0273-2.cs b/mcs/errors/cs0273-2.cs
+new file mode 100644
+index 00000000000..b0bdbef9e75
+--- /dev/null
++++ b/mcs/errors/cs0273-2.cs
+@@ -0,0 +1,9 @@
++// CS0273: The accessibility modifier of the `C.S2.set' accessor must be more restrictive than the modifier of the property or indexer `C.S2'
++// Line: 7
++// Compiler options: -langversion:7.2
++
++ class C
++ {
++	private string S2 { get; private protected set; }
++ }
++
+diff --git a/mcs/errors/cs0280.cs b/mcs/errors/cs0280.cs
+new file mode 100644
+index 00000000000..62be8e39585
+--- /dev/null
++++ b/mcs/errors/cs0280.cs
+@@ -0,0 +1,22 @@
++// CS0280: `C.Fixable.GetPinnableReference(int)' has the wrong signature to be used in extensible fixed statement
++// Line: 11
++// Compiler options: -unsafe -langversion:latest -warnaserror
++
++using System;
++
++unsafe class C
++{
++	public static void Main ()
++	{
++		fixed (int* p = new Fixable ()) {
++		}
++	}
++
++	struct Fixable
++	{
++		public ref int GetPinnableReference (int i = 1)
++		{
++			throw new NotImplementedException ();
++		}
++	}
++}
+\ No newline at end of file
+diff --git a/mcs/errors/cs0826-9.cs b/mcs/errors/cs0826-9.cs
+deleted file mode 100644
+index 4e098969b8c..00000000000
+--- a/mcs/errors/cs0826-9.cs
++++ /dev/null
+@@ -1,16 +0,0 @@
+-// CS0826: The type of an implicitly typed array cannot be inferred from the initializer. Try specifying array type explicitly
+-// Line: 8
+-
+-class C
+-{
+-	static void Main()
+-	{
+-		object o = 1;
+-		dynamic d = 1;
+-		
+-		var a = new[] {
+-			new { X = o },
+-			new { X = d }
+-		};
+-	}
+-}
+diff --git a/mcs/errors/cs1013-1.cs b/mcs/errors/cs1013-1.cs
+new file mode 100644
+index 00000000000..01827df4995
+--- /dev/null
++++ b/mcs/errors/cs1013-1.cs
+@@ -0,0 +1,8 @@
++// CS1013: Invalid number
++// Line : 6
++
++class X
++{
++    static int i = 0b;
++    static void Main () {}
++}
+\ No newline at end of file
+diff --git a/mcs/errors/cs1013-2.cs b/mcs/errors/cs1013-2.cs
+new file mode 100644
+index 00000000000..c868cb2a769
+--- /dev/null
++++ b/mcs/errors/cs1013-2.cs
+@@ -0,0 +1,7 @@
++// CS1013: Invalid number
++// Line : 6
++
++class X
++{
++    static int i = 0x0_;
++}
+\ No newline at end of file
+diff --git a/mcs/errors/cs1013-3.cs b/mcs/errors/cs1013-3.cs
+new file mode 100644
+index 00000000000..3145b1ba596
+--- /dev/null
++++ b/mcs/errors/cs1013-3.cs
+@@ -0,0 +1,7 @@
++// CS1013: Invalid number
++// Line : 6
++
++class X
++{
++    static int i = 1_;
++}
+\ No newline at end of file
+diff --git a/mcs/errors/cs1013-4.cs b/mcs/errors/cs1013-4.cs
+new file mode 100644
+index 00000000000..3a5e744ff4f
+--- /dev/null
++++ b/mcs/errors/cs1013-4.cs
+@@ -0,0 +1,7 @@
++// CS1013: Invalid number
++// Line : 6
++
++class X
++{
++    static double i = 1_.2;
++}
+\ No newline at end of file
+diff --git a/mcs/errors/cs1013-5.cs b/mcs/errors/cs1013-5.cs
+new file mode 100644
+index 00000000000..8082743c0b5
+--- /dev/null
++++ b/mcs/errors/cs1013-5.cs
+@@ -0,0 +1,7 @@
++// CS1013: Invalid number
++// Line : 6
++
++class X
++{
++    static int i = 1_e1;
++}
+\ No newline at end of file
+diff --git a/mcs/errors/cs1013-6.cs b/mcs/errors/cs1013-6.cs
+new file mode 100644
+index 00000000000..d2cea2c72dd
+--- /dev/null
++++ b/mcs/errors/cs1013-6.cs
+@@ -0,0 +1,7 @@
++// CS1013: Invalid number
++// Line : 6
++
++class X
++{
++    static float i = 1_f;
++}
+\ No newline at end of file
+diff --git a/mcs/errors/cs1013-7.cs b/mcs/errors/cs1013-7.cs
+new file mode 100644
+index 00000000000..8030d6ed095
+--- /dev/null
++++ b/mcs/errors/cs1013-7.cs
+@@ -0,0 +1,7 @@
++// CS1013: Invalid number
++// Line : 6
++
++class X
++{
++    static int i = 0x_1;
++}
+\ No newline at end of file
+diff --git a/mcs/errors/cs1013-8.cs b/mcs/errors/cs1013-8.cs
+new file mode 100644
+index 00000000000..d26c7acacb7
+--- /dev/null
++++ b/mcs/errors/cs1013-8.cs
+@@ -0,0 +1,7 @@
++// CS1013: Invalid number
++// Line : 6
++
++class X
++{
++    static int i = 0b_1;
++}
+\ No newline at end of file
+diff --git a/mcs/errors/cs1021-4.cs b/mcs/errors/cs1021-4.cs
+new file mode 100644
+index 00000000000..75c2ff70360
+--- /dev/null
++++ b/mcs/errors/cs1021-4.cs
+@@ -0,0 +1,8 @@
++// CS1021: Integral constant is too large
++// Line: 6
++
++class X {
++	public static void Main() {
++		int h = 0b11111111111111111111111111111111111111111111111111111111111111111;
++	}
++}
+diff --git a/mcs/errors/cs1061-18.cs b/mcs/errors/cs1061-18.cs
+new file mode 100644
+index 00000000000..3ac82b7f2d3
+--- /dev/null
++++ b/mcs/errors/cs1061-18.cs
+@@ -0,0 +1,10 @@
++// CS1061: Type `int' does not contain a definition for `__0' and no extension method `__0' of type `int' could be found. Are you missing an assembly reference?
++// Line: 8
++
++static class C
++{
++	static void Main ()
++	{
++		int c = 0.__0;
++	}
++}
+\ No newline at end of file
+diff --git a/mcs/errors/cs1525-27.cs b/mcs/errors/cs1525-27.cs
+index dc184931667..d4c1f326be2 100644
+--- a/mcs/errors/cs1525-27.cs
++++ b/mcs/errors/cs1525-27.cs
+@@ -1,4 +1,4 @@
+-// CS1525: Unexpected symbol `fe', expecting `class', `delegate', `enum', `interface', `partial', or `struct'
++// CS1525: Unexpected symbol `fe', expecting `class', `delegate', `enum', `interface', `partial', `ref', or `struct'
+ // Line: 6
+ 
+ namespace X
+diff --git a/mcs/errors/cs1525-43.cs b/mcs/errors/cs1525-43.cs
+index d83d4d847fa..26f466a2528 100644
+--- a/mcs/errors/cs1525-43.cs
++++ b/mcs/errors/cs1525-43.cs
+@@ -1,4 +1,4 @@
+-// CS1525: Unexpected symbol `)', expecting `(', `[', `out', `params', `ref', `this', or `type'
++// CS1525: Unexpected symbol `)'
+ // Line: 6
+ 
+ class TestClass
+diff --git a/mcs/errors/cs1527-2.cs b/mcs/errors/cs1527-2.cs
+index d38945f3c89..0256ee2b354 100644
+--- a/mcs/errors/cs1527-2.cs
++++ b/mcs/errors/cs1527-2.cs
+@@ -1,4 +1,4 @@
+-// CS1527: Namespace elements cannot be explicitly declared as private, protected or protected internal
++// CS1527: Namespace elements cannot be explicitly declared as private, protected, protected internal, or private protected
+ // Line: 4
+ 
+ protected interface IFoo {
+diff --git a/mcs/errors/cs1527-3.cs b/mcs/errors/cs1527-3.cs
+index 763c75958ee..469d74cbb99 100644
+--- a/mcs/errors/cs1527-3.cs
++++ b/mcs/errors/cs1527-3.cs
+@@ -1,4 +1,4 @@
+-// CS1527: Namespace elements cannot be explicitly declared as private, protected or protected internal
++// CS1527: Namespace elements cannot be explicitly declared as private, protected, protected internal, or private protected
+ // Line: 4
+ 
+ protected internal enum E {
+diff --git a/mcs/errors/cs1527.cs b/mcs/errors/cs1527.cs
+index 189cc472f4c..e847fd14e11 100644
+--- a/mcs/errors/cs1527.cs
++++ b/mcs/errors/cs1527.cs
+@@ -1,4 +1,5 @@
+-// CS1527: Namespace elements cannot be explicitly declared as private, protected or protected internal
+-// Line:
++// CS1527: Namespace elements cannot be explicitly declared as private, protected, protected internal, or private protected
++// Line: 4
++
+ private class X {
+ }
+diff --git a/mcs/errors/cs1611-2.cs b/mcs/errors/cs1611-2.cs
+new file mode 100644
+index 00000000000..882231378f0
+--- /dev/null
++++ b/mcs/errors/cs1611-2.cs
+@@ -0,0 +1,8 @@
++// CS1611: The params parameter cannot be declared as ref, out or in
++// Line: 6
++// Compiler options: -langversion:latest
++
++class Test
++{
++    public static void Error (params in int args) {}
++}
+\ No newline at end of file
+diff --git a/mcs/errors/cs1611.cs b/mcs/errors/cs1611.cs
+index 8df10fac0ce..469e083ec3c 100644
+--- a/mcs/errors/cs1611.cs
++++ b/mcs/errors/cs1611.cs
+@@ -1,4 +1,4 @@
+-// CS1611: The params parameter cannot be declared as ref or out
++// CS1611: The params parameter cannot be declared as ref, out or in
+ // Line: 6
+ 
+ class Test
+diff --git a/mcs/errors/cs1644-61.cs b/mcs/errors/cs1644-61.cs
+new file mode 100644
+index 00000000000..d58ba64c7ec
+--- /dev/null
++++ b/mcs/errors/cs1644-61.cs
+@@ -0,0 +1,11 @@
++// CS1644: Feature `digit separators' cannot be used because it is not part of the C# 6.0 language specification
++// Line: 9
++// Compiler options: -langversion:6
++
++class X
++{
++	int Test ()
++	{
++		var i = 1_0;
++	}
++}
+diff --git a/mcs/errors/cs1644-62.cs b/mcs/errors/cs1644-62.cs
+new file mode 100644
+index 00000000000..5a29839610d
+--- /dev/null
++++ b/mcs/errors/cs1644-62.cs
+@@ -0,0 +1,10 @@
++// CS1644: Feature `private protected' cannot be used because it is not part of the C# 6.0 language specification
++// Line: 7
++// Compiler options: -langversion:6
++
++class C
++{
++	private protected enum E
++	{
++	}
++}
+\ No newline at end of file
+diff --git a/mcs/errors/cs1644-63.cs b/mcs/errors/cs1644-63.cs
+new file mode 100644
+index 00000000000..ce61d5ce046
+--- /dev/null
++++ b/mcs/errors/cs1644-63.cs
+@@ -0,0 +1,22 @@
++// CS1644: Feature `extensible fixed statement' cannot be used because it is not part of the C# 7.2 language specification 
++// Line: 11
++// Compiler options: -unsafe -langversion:7.2
++
++using System;
++
++unsafe class C
++{
++	public static void Main ()
++	{
++		fixed (int* p = new Fixable ()) {
++		}
++	}
++
++	struct Fixable
++	{
++		public ref int GetPinnableReference ()
++		{
++			throw new NotImplementedException ();
++		}
++	}
++}
+\ No newline at end of file
+diff --git a/mcs/errors/cs1644-64.cs b/mcs/errors/cs1644-64.cs
+new file mode 100644
+index 00000000000..88917a0a5d5
+--- /dev/null
++++ b/mcs/errors/cs1644-64.cs
+@@ -0,0 +1,13 @@
++// CS1644: Feature `expression body property accessor' cannot be used because it is not part of the C# 6.0 language specification 
++// Line: 11
++// Compiler options: -langversion:6
++
++using System;
++
++class C
++{
++	public int Integer
++	{
++		get => 0;
++	}
++}
+\ No newline at end of file
+diff --git a/mcs/errors/cs1644-65.cs b/mcs/errors/cs1644-65.cs
+new file mode 100644
+index 00000000000..dea648b7846
+--- /dev/null
++++ b/mcs/errors/cs1644-65.cs
+@@ -0,0 +1,13 @@
++// CS1644: Feature `expression body property accessor' cannot be used because it is not part of the C# 6.0 language specification 
++// Line: 11
++// Compiler options: -langversion:6
++
++using System;
++
++class C
++{
++	public int this[int i]
++	{
++		get => i;
++	}
++}
+\ No newline at end of file
+diff --git a/mcs/errors/cs1644-66.cs b/mcs/errors/cs1644-66.cs
+new file mode 100644
+index 00000000000..3f393b50d30
+--- /dev/null
++++ b/mcs/errors/cs1644-66.cs
+@@ -0,0 +1,17 @@
++// CS1644: Feature `expression body event accessor' cannot be used because it is not part of the C# 6.0 language specification 
++// Line: 11
++// Compiler options: -langversion:6
++
++using System;
++
++class C
++{
++	public event EventHandler Event
++	{
++		add => Ignore ();
++	}
++
++	static void Ignore ()
++	{
++	}
++}
+\ No newline at end of file
+diff --git a/mcs/errors/cs1763-2.cs b/mcs/errors/cs1763-2.cs
+index 72f5370949a..7e4d091fc72 100644
+--- a/mcs/errors/cs1763-2.cs
++++ b/mcs/errors/cs1763-2.cs
+@@ -1,4 +1,4 @@
+-// CS1763: Optional parameter `o' of type `object' can only be initialized with `null'
++// CS1763: Optional parameter `o' of type `object' can only be initialized with default value
+ // Line: 6
+ 
+ class C
+diff --git a/mcs/errors/cs1763.cs b/mcs/errors/cs1763.cs
+index d10a7bf2c20..03b5f28a19d 100644
+--- a/mcs/errors/cs1763.cs
++++ b/mcs/errors/cs1763.cs
+@@ -1,4 +1,4 @@
+-// CS1763: Optional parameter `o' of type `object' can only be initialized with `null'
++// CS1763: Optional parameter `o' of type `object' can only be initialized with default value
+ // Line: 6
+ 
+ class C
+diff --git a/mcs/errors/cs8326.cs b/mcs/errors/cs8326.cs
+new file mode 100644
+index 00000000000..efd3a84fea7
+--- /dev/null
++++ b/mcs/errors/cs8326.cs
+@@ -0,0 +1,13 @@
++// CS8326: Both ref conditional operators must be ref values
++// Line: 11
++
++class Program
++{
++	static int x, y;
++
++	public static void Main ()
++	{
++		bool b = false;
++		ref int targetBucket = ref b ? x : y;
++	}
++}
+\ No newline at end of file
+diff --git a/mcs/errors/cs8327.cs b/mcs/errors/cs8327.cs
+new file mode 100644
+index 00000000000..8d0ccd86a70
+--- /dev/null
++++ b/mcs/errors/cs8327.cs
+@@ -0,0 +1,14 @@
++// CS8327: The ref conditional expression types `int' and `byte' have to match
++// Line: 12
++
++class Program
++{
++	static int x;
++	static byte y;
++
++	public static void Main ()
++	{
++		bool b = false;
++		ref int targetBucket = ref b ? ref x : ref y;
++	}
++}
+\ No newline at end of file
+diff --git a/mcs/errors/cs0428-2.cs b/mcs/errors/cs8385-2.cs
+similarity index 50%
+rename from mcs/errors/cs0428-2.cs
+rename to mcs/errors/cs8385-2.cs
+index 5f468fd519a..cc7860faa62 100644
+--- a/mcs/errors/cs0428-2.cs
++++ b/mcs/errors/cs8385-2.cs
+@@ -1,4 +1,4 @@
+-// CS0428: Cannot convert method group `Main' to non-delegate type `void*'. Consider using parentheses to invoke the method
++// CS8385: The given expression cannot be used in a fixed statement
+ // Line: 9
+ // Compiler options: -unsafe
+ 
+diff --git a/mcs/errors/cs0213-2.cs b/mcs/errors/cs8385.cs
+similarity index 54%
+rename from mcs/errors/cs0213-2.cs
+rename to mcs/errors/cs8385.cs
+index ae72e4cd9aa..5fa9f794ccf 100644
+--- a/mcs/errors/cs0213-2.cs
++++ b/mcs/errors/cs8385.cs
+@@ -1,4 +1,4 @@
+-// CS0213: You cannot use the fixed statement to take the address of an already fixed expression
++// CS8385: The given expression cannot be used in a fixed statement
+ // Line: 9
+ // Compiler options: -unsafe
+ 
+diff --git a/mcs/errors/known-issues-net_4_x b/mcs/errors/known-issues-net_4_x
+index c9ed9317350..54902e03e7b 100644
+--- a/mcs/errors/known-issues-net_4_x
++++ b/mcs/errors/known-issues-net_4_x
+@@ -14,6 +14,9 @@
+ # Parser problems
+ cs0080.cs 
+ 
++# Undocumented switch governing rules
++cs0151-4.cs NO ERROR
++
+ # Operators
+ cs0457-2.cs
+ cs0457.cs
+diff --git a/mcs/ilasm/Makefile b/mcs/ilasm/Makefile
+index 090d1cc3231..4ca11545781 100644
+--- a/mcs/ilasm/Makefile
++++ b/mcs/ilasm/Makefile
+@@ -13,7 +13,7 @@ EXTRA_DISTFILES = \
+ 	$(wildcard tests/*.il)
+ 
+ ILParser.cs: parser/ILParser.jay $(topdir)/jay/skeleton.cs
+-	$(topdir)/jay/jay -ct < $(topdir)/jay/skeleton.cs $(CURDIR)/$< >$@
++	$(topdir)/jay/jay -ct -o $@ $(CURDIR)/$< < $(topdir)/jay/skeleton.cs
+ 
+ include ../build/executable.make
+ 
+diff --git a/mcs/jay/defs.h b/mcs/jay/defs.h
+index 2aade48dac2..3bd3c5859ce 100644
+--- a/mcs/jay/defs.h
++++ b/mcs/jay/defs.h
+@@ -236,12 +236,14 @@ extern char *input_file_name;
+ extern char *prolog_file_name;
+ extern char *local_file_name;
+ extern char *verbose_file_name;
++extern char *output_file_name;
+ 
+ extern FILE *action_file;
+ extern FILE *input_file;
+ extern FILE *prolog_file;
+ extern FILE *local_file;
+ extern FILE *verbose_file;
++extern FILE *output_file;
+ 
+ extern int nitems;
+ extern int nrules;
+diff --git a/mcs/jay/main.c b/mcs/jay/main.c
+index fcac218b1df..7fb5e6c8ccb 100644
+--- a/mcs/jay/main.c
++++ b/mcs/jay/main.c
+@@ -63,6 +63,7 @@ char *input_file_name = "";
+ char *prolog_file_name;
+ char *local_file_name;
+ char *verbose_file_name;
++char *output_file_name = 0;
+ 
+ FILE *action_file;	/*  a temp file, used to save actions associated    */
+ 			/*  with rules until the parser is written	    */
+@@ -70,6 +71,7 @@ FILE *input_file;	/*  the input file				    */
+ FILE *prolog_file;	/*  temp files, used to save text until all	    */
+ FILE *local_file;	/*  symbols have been defined			    */
+ FILE *verbose_file;	/*  y.output					    */
++FILE *output_file; /* defaults to stdout */
+ 
+ int nitems;
+ int nrules;
+@@ -106,6 +108,7 @@ int k;
+     if (action_file) { fclose(action_file); unlink(action_file_name); }
+     if (prolog_file) { fclose(prolog_file); unlink(prolog_file_name); }
+     if (local_file) { fclose(local_file); unlink(local_file_name); }
++    if (output_file && (output_file != stdout)) { fclose(output_file); if (k != 0) unlink(output_file_name); }
+     exit(k);
+ }
+ 
+@@ -137,7 +140,7 @@ set_signals()
+ 
+ usage()
+ {
+-    fprintf(stderr, "usage: %s [-tvcp] [-b file_prefix] filename\n", myname);
++    fprintf(stderr, "usage: %s [-tvcp] [-b file_prefix] [-o output_filename] input_filename\n", myname);
+     exit(1);
+ }
+ 
+@@ -167,9 +170,9 @@ char *argv[];
+ 	    if (i + 1 < argc) usage();
+ 	    return;
+ 
+-        case '-':
+-            ++i;
+-            goto no_more_options;
++    case '-':
++        ++i;
++        goto no_more_options;
+ 
+ 	case 'b':
+ 	    if (*++s)
+@@ -180,13 +183,22 @@ char *argv[];
+ 		usage();
+ 	    continue;
+ 
+-        case 't':
+-            tflag = 1;
+-            break;
++    case 'o':
++        if (*++s)
++            output_file_name = s;
++        else if (++i < argc)
++            output_file_name = argv[i];
++        else
++            usage();
++        continue;
++
++    case 't':
++        tflag = 1;
++        break;
+ 
+ 	case 'p':
+-            print_skel_dir ();
+-            break;
++        print_skel_dir ();
++        break;
+ 
+ 	case 'c':
+ 	    csharp = 1;
+@@ -217,12 +229,12 @@ char *argv[];
+ 		vflag = 1;
+ 		break;
+ 
+-            case 'p':
+-                print_skel_dir ();
+-                break;
++        case 'p':
++            print_skel_dir ();
++            break;
+ 
+-            case 'c':
+-		csharp = 1;
++        case 'c':
++		    csharp = 1;
+ 	        line_format = "#line %d \"%s\"\n";
+         	default_line_format = "#line default\n";
+ 
+@@ -355,6 +367,17 @@ open_files()
+ 	if (verbose_file == 0)
+ 	    open_error(verbose_file_name);
+     }
++
++    if (output_file == 0)
++    {
++        if (output_file_name != 0) {
++            output_file = fopen(output_file_name, "w");
++            if (output_file == 0)
++                open_error(output_file_name);
++        } else {
++            output_file = stdout;
++        }
++    }
+ }
+ 
+ 
+diff --git a/mcs/jay/output.c b/mcs/jay/output.c
+index d1e2c14a1b2..ab9b2043be9 100644
+--- a/mcs/jay/output.c
++++ b/mcs/jay/output.c
+@@ -73,7 +73,7 @@ output () {
+       fprintf(stderr, "jay: line %d is too long\n", lno), done(1);
+     switch (buf[0]) {
+     case '#':	continue;
+-    case 't':	if (!tflag) fputs("//t", stdout);
++    case 't':	if (!tflag) fputs("//t", output_file);
+     case '.':	break;
+     default:
+       cp = strtok(buf, " \t\r\n");
+@@ -93,7 +93,7 @@ output () {
+           fprintf(stderr, "jay: unknown call (%s) in line %d\n", cp, lno);
+       continue;
+     }
+-    fputs(buf+1, stdout), ++ outline;
++    fputs(buf+1, output_file), ++ outline;
+   }
+   free_parser();
+ }
+@@ -103,19 +103,19 @@ output_rule_data()
+     register int i;
+     register int j;
+ 
+-	printf("/*\n All more than 3 lines long rules are wrapped into a method\n*/\n");
++	fprintf(output_file, "/*\n All more than 3 lines long rules are wrapped into a method\n*/\n");
+ 
+     for (i = 0; i < nmethods; ++i)
+ 	{
+-		printf("%s", methods[i]);
++		fprintf(output_file, "%s", methods[i]);
+ 		FREE(methods[i]);
+-		printf("\n\n");
++		fprintf(output_file, "\n\n");
+ 	}
+ 	FREE(methods);
+ 
+-	printf(default_line_format, ++outline + 1);
++	fprintf(output_file, default_line_format, ++outline + 1);
+ 
+-    printf("  %s static %s short [] yyLhs  = {%16d,",
++    fprintf(output_file, "  %s static %s short [] yyLhs  = {%16d,",
+ 	   csharp ? "" : " protected",
+ 	   csharp ? "readonly" : "final",
+ 	    symbol_value[start_symbol]);
+@@ -126,18 +126,18 @@ output_rule_data()
+ 	if (j >= 10)
+ 	{
+ 	    ++outline;
+-	    putchar('\n');
++	    putc('\n', output_file);
+ 	    j = 1;
+ 	}
+         else
+ 	    ++j;
+ 
+-        printf("%5d,", symbol_value[rlhs[i]]);
++        fprintf(output_file, "%5d,", symbol_value[rlhs[i]]);
+     }
+     outline += 2;
+-    printf("\n  };\n");
++    fprintf(output_file, "\n  };\n");
+ 
+-    printf("  %s static %s short [] yyLen = {%12d,",
++    fprintf(output_file, "  %s static %s short [] yyLen = {%12d,",
+ 	   csharp ? "" : "protected",
+ 	   csharp ? "readonly" : "final",
+ 	   2);
+@@ -148,16 +148,16 @@ output_rule_data()
+ 	if (j >= 10)
+ 	{
+ 	    ++outline;
+-	    putchar('\n');
++	    putc('\n', output_file);
+ 	    j = 1;
+ 	}
+ 	else
+ 	  j++;
+ 
+-        printf("%5d,", rrhs[i + 1] - rrhs[i] - 1);
++        fprintf(output_file, "%5d,", rrhs[i + 1] - rrhs[i] - 1);
+     }
+     outline += 2;
+-    printf("\n  };\n");
++    fprintf(output_file, "\n  };\n");
+ }
+ 
+ 
+@@ -165,7 +165,7 @@ output_yydefred()
+ {
+     register int i, j;
+ 
+-    printf("  %s static %s short [] yyDefRed = {%13d,",
++    fprintf(output_file, "  %s static %s short [] yyDefRed = {%13d,",
+ 	   csharp ? "" : "protected",
+ 	   csharp ? "readonly" : "final",	   
+ 	    (defred[0] ? defred[0] - 2 : 0));
+@@ -178,15 +178,15 @@ output_yydefred()
+ 	else
+ 	{
+ 	    ++outline;
+-	    putchar('\n');
++	    putc('\n', output_file);
+ 	    j = 1;
+ 	}
+ 
+-	printf("%5d,", (defred[i] ? defred[i] - 2 : 0));
++	fprintf(output_file, "%5d,", (defred[i] ? defred[i] - 2 : 0));
+     }
+ 
+     outline += 2;
+-    printf("\n  };\n");
++    fprintf(output_file, "\n  };\n");
+ }
+ 
+ 
+@@ -309,7 +309,7 @@ goto_actions()
+     state_count = NEW2(nstates, short);
+ 
+     k = default_goto(start_symbol + 1);
+-    printf("  protected static %s short [] yyDgoto  = {%14d,", csharp ? "readonly" : "final", k);
++    fprintf(output_file, "  protected static %s short [] yyDgoto  = {%14d,", csharp ? "readonly" : "final", k);
+     save_column(start_symbol + 1, k);
+ 
+     j = 10;
+@@ -318,19 +318,19 @@ goto_actions()
+ 	if (j >= 10)
+ 	{
+ 	    ++outline;
+-	    putchar('\n');
++	    putc('\n', output_file);
+ 	    j = 1;
+ 	}
+ 	else
+ 	    ++j;
+ 
+ 	k = default_goto(i);
+-	printf("%5d,", k);
++	fprintf(output_file, "%5d,", k);
+ 	save_column(i, k);
+     }
+ 
+     outline += 2;
+-    printf("\n  };\n");
++    fprintf(output_file, "\n  };\n");
+     FREE(state_count);
+ }
+ 
+@@ -633,7 +633,7 @@ output_base()
+ {
+     register int i, j;
+ 
+-    printf("  protected static %s short [] yySindex = {%13d,", csharp? "readonly":"final", base[0]);
++    fprintf(output_file, "  protected static %s short [] yySindex = {%13d,", csharp? "readonly":"final", base[0]);
+ 
+     j = 10;
+     for (i = 1; i < nstates; i++)
+@@ -641,17 +641,17 @@ output_base()
+ 	if (j >= 10)
+ 	{
+ 	    ++outline;
+-	    putchar('\n');
++	    putc('\n', output_file);
+ 	    j = 1;
+ 	}
+ 	else
+ 	    ++j;
+ 
+-	printf("%5d,", base[i]);
++	fprintf(output_file, "%5d,", base[i]);
+     }
+ 
+     outline += 2;
+-    printf("\n  };\n  protected static %s short [] yyRindex = {%13d,",
++    fprintf(output_file, "\n  };\n  protected static %s short [] yyRindex = {%13d,",
+ 	   csharp ? "readonly" : "final",
+ 	    base[nstates]);
+ 
+@@ -661,17 +661,17 @@ output_base()
+ 	if (j >= 10)
+ 	{
+ 	    ++outline;
+-	    putchar('\n');
++	    putc('\n', output_file);
+ 	    j = 1;
+ 	}
+ 	else
+ 	    ++j;
+ 
+-	printf("%5d,", base[i]);
++	fprintf(output_file, "%5d,", base[i]);
+     }
+ 
+     outline += 2;
+-    printf("\n  };\n  protected static %s short [] yyGindex = {%13d,",
++    fprintf(output_file, "\n  };\n  protected static %s short [] yyGindex = {%13d,",
+ 	   csharp ? "readonly" : "final",
+ 	    base[2*nstates]);
+ 
+@@ -681,17 +681,17 @@ output_base()
+ 	if (j >= 10)
+ 	{
+ 	    ++outline;
+-	    putchar('\n');
++	    putc('\n', output_file);
+ 	    j = 1;
+ 	}
+ 	else
+ 	    ++j;
+ 
+-	printf("%5d,", base[i]);
++	fprintf(output_file, "%5d,", base[i]);
+     }
+ 
+     outline += 2;
+-    printf("\n  };\n");
++    fprintf(output_file, "\n  };\n");
+     FREE(base);
+ }
+ 
+@@ -702,7 +702,7 @@ output_table()
+     register int i;
+     register int j;
+ 
+-    printf("  protected static %s short [] yyTable = {%14d,", csharp ? "readonly" : "final", table[0]);
++    fprintf(output_file, "  protected static %s short [] yyTable = {%14d,", csharp ? "readonly" : "final", table[0]);
+ 
+     j = 10;
+     for (i = 1; i <= high; i++)
+@@ -710,17 +710,17 @@ output_table()
+ 	if (j >= 10)
+ 	{
+ 	    ++outline;
+-	    putchar('\n');
++	    putc('\n', output_file);
+ 	    j = 1;
+ 	}
+ 	else
+ 	    ++j;
+ 
+-	printf("%5d,", table[i]);
++	fprintf(output_file, "%5d,", table[i]);
+     }
+ 
+     outline += 2;
+-    printf("\n  };\n");
++    fprintf(output_file, "\n  };\n");
+     FREE(table);
+ }
+ 
+@@ -731,7 +731,7 @@ output_check()
+     register int i;
+     register int j;
+ 
+-    printf("  protected static %s short [] yyCheck = {%14d,",
++    fprintf(output_file, "  protected static %s short [] yyCheck = {%14d,",
+ 	   csharp ? "readonly" : "final",
+ 	    check[0]);
+ 
+@@ -741,17 +741,17 @@ output_check()
+ 	if (j >= 10)
+ 	{
+ 	    ++outline;
+-	    putchar('\n');
++	    putc('\n', output_file);
+ 	    j = 1;
+ 	}
+ 	else
+ 	    ++j;
+ 
+-	printf("%5d,", check[i]);
++	fprintf(output_file, "%5d,", check[i]);
+     }
+ 
+     outline += 2;
+-    printf("\n  };\n");
++    fprintf(output_file, "\n  };\n");
+     FREE(check);
+ }
+ 
+@@ -801,30 +801,30 @@ char *prefix;
+ 	if (is_C_identifier(s))
+ 	{
+ 	    if (prefix)
+-	        printf("  %s ", prefix);
++	        fprintf(output_file, "  %s ", prefix);
+ 	    c = *s;
+ 	    if (c == '"')
+ 	    {
+ 		while ((c = *++s) != '"')
+ 		{
+-		    putchar(c);
++		    putc(c, output_file);
+ 		}
+ 	    }
+ 	    else
+ 	    {
+ 		do
+ 		{
+-		    putchar(c);
++		    putc(c, output_file);
+ 		}
+ 		while (c = *++s);
+ 	    }
+ 	    ++outline;
+-	    printf(" = %d%s\n", symbol_value[i], csharp ? ";" : ";");
++	    fprintf(output_file, " = %d%s\n", symbol_value[i], csharp ? ";" : ";");
+ 	}
+     }
+ 
+     ++outline;
+-    printf("  %s yyErrorCode = %d%s\n", prefix ? prefix : "", symbol_value[1], csharp ? ";" : ";");
++    fprintf(output_file, "  %s yyErrorCode = %d%s\n", prefix ? prefix : "", symbol_value[1], csharp ? ";" : ";");
+ }
+ 
+ 
+@@ -842,14 +842,14 @@ char *name;
+     if ((c = getc(in)) != EOF) {
+       if (c ==  '\n')
+ 	++outline;
+-      putchar(c);
++      putc(c, output_file);
+       while ((c = getc(in)) != EOF)
+       {
+ 	if (c == '\n')
+ 	    ++outline;
+-    	putchar(c);
++    	putc(c, output_file);
+       }
+-      printf(default_line_format, ++outline + 1);
++      fprintf(output_file, default_line_format, ++outline + 1);
+     }
+     fclose(in);
+ }
+@@ -862,67 +862,67 @@ output_debug()
+     char * prefix = tflag ? "" : "//t";
+ 
+     ++outline;
+-    printf("  protected %s int yyFinal = %d;\n", csharp ? "const" : "static final", final_state);
++    fprintf(output_file, "  protected %s int yyFinal = %d;\n", csharp ? "const" : "static final", final_state);
+ 
+       ++outline;
+-	  printf ("%s // Put this array into a separate class so it is only initialized if debugging is actually used\n", prefix);
+-	  printf ("%s // Use MarshalByRefObject to disable inlining\n", prefix);
+-	  printf("%s class YYRules %s {\n", prefix, csharp ? ": MarshalByRefObject" : "");
+-      printf("%s  public static %s string [] yyRule = {\n", prefix, csharp ? "readonly" : "final");
++	  fprintf(output_file, "%s // Put this array into a separate class so it is only initialized if debugging is actually used\n", prefix);
++	  fprintf(output_file, "%s // Use MarshalByRefObject to disable inlining\n", prefix);
++	  fprintf(output_file, "%s class YYRules %s {\n", prefix, csharp ? ": MarshalByRefObject" : "");
++      fprintf(output_file, "%s  public static %s string [] yyRule = {\n", prefix, csharp ? "readonly" : "final");
+       for (i = 2; i < nrules; ++i)
+       {
+-	  printf("%s    \"%s :", prefix, symbol_name[rlhs[i]]);
++	  fprintf(output_file, "%s    \"%s :", prefix, symbol_name[rlhs[i]]);
+ 	  for (j = rrhs[i]; ritem[j] > 0; ++j)
+ 	  {
+ 	      s = symbol_name[ritem[j]];
+ 	      if (s[0] == '"')
+ 	      {
+-		  printf(" \\\"");
++		  fprintf(output_file, " \\\"");
+ 		  while (*++s != '"')
+ 		  {
+ 		      if (*s == '\\')
+ 		      {
+ 			  if (s[1] == '\\')
+-			      printf("\\\\\\\\");
++			      fprintf(output_file, "\\\\\\\\");
+ 			  else
+-			      printf("\\\\%c", s[1]);
++			      fprintf(output_file, "\\\\%c", s[1]);
+ 			  ++s;
+ 		      }
+ 		      else
+-			  putchar(*s);
++			  putc(*s, output_file);
+ 		  }
+-		  printf("\\\"");
++		  fprintf(output_file, "\\\"");
+ 	      }
+ 	      else if (s[0] == '\'')
+ 	      {
+ 		  if (s[1] == '"')
+-		      printf(" '\\\"'");
++		      fprintf(output_file, " '\\\"'");
+ 		  else if (s[1] == '\\')
+ 		  {
+ 		      if (s[2] == '\\')
+-			  printf(" '\\\\\\\\");
++			  fprintf(output_file, " '\\\\\\\\");
+ 		      else
+-			  printf(" '\\\\%c", s[2]);
++			  fprintf(output_file, " '\\\\%c", s[2]);
+ 		      s += 2;
+ 		      while (*++s != '\'')
+-			  putchar(*s);
+-		      putchar('\'');
++			  putc(*s, output_file);
++		      putc('\'', output_file);
+ 		  }
+ 		  else
+-		      printf(" '%c'", s[1]);
++		      fprintf(output_file, " '%c'", s[1]);
+ 	      }
+ 	      else
+-		  printf(" %s", s);
++		  fprintf(output_file, " %s", s);
+ 	  }
+ 	  ++outline;
+-	  printf("\",\n");
++	  fprintf(output_file, "\",\n");
+       }
+       ++ outline;
+-      printf("%s  };\n", prefix);
+-	  printf ("%s public static string getRule (int index) {\n", prefix);
+-	  printf ("%s    return yyRule [index];\n", prefix);
+-	  printf ("%s }\n", prefix);
+-	  printf ("%s}\n", prefix);
++      fprintf(output_file, "%s  };\n", prefix);
++	  fprintf(output_file, "%s public static string getRule (int index) {\n", prefix);
++	  fprintf(output_file, "%s    return yyRule [index];\n", prefix);
++	  fprintf(output_file, "%s }\n", prefix);
++	  fprintf(output_file, "%s}\n", prefix);
+ 
+     max = 0;
+     for (i = 2; i < ntokens; ++i)
+@@ -931,7 +931,7 @@ output_debug()
+ 
+ 	/* need yyNames for yyExpecting() */
+ 
+-      printf("  protected static %s string [] yyNames = {", csharp ? "readonly" : "final");
++      fprintf(output_file, "  protected static %s string [] yyNames = {", csharp ? "readonly" : "final");
+       symnam = (char **) MALLOC((max+1)*sizeof(char *));
+       if (symnam == 0) no_space();
+   
+@@ -943,7 +943,7 @@ output_debug()
+ 	  symnam[symbol_value[i]] = symbol_name[i];
+       symnam[0] = "end-of-file";
+   
+-      j = 70; fputs("    ", stdout);
++      j = 70; fputs("    ", output_file);
+       for (i = 0; i <= max; ++i)
+       {
+ 	  if (s = symnam[i])
+@@ -965,25 +965,25 @@ output_debug()
+ 		  if (j > 70)
+ 		  {
+ 		      ++outline;
+-		      printf("\n    ");
++		      fprintf(output_file, "\n    ");
+ 		      j = k;
+ 		  }
+-		  printf("\"\\\"");
++		  fprintf(output_file, "\"\\\"");
+ 		  s = symnam[i];
+ 		  while (*++s != '"')
+ 		  {
+ 		      if (*s == '\\')
+ 		      {
+-			  printf("\\\\");
++			  fprintf(output_file, "\\\\");
+ 			  if (*++s == '\\')
+-			      printf("\\\\");
++			      fprintf(output_file, "\\\\");
+ 			  else
+-			      putchar(*s);
++			      putc(*s, output_file);
+ 		      }
+ 		      else
+-			  putchar(*s);
++			  putc(*s, output_file);
+ 		  }
+-		  printf("\\\"\",");
++		  fprintf(output_file, "\\\"\",");
+ 	      }
+ 	      else if (s[0] == '\'')
+ 	      {
+@@ -993,10 +993,10 @@ output_debug()
+ 		      if (j > 70)
+ 		      {
+ 			  ++outline;
+-		      	  printf("\n    ");
++		      	  fprintf(output_file, "\n    ");
+ 			  j = 7;
+ 		      }
+-		      printf("\"'\\\"'\",");
++		      fprintf(output_file, "\"'\\\"'\",");
+ 		  }
+ 		  else
+ 		  {
+@@ -1015,25 +1015,25 @@ output_debug()
+ 		      if (j > 70)
+ 		      {
+ 			  ++outline;
+-		      	  printf("\n    ");
++		      	  fprintf(output_file, "\n    ");
+ 			  j = k;
+ 		      }
+-		      printf("\"'");
++		      fprintf(output_file, "\"'");
+ 		      s = symnam[i];
+ 		      while (*++s != '\'')
+ 		      {
+ 			  if (*s == '\\')
+ 			  {
+-			      printf("\\\\");
++			      fprintf(output_file, "\\\\");
+ 			      if (*++s == '\\')
+-				  printf("\\\\");
++				  fprintf(output_file, "\\\\");
+ 			      else
+-				  putchar(*s);
++				  putc(*s, output_file);
+ 			  }
+ 			  else
+-			      putchar(*s);
++			      putc(*s, output_file);
+ 		      }
+-		      printf("'\",");
++		      fprintf(output_file, "'\",");
+ 		  }
+ 	      }
+ 	      else
+@@ -1043,12 +1043,12 @@ output_debug()
+ 		  if (j > 70)
+ 		  {
+ 		      ++outline;
+-		      printf("\n    ");
++		      fprintf(output_file, "\n    ");
+ 		      j = k;
+ 		  }
+-		  putchar('"');
+-		  do { putchar(*s); } while (*++s);
+-		  printf("\",");
++		  putc('"', output_file);
++		  do { putc(*s, output_file); } while (*++s);
++		  fprintf(output_file, "\",");
+ 	      }
+ 	  }
+ 	  else
+@@ -1057,14 +1057,14 @@ output_debug()
+ 	      if (j > 70)
+ 	      {
+ 		  ++outline;
+-		  printf("\n    ");
++		  fprintf(output_file, "\n    ");
+ 		  j = 5;
+ 	      }
+-	      printf("null,");
++	      fprintf(output_file, "null,");
+ 	  }
+       }
+       outline += 2;
+-      printf("\n  };\n");
++      fprintf(output_file, "\n  };\n");
+       FREE(symnam);
+ }
+ 
+@@ -1084,19 +1084,19 @@ output_trailing_text()
+ 	if ((c = getc(in)) == EOF)
+ 	    return;
+         ++outline;
+-	printf(line_format, lineno, input_file_name);
++	fprintf(output_file, line_format, lineno, input_file_name);
+ 	if (c == '\n')
+ 	    ++outline;
+-	putchar(c);
++	putc(c, output_file);
+ 	last = c;
+     }
+     else
+     {
+ 	++outline;
+-	printf(line_format, lineno, input_file_name);
+-	do { putchar(c); } while ((c = *++cptr) != '\n');
++	fprintf(output_file, line_format, lineno, input_file_name);
++	do { putc(c, output_file); } while ((c = *++cptr) != '\n');
+ 	++outline;
+-	putchar('\n');
++	putc('\n', output_file);
+ 	last = '\n';
+     }
+ 
+@@ -1104,16 +1104,16 @@ output_trailing_text()
+     {
+ 	if (c == '\n')
+ 	    ++outline;
+-	putchar(c);
++	putc(c, output_file);
+ 	last = c;
+     }
+ 
+     if (last != '\n')
+     {
+ 	++outline;
+-	putchar('\n');
++	putc('\n', output_file);
+     }
+-    printf(default_line_format, ++outline + 1);
++    fprintf(output_file, default_line_format, ++outline + 1);
+ }
+ 
+ 
+@@ -1132,22 +1132,22 @@ output_semantic_actions()
+     last = c;
+     if (c == '\n')
+ 	++outline;
+-    putchar(c);
++    putc(c, output_file);
+     while ((c = getc(action_file)) != EOF)
+     {
+ 	if (c == '\n')
+ 	    ++outline;
+-	putchar(c);
++	putc(c, output_file);
+ 	last = c;
+     }
+ 
+     if (last != '\n')
+     {
+ 	++outline;
+-	putchar('\n');
++	putc('\n', output_file);
+     }
+ 
+-    printf(default_line_format, ++outline + 1);
++    fprintf(output_file, default_line_format, ++outline + 1);
+ }
+ 
+ 
+diff --git a/mcs/mcs/Makefile b/mcs/mcs/Makefile
+index dbd71a3d581..dbf040afdd6 100644
+--- a/mcs/mcs/Makefile
++++ b/mcs/mcs/Makefile
+@@ -32,7 +32,7 @@ BUILT_SOURCES = cs-parser.cs
+ CLEAN_FILES += y.output
+ 
+ %-parser.cs: %-parser.jay $(topdir)/jay/skeleton.cs
+-	$(topdir)/jay/jay $(JAY_FLAGS) < $(topdir)/jay/skeleton.cs $< > jay-tmp.out && mv jay-tmp.out $@
++	$(topdir)/jay/jay $(JAY_FLAGS) -o jay-tmp.out $< < $(topdir)/jay/skeleton.cs && mv jay-tmp.out $@
+ 
+ KEEP_OUTPUT_FILE_COPY = yes
+ 
+diff --git a/mcs/mcs/argument.cs b/mcs/mcs/argument.cs
+index 5b1003dbadf..4c75e41a9e5 100644
+--- a/mcs/mcs/argument.cs
++++ b/mcs/mcs/argument.cs
+@@ -38,6 +38,8 @@ namespace Mono.CSharp
+ 			// Conditional instance expression inserted as the first argument
+ 			ExtensionTypeConditionalAccess = 5 | ConditionalAccessFlag,
+ 
++			Readonly = 6,
++
+ 			ConditionalAccessFlag = 1 << 7
+ 		}
+ 
+diff --git a/mcs/mcs/assembly.cs b/mcs/mcs/assembly.cs
+index aa4c54317a2..96e43e70d99 100644
+--- a/mcs/mcs/assembly.cs
++++ b/mcs/mcs/assembly.cs
+@@ -554,7 +554,8 @@ namespace Mono.CSharp
+ 						if (prop != null) {
+ 							AttributeEncoder encoder = new AttributeEncoder ();
+ 							encoder.EncodeNamedPropertyArgument (prop, new BoolLiteral (Compiler.BuiltinTypes, true, Location.Null));
+-							SetCustomAttribute (pa.Constructor, encoder.ToArray ());
++							SetCustomAttribute (pa.Constructor, encoder.ToArray (out var references));
++							module.AddAssemblyReferences (references);
+ 						}
+ 					}
+ 				}
+diff --git a/mcs/mcs/attribute.cs b/mcs/mcs/attribute.cs
+index 83d403118ad..faf2cfaa1d8 100644
+--- a/mcs/mcs/attribute.cs
++++ b/mcs/mcs/attribute.cs
+@@ -1064,8 +1064,10 @@ namespace Mono.CSharp {
+ 			}
+ 
+ 			byte[] cdata;
++			List<Assembly> references;
+ 			if (pos_args == null && named_values == null) {
+ 				cdata = AttributeEncoder.Empty;
++				references = null;
+ 			} else {
+ 				AttributeEncoder encoder = new AttributeEncoder ();
+ 
+@@ -1138,7 +1140,7 @@ namespace Mono.CSharp {
+ 					encoder.EncodeEmptyNamedArguments ();
+ 				}
+ 
+-				cdata = encoder.ToArray ();
++				cdata = encoder.ToArray (out references);
+ 			}
+ 
+ 			if (!IsConditionallyExcluded (ctor.DeclaringType)) {
+@@ -1157,6 +1159,8 @@ namespace Mono.CSharp {
+ 					Error_AttributeEmitError (e.Message);
+ 					return;
+ 				}
++
++				context.Module.AddAssemblyReferences (references);
+ 			}
+ 
+ 			if (!usage_attr.AllowMultiple && allEmitted != null) {
+@@ -1415,6 +1419,7 @@ namespace Mono.CSharp {
+ 		byte[] buffer;
+ 		int pos;
+ 		const ushort Version = 1;
++		List<Assembly> imports;
+ 
+ 		static AttributeEncoder ()
+ 		{
+@@ -1594,7 +1599,15 @@ namespace Mono.CSharp {
+ 		public void EncodeTypeName (TypeSpec type)
+ 		{
+ 			var old_type = type.GetMetaInfo ();
+-			Encode (type.MemberDefinition.IsImported ? old_type.AssemblyQualifiedName : old_type.FullName);
++			if (type.MemberDefinition.IsImported) {
++				if (imports == null)
++					imports = new List<Assembly> ();
++
++				imports.Add (old_type.Assembly);
++				Encode (old_type.AssemblyQualifiedName);
++			} else {
++				Encode (old_type.FullName);
++			}
+ 		}
+ 
+ 		public void EncodeTypeName (TypeContainer type)
+@@ -1675,8 +1688,10 @@ namespace Mono.CSharp {
+ 			Encode (value);
+ 		}
+ 
+-		public byte[] ToArray ()
++		public byte[] ToArray (out List<Assembly> assemblyReferences)
+ 		{
++			assemblyReferences = imports;
++
+ 			byte[] buf = new byte[pos];
+ 			Array.Copy (buffer, buf, pos);
+ 			return buf;
+@@ -1990,7 +2005,8 @@ namespace Mono.CSharp {
+ 			encoder.Encode ((int) state);
+ 			encoder.EncodeEmptyNamedArguments ();
+ 
+-			builder.SetCustomAttribute ((ConstructorInfo) ctor.GetMetaInfo (), encoder.ToArray ());
++			builder.SetCustomAttribute ((ConstructorInfo) ctor.GetMetaInfo (), encoder.ToArray (out var references));
++			module.AddAssemblyReferences (references);
+ 		}
+ 	}
+ 
+@@ -2024,7 +2040,8 @@ namespace Mono.CSharp {
+ 			encoder.Encode ((int) modes);
+ 			encoder.EncodeEmptyNamedArguments ();
+ 
+-			builder.SetCustomAttribute ((ConstructorInfo) ctor.GetMetaInfo (), encoder.ToArray ());
++			builder.SetCustomAttribute ((ConstructorInfo) ctor.GetMetaInfo (), encoder.ToArray (out var references));
++			module.AddAssemblyReferences (references);
+ 		}
+ 	}
+ 
+@@ -2050,7 +2067,8 @@ namespace Mono.CSharp {
+ 			encoder.Encode ((uint) bits[0]);
+ 			encoder.EncodeEmptyNamedArguments ();
+ 
+-			builder.SetCustomAttribute ((ConstructorInfo) ctor.GetMetaInfo (), encoder.ToArray ());
++			builder.SetCustomAttribute ((ConstructorInfo) ctor.GetMetaInfo (), encoder.ToArray (out var references));
++			module.AddAssemblyReferences (references);
+ 		}
+ 
+ 		public void EmitAttribute (FieldBuilder builder, decimal value, Location loc)
+@@ -2068,7 +2086,8 @@ namespace Mono.CSharp {
+ 			encoder.Encode ((uint) bits[0]);
+ 			encoder.EncodeEmptyNamedArguments ();
+ 
+-			builder.SetCustomAttribute ((ConstructorInfo) ctor.GetMetaInfo (), encoder.ToArray ());
++			builder.SetCustomAttribute ((ConstructorInfo) ctor.GetMetaInfo (), encoder.ToArray (out var references));
++			module.AddAssemblyReferences (references);
+ 		}
+ 	}
+ 
+@@ -2092,7 +2111,8 @@ namespace Mono.CSharp {
+ 			encoder.EncodeTypeName (type);
+ 			encoder.EncodeEmptyNamedArguments ();
+ 
+-			builder.SetCustomAttribute ((ConstructorInfo) ctor.GetMetaInfo (), encoder.ToArray ());
++			builder.SetCustomAttribute ((ConstructorInfo) ctor.GetMetaInfo (), encoder.ToArray (out var references));
++			module.AddAssemblyReferences (references);
+ 		}
+ 	}
+ 
+diff --git a/mcs/mcs/class.cs b/mcs/mcs/class.cs
+index 6b1adc297a3..dc61f6dc627 100644
+--- a/mcs/mcs/class.cs
++++ b/mcs/mcs/class.cs
+@@ -2117,7 +2117,8 @@ namespace Mono.CSharp
+ 			encoder.Encode (GetAttributeDefaultMember ());
+ 			encoder.EncodeEmptyNamedArguments ();
+ 
+-			TypeBuilder.SetCustomAttribute ((ConstructorInfo) ctor.GetMetaInfo (), encoder.ToArray ());
++			TypeBuilder.SetCustomAttribute ((ConstructorInfo) ctor.GetMetaInfo (), encoder.ToArray (out var references));
++			Module.AddAssemblyReferences (references);
+ 		}
+ 
+ 		public override void VerifyMembers ()
+@@ -3962,7 +3963,10 @@ namespace Mono.CSharp
+ 					Report.Error (4013, Location,
+ 						"Local variables of type `{0}' cannot be used inside anonymous methods, lambda expressions or query expressions",
+ 						MemberType.GetSignatureForError ());
+-				} else if (MemberType.IsByRefLike) {
++				} else if (MemberType.IsSpecialRuntimeType) {
++					Report.Error (610, Location,
++						"Field or property cannot be of type `{0}'", MemberType.GetSignatureForError ());
++				} else {
+ 					if ((ModFlags & (Modifiers.ABSTRACT | Modifiers.EXTERN)) != 0)
+ 						return;
+ 
+@@ -3975,9 +3979,6 @@ namespace Mono.CSharp
+ 					Report.Error (8345, Location,
+ 						"Field or auto-implemented property cannot be of type `{0}' unless it is an instance member of a ref struct",
+ 						MemberType.GetSignatureForError ());
+-				} else {
+-					Report.Error (610, Location, 
+-						"Field or property cannot be of type `{0}'", MemberType.GetSignatureForError ());
+ 				}
+ 			}
+ 		}
+diff --git a/mcs/mcs/convert.cs b/mcs/mcs/convert.cs
+index ae153fc49e8..2c8d2a0204c 100644
+--- a/mcs/mcs/convert.cs
++++ b/mcs/mcs/convert.cs
+@@ -1232,6 +1232,13 @@ namespace Mono.CSharp {
+ 					FindApplicableUserDefinedConversionOperators (rc, operators, source_type_expr, target_type, restr, ref candidates);
+ 				}
+ 
++				if (source_type_expr == source && source_type.IsNullableType) {
++					operators = MemberCache.GetUserOperator (source_type.TypeArguments [0], Operator.OpType.Implicit, declared_only);
++					if (operators != null) {
++						FindApplicableUserDefinedConversionOperators (rc, operators, source_type_expr, target_type, restr, ref candidates);
++					}
++				}
++
+ 				if (!implicitOnly) {
+ 					operators = MemberCache.GetUserOperator (source_type, Operator.OpType.Explicit, declared_only);
+ 					if (operators != null) {
+diff --git a/mcs/mcs/cs-parser.jay b/mcs/mcs/cs-parser.jay
+index 4d6fcb44c0d..4ca3bf74f3d 100644
+--- a/mcs/mcs/cs-parser.jay
++++ b/mcs/mcs/cs-parser.jay
+@@ -34,13 +34,16 @@ namespace Mono.CSharp
+ 			Params	= 1 << 4,
+ 			Arglist	= 1 << 5,
+ 			DefaultValue = 1 << 6,
++			ReadOnly = 1 << 7,
+ 			
+-			All = Ref | Out | This | Params | Arglist | DefaultValue,
++			All = Ref | Out | This | Params | Arglist | DefaultValue | ReadOnly,
+ 			PrimaryConstructor = Ref | Out | Params | DefaultValue
+ 		}
+ 		
+ 		static readonly object ModifierNone = 0;
+-	
++		static readonly object RefStructToken = new object ();
++		static readonly object RefPartialStructToken = new object ();
++
+ 		NamespaceContainer current_namespace;
+ 		TypeContainer current_container;
+ 		TypeDefinition current_type;
+@@ -338,6 +341,7 @@ namespace Mono.CSharp
+ %token OPEN_BRACKET_EXPR
+ %token OPEN_PARENS_DECONSTRUCT
+ %token REF_STRUCT
++%token REF_PARTIAL
+ 
+ // Make the parser go into eval mode parsing (statements and compilation units).
+ %token EVAL_STATEMENT_PARSER
+@@ -648,8 +652,8 @@ namespace_or_type_declaration
+ 			TypeContainer ds = (TypeContainer)$1;
+ 
+ 			if ((ds.ModFlags & (Modifiers.PRIVATE | Modifiers.PROTECTED)) != 0){
+-				report.Error (1527, ds.Location, 
+-				"Namespace elements cannot be explicitly declared as private, protected or protected internal");
++				report.Error (1527, ds.Location,
++				"Namespace elements cannot be explicitly declared as private, protected, protected internal, or private protected");
+ 			}
+ 
+ 			// Here is a trick, for explicit attributes we don't know where they belong to until
+@@ -1028,7 +1032,15 @@ struct_keyword
+ 			FeatureIsNotAvailable (GetLocation ($1), "ref structs");
+ 		}
+ 
+-		$$ = this;
++		$$ = RefStructToken;
++	  }
++	| REF_PARTIAL STRUCT
++	  {
++		if (lang_version < LanguageVersion.V_7_2) {
++			FeatureIsNotAvailable (GetLocation ($1), "ref structs");
++		}
++
++		$$ = RefPartialStructToken;
+ 	  }
+ 	;
+ 
+@@ -1043,8 +1055,13 @@ struct_declaration
+ 		if ((mods & Modifiers.READONLY) != 0 && lang_version < LanguageVersion.V_7_2) {
+ 			FeatureIsNotAvailable (GetLocation ($4), "readonly structs");
+ 		}
+-		if ($4 != null)
++		if ($4 != null) {
+ 			mods |= Modifiers.REF;
++			if ($4 == RefPartialStructToken) {
++				mods |= Modifiers.PARTIAL;
++				$3 = $4;
++			}
++		}
+ 
+ 		lexer.ConstraintsParsing = true;
+ 		valid_param_mod = ParameterModifierType.PrimaryConstructor;
+@@ -1469,7 +1486,7 @@ method_header
+ 	  OPEN_PARENS
+ 	  {
+ 		lexer.parsing_generic_declaration = false;
+-	  	valid_param_mod = ParameterModifierType.All;
++		valid_param_mod = ParameterModifierType.All;
+ 	  }
+ 	  opt_formal_parameter_list CLOSE_PARENS 
+ 	  {
+@@ -1569,7 +1586,7 @@ constructor_body
+ 	 expression SEMICOLON
+ 	 {
+ 		lexer.parsing_block = 0;
+-		current_block.AddStatement (new ContextualReturn ((Expression) $3));
++		current_block.AddStatement (CreateExpressionBodiedStatement ((Expression) $3));
+ 		var b = end_block (GetLocation ($4));
+ 		b.IsCompilerGenerated = true;
+ 		$$ = b;
+@@ -1590,7 +1607,7 @@ expression_block
+ 	 lambda_arrow_expression SEMICOLON
+ 	 {
+ 		lexer.parsing_block = 0;
+-		current_block.AddStatement (new ContextualReturn ((Expression) $3));
++		current_block.AddStatement (CreateExpressionBodiedStatement ((Expression) $3));
+ 		var b = end_block (GetLocation ($4));
+ 		b.IsCompilerGenerated = true;
+ 		$$ = b;
+@@ -1794,7 +1811,9 @@ parameter_modifiers
+   		Parameter.Modifier mod = (Parameter.Modifier)$1 | p2;
+   		if (((Parameter.Modifier)$1 & p2) == p2) {
+   			Error_DuplicateParameterModifier (lexer.Location, p2);
+-  		} else {
++		} else if ((mod & ~(Parameter.Modifier.This | Parameter.Modifier.ReadOnly)) == 0) {
++			// ok
++		} else {
+ 	  		switch (mod & ~Parameter.Modifier.This) {
+   				case Parameter.Modifier.REF:
+ 					report.Error (1101, lexer.Location, "The parameter modifiers `this' and `ref' cannot be used altogether");
+@@ -1836,6 +1855,13 @@ parameter_modifier
+ 	  			
+ 		$$ = Parameter.Modifier.This;
+ 	  }
++	| IN
++	  {
++		if (lang_version < LanguageVersion.V_7_2)
++			FeatureIsNotAvailable (GetLocation ($1), "readonly references");
++
++		$$ = Parameter.Modifier.ReadOnly;
++	  }
+ 	;
+ 
+ parameter_array
+@@ -1871,7 +1897,7 @@ params_modifier
+ 		if ((mod & Parameter.Modifier.This) != 0) {
+ 			report.Error (1104, GetLocation ($1), "The parameter modifiers `this' and `params' cannot be used altogether");
+ 		} else {
+-			report.Error (1611, GetLocation ($1), "The params parameter cannot be declared as ref or out");
++			report.Error (1611, GetLocation ($1), "The params parameter cannot be declared as ref, out or in");
+ 		}	  
+ 	  }
+ 	| PARAMS params_modifier
+@@ -2004,7 +2030,7 @@ indexer_declaration
+ 	: opt_attributes opt_modifiers
+ 	  ref_member_type indexer_declaration_name OPEN_BRACKET
+ 	  {
+-	  	valid_param_mod = ParameterModifierType.Params | ParameterModifierType.DefaultValue;
++		valid_param_mod = ParameterModifierType.Params | ParameterModifierType.DefaultValue | ParameterModifierType.ReadOnly;
+ 	  }
+ 	  opt_formal_parameter_list CLOSE_BRACKET 
+ 	  {
+@@ -2181,6 +2207,11 @@ set_accessor_declaration
+ accessor_body
+ 	: block
+ 	| expression_block
++	  {
++		if (lang_version < LanguageVersion.V_7) {
++			FeatureIsNotAvailable (GetLocation ($1), "expression body property accessor");
++		}
++	  }
+ 	| SEMICOLON
+ 	  {
+ 		// TODO: lbag
+@@ -2331,7 +2362,7 @@ operator_type
+ operator_declarator
+ 	: operator_type OPERATOR overloadable_operator OPEN_PARENS
+ 	  {
+-		valid_param_mod = ParameterModifierType.DefaultValue;
++		valid_param_mod = ParameterModifierType.DefaultValue | ParameterModifierType.ReadOnly;
+ 		if ((Operator.OpType) $3 == Operator.OpType.Is)
+ 			valid_param_mod |= ParameterModifierType.Out;
+ 	  }
+@@ -2418,7 +2449,7 @@ overloadable_operator
+ conversion_operator_declarator
+ 	: IMPLICIT OPERATOR type OPEN_PARENS
+ 	  {
+-		valid_param_mod = ParameterModifierType.DefaultValue;
++		valid_param_mod = ParameterModifierType.DefaultValue | ParameterModifierType.ReadOnly;
+ 	  }
+ 	  opt_formal_parameter_list CLOSE_PARENS
+ 	  {
+@@ -2441,7 +2472,7 @@ conversion_operator_declarator
+ 	  }
+ 	| EXPLICIT OPERATOR type OPEN_PARENS
+ 	  {
+-		valid_param_mod = ParameterModifierType.DefaultValue;
++		valid_param_mod = ParameterModifierType.DefaultValue | ParameterModifierType.ReadOnly;
+ 	  }
+ 	  opt_formal_parameter_list CLOSE_PARENS
+ 	  {
+@@ -2850,6 +2881,11 @@ event_accessor_block
+ 	  }
+ 	| block
+ 	| expression_block
++	  {
++		if (lang_version < LanguageVersion.V_7) {
++			FeatureIsNotAvailable (GetLocation ($1), "expression body event accessor");
++		}
++	  }
+ 	;
+ 
+ attributes_without_members
+@@ -3014,7 +3050,7 @@ delegate_declaration
+ 	  ref_member_type type_declaration_name
+ 	  OPEN_PARENS
+ 	  {
+-		valid_param_mod = ParameterModifierType.Ref | ParameterModifierType.Out | ParameterModifierType.Params | ParameterModifierType.DefaultValue;
++		valid_param_mod = ParameterModifierType.Ref | ParameterModifierType.Out | ParameterModifierType.Params | ParameterModifierType.DefaultValue | ParameterModifierType.ReadOnly;
+ 	  }
+ 	  opt_formal_parameter_list CLOSE_PARENS
+ 	  {
+@@ -3927,7 +3963,15 @@ non_simple_argument
+ 	  {
+ 		$$ = new Argument (new Arglist (GetLocation ($1)));
+ 		lbag.AddLocation ($$, GetLocation ($2), GetLocation ($3));
+-	  }	  
++	  }
++	| IN variable_reference
++	  {
++		if (lang_version < LanguageVersion.V_7_2)
++			FeatureIsNotAvailable (GetLocation ($1), "readonly references");
++
++		$$ = new Argument ((Expression) $2, Argument.AType.Readonly);
++		lbag.AddLocation ($$, GetLocation ($1));
++	  }
+ 	;
+ 
+ out_variable_declaration
+@@ -4408,7 +4452,7 @@ opt_anonymous_method_signature
+ anonymous_method_signature
+ 	: OPEN_PARENS
+ 	  {
+-	  	valid_param_mod = ParameterModifierType.Ref | ParameterModifierType.Out;
++		valid_param_mod = ParameterModifierType.Ref | ParameterModifierType.Out | ParameterModifierType.ReadOnly;
+ 	  }
+ 	  opt_formal_parameter_list CLOSE_PARENS
+ 	  {
+@@ -5014,36 +5058,47 @@ null_coalescing_expression
+ 	  }
+ 	;
+ 
++
++conditional_oper_expr
++	: expression
++	| stackalloc_expression
++	;
++
+ conditional_expression
+ 	: null_coalescing_expression
+-	| null_coalescing_expression INTERR expression COLON expression
++	| null_coalescing_expression INTERR conditional_oper_expr COLON conditional_oper_expr
+ 	  {
+ 		$$ = new Conditional (new BooleanExpression ((Expression) $1), (Expression) $3, (Expression) $5, GetLocation ($2));
+ 		lbag.AddLocation ($$, GetLocation ($4));
+ 	  }
+-	| null_coalescing_expression INTERR expression COLON THROW prefixed_unary_expression
++	| null_coalescing_expression INTERR conditional_oper_expr COLON THROW prefixed_unary_expression
+ 	  {
+ 		if (lang_version < LanguageVersion.V_7)
+-			FeatureIsNotAvailable (lexer.Location, "throw expression");
++			FeatureIsNotAvailable (GetLocation ($5), "throw expression");
+ 
+ 		var expr = new ThrowExpression ((Expression) $6, GetLocation ($5));
+ 		$$ = new Conditional (new BooleanExpression ((Expression) $1), (Expression) $3, expr, GetLocation ($2));
+ 		lbag.AddLocation ($$, GetLocation ($4));
+ 	  }
+-	| null_coalescing_expression INTERR expression error
++	| null_coalescing_expression INTERR reference_expression COLON reference_expression
++	  {
++		$$ = new Conditional (new BooleanExpression ((Expression) $1), (Expression) $3, (Expression) $5, GetLocation ($2));
++		lbag.AddLocation ($$, GetLocation ($4));
++	  }
++	| null_coalescing_expression INTERR conditional_oper_expr error
+ 	  {
+ 		Error_SyntaxError (yyToken);
+ 
+ 		$$ = new Conditional (new BooleanExpression ((Expression) $1), (Expression) $3, null, GetLocation ($2));
+ 	  }
+-	| null_coalescing_expression INTERR expression COLON error
++	| null_coalescing_expression INTERR conditional_oper_expr COLON error
+ 	  {
+ 		Error_SyntaxError (yyToken);
+ 
+ 		$$ = new Conditional (new BooleanExpression ((Expression) $1), (Expression) $3, null, GetLocation ($2));
+ 		lbag.AddLocation ($$, GetLocation ($4));
+ 	  }
+-	| null_coalescing_expression INTERR expression COLON CLOSE_BRACE
++	| null_coalescing_expression INTERR conditional_oper_expr COLON CLOSE_BRACE
+ 	  {
+ 		Error_SyntaxError (Token.CLOSE_BRACE);
+ 
+@@ -5308,7 +5363,7 @@ lambda_expression
+ 	  }
+ 	| OPEN_PARENS_LAMBDA
+ 	  {
+-	  	valid_param_mod = ParameterModifierType.Ref | ParameterModifierType.Out;
++		valid_param_mod = ParameterModifierType.Ref | ParameterModifierType.Out | ParameterModifierType.ReadOnly;
+ 	  }
+ 	  opt_lambda_parameter_list CLOSE_PARENS ARROW 
+ 	  {
+@@ -5322,7 +5377,7 @@ lambda_expression
+ 	  }
+ 	| ASYNC OPEN_PARENS_LAMBDA
+ 	  {
+-	  	valid_param_mod = ParameterModifierType.Ref | ParameterModifierType.Out;	  
++		valid_param_mod = ParameterModifierType.Ref | ParameterModifierType.Out | ParameterModifierType.ReadOnly;
+ 	  }
+ 	  opt_lambda_parameter_list CLOSE_PARENS ARROW 
+ 	  {
+@@ -5522,10 +5577,17 @@ modifiers
+ 		if ((m1 & m2) != 0) {
+ 			report.Error (1004, lexer.Location - ModifiersExtensions.Name (m2).Length,
+ 				"Duplicate `{0}' modifier", ModifiersExtensions.Name (m2));
+-		} else if ((m2 & Modifiers.AccessibilityMask) != 0 && (m1 & Modifiers.AccessibilityMask) != 0 &&
+-			((m2 | m1 & Modifiers.AccessibilityMask) != (Modifiers.PROTECTED | Modifiers.INTERNAL))) {
+-			report.Error (107, lexer.Location - ModifiersExtensions.Name (m2).Length,
+-				"More than one protection modifier specified");
++		} else if ((m2 & Modifiers.AccessibilityMask) != 0 && (m1 & Modifiers.AccessibilityMask) != 0) {
++			var accessibility = (m2 | m1 & Modifiers.AccessibilityMask);
++
++			if (accessibility == (Modifiers.PRIVATE | Modifiers.PROTECTED)) {
++				if (lang_version < LanguageVersion.V_7_2) {
++					FeatureIsNotAvailable (lexer.Location, "private protected");
++				}
++			} else if (accessibility != (Modifiers.PROTECTED | Modifiers.INTERNAL)) {
++				report.Error (107, lexer.Location - ModifiersExtensions.Name (m2).Length,
++					"More than one protection modifier specified");
++			}
+ 		}
+ 		
+ 		$$ = m1 | m2;
+@@ -6223,11 +6285,28 @@ block_variable_initializer
+ 	| STACKALLOC simple_type
+ 	  {
+ 		report.Error (1575, GetLocation ($1), "A stackalloc expression requires [] after type");
+-		$$ = new StackAlloc ((Expression) $2, null, GetLocation ($1));		
++		$$ = new StackAlloc ((Expression) $2, null, GetLocation ($1));
+ 	  }
+ 	| reference_expression
+ 	;
+ 
++stackalloc_expression
++	: STACKALLOC simple_type OPEN_BRACKET_EXPR expression CLOSE_BRACKET
++	  {
++		if (lang_version < LanguageVersion.V_7_2) {
++			FeatureIsNotAvailable (GetLocation ($1), "ref structs");
++		}
++
++		$$ = new SpanStackAlloc ((Expression) $2, (Expression) $4, GetLocation ($1));
++		lbag.AddLocation ($$, GetLocation ($3), GetLocation ($5));
++	  }
++	| STACKALLOC simple_type
++	  {
++		report.Error (1575, GetLocation ($1), "A stackalloc expression requires [] after type");
++		$$ = new StackAlloc ((Expression) $2, null, GetLocation ($1));
++	  }
++	;
++
+ reference_expression
+ 	: REF expression
+ 	  {
+@@ -7699,7 +7778,7 @@ doc_cref
+ 	  }
+ 	| doc_type_declaration_name DOT THIS OPEN_BRACKET
+ 	  {
+-		valid_param_mod = ParameterModifierType.Ref | ParameterModifierType.Out;
++		valid_param_mod = ParameterModifierType.Ref | ParameterModifierType.Out | ParameterModifierType.ReadOnly;
+ 	  }
+ 	  opt_doc_parameters CLOSE_BRACKET
+ 	  {
+@@ -7743,7 +7822,7 @@ opt_doc_method_sig
+ 	: /* empty */
+ 	| OPEN_PARENS
+ 	  {
+-		valid_param_mod = ParameterModifierType.Ref | ParameterModifierType.Out;
++		valid_param_mod = ParameterModifierType.Ref | ParameterModifierType.Out | ParameterModifierType.ReadOnly;
+ 	  }
+ 	  opt_doc_parameters CLOSE_PARENS
+ 	  {
+@@ -7951,6 +8030,14 @@ static bool IsUnaryOperator (Operator.OpType op)
+ 	return false;
+ }
+ 
++static Statement CreateExpressionBodiedStatement (Expression expr)
++{
++	if (expr is ThrowExpression te)
++		return new StatementExpression (te);
++
++	return new ContextualReturn (expr);
++}
++
+ void syntax_error (Location l, string msg)
+ {
+ 	report.Error (1003, l, "Syntax error, " + msg);
+@@ -8430,6 +8517,8 @@ static string GetTokenName (int token)
+ 	case Token.READONLY:
+ 		return "readonly";
+ 	case Token.REF:
++	case Token.REF_STRUCT:
++	case Token.REF_PARTIAL:
+ 		return "ref";
+ 	case Token.RETURN:
+ 		return "return";
+@@ -8444,7 +8533,6 @@ static string GetTokenName (int token)
+ 	case Token.STATIC:
+ 		return "static";
+ 	case Token.STRUCT:
+-	case Token.REF_STRUCT:
+ 		return "struct";
+ 	case Token.SWITCH:
+ 		return "switch";
+diff --git a/mcs/mcs/cs-tokenizer.cs b/mcs/mcs/cs-tokenizer.cs
+index 37edb5c1224..db5ba1f1f1b 100644
+--- a/mcs/mcs/cs-tokenizer.cs
++++ b/mcs/mcs/cs-tokenizer.cs
+@@ -825,8 +825,7 @@ namespace Mono.CSharp
+ 					next_token == Token.CLASS ||
+ 					next_token == Token.STRUCT ||
+ 					next_token == Token.INTERFACE ||
+-					next_token == Token.VOID ||
+-					next_token == Token.REF_STRUCT;
++					next_token == Token.VOID;
+ 
+ 				PopPosition ();
+ 
+@@ -916,14 +915,20 @@ namespace Mono.CSharp
+ 
+ 				break;
+ 			case Token.REF:
+-				if (peek_token () == Token.STRUCT) {
++				var pp = peek_token ();
++				switch (pp) {
++				case Token.STRUCT:
+ 					token ();
+ 					res = Token.REF_STRUCT;
++					break;
++				case Token.PARTIAL:
++					token ();
++					res = Token.REF_PARTIAL;
++					break;
+ 				}
+ 				break;
+ 			}
+ 
+-
+ 			return res;
+ 		}
+ 
+@@ -1212,6 +1217,7 @@ namespace Mono.CSharp
+ 
+ 				case Token.REF:
+ 				case Token.OUT:
++				case Token.IN:
+ 					can_be_type = is_type = false;
+ 					continue;
+ 
+@@ -1406,6 +1412,8 @@ namespace Mono.CSharp
+ 			case Token.INTERPOLATED_STRING:
+ 			case Token.THROW:
+ 			case Token.DEFAULT_COLON:
++			case Token.REF:
++			case Token.STACKALLOC:
+ 				next_token = Token.INTERR;
+ 				break;
+ 				
+@@ -1567,28 +1575,53 @@ namespace Mono.CSharp
+ 		{
+ 			int d;
+ 			bool seen_digits = false;
+-			
+-			if (c != -1){
++			bool digit_separator = false;
++			int prev = c;
++			var loc = Location;
++
++			if (prev != -1){
+ 				if (number_pos == MaxNumberLength)
+ 					Error_NumericConstantTooLong ();
+-				number_builder [number_pos++] = (char) c;
++				number_builder [number_pos++] = (char) prev;
+ 			}
+-			
++
+ 			//
+ 			// We use peek_char2, because decimal_digits needs to do a 
+ 			// 2-character look-ahead (5.ToString for example).
+ 			//
+ 			while ((d = peek_char2 ()) != -1){
+-				if (d >= '0' && d <= '9'){
++				if (d >= '0' && d <= '9') {
+ 					if (number_pos == MaxNumberLength)
+ 						Error_NumericConstantTooLong ();
+-					number_builder [number_pos++] = (char) d;
+-					get_char ();
++					number_builder [number_pos++] = (char)d;
++					prev = get_char ();
+ 					seen_digits = true;
+-				} else
+-					break;
++					continue;
++				} else if (d == '_') {
++					if (!digit_separator) {
++						if (context.Settings.Version < LanguageVersion.V_7)
++							Report.FeatureIsNotAvailable (context, Location, "digit separators");
++
++						digit_separator = true;
++					}
++
++					if (prev == '.')
++						break;
++
++					if (prev == 'e' || prev == 'E')
++						Error_InvalidNumber ();
++
++					prev = get_char();
++					continue;
++				}
++
++				break;
+ 			}
+ 			
++			if (prev == '_') {
++				Error_InvalidNumber ();
++			}
++
+ 			return seen_digits;
+ 		}
+ 
+@@ -1716,9 +1749,8 @@ namespace Mono.CSharp
+ 			} catch (OverflowException) {
+ 				Error_NumericConstantTooLong ();
+ 				return new IntLiteral (context.BuiltinTypes, 0, loc);
+-			}
+-			catch (FormatException) {
+-				Report.Error (1013, Location, "Invalid number");
++			} catch (FormatException) {
++				Error_InvalidNumber ();
+ 				return new IntLiteral (context.BuiltinTypes, 0, loc);
+ 			}
+ 		}
+@@ -1757,14 +1789,41 @@ namespace Mono.CSharp
+ 		{
+ 			int d;
+ 			ulong ul;
+-			
+-			get_char ();
++			bool digit_separator = false;
++			int prev = get_char ();
++
+ 			while ((d = peek_char ()) != -1){
+ 				if (is_hex (d)){
+ 					number_builder [number_pos++] = (char) d;
+ 					get_char ();
+-				} else
+-					break;
++
++					prev = d;
++					continue;
++				}
++
++				if (d == '_') {
++					if (prev == 'x' || prev == 'X')
++						Error_InvalidNumber ();
++
++					get_char ();
++
++					if (!digit_separator) {
++						if (context.Settings.Version < LanguageVersion.V_7)
++							Report.FeatureIsNotAvailable (context, Location, "digit separators");
++
++						digit_separator = true;
++					}
++
++					prev = d;
++					continue;
++				}
++
++				break;
++			}
++
++			if (number_pos == 0 || prev == '_') {
++				Error_InvalidNumber ();
++				return new IntLiteral (context.BuiltinTypes, 0, loc);
+ 			}
+ 			
+ 			string s = new String (number_builder, 0, number_pos);
+@@ -1779,13 +1838,65 @@ namespace Mono.CSharp
+ 			} catch (OverflowException){
+ 				Error_NumericConstantTooLong ();
+ 				return new IntLiteral (context.BuiltinTypes, 0, loc);
+-			}
+-			catch (FormatException) {
+-				Report.Error (1013, Location, "Invalid number");
++			} catch (FormatException) {
++				Error_InvalidNumber ();
+ 				return new IntLiteral (context.BuiltinTypes, 0, loc);
+ 			}
+ 		}
+ 
++		ILiteralConstant handle_binary (Location loc)
++		{
++			int d;
++			ulong ul = 0;
++			bool digit_separator = false;
++			int digits = 0;
++			int prev = get_char ();
++
++			while ((d = peek_char ()) != -1){
++
++				if (d == '0' || d == '1') {
++					ul = (ul << 1);
++					digits++;
++					if (d == '1')
++						ul |= 1;
++					get_char ();
++					if (digits > 64) {
++						Error_NumericConstantTooLong ();
++						return new IntLiteral (context.BuiltinTypes, 0, loc);
++					}
++
++					prev = d;
++					continue;
++				}
++
++				if (d == '_') {
++					if (prev == 'b' || prev == 'B')
++						Error_InvalidNumber ();
++
++					get_char ();
++
++					if (!digit_separator) {
++						if (context.Settings.Version < LanguageVersion.V_7)
++							Report.FeatureIsNotAvailable (context, Location, "digit separators");
++						
++						digit_separator = true;
++					}
++
++					prev = d;
++					continue;
++				}
++				 
++				break;
++			}
++
++			if (digits == 0 || prev == '_') {
++				Error_InvalidNumber ();
++				return new IntLiteral (context.BuiltinTypes, 0, loc);
++			}
++
++			return integer_type_suffix (ul, peek_char (), loc);
++		}
++		
+ 		//
+ 		// Invoked if we know we have .digits or digits
+ 		//
+@@ -1817,7 +1928,20 @@ namespace Mono.CSharp
+ 
+ 						return Token.LITERAL;
+ 					}
++
++					if (peek == 'b' || peek == 'B'){
++						if (context.Settings.Version < LanguageVersion.V_7)
++							Report.FeatureIsNotAvailable (context, Location, "binary literals");
++
++						val = res = handle_binary (loc);
++#if FULL_AST
++						res.ParsedValue = reader.ReadChars (read_start, reader.Position - 1);
++#endif
++
++						return Token.LITERAL;
++					}
+ 				}
++
+ 				decimal_digits (c);
+ 				c = peek_char ();
+ 			}
+@@ -1869,7 +1993,7 @@ namespace Mono.CSharp
+ 						Error_NumericConstantTooLong ();
+ 					number_builder [number_pos++] = '+';
+ 				}
+-					
++
+ 				decimal_digits (c);
+ 				c = peek_char ();
+ 			}
+@@ -2944,6 +3068,11 @@ namespace Mono.CSharp
+ 		{
+ 			Report.Error (1021, Location, "Integral constant is too large");			
+ 		}
++
++		void Error_InvalidNumber ()
++		{
++			Report.Error (1013, Location, "Invalid number");
++		}
+ 		
+ 		void Error_InvalidDirective ()
+ 		{
+diff --git a/mcs/mcs/ecore.cs b/mcs/mcs/ecore.cs
+index 20ee9e73b19..d5926bf4d1f 100644
+--- a/mcs/mcs/ecore.cs
++++ b/mcs/mcs/ecore.cs
+@@ -241,7 +241,7 @@ namespace Mono.CSharp {
+ 
+ 		protected void CheckExpressionVariable (ResolveContext rc)
+ 		{
+-			if (rc.HasAny (ResolveContext.Options.BaseInitializer | ResolveContext.Options.FieldInitializerScope)) {
++			if (rc.HasAny (ResolveContext.Options.BaseInitializer | ResolveContext.Options.FieldInitializerScope) && rc.CurrentAnonymousMethod == null) {
+ 				rc.Report.Error (8200, loc, "Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers");
+ 			} else if (rc.HasSet (ResolveContext.Options.QueryClauseScope)) {
+ 				rc.Report.Error (8201, loc, "Out variable and pattern variable declarations are not allowed within a query clause");
+diff --git a/mcs/mcs/expression.cs b/mcs/mcs/expression.cs
+index 518ccc8ef43..87db14a0ce7 100644
+--- a/mcs/mcs/expression.cs
++++ b/mcs/mcs/expression.cs
+@@ -920,7 +920,7 @@ namespace Mono.CSharp
+ 
+ 		public override bool ContainsEmitWithAwait ()
+ 		{
+-			throw new NotImplementedException ();
++			return false;
+ 		}
+ 
+ 		public override Expression CreateExpressionTree (ResolveContext ec)
+@@ -2051,7 +2051,11 @@ namespace Mono.CSharp
+ 
+ 						if (d.BuiltinType == BuiltinTypeSpec.Type.Dynamic)
+ 							return this;
+-						
++
++						// TODO: Requires custom optimized version with variable store
++						if (Variable != null)
++							return this;
++
+ 						//
+ 						// Turn is check into simple null check for implicitly convertible reference types
+ 						//
+@@ -2757,6 +2761,12 @@ namespace Mono.CSharp
+ 			}
+ 		}
+ 
++		public override bool IsNull {
++			get {
++				return TypeSpec.IsReferenceType (type);
++			}
++		}
++
+ 		public override bool ContainsEmitWithAwait ()
+ 		{
+ 			return false;
+@@ -5669,6 +5679,12 @@ namespace Mono.CSharp
+ 				ConvCast.Emit (ec, enum_conversion);
+ 		}
+ 
++		public override void EmitPrepare (EmitContext ec)
++		{
++			Left.EmitPrepare (ec);
++			Right.EmitPrepare (ec);
++		}
++
+ 		public override void EmitSideEffect (EmitContext ec)
+ 		{
+ 			if ((oper & Operator.LogicalMask) != 0 ||
+@@ -6385,7 +6401,7 @@ namespace Mono.CSharp
+ 							}
+ 						}
+ 
+-						if (conv_false_expr != null) {
++						if (conv_false_expr != null && false_type != InternalType.ErrorType && true_type != InternalType.ErrorType) {
+ 							ec.Report.Error (172, true_expr.Location,
+ 								"Type of conditional expression cannot be determined as `{0}' and `{1}' convert implicitly to each other",
+ 									true_type.GetSignatureForError (), false_type.GetSignatureForError ());
+@@ -6398,7 +6414,7 @@ namespace Mono.CSharp
+ 				} else if ((conv = Convert.ImplicitConversion (ec, false_expr, true_type, loc)) != null) {
+ 					false_expr = conv;
+ 				} else {
+-					if (false_type != InternalType.ErrorType) {
++					if (false_type != InternalType.ErrorType && true_type != InternalType.ErrorType) {
+ 						ec.Report.Error (173, true_expr.Location,
+ 							"Type of conditional expression cannot be determined because there is no implicit conversion between `{0}' and `{1}'",
+ 							true_type.GetSignatureForError (), false_type.GetSignatureForError ());
+@@ -6427,6 +6443,30 @@ namespace Mono.CSharp
+ 			return this;
+ 		}
+ 
++		public override Expression DoResolveLValue (ResolveContext rc, Expression right_side)
++		{
++			expr = expr.Resolve (rc);
++			true_expr = true_expr.Resolve (rc);
++			false_expr = false_expr.Resolve (rc);
++
++			if (true_expr == null || false_expr == null || expr == null)
++				return null;
++			
++			if (!(true_expr is ReferenceExpression && false_expr is ReferenceExpression)) {
++				rc.Report.Error (8326, expr.Location, "Both ref conditional operators must be ref values");
++				return null;
++			}
++
++			if (!TypeSpecComparer.IsEqual (true_expr.Type, false_expr.Type)) {
++				rc.Report.Error (8327, true_expr.Location, "The ref conditional expression types `{0}' and `{1}' have to match",
++				                 true_expr.Type.GetSignatureForError (), false_expr.Type.GetSignatureForError ()); 
++			}
++
++			eclass = ExprClass.Value;
++			type = true_expr.Type;
++			return this;
++		}
++
+ 		public override void Emit (EmitContext ec)
+ 		{
+ 			Label false_target = ec.DefineLabel ();
+@@ -6774,7 +6814,7 @@ namespace Mono.CSharp
+ 						"Cannot use fixed variable `{0}' inside an anonymous method, lambda expression or query expression",
+ 						GetSignatureForError ());
+ 				} else if (local_info.IsByRef || local_info.Type.IsByRefLike) {
+-					if (ec.CurrentAnonymousMethod is StateMachineInitializer) {
++					if (local_info.Type.IsSpecialRuntimeType || ec.CurrentAnonymousMethod is StateMachineInitializer) {
+ 						// It's reported later as 4012/4013
+ 					} else {
+ 						ec.Report.Error (8175, loc,
+@@ -11877,12 +11917,17 @@ namespace Mono.CSharp
+ 			if (!TypeManager.VerifyUnmanaged (ec.Module, otype, loc))
+ 				return null;
+ 
+-			type = PointerContainer.MakeType (ec.Module, otype);
++			ResolveExpressionType (ec, otype);
+ 			eclass = ExprClass.Value;
+ 
+ 			return this;
+ 		}
+ 
++		protected virtual void ResolveExpressionType (ResolveContext rc, TypeSpec elementType)
++		{
++			type = PointerContainer.MakeType (rc.Module, elementType);
++		}
++
+ 		public override void Emit (EmitContext ec)
+ 		{
+ 			int size = BuiltinTypeSpec.GetSize (otype);
+@@ -11931,14 +11976,36 @@ namespace Mono.CSharp
+ 		public bool ResolveSpanConversion (ResolveContext rc, TypeSpec spanType)
+ 		{
+ 			ctor = MemberCache.FindMember (spanType, MemberFilter.Constructor (ParametersCompiled.CreateFullyResolved (PointerContainer.MakeType (rc.Module, rc.Module.Compiler.BuiltinTypes.Void), rc.Module.Compiler.BuiltinTypes.Int)), BindingRestriction.DeclaredOnly) as MethodSpec;
+-			if (ctor == null)
++			if (ctor == null) {
++				this.type = InternalType.ErrorType;
+ 				return false;
++			}
+ 			
+ 			this.type = spanType;
+ 			return true;
+ 		}
+ 	}
+ 
++	class SpanStackAlloc : StackAlloc
++	{
++		public SpanStackAlloc (Expression type, Expression count, Location l)
++			: base (type, count, l)
++		{
++		}
++
++		protected override void ResolveExpressionType (ResolveContext rc, TypeSpec elementType)
++		{
++			var span = rc.Module.PredefinedTypes.SpanGeneric.Resolve ();
++			if (span == null) {
++				type = InternalType.ErrorType;
++				return;
++			}
++
++			type = span.MakeGenericType (rc, new [] { elementType });
++			ResolveSpanConversion (rc, type);
++		}
++	}
++
+ 	//
+ 	// An object initializer expression
+ 	//
+@@ -13085,6 +13152,9 @@ namespace Mono.CSharp
+ 			if (expr is IAssignMethod)
+ 				return true;
+ 
++			if (expr is Conditional)
++				return true;
++
+ 			var invocation = expr as Invocation;
+ 			if (invocation?.Type.Kind == MemberKind.ByRef)
+ 				return true;
+@@ -13232,6 +13302,10 @@ namespace Mono.CSharp
+ 			this.loc = loc;
+ 		}
+ 
++		protected override void CloneTo (CloneContext clonectx, Expression t)
++		{
++		}
++
+ 		public override Expression CreateExpressionTree (ResolveContext ec)
+ 		{
+ 			throw new NotImplementedException ();
+diff --git a/mcs/mcs/field.cs b/mcs/mcs/field.cs
+index 86bb028defc..8c667328143 100644
+--- a/mcs/mcs/field.cs
++++ b/mcs/mcs/field.cs
+@@ -542,7 +542,7 @@ namespace Mono.CSharp
+ 				}
+ 			);
+ 
+-			fixed_buffer_type.SetCustomAttribute ((ConstructorInfo) ctor.GetMetaInfo (), encoder.ToArray ());
++			fixed_buffer_type.SetCustomAttribute ((ConstructorInfo) ctor.GetMetaInfo (), encoder.ToArray (out _));
+ #endif
+ 			//
+ 			// Don't emit FixedBufferAttribute attribute for private types
+@@ -559,7 +559,8 @@ namespace Mono.CSharp
+ 			encoder.Encode (buffer_size);
+ 			encoder.EncodeEmptyNamedArguments ();
+ 
+-			FieldBuilder.SetCustomAttribute ((ConstructorInfo) ctor.GetMetaInfo (), encoder.ToArray ());
++			FieldBuilder.SetCustomAttribute ((ConstructorInfo) ctor.GetMetaInfo (), encoder.ToArray (out var references));
++			Module.AddAssemblyReferences (references);
+ 		}
+ 	}
+ 
+diff --git a/mcs/mcs/generic.cs b/mcs/mcs/generic.cs
+index ec2965df63b..0c7032b2088 100644
+--- a/mcs/mcs/generic.cs
++++ b/mcs/mcs/generic.cs
+@@ -3381,7 +3381,7 @@ namespace Mono.CSharp {
+ 					continue;
+ 
+ 				var bound = candidates [ci];
+-				if (bound.Type == best_candidate)
++				if (TypeSpecComparer.IsEqual (bound.Type, best_candidate))
+ 					continue;
+ 
+ 				int cii = 0;
+diff --git a/mcs/mcs/modifiers.cs b/mcs/mcs/modifiers.cs
+index 926ab5d1848..21dd52b3b14 100644
+--- a/mcs/mcs/modifiers.cs
++++ b/mcs/mcs/modifiers.cs
+@@ -74,6 +74,8 @@ namespace Mono.CSharp
+ 				return "internal";
+ 			case Modifiers.PRIVATE:
+ 				return "private";
++			case Modifiers.PRIVATE | Modifiers.PROTECTED:
++				return "private protected";
+ 			default:
+ 				throw new NotImplementedException (mod.ToString ());
+ 			}
+@@ -129,12 +131,16 @@ namespace Mono.CSharp
+ 			if ((modB & Modifiers.PUBLIC) != 0) {
+ 				flags = Modifiers.PROTECTED | Modifiers.INTERNAL | Modifiers.PRIVATE;
+ 			} else if ((modB & Modifiers.PROTECTED) != 0) {
+-				if ((modB & Modifiers.INTERNAL) != 0)
+-					flags = Modifiers.PROTECTED | Modifiers.INTERNAL;
+-
+-				flags |= Modifiers.PRIVATE;
+-			} else if ((modB & Modifiers.INTERNAL) != 0)
++				if ((modB & Modifiers.INTERNAL) != 0) {
++					flags = Modifiers.PROTECTED | Modifiers.INTERNAL | Modifiers.PRIVATE;
++				} else {
++					modA &= ~Modifiers.PROTECTED;
++					flags = Modifiers.PRIVATE;
++				}
++			} else if ((modB & Modifiers.INTERNAL) != 0) {
++				modA &= ~Modifiers.PROTECTED;
+ 				flags = Modifiers.PRIVATE;
++			}
+ 
+ 			return modB != modA && (modA & (~flags)) == 0;
+ 		}
+@@ -151,6 +157,8 @@ namespace Mono.CSharp
+ 			} else {
+ 				if ((mod_flags & Modifiers.PUBLIC) != 0)
+ 					t = TypeAttributes.NestedPublic;
++				else if ((mod_flags & (Modifiers.PROTECTED | Modifiers.PRIVATE)) == (Modifiers.PROTECTED | Modifiers.PRIVATE))
++					t = TypeAttributes.NestedFamANDAssem;
+ 				else if ((mod_flags & Modifiers.PRIVATE) != 0)
+ 					t = TypeAttributes.NestedPrivate;
+ 				else if ((mod_flags & (Modifiers.PROTECTED | Modifiers.INTERNAL)) == (Modifiers.PROTECTED | Modifiers.INTERNAL))
+@@ -173,18 +181,27 @@ namespace Mono.CSharp
+ 		{
+ 			FieldAttributes fa = 0;
+ 
+-			if ((mod_flags & Modifiers.PUBLIC) != 0)
++			switch (mod_flags & Modifiers.AccessibilityMask) {
++			case Modifiers.PUBLIC:
+ 				fa |= FieldAttributes.Public;
+-			if ((mod_flags & Modifiers.PRIVATE) != 0)
++				break;
++			case Modifiers.PRIVATE:
+ 				fa |= FieldAttributes.Private;
+-			if ((mod_flags & Modifiers.PROTECTED) != 0) {
+-				if ((mod_flags & Modifiers.INTERNAL) != 0)
+-					fa |= FieldAttributes.FamORAssem;
+-				else 
+-					fa |= FieldAttributes.Family;
+-			} else {
+-				if ((mod_flags & Modifiers.INTERNAL) != 0)
+-					fa |= FieldAttributes.Assembly;
++				break;
++			case Modifiers.PROTECTED | Modifiers.INTERNAL:
++				fa |= FieldAttributes.FamORAssem;
++				break;
++			case Modifiers.PROTECTED:
++				fa |= FieldAttributes.Family;
++				break;
++			case Modifiers.INTERNAL:
++				fa |= FieldAttributes.Assembly;
++				break;
++			case Modifiers.PRIVATE | Modifiers.PROTECTED:
++				fa |= FieldAttributes.FamANDAssem;
++				break;
++			default:
++				throw new NotImplementedException (mod_flags.ToString ());
+ 			}
+ 
+ 			if ((mod_flags & Modifiers.STATIC) != 0)
+@@ -215,6 +232,9 @@ namespace Mono.CSharp
+ 			case Modifiers.INTERNAL:
+ 				ma |= MethodAttributes.Assembly;
+ 				break;
++			case Modifiers.PRIVATE | Modifiers.PROTECTED:
++				ma |= MethodAttributes.FamANDAssem;
++				break;
+ 			default:
+ 				throw new NotImplementedException (mod_flags.ToString ());
+ 			}
+diff --git a/mcs/mcs/module.cs b/mcs/mcs/module.cs
+index 2293d825b36..4680433bb01 100644
+--- a/mcs/mcs/module.cs
++++ b/mcs/mcs/module.cs
+@@ -480,6 +480,18 @@ namespace Mono.CSharp
+ 			attributes.AddAttribute (attr);
+ 		}
+ 
++		public void AddAssemblyReferences (List<Assembly> names)
++		{
++			if (names == null)
++				return;
++
++#if STATIC
++			foreach (var name in names) {
++				Builder.__GetAssemblyToken (name);
++			}
++#endif
++		}
++
+ 		public override void AddTypeContainer (TypeContainer tc)
+ 		{
+ 			AddTypeContainerMember (tc);
+diff --git a/mcs/mcs/parameter.cs b/mcs/mcs/parameter.cs
+index cc10eee162b..95851478010 100644
+--- a/mcs/mcs/parameter.cs
++++ b/mcs/mcs/parameter.cs
+@@ -221,12 +221,13 @@ namespace Mono.CSharp {
+ 			REF = 1 << 1,
+ 			OUT = 1 << 2,
+ 			This = 1 << 3,
+-			CallerMemberName = 1 << 4,
+-			CallerLineNumber = 1 << 5,
+-			CallerFilePath = 1 << 6,
++			ReadOnly = 1 << 4,
++			CallerMemberName = 1 << 5,
++			CallerLineNumber = 1 << 6,
++			CallerFilePath = 1 << 7,
+ 
+ 			RefOutMask = REF | OUT,
+-			ModifierMask = PARAMS | REF | OUT | This,
++			ModifierMask = PARAMS | REF | OUT | This | ReadOnly,
+ 			CallerMask = CallerMemberName | CallerLineNumber | CallerFilePath
+ 		}
+ 
+@@ -1474,9 +1475,9 @@ namespace Mono.CSharp {
+ 					}
+ 				}
+ 
+-				if (!expr.IsNull && TypeSpec.IsReferenceType (parameter_type) && parameter_type.BuiltinType != BuiltinTypeSpec.Type.String) {
++				if (!res.IsNull && TypeSpec.IsReferenceType (parameter_type) && parameter_type.BuiltinType != BuiltinTypeSpec.Type.String) {
+ 					rc.Report.Error (1763, Location,
+-						"Optional parameter `{0}' of type `{1}' can only be initialized with `null'",
++						"Optional parameter `{0}' of type `{1}' can only be initialized with default value",
+ 						p.Name, parameter_type.GetSignatureForError ());
+ 
+ 					return;
+diff --git a/mcs/mcs/report.cs b/mcs/mcs/report.cs
+index cc3d82b26e0..5d64c8e766e 100644
+--- a/mcs/mcs/report.cs
++++ b/mcs/mcs/report.cs
+@@ -42,7 +42,7 @@ namespace Mono.CSharp {
+ 		public static readonly int[] AllWarnings = new int[] {
+ 			28, 67, 78,
+ 			105, 108, 109, 114, 162, 164, 168, 169, 183, 184, 197,
+-			219, 251, 252, 253, 278, 282,
++			219, 251, 252, 253, 278, 280, 282,
+ 			402, 414, 419, 420, 429, 436, 437, 440, 458, 464, 465, 467, 469, 472, 473,
+ 			612, 618, 626, 628, 642, 649, 652, 657, 658, 659, 660, 661, 665, 672, 675, 693,
+ 			728,
+@@ -107,6 +107,15 @@ namespace Mono.CSharp {
+ 			case LanguageVersion.V_7:
+ 				version = "7.0";
+ 				break;
++			case LanguageVersion.V_7_1:
++				version = "7.1";
++				break;
++			case LanguageVersion.V_7_2:
++				version = "7.2";
++				break;
++			case LanguageVersion.V_7_3:
++				version = "7.3";
++				break;
+ 			default:
+ 				throw new InternalErrorException ("Invalid feature version", compiler.Settings.Version);
+ 			}
+diff --git a/mcs/mcs/settings.cs b/mcs/mcs/settings.cs
+index 37664187c71..976c9b68128 100644
+--- a/mcs/mcs/settings.cs
++++ b/mcs/mcs/settings.cs
+@@ -32,10 +32,11 @@ namespace Mono.CSharp {
+ 		V_7 = 7,
+ 		V_7_1 = 71,
+ 		V_7_2 = 72,
++		V_7_3 = 73,
+ 		Experimental = 100,
+ 
+ 		Default = V_7,
+-		Latest = V_7_2
++		Latest = V_7_3
+ 	}
+ 
+ 	public enum RuntimeVersion
+@@ -1270,6 +1271,7 @@ namespace Mono.CSharp {
+ 			case "/highentropyva+":
+ 			case "/highentropyva-":
+ 			case "/link":
++			case "/sourcelink":
+ 			case "/moduleassemblyname":
+ 			case "/nowin32manifest":
+ 			case "/pdb":
+diff --git a/mcs/mcs/statement.cs b/mcs/mcs/statement.cs
+index 9c51128548f..c8b77c1adc1 100644
+--- a/mcs/mcs/statement.cs
++++ b/mcs/mcs/statement.cs
+@@ -928,8 +928,7 @@ namespace Mono.CSharp {
+ 		public override Reachability MarkReachable (Reachability rc)
+ 		{
+ 			base.MarkReachable (rc);
+-			expr.MarkReachable (rc);
+-			return rc;
++			return expr.MarkReachable (rc);
+ 		}
+ 
+ 		public override bool Resolve (BlockContext ec)
+@@ -2419,6 +2418,7 @@ namespace Mono.CSharp {
+ 			IsLocked = 1 << 8,
+ 			SymbolFileHidden = 1 << 9,
+ 			ByRef = 1 << 10,
++			PointerByRef = 1 << 11,
+ 
+ 			ReadonlyMask = 1 << 20
+ 		}
+@@ -2609,20 +2609,22 @@ namespace Mono.CSharp {
+ 
+ 			if (IsByRef) {
+ 				builder = ec.DeclareLocal (ReferenceContainer.MakeType (ec.Module, Type), IsFixed);
++			} else if ((flags & Flags.PointerByRef) != 0) {
++				builder = ec.DeclareLocal (ReferenceContainer.MakeType (ec.Module, ((PointerContainer) Type).Element), IsFixed);
+ 			} else {
+ 				//
+ 				// All fixed variabled are pinned, a slot has to be alocated
+ 				//
+-				builder = ec.DeclareLocal(Type, IsFixed);
++				builder = ec.DeclareLocal (Type, IsFixed);
+ 			}
+ 
+ 			if ((flags & Flags.SymbolFileHidden) == 0)
+ 				ec.DefineLocalVariable (name, builder);
+ 		}
+ 
+-		public static LocalVariable CreateCompilerGenerated (TypeSpec type, Block block, Location loc, bool writeToSymbolFile = false)
++		public static LocalVariable CreateCompilerGenerated (TypeSpec type, Block block, Location loc, bool writeToSymbolFile = false, Flags additionalFlags = 0)
+ 		{
+-			LocalVariable li = new LocalVariable (block, GetCompilerGeneratedName (block), Flags.CompilerGenerated | Flags.Used, loc);
++			LocalVariable li = new LocalVariable (block, GetCompilerGeneratedName (block), Flags.CompilerGenerated | Flags.Used | additionalFlags, loc);
+ 			if (!writeToSymbolFile)
+ 				li.flags |= Flags.SymbolFileHidden;
+ 			
+@@ -2725,6 +2727,11 @@ namespace Mono.CSharp {
+ 			flags |= Flags.Used;
+ 		}
+ 
++		public void SetIsPointerByRef ()
++		{
++			flags |= Flags.PointerByRef;
++		}
++
+ 		public void SetHasAddressTaken ()
+ 		{
+ 			flags |= (Flags.AddressTaken | Flags.Used);
+@@ -6562,18 +6569,26 @@ namespace Mono.CSharp {
+ 
+ 				// TODO: Should use Binary::Add
+ 				pinned_string.Emit (ec);
+-				ec.Emit (OpCodes.Conv_I);
++				ec.Emit (OpCodes.Conv_U);
+ 
+ 				var m = ec.Module.PredefinedMembers.RuntimeHelpersOffsetToStringData.Resolve (loc);
+ 				if (m == null)
+ 					return;
+ 
++				var null_value = ec.DefineLabel ();
++				vi.EmitAssign (ec);
++				vi.Emit (ec);
++				ec.Emit (OpCodes.Brfalse_S, null_value);
++
++				vi.Emit (ec);
+ 				PropertyExpr pe = new PropertyExpr (m, pinned_string.Location);
+ 				//pe.InstanceExpression = pinned_string;
+ 				pe.Resolve (new ResolveContext (ec.MemberContext)).Emit (ec);
+ 
+ 				ec.Emit (OpCodes.Add);
+ 				vi.EmitAssign (ec);
++
++				ec.MarkLabel (null_value);
+ 			}
+ 
+ 			public override void EmitExit (EmitContext ec)
+@@ -6660,31 +6675,94 @@ namespace Mono.CSharp {
+ 					return new ExpressionEmitter (res, li);
+ 				}
+ 
+-				bool already_fixed = true;
+-
+ 				//
+ 				// Case 4: & object.
+ 				//
+ 				Unary u = res as Unary;
+ 				if (u != null) {
++					bool already_fixed = true;
++
+ 					if (u.Oper == Unary.Operator.AddressOf) {
+ 						IVariableReference vr = u.Expr as IVariableReference;
+ 						if (vr == null || !vr.IsFixed) {
+ 							already_fixed = false;
+ 						}
+ 					}
+-				} else if (initializer is Cast) {
++
++					if (already_fixed) {
++						bc.Report.Error (213, loc, "You cannot use the fixed statement to take the address of an already fixed expression");
++						return null;
++					}
++
++					res = Convert.ImplicitConversionRequired (bc, res, li.Type, loc);
++					return new ExpressionEmitter (res, li);
++				}
++
++				if (initializer is Cast) {
+ 					bc.Report.Error (254, initializer.Location, "The right hand side of a fixed statement assignment may not be a cast expression");
+ 					return null;
+ 				}
+ 
+-				if (already_fixed) {
+-					bc.Report.Error (213, loc, "You cannot use the fixed statement to take the address of an already fixed expression");
++				//
++				// Case 5: by-ref GetPinnableReference method on the rhs expression
++				//
++				var method = GetPinnableReference (bc, res);
++				if (method == null) {
++					bc.Report.Error (8385, initializer.Location, "The given expression cannot be used in a fixed statement");
++					return null;
++				}
++
++				var compiler = bc.Module.Compiler;
++				if (compiler.Settings.Version < LanguageVersion.V_7_3) {
++					bc.Report.FeatureIsNotAvailable (compiler, initializer.Location, "extensible fixed statement");
++				}
++
++				method.InstanceExpression = res;
++				res = new Invocation.Predefined (method, null).ResolveLValue (bc, EmptyExpression.OutAccess);
++				if (res == null)
++					return null;
++
++				ReferenceContainer rType = (ReferenceContainer)method.BestCandidateReturnType;
++				PointerContainer lType = li.Type as PointerContainer;
++				if (rType.Element != lType?.Element) {
++					// CSC: Should be better error code
++					res.Error_ValueCannotBeConverted (bc, lType, false);
++					return null;
+ 				}
+ 
+-				res = Convert.ImplicitConversionRequired (bc, res, li.Type, loc);
++				li.SetIsPointerByRef ();
+ 				return new ExpressionEmitter (res, li);
+ 			}
++
++			MethodGroupExpr GetPinnableReference (BlockContext bc, Expression expr)
++			{
++				TypeSpec type = expr.Type;
++				var mexpr = Expression.MemberLookup (bc, false, type,
++					"GetPinnableReference", 0, Expression.MemberLookupRestrictions.ExactArity, loc);
++
++				if (mexpr == null)
++					return null;
++
++				var mg = mexpr as MethodGroupExpr;
++				if (mg == null)
++					return null;
++
++				mg.InstanceExpression = expr;
++
++				// TODO: handle extension methods
++				Arguments args = new Arguments (0);
++				mg = mg.OverloadResolve (bc, ref args, null, OverloadResolver.Restrictions.None);
++
++				if (mg == null || mg.BestCandidate.IsStatic || !mg.BestCandidate.IsPublic || mg.BestCandidateReturnType.Kind != MemberKind.ByRef || !mg.BestCandidate.Parameters.IsEmpty) {
++					if (bc.Module.Compiler.Settings.Version > LanguageVersion.V_7_2) {
++						bc.Report.Warning (280, 2, expr.Location, "`{0}' has the wrong signature to be used in extensible fixed statement", mg.GetSignatureForError ());
++					}
++
++					return null;
++				}
++
++				return mg;
++			}
+ 		}
+ 
+ 
+diff --git a/mcs/mcs/tuples.cs b/mcs/mcs/tuples.cs
+index 901efdc9541..0b56859615f 100644
+--- a/mcs/mcs/tuples.cs
++++ b/mcs/mcs/tuples.cs
+@@ -267,6 +267,11 @@ namespace Mono.CSharp
+ 			this.Location = expr.Location;
+ 		}
+ 
++		public TupleLiteralElement Clone (CloneContext clonectx)
++		{
++			return new TupleLiteralElement (Name, Expr.Clone (clonectx), Location);
++		}
++
+ 		public string Name { get; private set; }
+ 		public Expression Expr { get; set; }
+ 		public Location Location { get; private set; }
+@@ -288,6 +293,16 @@ namespace Mono.CSharp
+ 			}
+ 		}
+ 
++		protected override void CloneTo (CloneContext clonectx, Expression t)
++		{
++			var clone = new List<TupleLiteralElement> (elements.Count);
++			foreach (var te in elements)
++				clone.Add (te.Clone (clonectx));
++
++			TupleLiteral target = (TupleLiteral)t;
++			target.elements = clone;
++		}
++
+ 		public static bool ContainsNoTypeElement (TypeSpec type)
+ 		{
+ 			var ta = type.TypeArguments;
+@@ -432,6 +447,7 @@ namespace Mono.CSharp
+ 	{
+ 		Expression source;
+ 		List<Expression> targetExprs;
++		List<Expression> tempExprs;
+ 		List<BlockVariable> variables;
+ 		Expression instance;
+ 
+@@ -440,6 +456,8 @@ namespace Mono.CSharp
+ 			this.source = source;
+ 			this.targetExprs = targetExprs;
+ 			this.loc = loc;
++
++			tempExprs = new List<Expression> ();
+ 		}
+ 
+ 		public TupleDeconstruct (List<BlockVariable> variables, Expression source, Location loc)
+@@ -447,6 +465,8 @@ namespace Mono.CSharp
+ 			this.source = source;
+ 			this.variables = variables;
+ 			this.loc = loc;
++
++			tempExprs = new List<Expression> ();
+ 		}
+ 
+ 		public override Expression CreateExpressionTree (ResolveContext ec)
+@@ -492,6 +512,15 @@ namespace Mono.CSharp
+ 					instance = expr_variable.CreateReferenceExpression (rc, loc);
+ 				}
+ 
++				var element_srcs = new List<Expression> ();
++				var src_names = new List<string> ();
++				for (int i = 0; i < target_count; ++i) {
++					var element_src = tupleLiteral == null ? new MemberAccess (instance, NamedTupleSpec.GetElementPropertyName (i)) : tupleLiteral.Elements [i].Expr;
++					element_srcs.Add (element_src);
++					if (element_src is VariableReference)
++						src_names.Add ((element_src as VariableReference)?.Name);
++				}
++
+ 				for (int i = 0; i < target_count; ++i) {
+ 					var tle = src_type.TypeArguments [i];
+ 
+@@ -522,8 +551,17 @@ namespace Mono.CSharp
+ 						variable.PrepareAssignmentAnalysis ((BlockContext)rc);
+ 					}
+ 
+-					var element_src = tupleLiteral == null ? new MemberAccess (instance, NamedTupleSpec.GetElementPropertyName (i)) : tupleLiteral.Elements [i].Expr;
+-					targetExprs [i] = new SimpleAssign (targetExprs [i], element_src).Resolve (rc);
++					var element_target = (targetExprs [i] as SimpleName)?.LookupNameExpression (rc, MemberLookupRestrictions.None);
++
++					if (element_target != null && src_names.Contains ((element_target as VariableReference)?.Name)) {
++						var tempType = element_target.Resolve (rc).Type;
++
++						var temp = new LocalTemporary (tempType);
++						tempExprs.Add (new SimpleAssign (temp, element_srcs [i]).Resolve (rc));
++						targetExprs [i] = new SimpleAssign (targetExprs [i], temp).Resolve (rc);
++					} else {
++						targetExprs [i] = new SimpleAssign (targetExprs [i], element_srcs [i]).Resolve (rc);
++					}
+ 				}
+ 
+ 				eclass = ExprClass.Value;
+@@ -557,9 +595,24 @@ namespace Mono.CSharp
+ 			if (instance != null)
+ 				((ExpressionStatement)source).EmitStatement (ec);
+ 
+-			foreach (ExpressionStatement expr in targetExprs)
++			foreach (ExpressionStatement expr in tempExprs) {
++				var temp = (expr as Assign)?.Target as LocalTemporary;
++				if (temp == null)
++					continue;
++
++				temp.AddressOf (ec, AddressOp.LoadStore);
++				ec.Emit (OpCodes.Initobj, temp.Type);
++				expr.Emit (ec);
++			}
++
++			foreach (ExpressionStatement expr in targetExprs) {
+ 				expr.Emit (ec);
+ 
++				var temp = (expr as Assign)?.Source as LocalTemporary;
++				if (temp != null)
++					temp.Release (ec);
++			}
++
+ 			var ctor = MemberCache.FindMember (type, MemberFilter.Constructor (null), BindingRestriction.DeclaredOnly | BindingRestriction.InstanceOnly) as MethodSpec;
+ 			ec.Emit (OpCodes.Newobj, ctor);
+ 		}
+@@ -574,9 +627,24 @@ namespace Mono.CSharp
+ 			
+ 			if (instance != null)
+ 				((ExpressionStatement) source).EmitStatement (ec);
+-			
+-			foreach (ExpressionStatement expr in targetExprs)
++
++			foreach (ExpressionStatement expr in tempExprs) {
++				var temp = (expr as Assign)?.Target as LocalTemporary;
++				if (temp == null)
++					continue;
++
++				temp.AddressOf (ec, AddressOp.LoadStore);
++				ec.Emit (OpCodes.Initobj, temp.Type);
++				expr.EmitStatement (ec);
++			}
++
++			foreach (ExpressionStatement expr in targetExprs) {
+ 				expr.EmitStatement (ec);
++
++				var temp = (expr as Assign)?.Source as LocalTemporary;
++				if (temp != null)
++					temp.Release (ec);
++			}
+ 		}
+ 
+ 		public void Emit (EmitContext ec, bool leave_copy)
+@@ -594,6 +662,7 @@ namespace Mono.CSharp
+ 
+ 		public override void FlowAnalysis (FlowAnalysisContext fc)
+ 		{
++			source.FlowAnalysis (fc);
+ 			foreach (var expr in targetExprs)
+ 				expr.FlowAnalysis (fc);
+ 		}
+diff --git a/mcs/tests/dtest-066.cs b/mcs/tests/dtest-066.cs
+new file mode 100644
+index 00000000000..893fb40dffa
+--- /dev/null
++++ b/mcs/tests/dtest-066.cs
+@@ -0,0 +1,13 @@
++class C
++{
++	static void Main()
++	{
++		object o = 1;
++		dynamic d = 1;
++		
++		var a = new[] {
++			new { X = o },
++			new { X = d }
++		};
++	}
++}
+diff --git a/mcs/tests/gtest-647.cs b/mcs/tests/gtest-647.cs
+new file mode 100644
+index 00000000000..4aae641f85f
+--- /dev/null
++++ b/mcs/tests/gtest-647.cs
+@@ -0,0 +1,34 @@
++using System;
++
++public class Program
++{
++	public static int Main ()
++	{
++		int B = default (MyStruct?); 
++		if (MyStruct.counter != 1)
++			return 1;
++
++		switch (default (MyStruct?)) {
++			case 0:
++				break;
++			default:
++				return 2;
++		}
++
++		if (MyStruct.counter != 2)
++			return 4;
++
++		return 0;
++	}
++
++	public struct MyStruct
++	{
++		public static int counter;
++
++		public static implicit operator int (MyStruct? s)
++		{
++			++counter;
++			return 0;
++		}
++	}
++}
+\ No newline at end of file
+diff --git a/mcs/tests/test-928.cs b/mcs/tests/test-928.cs
+index 90180137957..290ee4d1fb3 100644
+--- a/mcs/tests/test-928.cs
++++ b/mcs/tests/test-928.cs
+@@ -15,6 +15,24 @@ unsafe class Program
+ 		}
+ 	}
+ 
++	public static bool StringNull (string s)
++	{
++		unsafe {
++			fixed (char *a = s) {
++				return a == null;
++			}
++		}
++	}
++
++	public static bool ArrayNull (int[] a)
++	{
++		unsafe {
++			fixed (int *e = a) {
++				return e == null;
++			}
++		}
++	}
++
+ 	public static int Main ()
+ 	{
+ 		Test ();
+@@ -24,6 +42,12 @@ unsafe class Program
+ 		if (lv.IsPinned)
+ 			return 1;
+ 
++		if (!StringNull (null))
++			return 1;
++
++		if (!ArrayNull (null))
++			return 2;
++
+ 		return 0;
+ 	}
+ }
+diff --git a/mcs/tests/test-948.cs b/mcs/tests/test-948.cs
+index 34b3ab9a0c4..563e37dc7d5 100644
+--- a/mcs/tests/test-948.cs
++++ b/mcs/tests/test-948.cs
+@@ -1,4 +1,4 @@
+-// Compiler options: -langversion:7.2 -unsafe
++// Compiler options: -langversion:7.2 /unsafe
+ 
+ using System;
+ 
+@@ -7,10 +7,16 @@ class X
+ 	public static void Main ()
+ 	{
+ 		Span<int> stackSpan = stackalloc int[100];
++
++		bool b = false;
++
++		var r1 = !b ? stackalloc char[1] : throw null;
++		var r2 = b ? throw null : stackalloc char[1];
++		var r3 = b ? stackalloc char[1] : stackalloc char[2];
+ 	}
+ 
++	// Disables verifier
+ 	unsafe void Foo ()
+ 	{
+-
+ 	}
+-}
+\ No newline at end of file
++}
+diff --git a/mcs/tests/test-950.cs b/mcs/tests/test-950.cs
+new file mode 100644
+index 00000000000..fef764c85cc
+--- /dev/null
++++ b/mcs/tests/test-950.cs
+@@ -0,0 +1,12 @@
++using System;
++
++public class B
++{
++	public static void Main ()
++	{
++		int a = 1_0_3;
++		double b = 0__0e+1_1;
++		int c = 0b0__1_0;
++		int d = 0x0__F_0;
++	}
++}
+\ No newline at end of file
+diff --git a/mcs/tests/test-960.cs b/mcs/tests/test-960.cs
+new file mode 100644
+index 00000000000..ac2a1ca7435
+--- /dev/null
++++ b/mcs/tests/test-960.cs
+@@ -0,0 +1,20 @@
++// Compiler options: -langversion:7.2
++
++public class B
++{
++	private protected enum E
++	{
++	}
++
++	public int Index { get; protected private set; }
++
++	internal string S1 { get; private protected set; }
++
++	protected string S2 { get; private protected set; }
++
++	private protected int field;
++
++	public static void Main ()
++	{
++	}
++}
+\ No newline at end of file
+diff --git a/mcs/tests/test-961.cs b/mcs/tests/test-961.cs
+new file mode 100644
+index 00000000000..efe19673875
+--- /dev/null
++++ b/mcs/tests/test-961.cs
+@@ -0,0 +1,34 @@
++// Compiler options: -langversion:latest
++
++using System;
++
++public static class B {
++	public static void Main ()
++	{
++		int lo = 1;
++		Bar (in lo);		
++	}
++
++	public static void Bar (in int arg)
++	{
++	}
++
++	static void Foo (this in int src)
++	{
++		D p = (in int a) => {};
++	}
++
++}
++
++delegate void D (in int arg);
++
++class M
++{
++	int this[in int a] { set { } }
++	public static implicit operator string (in M m) => null;
++	public M (in int arg) { }
++
++	public void Test2 (in int arg)
++	{
++	}
++}
+\ No newline at end of file
+diff --git a/mcs/tests/test-anon-123.cs b/mcs/tests/test-anon-123.cs
+index 91c72b45afe..45aab27c0a5 100644
+--- a/mcs/tests/test-anon-123.cs
++++ b/mcs/tests/test-anon-123.cs
+@@ -1,3 +1,4 @@
++// Compiler options: -langversion:latest
+ // Cloning tests
+ 
+ using System;
+@@ -103,7 +104,11 @@ public class C : B
+ 			default:
+ 				break;
+ 			}
+-		});		
++		});
++
++		Test (() => {
++			char ch = default;
++		});
+ 		
+ 		var c = new C ();
+ 		c.InstanceTests ();
+diff --git a/mcs/tests/test-binaryliteral.cs b/mcs/tests/test-binaryliteral.cs
+new file mode 100644
+index 00000000000..3d9cc89bcbd
+--- /dev/null
++++ b/mcs/tests/test-binaryliteral.cs
+@@ -0,0 +1,57 @@
++
++class Demo {
++	static int Main ()
++	{
++		if (0b1 != 1)
++			return 1;
++		var hex1 = 0x123ul;
++		var bin1  = 0b100100011ul;
++		var bin11 = 0b100100011lu;
++		if (hex1 != bin1)
++			return 2;
++		if (hex1 != bin11)
++			return 3;
++		if (hex1.GetType () != bin1.GetType ())
++			return 4;
++		if (hex1.GetType () != bin11.GetType ())
++			return 5;
++
++		var hex2 = 0x7FFFFFFF;
++		var bin2 = 0b1111111111111111111111111111111;
++
++		if (hex2 != bin2)
++			return 6;
++		if (hex2.GetType () != bin2.GetType ())
++			return 7;
++
++		var hex3 = 0xFFFFFFFF;
++		var bin3 = 0b11111111111111111111111111111111;
++		if (hex3 != bin3)
++			return 8;
++		if (hex3.GetType () != bin3.GetType ())
++			return 9;
++
++		var hex4 = 0xFFFFFFFFu;
++		var bin4 = 0b11111111111111111111111111111111u;
++		if (hex4 != bin4)
++			return 10;
++		if (hex4.GetType () != bin4.GetType ())
++			return 11;
++
++		var hex5 = 0x7FFFFFFFFFFFFFFF;
++		var bin5 = 0b111111111111111111111111111111111111111111111111111111111111111;
++		if (hex5 != bin5)
++			return 12;
++		if (hex5.GetType () != bin5.GetType ())
++			return 13;
++
++		var hex6 = 0xFFFFFFFFFFFFFFFF;
++		var bin6 = 0b1111111111111111111111111111111111111111111111111111111111111111;
++		if (hex6 != bin6)
++			return 14;
++		if (hex6.GetType () != bin6.GetType ())
++			return 15;
++
++		return 0;
++	}
++}
+\ No newline at end of file
+diff --git a/mcs/tests/test-decl-expr-05.cs b/mcs/tests/test-decl-expr-05.cs
+index 730fd4278ca..907cde0b8d7 100644
+--- a/mcs/tests/test-decl-expr-05.cs
++++ b/mcs/tests/test-decl-expr-05.cs
+@@ -6,6 +6,11 @@ class X
+ 		{
+ 			arg = s.ToString ();
+ 		}
++
++		while (true && Call (out string s2))
++		{
++			arg = s2.ToString ();
++		}
+ 	}
+ 
+ 	static bool Call (out string s)
+diff --git a/mcs/tests/test-decl-expr-06.cs b/mcs/tests/test-decl-expr-06.cs
+new file mode 100644
+index 00000000000..9734f2ec2a7
+--- /dev/null
++++ b/mcs/tests/test-decl-expr-06.cs
+@@ -0,0 +1,17 @@
++using System;
++
++public class C
++{
++	Func<bool> f = () => Foo (out int arg);
++
++	static bool Foo (out int arg)
++	{
++		arg = 2;
++		return false;
++	}
++
++	public static void Main ()
++	{
++		new C ();
++	}
++}
+\ No newline at end of file
+diff --git a/mcs/tests/test-default-01.cs b/mcs/tests/test-default-01.cs
+index 823e33c451b..28aff830cd9 100644
+--- a/mcs/tests/test-default-01.cs
++++ b/mcs/tests/test-default-01.cs
+@@ -41,7 +41,11 @@ static class X
+ 	static System.Func<int> M4 ()
+ 	{
+ 		return () => default;
+-	} 
++	}
++
++	static void Foo (II a = default (II), II b = default, II c = (II) null)
++	{
++	}
+ }
+ /*
+ enum E
+@@ -49,4 +53,10 @@ enum E
+ 	A = default,
+ 	B = default + 1
+ }
+-*/
+\ No newline at end of file
++*/
++
++
++interface II
++{
++
++}
+\ No newline at end of file
+diff --git a/mcs/tests/test-fixed-01.cs b/mcs/tests/test-fixed-01.cs
+new file mode 100644
+index 00000000000..4684b0c5a06
+--- /dev/null
++++ b/mcs/tests/test-fixed-01.cs
+@@ -0,0 +1,20 @@
++// Compiler options: -unsafe -langversion:latest
++
++unsafe class C
++{
++	public static void Main ()
++	{
++		fixed (int* p = new Fixable ()) {
++			System.Console.WriteLine (*p);
++			System.Console.WriteLine (p [2]);
++		}
++	}
++
++	struct Fixable
++	{
++		public ref int GetPinnableReference ()
++		{
++			return ref (new int[] { 1, 2, 3 })[0];
++		}
++	}
++}
+\ No newline at end of file
+diff --git a/mcs/tests/test-pattern-13.cs b/mcs/tests/test-pattern-13.cs
+new file mode 100644
+index 00000000000..315c7a9e4be
+--- /dev/null
++++ b/mcs/tests/test-pattern-13.cs
+@@ -0,0 +1,19 @@
++using System;
++
++class C : B
++{
++
++}
++
++public class B
++{
++	public static void Main ()
++	{
++		C c = new C ();
++
++		if (c is B b)
++		{
++			Console.WriteLine (b == null);
++		}
++	}
++}
+\ No newline at end of file
+diff --git a/mcs/tests/test-ref-07.cs b/mcs/tests/test-ref-07.cs
+index 4aa16579752..f17cfb443b5 100644
+--- a/mcs/tests/test-ref-07.cs
++++ b/mcs/tests/test-ref-07.cs
+@@ -1,6 +1,6 @@
+ // Compiler options: -langversion:latest
+ 
+-public readonly partial ref struct Test
++public readonly ref partial struct Test
+ {
+ 	public static void Main ()
+ 	{
+@@ -14,6 +14,11 @@ public readonly partial ref struct Test
+ 	}
+ }
+ 
++ref partial struct Test
++{
++
++}
++
+ ref struct Second
+ {
+ 	Test field;
+diff --git a/mcs/tests/test-ref-11.cs b/mcs/tests/test-ref-11.cs
+new file mode 100644
+index 00000000000..8d392a77d07
+--- /dev/null
++++ b/mcs/tests/test-ref-11.cs
+@@ -0,0 +1,13 @@
++class Program
++{
++	static int x;
++	static int y;
++
++    public static int Main ()
++    {
++    	bool b = false;
++        ref int targetBucket = ref b ? ref x : ref y;
++
++        return 0;
++    }
++}
+\ No newline at end of file
+diff --git a/mcs/tests/test-ref-12.cs b/mcs/tests/test-ref-12.cs
+new file mode 100644
+index 00000000000..786a4162f4f
+--- /dev/null
++++ b/mcs/tests/test-ref-12.cs
+@@ -0,0 +1,22 @@
++// Compiler options: -unsafe
++
++unsafe class X
++{
++	public static void Main ()
++	{
++		void* pointer = null;
++ 		Bar (ref Foo (ref *(byte*)pointer));
++	}
++
++	static int field;
++
++	static ref int Foo (ref byte b)
++	{
++		return ref field;
++	}
++
++	static void Bar (ref int i)
++	{
++
++	}
++}
+\ No newline at end of file
+diff --git a/mcs/tests/test-tuple-02.cs b/mcs/tests/test-tuple-02.cs
+index c0492759452..ab722642aeb 100644
+--- a/mcs/tests/test-tuple-02.cs
++++ b/mcs/tests/test-tuple-02.cs
+@@ -26,6 +26,11 @@ class TupleConversions
+ 		(string v1, object v2) b = ("a", "b");
+ 
+ 		(int v1, long v2)? x = null;
++
++        var array = new [] {
++            (name: "A", offset: 0),
++            (name: "B", size: 4)
++        };		
+ 	}
+ 
+ 	static void Foo<T> (T arg)
+diff --git a/mcs/tests/test-tuple-08.cs b/mcs/tests/test-tuple-08.cs
+new file mode 100644
+index 00000000000..fd3375b4df6
+--- /dev/null
++++ b/mcs/tests/test-tuple-08.cs
+@@ -0,0 +1,24 @@
++using System;
++using System.Collections.Generic;
++using System.Threading.Tasks;
++
++class X
++{
++	public static void Main ()
++	{
++		var x = new X ();
++		x.Test ().Wait ();
++	}
++
++	int a, b;
++
++	async Task Test ()
++	{
++		(a, b) = await Waiting ();
++	}
++
++	Task<(int, int)> Waiting ()
++	{
++		return Task.FromResult ((1, 3));
++	}
++}
+\ No newline at end of file
+diff --git a/mcs/tests/test-tuple-10.cs b/mcs/tests/test-tuple-10.cs
+new file mode 100644
+index 00000000000..82f4e01ec1f
+--- /dev/null
++++ b/mcs/tests/test-tuple-10.cs
+@@ -0,0 +1,9 @@
++using System.Linq;
++
++class Program {
++    public static int Main ()
++    {
++        var l = (from f in (typeof (Program)).GetFields() select (name: f.Name, offset: 0)).ToList();
++        return 0;
++    }
++}
+\ No newline at end of file
+diff --git a/mcs/tests/test-tuple-11.cs b/mcs/tests/test-tuple-11.cs
+new file mode 100644
+index 00000000000..b2aeb24026c
+--- /dev/null
++++ b/mcs/tests/test-tuple-11.cs
+@@ -0,0 +1,20 @@
++using System;
++
++class Program
++{
++	public static int Main ()
++	{
++		int x = 1;
++		int y = 2;
++
++		(x, y) = (y, x);
++
++		if (x != 2)
++			return 1;
++
++		if (y != 1)
++			return 2;
++
++		return 0;
++	}
++}
+diff --git a/mcs/tests/ver-il-net_4_x.xml b/mcs/tests/ver-il-net_4_x.xml
+index 4dbc7042a8a..2bde8270338 100644
+--- a/mcs/tests/ver-il-net_4_x.xml
++++ b/mcs/tests/ver-il-net_4_x.xml
+@@ -3168,6 +3168,33 @@
+       </method>
+     </type>
+   </test>
++  <test name="dtest-066.cs">
++    <type name="C">
++      <method name="Void Main()" attrs="145">
++        <size>41</size>
++      </method>
++      <method name="Void .ctor()" attrs="6278">
++        <size>7</size>
++      </method>
++    </type>
++    <type name="&lt;&gt;__AnonType0`1[&lt;X&gt;__T]">
++      <method name="&lt;X&gt;__T get_X()" attrs="2182">
++        <size>7</size>
++      </method>
++      <method name="Boolean Equals(System.Object)" attrs="198">
++        <size>39</size>
++      </method>
++      <method name="Int32 GetHashCode()" attrs="198">
++        <size>63</size>
++      </method>
++      <method name="System.String ToString()" attrs="198">
++        <size>67</size>
++      </method>
++      <method name="Void .ctor(&lt;X&gt;__T)" attrs="6278">
++        <size>14</size>
++      </method>
++    </type>
++  </test>
+   <test name="dtest-anontype-01.cs">
+     <type name="C">
+       <method name="Void Main()" attrs="150">
+@@ -11064,7 +11091,7 @@
+     </type>
+     <type name="X">
+       <method name="Int32 Beer(System.Nullable`1[IrishPub])" attrs="145">
+-        <size>72</size>
++        <size>60</size>
+       </method>
+       <method name="Int32 Test(System.Nullable`1[System.Int32])" attrs="145">
+         <size>62</size>
+@@ -19508,7 +19535,7 @@
+     </type>
+     <type name="C">
+       <method name="Int32 Main()" attrs="150">
+-        <size>267</size>
++        <size>255</size>
+       </method>
+       <method name="Void .ctor()" attrs="6278">
+         <size>7</size>
+@@ -19742,7 +19769,7 @@
+   <test name="gtest-629.cs">
+     <type name="Program">
+       <method name="Void Main()" attrs="150">
+-        <size>116</size>
++        <size>121</size>
+       </method>
+       <method name="Void .ctor()" attrs="6278">
+         <size>7</size>
+@@ -20147,6 +20174,21 @@
+       </method>
+     </type>
+   </test>
++  <test name="gtest-647.cs">
++    <type name="Program">
++      <method name="Int32 Main()" attrs="150">
++        <size>99</size>
++      </method>
++      <method name="Void .ctor()" attrs="6278">
++        <size>7</size>
++      </method>
++    </type>
++    <type name="Program+MyStruct">
++      <method name="Int32 op_Implicit(System.Nullable`1[Program+MyStruct])" attrs="2198">
++        <size>22</size>
++      </method>
++    </type>
++  </test>
+   <test name="gtest-anontype-01.cs">
+     <type name="Test">
+       <method name="Int32 Main()" attrs="150">
+@@ -47609,7 +47651,7 @@
+         <size>7</size>
+       </method>
+       <method name="Void CopyTo(Int32, Char[], Int32, Int32)" attrs="145">
+-        <size>73</size>
++        <size>78</size>
+       </method>
+     </type>
+   </test>
+@@ -51468,10 +51510,10 @@
+   <test name="test-88.cs">
+     <type name="X">
+       <method name="Void f(System.String)" attrs="145">
+-        <size>20</size>
++        <size>12</size>
+       </method>
+       <method name="Int32 Main()" attrs="150">
+-        <size>70</size>
++        <size>62</size>
+       </method>
+       <method name="Void .ctor()" attrs="6278">
+         <size>7</size>
+@@ -52148,7 +52190,7 @@
+         <size>14</size>
+       </method>
+       <method name="Void Outer(System.String)" attrs="145">
+-        <size>29</size>
++        <size>34</size>
+       </method>
+       <method name="Void Inner(Char* ByRef, Char*)" attrs="145">
+         <size>10</size>
+@@ -52359,10 +52401,10 @@
+   <test name="test-928.cs">
+     <type name="Program">
+       <method name="Void Test()" attrs="150">
+-        <size>25</size>
++        <size>30</size>
+       </method>
+       <method name="Int32 Main()" attrs="150">
+-        <size>105</size>
++        <size>141</size>
+       </method>
+       <method name="Boolean &lt;Main&gt;m__0(System.Reflection.LocalVariableInfo)" attrs="145">
+         <size>29</size>
+@@ -52370,6 +52412,12 @@
+       <method name="Void .ctor()" attrs="6278">
+         <size>7</size>
+       </method>
++      <method name="Boolean StringNull(System.String)" attrs="150">
++        <size>32</size>
++      </method>
++      <method name="Boolean ArrayNull(Int32[])" attrs="150">
++        <size>45</size>
++      </method>
+     </type>
+   </test>
+   <test name="test-929.cs">
+@@ -52814,7 +52862,7 @@
+   <test name="test-948.cs">
+     <type name="X">
+       <method name="Void Main()" attrs="150">
+-        <size>16</size>
++        <size>103</size>
+       </method>
+       <method name="Void Foo()" attrs="129">
+         <size>2</size>
+@@ -52834,6 +52882,16 @@
+       </method>
+     </type>
+   </test>
++  <test name="test-950.cs">
++    <type name="B">
++      <method name="Void Main()" attrs="150">
++        <size>23</size>
++      </method>
++      <method name="Void .ctor()" attrs="6278">
++        <size>7</size>
++      </method>
++    </type>
++  </test>
+   <test name="test-96.cs">
+     <type name="N1.A">
+       <method name="Int32 Main()" attrs="150">
+@@ -52858,6 +52916,80 @@
+       </method>
+     </type>
+   </test>
++  <test name="test-960.cs">
++    <type name="B">
++      <method name="Int32 get_Index()" attrs="2182">
++        <size>14</size>
++      </method>
++      <method name="Void set_Index(Int32)" attrs="2178">
++        <size>8</size>
++      </method>
++      <method name="System.String get_S1()" attrs="2179">
++        <size>14</size>
++      </method>
++      <method name="Void set_S1(System.String)" attrs="2178">
++        <size>8</size>
++      </method>
++      <method name="System.String get_S2()" attrs="2180">
++        <size>14</size>
++      </method>
++      <method name="Void set_S2(System.String)" attrs="2178">
++        <size>8</size>
++      </method>
++      <method name="Void Main()" attrs="150">
++        <size>2</size>
++      </method>
++      <method name="Void .ctor()" attrs="6278">
++        <size>7</size>
++      </method>
++    </type>
++  </test>
++  <test name="test-961.cs">
++    <type name="B">
++      <method name="Void Main()" attrs="150">
++        <size>10</size>
++      </method>
++      <method name="Void Foo(Int32)" attrs="145">
++        <size>32</size>
++      </method>
++      <method name="Void &lt;Foo&gt;m__0(Int32)" attrs="145">
++        <size>2</size>
++      </method>
++    </type>
++    <type name="D">
++      <method name="Void Invoke(Int32)" attrs="454">
++        <size>0</size>
++      </method>
++      <method name="System.IAsyncResult BeginInvoke(Int32, System.AsyncCallback, System.Object)" attrs="454">
++        <size>0</size>
++      </method>
++      <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
++        <size>0</size>
++      </method>
++      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
++        <size>0</size>
++      </method>
++    </type>
++    <type name="M">
++      <method name="Void set_Item(Int32, Int32)" attrs="2177">
++        <size>2</size>
++      </method>
++      <method name="System.String op_Implicit(M)" attrs="2198">
++        <size>9</size>
++      </method>
++      <method name="Void Test2(Int32)" attrs="134">
++        <size>2</size>
++      </method>
++      <method name="Void .ctor(Int32)" attrs="6278">
++        <size>8</size>
++      </method>
++    </type>
++    <type name="B">
++      <method name="Void Bar(Int32)" attrs="150">
++        <size>2</size>
++      </method>
++    </type>
++  </test>
+   <test name="test-97.cs">
+     <type name="X">
+       <method name="Int32 Main()" attrs="150">
+@@ -54448,7 +54580,7 @@
+         <size>19</size>
+       </method>
+       <method name="Void Main()" attrs="150">
+-        <size>247</size>
++        <size>281</size>
+       </method>
+       <method name="Void &lt;BaseM&gt;__BaseCallProxy0()" attrs="129">
+         <size>7</size>
+@@ -54518,6 +54650,9 @@
+       <method name="Void &lt;Main&gt;m__5(E)" attrs="145">
+         <size>35</size>
+       </method>
++      <method name="Void &lt;Main&gt;m__6()" attrs="145">
++        <size>4</size>
++      </method>
+     </type>
+   </test>
+   <test name="test-anon-124.cs">
+@@ -67020,6 +67155,16 @@
+       </method>
+     </type>
+   </test>
++  <test name="test-binaryliteral.cs">
++    <type name="Demo">
++      <method name="Int32 Main()" attrs="145">
++        <size>503</size>
++      </method>
++      <method name="Void .ctor()" attrs="6278">
++        <size>7</size>
++      </method>
++    </type>
++  </test>
+   <test name="test-cls-00.cs">
+     <type name="CLSCLass_6">
+       <method name="Void add_Disposed(Delegate)" attrs="2182">
+@@ -68641,7 +68786,7 @@
+   <test name="test-decl-expr-05.cs">
+     <type name="X">
+       <method name="Void Test(System.String)" attrs="129">
+-        <size>29</size>
++        <size>62</size>
+       </method>
+       <method name="Boolean Call(System.String ByRef)" attrs="145">
+         <size>17</size>
+@@ -68654,6 +68799,22 @@
+       </method>
+     </type>
+   </test>
++  <test name="test-decl-expr-06.cs">
++    <type name="C">
++      <method name="Boolean Foo(Int32 ByRef)" attrs="145">
++        <size>13</size>
++      </method>
++      <method name="Void Main()" attrs="150">
++        <size>8</size>
++      </method>
++      <method name="Boolean &lt;f&gt;m__0()" attrs="145">
++        <size>15</size>
++      </method>
++      <method name="Void .ctor()" attrs="6278">
++        <size>42</size>
++      </method>
++    </type>
++  </test>
+   <test name="test-default-01.cs">
+     <type name="X">
+       <method name="Void Main()" attrs="150">
+@@ -68674,6 +68835,9 @@
+       <method name="Int32 &lt;M4&gt;m__0()" attrs="145">
+         <size>9</size>
+       </method>
++      <method name="Void Foo(II, II, II)" attrs="145">
++        <size>2</size>
++      </method>
+     </type>
+   </test>
+   <test name="test-default-02.cs">
+@@ -69158,6 +69322,21 @@
+       </method>
+     </type>
+   </test>
++  <test name="test-fixed-01.cs">
++    <type name="C">
++      <method name="Void Main()" attrs="150">
++        <size>39</size>
++      </method>
++      <method name="Void .ctor()" attrs="6278">
++        <size>7</size>
++      </method>
++    </type>
++    <type name="C+Fixable">
++      <method name="Int32&amp; GetPinnableReference()" attrs="134">
++        <size>32</size>
++      </method>
++    </type>
++  </test>
+   <test name="test-interpolation-01.cs">
+     <type name="Test">
+       <method name="Int32 Main()" attrs="150">
+@@ -72564,7 +72743,7 @@
+     </type>
+     <type name="X+&lt;Test&gt;c__Iterator0">
+       <method name="Boolean MoveNext()" attrs="486">
+-        <size>184</size>
++        <size>206</size>
+       </method>
+       <method name="Int32 System.Collections.Generic.IEnumerator&lt;int&gt;.get_Current()" attrs="2529">
+         <size>14</size>
+@@ -72750,6 +72929,21 @@
+       </method>
+     </type>
+   </test>
++  <test name="test-pattern-13.cs">
++    <type name="C">
++      <method name="Void .ctor()" attrs="6278">
++        <size>7</size>
++      </method>
++    </type>
++    <type name="B">
++      <method name="Void Main()" attrs="150">
++        <size>35</size>
++      </method>
++      <method name="Void .ctor()" attrs="6278">
++        <size>7</size>
++      </method>
++    </type>
++  </test>
+   <test name="test-pragma-unrecognized.cs">
+     <type name="C">
+       <method name="Void Main()" attrs="150">
+@@ -73155,6 +73349,11 @@
+     </type>
+   </test>
+   <test name="test-ref-07.cs">
++    <type name="TestMain">
++      <method name="Void Main()" attrs="150">
++        <size>6</size>
++      </method>
++    </type>
+     <type name="Test">
+       <method name="Void Main()" attrs="150">
+         <size>18</size>
+@@ -73243,6 +73442,32 @@
+       </method>
+     </type>
+   </test>
++  <test name="test-ref-11.cs">
++    <type name="Program">
++      <method name="Int32 Main()" attrs="150">
++        <size>34</size>
++      </method>
++      <method name="Void .ctor()" attrs="6278">
++        <size>7</size>
++      </method>
++    </type>
++  </test>
++  <test name="test-ref-12.cs">
++    <type name="X">
++      <method name="Void Main()" attrs="150">
++        <size>16</size>
++      </method>
++      <method name="Int32&amp; Foo(Byte ByRef)" attrs="145">
++        <size>14</size>
++      </method>
++      <method name="Void Bar(Int32 ByRef)" attrs="145">
++        <size>2</size>
++      </method>
++      <method name="Void .ctor()" attrs="6278">
++        <size>7</size>
++      </method>
++    </type>
++  </test>
+   <test name="test-static-using-01.cs">
+     <type name="A.B.X">
+       <method name="Int32 Test()" attrs="150">
+@@ -73482,7 +73707,7 @@
+         <size>32</size>
+       </method>
+       <method name="Int32 Test()" attrs="134">
+-        <size>10</size>
++        <size>2</size>
+       </method>
+       <method name="System.Object Foo()" attrs="129">
+         <size>10</size>
+@@ -73491,16 +73716,16 @@
+         <size>23</size>
+       </method>
+       <method name="Void Test3(Int32 ByRef)" attrs="145">
+-        <size>3</size>
++        <size>2</size>
+       </method>
+       <method name="Int32 get_Item(Int32)" attrs="2177">
+-        <size>10</size>
++        <size>2</size>
+       </method>
+       <method name="Void add_Event(System.Action)" attrs="2182">
+-        <size>3</size>
++        <size>2</size>
+       </method>
+       <method name="Void remove_Event(System.Action)" attrs="2182">
+-        <size>3</size>
++        <size>2</size>
+       </method>
+       <method name="Void TestExpr_1(Boolean)" attrs="129">
+         <size>21</size>
+@@ -73527,7 +73752,7 @@
+         <size>7</size>
+       </method>
+       <method name="Int32 TestExpr_6(Int32 ByRef)" attrs="145">
+-        <size>10</size>
++        <size>2</size>
+       </method>
+       <method name="Int32 TestExpr_7(Int32 ByRef)" attrs="129">
+         <size>15</size>
+@@ -73569,7 +73794,7 @@
+   <test name="test-tuple-02.cs">
+     <type name="TupleConversions">
+       <method name="Void Main()" attrs="150">
+-        <size>314</size>
++        <size>368</size>
+       </method>
+       <method name="Void Foo[T](T)" attrs="145">
+         <size>2</size>
+@@ -73761,6 +73986,29 @@
+       </method>
+     </type>
+   </test>
++  <test name="test-tuple-10.cs">
++    <type name="Program">
++      <method name="Int32 Main()" attrs="150">
++        <size>65</size>
++      </method>
++      <method name="System.ValueTuple`2[System.String,System.Int32] &lt;Main&gt;m__0(System.Reflection.FieldInfo)" attrs="145">
++        <size>21</size>
++      </method>
++      <method name="Void .ctor()" attrs="6278">
++        <size>7</size>
++      </method>
++    </type>
++  </test>
++  <test name="test-tuple-11.cs">
++    <type name="Program">
++      <method name="Int32 Main()" attrs="150">
++        <size>70</size>
++      </method>
++      <method name="Void .ctor()" attrs="6278">
++        <size>7</size>
++      </method>
++    </type>
++  </test>
+   <test name="test-var-01.cs">
+     <type name="Test">
+       <method name="Int32 Main()" attrs="150">
+@@ -73896,4 +74144,4 @@
+       </method>
+     </type>
+   </test>
+-</tests>
+\ No newline at end of file
++</tests>
+diff --git a/msvc/scripts/System.Web.pre b/msvc/scripts/System.Web.pre
+index c071bf45bfd..8f8d262597f 100644
+--- a/msvc/scripts/System.Web.pre
++++ b/msvc/scripts/System.Web.pre
+@@ -1 +1 @@
+-@MONO@ $(ProjectDir)\..\lib\net_4_x\culevel.exe -o $(ProjectDir)\System.Web\UplevelHelper.cs $(ProjectDir)\UplevelHelperDefinitions.xml
++@MONO@ $([MSBuild]::GetDirectoryNameOfFileAbove($(TargetDir), culevel.exe))\culevel.exe -o $(ProjectDir)\System.Web\UplevelHelper.cs $(ProjectDir)\UplevelHelperDefinitions.xml
+diff --git a/msvc/scripts/genproj.cs b/msvc/scripts/genproj.cs
+index 3987abb212b..1440800b2b3 100644
+--- a/msvc/scripts/genproj.cs
++++ b/msvc/scripts/genproj.cs
+@@ -27,27 +27,43 @@ public enum Target {
+ 
+ class SlnGenerator {
+ 	public static readonly string NewLine = "\r\n"; //Environment.NewLine; // "\n"; 
+-	public SlnGenerator (string formatVersion = "2012")
++	public SlnGenerator (string slnVersion)
+ 	{
+-		switch (formatVersion) {
+-		case "2008":
+-			this.header = MakeHeader ("10.00", "2008");
+-			break;
+-		default:
+-			this.header = MakeHeader ("12.00", "2012");
+-			break;
+-		}
++		Console.WriteLine("Requested sln version is {0}", slnVersion);
++		this.header = MakeHeader ("12.00", "15", "15.0.0.0");
+ 	}
+ 
+-	const string project_start = "Project(\"{{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}}\") = \"{0}\", \"{1}\", \"{2}\""; // Note: No need to double up on {} around {2}
++	const string project_start = "Project(\"{0}\") = \"{1}\", \"{2}\", \"{3}\""; // Note: No need to double up on {} around {2}
+ 	const string project_end = "EndProject";
+ 
++	public List<string> profiles = new List<string> {
++		"net_4_x",
++		"monodroid",
++		"monotouch",
++		"monotouch_tv",
++		"monotouch_watch",
++		"orbis",
++		"unreal",
++		"wasm",
++		"winaot",
++		"xammac",
++	};
++
++	const string jay_vcxproj_guid = "{5D485D32-3B9F-4287-AB24-C8DA5B89F537}";
++	const string jay_sln_guid = "{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}";
++
+ 	public List<MsbuildGenerator.VsCsproj> libraries = new List<MsbuildGenerator.VsCsproj> ();
+ 	string header;
+ 
+-	string MakeHeader (string formatVersion, string yearTag)
++	string MakeHeader (string formatVersion, string yearTag, string minimumVersion)
+ 	{
+-		return string.Format ("Microsoft Visual Studio Solution File, Format Version {0}" + NewLine + "# Visual Studio {1}", formatVersion, yearTag);
++		return string.Format (
++			"Microsoft Visual Studio Solution File, Format Version {0}" + NewLine + 
++			"# Visual Studio {1}" + NewLine + 
++			"MinimumVisualStudioVersion = {2}", 
++			formatVersion, yearTag,
++			minimumVersion
++		);
+ 	}
+ 
+ 	public void Add (MsbuildGenerator.VsCsproj vsproj)
+@@ -59,6 +75,40 @@ class SlnGenerator {
+ 		}
+ 	}
+ 
++	private void WriteProjectReference (StreamWriter sln, string prefixGuid, string library, string relativePath, string projectGuid, params string[] dependencyGuids)
++	{
++		sln.WriteLine (project_start, prefixGuid, library, relativePath, projectGuid);
++
++		foreach (var guid in dependencyGuids) {
++    		sln.WriteLine ("    ProjectSection(ProjectDependencies) = postProject");
++    		sln.WriteLine ("        {0} = {0}", guid);
++    		sln.WriteLine ("    EndProjectSection");
++		}
++
++		sln.WriteLine (project_end);
++	}
++
++	private void WriteProjectReference (StreamWriter sln, string slnFullPath, MsbuildGenerator.VsCsproj proj)
++	{
++		var unixProjFile = proj.csProjFilename.Replace ("\\", "/");
++		var fullProjPath = Path.GetFullPath (unixProjFile);
++		var relativePath = MsbuildGenerator.GetRelativePath (slnFullPath, fullProjPath);
++		var dependencyGuids = new string[0];
++		if (proj.preBuildEvent.Contains ("jay"))
++			dependencyGuids = new [] { jay_vcxproj_guid };
++		WriteProjectReference(sln, "{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}", proj.library, relativePath, proj.projectGuid, dependencyGuids);
++	}
++
++	private void WriteProjectConfigurationPlatforms (StreamWriter sln, string guid, string platformToBuild)
++	{
++		foreach (var profile in profiles) {
++			sln.WriteLine ("\t\t{0}.Debug|{1}.ActiveCfg = Debug|{2}", guid, profile, platformToBuild);
++			sln.WriteLine ("\t\t{0}.Debug|{1}.Build.0 = Debug|{2}", guid, profile, platformToBuild);
++			sln.WriteLine ("\t\t{0}.Release|{1}.ActiveCfg = Release|{2}", guid, profile, platformToBuild);
++			sln.WriteLine ("\t\t{0}.Release|{1}.Build.0 = Release|{2}", guid, profile, platformToBuild);
++		}
++	}
++
+ 	public void Write (string filename)
+ 	{
+ 		var fullPath = Path.GetDirectoryName (filename) + "/";
+@@ -66,27 +116,32 @@ class SlnGenerator {
+ 		using (var sln = new StreamWriter (filename)) {
+ 			sln.WriteLine ();
+ 			sln.WriteLine (header);
++
++			// Manually insert jay's vcxproj. We depend on jay.exe to perform build steps later.
++			WriteProjectReference (sln, jay_sln_guid, "jay", "mcs\\jay\\jay.vcxproj", jay_vcxproj_guid);
++
+ 			foreach (var proj in libraries) {
+-				var unixProjFile = proj.csProjFilename.Replace ("\\", "/");
+-				var fullProjPath = Path.GetFullPath (unixProjFile);
+-				sln.WriteLine (project_start, proj.library, MsbuildGenerator.GetRelativePath (fullPath, fullProjPath), proj.projectGuid);
+-				sln.WriteLine (project_end);
++				WriteProjectReference (sln, fullPath, proj);
+ 			}
++
+ 			sln.WriteLine ("Global");
+ 
+ 			sln.WriteLine ("\tGlobalSection(SolutionConfigurationPlatforms) = preSolution");
+-			sln.WriteLine ("\t\tDebug|Any CPU = Debug|Any CPU");
+-			sln.WriteLine ("\t\tRelease|Any CPU = Release|Any CPU");
++			foreach (var profile in profiles) {
++				sln.WriteLine ("\t\tDebug|{0} = Debug|{0}", profile);
++				sln.WriteLine ("\t\tRelease|{0} = Release|{0}", profile);
++			}
+ 			sln.WriteLine ("\tEndGlobalSection");
+ 
+ 			sln.WriteLine ("\tGlobalSection(ProjectConfigurationPlatforms) = postSolution");
++
++			// Manually insert jay's configurations because they are different
++			WriteProjectConfigurationPlatforms (sln, jay_vcxproj_guid, "Win32");
++
+ 			foreach (var proj in libraries) {
+-				var guid = proj.projectGuid;
+-				sln.WriteLine ("\t\t{0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU", guid);
+-				sln.WriteLine ("\t\t{0}.Debug|Any CPU.Build.0 = Debug|Any CPU", guid);
+-				sln.WriteLine ("\t\t{0}.Release|Any CPU.ActiveCfg = Release|Any CPU", guid);
+-				sln.WriteLine ("\t\t{0}.Release|Any CPU.Build.0 = Release|Any CPU", guid);
++				WriteProjectConfigurationPlatforms (sln, proj.projectGuid, "Any CPU");
+ 			}
++
+ 			sln.WriteLine ("\tEndGlobalSection");
+ 
+ 			sln.WriteLine ("\tGlobalSection(SolutionProperties) = preSolution");
+@@ -634,6 +689,7 @@ class MsbuildGenerator {
+ 		public List<VsCsproj> projReferences = new List<VsCsproj> ();
+ 		public string library;
+ 		public MsbuildGenerator MsbuildGenerator;
++		public string preBuildEvent, postBuildEvent;
+ 	}
+ 
+ 	public VsCsproj Csproj;
+@@ -682,7 +738,7 @@ class MsbuildGenerator {
+ 				fx_version = "4.0";
+ 				profile = "net_4_0";
+ 			} else if (response.Contains (profile_4_x)) {
+-				fx_version = "4.5";
++				fx_version = "4.6.2";
+ 				profile = "net_4_x";
+ 			}
+ 		}
+@@ -882,6 +938,26 @@ class MsbuildGenerator {
+ 
+ 		bool basic_or_build = (library.Contains ("-basic") || library.Contains ("-build"));
+ 
++		// If an EXE is built with nostdlib, it won't work unless run with mono.exe. This stops our build steps
++		//  from working in visual studio (because we already replace @MONO@ with '' on Windows.)
++
++		if (Target != Target.Library)
++			StdLib = true;
++
++		// We have our target framework set to 4.5 in many places because broken scripts check for files with 4.5
++		//  in the path, even though we compile code that uses 4.6 features. So we need to manually fix that here.
++
++		if (fx_version == "4.5")
++			fx_version = "4.6.2";
++
++		// The VS2017 signing system fails to sign using this key for some reason, so for now,
++		//  just disable code signing for the nunit assemblies. It's not important.
++		// I'd rather fix this by updating the makefiles but it seems to be impossible to disable
++		//  code signing in our make system...
++
++		if (StrongNameKeyFile?.Contains("nunit.snk") ?? false)
++			StrongNameKeyFile = null;
++
+ 		//
+ 		// Replace the template values
+ 		//
+@@ -894,6 +970,9 @@ class MsbuildGenerator {
+ 				"    <AssemblyOriginatorKeyFile>{0}</AssemblyOriginatorKeyFile>",
+ 				StrongNameKeyFile, StrongNameDelaySign ? "    <DelaySign>true</DelaySign>" + NewLine : "");
+ 		}
++
++		string assemblyName = Path.GetFileNameWithoutExtension (output_name);
++
+ 		Csproj.output = template.
+ 			Replace ("@OUTPUTTYPE@", Target == Target.Library ? "Library" : "Exe").
+ 			Replace ("@SIGNATURE@", strongNameSection).
+@@ -906,7 +985,7 @@ class MsbuildGenerator {
+ 			Replace ("@NOCONFIG@", "<NoConfig>" + (!load_default_config).ToString () + "</NoConfig>").
+ 			Replace ("@ALLOWUNSAFE@", Unsafe ? "<AllowUnsafeBlocks>true</AllowUnsafeBlocks>" : "").
+ 			Replace ("@FX_VERSION", fx_version).
+-			Replace ("@ASSEMBLYNAME@", Path.GetFileNameWithoutExtension (output_name)).
++			Replace ("@ASSEMBLYNAME@", assemblyName).
+ 			Replace ("@OUTPUTDIR@", build_output_dir).
+ 			Replace ("@OUTPUTSUFFIX@", Path.GetFileName (build_output_dir)).
+ 			Replace ("@DEFINECONSTANTS@", defines.ToString ()).
+@@ -920,7 +999,11 @@ class MsbuildGenerator {
+ 			Replace ("@ADDITIONALLIBPATHS@", String.Empty).
+ 			Replace ("@RESOURCES@", resources.ToString ()).
+ 			Replace ("@OPTIMIZE@", Optimize ? "true" : "false").
+-			Replace ("@SOURCES@", sources.ToString ());
++			Replace ("@SOURCES@", sources.ToString ()).
++			Replace ("@METADATAVERSION@", assemblyName == "mscorlib" ? "<RuntimeMetadataVersion>Mono</RuntimeMetadataVersion>" : "");
++
++		Csproj.preBuildEvent = prebuild;
++		Csproj.postBuildEvent = postbuild;
+ 
+ 		//Console.WriteLine ("Generated {0}", ofile.Replace ("\\", "/"));
+ 		using (var o = new StreamWriter (generatedProjFile)) {
+@@ -939,15 +1022,13 @@ class MsbuildGenerator {
+ 		if (q != -1)
+ 			target = target + Load (library.Substring (0, q) + suffix);
+ 
+-		if (target.IndexOf ("@MONO@") != -1){
+-			target_unix = target.Replace ("@MONO@", "mono").Replace ("@CAT@", "cat");
+-			target_windows = target.Replace ("@MONO@", "").Replace ("@CAT@", "type");
+-		} else {
+-			target_unix = target.Replace ("jay.exe", "jay");
+-			target_windows = target;
+-		}
++		target_unix = target.Replace ("@MONO@", "mono").Replace ("@CAT@", "cat");
++		target_windows = target.Replace ("@MONO@", "").Replace ("@CAT@", "type");
++
++		target_unix = target_unix.Replace ("\\jay\\jay.exe", "\\jay\\jay\\jay");
++
+ 		target_unix = target_unix.Replace ("@COPY@", "cp");
+-		target_windows = target_unix.Replace ("@COPY@", "copy");
++		target_windows = target_windows.Replace ("@COPY@", "copy");
+ 
+ 		target_unix = target_unix.Replace ("\r", "");
+ 		const string condition_unix    = "Condition=\" '$(OS)' != 'Windows_NT' \"";

--- a/pkgs/development/compilers/mono/bootstrap/patches/mono-6.12.0-add-runpath.patch
+++ b/pkgs/development/compilers/mono/bootstrap/patches/mono-6.12.0-add-runpath.patch
@@ -1,0 +1,185 @@
+mono: metadata: add <runpath> element to .config files.
+
+This new element is of the form:
+
+<runpath path="/path1/to/libs:/path2/to/libs:..."/>
+
+(the : will actually be whatever G_SEARCHPATH_SEPARATOR_S is, so likely ; on
+windows and : elsewhere).
+
+* mono/metadata/metadata-internals.h (struct _MonoImage): new 'runpath' field.
+* mono/metadata/mono-config.c (runpath_init, runpath_start, runpath_handler):
+  new functions and parser using them to populate runpath field from <runpath>
+  element.
+  (mono_config_init): register runpath_handler.
+* mono/metadata/assembly.c (mono_assembly_load_full_gac_base_default): new
+  'requesting' parameter, use it to search the requesting assembly's runpath
+  first.
+  (mono_assembly_request_byname_nosearch): use it.
+
+
+diff --git a/mono/metadata/assembly.c b/mono/metadata/assembly.c
+index f9feaacf2c1..8c71ad0eb95 100644
+--- a/mono/metadata/assembly.c
++++ b/mono/metadata/assembly.c
+@@ -376,7 +376,7 @@ mono_assembly_invoke_search_hook_internal (MonoAssemblyLoadContext *alc, MonoAss
+ static MonoAssembly*
+ mono_assembly_request_byname_nosearch (MonoAssemblyName *aname, const MonoAssemblyByNameRequest *req, MonoImageOpenStatus *status);
+ static MonoAssembly*
+-mono_assembly_load_full_gac_base_default (MonoAssemblyName *aname, const char *basedir, MonoAssemblyLoadContext *alc, MonoAssemblyContextKind asmctx, MonoImageOpenStatus *status);
++mono_assembly_load_full_gac_base_default (MonoAssemblyName *aname, MonoAssembly *requesting, const char *basedir, MonoAssemblyLoadContext *alc, MonoAssemblyContextKind asmctx, MonoImageOpenStatus *status);
+ static MonoAssembly*
+ chain_redirections_loadfrom (MonoAssemblyLoadContext *alc, MonoImage *image, MonoImageOpenStatus *out_status);
+ static MonoAssembly*
+@@ -4655,7 +4655,7 @@ mono_assembly_request_byname_nosearch (MonoAssemblyName *aname,
+ 	}
+ 
+ #ifndef ENABLE_NETCORE
+-	result = mono_assembly_load_full_gac_base_default (aname, req->basedir, req->request.alc, req->request.asmctx, status);
++	result = mono_assembly_load_full_gac_base_default (aname, req->requesting_assembly, req->basedir, req->request.alc, req->request.asmctx, status);
+ #endif
+ 	return result;
+ }
+@@ -4667,6 +4667,7 @@ mono_assembly_request_byname_nosearch (MonoAssemblyName *aname,
+  */
+ MonoAssembly*
+ mono_assembly_load_full_gac_base_default (MonoAssemblyName *aname,
++                                          MonoAssembly *requesting,
+ 					  const char *basedir,
+ 					  MonoAssemblyLoadContext *alc,
+ 					  MonoAssemblyContextKind asmctx,
+@@ -4718,6 +4719,23 @@ mono_assembly_load_full_gac_base_default (MonoAssemblyName *aname,
+ 			filename = g_strconcat (aname->name, ext, (const char*)NULL);
+ 		}
+ 
++                if (requesting
++                    && requesting->image
++                    && requesting->image->runpath) {
++                    char **runpath = requesting->image->runpath;
++                    int j;
++                    for (j = 0; runpath[j]; j++) {
++                        fullpath = g_build_filename (runpath[j], filename, NULL);
++                        result = mono_assembly_request_open (fullpath, &req, status);
++                        g_free (fullpath);
++                        if (result) {
++                            result->in_gac = FALSE;
++                            g_free (filename);
++                            return result;
++                        }
++                    }
++                }
++
+ #ifndef DISABLE_GAC
+ 		const gboolean refonly = asmctx == MONO_ASMCTX_REFONLY;
+ 
+diff --git a/mono/metadata/image.c b/mono/metadata/image.c
+index e0b86dd3d09..12a8094e4e0 100644
+--- a/mono/metadata/image.c
++++ b/mono/metadata/image.c
+@@ -2363,6 +2363,9 @@ mono_image_close_except_pools (MonoImage *image)
+ 
+ 	mono_metadata_clean_for_image (image);
+ 
++        if (image->runpath)
++            g_strfreev (image->runpath);
++
+ 	/*
+ 	 * The caches inside a MonoImage might refer to metadata which is stored in referenced 
+ 	 * assemblies, so we can't release these references in mono_assembly_close () since the
+diff --git a/mono/metadata/metadata-internals.h b/mono/metadata/metadata-internals.h
+index 9388d69b0fd..93f4b880c61 100644
+--- a/mono/metadata/metadata-internals.h
++++ b/mono/metadata/metadata-internals.h
+@@ -423,6 +423,12 @@ struct _MonoImage {
+ 	/**/
+ 	MonoTableInfo        tables [MONO_TABLE_NUM];
+ 
++    /*
++      Search path to be tried first when looking for assemblies referenced by
++      this image, or NULL. Is a NULL-terminated vector.
++     */
++        char               **runpath;
++
+ 	/*
+ 	 * references is initialized only by using the mono_assembly_open
+ 	 * function, and not by using the lowlevel mono_image_open.
+diff --git a/mono/metadata/mono-config.c b/mono/metadata/mono-config.c
+index d973de53c8c..8888c7b4fac 100644
+--- a/mono/metadata/mono-config.c
++++ b/mono/metadata/mono-config.c
+@@ -21,6 +21,7 @@
+ #include "mono/metadata/metadata-internals.h"
+ #include "mono/metadata/object-internals.h"
+ #include "mono/utils/mono-logger-internals.h"
++#include "mono/utils/mono-path.h"
+ 
+ #if defined(TARGET_PS3)
+ #define CONFIG_OS "CellOS"
+@@ -464,6 +465,59 @@ aot_cache_handler = {
+ 	NULL, /* finish */
+ };
+ 
++static void*
++runpath_init (MonoImage *assembly)
++{
++    return assembly;
++}
++
++static void
++runpath_start (gpointer user_data,
++               const gchar         *element_name,
++               const gchar        **attribute_names,
++               const gchar        **attribute_values)
++{
++    MonoImage *assembly = (MonoImage *) user_data;
++    int i;
++
++    if (strcmp (element_name, "runpath") != 0)
++        return;
++
++    for (i = 0; attribute_names[i]; i++)
++        {
++            if(!strcmp (attribute_names [i], "path"))
++                {
++                    char **splitted, **dest;
++
++                    splitted = g_strsplit (attribute_values[i],
++                                           G_SEARCHPATH_SEPARATOR_S,
++                                           1000);
++                    if (assembly->runpath)
++                        g_strfreev (assembly->runpath);
++                    assembly->runpath = dest = splitted;
++                    while (*splitted) {
++                        char *tmp = *splitted;
++                        if (*tmp)
++                            *dest++ = mono_path_canonicalize (tmp);
++                        g_free (tmp);
++                        splitted++;
++                    }
++                    *dest = *splitted;
++                    break;
++                }
++        }
++}
++
++static const MonoParseHandler
++runpath_handler = {
++    "runpath",
++    runpath_init,
++    runpath_start,
++    NULL, /* text */
++    NULL, /* end */
++    NULL, /* finish */
++};
++
+ static int inited = 0;
+ 
+ static void
+@@ -476,6 +530,7 @@ mono_config_init (void)
+ #endif
+ 	g_hash_table_insert (config_handlers, (gpointer) legacyUEP_handler.element_name, (gpointer) &legacyUEP_handler);
+ 	g_hash_table_insert (config_handlers, (gpointer) aot_cache_handler.element_name, (gpointer) &aot_cache_handler);
++        g_hash_table_insert (config_handlers, (gpointer) runpath_handler.element_name, (gpointer) &runpath_handler);
+ }
+ 
+ /**

--- a/pkgs/development/compilers/mono/bootstrap/pnet.nix
+++ b/pkgs/development/compilers/mono/bootstrap/pnet.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  autoreconfHook,
+  automake,
+  bison,
+  flex,
+  libatomic_ops,
+  libffi,
+  libtool,
+  boehmgc,
+  perl,
+  python3,
+  texinfo,
+  treecc,
+  guixPatches,
+}:
+
+stdenv.mkDerivation {
+  pname = "pnet";
+  version = "0.8.0-unstable-2011-06-15";
+
+  src = fetchgit {
+    url = "git://git.sv.gnu.org/dotgnu-pnet/pnet.git";
+    rev = "3baf94734d8dc3fdabba68a8891e67a43ed6c4bd";
+    hash = "sha256-xv4aA7M7/i2DOw6g6zc4xbKTKRu7/BxWvBVQ9F/e9m8=";
+  };
+
+  patches = [
+    guixPatches."pnet-newer-libgc-fix.patch"
+    guixPatches."pnet-newer-texinfo-fix.patch"
+    guixPatches."pnet-fix-line-number-info.patch"
+    guixPatches."pnet-fix-off-by-one.patch"
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    automake
+    bison
+    flex
+    libatomic_ops
+    libtool
+    perl
+    python3
+    texinfo
+    treecc
+  ];
+
+  buildInputs = [
+    boehmgc
+    libffi
+  ];
+
+  postPatch = ''
+    rm -rf libffi libgc
+    rm -f compile configure config.guess config.sub depcomp install-sh ltconfig ltcf-c.sh ltmain.sh
+    find . \( -name 'Makefile' -o -name 'Makefile.in' -o -name '_grammar.c' -o -name '_grammar.h' -o -name '_scanner.c' -o -name '_scanner.h' \) -delete
+
+    substituteInPlace configure.in \
+      --replace-fail "GCLIBS='\$(top_builddir)/libgc/.libs/libgc.a'" "GCLIBS='-lgc'" \
+      --replace-fail "search_libjit=true" $'search_libjit=false\nJIT_LIBS=-ljit'
+
+    substituteInPlace Makefile.am \
+      --replace-fail "OPT_SUBDIRS += libffi" "" \
+      --replace-fail "OPT_SUBDIRS += libgc" ""
+    substituteInPlace support/hb_gc.c \
+      --replace-fail '#include "../libgc/include/gc.h"' '#include <gc.h>' \
+      --replace-fail '#include "../libgc/include/gc_typed.h"' '#include <gc/gc_typed.h>'
+    perl -0pi -e 's/^TREECC_OUTPUT =.*$/TREECC_OUTPUT =/mg' \
+      codegen/Makefile.am cscc/bf/Makefile.am cscc/csharp/Makefile.am cscc/c/Makefile.am cscc/java/Makefile.am
+    substituteInPlace cscc/csharp/cs_grammar.y --replace-fail YYLEX 'yylex()'
+    substituteInPlace cscc/common/cc_main.h \
+      --replace-fail 'CCPreProc CCPreProcessorStream;' 'extern CCPreProc CCPreProcessorStream;'
+    substituteInPlace csdoc/scanner.c \
+      --replace-fail $'int\ttoken;' $'extern int\ttoken;'
+    substituteInPlace doc/cvmdoc.py --replace-fail python1.5 python
+    substituteInPlace profiles/full --replace-fail 'IL_CONFIG_UNROLL=y' 'IL_CONFIG_UNROLL=n'
+  '';
+
+  hardeningDisable = [ "format" ];
+
+  env.CFLAGS = "-O2 -g -Wno-pointer-to-int-cast -Wno-error=implicit-function-declaration -Wno-error=incompatible-pointer-types";
+
+  postInstall = ''
+    rm -f "$out/share/man/man1/cli-unknown-ar.1.gz"
+  '';
+
+  meta = {
+    description = "DotGNU Portable.NET C# compiler and runtime";
+    homepage = "http://www.gnu.org/software/dotgnu/html2.0/pnet.html";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/development/compilers/mono/bootstrap/pnetlib.nix
+++ b/pkgs/development/compilers/mono/bootstrap/pnetlib.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  autoreconfHook,
+  automake,
+  libtool,
+  perl,
+  treecc,
+  pnet,
+}:
+
+stdenv.mkDerivation {
+  pname = "pnetlib";
+  version = "0.8.0-unstable-2011-03-21";
+
+  src = fetchgit {
+    url = "git://git.sv.gnu.org/dotgnu-pnet/pnetlib.git";
+    rev = "c3c12b8b0c65f5482d03d6a4865f7670e98baf4c";
+    sha256 = "04dikki3lr3m1cacirld90rpi95656b2y2mc5rkycb7s0yfdz1nk";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    automake
+    libtool
+    perl
+    treecc
+  ];
+
+  buildInputs = [ pnet ];
+
+  postPatch = ''
+    rm -f configure config.guess config.sub install-sh ltmain.sh
+    find . \( -name 'Makefile' -o -name 'Makefile.in' \) -delete
+    perl -0pi -e 's/System\.Windows\.Forms//g' tests/Makefile.am
+    perl -0pi -e 's/^TESTS_ENVIRONMENT.*$/LOG_COMPILER = \$(SHELL)\nAM_LOG_FLAGS = \$(top_builddir)\/tools\/run_test.sh \$(top_builddir)/mg' tests/Makefile.am
+    substituteInPlace tools/run_test.sh.in --replace-fail en_US en_US.utf8
+    perl -0pi -e 's|exec \$LN_S clrwrap "\$1"|echo "#!\@SHELL\@" >> \$1\necho exec \$CLRWRAP \$(dirname \$(dirname \$1))/lib/cscc/lib/\$(basename \$1).exe >> \$1\nchmod +x \$1|g' tools/wrapper.sh.in
+  '';
+
+  env.CFLAGS = "-O2 -g -Wno-pointer-to-int-cast";
+
+  doCheck = false;
+
+  meta = {
+    description = "DotGNU Portable.NET class libraries";
+    homepage = "http://www.gnu.org/software/dotgnu/html2.0/pnet.html";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/development/compilers/mono/bootstrap/treecc.nix
+++ b/pkgs/development/compilers/mono/bootstrap/treecc.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+}:
+
+stdenv.mkDerivation {
+  pname = "treecc";
+  version = "0.3.10";
+
+  src = fetchurl {
+    url = "mirror://savannah/dotgnu-pnet/treecc-0.3.10.tar.gz";
+    hash = "sha256-Xp0gppOODG/t/tDKvH6emEAk5IgbdI0Hbox18a627+c=";
+  };
+
+  meta = {
+    description = "Tree Compiler-Compiler";
+    homepage = "https://www.gnu.org/software/dotgnu/";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/development/compilers/mono/generic.nix
+++ b/pkgs/development/compilers/mono/generic.nix
@@ -21,11 +21,15 @@
   cmake,
   which,
   gnumake42,
+  bootstrapMono ? null,
   enableParallelBuilding ? true,
   extraPatches ? [ ],
   env ? { },
 }:
 
+let
+  useBootstrap = bootstrapMono != null;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "mono";
   inherit version src env;
@@ -43,7 +47,8 @@ stdenv.mkDerivation (finalAttrs: {
     which
     gnumake42
     gettext
-  ];
+  ]
+  ++ lib.optional useBootstrap bootstrapMono;
   buildInputs = [
     glib
     gettext
@@ -58,7 +63,19 @@ stdenv.mkDerivation (finalAttrs: {
     "--x-includes=${libx11.dev}/include"
     "--x-libraries=${libx11.out}/lib"
     "--with-libgdiplus=${libgdiplus}/lib/libgdiplus.so"
-  ];
+  ]
+  ++ lib.optional useBootstrap "--with-csc=mcs";
+
+  postPatch = lib.optionalString useBootstrap ''
+    find . -type f \( -name '*.dll' -o -name '*.DLL' -o -name '*.exe' -o -name '*.EXE' -o -name '*.so' \) -delete
+
+    substituteInPlace mcs/class/aot-compiler/Makefile \
+      --replace-fail "IMAGES = \$(mscorlib_aot_image) \$(mcs_aot_image) \$(CSC_IMAGES)" "IMAGES = \$(mscorlib_aot_image) \$(mcs_aot_image)"
+
+    substituteInPlace mcs/Makefile \
+      --replace-fail "net_4_x_SUBDIRS := build class ilasm tools tests errors docs mcs class/aot-compiler packages" \
+                     "net_4_x_SUBDIRS := build class ilasm tools tests errors docs mcs class/aot-compiler"
+  '';
 
   configurePhase = ''
     patchShebangs autogen.sh mcs/build/start-compiler-server.sh
@@ -72,6 +89,36 @@ stdenv.mkDerivation (finalAttrs: {
   # Patch all the necessary scripts
   preBuild = ''
     makeFlagsArray=(INSTALL=`type -tp install`)
+  ''
+  + lib.optionalString useBootstrap ''
+    pushd external/binary-reference-assemblies
+    for file in $(find . -name Makefile); do
+      substituteInPlace "$file" \
+        --replace-quiet "CSC_COMMON_ARGS := " "CSC_COMMON_ARGS := -delaysign+ "
+      for reference in \
+        "IBM.Data.DB2:System.Xml" "Mono.Data.Sqlite:System.Xml" \
+        "System.Data.DataSetExtensions:System.Xml" "System.Data.OracleClient:System.Xml" \
+        "System.IdentityModel:System.Configuration" "System.Design:Accessibility" \
+        "System.Web.Extensions.Design:System.Windows.Forms System.Web" "System.ServiceModel.Routing:System.Xml" \
+        "System.Web.Abstractions:System" "System.Reactive.Windows.Forms:System" \
+        "System.Windows.Forms.DataVisualization:Accessibility" "Facades/System.ServiceModel.Primitives:System.Xml" \
+        "Facades/System.Dynamic.Runtime:System" "Facades/System.Xml.XDocument:System.Xml" \
+        "Facades/System.Runtime.Serialization.Xml:System.Xml" "Facades/System.Data.Common:System System.Xml"
+      do
+        assembly=''${reference%%:*}
+        references=''${reference#*:}
+        substituteInPlace "$file" \
+          --replace-quiet "''${assembly}_REFS := " "''${assembly}_REFS := $references "
+      done
+    done
+    if [ -f build/monodroid/Makefile ]; then
+      substituteInPlace build/monodroid/Makefile \
+        --replace-quiet "ECMA_KEY := ../../../../../mono/" "ECMA_KEY := ../../../../"
+    fi
+    make -j"$NIX_BUILD_CORES" V=1 SKIP_AOT=1 CSC=mcs
+    popd
+  ''
+  + ''
     substituteInPlace mcs/class/corlib/System/Environment.cs --replace-fail /usr/share "$out/share"
   '';
 
@@ -90,6 +137,12 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     echo "Updating Mono key store"
     $out/bin/cert-sync ${cacert}/etc/ssl/certs/ca-bundle.crt
+  ''
+  + lib.optionalString useBootstrap ''
+    [ -e "$out/lib/mono/4.5/csc.exe" ] || ln -sf mcs "$out/bin/csc"
+    for tool in csi vbc; do
+      [ -e "$out/lib/mono/4.5/$tool.exe" ] || rm -f "$out/bin/$tool"
+    done
   ''
   # According to [1], gmcs is just mcs
   # [1] https://github.com/mono/mono/blob/master/scripts/gmcs.in

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4428,6 +4428,10 @@ with pkgs;
 
   mono6 = callPackage ../development/compilers/mono/6.nix { };
 
+  monoBootstrap = recurseIntoAttrsWith { search = false; } (
+    callPackage ../development/compilers/mono/bootstrap { }
+  );
+
   mozart2 = callPackage ../development/compilers/mozart {
     emacs = emacs-nox;
     jre_headless = jre8_headless; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731


### PR DESCRIPTION
## Do not merge: Kept as proof of concept for a mono bootstrap

Prepared with assistance from Codex.

Adapts the [Guix fully-bootstrapped Mono work](https://guix.gnu.org/en/blog/2024/adding-a-fully-bootstrapped-mono/) to Nixpkgs. This replaces the prebuilt Mono bootstrap tarball with a source-built chain rooted at DotGNU Portable.NET (`pnet`, `pnetlib`, and `treecc`) and uses that chain to build the regular `pkgs.mono` package in place.

`pkgs.mono` currently needs a prebuilt Mono compiler/runtime to build Mono. This PR removes that binary bootstrap dependency: Mono 6.14.1 is built from source using a chain of historical Mono releases, with the earliest C# compiler/runtime provided by Portable.NET.

## Bootstrap Chain

The new `monoBootstrap` package set is exposed next to `mono6` and hidden from package search with `recurseIntoAttrsWith { search = false; }`.

```text
pnet / pnetlib / treecc
  -> mono-1.2.6
  -> mono-1.9.1
  -> mono-2.4.2.3
  -> mono-2.6.4
  -> mono-2.11.4
  -> mono-3.0.12
  -> mono-3.12.1
  -> mono-4.9.0
  -> mono-5.0.1
  -> mono-5.1.0
  -> mono-5.2.0.224
  -> mono-5.4.0.212
  -> mono-pre-5.8.0
  -> mono-5.8.0.108
  -> mono-pre-5.10.0
  -> mono-5.10.0.160
  -> mono-6.12.0.206
  -> pkgs.mono / mono-6.14.1
```

The final `mono` derivation consumes `monoBootstrap.mono-6_12_0` through `bootstrapMono`, so downstream users keep using the existing `mono` attribute rather than a variant package.

## Notes

- The bootstrap stage count is intentional. Documented skip experiments failed when older `mcs` versions were asked to compile later Mono source trees.
- patch files pulled from the Guix port and related downstream packaging history.
- intermediate bootstrap outputs are trimmed to remove unused docs, static archives, monodoc data, and unused reference-assembly API directories.

## Verification

- `nix-build -A mono6 --no-out-link`
- `nix-instantiate --eval -A mono6.version --strict`
- `nix fmt -- pkgs/development/compilers/mono/6.nix pkgs/development/compilers/mono/generic.nix pkgs/development/compilers/mono/bootstrap/default.nix pkgs/development/compilers/mono/bootstrap/mono.nix pkgs/development/compilers/mono/bootstrap/pnet.nix pkgs/development/compilers/mono/bootstrap/pnetlib.nix pkgs/development/compilers/mono/bootstrap/treecc.nix`
- Smoke-tested `mono`, `mcs`, `csc`, and `resgen` from the final output.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
