### PR TITLE
mailspring: 1.21.0 -> 1.21.1

### DIFF
--- a/pkgs/by-name/ma/mailspring/darwin.nix
+++ b/pkgs/by-name/ma/mailspring/darwin.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://github.com/Foundry376/Mailspring/releases/download/${finalAttrs.version}/Mailspring-AppleSilicon.zip";
-    hash = "sha256-P4VP/EHQKb8WFhZhJZyaaJ1KLpPl0fZwBzozZynn62w=";
+    hash = "sha256-U8yh7Qsxu1AmqMVV2p9MmvNHH922yBEqWA8OsQleoCQ=";
   };
   dontUnpack = true;
 

--- a/pkgs/by-name/ma/mailspring/linux.nix
+++ b/pkgs/by-name/ma/mailspring/linux.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://github.com/Foundry376/Mailspring/releases/download/${finalAttrs.version}/mailspring-${finalAttrs.version}-amd64.deb";
-    hash = "sha256-xla2M3k6KXSyn2Ta4PQfWC+0AVkstwbjviaq1ie+awM=";
+    hash = "sha256-pyEWypqujSYYmbpUgcUMJoew4nIjE/dQWTVdYTxhmN4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ma/mailspring/package.nix
+++ b/pkgs/by-name/ma/mailspring/package.nix
@@ -5,7 +5,7 @@
 }:
 let
   pname = "mailspring";
-  version = "1.21.0";
+  version = "1.21.1";
 
   meta = {
     description = "Beautiful, fast and maintained fork of Nylas Mail by one of the original authors";


### PR DESCRIPTION
Updated to 1.21.1.
Changelog: https://github.com/Foundry376/Mailspring/releases/tag/1.21.1



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
