### PR TITLE
rke2_1_36: init at 1.36.1+rke2r1

### DIFF
--- a/nixos/tests/rancher/auto-deploy.nix
+++ b/nixos/tests/rancher/auto-deploy.nix
@@ -275,9 +275,16 @@ in
             k3s = ''
               machine.wait_until_succeeds("kubectl -n kube-system rollout status deployment traefik")
             '';
-            rke2 = ''
-              machine.wait_until_succeeds("kubectl -n kube-system rollout status daemonset rke2-ingress-nginx-controller")
-            '';
+            rke2 =
+              # Starting from v1.36, RKE2 also uses traefik as default load balancer
+              if lib.versionAtLeast rancherPackage.version "1.36" then
+                ''
+                  machine.wait_until_succeeds("kubectl -n kube-system rollout status daemonset rke2-traefik")
+                ''
+              else
+                ''
+                  machine.wait_until_succeeds("kubectl -n kube-system rollout status daemonset rke2-ingress-nginx-controller")
+                '';
           }
           .${rancherDistro}
         }

--- a/pkgs/applications/networking/cluster/rke2/1_36/images-versions.json
+++ b/pkgs/applications/networking/cluster/rke2/1_36/images-versions.json
@@ -1,0 +1,138 @@
+{
+  "images-calico-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
+    "sha256": "bc9fb1ba72af6185de90e4e0f8a384993657c4b0fdedbb14e7ca5cf93bf2303d"
+  },
+  "images-calico-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
+    "sha256": "38fc5ecd017e9a66e3831ece42efedcfedaafc000759eaa4fb9f19a68122ec51"
+  },
+  "images-calico-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
+    "sha256": "e86ac7f4cf14e4f02fcdd0e3d74e832fa43654f592068c2b5d8c044c69e2b749"
+  },
+  "images-calico-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
+    "sha256": "03df93db61bc54f351bb6131c632279c265d4b71af0a90e2a6898f9b99b453f4"
+  },
+  "images-canal-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
+    "sha256": "5cce5314ed6ff237c646723456c81876e89517b9164368728a9df00697655858"
+  },
+  "images-canal-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
+    "sha256": "3a7828ce0143c3eb91cae940cebdfa0145960e91be056e88a8b077ee39ccc54d"
+  },
+  "images-canal-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
+    "sha256": "e8346348137747fbd626846e5b71d182c49e8a1dcb997ea9e91f50e7bd907129"
+  },
+  "images-canal-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
+    "sha256": "ede6d29451a99d7f4663b6a2b8eb0cfa093f83b7b025fd5c4899fb02edac703d"
+  },
+  "images-cilium-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
+    "sha256": "8c52261340b4af54186f83d2913c676a2dcef820f25a1b42b8c51cfef1dcdbc6"
+  },
+  "images-cilium-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
+    "sha256": "865913456dc55b2ba4748b0fe76489e4960a60990f207341c66bcbf9e93e95b3"
+  },
+  "images-cilium-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
+    "sha256": "4170bfc7d0ebf9167a94d24e393fbff0fc7dce4da1443257709fdbe603ffc579"
+  },
+  "images-cilium-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
+    "sha256": "016caf748e5c39460b9618d998d261c7db8fe8348f9fa43d35693a47d4913b86"
+  },
+  "images-core-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
+    "sha256": "03a72f2c228131b7cb616c5b7758cd1c00b7f3e7d589573c5faf837e4e2ab764"
+  },
+  "images-core-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
+    "sha256": "37acd15d183693fb0bb465840590593ed78d72415752a052d282a418fdb905cf"
+  },
+  "images-core-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
+    "sha256": "4798bf3293e7b5b62e694bee8a811c3ace86bb5c7516c9f196a4ba48dc947c3f"
+  },
+  "images-core-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
+    "sha256": "ff8c770fa2b17151e333a0a4449bc4dc3cd5c65662ec88b2ffc31fde6a40d0ed"
+  },
+  "images-flannel-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
+    "sha256": "0e5c71c9ecd89f11bb1cc0ea72a0297090e7a44395efe5fd74e14af3db3581a8"
+  },
+  "images-flannel-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
+    "sha256": "23695fd8c2a77f043a089c44437d12b5bde88422dbcd1d70edcda7a78f651137"
+  },
+  "images-flannel-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
+    "sha256": "d9f75aaace63bcba2cbaeba2662d9877d39ec822621fd96824e9ec3fbe62a79c"
+  },
+  "images-flannel-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
+    "sha256": "8aa8e19b739bc3fd897115f92d54acd081453441ee4dae8ca694ec47662838a7"
+  },
+  "images-harvester-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
+    "sha256": "c9442d489c4170fc515d04c2c5c7c76ff3ca2fb4093a94aea0d0a6fb1719c5d3"
+  },
+  "images-harvester-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
+    "sha256": "9551558d7baba1a78de7954f4801cf4329b5fb5ffd0cc3566b9fa32732ff950c"
+  },
+  "images-harvester-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
+    "sha256": "11ea150625fc1a4700cec2859367692d533f7f9288f7196b331a77682766d742"
+  },
+  "images-harvester-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
+    "sha256": "045db3938a0a11f6d5b4936f63471fec48fd76d29ef85e9cfe6bae5bddd8525e"
+  },
+  "images-ingress-nginx-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-ingress-nginx.linux-amd64.tar.gz",
+    "sha256": "0af77531d170d30b844518bb4665b29f3f386cf160f7c2b955467516f4d04dc3"
+  },
+  "images-ingress-nginx-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-ingress-nginx.linux-amd64.tar.zst",
+    "sha256": "d5b7d3f12de0799cebf84fc6260fc4f093f2837c5fef6fc84849d8f1da5cbc22"
+  },
+  "images-ingress-nginx-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-ingress-nginx.linux-arm64.tar.gz",
+    "sha256": "8c5d5eea216102e5dd07621671f2e462dfade184f20c81adb8facbaa58e59c2c"
+  },
+  "images-ingress-nginx-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-ingress-nginx.linux-arm64.tar.zst",
+    "sha256": "363f42d83118e3398e72996f6b42477230000ffd50d93fdda570140ea020539b"
+  },
+  "images-multus-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
+    "sha256": "ec3d8557e36db43acd9a76c38242de6feea354e41ae3ff8b9ab55de82ee19026"
+  },
+  "images-multus-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
+    "sha256": "8be7075092a5e179e50fb526ea730018103d9f8a609f22f0d1431482690a9d7f"
+  },
+  "images-multus-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
+    "sha256": "caebabf77d9d3190d76156990d8eaa0c2df5cb563a8447f1e506b50f4104e1a0"
+  },
+  "images-multus-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
+    "sha256": "39bd89d250894254f7c1f9b061401a574716574ab3f51cc3a82c03eb4e804825"
+  },
+  "images-vsphere-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
+    "sha256": "d07ed8b72db67fae9024540fca3eed7990b4a4b3a7ba6eef78a2eae8e6b3b4d3"
+  },
+  "images-vsphere-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
+    "sha256": "4cd43197b21bd1344c0a7e87a7f28c8766b3edfab8e2fb2bb6954d144f3b44a7"
+  }
+}

