### PR TITLE
Firefox: 151.0 -> 151.0.1

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,1859 +1,1859 @@
 {
-  version = "151.0";
+  version = "151.0.1";
   sources = [
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ach/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/ach/firefox-151.0.1.tar.xz";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "a5a76be506df358bbae61cdc6784823d394c2b002684eecf338341ab5c446663";
+      sha256 = "61a2820f1467e466efeebbe591e58573f6141b3fcaae4fda1de5894fe8aa50a1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/af/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/af/firefox-151.0.1.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "2678780a72e4f57161eacc44199210e1400d22d3dcea56453507ba01be55530f";
+      sha256 = "a1012db8f1cfbd81067469635cdfdb5ac579282ce2d0911ac860a987d7b125c8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/an/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/an/firefox-151.0.1.tar.xz";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "c0b0420bebbf728d49ac4e8722eff64eecc66d4bf859e93d43133c4c17aa11c9";
+      sha256 = "56f00740d66694edd7f6c23950e2d94b99a7c76954e7078688d6bf1bae105f81";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ar/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/ar/firefox-151.0.1.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "9de18d9a1d1f01e2545c82efb9364052b15fe7daff002a5057e03c9f3b2c2171";
+      sha256 = "7973468a087737c367ae1984ce07ea7a5f9ebf9ebcc6a326f9ea9a2197f6ce2f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ast/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/ast/firefox-151.0.1.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "89fc9a1a8996fb329c86afde7e48c905d47594582176f36f8dc00a658b456d83";
+      sha256 = "8efb53d2ff4f263d5cedbbbc87b6ad08f93be6b2894d7f4fa68f73c69288873b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/az/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/az/firefox-151.0.1.tar.xz";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "83cdd42b96cf2949f7276787889c1bc669d7bae6d948340b977effd0a0c797fc";
+      sha256 = "b6ba04e76040cab4b21ec724a1eafc793130ab6fb66d6f7b0eeb13e04df51286";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/be/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/be/firefox-151.0.1.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "fea2becc0482203bf95707b85021df967621e7e6a48b5663e117d8ff2267b24f";
+      sha256 = "6c342fa1319896e01bc6407303d7a987d8c35a4a8f4bd32373b12077ccc28a3b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/bg/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/bg/firefox-151.0.1.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "2c7ce49a800913424a0a00f3674dca3a25cb30d3a5093348d4916d8b7a439c5d";
+      sha256 = "5d17e5f1dd079eeb5c9839bb8fd67e9c0599fc9585c4efe173746f9777d01add";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/bn/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/bn/firefox-151.0.1.tar.xz";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "1606962c0a5f3b6d9eb75fdd05d1ca221585057748564fd0521d6af1ea55cf37";
+      sha256 = "5747c1cf35f2fde7a1cf3d21189f7290325f3f7c1c81bb3b1c8424693fe311ae";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/br/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/br/firefox-151.0.1.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "30ffca3e5261fa6b14915e36a057757013a0b78e5a6a27cc78443bcea28563da";
+      sha256 = "abef43dc82fe9d8a07ffb635e6dc41df72a89c4789b0e74846b7031691f9367a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/bs/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/bs/firefox-151.0.1.tar.xz";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "638080f855f5ed767666c270c1f0a7af7132f60b02e3d4aec377a806ccdd7476";
+      sha256 = "4c590e6c2b02e04bdd9169c406fdbacddd977aed5149119a6e7279ab04dd4ec5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ca-valencia/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/ca-valencia/firefox-151.0.1.tar.xz";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "ca0653846f1b9015be4b001f136d1fccdcdaba39a1d563c3db8c7701b4b2bcfa";
+      sha256 = "0cff64aeaaa652477dd8898a22be3f35444bdf6a07083cabe2105eb05598b4b9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ca/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/ca/firefox-151.0.1.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "4f041b300b31b163e9fde50f33b82351b43295f6f20af14095ac0d46c5beaacf";
+      sha256 = "ffaf1881ce983698ce2646d86789ce8f5e1ec57c17277748abe5bc996c1b6bd4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/cak/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/cak/firefox-151.0.1.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "46d0f9346e0a3c1b1fc94a529db75a9b6a31468481face0b9b6a1489a493c24d";
+      sha256 = "152b6514e1428666dd29c8525666a8c7f2cacedcbff185cd7daea7c4d00b3e45";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/cs/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/cs/firefox-151.0.1.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "de972f37854c2958db42f5f017eb4ce1d564365bbb71b310ebd810922b507149";
+      sha256 = "f662ca8f30627c25f287aa4bcf153bff809b1bb7722235c222a82ccefecbc5f4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/cy/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/cy/firefox-151.0.1.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "e02ddd1b459c9d9a8c0ea3e87d6210eb0f48936dce911d38c0a84ade4e801fa8";
+      sha256 = "e81472d3da883f999f933f6d400c1af78fa30b6489720e03848b8628cede13b9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/da/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/da/firefox-151.0.1.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "aec2b1b944ffc2a52862eaf125cf236ff56cc03b4e1e8cfdc1e587de8d26fb9c";
+      sha256 = "b49fcfc2b0849075cffc495b7c51d71e87abb85f365bfc17ab2b6050467ec868";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/de/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/de/firefox-151.0.1.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "ed2b60c73db03b28d0ee2a135afc23489e911b55adf423ea2b6298d8afafb206";
+      sha256 = "a89f7ea40ad12ce81c7a947f618bdc6a4ab4ef896a5dbd7f05bc9cb7a934e962";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/dsb/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/dsb/firefox-151.0.1.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "7328eb1d6abd3b579fd882ee6d55c5e6365d7d0f9238fbf5b2695780b6b647a7";
+      sha256 = "681a632023790dae1568887467e1a28458a76d82ac5f913ac5bdd74e8fe5159b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/el/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/el/firefox-151.0.1.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "f64b8b1cdc959187bb48b9cc1b6f59793a0cbcc2906c82091605074870a075f5";
+      sha256 = "84a393d80a6b64a6c3418139f2fe0521bb008f93e9adb734efb0e90ea24c9fea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/en-CA/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/en-CA/firefox-151.0.1.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "68ae97f7a4bffeed62c5810dc8b47939919ea7fc37fd237ccb2f225dd05cd692";
+      sha256 = "1e803519acbb803f010af98b813e564511edab8074e887a819608e425febaadf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/en-GB/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/en-GB/firefox-151.0.1.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "33c96a93750ac75ddb55f751d747442413d2b41a0f186c75384aec90b9b7b0a6";
+      sha256 = "dd2c24b888debe750e59d1d3b3f69a23f9562a86195fb28832e1db0dca857a0a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/en-US/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/en-US/firefox-151.0.1.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "8ff8557a5ca3903ebbc1d18570684075f623465be5e362d63a95b3acc523f824";
+      sha256 = "de1a20b7126a2ac91f12fc22e763f053d56c1716d52b7c734f519abe10f4e236";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/eo/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/eo/firefox-151.0.1.tar.xz";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "f1eacece6c91eaa07e086c4cc5ef5361e83f8832032f515cd5dacffdf8a547bb";
+      sha256 = "2bcdd21cb8f19df5d45b1b7d954df3591ed8b172606aedd359e06006533f082a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/es-AR/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/es-AR/firefox-151.0.1.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "bde1ba71c68851b60ea720b0f5d629baf21710b67222c7444b76cda306c5afd3";
+      sha256 = "462b0b7ab4767ae0c1efb9c9d9a1b23db785fcda218670d5288c4338948b3036";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/es-CL/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/es-CL/firefox-151.0.1.tar.xz";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "18db222688543a1a8b08c8f26c3305ba00649a25b2283647cccfd6a994f3ca59";
+      sha256 = "7b4ff843b453ee10bd40d5cc641512871c3c457fef4c8979cf466bfacbebc50d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/es-ES/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/es-ES/firefox-151.0.1.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "1653505adfaad6bc1d2dfd72845bb476331683e11c42a3f79f1093c334ec493c";
+      sha256 = "816f375dd6c95bdc25c566a6b107996b527f413f56ce8af7cf63c9e330a489b4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/es-MX/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/es-MX/firefox-151.0.1.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "bddaa285441594afff25907ff70b1ffb04fb459fe3409c86d513f99bed6e6c16";
+      sha256 = "a2087a0a8e1b7d681cd71f3c25fc26c66963d62bf088c279284bdeeb67900cf1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/et/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/et/firefox-151.0.1.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "6aa74d1dec6b0b11ae56f3a416d3b3d0526be9ce2371a770a926a7f8374afd19";
+      sha256 = "3d003d1d4c9511f6a727b9207ff99f371368764f13eb5be9eb5976db1d41d34f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/eu/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/eu/firefox-151.0.1.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "ef86f5dd4bb5ec021b3dbb13db89644a8f183948e09f7515e57b2080940ae994";
+      sha256 = "0515f84f9cdbff55a02a33d1739a72c3e4cfd90b2833d4cccb2f1ea40ff6d0fc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/fa/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/fa/firefox-151.0.1.tar.xz";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "c2f629d4c8f15057b96f6ae592c3cc16e72c7866137e09401af51b728bc2c5e2";
+      sha256 = "da9c0eb0fd54648b98dbdb567c423c971dd5b6b455120b553c4a7bd52f5729eb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ff/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/ff/firefox-151.0.1.tar.xz";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "94ba483a64b80511ffb566424c60f5f77937a2141fff865c214365b67ba81a3a";
+      sha256 = "8296718a3db6dd49b2b4f9e440950300ff064835978148a77fb24a83df17d004";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/fi/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/fi/firefox-151.0.1.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "fdf9bb2d329421e07ac79ebf7cbd860889804963936b9e5149c8bfe9a6895175";
+      sha256 = "dd436f3c8f2fcfcd8a43e501eb7e15f58f0e8aebb8bf45a2912cdae5a292c0fb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/fr/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/fr/firefox-151.0.1.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "de54178a0380a57b38ff6cb944105bf7937d9aa116e193f7d279b58a8f466d01";
+      sha256 = "0265e87a94cfbcb098d0f4d92cd89085c5ee8789457542b5c7fdb6ae3cc59ce6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/fur/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/fur/firefox-151.0.1.tar.xz";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "6712064abdf6578299b8a4c0c2e090200d8cf1c23ae8304973d06be13c197506";
+      sha256 = "525f3f9d3c505bbcd58c2e3d1c4386468d2038648ce212f1e22b98b2ce7a461c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/fy-NL/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/fy-NL/firefox-151.0.1.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "b7f3672bdba80059b4cf22c94acea7dd7cac47c31d2948f16ada9885ea98e65a";
+      sha256 = "5f691eebad4a5b511a6e2211c6c0b6b7a58d938ba506c19a6edc253c31eba3cc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ga-IE/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/ga-IE/firefox-151.0.1.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "60a8ac9ade98ce8b582406b60bb02219d72b507d59d39759265e6e3617d2a361";
+      sha256 = "e60ccb09b7ea3d7c023f580d8af7eb23c6fd1343b9e83dae6888feded244c9fa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/gd/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/gd/firefox-151.0.1.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "0295116c9db870de81de3d9402667801940f1ce86f01abb59841055aca2fd708";
+      sha256 = "b5574f8cff9d7b1118c2d4017ac160cc906d72035c4600d430667967b4012d60";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/gl/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/gl/firefox-151.0.1.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "73327accfc87945fb50172ab7e460ff457e2173a81821594f25c529e73a09051";
+      sha256 = "4aab8e96e572b200ba94a186d7a0cfc7fdac0bab18a4b81c952cb01f32137ba8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/gn/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/gn/firefox-151.0.1.tar.xz";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "41be6729fab3b4caa59cee438a1ef9569cb5edf863679546163cbb2c4c74550a";
+      sha256 = "3bc7756bf94c0c4313ddbe3670e4b89d4a0f8df73dd863bdca2df5439b6f98b7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/gu-IN/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/gu-IN/firefox-151.0.1.tar.xz";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "4ae5d1be64034316b4ec013dccb3d553cd001a0b1fb157b23c428dcccddec8f9";
+      sha256 = "011c9f52b02137d780a6c26f7a0f43bb575630d1f0516d2b26824c08b4a8a514";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/he/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/he/firefox-151.0.1.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "c20dbb8107bac56fe3a5b8a80b5add649a345b58f8fb7247f41b5559fa65d587";
+      sha256 = "9aca4e14d7d05410af5994b25cef49fdcc05d48f242b1fddb2fe374f81dddbca";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/hi-IN/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/hi-IN/firefox-151.0.1.tar.xz";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "5f189fd5aca90cd10bc07e4e6a0f0ef7ebd113be34e064d4e06ce76420160be1";
+      sha256 = "645b8dbbed0652fa33ea491990633dac63ff1a29b8fb231060cb3aec27e293a2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/hr/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/hr/firefox-151.0.1.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "3defb65ec98e3f2a1122c19695238247a70102fbdfede4acbe5cdac2e55e156d";
+      sha256 = "80c914b2f148e01db34a042888c32101b6786ce1a7f8724bb6139a8c71e53f60";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/hsb/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/hsb/firefox-151.0.1.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "3378387b0b9921e811124f0bdb778b738a5e5a98747f55e68e92fa32a9f33203";
+      sha256 = "f73d3cd125eb8bb4f9ca0ab85a5c080cbf28d2bc58b2e0843eff684f81b44e25";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/hu/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/hu/firefox-151.0.1.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "4ee2039fbb3ff5342d4c8c40a04dfbd03b4edfb7b9bc773cbe361813e5123d83";
+      sha256 = "041d0cb6f14d85af63879c727ab4b0db06dece53bcca6cbc4e173bb5098c2b9f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/hy-AM/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/hy-AM/firefox-151.0.1.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "acd5e851802bc446013596ef0c1e42f0baeda5bdee194b912eafad0b9f44bf19";
+      sha256 = "a7f545d9ea20dcfd265acfda170bb308d5bbe443a5101e5ee7632622bfefe126";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ia/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/ia/firefox-151.0.1.tar.xz";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "5682d525831b08638cde736942e09e41cee33fd4f09954d975f20329bc9828bc";
+      sha256 = "725957640fcab48f96776354ac05547048ed575a8f28c73044771d8aac7fd508";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/id/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/id/firefox-151.0.1.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "d8819f3ac8b15604ae75d385fec91623e127a27ddcffb1fafdea4d340ab24e0e";
+      sha256 = "165597750eb3211b43ffb5e9bb1f2db43c3a6dc3abc290f597ba655ef6321a69";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/is/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/is/firefox-151.0.1.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "7cf148001db49c7e9ffcc99cebec6f3c33c5b55ec9a39f67098d0157ed7e3aa9";
+      sha256 = "fe8b4baed537ab81152cdcdc7efd823ef48ca88ce96bf9f9e765a7a7d334a008";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/it/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/it/firefox-151.0.1.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "f0d3f5e44975ae57004089d1a6f3852df7d6895eed8a19c99c03b0d68baf8432";
+      sha256 = "fb8849d8ce91aa211332ca1bf8e5882e77e0cca3b2c5e10993904ad9c0667f95";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ja/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/ja/firefox-151.0.1.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "051c8121400cd48eb31de084de36067319eedc2a7f7a741674def831704ef48d";
+      sha256 = "ec030e0ff95a41417e777be9cd69941aa2a83df2ecfe418f325dd8384e78e2c5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ka/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/ka/firefox-151.0.1.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "214d50dd8ad9978f36165d4bfeaf4ff29f0b2638b735d722c599067150a7b78f";
+      sha256 = "153077e3d084b34248ed91d40d77d0b9146fb266c8e8fb8a9520004179b50fc6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/kab/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/kab/firefox-151.0.1.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "4eaba0a8dbfe33cea09a6fd8fdbee810a252cfdb459077ef158461001053a163";
+      sha256 = "37e62a1504db41779b655055fd974e298dbca229408d1614e2067fa98bbb12af";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/kk/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/kk/firefox-151.0.1.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "01304cce83ee42b05f1ed2874313fae712bcadc27a403aac9aa0189c24dc04d6";
+      sha256 = "2dec759e4887c90929d539f215fca7105ebc3e559afd593aa7e81ca03dc8b397";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/km/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/km/firefox-151.0.1.tar.xz";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "823a55f2e80fb42091dc06edcb4637f0f118ea6714e6584aa7daaaea6dfb70a0";
+      sha256 = "b6151d344e2c737387df8589157f2ef4768f4e624127ab45488be2f1a61174c2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/kn/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/kn/firefox-151.0.1.tar.xz";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "7d0657004dd58983151b206bc4344e6ed7865b1b97c6e66f8b33b97484e72a27";
+      sha256 = "fbdc1100948be013e6289f98b906c909a207586882d460592546582d8f50c4f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ko/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/ko/firefox-151.0.1.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "b2cc1ae32477a9020aa5f7133678b8ecd39df9dec14ee834aa87929c6f3ffd1f";
+      sha256 = "e5c2bf0010570292ca361a3469259b763fa9e8dd97773ca4a9dde0ce34915162";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/lij/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/lij/firefox-151.0.1.tar.xz";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "7d919594a4282695c54cb023e857e8a00c1502eaaab92d53ad94ed85ec77878d";
+      sha256 = "4a4658283eea4d950131a5977686088bd317ed9cd3ebc9f59faf5215bed53e71";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/lt/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/lt/firefox-151.0.1.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "dc64657b46d99ff0e79553c26dd082cbcff18da23e3a1439c7fe8fb16f78e350";
+      sha256 = "c20043da6aceedbb26810767033c7970fa88497ffa6f65498ba8be28bc941320";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/lv/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/lv/firefox-151.0.1.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "4fb0f0f9a2084eb497df9d5d2743eb1695098b9e1de0ebb1b2ff1d4503185671";
+      sha256 = "56738b9a5e658da4f531467d60fcbdfdee5df6dc1f91700371e02418088f2415";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/mk/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/mk/firefox-151.0.1.tar.xz";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "fc658480be05cb3d9196cf196d6c73535a76248d6c4d71607808efcf9c1f1741";
+      sha256 = "4ea776396bcebe2e384c5bc2b20a3d930b5c2f190de1f927ded4305a9d230eec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/mr/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/mr/firefox-151.0.1.tar.xz";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "879e9051bc452e19c14b2106f517bf2a6706f5640f4035619f3d1ae665d4f693";
+      sha256 = "43c92a2fb0b370cb882c84afefb62c5c222a74dbe47009ec5e25a1fa469b3b32";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ms/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/ms/firefox-151.0.1.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "7603b8dd2ade484d72d38e59581975a37bafde52c7abf3adeaa6a0257fc05bd5";
+      sha256 = "cd202d114f3709bd3e50bd8af3851e433ac8e8bb8f65ef747108788a1ac8e9f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/my/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/my/firefox-151.0.1.tar.xz";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "fa40162961669df54755432acec901041f1f0eb5348d96e9833fff53e1ffbfe1";
+      sha256 = "923a7da8bc226a78e6db3085edcf674b696d4168a2a40b04a376baf73ac44c42";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/nb-NO/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/nb-NO/firefox-151.0.1.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "ed971ddae3ff471101a0e5e7a349cd2a8ae33caa971af2490359688af5603f20";
+      sha256 = "3273d1b2bc1e12c12408b1e332e1b94038316b642293ba231ecb07d66eafa3cf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ne-NP/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/ne-NP/firefox-151.0.1.tar.xz";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "dafb39613109054ec59882a2d2a011c4e3e1e8b1e8425214e5efd67edc543d3d";
+      sha256 = "d49470d840b6dd88f8ad928bbfbaeee693bdcf3e6afc39fa421ddc8e65765eef";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/nl/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/nl/firefox-151.0.1.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "d13c193297807eab501b3a268d3e2c3378509f6f5c3694e14516a8772e6f87cd";
+      sha256 = "ea00461c187f8ab8128ee590966ff478cc55ee75c23b0d3b592883dbe5b00082";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/nn-NO/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/nn-NO/firefox-151.0.1.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "e3aab38123b129e7274eedb47b12e7fe614bb2d3b5db8916f206057a6f611aa5";
+      sha256 = "ff6a9639c7e1e2141a8df10d318ed5106c116f63af2f8a3dd2fe7e8132042ee9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/oc/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/oc/firefox-151.0.1.tar.xz";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "24570c0a704b4955b66f50972595e000dae514ec8faadd64fced24c680bf7620";
+      sha256 = "2e2eb2eaf7803cc0d12abdf34fc1f621a894afc2ffc8595417a59d6db39f1f31";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/pa-IN/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/pa-IN/firefox-151.0.1.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "c1d0d10ad699ae98bff12df474fa5c88b36afa22a34654efca28b3c1011c325a";
+      sha256 = "b3512092edbb65c745353fa9f4dd1f2eb62c6b3824949000fa2c7739cfe9c5e1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/pl/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/pl/firefox-151.0.1.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "168b01c00acdd364c323d39b8144b23e4da54471950496c7389c3be43a5ecb0a";
+      sha256 = "684f582213e2f1546375e93f3bfe7e270fed9971ceb6cd91b2675253de9c6125";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/pt-BR/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/pt-BR/firefox-151.0.1.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "75b9850e8ddcbf144609b6ff737cdd5e05d674e2af899cbed26a44f80868d346";
+      sha256 = "0ca4a10d208fceb88dda03fcd76c950be9c9b0aa5ea669e98dec17c6cee75151";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/pt-PT/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/pt-PT/firefox-151.0.1.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "adb608c47a46f4840e280dae4279c146c3d1a36b1204c3ff630480f5023e2c05";
+      sha256 = "8b54d199b674056067bc318abaadaea32f9b7e02033bf4938ff0df685938735c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/rm/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/rm/firefox-151.0.1.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "22bc13a10e7f94db2f91cc22e1562339d0d69c59e668c35c9cbe37bfab488041";
+      sha256 = "ef6a582b6ca79d3caf53dc6b5eaeac4b76de23039085eb7484860f5034757cf6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ro/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/ro/firefox-151.0.1.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "7d774462f72d5dcb6137ae42c51484b29da8fc9f5c00b30be41671b9cb7940c6";
+      sha256 = "8924b5d80a848d917dd2bdb7865657fa0f8c5b5b6c0b107ed15540c3c7663c05";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ru/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/ru/firefox-151.0.1.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "41e9a27b194f047759fb1ce94f7a79e3e5538c40dcaf1b2235dc7088c5d1eecb";
+      sha256 = "cb018797a449c728a37ecc2aa05e6ec935f2697a2378642e83b14deb0b33dd42";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/sat/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/sat/firefox-151.0.1.tar.xz";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "b5cd47ad373c9d1168ab081b3cb948bd566c934d99df377b71bc9e0e70e64c70";
+      sha256 = "0ca07f6863bb979a9282ac958ad0ffac605bccaefdf7166a9ada48da22103939";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/sc/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/sc/firefox-151.0.1.tar.xz";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "a08c3ee253655fe5b6505062331a6a4697534090cd2da7f13253dfb743f4148d";
+      sha256 = "b8b4ae2b324ee95660ae21e03f0657c6b937a0ae308d00896e595d28c02338e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/sco/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/sco/firefox-151.0.1.tar.xz";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "f7f5ddf183b9efd2a7f2c527d672ed472e2e66f9de2abdafe4e450c400fb6277";
+      sha256 = "90c151f941943f9629b824aba21ec09f84d689298d695554fdc6a9fcab077174";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/si/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/si/firefox-151.0.1.tar.xz";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "ece465b47735bd672da91e4446380536c703844684dc2083641179f72e935bba";
+      sha256 = "0322ff8dc2a1197416148267685346017acb0797099ca5b3189d5e7d338f828e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/sk/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/sk/firefox-151.0.1.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "8f446f6f88db393cd8bb23d54ea6bc4a048ba22a458649773c5adf132c2726c8";
+      sha256 = "93521d464b84e285442ec2bfa2474acd556025922ba2d9b9b6287c324a13dc36";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/skr/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/skr/firefox-151.0.1.tar.xz";
       locale = "skr";
       arch = "linux-x86_64";
-      sha256 = "809a46d9f569f214b8f84df27190acd20d4ca81d596cb801dd0b49c20877b318";
+      sha256 = "7a7b2920b68c8e286648c84971b2f0818b5a269adf99b53b669e81857177a379";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/sl/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/sl/firefox-151.0.1.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "978575c6e1f15315575641c5c466f7776edc28b707539bbc8de6baf1a0a76647";
+      sha256 = "ebb11d5432ab6d7fa6438b5fd58eb2af39ad8fc38dbd7219ae863ac13041a7bf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/son/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/son/firefox-151.0.1.tar.xz";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "aee5ec60a06e0f15371fe9a753377952b4be38d68dc2d28fe8eec4efe498a6f4";
+      sha256 = "d73401022115ecb7ef4dad4052e7db74da22f858cd0698e190a890dcab7be879";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/sq/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/sq/firefox-151.0.1.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "cfb2365bd00aaa111c74d72f535534b204e3fdc56ed13ecd3ce9ed5170b31324";
+      sha256 = "06bc06dc03cf33986d097e183bcf8b23bfc1d4fe65fffa2ebd920cc31503dd4a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/sr/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/sr/firefox-151.0.1.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "c678b10aecdcc118d64dc4880abd90460d9a8a4c156dad1e7f8614a0b58c46da";
+      sha256 = "5173638f28ca6f3426402a5682124bda86ff629904a3fe2c4e9c0e9d832f4316";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/sv-SE/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/sv-SE/firefox-151.0.1.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "5be1cef027daa6513289e5462dc7faa4e2471c683f11279bd8713e72c5ac8e45";
+      sha256 = "d38203966f436f5743bd251d44ee03e1fa05c314868d1342ebc821f1d4cb706b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/szl/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/szl/firefox-151.0.1.tar.xz";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "ed732c3160e2cdb0a2890e3d6cf5553b8b10913a8bd2bab20f1184acaf045bf0";
+      sha256 = "427800b2dc4f4a2a353a0de18cb76c27e46230a98f8dde8772756d3b582c7a63";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ta/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/ta/firefox-151.0.1.tar.xz";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "fc50ee0a5ecff1f88dee5382e8235373e3c9607bc0fe43884cd17e54317a1e5f";
+      sha256 = "afefed9a26904d5896c915b9cdeb1cc47c53bfaaf6a8bd0378ab3c4b5bf2cdf6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/te/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/te/firefox-151.0.1.tar.xz";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "352ded5957561e7891bd52aaf2339d8aa8d40112b99fae1007513d4556a9bace";
+      sha256 = "3fc94029630831d7e0684a21db8b017c2949774772563076803a2e38de729fe9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/tg/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/tg/firefox-151.0.1.tar.xz";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "ef03eabaf3c5631c85026f6bebddc3b745be0b1f4bdb81ef30ffca7566ecba0d";
+      sha256 = "43a29ed8f50d7dea5a74419ffb11fce99009955537412225455489a5ab19f1da";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/th/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/th/firefox-151.0.1.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "692df7973e0757f5559d644073d63f721c85016d9ec5fca99f7e4319a778c211";
+      sha256 = "d107cb828c3790d006c75dbf83530bcaf51d350beb7498461f6149fcb8eaa074";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/tl/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/tl/firefox-151.0.1.tar.xz";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "a24216ca2b1ecd9803b8783394ac200af4444d6607d109c6925486dcd394c2d0";
+      sha256 = "2e52d7b47c29f8807f8a2151b59f9eb823f802fc3f09bbab6f0e61994a71f95f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/tr/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/tr/firefox-151.0.1.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "334b0e6b19f88b4e9a339ffd08eb36a68c5b056809e30c44677e9e79704e430b";
+      sha256 = "b1c0afeb43f6216f32cb971fd22aea5c8919dfb71feb414f481e832aa17f9fdd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/trs/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/trs/firefox-151.0.1.tar.xz";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "83699dda01b1d87ebc038543ab8c942f4709dda3ecf9e008025c5fe324099754";
+      sha256 = "a9574de4352415f6c51deddac4c0d8965d6e0e9442ba9f9f088aa66feadfeb6b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/uk/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/uk/firefox-151.0.1.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "b5d36836fdc9fcbd13af2172e139c4c7a619616ab6c363da4772a4dab15c6379";
+      sha256 = "c7400fb14d8143b0614a266bb6b3086fdf3690d4d92d652c8d58b249a030102a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/ur/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/ur/firefox-151.0.1.tar.xz";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "c1be7be733aac68adcc6e36c1cee0b4da633c425fb7e52aad06cd9dbb9e8f48a";
+      sha256 = "470cba5d078f21d5027787b38e66b86f75578530950c3084579f2d78bd4bc2ce";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/uz/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/uz/firefox-151.0.1.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "208cb307466f94f0a20645c80e1ffdea9b77206da623eb46ae8448eb6f68b5b0";
+      sha256 = "469bdb5ec3d8c0cce7f6e9a9fcd2bd3040adec5312bc2cd087c9787738b73e2e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/vi/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/vi/firefox-151.0.1.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "eba173f003dc1666b9310bca22e2c5603c61dedf33d9f8bf9ddee2ff57541578";
+      sha256 = "81185bd512437e464da18b82aad21a4a0c715e8324846b8d1425c91493e01cda";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/xh/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/xh/firefox-151.0.1.tar.xz";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "a5bc75166b5635d9562653b68247e7d5d1c321a9523c5b5050eee0a47aaa002f";
+      sha256 = "21bc1b876b34bc40e4058495ce5d1418dcdfaeb7d1b110261fdef9cd83919c70";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/zh-CN/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/zh-CN/firefox-151.0.1.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "097c3b40899efc6f925ae517b095d250d27a6144607d033aa39dfb41d2784871";
+      sha256 = "1c33185bdf78eaac9dada58094e007d7e8e1ee8d214c155ee0f4bdbc1d465e27";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-x86_64/zh-TW/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-x86_64/zh-TW/firefox-151.0.1.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "51a74af0d6cc092b62c64d9b2a01a8d126a7603ff1956a8191801946f4068356";
+      sha256 = "a5a0a5d257f9d7b7d751e98095c2e7615c187a34fb4dfc43603e52552a58e42a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ach/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/ach/firefox-151.0.1.tar.xz";
       locale = "ach";
       arch = "linux-aarch64";
-      sha256 = "4d4c66823249c61e40cb6b934118d9abe23a3c29310f1456b994dd4c5eb5115f";
+      sha256 = "df0706dabdb84c972916eb6fdd29d9ecc2a9d359b103fba51026f674ec295974";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/af/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/af/firefox-151.0.1.tar.xz";
       locale = "af";
       arch = "linux-aarch64";
-      sha256 = "453a26ab55010c644c668de23a0f53fd8967a132aeac0686f48d5ac5387c545e";
+      sha256 = "3d390292691a92711f036915942a6116909aaf219dd359c6c7b1438239d3006a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/an/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/an/firefox-151.0.1.tar.xz";
       locale = "an";
       arch = "linux-aarch64";
-      sha256 = "5c954cc7a6b1cb58b24e6d44c3183dede5fd923bd7f6a7ad9e1be74a825fb898";
+      sha256 = "bb5f882521d5b9bfeeac1e2fccd181ea1c64e213fa6d30474aacc546b034e3d4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ar/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/ar/firefox-151.0.1.tar.xz";
       locale = "ar";
       arch = "linux-aarch64";
-      sha256 = "7cdb9b1a1bd08fdb2058ae8d1561c286e47aa32abcb775cbf6208451e6c47807";
+      sha256 = "2e6e919de65ef7e77afe87369a97e3a67e3d53d221adde17fda7667a0fec4864";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ast/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/ast/firefox-151.0.1.tar.xz";
       locale = "ast";
       arch = "linux-aarch64";
-      sha256 = "5e8fcdba1ff9a9a0a85d64e9822faeb1ccc76c116f0928c3e26d886cf4a29ea8";
+      sha256 = "61e1333ef48499f7fe09c69f61b15bb597d1f4acadda50aa509faf6ba4e5e7b1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/az/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/az/firefox-151.0.1.tar.xz";
       locale = "az";
       arch = "linux-aarch64";
-      sha256 = "8fcc0a17ea899271eb0d57f835621a8cda4a654a5d15f76aa2ddcca59903f4e2";
+      sha256 = "0abd8c68c62455ae8c220387ceb183eb2ba0e52661ba5355ec5b998e32b62b3f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/be/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/be/firefox-151.0.1.tar.xz";
       locale = "be";
       arch = "linux-aarch64";
-      sha256 = "c203d795c605785b174db9de567adbcb31476361a6664316848327ba6a4f3995";
+      sha256 = "0c2726fb288eb4059e51c153b044e1b8360e9c76d0184e7f33be9132c0e5220f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/bg/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/bg/firefox-151.0.1.tar.xz";
       locale = "bg";
       arch = "linux-aarch64";
-      sha256 = "dfd0ea5a0ea0a160450c169f631cf95739ddc4d6f5e0744342a492f6d8c766d4";
+      sha256 = "07e76223003152343fb6590087b80bd58dcd02305e75e2a417b4df65ba5e56df";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/bn/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/bn/firefox-151.0.1.tar.xz";
       locale = "bn";
       arch = "linux-aarch64";
-      sha256 = "c187bc56514729c7a348443e0993838757fd31421a23f8b22bbb7c3d231f4dd5";
+      sha256 = "8190f3982722c9c4beca56f27966d4819038788a7a5370fbe0c6886e3a7ac6e9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/br/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/br/firefox-151.0.1.tar.xz";
       locale = "br";
       arch = "linux-aarch64";
-      sha256 = "7041ed716353625317361cdf45443c500fb2f85a8a7befbc0cc5d7ed6ed615a4";
+      sha256 = "931b82455562d32e62c28c895cf3552f23b893eef8dca94c7bc93c2c58f0fcb5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/bs/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/bs/firefox-151.0.1.tar.xz";
       locale = "bs";
       arch = "linux-aarch64";
-      sha256 = "2d6fffa260bf99eb84776da218b9faf1ed99c0ad0bf779a58d25a8e4f4620ed4";
+      sha256 = "d1e8becbc0b03bc38f33832a5b310ee484abbe7d5a851b6fd0f3204ffd5a390c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ca-valencia/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/ca-valencia/firefox-151.0.1.tar.xz";
       locale = "ca-valencia";
       arch = "linux-aarch64";
-      sha256 = "7ac0936aaeaf180f2c0c7150d3e73635178d79e928ac5cfd859507d8b26040f7";
+      sha256 = "d5a8d6dbaeee0d6c99f1e8929da8ff41d261825706a4f46acee6f4f70c0a3393";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ca/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/ca/firefox-151.0.1.tar.xz";
       locale = "ca";
       arch = "linux-aarch64";
-      sha256 = "c14784c510d47787690b6bcf9f15f27fdaa672b0e3c26bdf06a4e39c0ed0024e";
+      sha256 = "64a72f4da2c01478c08a6bdfd1a87f08a4ad51fb0ff16657f814dbd97ca88728";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/cak/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/cak/firefox-151.0.1.tar.xz";
       locale = "cak";
       arch = "linux-aarch64";
-      sha256 = "ce40bf71a941255a9f845cb21cba068c7100a3d10b8314570ad149ce1cc7dcf3";
+      sha256 = "4aa355ac43e24a5ec2f9711aa82a74164ec04044bd912487df4810a741ab1c43";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/cs/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/cs/firefox-151.0.1.tar.xz";
       locale = "cs";
       arch = "linux-aarch64";
-      sha256 = "502fbbcf920da48afe40fc60a99b4537675ce814697dd03e6fc67bde131e03e3";
+      sha256 = "4d9f5df9d0cf4e869937035c7d52a5840e04a009ac4b5c6be512a4123c04fc46";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/cy/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/cy/firefox-151.0.1.tar.xz";
       locale = "cy";
       arch = "linux-aarch64";
-      sha256 = "66876956205c2b99db209620c6729e3d14a5c7cda4e00fcff3c21510925ca338";
+      sha256 = "ecfe8e509ad5b8b47f7d19038570b67dfdad798d221b0f929931a28766bf29f6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/da/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/da/firefox-151.0.1.tar.xz";
       locale = "da";
       arch = "linux-aarch64";
-      sha256 = "3df00da062bebc7057c049cf34a1cb052462c4718f0396955f730ffd4b80b1a4";
+      sha256 = "9a41439aafc17bf933143fec929c1d0553af2e6709b72397ab5188522999b345";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/de/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/de/firefox-151.0.1.tar.xz";
       locale = "de";
       arch = "linux-aarch64";
-      sha256 = "fedfb8c6d357e25afff212f85686447cb1a2963e43e5a9efeb6da824e4c0da12";
+      sha256 = "626ca1a629743e1abf5888dcb94d77527815ac95318a05204fea8ec0b499817f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/dsb/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/dsb/firefox-151.0.1.tar.xz";
       locale = "dsb";
       arch = "linux-aarch64";
-      sha256 = "752b6a1f2e2a34574dd8f7414b878d2b8f76bf5b0ceb36732d7341e53e9a75a6";
+      sha256 = "84fc33c16ff5f9bb93e87ebaef840fe41c7fd43b16aca6f2135e873cfe2b7b72";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/el/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/el/firefox-151.0.1.tar.xz";
       locale = "el";
       arch = "linux-aarch64";
-      sha256 = "f31ddcbca79f41600184d8c9dbda56618a64442d904f57bb878bc0adf18713ce";
+      sha256 = "f4841e5b659416e8714f120c3538ebbfdedd74010c2ec57b2784f3fc4cf05a33";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/en-CA/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/en-CA/firefox-151.0.1.tar.xz";
       locale = "en-CA";
       arch = "linux-aarch64";
-      sha256 = "55ba52d8e39e61f634f0d066184c4dc1fe3fbf6619afb8d3bdef5f0295f03223";
+      sha256 = "9026d3519381ca247df296f46b88d049e7f3fd85fa4ee9eb8c216262d7d630bd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/en-GB/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/en-GB/firefox-151.0.1.tar.xz";
       locale = "en-GB";
       arch = "linux-aarch64";
-      sha256 = "1175a01cf65e2994623e1a0a22b151f2d6fe4d9f41d5ab2288ee0bd24fc3c886";
+      sha256 = "19bdbeb61512e06bc6509fe12e0ca9a7bcd2496d34644c11d48fd88d3508fce5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/en-US/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/en-US/firefox-151.0.1.tar.xz";
       locale = "en-US";
       arch = "linux-aarch64";
-      sha256 = "d4da9e278e933238a2cb873ecacd4cbb00e3b6d4b35fbbe3aa949c4bdd816230";
+      sha256 = "97656526bdf52326b68530afcb93f80f540b048681457728e4db2cb42de71ade";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/eo/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/eo/firefox-151.0.1.tar.xz";
       locale = "eo";
       arch = "linux-aarch64";
-      sha256 = "f82c3e6030f5f4148ebd65552a159da6d1eb0c0170c19748ae098b749d92dbfb";
+      sha256 = "cd672463b7234e6fa74ddf27f7d1e82b2ae3dadcd4702b70f416a073fdf59f8f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/es-AR/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/es-AR/firefox-151.0.1.tar.xz";
       locale = "es-AR";
       arch = "linux-aarch64";
-      sha256 = "bbcf0d66e2177c47f8e1f8ab02b0939561fefec733931acfbf3f31f66dc4ddf7";
+      sha256 = "7da1d691534a8fc1247a02dce0cfb628a88e2e6355fde05da4f1d879b72e6355";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/es-CL/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/es-CL/firefox-151.0.1.tar.xz";
       locale = "es-CL";
       arch = "linux-aarch64";
-      sha256 = "2b46e200f7e6e862ae01183c46fe1c970eedf516c649449c32dfe56cb5a36658";
+      sha256 = "14da659fc42ab100d99badfa1858e53908c728ab3d62f5c3474cc843ae012546";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/es-ES/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/es-ES/firefox-151.0.1.tar.xz";
       locale = "es-ES";
       arch = "linux-aarch64";
-      sha256 = "7430ac325d6a226f186203979ba0372357ee13f8389f6ca00771639713095ee7";
+      sha256 = "ee9001e816e0f8ebeeac71c2bbfeacc5970cf6347641a17335985060fcca916d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/es-MX/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/es-MX/firefox-151.0.1.tar.xz";
       locale = "es-MX";
       arch = "linux-aarch64";
-      sha256 = "261bddd2daab4bd05a641e76c34d4437678f4c8df0c8b569e60cda01ebfe71b8";
+      sha256 = "8f06264a803047e7c42f714f42bb121de118615a1abc80ff5dadcdd5d1db3583";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/et/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/et/firefox-151.0.1.tar.xz";
       locale = "et";
       arch = "linux-aarch64";
-      sha256 = "acd971403e78b3ad1a1fe4dc0b204920dded7bd6e87c277b019d3c82561c1dd8";
+      sha256 = "04e1d3ed4da4a138f7f4c0aa7acb9143aa5319d9b153f0fd3c860580efbba2f0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/eu/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/eu/firefox-151.0.1.tar.xz";
       locale = "eu";
       arch = "linux-aarch64";
-      sha256 = "856051d95bf03e4ef51c381380e6e2c76716d01aa7b9857e2fe40d8b6da0fb23";
+      sha256 = "2aab0ebbb8ab7c580b2cbd844edd0fb6737b4cd643b75d2a3736388b783e4433";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/fa/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/fa/firefox-151.0.1.tar.xz";
       locale = "fa";
       arch = "linux-aarch64";
-      sha256 = "340947ba7768ee52c8961f6536080d469e6cac8242994da3dec313365394f87d";
+      sha256 = "df1c297c26375919e0944edf926f8e6135623c97cc3b0c2f865e7d592b1c90c6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ff/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/ff/firefox-151.0.1.tar.xz";
       locale = "ff";
       arch = "linux-aarch64";
-      sha256 = "07abc0addba4524c2edb1bfb98aacf3845598f0361c94dea184743b5785c3a16";
+      sha256 = "234848cd34eb9b9018e6ba3b42424e601bcbe34f98e3bd22286e564221c131ab";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/fi/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/fi/firefox-151.0.1.tar.xz";
       locale = "fi";
       arch = "linux-aarch64";
-      sha256 = "2227beb7fe0a3563a38f02378a4fc81bea5f01567815ae74b02321ed78c5fdcb";
+      sha256 = "37184a51cb99f4303098ae5e4e0153cf3efc778977ae73ac18391d7115628025";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/fr/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/fr/firefox-151.0.1.tar.xz";
       locale = "fr";
       arch = "linux-aarch64";
-      sha256 = "bbdd8e6c1a20f906078b0847d25418c60798f9f016f99109c4244ac97137765a";
+      sha256 = "bc91c01309a76b0856d54f8907f345124f4e65cd2263829cd79df3abb7731a40";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/fur/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/fur/firefox-151.0.1.tar.xz";
       locale = "fur";
       arch = "linux-aarch64";
-      sha256 = "3d7387c47f35b3d9388b9d4cebfcd1b0250b0034215a134352088b8a3cfefcc5";
+      sha256 = "9e2d34556d0c107bdc69f09967ae9def6fe3ba787389cb41927e3c78c9137196";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/fy-NL/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/fy-NL/firefox-151.0.1.tar.xz";
       locale = "fy-NL";
       arch = "linux-aarch64";
-      sha256 = "2bead167fc0cc24819a13fddc3cbd19f227dfd692636f6eaee01bd1300229358";
+      sha256 = "9774eefca44e890e7a06795d139fad29788c85bf040f6e5c0ebebcbbdfcbce55";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ga-IE/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/ga-IE/firefox-151.0.1.tar.xz";
       locale = "ga-IE";
       arch = "linux-aarch64";
-      sha256 = "897eab817a35c7438ed35a1eb8c9172fa26871027f8a76a74b804d3aeace3f32";
+      sha256 = "617a68798a0b114bb0ab73e172778af278a004345e70c1fb61232f9aa4dfcbe9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/gd/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/gd/firefox-151.0.1.tar.xz";
       locale = "gd";
       arch = "linux-aarch64";
-      sha256 = "47b26129774bedbc8b713555385c5441fc14a22ca8d338e9a903c80cb71e0c70";
+      sha256 = "1831a8a54f3eadd3ff7f4259d975be81eb0fe19ec234d8ef22084f911bad3082";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/gl/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/gl/firefox-151.0.1.tar.xz";
       locale = "gl";
       arch = "linux-aarch64";
-      sha256 = "5f94849277f41eaa2721be4f5cb46b885307922d84b9200210ec2c57e36f0e5f";
+      sha256 = "1de92317fd3fd30e702a8cfca0531f8534ffe84c573905ca66beafee57558033";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/gn/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/gn/firefox-151.0.1.tar.xz";
       locale = "gn";
       arch = "linux-aarch64";
-      sha256 = "31caf29f7b061b7b3d4c606751f0c96b86756edfd8bb49c048e1ff929a807e8a";
+      sha256 = "42bf2fe4277bb95e0fcdedba69a4c6d5f39d4b13b678e99054113c38ba1df232";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/gu-IN/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/gu-IN/firefox-151.0.1.tar.xz";
       locale = "gu-IN";
       arch = "linux-aarch64";
-      sha256 = "36f94e92406eec7e824b8d1a966b2efb21a5e2da5cc1eaa83d22000280445b92";
+      sha256 = "4ade104dfdaa31456e94ff200e00a47c07e343cf5231971f8c703463060f0a5b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/he/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/he/firefox-151.0.1.tar.xz";
       locale = "he";
       arch = "linux-aarch64";
-      sha256 = "4fd6527bfdbb0e891b356aa794f2a4d44175a5b22a02f769b25b03d7dc3c02e9";
+      sha256 = "f9ce23daf72fe3437ef06d313483c0418b5a74b1328ffc4a05cdab0daf1df6dd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/hi-IN/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/hi-IN/firefox-151.0.1.tar.xz";
       locale = "hi-IN";
       arch = "linux-aarch64";
-      sha256 = "8eb2e5af2d641c13754a814acf81b74c4fad13d83ac39352e9927ca7e4965615";
+      sha256 = "5197949591c51f73efe20d70ab2f4081a393aec1cf07e7d55f940d02c52fd230";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/hr/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/hr/firefox-151.0.1.tar.xz";
       locale = "hr";
       arch = "linux-aarch64";
-      sha256 = "3a943323402b86a0e0fb28308c2e31325832861043fb3b9fb7d5e99e04470701";
+      sha256 = "5116200ad3bd8b59fb6b109e217dfc0f1771fdcf80f1f9f767c4fa9eb5cd48d0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/hsb/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/hsb/firefox-151.0.1.tar.xz";
       locale = "hsb";
       arch = "linux-aarch64";
-      sha256 = "45d8c6b8183c58b6cc6c5c142ee65573328f1f18af4324fd90d6c7499135740b";
+      sha256 = "a8fbc946e285ee808b45a75491ba2cb675cb153923c739a53bfef238ec0093dd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/hu/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/hu/firefox-151.0.1.tar.xz";
       locale = "hu";
       arch = "linux-aarch64";
-      sha256 = "301003aab101cfc707ff2408bec65c2ace19e503dca65ab870c5a8e445a00a4b";
+      sha256 = "4df5d08ace838b92cf067a2e2842e11e60cc5246244238278df810e26c8a8d90";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/hy-AM/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/hy-AM/firefox-151.0.1.tar.xz";
       locale = "hy-AM";
       arch = "linux-aarch64";
-      sha256 = "f381477388be8bdf53ce9532511755211585f564a2b3168bf01d86584baf8c4b";
+      sha256 = "6b24246e671d6bb4fb37582dd53e6005d93be490cf6ab42a9f5d8a22c0414848";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ia/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/ia/firefox-151.0.1.tar.xz";
       locale = "ia";
       arch = "linux-aarch64";
-      sha256 = "63f12016855425d4e7df1f17ed3b1c379e72ea7418019c83b534635b021bba3b";
+      sha256 = "89a98cd7b9e9932566715bf79b37ab5b610974b1733e9f3c5db0957cc79ad092";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/id/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/id/firefox-151.0.1.tar.xz";
       locale = "id";
       arch = "linux-aarch64";
-      sha256 = "cd3270e929525fa75553cdc86bccc4c811ec3fe7115f3ae8f562df8e6e2ed4a7";
+      sha256 = "6ce940d5d13cb4161a52eaf43aa91f24b2395d911c95c69f893edd07a92b8e41";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/is/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/is/firefox-151.0.1.tar.xz";
       locale = "is";
       arch = "linux-aarch64";
-      sha256 = "804e9e3ad94148f42ec2c9a8fb78a85acfe8024638ea1ac60bdfd415e1924eb1";
+      sha256 = "583c7f023dfd4e9783d789e6805782914f374f9c39fbe0817829a16e5e245bd8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/it/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/it/firefox-151.0.1.tar.xz";
       locale = "it";
       arch = "linux-aarch64";
-      sha256 = "a2588cb97bc2faf6855034d7b571b9db4b960798b2bac7998e6f5dd596ec550b";
+      sha256 = "e16acb2462e3bbd775d97f6a8beab427f0f21189d3ee39a4eb1df20cae3ad388";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ja/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/ja/firefox-151.0.1.tar.xz";
       locale = "ja";
       arch = "linux-aarch64";
-      sha256 = "aaf4dada0d1499109f651d8e9c372f1530ed8ba0989a9860bb49165646b95156";
+      sha256 = "55092bcffa91e87b4e3a48bbe9776587bbdb403346b42d35e8224a8442f10e33";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ka/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/ka/firefox-151.0.1.tar.xz";
       locale = "ka";
       arch = "linux-aarch64";
-      sha256 = "223d84dc1a58cd4bd90bb31571e601c23d6f4642e6045d9ed038741100c9887f";
+      sha256 = "65ef03d8ea3ee0f70c1a89e2e5e32e569529dd846107d3b631d64d45a1ad4c2c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/kab/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/kab/firefox-151.0.1.tar.xz";
       locale = "kab";
       arch = "linux-aarch64";
-      sha256 = "f41adc567742bed4db9a5432516afbf7974379743418b9bc25aa4860cf7e6886";
+      sha256 = "d4e3fe83fc709ea888c9995ceece1435d62f669ac2745d7ef15797cb9cda0b3b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/kk/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/kk/firefox-151.0.1.tar.xz";
       locale = "kk";
       arch = "linux-aarch64";
-      sha256 = "47102d0dd408d7a0be7fd4f2ff258db6ff14bd40c5e57368dfadf93bbd2920fc";
+      sha256 = "cee6fa49dafea14a39e011f84bcb062b3dea4944f52fa16c02b434cd55b0b550";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/km/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/km/firefox-151.0.1.tar.xz";
       locale = "km";
       arch = "linux-aarch64";
-      sha256 = "e190fbaa4880a3ecf065d1add6fc171f26005d6bfbf7f7429281a10a41648c13";
+      sha256 = "d261002faca080c3f9176cb96a232368471b7b29d1dc7b9a6bceeffbbe700f6d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/kn/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/kn/firefox-151.0.1.tar.xz";
       locale = "kn";
       arch = "linux-aarch64";
-      sha256 = "6707476be236bd6ca950e1fcc0ddb173b10ad3b5b6dce23caa4f3929cb740b73";
+      sha256 = "57f16b61e3d92c3d46e3ad4d18dfd208ec8634b511e3259f82e97b29f4835ee1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ko/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/ko/firefox-151.0.1.tar.xz";
       locale = "ko";
       arch = "linux-aarch64";
-      sha256 = "472c7c2b8dcef4b1674f88e7cb076c368cb9d4d1bb83944f385ca082afacfd3a";
+      sha256 = "ee7a8d1d889e883f83e15b5e465aacb057266e04396abf85546925d8aedfc769";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/lij/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/lij/firefox-151.0.1.tar.xz";
       locale = "lij";
       arch = "linux-aarch64";
-      sha256 = "be6a8a248d747a363ebc5e780476706e557404d5747190c64226426a5bc40cf8";
+      sha256 = "52df47f2ebde1111491ba31dc802d0afd4c8c457ca3ea04f0a3c30f366adc53c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/lt/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/lt/firefox-151.0.1.tar.xz";
       locale = "lt";
       arch = "linux-aarch64";
-      sha256 = "5af4b0d97be054271513a59a9b06ac14b647125f62c926cecac8ad27affe3b84";
+      sha256 = "960b18ae776cc44abc266ec5deced3d66f187839d1e8eb7342b349ca54503d23";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/lv/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/lv/firefox-151.0.1.tar.xz";
       locale = "lv";
       arch = "linux-aarch64";
-      sha256 = "9d76aa87ff3076db11ebe18718177333a16de585e93fbf00c53331f01baad2ab";
+      sha256 = "18a25f417418ec1ba16cf97da601d8d498c1064dd2e11b2b9a6aa96f73e059d8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/mk/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/mk/firefox-151.0.1.tar.xz";
       locale = "mk";
       arch = "linux-aarch64";
-      sha256 = "af70014688638ef15ca8468211fe85d0ade71a9a9214823b6c3a0e2ed9625fef";
+      sha256 = "5b4c84e1127f552902a170bedb35edd8207e4dbbd97c996700ab9e4ef1739604";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/mr/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/mr/firefox-151.0.1.tar.xz";
       locale = "mr";
       arch = "linux-aarch64";
-      sha256 = "0641fb7c9db0e897f6787f0a35fb592551d481194486368366f537e2816d73c1";
+      sha256 = "05be0187dff40af405eb66e26d7db0564565690e33f4555d104e9cea2d5f0984";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ms/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/ms/firefox-151.0.1.tar.xz";
       locale = "ms";
       arch = "linux-aarch64";
-      sha256 = "e65b4c42da3e6dea72916bf1e1e1b96ddccdccae54a3310794702168b4ccf4b2";
+      sha256 = "abab034f45a1ee9ff75d598159bce055a54036b4e77bc65d1bb87e163ece7632";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/my/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/my/firefox-151.0.1.tar.xz";
       locale = "my";
       arch = "linux-aarch64";
-      sha256 = "f18ac1d33d9caf22a22be663ebdb60036239ae23ed3ffd4812fd54ece35632d7";
+      sha256 = "412ba9da8c07e3024ec2e8ec3a3f69e6fdaf79214e6a7d04d6a73bb47f32d81e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/nb-NO/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/nb-NO/firefox-151.0.1.tar.xz";
       locale = "nb-NO";
       arch = "linux-aarch64";
-      sha256 = "6494946da10f46f8f5b8f73791fe65fd4afdf782d479673d0dcb79b3561f48ee";
+      sha256 = "11ee015849fd8f08a2c86bc6ae42f683df41c1d4618c1319dc2311303f27d4c1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ne-NP/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/ne-NP/firefox-151.0.1.tar.xz";
       locale = "ne-NP";
       arch = "linux-aarch64";
-      sha256 = "4715032337151369371dc87b354e2aef30becdd883c474e975552a0eb2f3aaee";
+      sha256 = "9ebe2524c372f1ee10389052c21094a1a7791070d8bdf6a7f5897232fb81aac2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/nl/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/nl/firefox-151.0.1.tar.xz";
       locale = "nl";
       arch = "linux-aarch64";
-      sha256 = "03218d3d7f1779faba98c87a60f0400537d221ed032053307564ae88e99408cf";
+      sha256 = "a20b6255c1e3c2fb2de03003aad1ba86448e636b2a25ea883b91fabe2b9bdcae";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/nn-NO/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/nn-NO/firefox-151.0.1.tar.xz";
       locale = "nn-NO";
       arch = "linux-aarch64";
-      sha256 = "5b963090678584cbbefb4ff1796a0cbd5a0f6b00e62cbc1f5b107a75496e8071";
+      sha256 = "dd5ec2d4699fc4fb4bf9bd6063928cc0b483a4a69342ce4d9004ba179ed2f8d8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/oc/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/oc/firefox-151.0.1.tar.xz";
       locale = "oc";
       arch = "linux-aarch64";
-      sha256 = "5aff1aa7a6dc0f965c880c251438a43b87eec32eb89f454a9af880ff555be780";
+      sha256 = "90cb625cd426d432f46e3f6038dec8b1f93d3a7a100cd1a4c0da5395e3d7e429";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/pa-IN/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/pa-IN/firefox-151.0.1.tar.xz";
       locale = "pa-IN";
       arch = "linux-aarch64";
-      sha256 = "a6a3db8b68c023cfaa9b3ce0108db6deab426c6980635560dfd55c6d74faf0ab";
+      sha256 = "abb142cd43e2a47aed4cb5cf6600e1cd71b2130dcd551a1361f78a02763d928f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/pl/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/pl/firefox-151.0.1.tar.xz";
       locale = "pl";
       arch = "linux-aarch64";
-      sha256 = "3ac9a58d9b919c0cf7ee6ed320a4df15eaa9232ea6bb24eed5bec973d6384648";
+      sha256 = "727d9b3e44d7a65b7e785dbf5c4636952a41588a677f9040c0544ac4560fe40d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/pt-BR/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/pt-BR/firefox-151.0.1.tar.xz";
       locale = "pt-BR";
       arch = "linux-aarch64";
-      sha256 = "b31f2ba16bbe34aa2966e8664b97ec98fdae095372fe8c46276e178cbd55b5a2";
+      sha256 = "99c9bf4e71e335b47945db96a320c28451840dfe5f678eb5117f127ae53c9331";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/pt-PT/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/pt-PT/firefox-151.0.1.tar.xz";
       locale = "pt-PT";
       arch = "linux-aarch64";
-      sha256 = "fa78b348228d366fe77f8ba9d2dabac76d125b351e43c6d90c4ca4797e99f776";
+      sha256 = "7224f3da0e6d643943f6a9af55697975af8ce61c1103b32dab3831b2b1d1dfb0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/rm/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/rm/firefox-151.0.1.tar.xz";
       locale = "rm";
       arch = "linux-aarch64";
-      sha256 = "1005ee1c52ac5f4a65dc8188a342cf9cb247761dd0e248333898b49204575d57";
+      sha256 = "08b2dc7435d27854b9edbb6595d9418bf7b360511c8cd5e9b7bbdbc8f08a3f9a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ro/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/ro/firefox-151.0.1.tar.xz";
       locale = "ro";
       arch = "linux-aarch64";
-      sha256 = "d056b0d8f85957b5b0b6437158885ec779d400eab51f09d9430ef6c4c89a35e5";
+      sha256 = "ef1b73ad0fc46c892c8c6b9c3dd066d8ff39b4d7b156f1a4a01560e7e54b53f1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ru/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/ru/firefox-151.0.1.tar.xz";
       locale = "ru";
       arch = "linux-aarch64";
-      sha256 = "2ba3f9a81865c0c779901fb77292136ccd37788ce26fc52d8c9656cffc9550c0";
+      sha256 = "86d7f5fd85a1c97733ebfd1c00c28e76f4394818dfa3e57d3612ad9f5d91615e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/sat/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/sat/firefox-151.0.1.tar.xz";
       locale = "sat";
       arch = "linux-aarch64";
-      sha256 = "3e5064f43181292186a7d6b4ec80f5e788c0114abeeb6901f9408bb1dee035a7";
+      sha256 = "da49cfabdb92eb6499c864a1f0d3776d23a127f839b30559638319d01b646399";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/sc/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/sc/firefox-151.0.1.tar.xz";
       locale = "sc";
       arch = "linux-aarch64";
-      sha256 = "fcf533c590a06c80fdebc594b436501ee2041296783f5342565f138a587fed96";
+      sha256 = "5f81ca80aff2f083cc9c42a1cbc2cd81f17b63d99da784d7946b68da3332d4d6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/sco/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/sco/firefox-151.0.1.tar.xz";
       locale = "sco";
       arch = "linux-aarch64";
-      sha256 = "8e94cfafbef16aea4e0194517ec08ce42db5fd3323f35ead72fc3df667c0393e";
+      sha256 = "702129887616a3b639c7d5de1a12057c48695af18507f42539935b6caea1a583";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/si/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/si/firefox-151.0.1.tar.xz";
       locale = "si";
       arch = "linux-aarch64";
-      sha256 = "3261a60c1cd7408daadebff15297820035270927431d0810dc4ac174bb28257b";
+      sha256 = "a8feee906e77c2024b434a240e34c2a8388d9cdad124c53818110a3fd75e644e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/sk/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/sk/firefox-151.0.1.tar.xz";
       locale = "sk";
       arch = "linux-aarch64";
-      sha256 = "0f4f25d0a21d0b7e0fb7b740cc07f9c51dc9652dfb0d6d082902ee2883a85f12";
+      sha256 = "8c8c80842177681d709333918908d72a53894f83b45d6e43c2861f63e97614da";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/skr/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/skr/firefox-151.0.1.tar.xz";
       locale = "skr";
       arch = "linux-aarch64";
-      sha256 = "4d3d9d93aa6df5af0aa9d97f5e0a8e49b3d95a3c8786905a57dd53411b3ee4d2";
+      sha256 = "19a1b91c8bd94a57b19118afba87b53374d9fb12dc313ba584d281d2e8eebd93";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/sl/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/sl/firefox-151.0.1.tar.xz";
       locale = "sl";
       arch = "linux-aarch64";
-      sha256 = "8930a0146a6aaf89f8dbb619f25b9a48035835d5509f235b83e4e141ff3d0185";
+      sha256 = "9b7022848bd043840da6cc4efb280e70451c3677f819a231a0c560ff54c26e82";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/son/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/son/firefox-151.0.1.tar.xz";
       locale = "son";
       arch = "linux-aarch64";
-      sha256 = "435cd666d88654aeff6e036c4cb60fc971370168284a16d3748430a8b5860abf";
+      sha256 = "3700fd30787ae86b414b224448e2f7f0aab93c78069adf87b5b62ab37b412f6c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/sq/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/sq/firefox-151.0.1.tar.xz";
       locale = "sq";
       arch = "linux-aarch64";
-      sha256 = "524059ec4d47efd0b766e23025651a9962a25cce63f96aaead3749022024a2d2";
+      sha256 = "ef914d4e2617898f55179e599c2c52a97d4c59804987c5da7a6ff9c9de3dd6fc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/sr/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/sr/firefox-151.0.1.tar.xz";
       locale = "sr";
       arch = "linux-aarch64";
-      sha256 = "60d098e365ea1a884f73e763d529cacac64367b50c511664b8479a689d6183d1";
+      sha256 = "f8fd4c32a45e8eacb209f2c8ac3f77f19b2369dfac932c95a240f537ab35b023";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/sv-SE/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/sv-SE/firefox-151.0.1.tar.xz";
       locale = "sv-SE";
       arch = "linux-aarch64";
-      sha256 = "ade0f10936ba4f48f691bbb3ff8133ce1c00aeb1641fa5f79860db893f9eb035";
+      sha256 = "2579648f4b181f1df7b1f2b10fcde319a650483f9f619114dc072ca4dbeaf1bf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/szl/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/szl/firefox-151.0.1.tar.xz";
       locale = "szl";
       arch = "linux-aarch64";
-      sha256 = "0ad2833df04891dc189bd25e2f8886cbea70b2f21196fc4e4abbebfd3cbfae13";
+      sha256 = "741617fe1e9bf6cf994da47c8213ae938a88de2a0a6838d901902d776fee02fa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ta/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/ta/firefox-151.0.1.tar.xz";
       locale = "ta";
       arch = "linux-aarch64";
-      sha256 = "f600771a35906f42bfb09ac50a431ccca238f077b3da8780f04df1b6d776efec";
+      sha256 = "4d0a031135a175422d339f0abbc43210a908ff16e340761c5eac1e8c44d7e569";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/te/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/te/firefox-151.0.1.tar.xz";
       locale = "te";
       arch = "linux-aarch64";
-      sha256 = "6f4209f11c65ff3d64e375ea036bb169a8bf2c940d018f02f06858011ad0e107";
+      sha256 = "e3f1df9fe5f99664638b50b7c585447d0945edf09ba02e4de0eb330fdb112ffa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/tg/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/tg/firefox-151.0.1.tar.xz";
       locale = "tg";
       arch = "linux-aarch64";
-      sha256 = "971a9c98354226f8b64dc53b365c4de5c42e05873998c4b7d6196225bf70a315";
+      sha256 = "3151c8321979058ef50a82290263cb9da753b6f89e715d32ab2835a082f1e601";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/th/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/th/firefox-151.0.1.tar.xz";
       locale = "th";
       arch = "linux-aarch64";
-      sha256 = "6b2b5855f3fb5baa289dd08b70ed12c7eb9f711788ad6953cfcd091104da4668";
+      sha256 = "49046b2e4ec83c90bab357f49e25c568f8c69a45b0b14c5dbff46ff3e0b58ee9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/tl/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/tl/firefox-151.0.1.tar.xz";
       locale = "tl";
       arch = "linux-aarch64";
-      sha256 = "d39a71d80a7c5e3d9b50cfe72a592660e9a1274f9f9d037ece91392e4eb02621";
+      sha256 = "aa0d5e1753b5fa51269c348f868301372cddbadc9cd1fbd89859e15d52d790df";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/tr/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/tr/firefox-151.0.1.tar.xz";
       locale = "tr";
       arch = "linux-aarch64";
-      sha256 = "6a1ca8f4adcc89e91fed8262ab27e3b121513ee2e1395c357df5287b88ba8908";
+      sha256 = "7481fd25241e89ea816d875fca73ca1bb05e286357fb921bf40116265f4daa2b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/trs/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/trs/firefox-151.0.1.tar.xz";
       locale = "trs";
       arch = "linux-aarch64";
-      sha256 = "cfcbe9876f5631870f8e8234e3ba88043d212efb98fe53f92d6881a04e5e9a04";
+      sha256 = "6d35728573a796801a0c1ba7d1c5d625aca35648187ce3f9d009629fd6a18308";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/uk/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/uk/firefox-151.0.1.tar.xz";
       locale = "uk";
       arch = "linux-aarch64";
-      sha256 = "eaa24d387af026dec90897796ea339bff915d44d00b9d5b2d69f05c0f1019511";
+      sha256 = "1c0c4098688be321f954028a1291ec5b26facd8094f326c459ec1c7494f58570";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/ur/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/ur/firefox-151.0.1.tar.xz";
       locale = "ur";
       arch = "linux-aarch64";
-      sha256 = "b1451aaadb1361f38e5392473d8bb60180b5277e86704fac2fe6abe4aaa18ec8";
+      sha256 = "a8270333c2a7519f63b0f54b0925cc80c4067b282d051295f91031d949f499e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/uz/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/uz/firefox-151.0.1.tar.xz";
       locale = "uz";
       arch = "linux-aarch64";
-      sha256 = "4d1d48ed78db3e2f995a76bf60f49cb5f69502166a826ebd4c3c3e19d5c32b95";
+      sha256 = "b9c37be1a8a906cd861360704665e67c146786932471f3d1ff35d44e07ee6d47";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/vi/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/vi/firefox-151.0.1.tar.xz";
       locale = "vi";
       arch = "linux-aarch64";
-      sha256 = "71ad190c7d6a0ae9f615680be9138dfda59735abd8a8995341fd964f0583f629";
+      sha256 = "699ae0787d70f32090a792039ac5301f286070d5aaeee9e8f1f71fd46d921b93";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/xh/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/xh/firefox-151.0.1.tar.xz";
       locale = "xh";
       arch = "linux-aarch64";
-      sha256 = "2fd567ecac47f6b92ee2562fa4472958e688d512fbeaba20f1f968560259daff";
+      sha256 = "c2dca1da713622152c167e71f968c3d6cd2492f0f3f8350fe95185e2de447f77";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/zh-CN/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/zh-CN/firefox-151.0.1.tar.xz";
       locale = "zh-CN";
       arch = "linux-aarch64";
-      sha256 = "2a5312e573d7c883fa984a28bc7174ebef73dc6814a9690a4d59652cf6c59b7b";
+      sha256 = "487d297127977fcef82a312dfb0321b7d432b88ba3bb960cd1df0b3ffc458443";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/linux-aarch64/zh-TW/firefox-151.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/linux-aarch64/zh-TW/firefox-151.0.1.tar.xz";
       locale = "zh-TW";
       arch = "linux-aarch64";
-      sha256 = "8263f9fdad943430a35ad735ed550512f1c05773d49365e61ac9f5ab6ee9a4c7";
+      sha256 = "cb9b86d62806b4a6e85d60f64e1483c3ee09ae7b487b24b8654e956d44519cba";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ach/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/ach/Firefox%20151.0.1.dmg";
       locale = "ach";
       arch = "mac";
-      sha256 = "2d39a1c9e5973b5608b8b96e688c4fa118dce9dff46a83d023ec21c2ad95e0db";
+      sha256 = "b4eec660ee36c714c9e491c9516051140e5fad9df1abd6b225585cc04e7f9c4c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/af/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/af/Firefox%20151.0.1.dmg";
       locale = "af";
       arch = "mac";
-      sha256 = "8be5f0a52046e841f3bcf7e99c66f907f8bbe27ec68d20de7c22eb952b83502f";
+      sha256 = "f960d233893b6a71c880fed0eb24920b0baa88146ed45ef092cf57974f7b6411";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/an/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/an/Firefox%20151.0.1.dmg";
       locale = "an";
       arch = "mac";
-      sha256 = "0b8dc181726ef44249ece9c7c7ac7b68b6ca861d1c8a934875769cfbbc2eb127";
+      sha256 = "fbcac4fdc76de05e8b03d7de2b9eae3d275ad6a9ed5cd52a005d81ca55e426ed";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ar/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/ar/Firefox%20151.0.1.dmg";
       locale = "ar";
       arch = "mac";
-      sha256 = "7028f599f7cb009df4934670c60988a160e69a4db92890560e17c1ffb8f45fa7";
+      sha256 = "b069ae7d7bed91797471e0161ba782fcf63ac3a88c085f5caa22addf03db78d0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ast/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/ast/Firefox%20151.0.1.dmg";
       locale = "ast";
       arch = "mac";
-      sha256 = "8f3b2aab5f194eb6fd925efee31b553e8d2373dfa72388a687935e9d4f857115";
+      sha256 = "abe4d3185fc4327545dd7be82ab7f710151a0672f5254fbd166783d49b019a1c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/az/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/az/Firefox%20151.0.1.dmg";
       locale = "az";
       arch = "mac";
-      sha256 = "e052f1df0ad6b23e8134a248afe884adcf2f2aa6f7826d4f91dbbede14353f13";
+      sha256 = "fdc8f921085c7a915d5193d80ae0efd10df98c55a88ae92977e462f61be0b984";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/be/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/be/Firefox%20151.0.1.dmg";
       locale = "be";
       arch = "mac";
-      sha256 = "b5fe8f4bbaff0340469fdcff80ea43856edac81083de408ff0a601f7fd5f5ba5";
+      sha256 = "2ee2267e528ae686b8e1cc39ccce3d5dc1f6cd1a51e27c4a18449b10a462c90f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/bg/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/bg/Firefox%20151.0.1.dmg";
       locale = "bg";
       arch = "mac";
-      sha256 = "c61d5c3cc6a283affcdafd9a543be25eace71dc3a0cb5552df99d6020637ef1b";
+      sha256 = "83ecd942329bee9613e32817a6d6149c50284d4c30dc2d99916f46141e24d8a8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/bn/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/bn/Firefox%20151.0.1.dmg";
       locale = "bn";
       arch = "mac";
-      sha256 = "117d920b15830d40cd942c92bb06d65dc68ea8039d9b8713caaf4e7ebc91a70b";
+      sha256 = "cb1d2bca681ee962710757774dc02d21268a44a1b7f6ce08d11e98b08e01863a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/br/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/br/Firefox%20151.0.1.dmg";
       locale = "br";
       arch = "mac";
-      sha256 = "22dfba1d0eef3c8b47c933b5731bcad3b8e468bf57fecf5aba128f916ce0e02b";
+      sha256 = "2eb675b32258c4bfcf793dc5910b31bb01756898b2782ef952e140a9cf927b0a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/bs/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/bs/Firefox%20151.0.1.dmg";
       locale = "bs";
       arch = "mac";
-      sha256 = "17260432f94af0fb8be4e8fcd02af222dbcc1a18813909e3988524277de298b6";
+      sha256 = "ee478a0b26689a5ee2ccc4a2571370779f583453302b69446bf5f3a17bf2fb04";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ca-valencia/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/ca-valencia/Firefox%20151.0.1.dmg";
       locale = "ca-valencia";
       arch = "mac";
-      sha256 = "4de7f7f242af6f3f69f0a3106e339d512d2e8c2a9e19463efe1f3391dcf25e6d";
+      sha256 = "0674dc309ba410cc7cde29722a107da52d7aea00d23063ab8109cbad1086107c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ca/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/ca/Firefox%20151.0.1.dmg";
       locale = "ca";
       arch = "mac";
-      sha256 = "6f47a78a307c208ac05d1b2990d827388d228255292984a6ced2edf7541bdae3";
+      sha256 = "027a2f449b2e757c54683ac4d9928ab9e032e5bd44216c5b72ef1cc276345d29";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/cak/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/cak/Firefox%20151.0.1.dmg";
       locale = "cak";
       arch = "mac";
-      sha256 = "28ab337e4e849994cc84cb21f810f35cadb208fe0537c094f03a1c23d3db62f0";
+      sha256 = "a05e309736c58cac7a02e6a63df100b1bd55e8e91d2930266739299543266f72";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/cs/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/cs/Firefox%20151.0.1.dmg";
       locale = "cs";
       arch = "mac";
-      sha256 = "120d79c879655e340809439593d5acde0b923fb09436dcad4ab8ead2a54c20e9";
+      sha256 = "a96cd917ae1a948f5307d3f592ebbbe7dfd40553de94f5db224e0254f111fabd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/cy/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/cy/Firefox%20151.0.1.dmg";
       locale = "cy";
       arch = "mac";
-      sha256 = "21a8a9617c45ef59cd8124d6ac6f767b3608a3964291aed503b0c4e970301f91";
+      sha256 = "94642cee9e8db3f4e8f0f7aa59433cdb01ea97ba33306974abcbf50962a9dcf6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/da/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/da/Firefox%20151.0.1.dmg";
       locale = "da";
       arch = "mac";
-      sha256 = "77e80b452fcbfd0144a0a0fe22c5862e0086b6260e4e2422db36dbfd1ba7580a";
+      sha256 = "880c5afc3c0d99405bee4d8ced5b4fe57b8e256fa90050a9e9104ffce27e0b6b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/de/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/de/Firefox%20151.0.1.dmg";
       locale = "de";
       arch = "mac";
-      sha256 = "3b55f70332a89617ccf0708e17201c2d08d7e63ef60e3a982a3db9b27c184050";
+      sha256 = "d9ac61b0afd2f27d414fdb77b8a61205f6f61c8ab7350f4178cf85aa63e15b35";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/dsb/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/dsb/Firefox%20151.0.1.dmg";
       locale = "dsb";
       arch = "mac";
-      sha256 = "5b3f0ef2edfa4c8121f4c991d8dfcd21429fa2a5b07e4cb50ad93f50edec9d3f";
+      sha256 = "e3f4a55b26ec348984326a992db5664ca8b47ceb3d6f9dbce3cffbc37ce68f63";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/el/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/el/Firefox%20151.0.1.dmg";
       locale = "el";
       arch = "mac";
-      sha256 = "22b40a82ac79d718984d72ef997fcab82e2d1bc196866bab1076097d42c75b25";
+      sha256 = "b43cf704c8c3628db59ce3915aea5c4a8eaa7566e972db73c21f8468217d13cf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/en-CA/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/en-CA/Firefox%20151.0.1.dmg";
       locale = "en-CA";
       arch = "mac";
-      sha256 = "88788f4a518bb4472da7d0b34a5ad8f9e81ec3602dfecce54c7a8e37e97e435f";
+      sha256 = "f75201481eeb8ce79cdc0188ba045765ff326a9c56f8ec322720f07c918c01cc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/en-GB/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/en-GB/Firefox%20151.0.1.dmg";
       locale = "en-GB";
       arch = "mac";
-      sha256 = "c16fad26df7572f2bce210e8e9665287529802b102031a7055998e8154e9dfd8";
+      sha256 = "58f46cdd5fef29e04b9974b7f09049140c29ec260231b41403690ed6004a0a85";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/en-US/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/en-US/Firefox%20151.0.1.dmg";
       locale = "en-US";
       arch = "mac";
-      sha256 = "5a56ebd8f0f8cec94a86e04c6793e1d1502b40206f5d4c86fff5b7a270e84f6b";
+      sha256 = "6e3714ef92305e1164fcb7188e47cc1f076f7836c631a428470b154a188fb3e9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/eo/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/eo/Firefox%20151.0.1.dmg";
       locale = "eo";
       arch = "mac";
-      sha256 = "0c456aa7549ed28c1c0f832dfe7a13706c1806e40c561c74aefc00aa5b8fcbfa";
+      sha256 = "72f375dc7ab7b3f61d6bea2374568f9eee4767bf4e9a1bc038da0917206cbe88";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/es-AR/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/es-AR/Firefox%20151.0.1.dmg";
       locale = "es-AR";
       arch = "mac";
-      sha256 = "8129602f5cfa38743608d6e49f6226654f9342111a6acbe78db23bb959781d4d";
+      sha256 = "b133a24e2acc8417e403eb7ff8147336c434539bc168051dc796abdcb8bfc2f7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/es-CL/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/es-CL/Firefox%20151.0.1.dmg";
       locale = "es-CL";
       arch = "mac";
-      sha256 = "daf2793a2592caa18c828f988b5d1619af175548998c9cf2fd4f5043e18b7961";
+      sha256 = "360b0eb50e8e8de3962ab9ff6530ebd70652cd389921769a9a5919ba3d4f3e84";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/es-ES/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/es-ES/Firefox%20151.0.1.dmg";
       locale = "es-ES";
       arch = "mac";
-      sha256 = "ba86083477a736ef1f0fa524e246b1585dc67ed47b2fd78b3aba287504f87972";
+      sha256 = "7ffd72366da8315e6a4c18ef43b242b5571fdd6e9bef296f9cacb29313b4f600";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/es-MX/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/es-MX/Firefox%20151.0.1.dmg";
       locale = "es-MX";
       arch = "mac";
-      sha256 = "3f775b73be767c849d6be8d7c73241f94b42feddb1b47cdb8aa1ed505c1de70c";
+      sha256 = "47549b8e10fc48371fa19bd456e635159eef1b4113fe94c567497f777515c410";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/et/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/et/Firefox%20151.0.1.dmg";
       locale = "et";
       arch = "mac";
-      sha256 = "c6c693338ef422c671e0efc1196ec9d1c7aae91636f374890fdec06766492f59";
+      sha256 = "70407612a08a0ec2996051e4ac25ad46863a49e28b9563278c46b1fc4bd938c3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/eu/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/eu/Firefox%20151.0.1.dmg";
       locale = "eu";
       arch = "mac";
-      sha256 = "e5428751b2dface5a8832d24e4f7b38934eb45841dba78081c3f1ef36138a3fd";
+      sha256 = "bb33a67b7aac2ae8eb4b2ff2c47ccafc8135a06e8dd2a41150bf8ed624ed7f18";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/fa/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/fa/Firefox%20151.0.1.dmg";
       locale = "fa";
       arch = "mac";
-      sha256 = "f6e6c6bd4c17586a6a4e344549ecf23967fd441eee47d2c3e23d97c5c045dbdc";
+      sha256 = "6a6a14df882191b5571b5f8b083912272e039b48e7cbc8f9b31320bc9ea7e169";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ff/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/ff/Firefox%20151.0.1.dmg";
       locale = "ff";
       arch = "mac";
-      sha256 = "74dc9142a8a5265e0641c5d5ae089c8235494c832c4b3a15ff09936983e1e1df";
+      sha256 = "f523f72466bb5bf43f801d379c17caa30a2d50ed994440fc8c4bb121eb2e72f4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/fi/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/fi/Firefox%20151.0.1.dmg";
       locale = "fi";
       arch = "mac";
-      sha256 = "54d1871001103db13cbef39663d0ac4ac41331f38eef2610a8d06eeeb40d06b9";
+      sha256 = "bd3b56b2684ee0d3e3d7ed931224c8418b08216ca976b03d47c72c0be8d60870";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/fr/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/fr/Firefox%20151.0.1.dmg";
       locale = "fr";
       arch = "mac";
-      sha256 = "2945ac1a35e68af52bd2bdb74fb59ddee58cce3abb160bdc694e7064ebcff603";
+      sha256 = "9c4460dfaa2f2cb8f29faa6aa2bce3b81c86b21689e062bd41666a2b6e15c66f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/fur/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/fur/Firefox%20151.0.1.dmg";
       locale = "fur";
       arch = "mac";
-      sha256 = "ee76ab05b432cb78775bd9cca54a5fe905a08cbdb42e1f06764f7f296a4c0b0e";
+      sha256 = "a10f3129252d36ba85d66d991bd281f9f83a887e940d20a391f3a0824446bfeb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/fy-NL/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/fy-NL/Firefox%20151.0.1.dmg";
       locale = "fy-NL";
       arch = "mac";
-      sha256 = "cd2d505f1741ce5f7d2200f5c2517e6f7f63d1f340ea376cdf5a8c8e9f5039a5";
+      sha256 = "5f576c8d64b709b242625debbc7494b8d9ab118d4aa1a498b1159c779ed48369";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ga-IE/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/ga-IE/Firefox%20151.0.1.dmg";
       locale = "ga-IE";
       arch = "mac";
-      sha256 = "cc8c74663db69d805c23da0856346e597b4bbcd251b3b52a728d9d8c129fe613";
+      sha256 = "48f1b09d2692a4b2a8cb69adc61b83f798bb32c79c19ab4bd0f77826df927f45";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/gd/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/gd/Firefox%20151.0.1.dmg";
       locale = "gd";
       arch = "mac";
-      sha256 = "dcb0b2764b3fa3e93e528a05aaa03cabc39253840e18be466405a025b1c0575e";
+      sha256 = "31d80219cc20f8406451ad2fa4693f48e5c631f20837bdc16869abfd5e167b8d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/gl/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/gl/Firefox%20151.0.1.dmg";
       locale = "gl";
       arch = "mac";
-      sha256 = "c1e820cedc7afd360c557b8224c53f4159192fd832fd2b038beeb6ba93c2c031";
+      sha256 = "fb16cbe366e35c0f59022ae4317cbee949d615463afc76b7fd130b48fa18f7dc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/gn/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/gn/Firefox%20151.0.1.dmg";
       locale = "gn";
       arch = "mac";
-      sha256 = "df38dafe76adf333ed0e81a9d9e7bc97bd910cebd79ad6da32f5eaeb425fd98a";
+      sha256 = "9d642237962e171bdd14d7c98b4a0546bb5b2b75c9b03225e94d0866f28e7fea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/gu-IN/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/gu-IN/Firefox%20151.0.1.dmg";
       locale = "gu-IN";
       arch = "mac";
-      sha256 = "26d84919cdd099354972323eea2b64208192caa27f8fa0f69b0db2335fa18815";
+      sha256 = "86e390059f5869cab171d4d7117d03a59c200aff5e03b3a11823de114004bf63";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/he/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/he/Firefox%20151.0.1.dmg";
       locale = "he";
       arch = "mac";
-      sha256 = "494c384d75c51522cdc5217ecc29a35f098f198a28da6a23eff63227cacb153b";
+      sha256 = "0575b8c2a724a369d439c5e6090e891d9b2e3c43b49ee5e412c9fcaeb91e99e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/hi-IN/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/hi-IN/Firefox%20151.0.1.dmg";
       locale = "hi-IN";
       arch = "mac";
-      sha256 = "9064ab85dc7a42948451b9e150b4585c47d4089e7f146de8f16b1792bc443d67";
+      sha256 = "56f5a080dab0560e9d2c67e9235bb356aa6c705a46a7c37d16f132f015628a9b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/hr/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/hr/Firefox%20151.0.1.dmg";
       locale = "hr";
       arch = "mac";
-      sha256 = "22ab7c8e498aaa52f2fa7663c6192909eb6cb405bd798c8ef35c03c8ee2e2069";
+      sha256 = "932bb41ab0fa27d2e75ebf35fc328d6fe9cf1332021d17b7d520ffb7a116c797";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/hsb/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/hsb/Firefox%20151.0.1.dmg";
       locale = "hsb";
       arch = "mac";
-      sha256 = "72d2c2f7039cb69a42d2d01c82fedc2ca554e52efc99c0b3b7268f4c4c4642f1";
+      sha256 = "024fd5db76d8c24e18e79b761fa770992c698a7841e2dc3202de884249864cc1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/hu/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/hu/Firefox%20151.0.1.dmg";
       locale = "hu";
       arch = "mac";
-      sha256 = "1327fab2b176372242def645c46959f8febde709d6a299ddd919c6cc38000aab";
+      sha256 = "a85ba9b0c3b10594e7874c1b168644118b88ed52befc59827b8d9ce291879c19";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/hy-AM/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/hy-AM/Firefox%20151.0.1.dmg";
       locale = "hy-AM";
       arch = "mac";
-      sha256 = "bf05209da18f1d4663060f3c42f52c0314e9984fe00a2b2f138ce25697f08180";
+      sha256 = "9a557d7a84ca68c460004c48a157d4190a132f3c7ffd011cff253ea19174a193";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ia/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/ia/Firefox%20151.0.1.dmg";
       locale = "ia";
       arch = "mac";
-      sha256 = "5610bc3dd092016a20bfd5c7940ef91290849e62483307741b5beb743240e9b9";
+      sha256 = "cb91908522f6487063aceaf276a8b85814b7b606f3abcf0a695b9927c854e8d9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/id/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/id/Firefox%20151.0.1.dmg";
       locale = "id";
       arch = "mac";
-      sha256 = "de75e525827afa8c03fa62ded7780ba5f4e3ce180c0de1242b77be2740969f67";
+      sha256 = "368ab1fc7e2c3e6017d11c2d7d329964528185995dc4306f4234f86cc2d34f82";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/is/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/is/Firefox%20151.0.1.dmg";
       locale = "is";
       arch = "mac";
-      sha256 = "3591c354f0975e79913a69ff048485b1249ff414455c0c5ba13410a21c1e3b74";
+      sha256 = "268be662c9360c352054fb907879ef13f0f91e736c0467110e3c9a9c64634c93";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/it/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/it/Firefox%20151.0.1.dmg";
       locale = "it";
       arch = "mac";
-      sha256 = "9cf1462c22df347a242c92dae5d153ee1ddfd42ebee1dca034a0ef34d997280b";
+      sha256 = "23d91b18a1cd8576c2226b3d3befffc17188c793bc1407e977b3c9e333c04825";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ja-JP-mac/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/ja-JP-mac/Firefox%20151.0.1.dmg";
       locale = "ja-JP-mac";
       arch = "mac";
-      sha256 = "a67be8388093814c626245ce0ea734e8b5a53f4ccbba48b89de311ba71d43ec8";
+      sha256 = "627602994fa8bbeb10edd612b98e7c824246d7a2475622cb5b838fa5e7ae1d8d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ka/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/ka/Firefox%20151.0.1.dmg";
       locale = "ka";
       arch = "mac";
-      sha256 = "adf1a3db37bb1f7a744b0a7cb135a819eb94c0a6caf8496d69bac538be4fe268";
+      sha256 = "52540f6a440c6ca1c7efe5b4db9316dbd7f0c182abfcf11d5b736c6227962ae8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/kab/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/kab/Firefox%20151.0.1.dmg";
       locale = "kab";
       arch = "mac";
-      sha256 = "3d8ead23bb995c813cb304ea50a38e4afc0fca0d6b831471e9271951813df3f6";
+      sha256 = "65012c8c0f0cc20cec9104dad6b8f573961fedc781ed3091261669d8b608c682";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/kk/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/kk/Firefox%20151.0.1.dmg";
       locale = "kk";
       arch = "mac";
-      sha256 = "b45cf0fd8f0be04696760fb611741f73699cf082475a978aff67d11c8b3a5972";
+      sha256 = "6b9aa92faf47c854e069d56b456a3d4ad38cb4fad63c472354aedff1612605c8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/km/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/km/Firefox%20151.0.1.dmg";
       locale = "km";
       arch = "mac";
-      sha256 = "0c2f3d9fe97fae3e821c31f8a8c3a090002d846f8d02137ed86f1fac582bb7fb";
+      sha256 = "ea99a43ef47efb9282495382ca74ec8d1dc4a13251828a321c2dadefd863335e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/kn/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/kn/Firefox%20151.0.1.dmg";
       locale = "kn";
       arch = "mac";
-      sha256 = "a8047cb9522f2409c602615395dad280a4a32f196d8dca06c42ecf20d213e47b";
+      sha256 = "885339782efae2be7d934586a101f65d92a90c90b44982803f0c7d2cd1efd9cd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ko/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/ko/Firefox%20151.0.1.dmg";
       locale = "ko";
       arch = "mac";
-      sha256 = "621da9205b74cd355981a24e11b543ba722f27d29d74156ce5cd5e0a9a90ca7f";
+      sha256 = "c3d3e1402e1c8df9798af72b19c4368ef140b81f4f026d25a675a6fab1c4fb18";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/lij/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/lij/Firefox%20151.0.1.dmg";
       locale = "lij";
       arch = "mac";
-      sha256 = "c165dba6a98a0f0bd2d48f818629b44399e8d291214d6ba839a6f6958dab40f2";
+      sha256 = "7650a166ed2028bdbb3c89b214fa8f45841627cfef8f08b7fd4372705a79a282";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/lt/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/lt/Firefox%20151.0.1.dmg";
       locale = "lt";
       arch = "mac";
-      sha256 = "70fdfc57cfa3b0ad1d57bc5ce579d2954165926e63313e04b771b22036242f3d";
+      sha256 = "5515c30f36225ad41fa2143d835cecc5cadbfc0ac57e2ebf68adc63448ca90c2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/lv/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/lv/Firefox%20151.0.1.dmg";
       locale = "lv";
       arch = "mac";
-      sha256 = "e90b1aa53118af4d3046792837b58fe65fce664da1767727946e441a91ddf1fc";
+      sha256 = "aeea8324da387c297492310929b3b1d13e4897033aae8e32a0322b54a658397c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/mk/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/mk/Firefox%20151.0.1.dmg";
       locale = "mk";
       arch = "mac";
-      sha256 = "f9e174c7311bd790b02f1e021c844f8c3e2ac7ac265daf058fd28bbf7ff62595";
+      sha256 = "177d500450eab71f06a79cb3f6149f8c3d2a4da576a8a9f220172e567f81a91a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/mr/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/mr/Firefox%20151.0.1.dmg";
       locale = "mr";
       arch = "mac";
-      sha256 = "86535dc3590026331e65d0a3f8694516ce1b63fe7f14a4ccbf58409092aa5e9d";
+      sha256 = "fa117301c81745b5391745c59bcd0a8fcb73aa5e822fbbe006ff9ce2ab0c1d5e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ms/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/ms/Firefox%20151.0.1.dmg";
       locale = "ms";
       arch = "mac";
-      sha256 = "770d89f8cc096bfae6a4180cbb4e19bd825969d15df507d94d47d02ec9138548";
+      sha256 = "4149d908ae673e73fa6c39ff394dfb3e1eb7b04dc1b8988cd2725e4ba1709129";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/my/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/my/Firefox%20151.0.1.dmg";
       locale = "my";
       arch = "mac";
-      sha256 = "5045dd5fe643b89c53a9b9a3613e5ea3151b156c2d72746194a1157289812b37";
+      sha256 = "1e8fcc3060f2615b7fd1f3a3e9aa9b1213ec2e4c957ebe9ebfb7e52664503cd9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/nb-NO/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/nb-NO/Firefox%20151.0.1.dmg";
       locale = "nb-NO";
       arch = "mac";
-      sha256 = "504c14ac25a53f2bd2bf05313deee0041451298b17feb2c1edc4d48ac9272f24";
+      sha256 = "65e2593d91dde13db1afc03f6a5a9f8c90407cb733889797f8cdeb4c740a620d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ne-NP/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/ne-NP/Firefox%20151.0.1.dmg";
       locale = "ne-NP";
       arch = "mac";
-      sha256 = "c7654eaaa3d5b688a15e362d9b6e9585a8fa694fcae5792554a9fe76ea02d89d";
+      sha256 = "1fb1dc4beeb8efda3c7775ccfc419e9c3d9d605c177aca9e160d00c633085a9d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/nl/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/nl/Firefox%20151.0.1.dmg";
       locale = "nl";
       arch = "mac";
-      sha256 = "86e00a8576dfc96a24dd8665429fba11fa5ae5dc27dd167f933c18aabe556b70";
+      sha256 = "7ba835ee68d1c1007e4eb97210c9f63c62403e10784e021ac42d925a0d847ab8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/nn-NO/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/nn-NO/Firefox%20151.0.1.dmg";
       locale = "nn-NO";
       arch = "mac";
-      sha256 = "b8464fa7815ddf1bb973d17886508963933155babcda7de34ef9ff0c6d9ea916";
+      sha256 = "0b914a85da8023af5b15637befd1292e434c73901e262757565c0c0b725547f6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/oc/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/oc/Firefox%20151.0.1.dmg";
       locale = "oc";
       arch = "mac";
-      sha256 = "0c8c12574a6d828192a4de214b8f3e6a756ab639973269513f7923ff3e5fa434";
+      sha256 = "b6fdd333677d25545a5f0efe338d00afa19e91e62905ce89638c93cb657d46ab";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/pa-IN/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/pa-IN/Firefox%20151.0.1.dmg";
       locale = "pa-IN";
       arch = "mac";
-      sha256 = "876e6d2171eb62635c4367e3128820e95f0cb3aec515cf012e7107d08b45ce3f";
+      sha256 = "911c1a1c1a874117fd3577ead904806d024546e97b426d09335e2081ddc3385c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/pl/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/pl/Firefox%20151.0.1.dmg";
       locale = "pl";
       arch = "mac";
-      sha256 = "7e86dc6d6694d904f8171733a28aed0765a87a647bb4e5a10ace3bcaa08448e5";
+      sha256 = "f635a294c4444caacd8d5f18a2f359c666cd24a1abb48f9073409209a19e8daf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/pt-BR/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/pt-BR/Firefox%20151.0.1.dmg";
       locale = "pt-BR";
       arch = "mac";
-      sha256 = "f88ab74590262ab6e1bcc2535e3b868314ee796f9609c44eacadba3eb99f91ae";
+      sha256 = "b87907a9cafda96ac9f13daf3f459a141de5c1cafff0fc10c464505a554292b7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/pt-PT/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/pt-PT/Firefox%20151.0.1.dmg";
       locale = "pt-PT";
       arch = "mac";
-      sha256 = "c342cb4d4d3df34ef828da83a2546f33c759dc7c6d1c04d0394686a78bee690b";
+      sha256 = "b777a37243a5945aa12afa4dc885bd38e8cd0968a5ff03afd4b52936d06a11e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/rm/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/rm/Firefox%20151.0.1.dmg";
       locale = "rm";
       arch = "mac";
-      sha256 = "122b5a994623c84e693c35498f4b36773cb76d32b3cd235b2ad04789ce252796";
+      sha256 = "1d662a951b9ffd48ea00b956b1fe20110fc16e93463b4f92bbd2ac89b10c6243";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ro/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/ro/Firefox%20151.0.1.dmg";
       locale = "ro";
       arch = "mac";
-      sha256 = "ae0a2867d250c02f7776afd9a8887d4654289eb36c0ad23945f30e7948ecfbf6";
+      sha256 = "9c8777acbca42b8313973a1538efa6a03b989412d552ca97d418f4b1ee9bc209";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ru/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/ru/Firefox%20151.0.1.dmg";
       locale = "ru";
       arch = "mac";
-      sha256 = "244c044943ff9591226a2c92515a15e09253e7068525a5f7cb24936e2a2f847f";
+      sha256 = "07e3c9032ae830cda1088122288fe894a0af842433d51a543ed4f29c7f131bbd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/sat/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/sat/Firefox%20151.0.1.dmg";
       locale = "sat";
       arch = "mac";
-      sha256 = "a5e29a336d1f81b3d3a75bd59513beb9e3c5850c4f491b04e93e36b46012a43e";
+      sha256 = "6881e3bf9f334661f8e98c57080d281b44f58b3bb562c289d919d155a41a74b3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/sc/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/sc/Firefox%20151.0.1.dmg";
       locale = "sc";
       arch = "mac";
-      sha256 = "335b9b760f23d8d0c4e9933f3e8746cf4e247e75774e01eda6bc88e4384c0072";
+      sha256 = "6fe2b9a28aba5d2bdcb68e0d1b1dd37edf6e4f4866c4fd8e2e5c771a2bd5c9fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/sco/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/sco/Firefox%20151.0.1.dmg";
       locale = "sco";
       arch = "mac";
-      sha256 = "fccbaf475e1ba4b5644c64bc8e5f4a7a88dfb1141fb0f6327f20c50983c84157";
+      sha256 = "02b4be48439a141d8e0212032adfabc7481807cc5508ca21c2c36c52ad901cd1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/si/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/si/Firefox%20151.0.1.dmg";
       locale = "si";
       arch = "mac";
-      sha256 = "0d03aa6b67c7962090bbed14e62dd9d1a63e44a0338fb9381375620f41040258";
+      sha256 = "5f7c97ec1e462141bbb7df8d5ca40265a9eae5079ea86403781367ec9be745ef";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/sk/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/sk/Firefox%20151.0.1.dmg";
       locale = "sk";
       arch = "mac";
-      sha256 = "3b7e1c53d442480f5a50afc87cef5953d94699644b98f8746e781a281714f548";
+      sha256 = "06c35dc50d519963c2e4005d5b245d3b11780aeba76ee3b9d41082009de345a2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/skr/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/skr/Firefox%20151.0.1.dmg";
       locale = "skr";
       arch = "mac";
-      sha256 = "421feade271b0aca61414fd055f51325a13bf54d437a2621a46a324c6a41adb0";
+      sha256 = "d8bd78d22b6bb2d17aeb385c43befa6306d37f62c88ff71d7767fbe47664c77c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/sl/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/sl/Firefox%20151.0.1.dmg";
       locale = "sl";
       arch = "mac";
-      sha256 = "e174fb1265627a40caea4108cca38bac85e46a1823632535c921c957f8361e45";
+      sha256 = "b9bde50d525338d087341469d3c96eb971bf85b52c3bfd708bb1297e618e1f30";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/son/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/son/Firefox%20151.0.1.dmg";
       locale = "son";
       arch = "mac";
-      sha256 = "a29eb1bc927328a78584fc8f117c58e604fcba36905d4abba74100e52d4a57e4";
+      sha256 = "471b4eadfbaec606f55661a1b5ef74726a7b88ce921d1ac5c6876c8d0698e766";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/sq/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/sq/Firefox%20151.0.1.dmg";
       locale = "sq";
       arch = "mac";
-      sha256 = "c9073770bc330544949f0f901112739bfe888a41af3749375a2ea7038b8f3e6e";
+      sha256 = "f2a4b9b296f39be26a04171ace02b19bb9e63cf932da27aeee0472d154be6548";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/sr/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/sr/Firefox%20151.0.1.dmg";
       locale = "sr";
       arch = "mac";
-      sha256 = "74607510bb2575113c821e56607e62827717e06870b8666bf6ef663bb4daec5c";
+      sha256 = "4cd1d0de985d73545589c457db13df1d4e65b968171cc67522f142544a5b4321";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/sv-SE/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/sv-SE/Firefox%20151.0.1.dmg";
       locale = "sv-SE";
       arch = "mac";
-      sha256 = "4e76f9aa8133041935eff88ee21b5adc8ffe15f02252ad8673e3ecb99377ed70";
+      sha256 = "ee80c629cc02347f3ce38e9759ada5a826de6ce9f8296448558991e38c634704";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/szl/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/szl/Firefox%20151.0.1.dmg";
       locale = "szl";
       arch = "mac";
-      sha256 = "3e7d86c71324b143d5762f10bde04f4d0b895fbde28e4b21dedcfcea0a180f4e";
+      sha256 = "ca3c27cc72d3c0efb36505de3115f6a75e5a965d985a9cf604ef1efaf2c3c49c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ta/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/ta/Firefox%20151.0.1.dmg";
       locale = "ta";
       arch = "mac";
-      sha256 = "0aaca54a0ee8102bc0299e4cab82ee8a670dc51f0e73bdcd4c2de08324a201ef";
+      sha256 = "633d58c885ee03cdec2b7523add547a5d5c3bfa045c59dacb292b22e118c49fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/te/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/te/Firefox%20151.0.1.dmg";
       locale = "te";
       arch = "mac";
-      sha256 = "b49fda7de1e4c0c95fb5d698a28047f04b0f15690a55871f5f36621d857281c5";
+      sha256 = "9444afe5bf3beffeac7b275957369c72cc49576daf077bfa04c148cf411f2339";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/tg/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/tg/Firefox%20151.0.1.dmg";
       locale = "tg";
       arch = "mac";
-      sha256 = "8f12714be8dc4c81b5f6c1eeb33ffe7725e007d8edee0ab53b9326aa2c5071d1";
+      sha256 = "36f64971e8dc849ca84f6ece9d9f7978b4a30eb93eaedcd1f5f0a82a073584d2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/th/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/th/Firefox%20151.0.1.dmg";
       locale = "th";
       arch = "mac";
-      sha256 = "80a4d667c786351e4d04a780d6a6831e22ec8b80037581812c68198885311977";
+      sha256 = "b78f9e01d4b984bdab7abb13fdb6eb04d14ad9209d8c0399a42bafb6cff148e9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/tl/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/tl/Firefox%20151.0.1.dmg";
       locale = "tl";
       arch = "mac";
-      sha256 = "294263d9357a91402efd918b79d2e92bc2636466f854cab9d410805204a3dcba";
+      sha256 = "5d84fa4662d650a94dbed071c803a265964878878856e03015d95f1d5d1f5bf0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/tr/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/tr/Firefox%20151.0.1.dmg";
       locale = "tr";
       arch = "mac";
-      sha256 = "1a22023cc6a4cecc08b04bc22839cc8bc01bb4d9fb28d4239073184dd9ae6964";
+      sha256 = "f55331abc014aed5b7558e344201c13adb4b18e4f65420fbec9cc9afd0781e78";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/trs/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/trs/Firefox%20151.0.1.dmg";
       locale = "trs";
       arch = "mac";
-      sha256 = "b18b06eae54c6652c208396458396c8ead950834915a88a6488862348c9dd3d0";
+      sha256 = "7da013ba3285c604c11c861af1feb7cb10f9623df1dd494a57bcb8fdff567d17";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/uk/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/uk/Firefox%20151.0.1.dmg";
       locale = "uk";
       arch = "mac";
-      sha256 = "ee44556242a0cac4a0dcb1d5b007671efca606332ff0b1243fca47aaba2a3546";
+      sha256 = "07d6e378164dcc870aad339376c4d283dd4b324f0cf4c8d9e55ae4cdeacb1331";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/ur/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/ur/Firefox%20151.0.1.dmg";
       locale = "ur";
       arch = "mac";
-      sha256 = "1be4f462041efe4c60436b4ad09b6527b88d067e22a174211a327f8da5a731c4";
+      sha256 = "8aa2ea42db123d3ad94df84b8434edd867d81ef99dbf48f8502ce90bf0f244d4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/uz/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/uz/Firefox%20151.0.1.dmg";
       locale = "uz";
       arch = "mac";
-      sha256 = "207de25a1f96078edb35740833460b353e2420c7d298563a6253c24622fddc71";
+      sha256 = "9632b03e99c8d932c881b630c16f4f8981e8814ef0ced5076a9107603aa21c18";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/vi/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/vi/Firefox%20151.0.1.dmg";
       locale = "vi";
       arch = "mac";
-      sha256 = "e85b424cd12810f18763820917015fe3cbb2c676601a0acf75fb174512eede81";
+      sha256 = "d587387b82efe10155d9d328f1606c6a70c9371c61ccb5df59fb41c393d8473b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/xh/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/xh/Firefox%20151.0.1.dmg";
       locale = "xh";
       arch = "mac";
-      sha256 = "67a8917b40174c3ec119d4a6409460074436dd304a4d146fcf32f6e1f4e77348";
+      sha256 = "0f73a63c6d2e2b6335ff10ff28b86cc55fa3bf3d500c0f9e4ce03f846bd7f876";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/zh-CN/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/zh-CN/Firefox%20151.0.1.dmg";
       locale = "zh-CN";
       arch = "mac";
-      sha256 = "0b5dbff8b10723780f6fd8cf269b249821c1bfd8b405180aefadf42276e2dbb7";
+      sha256 = "058aa655528687da6bd04895265cde5262ab846301ea6ecfae44dde7306fda20";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/151.0/mac/zh-TW/Firefox%20151.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/151.0.1/mac/zh-TW/Firefox%20151.0.1.dmg";
       locale = "zh-TW";
       arch = "mac";
-      sha256 = "8723fddad3820f5b2ff3d4e5f25d75b52de0434e1243324902f09f101d7d862f";
+      sha256 = "e1917f66df1841c03c5f1395fbd1d93eed0933e6f4feeb522c75b2a50c86f0a7";
     }
   ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages/firefox.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages/firefox.nix
@@ -9,10 +9,10 @@
 
 buildMozillaMach rec {
   pname = "firefox";
-  version = "151.0";
+  version = "151.0.1";
   src = fetchurl {
     url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-    sha512 = "5e6b01236c6aad17889c1d33614637a13e41d659c3306b2dadf13ab50d91a36d1269fae6d405d31351e4defe589f47f31c0798b66ad87438720f5779bcb90401";
+    sha512 = "8492a1bb956b38373153938bd18b0e18e3a4ad0d2abc2017b45e02bc2768c8f468d5c06329a32485a03a67bb9c22102e6abff1e73080c77764735d430dc77277";
   };
 
   meta = {


### PR DESCRIPTION
https://www.firefox.com/en-US/firefox/151.0.1/releasenotes/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
