### PR TITLE
nixos/garage: add options for new `--single-node` and `--default-bucket` flags

### DIFF
--- a/nixos/modules/services/web-servers/garage.nix
+++ b/nixos/modules/services/web-servers/garage.nix
@@ -156,9 +156,10 @@ in
           isDefaultStateDirectory = lib.any isDefault paths;
         in
         {
-          ExecStart = "${cfg.package}/bin/garage server"
-          + lib.optionalString cfg.singleNode " --single-node"
-          + lib.optionalString cfg.defaultBucket " --default-bucket";
+          ExecStart =
+            "${cfg.package}/bin/garage server"
+            + lib.optionalString cfg.singleNode " --single-node"
+            + lib.optionalString cfg.defaultBucket " --default-bucket";
 
           StateDirectory = lib.mkIf isDefaultStateDirectory "garage";
           DynamicUser = lib.mkDefault true;

--- a/nixos/modules/services/web-servers/garage.nix
+++ b/nixos/modules/services/web-servers/garage.nix
@@ -157,8 +157,8 @@ in
         in
         {
           ExecStart = "${cfg.package}/bin/garage server"
-            + lib.optionalString cfg.singleNode " --single-node"
-            + lib.optionalString cfg.defaultBucket " --default-bucket";
+          + lib.optionalString cfg.singleNode " --single-node"
+          + lib.optionalString cfg.defaultBucket " --default-bucket";
 
           StateDirectory = lib.mkIf isDefaultStateDirectory "garage";
           DynamicUser = lib.mkDefault true;

--- a/nixos/modules/services/web-servers/garage.nix
+++ b/nixos/modules/services/web-servers/garage.nix
@@ -22,6 +22,16 @@ in
   };
 
   options.services.garage = {
+    defaultBucket = mkOption {
+      default = false;
+      example = true;
+      description = ''
+        Starts garage with the `--default-bucket` flag, available since version `2.3.0`. See <https://garagehq.deuxfleurs.fr/documentation/quick-start/#launching-the-garage-server>.
+        To function properly, the environment variables `GARAGE_DEFAULT_ACCESS_KEY`, `GARAGE_DEFAULT_SECRET_KEY` and `GARAGE_DEFAULT_BUCKET` need to be set. See <https://garagehq.deuxfleurs.fr/documentation/quick-start/#configuring-initial-access-credentials>.
+      '';
+      type = lib.types.bool;
+    };
+
     enable = mkEnableOption "Garage Object Storage (S3 compatible)";
 
     extraEnvironment = mkOption {
@@ -82,6 +92,13 @@ in
       description = "Garage configuration, see <https://garagehq.deuxfleurs.fr/documentation/reference-manual/configuration/> for reference.";
     };
 
+    singleNode = mkOption {
+      default = false;
+      example = true;
+      description = "Starts garage with the `--single-node` flag, available since version `2.3.0`. See <https://garagehq.deuxfleurs.fr/documentation/quick-start/#launching-the-garage-server>.";
+      type = lib.types.bool;
+    };
+
     package = mkOption {
       type = types.package;
       description = "Garage package to use, needs to be set explicitly. If you are upgrading from a major version, please read NixOS and Garage release notes for upgrade instructions.";
@@ -139,7 +156,9 @@ in
           isDefaultStateDirectory = lib.any isDefault paths;
         in
         {
-          ExecStart = "${cfg.package}/bin/garage server";
+          ExecStart = "${cfg.package}/bin/garage server"
+            + lib.optionalString cfg.singleNode " --single-node"
+            + lib.optionalString cfg.defaultBucket " --default-bucket";
 
           StateDirectory = lib.mkIf isDefaultStateDirectory "garage";
           DynamicUser = lib.mkDefault true;


### PR DESCRIPTION
These two optional launch flags were added in garage version 2.3.0, see https://garagehq.deuxfleurs.fr/documentation/quick-start/#launching-the-garage-server for more details.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
