### PR TITLE
wordbook: 0.4.0 -> 1.0.0

### DIFF
--- a/pkgs/by-name/wo/wordbook/package.nix
+++ b/pkgs/by-name/wo/wordbook/package.nix
@@ -1,29 +1,39 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
-  python3,
   meson,
   ninja,
   pkg-config,
   libadwaita,
-  espeak-ng,
   gobject-introspection,
   wrapGAppsHook4,
   appstream-glib,
   desktop-file-utils,
+  blueprint-compiler,
+  python3,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "wordbook";
-  version = "0.4.0";
-  pyproject = false; # Built with meson
+  version = "1.0.0";
 
   src = fetchFromGitHub {
-    owner = "fushinari";
+    owner = "mufeedali";
     repo = "Wordbook";
     tag = finalAttrs.version;
-    hash = "sha256-oiAXSDJJtlV6EIHzi+jFv+Ym1XHCMLx9DN1YRiXZNzc=";
+    hash = "sha256-sn0ssKz/Mf+GSH8+hXAuJ59wLSHIZGFSB/9HrZNrhuc=";
   };
+
+  wnSrc = fetchFromGitHub {
+    owner = "mufeedali";
+    repo = "wn";
+    rev = "9b51a749ff167a0b0ded55fc5b23448a0e21eb45";
+    hash = "sha256-Qh2hixZ/tilrLxVcms7hSLBnERRMUJa96ORODn8T9yo=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   nativeBuildInputs = [
     meson
@@ -33,33 +43,49 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     appstream-glib
     desktop-file-utils
     gobject-introspection
+    blueprint-compiler
+    python3
   ];
 
   buildInputs = [
     libadwaita
+    python3
+    python3.pkgs.pygobject3
+    python3.pkgs.backports-zstd
+    python3.pkgs.rapidfuzz
+    python3.pkgs.pydantic
   ];
 
-  dependencies = with python3.pkgs; [
-    pygobject3
-    wn
-  ];
+  # Copy the wn submodule to subprojects/wn
+  postPatch = ''
+    cp -rs ${finalAttrs.wnSrc}/* subprojects/wn/
+  '';
 
-  # prevent double wrapping
-  dontWrapGApps = true;
+  mesonFlags = [
+    "-Dinstall_wn_db=false"
+  ];
 
   preFixup = ''
-    makeWrapperArgs+=(
-      --prefix PATH ":" "${lib.makeBinPath [ espeak-ng ]}"
-      "''${gappsWrapperArgs[@]}"
+    gappsWrapperArgs+=(
+      --prefix PYTHONPATH : "${
+        python3.withPackages (
+          ps: with ps; [
+            pygobject3
+            backports-zstd
+            rapidfuzz
+            pydantic
+          ]
+        )
+      }/${python3.sitePackages}"
     )
   '';
 
   meta = {
     description = "Offline English-English dictionary application built for GNOME";
-    mainProgram = "wordbook";
-    homepage = "https://github.com/fushinari/Wordbook";
+    homepage = "https://github.com/mufeedali/Wordbook";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ zendo ];
+    mainProgram = "wordbook";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/mufeedali/Wordbook/releases/tag/1.0.0
https://github.com/mufeedali/Wordbook/compare/0.4.0...1.0.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
