### PR TITLE
ocamlPackages.camlp5: 8.05.00 → 8.05.01

### DIFF
--- a/pkgs/development/tools/ocaml/camlp5/default.nix
+++ b/pkgs/development/tools/ocaml/camlp5/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (
   in
   {
 
-    version = if lib.versionAtLeast ocaml.version "4.12" && !legacy then "8.05.00" else "7.14";
+    version = if lib.versionAtLeast ocaml.version "4.12" && !legacy then "8.05.01" else "7.14";
 
     pname = "ocaml${ocaml.version}-camlp5";
 
@@ -35,7 +35,7 @@ stdenv.mkDerivation (
           "rel${builtins.replaceStrings [ "." ] [ "" ] finalAttrs.version}";
       hash =
         {
-          "8.05.00" = "sha256-Y7d72gAxtyAQOIvLGua6Pib+FCoeMlbRYa9vzc+9hRo=";
+          "8.05.01" = "sha256-ym1cZIoAIwMnkGiygZf+TZxjhyO6WHYItWRXobdcKm0=";
           "8.03.2" = "sha256-nz+VfGR/6FdBvMzPPpVpviAXXBWNqM3Ora96Yzx964o=";
           "7.14" = "sha256-/ORtS0uc/GN+g3y6N5ftjL4OBSqV6iswLRbfpeNCprU=";
         }
@@ -80,8 +80,7 @@ stdenv.mkDerivation (
     dontStrip = true;
 
     meta = {
-      broken =
-        lib.versionAtLeast ocaml.version "5.04" && !lib.versionAtLeast finalAttrs.version "8.05.00";
+      broken = lib.versionAtLeast ocaml.version "5.4" && !lib.versionAtLeast finalAttrs.version "8.04.00";
       description = "Preprocessor-pretty-printer for OCaml";
       longDescription = ''
         Camlp5 is a preprocessor and pretty-printer for OCaml programs.


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
