### PR TITLE
nixos/mastodon: fix tootctl runtime path

### DIFF
--- a/nixos/modules/services/web-apps/mastodon.nix
+++ b/nixos/modules/services/web-apps/mastodon.nix
@@ -145,9 +145,11 @@ let
     pkgs.writeShellScriptBin "mastodon-tootctl" ''
       set -a
       export RAILS_ROOT="${cfg.package}"
+      export HOME="/var/lib/mastodon"
       source "${envFile}"
       source /var/lib/mastodon/.secrets_env
       ${sourceExtraEnv}
+      cd /var/lib/mastodon
 
       sudo=exec
       if [[ "$USER" != ${cfg.user} ]]; then


### PR DESCRIPTION
Fixing a bug if you run `mastodon-tootctl` outside of "/tmp" or a non-writeable directory for the `mastodon` user

```
[root@piproxy:/tmp]# mastodon-tootctl 
/root is not writable.
Bundler will use `/tmp/bundler20260521-75605-h0lijt75605' as your home directory temporarily.
Commands:
  tootctl accounts SUBCOMMAND ...ARGS                # Manage accounts
  tootctl cache SUBCOMMAND ...ARGS                   # Manage cache
  tootctl canonical_email_blocks SUBCOMMAND ...ARGS  # Manage canonical e-mail blocks
  tootctl domains SUBCOMMAND ...ARGS                 # Manage account domains
  tootctl email_domain_blocks SUBCOMMAND ...ARGS     # Manage e-mail domain blocks
  tootctl emoji SUBCOMMAND ...ARGS                   # Manage custom emoji
  tootctl feeds SUBCOMMAND ...ARGS                   # Manage feeds
  tootctl help [COMMAND]                             # Describe available commands or one specific command
  tootctl ip_blocks SUBCOMMAND ...ARGS               # Manage IP blocks
  tootctl maintenance SUBCOMMAND ...ARGS             # Various maintenance utilities
  tootctl media SUBCOMMAND ...ARGS                   # Manage media files
  tootctl preview_cards SUBCOMMAND ...ARGS           # Manage preview cards
  tootctl search SUBCOMMAND ...ARGS                  # Manage the search engine
  tootctl self-destruct                              # Erase the server from the federation
  tootctl settings SUBCOMMAND ...ARGS                # Manage dynamic settings
  tootctl statuses SUBCOMMAND ...ARGS                # Manage statuses
  tootctl upgrade SUBCOMMAND ...ARGS                 # Various version upgrade utilities
  tootctl version                                    # Show version
```

and
```
[root@piproxy:~]# HOME=/tmp mastodon-tootctl 
/nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/shared_helpers.rb:54:in `chdir': Permission denied @ dir_chdir0 - /root (Errno::EACCES)
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/shared_helpers.rb:54:in `block in chdir'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/shared_helpers.rb:53:in `synchronize'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/shared_helpers.rb:53:in `chdir'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/source/git.rb:428:in `load_gemspec'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/source/path.rb:169:in `block in load_spec_files'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/source/path.rb:168:in `each'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/source/path.rb:168:in `load_spec_files'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/source/git.rb:230:in `load_spec_files'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/source/path.rb:99:in `local_specs'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/source/git.rb:198:in `specs'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/lazy_specification.rb:200:in `materialize'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/lazy_specification.rb:145:in `materialize_for_installation'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/lazy_specification.rb:132:in `materialized_for_installation'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/match_platform.rb:20:in `each'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/match_platform.rb:20:in `filter_map'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/match_platform.rb:20:in `select_best_local_platform_match'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/materialization.rb:27:in `specs'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/materialization.rb:18:in `complete?'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/spec_set.rb:269:in `block in materialize_dependencies'
	from <internal:kernel>:187:in `loop'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/spec_set.rb:255:in `materialize_dependencies'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/spec_set.rb:131:in `materialize'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/definition.rb:653:in `materialize'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/definition.rb:239:in `specs'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/definition.rb:306:in `specs_for'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/runtime.rb:18:in `setup'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler.rb:166:in `setup'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/setup.rb:16:in `block in <top (required)>'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/ui/shell.rb:173:in `with_level'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/ui/shell.rb:119:in `silence'
	from /nix/store/yhccpwdqdavan4fj7xi31aaxpipngdb0-bundler-2.7.2/lib/ruby/gems/3.3.0/gems/bundler-2.7.2/lib/bundler/setup.rb:16:in `<top (required)>'
	from <internal:/nix/store/r1624vply7mjs6lzy5maqn72caykxmbx-ruby-3.3.10/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:139:in `require'
	from <internal:/nix/store/r1624vply7mjs6lzy5maqn72caykxmbx-ruby-3.3.10/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:139:in `require'
	from /nix/store/q56mgy040k7k5vn2ycff32vgbk5c8qyn-mastodon-4.5.9/config/boot.rb:17:in `<top (required)>'
	from /nix/store/q56mgy040k7k5vn2ycff32vgbk5c8qyn-mastodon-4.5.9/bin/tootctl:4:in `require_relative'
	from /nix/store/q56mgy040k7k5vn2ycff32vgbk5c8qyn-mastodon-4.5.9/bin/tootctl:4:in `<main>'

[root@piproxy:~]# 
```
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
