### PR TITLE
nixos/bind: add `domains` option for declarative DNS zone generation

### DIFF
--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -5,7 +5,6 @@
   ...
 }:
 let
-
   cfg = config.services.bind;
 
   bindPkg = config.services.bind.package;
@@ -160,16 +159,334 @@ let
       ) (lib.attrValues cfg.zones)}
     '';
   };
+
+  ## BEGIN Functions (Kept exactly as your original logic)
+  # Usage example
+  # gen_v4_records {Proteus-Desktop = [{ipv4 = "100.89.227.22";} {ipv4 = "10.0.0.3";}]; Proteus-NUC = [{ipv4 = "100.64.161.20"; } {ipv4 = "10.0.0.2";}];}
+  # => ''
+  # Proteus-Desktop IN A 100.89.227.22
+  # Proteus-Desktop IN A 10.0.0.3
+  # Proteus-NUC IN A 100.64.161.20
+  # Proteus-NUC IN A 10.0.0.2
+  # ''
+  gen_v4_records = lib.foldlAttrs (
+    acc_1: hostname: ifaces:
+    (lib.concatStrings [
+      (lib.optionalString (acc_1 != "") "${acc_1}\n") # Prepend if not first loop
+      (lib.foldl (
+        acc_2: iface:
+        (lib.concatStrings [
+          (lib.optionalString (acc_2 != "") "${acc_2}\n")
+          (lib.optionalString (iface.ipv4 != null) "${hostname} IN A ${iface.ipv4}")
+        ])
+      ) "" ifaces)
+    ])
+  ) "";
+  gen_v6_records = lib.foldlAttrs (
+    acc_1: hostname: ifaces:
+    (lib.concatStrings [
+      (lib.optionalString (acc_1 != "") "${acc_1}\n") # Prepend if not first loop
+      (lib.foldl (
+        acc_2: iface:
+        (lib.concatStrings [
+          (lib.optionalString (acc_2 != "") "${acc_2}\n")
+          (lib.optionalString (iface.ipv6 != null) "${hostname} IN AAAA ${iface.ipv6}")
+        ])
+      ) "" ifaces)
+    ])
+  ) "";
+
+  # gen_subdomain_records {Proteus-Desktop = [{ipv4 = "100.89.227.22"; ipv6 = "fd7a:115c:a1e0::1a01:e318"; domains.CNAME = ["garage"];} {ipv4 = "10.0.0.3"; ipv6 = "fdfe:dcba:9877::3";}]; Proteus-NUC = [{ipv4 = "100.64.161.20"; ipv6 = "fd7a:115c:a1e0::cd3a:a114"; domains = {A = ["@" "ns1" "v4"]; AAAA = ["@" "ns1" "v6"]; CNAME = ["aria2"];};} {ipv4 = "10.0.0.2"; ipv6 = "fdfe:dcba:9877::2"; domains = {A = ["ns1" "v4"]; AAAA = ["ns1" "v6"];};}];};
+  # => ''
+  # garage IN CNAME Proteus-Desktop
+  # @ IN A 100.64.161.20
+  # ns1 IN A 100.64.161.20
+  # v4 IN A 100.64.161.20
+  # @ IN AAAA fd7a:115c:a1e0::cd3a:a114
+  # ns1 IN AAAA fd7a:115c:a1e0::cd3a:a114
+  # v6 IN AAAA fd7a:115c:a1e0::cd3a:a114
+  # aria2 IN CNAME Proteus-NUC
+  # ns1 IN A 10.0.0.2
+  # v4 IN A 10.0.0.2
+  # ns1 IN AAAA fdfe:dcba:9877::2
+  # v6 IN AAAA fdfe:dcba:9877::2
+  # ''
+  gen_subdomain_records =
+    hosts_cfg:
+    lib.concatLines (
+      lib.foldlAttrs (
+        acc_1: hostname: ifaces:
+        acc_1
+        ++ (lib.foldl (
+          acc_2: iface:
+          (
+            acc_2
+            ++
+              (lib.foldlAttrs (
+                acc_3: type: subs:
+                acc_3
+                ++ (map (
+                  sub:
+                  "${sub} IN ${type} ${
+                    if type == "A" then
+                      iface.ipv4
+                    else if type == "AAAA" then
+                      iface.ipv6
+                    else if type == "CNAME" then
+                      hostname
+                    else
+                      throw "Unsupported record type ${type}"
+                  }"
+                ) subs)
+              ))
+                [ ]
+                iface.domains
+          )
+        ) [ ] ifaces)
+      ) [ ] hosts_cfg
+    );
+
+  # Usage example
+  # gen_reverse_v4_records "example.com" [{v4PrefixLen = 1; v6PrefixLen = 12;} {v4PrefixLen = 3; v6PrefixLen = 16;}] {Proteus-Desktop = [{ipv4 = "100.89.227.22"; ipv6 = "fd7a:115c:a1e0::1a01:e318"; domains.CNAME = ["garage"];} {ipv4 = "10.0.0.3"; ipv6 = "fdfe:dcba:9877::3";}]; Proteus-NUC = [{ipv4 = "100.64.161.20"; ipv6 = "fd7a:115c:a1e0::cd3a:a114"; domains = {A = ["@" "ns1" "v4"]; AAAA = ["@" "ns1" "v6"]; CNAME = ["aria2"];};} {ipv4 = "10.0.0.2"; ipv6 = "fdfe:dcba:9877::2"; domains = {A = ["ns1" "v4"]; AAAA = ["ns1" "v6"]; CNAME = ["git"];};}];}
+  # {
+  #   "0.0.10" = ''
+  #     3 IN PTR Proteus-Desktop.example.com
+  #     2 IN PTR Proteus-NUC.example.com
+  #     2 IN PTR ns1.example.com.
+  #     2 IN PTR v4.example.com.
+  #     2 IN PTR git.example.com.
+  #
+  #   '';
+  #   "100" = ''
+  #   22.227.89 IN PTR Proteus-Desktop.example.com
+  #   22.227.89 IN PTR garage.example.com.
+  #   20.161.64 IN PTR Proteus-NUC.example.com
+  #   20.161.64 IN PTR example.com.
+  #   20.161.64 IN PTR ns1.example.com.
+  #   20.161.64 IN PTR v4.example.com.
+  #   20.161.64 IN PTR aria2.example.com.
+  #
+  #   '';
+  # };
+  gen_reverse_v4_records =
+    domain: nets_cfg: hosts_cfg:
+    lib.zipAttrsWith (_: v: lib.concatLines (builtins.concatLists v)) (
+      lib.imap0 (
+        net_idx: net_cfg:
+        lib.foldlAttrs (
+          acc_0: hostname: ifaces:
+          acc_0
+          // (
+            let
+              iface = builtins.elemAt ifaces net_idx;
+
+              splited_ipv4 = lib.splitString "." iface.ipv4;
+              prefix = builtins.concatStringsSep "." (
+                lib.reverseList (lib.take net_cfg.v4PrefixLen splited_ipv4)
+              );
+              host_octets = builtins.concatStringsSep "." (
+                lib.reverseList (lib.drop net_cfg.v4PrefixLen splited_ipv4)
+              );
+            in
+            lib.optionalAttrs (iface.ipv4 != null) {
+              ${prefix} =
+                # Top merge
+                (lib.optionals (acc_0 ? ${prefix}) acc_0.${prefix})
+                ++ [ "${host_octets} IN PTR ${hostname}.${domain}." ]
+                ++ (lib.optionals (iface ? domains) (
+                  lib.foldlAttrs (
+                    acc_1: type: subs:
+                    acc_1
+                    ++ (lib.optionals (type != "AAAA") (
+                      map (
+                        sub:
+                        lib.optionalString (!lib.hasInfix "*" sub)
+                          "${host_octets} IN PTR ${if sub != "@" then "${sub}.${domain}." else "${domain}."}"
+                      ) subs
+                    ))
+                  ) [ ] iface.domains
+                ));
+            }
+          )
+        ) { } hosts_cfg
+      ) nets_cfg
+    );
+
+  gen_reverse_v6_records =
+    domain: nets_cfg: hosts_cfg:
+    lib.zipAttrsWith (_: v: lib.concatLines (builtins.concatLists v)) (
+      lib.imap0 (
+        net_idx: net_cfg:
+        lib.foldlAttrs (
+          acc_0: hostname: ifaces:
+          acc_0
+          // (
+            let
+              iface = builtins.elemAt ifaces net_idx;
+
+              # IPv6 Reverse Logic (Zero-Compression Expansion)
+              # 1. Split by "::" to handle zero-compression
+              # e.g., "fd7a:115c:a1e0::cd3a:a114" -> ["fd7a:115c:a1e0" "cd3a:a114"]
+              split_double_colon = lib.splitString "::" iface.ipv6;
+
+              # 2. Split the IP into a list, and pad add segments to 4 characters
+              # e.g., Left part: ["fd7a" "115c" "a1e0"], right part: ["cd3a" "a114"]
+              # Helper: Pad a string to 4 characters with leading zeros
+              pad_hex =
+                s:
+                let
+                  len = builtins.stringLength s;
+                in
+                if len == 0 then
+                  "0000"
+                else if len == 1 then
+                  "000${s}"
+                else if len == 2 then
+                  "00${s}"
+                else if len == 3 then
+                  "0${s}"
+                else
+                  s;
+              left_padded = map pad_hex (lib.splitString ":" (builtins.head split_double_colon));
+              right_padded = map pad_hex (lib.splitString ":" (lib.last split_double_colon));
+
+              # 3. Calculate and generate missing zero segments (IPv6 has 8 total segments)
+              # e.g., Missing count is `8 - (3 + 2) = 3`, so the missing_segments is: ["0000" "0000" "0000"]
+              miss_segs = builtins.genList (_: "0000") (
+                8 - (builtins.length left_padded + builtins.length right_padded)
+              );
+
+              # 4. Construct the full 32-character string, iterate and break it to chars list, them reverse it
+              # e.g., ["fd7a" "115c" "a1e0" "0000" "0000" "0000" "cd3a" "a114"]
+              # -> ["f" "d" "7" "a" "1" "1" "5" "c" "a" "1" "e" "0" "0" "0" "0" "0" "0" "0" "0" "0" "0" "0" "0" "0" "c" "d" "3" "a" "a" "1" "1" "4"]
+              # -> ["4" "1" "1" "a" "a" "3" "d" "c" "0" "0" "0" "0" "0" "0" "0" "0" "0" "0" "0" "0" "0" "e" "1" "a" "c" "5" "1" "1" "a" "7" "d" "f"]
+              formated_ipv6 = lib.reverseList (
+                lib.concatMap lib.stringToCharacters (left_padded ++ miss_segs ++ right_padded)
+              );
+
+              # For a /48 prefix. the PTR length is `32 - 48 / 4 = 20` hexes, and the prefix length is 12 hexes
+              # ["4" "1" "1" "a" "a" "3" "d" "c" "0" "0" "0" "0" "0" "0" "0" "0" "0" "0" "0" "0" "0" "e" "1" "a" "c" "5" "1" "1" "a" "7" "d" "f"]
+              # -> ["4" "1" "1" "a" "a" "3" "d" "c" "0" "0" "0" "0" "0" "0" "0" "0" "0" "0" "0" "0"]
+              # -> "4.1.1.a.a.3.d.c.0.0.0.0.0.0.0.0.0.0.0.0"
+              host_hexes = builtins.concatStringsSep "." (lib.take (32 - net_cfg.v6PrefixLen) formated_ipv6);
+              prefix = builtins.concatStringsSep "." (lib.drop (32 - net_cfg.v6PrefixLen) formated_ipv6);
+            in
+            lib.optionalAttrs (iface.ipv6 != null) {
+              ${prefix} =
+                (lib.optionals (acc_0 ? ${prefix}) acc_0.${prefix})
+                ++ [ "${host_hexes} IN PTR ${hostname}.${domain}." ]
+                ++ (lib.optionals (iface ? domains) (
+                  lib.foldlAttrs (
+                    acc_1: type: subs:
+                    acc_1
+                    ++ (lib.optionals (type != "A") (
+                      map (
+                        sub:
+                        lib.optionalString (!lib.hasInfix "*" sub)
+                          "${host_hexes} IN PTR ${if sub != "@" then "${sub}.${domain}." else "${domain}."}"
+                      ) subs
+                    ))
+                  ) [ ] iface.domains
+                ));
+            }
+          )
+        ) { } hosts_cfg
+      ) nets_cfg
+    );
+
+  # Compute Dynamic State based on options
+  gen_zone_head =
+    _cfg: domain: with _cfg.soa; ''
+      $ORIGIN ${domain}.
+      $TTL ${minimal_ttl}
+      @ IN SOA ${mName}. ${
+        lib.replaceString "@" "." rName
+      }. (${serial} ${refresh} ${retry} ${expire} ${minimal_ttl})
+      ; Nameserver definitions
+      @ IN NS ${mName}.
+    '';
+  ## END Functions
+
+  # Generate zones dynamically based on the networks defined in the options
+  processed_domains = lib.mapAttrs (
+    domain: _cfg:
+    let
+      partial_zone_head = gen_zone_head _cfg;
+      main_zone = pkgs.writeText "${_cfg.domain}.zone" (
+        partial_zone_head _cfg.domain
+        + ''
+          ; Grouped Host Records
+          ${lib.concatStringsSep "\n" (
+            map (net_cfg: ''
+              ${gen_v4_records _cfg.hosts}
+              ${gen_v6_records _cfg.hosts}
+            '') _cfg.networks
+          )}
+          ; Subdomain Services
+          ${gen_subdomain_records _cfg.hosts}
+        ''
+      );
+      # Generate reverse zones dynamically for all configured networks
+      reverse_v4_zones = lib.mapAttrs' (
+        prefix: records:
+        lib.nameValuePair "${prefix}.in-addr.arpa" (
+          pkgs.writeText "${prefix}.in-addr.arpa.zone" ''
+            ${partial_zone_head "${prefix}.in-addr.arpa"}
+            ; PTR Records
+            ${records}
+          ''
+        )
+      ) (gen_reverse_v4_records _cfg.domain _cfg.networks _cfg.hosts);
+      reverse_v6_zones = lib.mapAttrs' (
+        prefix: records:
+        lib.nameValuePair "${prefix}.ip6.arpa" (
+          pkgs.writeText "${prefix}.ip6.arpa.zone" ''
+            ${partial_zone_head "${prefix}.ip6.arpa"}
+            ; PTR Records
+            ${records}
+          ''
+        )
+      ) (gen_reverse_v6_records _cfg.domain _cfg.networks _cfg.hosts);
+    in
+    {
+      zones = {
+        ${_cfg.domain} = _cfg.bindZoneOptions // {
+          name = _cfg.domain;
+          file = if _cfg.mutable then main_zone.name else main_zone;
+        };
+      }
+      // (builtins.mapAttrs (
+        name: zone_file:
+        _cfg.bindZoneOptions
+        // {
+          inherit name;
+          file = if _cfg.mutable then zone_file.name else zone_file;
+        }
+      ) reverse_v4_zones)
+      // (builtins.mapAttrs (
+        name: zone_file:
+        _cfg.bindZoneOptions
+        // {
+          inherit name;
+          file = if _cfg.mutable then zone_file.name else zone_file;
+        }
+      ) reverse_v6_zones);
+
+      # Collect all the derivation files that need to be copied if mutable = true
+      inherit (_cfg) mutable;
+      zone_files = [
+        main_zone
+      ]
+      ++ (builtins.attrValues reverse_v4_zones)
+      ++ (builtins.attrValues reverse_v6_zones);
+    }
+  ) cfg.domains;
 in
