### PR TITLE
github-copilot-cli: improve dependency handling + add maintainer

### DIFF
--- a/pkgs/by-name/gi/github-copilot-cli/package.nix
+++ b/pkgs/by-name/gi/github-copilot-cli/package.nix
@@ -84,6 +84,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.unfree;
     maintainers = with lib.maintainers; [
       dbreyfogle
+      me-and
     ];
     mainProgram = "copilot";
     platforms = [

--- a/pkgs/by-name/gi/github-copilot-cli/package.nix
+++ b/pkgs/by-name/gi/github-copilot-cli/package.nix
@@ -4,6 +4,8 @@
   autoPatchelfHook,
   cacert,
   fetchurl,
+  glib,
+  libsecret,
   makeBinaryWrapper,
   bash,
   nodejs,
@@ -28,12 +30,25 @@ stdenv.mkDerivation (finalAttrs: {
     makeBinaryWrapper
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
-  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.cc.lib ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    stdenv.cc.cc.lib
+    glib
+    libsecret
+  ];
   sourceRoot = "package";
   dontStrip = true;
-  # keytar.node and computer.node have optional system-library deps not provided
-  # here; ignore missing deps rather than fail the build.
-  autoPatchelfIgnoreMissingDeps = true;
+  # computer.node requires GUI/media libraries (X11, pipewire, libei, libjpeg,
+  # libpng) for screen-capture and input-simulation features that are not
+  # relevant for CLI use; ignore those missing deps rather than fail the build
+  # or pull in heavy dependencies.
+  autoPatchelfIgnoreMissingDeps = [
+    "libX11.so.6"
+    "libXtst.so.6"
+    "libjpeg.so.8"
+    "libpng16.so.16"
+    "libpipewire-0.3.so.0"
+    "libei.so.1"
+  ];
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
-   **github-copilot-cli: improve dependency handling**

    Add glib and libsecret as dependencies for builds that might need them.
    Replace `autoPatchelfIgnoreMissingDeps = true` with an explicit list of
    the dependencies we're deliberately ignoring.

    GitHub Copilot CLI isn't an open source tool and the documentation isn't
    clear on what each possible dependency is used for.  I expect some
    dependencies are only used in rare scenarios or would never be used by
    the CLI tool and are just inhereted from some of the desktop Copilot
    applications.  That means there's a bit of a guessing game in balancing
    (a) the desire to provide all the tools Copilot might use and (b) not
    growing the package closure for no real benefit.

    I've added glib and libsecret as I don't think they significantly expand
    the closure and are relatively likely to be useful.  I've left out the
    tools that seem most useful for GUI and media interfaces as they're
    bulky and seem likely to be included because they're common with
    GUI-based Copilot tools rather than because they're needed for GitHub
    Copilot CLI.

-   **github-copilot-cli: add me-and as maintainer**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
