### PR TITLE
buildbot{,-full,-ui,-worker,-plugins}: switch to pyproject

### DIFF
--- a/pkgs/development/tools/continuous-integration/buildbot/master.nix
+++ b/pkgs/development/tools/continuous-integration/buildbot/master.nix
@@ -85,14 +85,13 @@ buildPythonApplication rec {
     hash = "sha256-yUtOJRI04/clCMImh5sokpj6MeBIXjEAdf9xnToqJZs=";
   };
 
-  build-system = [
-  ];
+  build-system = [ setuptools ];
 
   pythonRelaxDeps = [
     "twisted"
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     # core
     twisted
     jinja2
@@ -105,7 +104,6 @@ buildPythonApplication rec {
     autobahn
     pyjwt
     pyyaml
-    setuptools
     croniter
     importlib-resources
     packaging

--- a/pkgs/development/tools/continuous-integration/buildbot/pkg.nix
+++ b/pkgs/development/tools/continuous-integration/buildbot/pkg.nix
@@ -1,14 +1,15 @@
 {
   lib,
   buildPythonPackage,
+  setuptools,
   isPy3k,
   buildbot,
 }:
 
 buildPythonPackage {
-  format = "setuptools";
   pname = "buildbot_pkg";
   inherit (buildbot) src version;
+  pyproject = true;
 
   postPatch = ''
     cd pkg
@@ -16,6 +17,8 @@ buildPythonPackage {
     # Do we have to care about that with Nix...?
     substituteInPlace buildbot_pkg.py --replace "os.listdir = listdir" ""
   '';
+
+  build-system = [ setuptools ];
 
   # No tests
   doCheck = false;

--- a/pkgs/development/tools/continuous-integration/buildbot/plugins.nix
+++ b/pkgs/development/tools/continuous-integration/buildbot/plugins.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchurl,
-  callPackage,
+  setuptools,
   mock,
   cairosvg,
   klein,
@@ -13,9 +13,9 @@
   # this is exposed for potential plugins to use and for nix-update
   inherit buildbot-pkg;
   www = buildPythonPackage rec {
-    format = "setuptools";
     pname = "buildbot_www";
     inherit (buildbot-pkg) version;
+    pyproject = true;
 
     src = fetchurl {
       url = "https://github.com/buildbot/buildbot/releases/download/v${version}/${pname}-${version}.tar.gz";
@@ -27,7 +27,9 @@
       sed -i "s/'buildbot'//" setup.py
     '';
 
-    buildInputs = [
+    build-system = [ setuptools ];
+
+    dependencies = [
       buildbot-pkg
       mock
     ];
@@ -46,14 +48,16 @@
   console-view = buildPythonPackage rec {
     pname = "buildbot_console_view";
     inherit (buildbot-pkg) version;
-    format = "setuptools";
+    pyproject = true;
 
     src = fetchurl {
       url = "https://github.com/buildbot/buildbot/releases/download/v${version}/${pname}-${version}.tar.gz";
       hash = "sha256-VA6xqJBjD4XmQabTN8M+PLvfrG7Hq2ooxChtz2jAT8A=";
     };
 
-    buildInputs = [ buildbot-pkg ];
+    build-system = [ setuptools ];
+
+    dependencies = [ buildbot-pkg ];
 
     # No tests
     doCheck = false;
@@ -69,14 +73,16 @@
   waterfall-view = buildPythonPackage rec {
     pname = "buildbot_waterfall_view";
     inherit (buildbot-pkg) version;
-    format = "setuptools";
+    pyproject = true;
 
     src = fetchurl {
       url = "https://github.com/buildbot/buildbot/releases/download/v${version}/${pname}-${version}.tar.gz";
       hash = "sha256-c/Nmr0Uscalnndq72Y6jPM1JDs5OyOCERtuX/GXkxp8=";
     };
 
-    buildInputs = [ buildbot-pkg ];
+    build-system = [ setuptools ];
+
+    dependencies = [ buildbot-pkg ];
 
     # No tests
     doCheck = false;
@@ -92,14 +98,16 @@
   grid-view = buildPythonPackage rec {
     pname = "buildbot_grid_view";
     inherit (buildbot-pkg) version;
-    format = "setuptools";
+    pyproject = true;
 
     src = fetchurl {
       url = "https://github.com/buildbot/buildbot/releases/download/v${version}/${pname}-${version}.tar.gz";
       hash = "sha256-AmY8RkFX0POmVpW71nNz4+dFbr0FHGhNR3RJymDNoaw=";
     };
 
-    buildInputs = [ buildbot-pkg ];
+    build-system = [ setuptools ];
+
+    dependencies = [ buildbot-pkg ];
 
     # No tests
     doCheck = false;
@@ -115,14 +123,16 @@
   wsgi-dashboards = buildPythonPackage rec {
     pname = "buildbot_wsgi_dashboards";
     inherit (buildbot-pkg) version;
-    format = "setuptools";
+    pyproject = true;
 
     src = fetchurl {
       url = "https://github.com/buildbot/buildbot/releases/download/v${version}/${pname}-${version}.tar.gz";
       hash = "sha256-vofKxpIfbAs7HR43Y7ojHLQEn6/WIdjZPgZieBMsz74=";
     };
 
-    buildInputs = [ buildbot-pkg ];
+    build-system = [ setuptools ];
+
+    dependencies = [ buildbot-pkg ];
 
     # No tests
     doCheck = false;
@@ -138,15 +148,17 @@
   badges = buildPythonPackage rec {
     pname = "buildbot_badges";
     inherit (buildbot-pkg) version;
-    format = "setuptools";
+    pyproject = true;
 
     src = fetchurl {
       url = "https://github.com/buildbot/buildbot/releases/download/v${version}/${pname}-${version}.tar.gz";
       hash = "sha256-u7HF6X+ClT4rT3LJcTHXWi5oSxCKPXoUDH+QFRI2S0w=";
     };
 
-    buildInputs = [ buildbot-pkg ];
-    propagatedBuildInputs = [
+    build-system = [ setuptools ];
+
+    dependencies = [
+      buildbot-pkg
       cairosvg
       klein
       jinja2
@@ -163,5 +175,4 @@
       license = lib.licenses.gpl2;
     };
   };
-
 }

--- a/pkgs/development/tools/continuous-integration/buildbot/worker.nix
+++ b/pkgs/development/tools/continuous-integration/buildbot/worker.nix
@@ -7,6 +7,9 @@
   # patch
   coreutils,
 
+  # build system
+  setuptools,
+
   # propagates
   autobahn,
   msgpack,
@@ -15,7 +18,6 @@
   # tests
   parameterized,
   psutil,
-  setuptools-trial,
 
   # passthru
   nixosTests,
@@ -24,7 +26,7 @@
 buildPythonPackage {
   pname = "buildbot_worker";
   inherit (buildbot) src version;
-  format = "setuptools";
+  pyproject = true;
 
   postPatch = ''
     cd worker
@@ -33,11 +35,9 @@ buildPythonPackage {
       --replace /usr/bin/tail "${coreutils}/bin/tail"
   '';
 
-  nativeBuildInputs = [
-    setuptools-trial
-  ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     autobahn
     msgpack
     twisted


### PR DESCRIPTION
Related to #515974

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
