### PR TITLE
python3Packages.jedi-language-server: fix test with jedi 0.20.0

### DIFF
--- a/pkgs/development/python-modules/jedi-language-server/default.nix
+++ b/pkgs/development/python-modules/jedi-language-server/default.nix
@@ -37,6 +37,10 @@ buildPythonPackage rec {
     poetry-core
   ];
 
+  pythonRelaxDeps = [
+    "jedi"
+  ];
+
   dependencies = [
     docstring-to-markdown
     jedi


### PR DESCRIPTION
python3Packages.jedi-language-server: relax jedi version constraint

Broke after the jedi 0.20.0 bump in nixpkgs.

This fix relaxes the strict `jedi<0.20` runtime metadata requirement
by adding `pythonRelaxDeps = [ "jedi" ];`, following the same approach
as #522650 (which fixed the same issue for `python-lsp-server`).

No additional code or test patches were needed for this package.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
