### PR TITLE
angle: fix pkgsStatic.angle

### DIFF
--- a/pkgs/by-name/an/angle/package.nix
+++ b/pkgs/by-name/an/angle/package.nix
@@ -131,49 +131,57 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs build/toolchain/apple
   '';
 
-  installPhase = ''
-    runHook preInstall
+  installPhase =
+    let
+      hostPlatformLibraryExtension =
+        if stdenv.hostPlatform.isStatic then
+          stdenv.hostPlatform.extensions.staticLibrary
+        else
+          stdenv.hostPlatform.extensions.sharedLibrary;
+    in
+    ''
+      runHook preInstall
 
-    install -v -m755 -D \
-      *${stdenv.hostPlatform.extensions.sharedLibrary}* \
-      -t "$out/lib"
-    install -v -m755 -D \
-      angle_shader_translator \
-      gaussian_distribution_gentables \
-      -t "$out/bin"
+      install -v -m755 -D \
+        *${hostPlatformLibraryExtension}* \
+        -t "$out/lib"
+      install -v -m755 -D \
+        angle_shader_translator \
+        gaussian_distribution_gentables \
+        -t "$out/bin"
 
-    cp -rv ../../include "$out"
+      cp -rv ../../include "$out"
 
-    mkdir -p $out/lib/pkgconfig
+      mkdir -p $out/lib/pkgconfig
 
-    cat > $out/lib/pkgconfig/angle.pc <<EOF
-    prefix=${placeholder "out"}
-    exec_prefix=''${prefix}
-    libdir=''${prefix}/lib
-    includedir=''${prefix}/include
+      cat > $out/lib/pkgconfig/angle.pc <<EOF
+      prefix=${placeholder "out"}
+      exec_prefix=''${prefix}
+      libdir=''${prefix}/lib
+      includedir=''${prefix}/include
 
-    Name: angle
-    Description: ${finalAttrs.meta.description}
+      Name: angle
+      Description: ${finalAttrs.meta.description}
 
-    URL: ${finalAttrs.meta.homepage}
-    Version: ${lib.versions.major finalAttrs.version}
-    Libs: -L''${libdir} -l${
-      lib.concatStringsSep " -l" [
-        "EGL"
-        "EGL_vulkan_secondaries"
-        "GLESv1_CM"
-        "GLESv2"
-        "GLESv2_vulkan_secondaries"
-        "GLESv2_with_capture"
-        "VkICD_mock_icd"
-        "feature_support"
-      ]
-    }
-    Cflags: -I''${includedir}
-    EOF
+      URL: ${finalAttrs.meta.homepage}
+      Version: ${lib.versions.major finalAttrs.version}
+      Libs: -L''${libdir} -l${
+        lib.concatStringsSep " -l" [
+          "EGL"
+          "EGL_vulkan_secondaries"
+          "GLESv1_CM"
+          "GLESv2"
+          "GLESv2_vulkan_secondaries"
+          "GLESv2_with_capture"
+          "VkICD_mock_icd"
+          "feature_support"
+        ]
+      }
+      Cflags: -I''${includedir}
+      EOF
 
-    runHook postInstall
-  '';
+      runHook postInstall
+    '';
 
   meta = {
     description = "Conformant OpenGL ES implementation for Windows, Mac, Linux, iOS and Android";


### PR DESCRIPTION
This PR adds a simple conditional value to make the build script use the static library extension instead of the shared one on static builds. 

Fixes #522683.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
