### PR TITLE
fcp: init @ 0.2.2

### DIFF
--- a/pkgs/by-name/fc/fcp/package.nix
+++ b/pkgs/by-name/fc/fcp/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  expect,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "fcp";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "svetlitski";
+    repo = "fcp";
+    tag = "v${finalAttrs.version}";
+    sha256 = "sha256-YupsJRtju9JyGGzSTk+tyEGh4ifpJllXVifsFoZ4Rwc=";
+  };
+
+  cargoHash = "sha256-PsYmzHwFpgAJ3AClt5buSuAtlXxvKQyz3XeZBtTXsLs=";
+
+  nativeBuildInputs = [ expect ];
+
+  # character_device fails with "File name too long" on darwin
+  doCheck = !stdenv.hostPlatform.isDarwin;
+
+  postPatch = ''
+    patchShebangs tests/*.exp
+  '';
+
+  meta = {
+    description = "Significantly faster alternative to the classic Unix cp(1) command";
+    homepage = "https://github.com/svetlitski/fcp";
+    changelog = "https://github.com/svetlitski/fcp/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.unix;
+    maintainers = [
+      lib.maintainers.georgyo
+      lib.maintainers.flokli
+    ];
+    mainProgram = "fcp";
+  };
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -705,7 +705,6 @@ mapAliases {
   fcitx5-skk-qt = throw "'fcitx5-skk-qt' has been renamed to/replaced by 'qt6Packages.fcitx5-skk-qt'"; # Converted to throw 2025-10-27
   fcitx5-unikey = throw "'fcitx5-unikey' has been renamed to/replaced by 'qt6Packages.fcitx5-unikey'"; # Converted to throw 2025-10-27
   fcitx5-with-addons = throw "'fcitx5-with-addons' has been renamed to/replaced by 'qt6Packages.fcitx5-with-addons'"; # Converted to throw 2025-10-27
-  fcp = throw "'fcp' has been removed as it has been unmaintained upstream since August 2022"; # Added 2026-02-07
   fedifetcher = throw "'fedifetcher' has been removed because there is now a similar native feature in Mastodon."; # Added 2025-12-08
   fennel = throw "'fennel' has been renamed to/replaced by 'luaPackages.fennel'"; # Converted to throw 2025-10-27
   fetchbower = throw "fetchbower has been removed as bower was removed. It is recommended to migrate to yarn."; # Added 2025-09-17


### PR DESCRIPTION
Add back FCP, now at version 2.2

It was removed in https://github.com/NixOS/nixpkgs/pull/487943 because the nixpkgs maintainer was removed for inactivity and upstream development seemed stalled. It is still used though.

If possible, this should make it in the 26.05 release. I only noticed that this was removed when testing out the staging-26.05 branch ahead of the release.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
