### PR TITLE
python3Packages.aiorwlock: 1.5.0 -> 1.5.1

### DIFF
--- a/pkgs/development/python-modules/aiorwlock/default.nix
+++ b/pkgs/development/python-modules/aiorwlock/default.nix
@@ -7,7 +7,7 @@
   poetry-core,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "aiorwlock";
   version = "1.5.1";
   pyproject = true;
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "aio-libs";
     repo = "aiorwlock";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-+favszX1mVuuLWqKCIk+i5frX+y2kOArAUVIAJG1otY=";
   };
 
@@ -31,8 +31,8 @@ buildPythonPackage rec {
   meta = {
     description = "Read write lock for asyncio";
     homepage = "https://github.com/aio-libs/aiorwlock";
-    changelog = "https://github.com/aio-libs/aiorwlock/releases/tag/v${version}";
+    changelog = "https://github.com/aio-libs/aiorwlock/releases/tag/v${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ billhuang ];
   };
-}
+})

--- a/pkgs/development/python-modules/aiorwlock/default.nix
+++ b/pkgs/development/python-modules/aiorwlock/default.nix
@@ -5,31 +5,21 @@
   pytest-asyncio,
   pytestCheckHook,
   poetry-core,
-  fetchpatch,
 }:
 
 buildPythonPackage rec {
   pname = "aiorwlock";
-  version = "1.5.0";
+  version = "1.5.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "aio-libs";
     repo = "aiorwlock";
     tag = "v${version}";
-    hash = "sha256-QwjwuXjaxE1Y+Jzn8hJXY4wKltAT8mdOM7jJ9MF+DhA=";
+    hash = "sha256-+favszX1mVuuLWqKCIk+i5frX+y2kOArAUVIAJG1otY=";
   };
 
   build-system = [ poetry-core ];
-
-  patches = [
-    # Fix cross-event-loop race condition in lock acquisition
-    # https://github.com/aio-libs/aiorwlock/pull/503
-    (fetchpatch {
-      url = "https://github.com/aio-libs/aiorwlock/commit/05608d401e4a68c69c6b9f421dd20535a9dbe523.patch?full_index=1";
-      hash = "sha256-97c6Li6nq7ViNvUIdPL8f/ATOSsmiAMaJeBFj+jPJcM=";
-    })
-  ];
 
   nativeCheckInputs = [
     pytest-asyncio


### PR DESCRIPTION
Diff: https://github.com/aio-libs/aiorwlock/compare/v1.5.1...v1.5.1

Changelog: https://github.com/aio-libs/aiorwlock/releases/tag/v1.5.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
