### PR TITLE
yarn-berry-fetchers: Allow impure env vars

### DIFF
--- a/pkgs/by-name/ya/yarn-berry/fetcher/fetch-yarn-berry-deps.nix
+++ b/pkgs/by-name/ya/yarn-berry/fetcher/fetch-yarn-berry-deps.nix
@@ -47,6 +47,8 @@ stdenv.mkDerivation (
       cacert
     ];
 
+    impureEnvVars = lib.fetchers.proxyImpureEnvVars;
+
     buildPhase = ''
       runHook preBuild
 

--- a/pkgs/by-name/ya/yarn-berry/fetcher/yarn-berry-fetcher.nix
+++ b/pkgs/by-name/ya/yarn-berry/fetcher/yarn-berry-fetcher.nix
@@ -28,6 +28,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   env.YARN_ZIP_SUPPORTED_CACHE_VERSION = berryCacheVersion;
   env.LIBZIP_SYS_USE_PKG_CONFIG = 1;
 
+  impureEnvVars = lib.fetchers.proxyImpureEnvVars;
+
   nativeBuildInputs = [
     rustPlatform.bindgenHook
     pkg-config


### PR DESCRIPTION
The FOD fetchers for yarn-berry do not have any allowances for impure env vars, meaning it will not obey http and https proxies or custom CA certs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
