### PR TITLE
electron_{40,41,42}: updates

### DIFF
--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -34,14 +34,14 @@
     },
     "41": {
         "hashes": {
-            "aarch64-darwin": "b41988e6aa105e550931d9d2eff15c0bb99c39871c2ff5af87f105c44edc5a7a",
-            "aarch64-linux": "b69fb25275d744e272afe3775aed0cce20c8ad2309744558089c33da92c0432a",
-            "armv7l-linux": "f318e60b182fc791ba90bd7c586ee7e1f603daf90925b64d7c295e8b7a610875",
-            "headers": "1n1w2ngk44w9khbh4bnw6kfakawdxh3wii3hkynbjzj21swvqzrb",
-            "x86_64-darwin": "fc802de570925bf75ca5911ffd8a8736232de2c742430938b2b621c79af93db4",
-            "x86_64-linux": "8f1bbd1ea46c5e4fc5f3ae9a04554de9da2fe0c65fbd8751b8493d2b39bf7a97"
+            "aarch64-darwin": "3de9c5eba1cf79a512058134d65ecff899623375ff1419dff2fe11346a5c45dd",
+            "aarch64-linux": "c8d4294e052bc83b840523237538ae131d8e387243c25e763f0d14fabffa37c2",
+            "armv7l-linux": "45d9df68739b0328db884db8e403f40087ffb1725fefa4185f4898a161623633",
+            "headers": "015x9hjafkimpji1pvkd33yn4v89is2ggv0hvmy16c39f4vfkk7z",
+            "x86_64-darwin": "41f6f769fb555380214588675ad0728fa69aec90166ceb51ebd0f1a08d608cd2",
+            "x86_64-linux": "f3bf38de05ce8fafe1039251ebfaa75fd090b0a13cd861322ccd2f6db4d6bb82"
         },
-        "version": "41.6.1"
+        "version": "41.7.0"
     },
     "42": {
         "hashes": {

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -23,14 +23,14 @@
     },
     "40": {
         "hashes": {
-            "aarch64-darwin": "c3dd4d70aeb214a5b755af59e4e5d7b5b743f3f662a8a452b0afc2741953b7a5",
-            "aarch64-linux": "cb4454ae64f00f43cef86f57d38eff9a6cef7b1e0690debc1dc81323f98e6e63",
-            "armv7l-linux": "d3a99f2f734b407ab7de45dbb992825089a2f9e351c470a5fea0273ec027a681",
-            "headers": "0x534f94ds3qavwh90a4l63wpsagscwnbzi8399z067d2ghyzh18",
-            "x86_64-darwin": "a73b879e5cfa880e0b82e0a75d7a2ba1c892715d2db95dc6578277e74c7b8a04",
-            "x86_64-linux": "35efe7401822e8d2e474e13788a6191362c7494dd1f7ae327b70087e0768a667"
+            "aarch64-darwin": "42d8823af50d8720a3834a816ec32985f37935d412bd39344f4b16d139282568",
+            "aarch64-linux": "90eb3582e74ebebe6330c89506fbb356162d20e57cfe54cc5918759e63253a41",
+            "armv7l-linux": "623d4658b2186350cfae47941d870a1cbe508dd523a8f185ffd6ede479381ce4",
+            "headers": "1rq2wn46l7svsprzhs61h9c26nldacyhhwyawa863kkw68b8r5bd",
+            "x86_64-darwin": "d5b8f5e429a4904c5eeba0607532c8382a89c5da927cade207e54ef31337e783",
+            "x86_64-linux": "f5c140c64719659a1bc530237b5a3580fe031a0157d49ab67ff2192ad551e88e"
         },
-        "version": "40.10.0"
+        "version": "40.10.1"
     },
     "41": {
         "hashes": {

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -45,13 +45,13 @@
     },
     "42": {
         "hashes": {
-            "aarch64-darwin": "98d097299eb08094d0df3312b2d6e8677069d8defdab891143628d4f82f46117",
-            "aarch64-linux": "1e700f7f3daef794cc45235e51c1172664aed49a4e7737b8896ddc398bff4d7d",
-            "armv7l-linux": "576a317dda0dc8ea150d5b6f792c3eb0631a5065ec9c100af954d1cabddde93a",
-            "headers": "0r0g3iaji6a7gx51bv2ijq23zpcz8ip8kmfy0x9fxqpm9angvins",
-            "x86_64-darwin": "63b938cbe6696f67f172d8f7cb6c31a58c38853d03d33f047fcba8c628cc700f",
-            "x86_64-linux": "882047343a9e203c6cfc5d39b166ea9e025dd256943e0d3711f86725ad0e3bd9"
+            "aarch64-darwin": "f45f80da0a2d005530b70f6f6b00756dbf875947a21e533041a05b3c4d629f79",
+            "aarch64-linux": "1f2037dbdcb8b1327b855ec15fbe3fb8a7f27786b331d17866e88377a0606ad8",
+            "armv7l-linux": "00de1cc51859a4e064a2178cb29c899feadfabf24d926d8f684c30e6ab9b72a7",
+            "headers": "193c7vyzly6yln4zr0b7v5vlzixl9wz59lfmgwd86h4fc79kj9na",
+            "x86_64-darwin": "cd6a2d4feca84b7e7b2c4a5a13a443fc3c1173e77b05f798deaab2f0f41002a1",
+            "x86_64-linux": "9caeeb15dada37cb3a2d80bf0f5899d175db026a4def11560890bd2f19684909"
         },
-        "version": "42.1.0"
+        "version": "42.2.0"
     }
 }

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -34,14 +34,14 @@
     },
     "41": {
         "hashes": {
-            "aarch64-darwin": "3de9c5eba1cf79a512058134d65ecff899623375ff1419dff2fe11346a5c45dd",
-            "aarch64-linux": "c8d4294e052bc83b840523237538ae131d8e387243c25e763f0d14fabffa37c2",
-            "armv7l-linux": "45d9df68739b0328db884db8e403f40087ffb1725fefa4185f4898a161623633",
-            "headers": "015x9hjafkimpji1pvkd33yn4v89is2ggv0hvmy16c39f4vfkk7z",
-            "x86_64-darwin": "41f6f769fb555380214588675ad0728fa69aec90166ceb51ebd0f1a08d608cd2",
-            "x86_64-linux": "f3bf38de05ce8fafe1039251ebfaa75fd090b0a13cd861322ccd2f6db4d6bb82"
+            "aarch64-darwin": "a092f0c1aa722037fa07d3256d5bf4aef2833d990bf4d09fe907d588c35b341d",
+            "aarch64-linux": "8a8bc763406ad19954432922347ca7c3c8db130f966871687cfb8b4ddccfa28e",
+            "armv7l-linux": "895ecc3b61321699c24d3554272d116113c5dc2bf72df9b94ade87957cb8c9b3",
+            "headers": "1n1w2ngk44w9khbh4bnw6kfakawdxh3wii3hkynbjzj21swvqzrb",
+            "x86_64-darwin": "4e8ab5beb895c9fe29cd46090034b214e6b404868bf5e0a5f6eb92e5c8633cc4",
+            "x86_64-linux": "0165fc68656f49ad7ae0c4254b1ff3af1718c114b6007a2aeef5211e0562f174"
         },
-        "version": "41.7.0"
+        "version": "41.7.1"
     },
     "42": {
         "hashes": {

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -23,14 +23,14 @@
     },
     "40": {
         "hashes": {
-            "aarch64-darwin": "42d8823af50d8720a3834a816ec32985f37935d412bd39344f4b16d139282568",
-            "aarch64-linux": "90eb3582e74ebebe6330c89506fbb356162d20e57cfe54cc5918759e63253a41",
-            "armv7l-linux": "623d4658b2186350cfae47941d870a1cbe508dd523a8f185ffd6ede479381ce4",
-            "headers": "1rq2wn46l7svsprzhs61h9c26nldacyhhwyawa863kkw68b8r5bd",
-            "x86_64-darwin": "d5b8f5e429a4904c5eeba0607532c8382a89c5da927cade207e54ef31337e783",
-            "x86_64-linux": "f5c140c64719659a1bc530237b5a3580fe031a0157d49ab67ff2192ad551e88e"
+            "aarch64-darwin": "e889b35e399f374f5dca932195287b373c4b43f8bf242e50c35f88a751511a13",
+            "aarch64-linux": "b9725dd7a387960e778b66700836d178528ba2235c6b14135fb57ce4d3826257",
+            "armv7l-linux": "dd3bc8b27e905d7ac1f2d312b795e9f0f7491022aae5719ed5adf8ab4b203ef7",
+            "headers": "0f9c09vk9kn3c7phw3dm8k1iaf8gw3g2s37r3qdycf9akirprpf2",
+            "x86_64-darwin": "5d171014187fb737f34c70b09ea886215e3d88a1b79cb5370a0815c34dd15668",
+            "x86_64-linux": "0246201400600ac089c51a36f15a8045b5db723ba42b864f732a9b4e48731e97"
         },
-        "version": "40.10.1"
+        "version": "40.10.2"
     },
     "41": {
         "hashes": {

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -45,13 +45,13 @@
     },
     "42": {
         "hashes": {
-            "aarch64-darwin": "f45f80da0a2d005530b70f6f6b00756dbf875947a21e533041a05b3c4d629f79",
-            "aarch64-linux": "1f2037dbdcb8b1327b855ec15fbe3fb8a7f27786b331d17866e88377a0606ad8",
-            "armv7l-linux": "00de1cc51859a4e064a2178cb29c899feadfabf24d926d8f684c30e6ab9b72a7",
-            "headers": "193c7vyzly6yln4zr0b7v5vlzixl9wz59lfmgwd86h4fc79kj9na",
-            "x86_64-darwin": "cd6a2d4feca84b7e7b2c4a5a13a443fc3c1173e77b05f798deaab2f0f41002a1",
-            "x86_64-linux": "9caeeb15dada37cb3a2d80bf0f5899d175db026a4def11560890bd2f19684909"
+            "aarch64-darwin": "19f4b0a4fcc3574e79befb53495cca8de02a126210d04363cf76f67099d128ef",
+            "aarch64-linux": "2a375ff973fb7bddc538a4f67b2141947e9d72513a1baa2beabec2a7f65cd0f0",
+            "armv7l-linux": "5d15e602d978d53772ec0c58af4ef02d1ba514dc3d6752ffe79c0ad21804c38c",
+            "headers": "1jh4r2ivgrgwq3bvw3a89lic97xmr9r37y5xfy2sqzqlss6sq2c7",
+            "x86_64-darwin": "92bc6bc82cbfe4c855e9b8c55cf48c32f0448553bb74defe8cc436da9588a73e",
+            "x86_64-linux": "487a667ca6a734b958c16cff1df74d9d44d2c18a6cccdb4dd51f6301a356c420"
         },
-        "version": "42.2.0"
+        "version": "42.3.0"
     }
 }

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -45,13 +45,13 @@
     },
     "42": {
         "hashes": {
-            "aarch64-darwin": "15f47f905b59c37a2c1845595001589a1867e03c627a1880a8d6599e8ff65b21",
-            "aarch64-linux": "81a094306b68190e27fd253958e2047d4786d6a19035d118089100257b1c64f1",
-            "armv7l-linux": "6dad4f6c6ed82445cb10a86f6878dd7cb86ec49e5e48a2837ee1526f209e510b",
-            "headers": "0r0g3iaji6a7gx51bv2ijq23zpcz8ip8kmfy0x9fxqpm9angvins",
-            "x86_64-darwin": "1328a03d7f4f08946984b51dee62e761375bc9c912887965fb2dd900e65b2dfb",
-            "x86_64-linux": "05ffcaa8ae2f71a153217b5ffcd4aad7aed5428a70beb84b02888eb9a4097f6e"
+            "aarch64-darwin": "6c25b7496a0f3f4e325965ac3d934f9460e6b39fc2aa05b2aefecb1e212e7535",
+            "aarch64-linux": "8f6c2462e05491ab7a6ea6492fe7f62c8de1b01900978dd3dcbc878fde6f5e3e",
+            "armv7l-linux": "72cdb458b48306ec4939021198696926651a6a6dd47b8acf4486d77689ffe88f",
+            "headers": "193c7vyzly6yln4zr0b7v5vlzixl9wz59lfmgwd86h4fc79kj9na",
+            "x86_64-darwin": "7ea0a5378a615b816c6652c1e8f62b25fee751f34c669eb3eff122dcde98dffc",
+            "x86_64-linux": "ebe0fb1e5eb8a83a20612d660191d8292826d46d93701fe6390a9a5ab69aede0"
         },
-        "version": "42.1.0"
+        "version": "42.2.0"
     }
 }

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -34,14 +34,14 @@
     },
     "41": {
         "hashes": {
-            "aarch64-darwin": "33852f5e551e18c43e1031492fe62153759fc7968bd14f9cc179673517e10bd0",
-            "aarch64-linux": "2f99b486290989bc4d756ffc0448c93c728e03d519872e492b1cadd5d5905885",
-            "armv7l-linux": "27d03e18b3e3e484ceb7f7f05ace5eda075a5a468223797d4ae988a75424b6d0",
-            "headers": "1n1w2ngk44w9khbh4bnw6kfakawdxh3wii3hkynbjzj21swvqzrb",
-            "x86_64-darwin": "5e47e5ae1d0401b32838a9074fc13d291b09bad0cb61a265ad5388ef9eb8ade7",
-            "x86_64-linux": "9921145c87cb6f279e5baa2c5af8763a4695c84bc5206273dbbb0385b493513c"
+            "aarch64-darwin": "55db5abc88c2420e77f5b57fcb09608ddb5a6cdeaacfa0a517641e3c8c306605",
+            "aarch64-linux": "8d620805836959803a8460952424d5c6e463a5145097b4ddb2e1157da34342e6",
+            "armv7l-linux": "29f06b78139e26f6ebbb7735969d29668734b2e44a4f0e54b749bdcf6baac304",
+            "headers": "015x9hjafkimpji1pvkd33yn4v89is2ggv0hvmy16c39f4vfkk7z",
+            "x86_64-darwin": "cdc45610de036fa981ec2b1726c0d9e41c24cfe30c40fdf6ce8ec062bafc661a",
+            "x86_64-linux": "2a3598718754ff599f6fe3e7490686bb093a9c922a1631725d85b1fc0209b941"
         },
-        "version": "41.6.1"
+        "version": "41.7.0"
     },
     "42": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -23,14 +23,14 @@
     },
     "40": {
         "hashes": {
-            "aarch64-darwin": "ed4e021fe841be3b04c6c4cf3968a1628b9d84ca07b5362aa54c377b3fde18f0",
-            "aarch64-linux": "bfb57aa77b06e2179c5076274f9d61615414c295e16eabd99206a7553c9eacdc",
-            "armv7l-linux": "8f35c8b25f98d18d5d5852d2b244e64183dfb61b10b9a64b0be579f450f2cb73",
-            "headers": "0x534f94ds3qavwh90a4l63wpsagscwnbzi8399z067d2ghyzh18",
-            "x86_64-darwin": "f2caf8c9fe1c5c38259881824adce6b11a5a482576d47d7dc113a950e9315bf8",
-            "x86_64-linux": "303345908d998a83b953c9f60a8b0f07e8fa82ed839260784a7b5c2fc517a86f"
+            "aarch64-darwin": "fc48122b2f8d666f890ba4c4db54b57386b679bf036102cb29245bed18a38298",
+            "aarch64-linux": "f859a1e26fa8d06829e88dc5950ced43c043d6e862945edffa3ee40ef8dd0b7d",
+            "armv7l-linux": "75c06087fc56bb2dbfc9a7f14a0ab403b0b41949c860481b9599edcd29e5a06c",
+            "headers": "1rq2wn46l7svsprzhs61h9c26nldacyhhwyawa863kkw68b8r5bd",
+            "x86_64-darwin": "f54b0fdee2e6d22857fb81b435d1f67faf9151a7ac67561a1048885692314dd9",
+            "x86_64-linux": "f3e373e2211f9f8fc0218199d1d761949c7fb3400bee1f702598878dc9911c0d"
         },
-        "version": "40.10.0"
+        "version": "40.10.1"
     },
     "41": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -45,13 +45,13 @@
     },
     "42": {
         "hashes": {
-            "aarch64-darwin": "6c25b7496a0f3f4e325965ac3d934f9460e6b39fc2aa05b2aefecb1e212e7535",
-            "aarch64-linux": "8f6c2462e05491ab7a6ea6492fe7f62c8de1b01900978dd3dcbc878fde6f5e3e",
-            "armv7l-linux": "72cdb458b48306ec4939021198696926651a6a6dd47b8acf4486d77689ffe88f",
-            "headers": "193c7vyzly6yln4zr0b7v5vlzixl9wz59lfmgwd86h4fc79kj9na",
-            "x86_64-darwin": "7ea0a5378a615b816c6652c1e8f62b25fee751f34c669eb3eff122dcde98dffc",
-            "x86_64-linux": "ebe0fb1e5eb8a83a20612d660191d8292826d46d93701fe6390a9a5ab69aede0"
+            "aarch64-darwin": "caaf3fe945de448b908aec28eb2012eebd091dd7604d586ccba9d8dcde570564",
+            "aarch64-linux": "140bac763a2793c82782eef9c27272027a1aace5b02ad2dda99a1bb342063d35",
+            "armv7l-linux": "e4ddb1ff88404ca0c189a54466924eba6c67e0bd67aeeefe4f894ef09eff7423",
+            "headers": "1jh4r2ivgrgwq3bvw3a89lic97xmr9r37y5xfy2sqzqlss6sq2c7",
+            "x86_64-darwin": "c50daf833921ce7c9c4628d8fb8d9b294394cd4202a3dd4cd3a750dec6656ba9",
+            "x86_64-linux": "3c29fef7bf4873a57318fc25e77bc57bec1758e40ec8c56b4717f8dac2decc71"
         },
-        "version": "42.2.0"
+        "version": "42.3.0"
     }
 }

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -23,14 +23,14 @@
     },
     "40": {
         "hashes": {
-            "aarch64-darwin": "fc48122b2f8d666f890ba4c4db54b57386b679bf036102cb29245bed18a38298",
-            "aarch64-linux": "f859a1e26fa8d06829e88dc5950ced43c043d6e862945edffa3ee40ef8dd0b7d",
-            "armv7l-linux": "75c06087fc56bb2dbfc9a7f14a0ab403b0b41949c860481b9599edcd29e5a06c",
-            "headers": "1rq2wn46l7svsprzhs61h9c26nldacyhhwyawa863kkw68b8r5bd",
-            "x86_64-darwin": "f54b0fdee2e6d22857fb81b435d1f67faf9151a7ac67561a1048885692314dd9",
-            "x86_64-linux": "f3e373e2211f9f8fc0218199d1d761949c7fb3400bee1f702598878dc9911c0d"
+            "aarch64-darwin": "d54eec731e52b9daa25c80f8c5461928a5c8132e3af8f7dc9ecddde3e6da98d6",
+            "aarch64-linux": "f7cba7e899daae46e4dfaf292425dd61a97edfc6820d16d6ea6a600a8e968390",
+            "armv7l-linux": "a987bb7b31ed153ac304bc4dbcbfaa48139b60f3d33888ca1bbedb869dd74564",
+            "headers": "0f9c09vk9kn3c7phw3dm8k1iaf8gw3g2s37r3qdycf9akirprpf2",
+            "x86_64-darwin": "1928d63140157ede242d5111e2a5327abd01f2f9ae23e1a6bf1eb82a53029847",
+            "x86_64-linux": "e1dd0e162e248ca11aeca1485ccae8d813c7c7a6ef2959c42f1f8f486dad3963"
         },
-        "version": "40.10.1"
+        "version": "40.10.2"
     },
     "41": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -34,14 +34,14 @@
     },
     "41": {
         "hashes": {
-            "aarch64-darwin": "55db5abc88c2420e77f5b57fcb09608ddb5a6cdeaacfa0a517641e3c8c306605",
-            "aarch64-linux": "8d620805836959803a8460952424d5c6e463a5145097b4ddb2e1157da34342e6",
-            "armv7l-linux": "29f06b78139e26f6ebbb7735969d29668734b2e44a4f0e54b749bdcf6baac304",
-            "headers": "015x9hjafkimpji1pvkd33yn4v89is2ggv0hvmy16c39f4vfkk7z",
-            "x86_64-darwin": "cdc45610de036fa981ec2b1726c0d9e41c24cfe30c40fdf6ce8ec062bafc661a",
-            "x86_64-linux": "2a3598718754ff599f6fe3e7490686bb093a9c922a1631725d85b1fc0209b941"
+            "aarch64-darwin": "adbc1b646cbd2cb6d9e9b6c71bab2caa7c00b05faaa699585f52decd0e89dfa8",
+            "aarch64-linux": "336f67cce0d702066c9d42fbc1221a2ab136193b85c5ca102dafc4050ebb3a02",
+            "armv7l-linux": "c7d42966f343703353e1b14a37ac7724f3661f6f11095f845149cafbf3e90941",
+            "headers": "1n1w2ngk44w9khbh4bnw6kfakawdxh3wii3hkynbjzj21swvqzrb",
+            "x86_64-darwin": "c01e23366b2e51b2c57669831cb57333cc78d6db94b8be500db3347c5425c0a1",
+            "x86_64-linux": "15abcca021cd649a03aa73c058cdbb3a32bf9cb882191c4930073458de496189"
         },
-        "version": "41.7.0"
+        "version": "41.7.1"
     },
     "42": {
         "hashes": {

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -2796,10 +2796,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-0i3h/60XFgtX3/uJ5wI36o1EU0nKn0HawXBzv8RJuKs=",
+                    "hash": "sha256-MmVCtlvDxDKjWE45uhBI4bs0Qel5pBpbGuhHlQ4OzOg=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v41.6.1"
+                    "tag": "v41.7.0"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -4143,7 +4143,7 @@
         },
         "modules": "145",
         "node": "24.15.0",
-        "version": "41.6.1"
+        "version": "41.7.0"
     },
     "42": {
         "chrome": "148.0.7778.97",

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -1406,10 +1406,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-H4mLOoA2fdI5yF1qnXC1s1+BVO/ouxXOHh2ZzqJVAVc=",
+                    "hash": "sha256-0koDZtv9T/Jkg3cndIp/1ThYa3hgFf4UfwpY8yliyaY=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v40.10.0"
+                    "tag": "v40.10.1"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -2737,7 +2737,7 @@
         },
         "modules": "143",
         "node": "24.15.0",