-
 {
-
   ###### interface
 
   options = {
-
     services.bind = {
-
       enable = lib.mkEnableOption "BIND domain name server";
 
       package = lib.mkPackageOption pkgs "bind" { };
@@ -326,21 +643,249 @@ in
 
       checkConfig = lib.mkOption {
         type = lib.types.bool;
-        default = true;
+        default = lib.any (domain: !domain.mutable) (builtins.attrValues cfg.domains);
         description = ''
           Check configuration.
 
           The configuration will not be checked if you override the config file
-          with `configFile`.
+          with `configFile`. Or you have any mutable domains under `domains.<name>`
         '';
       };
+      domains = lib.mkOption {
+        type = lib.types.attrsOf (
+          lib.types.submodule (
+            { name, config, ... }:
+            {
+              options = {
+                mutable = lib.mkEnableOption ''
+                  Mutable zone files, copying them to the `services.bind.directory` during preStart to allow for dynamic DNS
+                  (DDNS) updates at runtime
+                '';
+                bindZoneOptions = lib.mkOption { type = lib.types.submodule bindZoneOptions; };
+                soa = {
+                  mName = lib.mkOption {
+                    type = lib.types.str;
+                    default = "ns1.${config.domain}";
+                    description = "The primary nameserver (MNAME) to be used in the zone's SOA record.";
+                  };
+                  rName = lib.mkOption {
+                    type = lib.types.str;
+                    default = "admin@${config.domain}";
+                    description = ''
+                      The administrator's email address (RNAME) for the zone's SOA record. The '@' symbol will be
+                      automatically replaced with a dot.
+                    '';
+                  };
+                  serial = lib.mkOption {
+                    type = lib.types.str;
+                    default = "1970010100";
+                    description = ''
+                      The serial number of the zone, used by secondary servers to detect when the zone has been updated. Often
+                      formatted as YYYYMMDDNN (e.g., 1970010100).
+                    '';
+                  };
+                  refresh = lib.mkOption {
+                    type = lib.types.str;
+                    default = "1h";
+                    description = ''
+                      The time interval before the zone should be refreshed by secondary nameservers (e.g., '3h' for 3 hours,
+                      or '10800' for seconds).
+                    '';
+                  };
+                  retry = lib.mkOption {
+                    type = lib.types.str;
+                    default = "15m";
+                    description = ''
+                      The time interval that should elapse before a failed refresh should be retried by secondary nameservers
+                      (e.g., '15m' or '900').
+                    '';
+                  };
+                  expire = lib.mkOption {
+                    type = lib.types.str;
+                    default = "1w";
+                    description = ''
+                      The upper limit on the time interval that can elapse before the zone is no longer authoritative on
+                      secondary servers if the primary is unreachable (e.g., '1w' for 1 week).
+                    '';
+                  };
+                  minimal_ttl = lib.mkOption {
+                    type = lib.types.str;
+                    default = "1d";
+                    description = ''
+                      The minimum TTL (Time to Live) for the zone, which determines how long negative responses (NXDOMAIN) are
+                      cached by resolvers (e.g., '1d' or '86400').
+                    '';
+                  };
+                };
+                domain = lib.mkOption {
+                  type = lib.types.str;
+                  default = name;
+                  description = ''
+                    The apex domain name (e.g., 'example.com'). Defaults to the attribute name of the domain definition.
+                  '';
+                };
+                networks = lib.mkOption {
+                  type = lib.types.listOf (
+                    lib.types.submodule {
+                      options = {
+                        v4PrefixLen = lib.mkOption {
+                          type = lib.types.ints.between 1 3;
+                          default = 24 / 8;
+                          description = ''
+                            The number of octets (not bits) that make up the IPv4 network prefix to split the reverse
+                            in-addr.arpa zones. For example, a value of 3 represents a /24 subnet.
+                          '';
+                        };
+                        v6PrefixLen = lib.mkOption {
+                          type = lib.types.ints.between 1 31;
+                          default = 64 / 4;
+                          description = ''
+                            The number of hexes (not bits) that make up the IPv6 network prefix to split the reverse ip6.arpa
+                            zones. For example, a value of 16 represents a /64 subnet.
+                          '';
+                        };
+                      };
+                    }
+                  );
+                  default = [ ];
+                  description = ''
+                    A list of network configurations used to generate reverse DNS (PTR) zones. The sequence of items here
+                    dictates the expected order of interface definitions in the `hosts` option.
+                  '';
+                };
+                hosts = lib.mkOption {
+                  type = lib.types.attrsOf (
+                    lib.types.listOf (
+                      lib.types.submodule {
+                        options = {
+                          ipv4 = lib.mkOption {
+                            type = with lib.types; nullOr str;
+                            default = null;
+                            description = "The IPv4 address for this host in the corresponding network.";
+                          };
+                          ipv6 = lib.mkOption {
+                            type = with lib.types; nullOr str;
+                            default = null;
+                            description = "The IPv6 address for this host in the corresponding network.";
+                          };
+                          domains = lib.mkOption {
+                            type = lib.types.submodule {
+                              options = {
+                                A = lib.mkOption {
+                                  type = with lib.types; listOf str;
+                                  default = [ ];
+                                  description = "List of subdomains that should resolve to this interface's IPv4 address.";
+                                };
+                                AAAA = lib.mkOption {
+                                  type = with lib.types; listOf str;
+                                  default = [ ];
+                                  description = "List of subdomains that should resolve to this interface's IPv6 address.";
+                                };
+                                CNAME = lib.mkOption {
+                                  type = with lib.types; listOf str;
+                                  default = [ ];
+                                  description = ''
+                                    List of subdomains that should be aliased to this host's hostname via CNAME records.
+                                  '';
+                                };
+                              };
+                            };
+                            default = { };
+                            description = ''
+                              Additional subdomain records (A, AAAA, CNAME) attached to this network interface.
+                            '';
+                          };
+                        };
+                      }
+                    )
+                  );
+                  default = { };
+                  description = ''
+                    An attribute set defining hosts and their per-network config for name resolution. The keys are the
+                    hostnames. The order of interfaces in the list must strictly align with the order defined in
+                    `service.bind.domains.networks`.
+                  '';
+                };
+              };
+            }
+          )
+        );
+        default = { };
+        description = ''
+          Declarative configuration for BIND DNS domains, supporting automatic generation of forward zones, reverse zones,
+          and subdomains based on hosts and network prefixes.
+        '';
+        example = {
+          "example.com" = {
+            networks = [
+              {
+                v4PrefixLen = 10 / 8;
+                v6PrefixLen = 64 / 4;
+              }
+              {
+                v4PrefixLen = 24 / 8;
+                v6PrefixLen = 64 / 4;
+              }
+            ];
+            hosts = {
+              Proteus-Desktop = [
+                {
+                  ipv4 = "100.89.227.22";
+                  ipv6 = "fd7a:115c:a1e0::1a01:e318";
+                  domains.CNAME = [ "garage" ];
+                }
+                {
+                  ipv4 = "10.0.0.3";
+                  ipv6 = "fdfe:dcba:9877::3";
+                }
+              ];
+              Proteus-NUC = [
+                {
+                  ipv4 = "100.64.161.20";
+                  ipv6 = "fd7a:115c:a1e0::cd3a:a114";
+                  domains = {
+                    A = [
+                      "@"
+                      "ns1"
+                      "v4"
+                    ];
+                    AAAA = [
+                      "@"
+                      "ns1"
+                      "v6"
+                    ];
+                    CNAME = [ "aria2" ];
+                  };
+                }
+                {
+                  ipv4 = "10.0.0.2";
+                  ipv6 = "fdfe:dcba:9877::2";
+                  domains = {
+                    A = [
+                      "ns1"
+                      "v4"
+                    ];
+                    AAAA = [
+                      "ns1"
+                      "v6"
+                    ];
+                  };
+                }
+              ];
+            };
+          };
+        };
+      };
     };
-
   };
 
   ###### implementation
 
   config = lib.mkIf cfg.enable {
+    services.bind.zones = lib.foldlAttrs (
+      acc: _: pcsd_domain:
+      acc // pcsd_domain.zones
+    ) { } processed_domains;
 
     networking.resolvconf.useLocalResolver = lib.mkDefault true;
 
@@ -365,11 +910,24 @@ in
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
 
-      preStart = ''
-        if ! [ -f ${bindRndcKeyFile} ]; then
-          ${lib.getExe' bindPkg "rndc-confgen"} -c ${bindRndcKeyFile} -a -A ${bindRndcMacType} 2>/dev/null
-        fi
-      '';
+      preStart =
+        let
+          # Filter out only the mutable domains
+          mutable_domains = lib.filterAttrs (_: pcsd_domain: pcsd_domain.mutable) processed_domains;
+          # Generate the install commands for all files (main + reverse) for each mutable domain
+          installScripts = lib.mapAttrsToList (
+            _: pcsd_domain:
+            lib.concatMapStringsSep "\n" (
+              file: "install -m 0644 ${file} ${config.services.bind.directory}/${file.name}"
+            ) pcsd_domain.zone_files
+          ) mutable_domains;
+        in
+        ''
+          if ! [ -f ${bindRndcKeyFile} ]; then
+            ${lib.getExe' bindPkg "rndc-confgen"} -c ${bindRndcKeyFile} -a -A ${bindRndcMacType} 2>/dev/null
+          fi
+        ''
+        + (lib.optionalString (mutable_domains != { }) (lib.concatLines installScripts));
 
       serviceConfig = {
         Type = "forking"; # Set type to forking, see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=900788

--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -664,7 +664,12 @@ in
                   Mutable zone files, copying them to the `services.bind.directory` during preStart to allow for dynamic DNS
                   (DDNS) updates at runtime
                 '';
-                bindZoneOptions = lib.mkOption { type = lib.types.submodule bindZoneOptions; };
+                bindZoneOptions = lib.mkOption {
+                  type = lib.types.submodule bindZoneOptions;
+                  description = ''
+                    List of zones we claim authority over.
+                  '';
+                };
                 soa = {
                   mName = lib.mkOption {
                     type = lib.types.str;

--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -160,7 +160,7 @@ let
     '';
   };
 
-  ## BEGIN Functions (Kept exactly as your original logic)
+  ## BEGIN Functions
   # Usage example
   # gen_v4_records {Proteus-Desktop = [{ipv4 = "100.89.227.22";} {ipv4 = "10.0.0.3";}]; Proteus-NUC = [{ipv4 = "100.64.161.20"; } {ipv4 = "10.0.0.2";}];}
   # => ''
@@ -644,6 +644,9 @@ in
       checkConfig = lib.mkOption {
         type = lib.types.bool;
         default = lib.any (domain: !domain.mutable) (builtins.attrValues cfg.domains);
+        defaultText = lib.literalExpression ''
+          lib.any (domain: !domain.mutable) (builtins.attrValues config.services.bind.domains)
+        '';
         description = ''
           Check configuration.
 

--- a/nixos/tests/bind.nix
+++ b/nixos/tests/bind.nix
@@ -1,51 +1,129 @@
-{
-  config,
-  lib,
-  pkgs,
-  ...
-}:
+{ lib, ... }:
 let
-  zones = lib.singleton {
-    name = ".";
-    master = true;
-    file = pkgs.writeText "root.zone" ''
-      $TTL 3600
-      . IN SOA ns.example.org. admin.example.org. ( 1 3h 1h 1w 1d )
-      . IN NS ns.example.org.
+  shared_cfg =
+    { pkgs, ... }:
+    {
+      environment.systemPackages = [ pkgs.dnsutils ];
 
-      ns.example.org. IN A    192.168.0.1
-      ns.example.org. IN AAAA abcd::1
+      services.bind = {
+        enable = true;
+        extraOptions = "empty-zones-enable no;";
 
-      1.0.168.192.in-addr.arpa IN PTR ns.example.org.
-    '';
-  };
+        zones = lib.singleton {
+          name = ".";
+          master = true;
+          file = pkgs.writeText "root.zone" ''
+            $TTL 3600
+            . IN SOA ns.example.org. admin.example.org. ( 1 3h 1h 1w 1d )
+            . IN NS ns.example.org.
+
+            ns.example.org. IN A    192.168.0.1
+            ns.example.org. IN AAAA abcd::1
+
+            1.0.168.192.in-addr.arpa IN PTR ns.example.org.
+          '';
+        };
+      };
+    };
 in
 {
   name = "bind";
 
-  nodes = {
-    machine = {
-      services.bind = {
-        enable = true;
+  nodes =
+    let
+      domains."example.com" = {
+        bindZoneOptions.master = true;
+        networks = [
+          {
+            v4PrefixLen = 10 / 8;
+            v6PrefixLen = 48 / 4;
+          }
+          {
+            v4PrefixLen = 24 / 8;
+            v6PrefixLen = 64 / 4;
+          }
+        ];
+        hosts = {
+          Host-0 = [
+            {
+              ipv4 = "100.89.227.22";
+              ipv6 = "fd7a:115c:a1e0::1a01:e318";
+              domains.CNAME = [ "s3" ];
+            }
+            {
+              ipv4 = "10.0.0.3";
+              ipv6 = "fdfe:dcba:9877::3";
+            }
+          ];
+          Host-1 = [
+            {
+              ipv4 = "100.64.161.20";
+              ipv6 = "fd7a:115c:a1e0::cd3a:a114";
+              domains = {
+                A = [
+                  "@"
+                  "ns1"
+                  "v4"
+                ];
+                AAAA = [
+                  "@"
+                  "ns1"
+                  "v6"
+                ];
+                CNAME = [ "aria2" ];
+              };
+            }
+            {
+              ipv4 = "10.0.0.2";
+              ipv6 = "fdfe:dcba:9877::2";
+              domains = {
+                A = [
+                  "ns1"
+                  "v4"
+                ];
+                AAAA = [
+                  "ns1"
+                  "v6"
+                ];
+              };
+            }
+          ];
+          # IPv4-only host
+          Host-v4-only = [
+            { ipv4 = "100.10.20.30"; }
+            { ipv4 = "10.0.0.4"; }
+          ];
+          # IPv6-only host
+          Host-v6-only = [
+            { ipv6 = "fd7a:115c:a1e0::1000"; }
+            { ipv6 = "fdfe:dcba:9877::4"; }
+          ];
+        };
+      };
+    in
+    {
+      machine = {
+        imports = [ shared_cfg ];
+      };
+      machineNonDefaultPort = {
+        imports = [ shared_cfg ];
+        services.bind.listenOnPort = 9053;
+      };
 
-        extraOptions = "empty-zones-enable no;";
-        inherit zones;
+      machineDynamicZoneGen = {
+        imports = [ shared_cfg ];
+        services.bind = { inherit domains; };
+      };
+
+      machineDynamicZoneGenMutable = {
+        imports = [ shared_cfg ];
+        services.bind.domains = lib.recursiveUpdate domains { "example.com".mutable = true; };
       };
     };
-
-    machineNonDefaultPort = {
-      services.bind = {
-        enable = true;
-
-        extraOptions = "empty-zones-enable no;";
-        inherit zones;
-
-        listenOnPort = 9053;
-      };
-    };
-  };
 
   testScript = ''
+    start_all()
+
     with subtest("Bind starts and responds"):
       machine.wait_for_unit("bind.service")
       machine.succeed("host 192.168.0.1 127.0.0.1 | grep -qF ns.example.org")
@@ -53,5 +131,100 @@ in
     with subtest("Bind starts and responds on nondefault port"):
       machineNonDefaultPort.wait_for_unit("bind.service")
       machineNonDefaultPort.succeed("host -p 9053 192.168.0.1 127.0.0.1 | grep -qF ns.example.org")
+
+    def run_dns_tests(node):
+        node.wait_for_unit("bind.service")
+        node.wait_for_open_port(53)
+
+        with subtest(f"[{node.name}] Test Primary Forward Records (Dual Stack)"):
+            # Test IPv4
+            host_0 = node.succeed("dig +short @127.0.0.1 Host-0.example.com A")
+            assert "100.89.227.22" in host_0, "Missing first A record for Host-0"
+            assert "10.0.0.3" in host_0, "Missing second A record for Host-0"
+            # Test IPv6
+            host_1 = node.succeed("dig +short @127.0.0.1 Host-1.example.com AAAA")
+            assert "fd7a:115c:a1e0::cd3a:a114" in host_1, "Missing first AAAA record for Host-1"
+            assert "fdfe:dcba:9877::2" in host_1, "Missing second AAAA record for Host-1"
+
+        with subtest(f"[{node.name}] Test Dual-Stack Forward Records (v4-only / v6-only)"):
+            # Test IPv4-only record
+            v4_only_rec_a = node.succeed("dig +short @127.0.0.1 v4.example.com A")
+            assert "100.64.161.20" in v4_only_rec_a, "Missing first v4-only A record for Host-1"
+            assert "10.0.0.2" in v4_only_rec_a, "Missing second v4-only A record for Host-1"
+
+            v4_only_rec_aaaa = node.succeed("dig +short @127.0.0.1 v4.example.com AAAA")
+            assert v4_only_rec_aaaa.strip() == "", f"Expected NO AAAA records for v4.example.com, got: {v4_only_rec_aaaa}"
+
+            # Test IPv6-only record
+            v6_only_rec_aaaa = node.succeed("dig +short @127.0.0.1 v6.example.com AAAA")
+            assert "fd7a:115c:a1e0::cd3a:a114" in v6_only_rec_aaaa, "Missing first v6-only AAAA record for Host-1"
+            assert "fdfe:dcba:9877::2" in v6_only_rec_aaaa, "Missing second second v6-only AAAA record for Host-1"
+
+            v6_only_rec_a = node.succeed("dig +short @127.0.0.1 v6.example.com A")
+            assert v6_only_rec_a.strip() == "", f"Expected NO A records for v6.example.com, got: {v6_only_rec_a}"
+
+        with subtest(f"[{node.name}] Test Single-Stack Forward Records (v4-only / v6-only)"):
+            # Test IPv4-only host
+            v4_only_a = node.succeed("dig +short @127.0.0.1 Host-v4-only.example.com A")
+            assert "100.10.20.30" in v4_only_a, "Missing A record for Host-v4-only"
+            assert "10.0.0.4" in v4_only_a, "Missing second A record for Host-v4-only"
+
+            v4_only_aaaa = node.succeed("dig +short @127.0.0.1 Host-v4-only.example.com AAAA")
+            assert v4_only_aaaa.strip() == "", f"Expected NO AAAA records for Host-v4-only, got: {v4_only_aaaa}"
+
+            # Test IPv6-only host
+            v6_only_aaaa = node.succeed("dig +short @127.0.0.1 Host-v6-only.example.com AAAA")
+            assert "fd7a:115c:a1e0::1000" in v6_only_aaaa, "Missing AAAA record for Host-v6-only"
+            assert "fdfe:dcba:9877::4" in v6_only_aaaa, "Missing second AAAA record for Host-v6-only"
+
+            v6_only_a = node.succeed("dig +short @127.0.0.1 Host-v6-only.example.com A")
+            assert v6_only_a.strip() == "", f"Expected NO A records for Host-v6-only, got: {v6_only_a}"
+
+        with subtest(f"[{node.name}] Test Subdomains (CNAME / @ / custom labels)"):
+            # CNAME for s3
+            s3_cname = node.succeed("dig +short @127.0.0.1 s3.example.com CNAME")
+            assert "Host-0.example.com." in s3_cname, "s3 CNAME did not resolve to Host-0"
+
+            # CNAME for aria2
+            aria2_cname = node.succeed("dig +short @127.0.0.1 aria2.example.com CNAME")
+            assert "Host-1.example.com." in aria2_cname, "aria2 CNAME did not resolve to Host-1"
+
+            # The '@' domain resolution (example.com root) mapped to Proteus-NUC
+            example_a = node.succeed("dig +short @127.0.0.1 example.com A")
+            assert "100.64.161.20" in example_a, "@ resolution failed for example.com"
+
+            # The 'ns1' subdomain mapped to Proteus-NUC's A records
+            ns1_a = node.succeed("dig +short @127.0.0.1 ns1.example.com A")
+            assert "10.0.0.2" in ns1_a, "ns1 resolution failed"
+
+        with subtest(f"[{node.name}] Test Reverse Lookups (IPv4 PTR)"):
+            # Network 1: 100.x.x.x
+            ptr_v4_net_1 = node.succeed("dig +short @127.0.0.1 -x 100.89.227.22")
+            assert "Host-0.example.com." in ptr_v4_net_1, "PTR failed for 100.89.227.22"
+
+            # Network 2: 10.0.0.x
+            ptr_v4_net_2 = node.succeed("dig +short @127.0.0.1 -x 10.0.0.2")
+            assert "Host-1.example.com." in ptr_v4_net_2, "PTR failed for 10.0.0.2"
+
+            # IPv4-only host
+            ptr_v4_only = node.succeed("dig +short @127.0.0.1 -x 100.10.20.30")
+            assert "Host-v4-only.example.com." in ptr_v4_only, "PTR failed for 100.10.20.30"
+
+        with subtest(f"[{node.name}] Test Reverse Lookups (IPv6 PTR)"):
+            # Network 1: fd7a:115c:a1e0::
+            ptr_v6_net_1 = node.succeed("dig +short @127.0.0.1 -x fd7a:115c:a1e0::1a01:e318")
+            assert "Host-0.example.com." in ptr_v6_net_1, "IPv6 PTR failed for Host-0"
+
+            # Network 2: fdfe:dcba:9877::
+            ptr_v6_net_2 = node.succeed("dig +short @127.0.0.1 -x fdfe:dcba:9877::2")
+            assert "Host-1.example.com." in ptr_v6_net_2, "IPv6 PTR failed for Host-1"
+
+            # IPv6-only host
+            ptr_v6_only = node.succeed("dig +short @127.0.0.1 -x fd7a:115c:a1e0::1000")
+            assert "Host-v6-only.example.com." in ptr_v6_only, "IPv6 PTR failed for Host-v6-only"
+
+    # Execute tests against both standalone VMs
+    run_dns_tests(machineDynamicZoneGen)
+    run_dns_tests(machineDynamicZoneGenMutable)
   '';
 }

--- a/nixos/tests/bind.nix
+++ b/nixos/tests/bind.nix
@@ -122,8 +122,6 @@ in
     };
 
   testScript = ''
-    start_all()
-
     with subtest("Bind starts and responds"):
       machine.wait_for_unit("bind.service")
       machine.succeed("host 192.168.0.1 127.0.0.1 | grep -qF ns.example.org")
@@ -132,7 +130,7 @@ in
       machineNonDefaultPort.wait_for_unit("bind.service")
       machineNonDefaultPort.succeed("host -p 9053 192.168.0.1 127.0.0.1 | grep -qF ns.example.org")
 
-    def run_dns_tests(node):
+    def run_dyn_zone_gen_tests(node):
         node.wait_for_unit("bind.service")
         node.wait_for_open_port(53)
 
@@ -224,7 +222,7 @@ in
             assert "Host-v6-only.example.com." in ptr_v6_only, "IPv6 PTR failed for Host-v6-only"
 
     # Execute tests against both standalone VMs
-    run_dns_tests(machineDynamicZoneGen)
-    run_dns_tests(machineDynamicZoneGenMutable)
+    run_dyn_zone_gen_tests(machineDynamicZoneGen)
+    run_dyn_zone_gen_tests(machineDynamicZoneGenMutable)
   '';
 }


### PR DESCRIPTION
Introduces `services.bind.domains`, a structured interface for configuring BIND zones without authoring raw zone files. Given host-to-address mappings and network prefix definitions, the module auto-generates:

- Forward zones (A and AAAA records per host)
- Subdomain records (A, AAAA, CNAME, and @ apex)
- Reverse zones (in-addr.arpa for IPv4, ip6.arpa for IPv6)
- SOA records with configurable mName, rName, serial, and TTL fields

The per-domain `mutable` flag enables DDNS & DNSSEC: generated zone files are installed to `services.bind.directory` at preStart so named can update or sign them at runtime. `checkConfig` is automatically disabled if any domain has `mutable = true`.

Computed zones are merged into `services.bind.zones`, so the existing interface remains fully usable alongside the new one.

Extends `nixos/tests/bind.nix` with a shared config module and a `run_dns_tests` helper covering dual-stack hosts, single-stack (v4-only and v6-only) hosts, CNAME and apex (@) subdomain records, IPv4 PTR lookups, and IPv6 PTR lookups -- exercised against both immutable and mutable zone generation modes.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
