### PR TITLE
awkaster: init at 0-unstable-2023-01-21

### DIFF
--- a/pkgs/by-name/aw/awkaster/package.nix
+++ b/pkgs/by-name/aw/awkaster/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gawk,
+  makeWrapper,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "awkaster";
+  version = "0-unstable-2023-01-21";
+
+  src = fetchFromGitHub {
+    owner = "TheMozg";
+    repo = "awk-raycaster";
+    rev = "ac7f1b03554ca1c662ea2951cdd9f0b586075890";
+    hash = "sha256-g8jrVCQsdEASzE0HUpACQIhMslXbBpMH9Z7+rYVwEqg=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 awkaster.awk \
+                    $out/share/awkaster/awkaster.awk
+
+    makeWrapper ${gawk}/bin/gawk \
+                $out/bin/awkaster \
+                --add-flags "-f $out/share/awkaster/awkaster.awk"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Pseudo-3D raycasting shooter written completely in gawk";
+    homepage = "https://github.com/TheMozg/awk-raycaster";
+    mainProgram = "awkaster";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ castorNova2 ];
+  };
+})

--- a/pkgs/by-name/zn/znake/package.nix
+++ b/pkgs/by-name/zn/znake/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  ncurses,
+  versionCheckHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "znake";
+  version = "1.18";
+
+  src = fetchurl {
+    url = "https://downloads.sourceforge.net/project/znake-ulven/znake-${finalAttrs.version}/znake-${finalAttrs.version}.tar.gz";
+    hash = "sha256-XgFzn8R7vBwtz13169Iu3UZxGZf9XH92Cvm4Bldyr1w=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  buildInputs = [ ncurses ];
+
+  # Fix multiple definition errors with GCC 10+
+  env.NIX_CFLAGS_COMPILE = "-fcommon";
+
+  postPatch = ''
+    substituteInPlace src/Makefile \
+      --replace-fail "CC=gcc" "CC=$CC" \
+      --replace-fail "CFLAGS=-Wall -lncurses" "CFLAGS+=-Wall -lncurses"
+
+    substituteInPlace src/main.c \
+      --replace-fail "int r;" "int r = TRUE;"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 src/znake $out/bin/znake
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Simple colorful clone of the famous game Snake";
+    homepage = "https://sourceforge.net/projects/znake-ulven/";
+    mainProgram = "znake";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ castorNova2 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Part of https://github.com/NixOS/nixpkgs/issues/380688.

Add a package of [awkaster](https://github.com/TheMozg/awk-raycaster) which is a pseudo-3D terminal shooter written entirely in gawk using raycasting techniques and inspired by the classic Wolfenstein 3D and Doom.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
