### PR TITLE
python3Packages.mpmath: skip failing test on x86_64-darwin

### DIFF
--- a/pkgs/development/python-modules/mpmath/default.nix
+++ b/pkgs/development/python-modules/mpmath/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   gmpy2,
@@ -45,6 +46,16 @@ buildPythonPackage (finalAttrs: {
     hypothesis
     pexpect
   ];
+
+  # Ugly hack to preserve the hash on non-`x86_64-darwin` platforms
+  ${if stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64 then "disabledTests" else null} =
+    [
+      # Expected:
+      #     -0.5440211108893698
+      # Got:
+      #     -0.5440211108893699
+      "contexts.rst"
+    ];
 
   meta = {
     homepage = "https://mpmath.org/";


### PR DESCRIPTION
## Things done

As title.

Note: this PR does not affect `x86_64-linux`, `aarch64-linux` and `aarch64-darwin`.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
