### PR TITLE
graphite: 0-unstable-2026-05-02 -> 0-unstable-2026-05-17

### DIFF
--- a/pkgs/by-name/gr/graphite/package.nix
+++ b/pkgs/by-name/gr/graphite/package.nix
@@ -15,7 +15,7 @@
   wasm-pack,
   cargo-about,
   nodejs,
-  wasm-bindgen-cli_0_2_100,
+  wasm-bindgen-cli_0_2_121,
   xz,
   removeReferencesTo,
   cef-binary,
@@ -30,16 +30,16 @@
 }:
 
 let
-  version = "0-unstable-2026-05-02";
-  rev = "ab7f59ca61004a1b11f9ae4b1c511cefc7a0f404";
+  version = "0-unstable-2026-05-25";
+  rev = "bbbe04903f28673a86203910b250bf12f3d38b55";
 
-  srcHash = "sha256-DV3/1dgtUiTmGkOm4z3GVJcWzvCjO/crzc/l8ovW0XA=";
-  shaderHash = "sha256-76hOCx1fpFBI5nVmIAIGd2StCRzhbCgs+GHMvxbflLc=";
-  cargoHash = "sha256-ZesLyXKjz2CSrAWUT5Hq6w97pR55I+C79qPwF0dqXXI=";
+  srcHash = "sha256-aEOH0NFUIt0iQNKNlAdKXobVPqbZbeQYB96lDzEsJ3U=";
+  shaderHash = "sha256-4lKBrGh1rfhTBczmCDvIF2KxLyEHzHdKVGgQ+jLd/Dw=";
+  cargoHash = "sha256-iW1hk67zexp/b7HO4q4le8/7ARIn+/VJIZ54RBau238=";
   npmHash = "sha256-AX5Jqk2E+WyQJyHbgvvq74MRsYmWUju4bOkabhYoeig=";
 
-  brandingRev = "1939ca82f3341427059e15bfa205f7c22aaf867a";
-  brandingHash = "sha256-SDnCpLuppHVE7cUVidevH2O/2ma0S2tuQDhFkS/JLvA=";
+  brandingRev = "0d004aa61e6b48d316e8e5db6d59ccc4788f192d";
+  brandingHash = "sha256-wAA6fR+NSxlCAqgwWmpiIAnji9k/jsMXpR0Vt04Ntmk=";
 
   src = fetchFromGitHub {
     owner = "GraphiteEditor";
@@ -96,7 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     npmHooks.npmConfigHook
     binaryen
-    wasm-bindgen-cli_0_2_100
+    wasm-bindgen-cli_0_2_121
     wasm-pack
     nodejs
     cargo-about

--- a/pkgs/by-name/gr/graphite/update.nu
+++ b/pkgs/by-name/gr/graphite/update.nu
@@ -4,11 +4,18 @@
 ^nix-update graphite --version=branch --version-regex '(0-unstable-.*)'
 
 let pkg = "./pkgs/by-name/gr/graphite/package.nix"
-let rev = (open $pkg | lines | where ($it | str contains 'rev = "') | first | str trim | parse 'rev = "{rev}";' | get 0.rev)
-let meta = (http get $"https://raw.githubusercontent.com/GraphiteEditor/Graphite/($rev)/.branding" | lines)
-let branding_rev = ($meta | get 0 | path basename | str replace ".tar.gz" "")
-let branding_hash = (^nix hash convert --to sri --hash-algo sha256 ($meta | get 1) | str trim)
+let rev = open $pkg | lines | where ($it | str contains 'rev = "') | first | str trim | parse 'rev = "{rev}";' | get 0.rev
+
+let shader_url = $"https://raw.githubusercontent.com/timon-schelling/graphite-artifacts/refs/heads/main/rev/($rev)/raster_nodes_shaders_entrypoint.wgsl"
+let shader_hash = ^nix store prefetch-file --hash-type sha256 $shader_url --json | from json | get hash
+
+let branding = http get $"https://raw.githubusercontent.com/GraphiteEditor/Graphite/($rev)/.branding" | lines
+let branding_url = $branding | get 0
+let branding_rev = $branding_url | path basename | str replace ".tar.gz" ""
+let branding_hash = ^nix store prefetch-file --hash-type sha256 --unpack $branding_url --json | from json | get hash
+
 open $pkg
+| str replace --regex 'shaderHash = "[^"]*"' $'shaderHash = "($shader_hash)"'
 | str replace --regex 'brandingRev = "[^"]*"' $'brandingRev = "($branding_rev)"'
 | str replace --regex 'brandingHash = "[^"]*"' $'brandingHash = "($branding_hash)"'
 | save --force $pkg


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
