### PR TITLE
openocd-adi: init at 0.12.0-1.3.1-1

### DIFF
--- a/pkgs/by-name/op/openocd-adi/package.nix
+++ b/pkgs/by-name/op/openocd-adi/package.nix
@@ -1,0 +1,30 @@
+{
+  openocd,
+  autoreconfHook,
+  lib,
+  fetchFromGitHub,
+}:
+
+openocd.overrideAttrs (old: {
+  pname = "openocd-adi";
+  version = "0.12.0-1.3.1-1";
+  src = fetchFromGitHub {
+    owner = "analogdevicesinc";
+    repo = "openocd";
+    tag = "0.12.0-1.3.1-1";
+    hash = "sha256-e25mAxUmbF/hZC+aWRMt9HdwKY0FClNrZXwP3888Z9A=";
+    # openocd disables the vendored libraries that use submodules and replaces them with nix versions.
+    # this works out as one of the submodule sources seems to be flakey.
+    fetchSubmodules = false;
+  };
+  nativeBuildInputs = old.nativeBuildInputs ++ [
+    autoreconfHook
+  ];
+  meta = openocd.meta // {
+    description = "ADI fork of OpenOCD";
+    homepage = "https://github.com/analogdevicesinc/openocd";
+    maintainers = with lib.maintainers; [
+      aiyion
+    ];
+  };
+})

--- a/pkgs/by-name/op/openocd/package.nix
+++ b/pkgs/by-name/op/openocd/package.nix
@@ -82,6 +82,9 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s "$rules" "$out/etc/udev/rules.d/"
   '';
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   meta = {
     description = "Free and Open On-Chip Debugging, In-System Programming and Boundary-Scan Testing";
     mainProgram = "openocd";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
