### PR TITLE
entroly: init at 1.0.11; python3Packages.entroly: init at 1.0.11; python3Packages.entroly-core: init at 1.0.11;

### DIFF
--- a/pkgs/by-name/en/entroly/package.nix
+++ b/pkgs/by-name/en/entroly/package.nix
@@ -1,0 +1,1 @@
+{ python3Packages }: with python3Packages; toPythonApplication entroly

--- a/pkgs/development/python-modules/entroly-core/default.nix
+++ b/pkgs/development/python-modules/entroly-core/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+let
+  version_v = "1.0.11";
+in
+buildPythonPackage (finalAttrs: {
+  pname = "entroly-core";
+  version = version_v;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "juyterman1000";
+    repo = "entroly";
+    rev = "entroly-v${version_v}";
+    hash = "sha256-gueS31OPVhJ/b63MrD16pQL6txmyd88VHODtwvgPQGg=";
+  };
+
+  build-system = (
+    with rustPlatform;
+    [
+      cargoSetupHook
+      maturinBuildHook
+    ]
+  );
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    src = "${finalAttrs.src}/entroly-core";
+    pname = "${finalAttrs.pname}-vendor";
+    inherit version_v;
+    hash = "sha256-wWvXU8f1u9ZdiqFADA0iQotHzS5VamL7jz64862lF/U=";
+  };
+
+  postUnpack = ''
+    export sourceRoot="source/entroly-core"
+    chmod -R u+w "$sourceRoot"
+  '';
+
+  pythonImportsCheck = [ "entroly_core" ];
+
+  meta = {
+    description = "Information-theoretic context optimization for AI coding agents";
+    homepage = "https://github.com/juyterman1000/entroly/entroly-core";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.guelakais ];
+  };
+})

--- a/pkgs/development/python-modules/entroly/default.nix
+++ b/pkgs/development/python-modules/entroly/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  entroly-core,
+  fetchFromGitHub,
+  git,
+  hatchling,
+  mcp,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "entroly";
+  version = "1.0.11";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "juyterman1000";
+    repo = "entroly";
+    rev = "entroly-v${finalAttrs.version}";
+    hash = "sha256-gueS31OPVhJ/b63MrD16pQL6txmyd88VHODtwvgPQGg=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    entroly-core
+    mcp
+  ];
+
+  nativeCheckInputs = [
+    git
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "entroly" ];
+
+  meta = {
+    description = "Information-theoretic context optimization for AI coding agents";
+    homepage = "https://github.com/juyterman1000/entroly";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.guelakais ];
+    mainProgram = "entroly";
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5092,8 +5092,9 @@ self: super: with self; {
     routerFeatures = true;
   };
 
-  entroly-core = callPackage ../development/python-modules/entroly-core { };
+  entroly = callPackage ../development/python-modules/entroly { };
 
+  entroly-core = callPackage ../development/python-modules/entroly-core { };
 
   entry-points-txt = callPackage ../development/python-modules/entry-points-txt { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5092,6 +5092,9 @@ self: super: with self; {
     routerFeatures = true;
   };
 
+  entroly-core = callPackage ../development/python-modules/entroly-core { };
+
+
   entry-points-txt = callPackage ../development/python-modules/entry-points-txt { };
 
   entrypoint2 = callPackage ../development/python-modules/entrypoint2 { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Added 3 new Packages
- entroly: (made out of python3Packages.entroly)
- python3Packages.entroly
- python3Packages.entroly-core
all of them at 0.19.13
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
