### PR TITLE
streamcontroller: 1.5.0-beta.13 -> 1.5.0-beta.14

### DIFF
--- a/pkgs/by-name/st/streamcontroller/package.nix
+++ b/pkgs/by-name/st/streamcontroller/package.nix
@@ -18,19 +18,19 @@
 }:
 let
   # We have to hardcode revision because upstream often create multiple releases for the same version number.
-  # This is the commit hash that maps to 1.5.0-beta.13 released on 2025-12-30
-  rev = "359de976eb23120d6e6a2d31104e15b37d1edfeb";
+  # This is the commit hash that maps to 1.5.0-beta.14 released on 2026-5-21
+  rev = "12052dec15d0e0948032c7ec11eff2da0d109106";
 in
 stdenv.mkDerivation {
   pname = "streamcontroller";
 
-  version = "1.5.0-beta.13";
+  version = "1.5.0-beta.14";
 
   src = fetchFromGitHub {
     repo = "StreamController";
     owner = "StreamController";
     inherit rev;
-    hash = "sha256-b5tRhXEQGRhaJd1Q/hlmqUTO+0F+3+lziYSi8QpUa9c=";
+    hash = "sha256-JGJc7bj58oZwvtExSv+tv7Ug84RYdEkcMBI3ZmqpaKY=";
   };
 
   # The installation method documented upstream
@@ -200,7 +200,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Elegant Linux app for the Elgato Stream Deck with support for plugins";
-    homepage = "https://core447.com/";
+    homepage = "https://streamcontroller.core447.com/";
     license = lib.licenses.gpl3;
     mainProgram = "streamcontroller";
     maintainers = with lib.maintainers; [ sifmelcara ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Update streamcontroller to latest release. Also updated the `homepage` metadata, as it's been changed upstream. Runs fine on my system with a standard streamdeck, however I don't have an XL or mini to test.

Changelog: https://github.com/StreamController/StreamController/releases/tag/1.5.0-beta.14

Github commit logs: https://github.com/StreamController/StreamController/compare/1.5.0-beta.13...1.5.0-beta.14

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