-        "version": "40.10.0"
+        "version": "40.10.1"
     },
     "41": {
         "chrome": "146.0.7680.216",

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -4202,10 +4202,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-QVWPIw2G5ai9dCLZ6K1ZuJKydMFexA17X1gtB3XeXKc=",
+                    "hash": "sha256-UshbCxXPTrY2YQetb0B8OLohlLhQ1EHbl/zP7eNV9Yk=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v42.1.0"
+                    "tag": "v42.2.0"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -5557,6 +5557,6 @@
         },
         "modules": "146",
         "node": "24.15.0",
-        "version": "42.1.0"
+        "version": "42.2.0"
     }
 }

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -2796,10 +2796,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-MmVCtlvDxDKjWE45uhBI4bs0Qel5pBpbGuhHlQ4OzOg=",
+                    "hash": "sha256-8I/3aDZgi5iIwujKnUQ/Uxx2VeFAuwvCPXgPl04HQdg=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v41.7.0"
+                    "tag": "v41.7.1"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -4143,7 +4143,7 @@
         },
         "modules": "145",
         "node": "24.15.0",
-        "version": "41.7.0"
+        "version": "41.7.1"
     },
     "42": {
         "chrome": "148.0.7778.97",

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -1406,10 +1406,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-0koDZtv9T/Jkg3cndIp/1ThYa3hgFf4UfwpY8yliyaY=",
+                    "hash": "sha256-zpM+4Jok6FGaSKH4JxHKf9xrWNbdEVUBvgvd3Q9JnlU=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v40.10.1"
+                    "tag": "v40.10.2"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -2737,7 +2737,7 @@
         },
         "modules": "143",
         "node": "24.15.0",
