### PR TITLE
python3Packages.python-lsp-server: fix test with jedi 0.20.0

### DIFF
--- a/pkgs/development/python-modules/python-lsp-server/default.nix
+++ b/pkgs/development/python-modules/python-lsp-server/default.nix
@@ -53,9 +53,15 @@ buildPythonPackage rec {
     hash = "sha256-Yq5dYaX+/hLvmPpHI8rhCcSlabQBPAyUrIQRgnoi17c=";
   };
 
+  patches = [
+    # https://github.com/python-lsp/python-lsp-server/pull/709
+    ./jedi-compat.patch
+  ];
+
   pythonRelaxDeps = [
     "autopep8"
     "flake8"
+    "jedi"
     "mccabe"
     "pycodestyle"
     "pydocstyle"

--- a/pkgs/development/python-modules/python-lsp-server/jedi-compat.patch
+++ b/pkgs/development/python-modules/python-lsp-server/jedi-compat.patch
@@ -1,0 +1,40 @@
+From 07bb69fe0c3168f9951914547dcb89309fea1b20 Mon Sep 17 00:00:00 2001
+From: Lumir Balhar <lbalhar@redhat.com>
+Date: Mon, 4 May 2026 12:09:22 +0200
+Subject: [PATCH] Fix test_snippets_completion to not depend on typeshed
+ overload ordering
+
+jedi 0.20.0 bundles a newer typeshed that adds a no-arg overload for
+defaultdict.__init__ as the first overload, causing format_snippet to
+hit the zero-params branch and produce "defaultdict()" instead of
+"defaultdict($0)". Replace defaultdict with a locally-defined function
+to make the test stable across typeshed updates.
+---
+ test/plugins/test_completion.py | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/test/plugins/test_completion.py b/test/plugins/test_completion.py
+index ae5021f5..bbaeabe0 100644
+--- a/test/plugins/test_completion.py
++++ b/test/plugins/test_completion.py
+@@ -322,7 +322,7 @@ def test_matplotlib_completions(config, workspace) -> None:
+ 
+ 
+ def test_snippets_completion(config, workspace) -> None:
+-    doc_snippets = "from collections import defaultdict \na=defaultdict"
++    doc_snippets = "from collections import defaultdict \ndef foo(a): pass\nfoo"
+     com_position = {"line": 0, "character": 35}
+     doc = Document(DOC_URI, workspace, doc_snippets)
+     config.capabilities["textDocument"] = {
+@@ -332,9 +332,9 @@ def test_snippets_completion(config, workspace) -> None:
+     completions = pylsp_jedi_completions(config, doc, com_position)
+     assert completions[0]["insertText"] == "defaultdict"
+ 
+-    com_position = {"line": 1, "character": len(doc_snippets)}
++    com_position = {"line": 2, "character": 3}
+     completions = pylsp_jedi_completions(config, doc, com_position)
+-    assert completions[0]["insertText"] == "defaultdict($0)"
++    assert completions[0]["insertText"] == "foo($0)"
+     assert completions[0]["insertTextFormat"] == lsp.InsertTextFormat.Snippet
+ 
+

--- a/pkgs/development/python-modules/spyder/default.nix
+++ b/pkgs/development/python-modules/spyder/default.nix
@@ -77,6 +77,7 @@ buildPythonPackage rec {
 
   pythonRelaxDeps = [
     "ipython"
+    "jedi"
     "python-lsp-server"
   ];
 


### PR DESCRIPTION
Broke after the jedi 0.20.0 bump.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
