### PR TITLE
meshtasticd: Override download cache timestamps

### DIFF
--- a/pkgs/by-name/me/meshtasticd/package.nix
+++ b/pkgs/by-name/me/meshtasticd/package.nix
@@ -5,6 +5,7 @@
   fetchzip,
   libarchive,
   pkg-config,
+  jq,
   platformio-core,
   writableTmpDirAsHomeHook,
   bluez,
@@ -62,6 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
     }))
     writableTmpDirAsHomeHook
     makeBinaryWrapper
+    jq
   ];
 
   buildInputs = [
@@ -82,6 +84,8 @@ stdenv.mkDerivation (finalAttrs: {
     cp -ar ${platformio-deps-native}/. platformio-deps-native
     chmod +w -R platformio-deps-native
     rm -f platformio-deps-native/core/appstate.json
+    jq "map_values($(date +%s))" platformio-deps-native/core/.cache/downloads/usage.db > usage_new.db
+    mv usage_new.db platformio-deps-native/core/.cache/downloads/usage.db
 
     export PLATFORMIO_CORE_DIR=platformio-deps-native/core
     export PLATFORMIO_LIBDEPS_DIR=platformio-deps-native/libdeps


### PR DESCRIPTION
Add a call to jq to set the timestamps of the PlatformIO downloads cache to the current time. This prevents attempts to download the project’s dependencies again during the build.

Fixes #521952

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
