### PR TITLE
maintainers: remove kirikaza

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14374,12 +14374,6 @@
     githubId = 451835;
     name = "Kirill Elagin";
   };
-  kirikaza = {
-    email = "k@kirikaza.ru";
-    github = "kirikaza";
-    githubId = 804677;
-    name = "Kirill Kazakov";
-  };
   kirillrdy = {
     email = "kirillrdy@gmail.com";
     github = "kirillrdy";

--- a/pkgs/by-name/mo/moolticute/package.nix
+++ b/pkgs/by-name/mo/moolticute/package.nix
@@ -54,10 +54,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/mooltipass/moolticute";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [
-      kirikaza
-      hughobrien
-    ];
+    maintainers = with lib.maintainers; [ hughobrien ];
     platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
## Reasons

- Last commented in [December 2023](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Akirikaza)
- Hasn't created any PRs / Issues since [Decembe 2023](https://github.com/NixOS/nixpkgs/issues?q=author%3Akirikaza)
- About 21 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Akirikaza%20-commenter%3Akirikaza%20-author%3Akirikaza%20-reviewed-by%3Akirikaza) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.