-        "version": "40.10.1"
+        "version": "40.10.2"
     },
     "41": {
         "chrome": "146.0.7680.216",

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -4146,7 +4146,7 @@
         "version": "41.7.1"
     },
     "42": {
-        "chrome": "148.0.7778.97",
+        "chrome": "148.0.7778.180",
         "chromium": {
             "deps": {
                 "gn": {
@@ -4155,15 +4155,15 @@
                     "version": "0-unstable-2026-04-01"
                 }
             },
-            "version": "148.0.7778.97"
+            "version": "148.0.7778.180"
         },
         "chromium_npm_hash": "sha256-JuVcY8iFRDWcPcP4Pg+qm5rnTXkiVfNsqSkXbDWqsE8=",
         "deps": {
             "src": {
                 "args": {
-                    "hash": "sha256-nr/bMzJ+4b7/WeT3yG6rddGHvBi51ZzDTdQLIvJYBtg=",
+                    "hash": "sha256-Cjna6Z4uzdyuqZCacu01f1p2DoNl/x7NaZmU/NoiD3k=",
                     "postFetch": "rm -rf $(find $out/third_party/blink/web_tests ! -name BUILD.gn -mindepth 1 -maxdepth 1); rm -r $out/content/test/data; rm -rf $out/courgette/testdata; rm -r $out/extensions/test/data; rm -r $out/media/test/data; ",
-                    "tag": "148.0.7778.97",
+                    "tag": "148.0.7778.180",
                     "url": "https://chromium.googlesource.com/chromium/src.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -4202,10 +4202,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-UshbCxXPTrY2YQetb0B8OLohlLhQ1EHbl/zP7eNV9Yk=",
+                    "hash": "sha256-HwfRacBv+em/gF+eEm+hAX+k/ZUBzj9DP30aPpydWXk=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v42.2.0"
+                    "tag": "v42.3.0"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -4235,8 +4235,8 @@
             },
             "src/third_party/angle": {
                 "args": {
-                    "hash": "sha256-3KVTEBcnQTn99ccdKzylzUvua2jlS4g8/nfIDdLk6ug=",
-                    "rev": "cc0e3572e8789f4a184dd9714a04b3d98ae81015",
+                    "hash": "sha256-HcfKm7UQmg3wMDOytmaYzm7Z7gRdOrRoqAKaE0ZdI4E=",
+                    "rev": "50fd896fb21cca91f325812d01d1e971593efc73",
                     "url": "https://chromium.googlesource.com/angle/angle.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -4709,8 +4709,8 @@
             },
             "src/third_party/harfbuzz/src": {
                 "args": {
-                    "hash": "sha256-/RT2OPWFiVwFqmNS4o+gE0JrcVO1cQDkCkgrSEe7BzE=",
-                    "rev": "4fc96139259ebc35f40118e0382ac8037d928e5c",
+                    "hash": "sha256-HWb3QbPl+RE2oI/Jwv5BjKwv9UnJ8VcJvk+uGy9cAqM=",
+                    "rev": "f027b8e9039f73bf803eae684fee2eb2d30e4180",
                     "url": "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -4733,8 +4733,8 @@
             },
             "src/third_party/icu": {
                 "args": {
-                    "hash": "sha256-yQ55MGzqkVkp/arTlmKqySBvQFtaPaBk9UUAFE0imhE=",
-                    "rev": "ff7995a708a10ab44db101358083c7f74752da9f",
+                    "hash": "sha256-rNErsn11FZUh8GXAl7jK+NyLHIKrQR3LuoM1qFFGtmM=",
+                    "rev": "3859e64eed5d34544b27fbcab0ac1685ce83df3c",
                     "url": "https://chromium.googlesource.com/chromium/deps/icu.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -5190,8 +5190,8 @@
             },
             "src/third_party/skia": {
                 "args": {
-                    "hash": "sha256-HsKHffZWTls362kjokxzdhaxb/xJD1g70VHGk9l6GVM=",
-                    "rev": "afe8b760ada5128164f9826866b4381a3463df41",
+                    "hash": "sha256-eOjFuMmXr9YtZ0e4yDB8JMjTrNWEg5OlTkAMGuHZIWE=",
+                    "rev": "a2888b27a98e4ff30085d4d2dba8a1a99baf6dfb",
                     "url": "https://skia.googlesource.com/skia.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -5465,8 +5465,8 @@
             },
             "src/third_party/webrtc": {
                 "args": {
-                    "hash": "sha256-jTJv53qt971Va5q6MaULysYiChBVmsFYxG9fzkcE0ak=",
-                    "rev": "9600e77d854090669817d22aa2fc941ee92aaacd",
+                    "hash": "sha256-k5cHE4XURJQrPURmXk4MMNV5k8+ryKfjmsVTzARRro4=",
+                    "rev": "9a7f650bcd14f241d20f88f4e1ea3b7300de72ac",
                     "url": "https://webrtc.googlesource.com/src.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -5505,8 +5505,8 @@
             },
             "src/v8": {
                 "args": {
-                    "hash": "sha256-x2FGL3J+JaWO1m6jBrcayR7Vlz90fYEAuufm4PULYyM=",
-                    "rev": "ddc9a95905de5268332a8f0216dc2bc67d26e829",
+                    "hash": "sha256-+cQdsWTgIohd3yOCsNCprSr4Ctes77fWGdmPxN2tQlM=",
+                    "rev": "ad6e4525c418a92147c8247ef9d144ce4c242a38",
                     "url": "https://chromium.googlesource.com/v8/v8.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -5557,6 +5557,6 @@
         },
         "modules": "146",
         "node": "24.15.0",
-        "version": "42.2.0"
+        "version": "42.3.0"
     }
 }


### PR DESCRIPTION
New round of electron updates!

### Electron 40

- Changelog: https://github.com/electron/electron/releases/tag/v40.10.1
- Diff: https://github.com/electron/electron/compare/refs/tags/v40.10.0...v40.10.1

### Electron 41

- Changelog: https://github.com/electron/electron/releases/tag/v41.7.0
- Diff: https://github.com/electron/electron/compare/refs/tags/v41.6.1...v41.7.0

### Electron 42 

- Changelog: https://github.com/electron/electron/releases/tag/v42.2.0
- Diff: https://github.com/electron/electron/compare/refs/tags/v42.1.0...v42.2.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
