### PR TITLE
rustfs: init at 1.0.0-beta.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16672,6 +16672,12 @@
     githubId = 963511;
     name = "Majiir Paktu";
   };
+  majinghe = {
+    email = "devops008@sina.com";
+    github = "majinghe";
+    githubId = 42570491;
+    name = "Jinghe Ma";
+  };
   makefu = {
     email = "makefu@syntax-fehler.de";
     github = "makefu";
@@ -30802,7 +30808,7 @@
     matrix = "@zeri:matrix.org";
     github = "zeri42";
     githubId = 68825133;
-  };
+ };
   zerodya = {
     name = "Nicola";
     email = "nicola.pagliuca@pm.me";

--- a/pkgs/by-name/ru/rustfs/package.nix
+++ b/pkgs/by-name/ru/rustfs/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  installShellFiles,
+  openssl,
+  protobuf,
+  stdenv,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rustfs";
+  version = "1.0.0-beta.3";
+
+  src = fetchFromGitHub {
+    owner = "rustfs";
+    repo = "rustfs";
+    rev = version;
+    hash = "sha256-9IVXAuXfFSNM+1CMfI4OsBLYjH9fcTdXsqtpjhz2Jm0=";
+  };
+
+  cargoHash = "sha256-i6Hwr6y59CjNCm6ogO6VjVgcCtm5DrKaRMjh2h3T8zY=";
+
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+    protobuf
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  PROTOC = "${protobuf}/bin/protoc";
+  RUSTFLAGS = "--cfg tokio_unstable";
+
+  cargoBuildFlags = [
+    "--package"
+    "rustfs"
+  ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A distributed object storage system written in Rust";
+    homepage = "https://github.com/rustfs/rustfs";
+    license = licenses.asl20;
+    maintainers = [ maintainers.majinghe ];
+    mainProgram = "rustfs";
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/by-name/ru/rustfs/package.nix
+++ b/pkgs/by-name/ru/rustfs/package.nix
@@ -9,14 +9,14 @@
   stdenv,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rustfs";
   version = "1.0.0-beta.3";
 
   src = fetchFromGitHub {
     owner = "rustfs";
     repo = "rustfs";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-9IVXAuXfFSNM+1CMfI4OsBLYjH9fcTdXsqtpjhz2Jm0=";
   };
 
@@ -42,7 +42,7 @@ rustPlatform.buildRustPackage rec {
 
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "A distributed object storage system written in Rust";
     homepage = "https://github.com/rustfs/rustfs";
     license = licenses.asl20;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
