### PR TITLE
python3Packages.wslink: 2.5.0 -> 2.5.7

### DIFF
--- a/pkgs/development/python-modules/wslink/default.nix
+++ b/pkgs/development/python-modules/wslink/default.nix
@@ -1,33 +1,26 @@
 {
   lib,
-  buildPythonPackage,
-  fetchFromGitHub,
-  setuptools,
   aiohttp,
-  msgpack,
+  buildPythonPackage,
   cryptography,
+  fetchFromGitHub,
+  hatchling,
+  msgpack,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "wslink";
-  version = "2.5.0";
+  version = "2.5.7";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "kitware";
     repo = "wslink";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-g1I8qCuqfv+pA3IP7b57PZ7vCsykpfJNG97NgJ+N5lE=";
+    hash = "sha256-47vHc+b5Z3ipkLZ5k0yEasNaKz0Seu2jiGBVmAI5u6U=";
   };
 
-  sourceRoot = "${finalAttrs.src.name}/python";
-
-  # add missing version string to dist-info
-  postPatch = ''
-    sed -i "/name *= */a\    version='${finalAttrs.version}'," setup.py
-  '';
-
-  build-system = [ setuptools ];
+  build-system = [ hatchling ];
 
   dependencies = [
     aiohttp
@@ -46,7 +39,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Python/JavaScript library for communicating over WebSocket";
     homepage = "https://github.com/Kitware/wslink";
-    changelog = "https://github.com/Kitware/wslink/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/Kitware/wslink/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ qbisi ];
   };


### PR DESCRIPTION
Diff: https://github.com/kitware/wslink/compare/v2.5.0...v2.5.7

Changelog: https://github.com/Kitware/wslink/releases/tag/v2.5.7


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
