### PR TITLE
pnpm: convert to alias

### DIFF
--- a/pkgs/build-support/node/fetch-pnpm-deps/default.nix
+++ b/pkgs/build-support/node/fetch-pnpm-deps/default.nix
@@ -6,15 +6,13 @@
   moreutils,
   cacert,
   makeSetupHook,
-  pnpm,
+  pnpm_11,
   pnpm-fixup-state-db,
   writableTmpDirAsHomeHook,
   yq,
   zstd,
 }:
 let
-  pnpmLatest = pnpm;
-
   supportedFetcherVersions = [
     1 # First version. Here to preserve backwards compatibility
     2 # Ensure consistent permissions. See https://github.com/NixOS/nixpkgs/pull/422975
@@ -26,7 +24,7 @@ in
     {
       hash ? "",
       pname,
-      pnpm ? pnpmLatest,
+      pnpm ? pnpm_11,
       pnpmWorkspaces ? [ ],
       prePnpmInstall ? "",
       pnpmInstallFlags ? [ ],

--- a/pkgs/by-name/pn/pnpm-fixup-state-db/package.nix
+++ b/pkgs/by-name/pn/pnpm-fixup-state-db/package.nix
@@ -2,7 +2,7 @@
   buildNpmPackage,
   lib,
   nodejs,
-  pnpm,
+  pnpm_11,
   tests,
 }:
 buildNpmPackage {
@@ -21,7 +21,7 @@ buildNpmPackage {
   '';
 
   passthru.tests = {
-    inherit (tests) pnpm;
+    inherit (tests) pnpm_11;
   };
 
   __structuredAttrs = true;
@@ -29,6 +29,6 @@ buildNpmPackage {
   meta = {
     license = lib.licenses.mit;
     mainProgram = "pnpm-fixup-state-db";
-    inherit (pnpm.meta) maintainers;
+    inherit (pnpm_11.meta) maintainers;
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1723,6 +1723,7 @@ mapAliases {
   pltScheme = throw "'pltScheme' has been renamed to/replaced by 'racket'"; # Converted to throw 2025-10-27
   plv8 = throw "'plv8' has been removed. Use 'postgresqlPackages.plv8' instead."; # Added 2025-07-19
   pn = throw "'pn' has been removed as upstream was archived in 2020"; # Added 2025-10-17
+  pnpm = pnpm_11; # Added 2026-05-21
   poac = throw "'poac' has been renamed to/replaced by 'cabinpkg'"; # Converted to throw 2025-10-27
   pocket-updater-utility = throw "'pocket-updater-utility' has been renamed to/replaced by 'pupdate'"; # Converted to throw 2025-10-27
   podofo010 = throw "'podofo010' has been renamed to/replaced by 'podofo_0_10'"; # Converted to throw 2025-10-27

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3119,7 +3119,6 @@ with pkgs;
     pnpm_10
     pnpm_11
     ;
-  pnpm = pnpm_11;
 
   inherit (callPackages ../build-support/node/fetch-pnpm-deps { })
     fetchPnpmDeps


### PR DESCRIPTION
This should not be merged before branch off!

To prevent usage of `pnpm` in nixpkgs, convert it to a proper alias.
pnpm updates often break our tooling, which means we have to do treewide
changes for some pnpm version updates. By forcing packages to pin to
a certain pnpm version, we can avoid this issue.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
