### PR TITLE
mpy-utils: drop fusepy, modernize derivation and unbreak on darwin

### DIFF
--- a/pkgs/by-name/mp/mpy-utils/package.nix
+++ b/pkgs/by-name/mp/mpy-utils/package.nix
@@ -1,23 +1,41 @@
 {
-  stdenv,
   lib,
   python3Packages,
   fetchPypi,
+  fetchpatch2,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "mpy-utils";
   version = "0.1.13";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
     hash = "sha256-die8hseaidhs9X7mfFvV8C8zn0uyw08gcHNqmjl+2Z4=";
   };
 
-  propagatedBuildInputs = with python3Packages; [
-    fusepy
+  patches = [
+    # https://github.com/nickzoic/mpy-utils/pull/20
+    (fetchpatch2 {
+      name = "use-mfusepy.patch";
+      url = "https://github.com/nickzoic/mpy-utils/commit/1513b4dc1096bd8861792cd13abafd2342fb5510.patch?full_index=1";
+      hash = "sha256-ZgSEP+4yJf/0itApSmVh/hSqW10Ty+/kOjxg+XJsnn4=";
+    })
+  ];
+
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [
+    mfusepy
     pyserial
+  ];
+
+  # Skip mpy_utils.replfuseops: importing it loads libfuse via ctypes, which
+  # requires macFUSE on Darwin and is not available in the build sandbox.
+  pythonImportsCheck = [
+    "mpy_utils"
+    "mpy_utils.replcontrol"
   ];
 
   meta = {
@@ -25,6 +43,5 @@ python3Packages.buildPythonApplication (finalAttrs: {
     homepage = "https://github.com/nickzoic/mpy-utils";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ aciceri ];
-    broken = stdenv.hostPlatform.isDarwin;
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- drop fusepy, see #522340. I've opened https://github.com/nickzoic/mpy-utils/pull/20 upstream switching to mfusepy but I'm not confident that it will be merged (the repo seems dormient since years) so I fetched the PR as a patch in the derivation
- modernize derivation
- realized that the only reason it was broken on darwin was because one of the script produced required fuse, however it builds so I unmarked it as broken for that architecture. I think it should work on darwin with macFUSE but I haven't tested it

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
