### PR TITLE
OVMF{,-{cloud-hypervisor,xen}}: minor improvements

### DIFF
--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -14,6 +14,7 @@
   qemu,
   dosfstools,
   mtools,
+
   fdSize2MB ? false,
   fdSize4MB ? secureBoot,
   secureBoot ? false,
@@ -38,6 +39,7 @@
   # Usually, this option is broken, do not use it except if you know what you are
   # doing.
   sourceDebug ? false,
+
   projectDscPath ?
     {
       x86_64 = "OvmfPkg/OvmfPkgX64.dsc";
@@ -56,11 +58,22 @@
     }
     .${stdenv.hostPlatform.parsed.cpu.name}
       or (throw "Unsupported OVMF `fwPrefix` on ${stdenv.hostPlatform.parsed.cpu.name}"),
+
+  metaDescription ? "Sample UEFI firmware for QEMU and KVM",
   metaPlatforms ? lib.subtractLists lib.platforms.i686 edk2.meta.platforms,
+  metaMaintainers ? (
+    with lib.maintainers;
+    [
+      adamcstephens
+      mjoerg
+      raitobezarius
+      sigmasquadron
+    ]
+  ),
+  metaTeams ? [ ],
 }:
 
 let
-
   platformSpecific = {
     x86_64.msVarsArgs = {
       flavor = "OVMF_4M";
@@ -96,7 +109,6 @@ let
   };
 
   buildPrefix = "Build/*/*";
-
 in
 
 assert msVarsTemplate -> fdSize4MB;
@@ -129,7 +141,9 @@ edk2.mkDerivation projectDscPath (finalAttrs: {
     dosfstools
     mtools
   ];
+
   strictDeps = true;
+  __structuredAttrs = true;
 
   hardeningDisable = [
     "format"
@@ -264,15 +278,11 @@ edk2.mkDerivation projectDscPath (finalAttrs: {
     };
 
   meta = {
-    description = "Sample UEFI firmware for QEMU and KVM";
+    description = metaDescription;
     homepage = "https://github.com/tianocore/tianocore.github.io/wiki/OVMF";
     license = lib.licenses.bsd2;
     platforms = metaPlatforms;
-    maintainers = with lib.maintainers; [
-      adamcstephens
-      raitobezarius
-      mjoerg
-      sigmasquadron
-    ];
+    teams = metaTeams;
+    maintainers = metaMaintainers;
   };
 })

--- a/pkgs/by-name/ov/OVMF-cloud-hypervisor/package.nix
+++ b/pkgs/by-name/ov/OVMF-cloud-hypervisor/package.nix
@@ -36,11 +36,7 @@
 }:
 
 let
-  cpuName = stdenv.hostPlatform.parsed.cpu.name;
-
   version = lib.getVersion edk2;
-
-  OvmfPkKek1AppPrefix = "4e32566d-8e9e-4f52-81d3-5bb9715f9727";
 
   debian-edk-src = fetchFromGitLab {
     domain = "salsa.debian.org";
@@ -56,9 +52,6 @@ let
     rev = "refs/tags/debian/2025.02-8";
     hash = "sha256-n/6T5UBwW8U49mYhITRZRgy2tNdipeU4ZgGGDu9OTkg=";
   };
-
-  buildPrefix = "Build/*/*";
-
 in
 
 edk2.mkDerivation projectDscPath (finalAttrs: {
@@ -81,6 +74,7 @@ edk2.mkDerivation projectDscPath (finalAttrs: {
   ];
 
   strictDeps = true;
+  __structuredAttrs = true;
 
   hardeningDisable = [
     "format"

--- a/pkgs/by-name/ov/OVMF-xen/package.nix
+++ b/pkgs/by-name/ov/OVMF-xen/package.nix
@@ -1,17 +1,9 @@
 { lib, OVMF }:
 
-(OVMF.override {
+OVMF.override {
   projectDscPath = "OvmfPkg/OvmfXen.dsc";
   fwPrefix = "OVMF";
+  metaDescription = "Sample UEFI firmware for Xen guests";
+  metaTeams = [ lib.teams.xen ];
   metaPlatforms = builtins.filter (lib.hasPrefix "x86_64-") OVMF.meta.platforms;
-}).overrideAttrs
-  (oldAttrs: {
-    __structuredAttrs = true;
-
-    pname = "OVMF-xen";
-
-    meta = oldAttrs.meta // {
-      description = "Sample UEFI firmware for Xen guests";
-      teams = [ lib.teams.xen ];
-    };
-  })
+}


### PR DESCRIPTION
- `__structuredAttrs`
- new overridable attributes for `meta`.
- removed some dead code.

Followup to #521333 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
