### PR TITLE
matcha: 0.37.0 -> 0.39.0

### DIFF
--- a/pkgs/by-name/ma/matcha/package.nix
+++ b/pkgs/by-name/ma/matcha/package.nix
@@ -14,16 +14,16 @@ buildGoModule (finalAttrs: {
   __structuredAttrs = true;
 
   pname = "matcha";
-  version = "0.37.0";
+  version = "0.39.0";
 
   src = fetchFromGitHub {
     owner = "floatpane";
     repo = "matcha";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-bvy7og6om+Mqn4J0GrtIx8VQQXUiy8Y7Kueyfj5FWWQ=";
+    hash = "sha256-tS6c/Nn18Awu4y9fskFpefhdqEUOdmFQNlPyIwGu3wI=";
   };
 
-  vendorHash = "sha256-SH7zP5+3R82mMx9vHY8QbPUkLr29pwbIbiV55UUQu+M=";
+  vendorHash = "sha256-rEH7GlsqqmpMVUkOn1f/iD3WgRCvd/1KZYoLOX3jNjY=";
   proxyVendor = true;
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [


### PR DESCRIPTION
## Description

Automated version bump for `matcha` email client.

- Old: 0.37.0
- New: 0.39.0
- Upstream release: https://github.com/floatpane/matcha/releases/tag/v0.39.0

## Things done

- Built on `x86_64-linux` via GitHub Actions
- Hashes regenerated from upstream tarball
- No package metadata changes beyond version + hashes

cc maintainer for review.