### PR TITLE
python3Packages: various fixes

### DIFF
--- a/pkgs/development/python-modules/executorch/default.nix
+++ b/pkgs/development/python-modules/executorch/default.nix
@@ -152,6 +152,7 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
     "pytest-xdist"
   ];
   pythonRelaxDeps = [
+    "mpmath"
     "scikit-learn"
     "torchao"
   ];

--- a/pkgs/development/python-modules/executorch/default.nix
+++ b/pkgs/development/python-modules/executorch/default.nix
@@ -56,6 +56,7 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
   pname = "executorch";
   version = "1.2.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "pytorch";

--- a/pkgs/development/python-modules/mlflow/default.nix
+++ b/pkgs/development/python-modules/mlflow/default.nix
@@ -32,6 +32,7 @@ buildPythonPackage (finalAttrs: {
   pname = "mlflow";
   version = "3.12.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "mlflow";

--- a/pkgs/development/python-modules/mlflow/default.nix
+++ b/pkgs/development/python-modules/mlflow/default.nix
@@ -47,6 +47,9 @@ buildPythonPackage (finalAttrs: {
 
   build-system = [ setuptools ];
 
+  pythonRelaxDeps = [
+    "cryptography"
+  ];
   dependencies = [
     aiohttp
     alembic

--- a/pkgs/development/python-modules/sigstore/default.nix
+++ b/pkgs/development/python-modules/sigstore/default.nix
@@ -51,6 +51,7 @@ buildPythonPackage (finalAttrs: {
   build-system = [ flit-core ];
 
   pythonRelaxDeps = [
+    "cryptography"
     "sigstore-models"
   ];
 
@@ -82,6 +83,15 @@ buildPythonPackage (finalAttrs: {
   ];
 
   pythonImportsCheck = [ "sigstore" ];
+
+  disabledTestPaths = [
+    # AttributeError: module 'cryptography.hazmat.primitives.asymmetric.ec' has no attribute 'SECT163K1'
+    #
+    # Uses ec.SECT163K1 which cryptography 48 removed entirely.
+    # Upstream considers this over-testing (sigstore itself never uses this curve at runtime):
+    # https://github.com/sigstore/sigstore-python/issues/1603
+    "test/unit/internal/test_key_details.py"
+  ];
 
   disabledTests = [
     # Tests require network access

--- a/pkgs/development/python-modules/sigstore/default.nix
+++ b/pkgs/development/python-modules/sigstore/default.nix
@@ -39,6 +39,7 @@ buildPythonPackage (finalAttrs: {
   pname = "sigstore";
   version = "4.1.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "sigstore";

--- a/pkgs/development/python-modules/sigstore/default.nix
+++ b/pkgs/development/python-modules/sigstore/default.nix
@@ -37,7 +37,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "sigstore";
-  version = "4.1.0";
+  version = "4.2.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -45,7 +45,7 @@ buildPythonPackage (finalAttrs: {
     owner = "sigstore";
     repo = "sigstore-python";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Wt9ZoMHTiMlbAab9p8/WF38/OiyCaqHPS5R7/fTAfxw=";
+    hash = "sha256-33JjQdYH/FptFUo0CecWItm9qH1wGQPHdk/JSdX8QfQ=";
   };
 
   build-system = [ flit-core ];


### PR DESCRIPTION
## Things done

- **python3Packages.sigstore: enable __structuredAttrs**
- **python3Packages.sigstore: relax cryptography**
- **python3Packages.sigstore: 4.1.0 -> 4.2.0**
  - Diff: https://github.com/sigstore/sigstore-python/compare/v4.1.0...v4.2.0
  - Changelog: https://github.com/sigstore/sigstore-python/blob/v4.2.0/CHANGELOG.md
- **python3Packages.mlflow: relax cryptography**
- **python3Packages.mlflow: enable __structuredAttrs**
- **python3Packages.executorch: relax mpmath**
- **python3Packages.executorch: enable __structuredAttrs**

cc @Bot-wxt1221

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test