### PR TITLE
treewide: remove double dependencies on nodejs+nodejs-slim

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/ms-vscode.js-debug/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-vscode.js-debug/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchFromGitHub,
   fetchNpmDeps,
-  nodejs,
   nodejs-slim,
   npmHooks,
   pkg-config,
@@ -38,7 +37,8 @@ let
       libsecret
     ];
     nativeBuildInputs = [
-      nodejs
+      nodejs-slim
+      nodejs-slim.npm
       nodejs-slim.python
       npmHooks.npmConfigHook
     ]

--- a/pkgs/applications/editors/vscode/extensions/prettier.prettier-vscode/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/prettier.prettier-vscode/default.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   fetchNpmDeps,
   libsecret,
-  nodejs,
   nodejs-slim,
   npmHooks,
   pkg-config,
@@ -37,7 +36,8 @@ let
     ];
 
     nativeBuildInputs = [
-      nodejs
+      nodejs-slim
+      nodejs-slim.npm
       nodejs-slim.python
       npmHooks.npmConfigHook
     ]

--- a/pkgs/build-support/node/build-npm-package/default.nix
+++ b/pkgs/build-support/node/build-npm-package/default.nix
@@ -4,7 +4,6 @@
   fetchNpmDeps,
   buildPackages,
   nodejs,
-  nodejs-slim,
   cctools,
 }@topLevelArgs:
 
@@ -102,7 +101,7 @@ lib.extendMkDerivation {
           (if npmConfigHook != null then npmConfigHook else npmHooks.npmConfigHook)
           (if npmBuildHook != null then npmBuildHook else npmHooks.npmBuildHook)
           (if npmInstallHook != null then npmInstallHook else npmHooks.npmInstallHook)
-          nodejs-slim.python
+          nodejs.python
         ]
         ++ lib.optionals stdenv.hostPlatform.isDarwin [ cctools ];
       buildInputs = buildInputs ++ [ nodejs ];

--- a/pkgs/build-support/node/fetch-yarn-deps/default.nix
+++ b/pkgs/build-support/node/fetch-yarn-deps/default.nix
@@ -9,7 +9,6 @@
   nix-prefetch-git,
   fetchurl,
   jq,
-  nodejs,
   nodejs-slim,
   prefetch-yarn-deps,
   fixup-yarn-lock,

--- a/pkgs/by-name/lo/logseq/package.nix
+++ b/pkgs/by-name/lo/logseq/package.nix
@@ -14,7 +14,6 @@
   darwin,
   makeDesktopItem,
   makeWrapper,
-  nodejs,
   nodejs-slim,
   removeReferencesTo,
   yarnBuildHook,
@@ -151,7 +150,8 @@ stdenv.mkDerivation (finalAttrs: {
       copyDesktopItems
       fakeGit
       makeWrapper
-      nodejs
+      nodejs-slim
+      nodejs-slim.npm
       (nodejs-slim.python.withPackages (ps: [ ps.setuptools ]))
       removeReferencesTo
       yarnBuildHook
@@ -200,7 +200,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     yarn --offline --cwd tldraw postinstall
 
-    export npm_config_nodedir=${nodejs}
+    export npm_config_nodedir=${nodejs-slim}
     pushd packages/amplify
     npm rebuild --verbose
     popd
@@ -247,7 +247,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     # remove references to nodejs
-    find static/out/*/resources/app/node_modules -type f -executable -exec remove-references-to -t ${nodejs} '{}' \;
+    find static/out/*/resources/app/node_modules -type f -executable -exec remove-references-to -t ${nodejs-slim} '{}' \;
   ''
   + lib.optionalString stdenv.hostPlatform.isLinux ''
     install -Dm644 static/icons/logseq.png "$out/share/icons/hicolor/512x512/apps/logseq.png"

--- a/pkgs/by-name/ma/matrix-appservice-discord/package.nix
+++ b/pkgs/by-name/ma/matrix-appservice-discord/package.nix
@@ -25,11 +25,11 @@ let
     nodejs = nodejs_20;
   };
   yarnConfigHook' = yarnConfigHook.override {
-    nodejs = nodejs_20;
+    nodejs-slim = nodejs_20;
     yarn = yarn';
   };
   yarnBuildHook' = yarnBuildHook.override {
-    nodejs = nodejs_20;
+    nodejs-slim = nodejs_20;
     yarn = yarn';
   };
   matrix-sdk-crypto-nodejs' = matrix-sdk-crypto-nodejs.override {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Follow up of https://github.com/NixOS/nixpkgs/pull/481461

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