--- a/pkgs/applications/networking/cluster/rke2/1_36/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/1_36/versions.nix
@@ -1,0 +1,13 @@
+{
+  rke2Version = "1.36.1+rke2r1";
+  rke2Commit = "b4a8e78038f35eb282a8d6e3c29797a1181fa961";
+  rke2TarballHash = "sha256-SD7+lNYu6/5iMxEmHEpkD8g9UCgN6gjkFsGdQn9o1Cc=";
+  rke2VendorHash = "sha256-gUgRAC9yKDa8JYb/jdCxZdP6500XxjqHprmYlPv5A8c=";
+  k8sImageTag = "v1.36.1-rke2r1-build20260512";
+  etcdVersion = "v3.6.7-k3s1-build20260512";
+  pauseVersion = "3.6";
+  ccmVersion = "v1.36.0-rc2.0.20260427154526-d239025e2a23-build20260429";
+  dockerizedVersion = "v1.36.1-rke2r1";
+  helmJobVersion = "v0.10.0-build20260513";
+  imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
+}

--- a/pkgs/applications/networking/cluster/rke2/builder.nix
+++ b/pkgs/applications/networking/cluster/rke2/builder.nix
@@ -46,6 +46,7 @@ lib:
   nixosTests,
 }:
 buildGoModule (finalAttrs: {
+  __structuredAttrs = true;
   pname = "rke2";
   version = rke2Version;
 

--- a/pkgs/applications/networking/cluster/rke2/default.nix
+++ b/pkgs/applications/networking/cluster/rke2/default.nix
@@ -11,7 +11,9 @@ rec {
 
   rke2_1_35 = common (import ./1_35/versions.nix) extraArgs;
 
+  rke2_1_36 = common (import ./1_36/versions.nix) extraArgs;
+
   # Automatically set by update script, changes shouldn't be backported
   rke2_stable = rke2_1_35;
-  rke2_latest = rke2_1_35;
+  rke2_latest = rke2_1_36;
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9840,6 +9840,7 @@ with pkgs;
     rke2_1_33
     rke2_1_34
     rke2_1_35
+    rke2_1_36
     rke2_stable
     rke2_latest
     ;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Release: https://github.com/rancher/rke2/releases/tag/v1.36.1%2Brke2r1

**Note: Upstream ingress-nginx Retirement & Transition to Traefik**
Because ingress-nginx was retired upstream as of March 2026, Traefik is now the default for new clusters starting in v1.36 (existing clusters will keep their current ingress upon upgrade to avoid breakage). This transition brings the following structural changes:

- Airgapped Environments: The rke2-images-core tarball now contains Traefik images instead of ingress-nginx. The standalone rke2-images-traefik tarball has been removed. Users who must continue using ingress-nginx will now need to manually provide the rke2-images-ingress-nginx tarball.
- Future Removal: The ingress-nginx chart will not receive any additional updates and will be completely removed in v1.37 for community users.

@maevii @zimbatm @stefan-bordei 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
