### PR TITLE
bluemoon: init at 2.15

### DIFF
--- a/pkgs/by-name/bl/bluemoon/package.nix
+++ b/pkgs/by-name/bl/bluemoon/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  ncurses,
+  asciidoctor,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bluemoon";
+  version = "2.15";
+
+  src = fetchFromGitLab {
+    owner = "esr";
+    repo = "bluemoon";
+    tag = finalAttrs.version;
+    hash = "sha256-3CNeiA7K8JkBXTYzq787QgVHfVvYXZ/0uRqVCZ5mMZo=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
+  nativeBuildInputs = [ asciidoctor ];
+
+  buildInputs = [ ncurses ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  preInstall = ''
+    make bluemoon.6
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Ncurses based solitaire TUI card game";
+    homepage = "https://gitlab.com/esr/bluemoon";
+    mainProgram = "bluemoon";
+    license = lib.licenses.bsd2;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ castorNova2 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Part of https://github.com/NixOS/nixpkgs/issues/380688.

Adds a package of [bluemoon](https://gitlab.com/esr/bluemoon) which is a ncurses based TUI soltaire game.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
