### PR TITLE
nixos/system-environment: Export PATH to systemd transient environment

### DIFF
--- a/nixos/modules/config/system-environment.nix
+++ b/nixos/modules/config/system-environment.nix
@@ -11,6 +11,23 @@ let
 
   cfg = config.environment;
 
+  suffixedVariables = lib.flip lib.mapAttrs cfg.profileRelativeSessionVariables (
+    envVar: suffixes:
+    lib.flip lib.concatMap cfg.profiles (profile: map (suffix: "${profile}${suffix}") suffixes)
+  );
+
+  combinedSessionVars = lib.zipAttrsWith (n: lib.concatLists) [
+    # Make sure security wrappers are prioritized without polluting
+    # shell environments with an extra entry. Sessions which depend on
+    # pam for its environment will otherwise have eg. broken sudo. In
+    # particular Gnome Shell sometimes fails to source a proper
+    # environment from a shell.
+    { PATH = [ config.security.wrapperDir ]; }
+
+    (lib.mapAttrs (n: lib.toList) cfg.sessionVariables)
+    suffixedVariables
+  ];
+
 in
 
 {
@@ -73,13 +90,11 @@ in
   };
 
   config = {
+    environment.etc."environment.d/50-systemd-path.conf".text = ''
+      PATH="${lib.concatStringsSep ":" combinedSessionVars.PATH}"
+    '';
     environment.etc."pam/environment".text =
       let
-        suffixedVariables = lib.flip lib.mapAttrs cfg.profileRelativeSessionVariables (
-          envVar: suffixes:
-          lib.flip lib.concatMap cfg.profiles (profile: map (suffix: "${profile}${suffix}") suffixes)
-        );
-
         # We're trying to use the same syntax for PAM variables and env variables.
         # That means we need to map the env variables that people might use to their
         # equivalent PAM variable.
@@ -88,21 +103,7 @@ in
         pamVariable =
           n: v: ''${n}   DEFAULT="${lib.concatStringsSep ":" (map replaceEnvVars (lib.toList v))}"'';
 
-        pamVariables = lib.concatStringsSep "\n" (
-          lib.mapAttrsToList pamVariable (
-            lib.zipAttrsWith (n: lib.concatLists) [
-              # Make sure security wrappers are prioritized without polluting
-              # shell environments with an extra entry. Sessions which depend on
-              # pam for its environment will otherwise have eg. broken sudo. In
-              # particular Gnome Shell sometimes fails to source a proper
-              # environment from a shell.
-              { PATH = [ config.security.wrapperDir ]; }
-
-              (lib.mapAttrs (n: lib.toList) cfg.sessionVariables)
-              suffixedVariables
-            ]
-          )
-        );
+        pamVariables = lib.concatStringsSep "\n" (lib.mapAttrsToList pamVariable combinedSessionVars);
       in
       ''
         ${pamVariables}


### PR DESCRIPTION
Since e73170e38a27be96071b8da0f18c0e2b150dc627, we no longer patch systemd to prevent it resetting `PATH` for generators. Generators that depended on this deviating behavior will no longer work, which ironically includes the upstream `systemd-xdg-autostart-generator`.

Previously, generators would see systemd's actual environment, which included environment variables set for the PAM session like `PATH`. To preserve the old behavior *exactly*, we'd really want to be replicating exactly what the `systemd-user` PAM service sets up, which could technically include things other than just what we put in `/etc/pam/environment`. But this is arguably a systemd bug (either because `systemd-xdg-autostart-generator` shouldn't use the generator's `PATH`, or because systemd should pass along the `PATH` it got from PAM), so for now, we can keep it simple and fix it by replicating what `/etc/pam/environment` does in `/etc/environment.d`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
