### PR TITLE
uiua-unstable: 0.18.1 -> 0.19.0-dev.4

### DIFF
--- a/pkgs/by-name/ui/uiua/0001-no-network-test.patch
+++ b/pkgs/by-name/ui/uiua/0001-no-network-test.patch
@@ -1,0 +1,11 @@
+diff --git a/tests/module.ua b/tests/module.ua
+index 92e463a6..ff3f0489 100644
+--- a/tests/module.ua
++++ b/tests/module.ua
+@@ -89,6 +89,3 @@ B ← A
+   D‼ ← ^0^1
+ └─╴
+ ⍤⤙≍ 6 M!D‼++ 1 2 3
+-
+-~ "gh: uiua-lang/example-module subfolder" ~ Lang
+-⍤⤙≍ "Uiua" Lang

--- a/pkgs/by-name/ui/uiua/package.nix
+++ b/pkgs/by-name/ui/uiua/package.nix
@@ -35,7 +35,7 @@ in
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "uiua";
-  inherit (versionInfo) version cargoHash;
+  inherit (versionInfo) version cargoHash patches;
 
   src = fetchFromGitHub {
     owner = "uiua-lang";

--- a/pkgs/by-name/ui/uiua/stable.nix
+++ b/pkgs/by-name/ui/uiua/stable.nix
@@ -4,4 +4,5 @@ rec {
   hash = "sha256-HB6YjWi4DEbLTwMhqtcF0IufK8YEmE4w/7n/nsL8VEw=";
   cargoHash = "sha256-B2eDBf5ycFpXBk9XIzkltdr6eDs/CHHufHtjoOAvg2E=";
   updateScript = ./update-stable.sh;
+  patches = [ ];
 }

--- a/pkgs/by-name/ui/uiua/unstable.nix
+++ b/pkgs/by-name/ui/uiua/unstable.nix
@@ -1,7 +1,8 @@
 rec {
-  version = "0.18.1";
+  version = "0.19.0-dev.4";
   tag = version;
-  hash = "sha256-HB6YjWi4DEbLTwMhqtcF0IufK8YEmE4w/7n/nsL8VEw=";
-  cargoHash = "sha256-B2eDBf5ycFpXBk9XIzkltdr6eDs/CHHufHtjoOAvg2E=";
+  hash = "sha256-Df/d6dCYXRG8uWVTpLR3I8llS1ujT3QFnx5TCZSxf+0=";
+  cargoHash = "sha256-cXD780n7qI8baDYyOdJvFBvXV2qCTiutgLc19+ewHnk=";
   updateScript = ./update-unstable.sh;
+  patches = [ ./0001-no-network-test.patch ];
 }


### PR DESCRIPTION
Diff: https://github.com/uiua-lang/uiua/compare/0.18.1...0.19.0-dev.4

~~Unfortunately this disables `tests::suite` for stable when its not a issue for it but hacking it in temporarily only for unstable doesn't seem worth it.~~

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
