### PR TITLE
importNpmLock.buildNodeModules: Add `importNpmLockArgs`

### DIFF
--- a/doc/languages-frameworks/javascript.section.md
+++ b/doc/languages-frameworks/javascript.section.md
@@ -270,6 +270,9 @@ It accepts an argument with the following attributes:
 `packageLock` (Attrset; optional)
 : Parsed contents of `package-lock.json`, as returned `lib.importJSON ./my-package-lock.json`. If not specified, the `package-lock.json` in `npmRoot` is used.
 
+`importNpmLockArgs` (Attrset; optional)
+: Extra arguments passed to `importNpmLock`
+
 `derivationArgs` (`mkDerivation` attrset; optional)
 : Arguments passed to `stdenv.mkDerivation`
 

--- a/pkgs/build-support/node/import-npm-lock/default.nix
+++ b/pkgs/build-support/node/import-npm-lock/default.nix
@@ -185,6 +185,7 @@ lib.fix (self: {
       packageLock ? importJSON (npmRoot + "/package-lock.json"),
       nodejs,
       derivationArgs ? { },
+      importNpmLockArgs ? { },
     }:
     let
       # Backwards compatibility: if derivationArgs contains passAsFile,
@@ -198,9 +199,12 @@ lib.fix (self: {
 
         dontUnpack = true;
 
-        npmDeps = self.importNpmLock {
-          inherit npmRoot package packageLock;
-        };
+        npmDeps = self.importNpmLock (
+          importNpmLockArgs
+          // {
+            inherit npmRoot package packageLock;
+          }
+        );
 
         package = toJSON package;
         packageLock = toJSON packageLock;


### PR DESCRIPTION
This allows passing arbitrary extra arguments (such as `fetcherOpts`) to the inner `importNpmLock` call of `buildNodeModules`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
