### PR TITLE
tuxvdmtool: init at 0.2.0-unstable-2026-03-15

### DIFF
--- a/pkgs/by-name/tu/tuxvdmtool/package.nix
+++ b/pkgs/by-name/tu/tuxvdmtool/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage {
+  name = "tuxvdmtool";
+  version = "0.2.0-unstable-2026-03-15";
+
+  src = fetchFromGitHub {
+    owner = "AsahiLinux";
+    repo = "tuxvdmtool";
+    rev = "e1acae287feabb49e3ecafa56d7cbfa7c3182fc9";
+    hash = "sha256-7ewIidjb8NbgTkVYLzvLICHzwb6vBph5Iu+ZgIeDZXI=";
+  };
+
+  cargoHash = "sha256-bnBtchG87ya7nlf20Zv3htnZDN5jv29DKY+8nx5CK5o=";
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Linux Apple Silicon to Apple Silicon VDM utility";
+    homepage = "https://github.com/AsahiLinux/tuxvdmtool#readme";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mjm ];
+    mainProgram = "tuxvdmtool";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
An AsahiLinux utility for getting a serial console between two Apple Silicon devices.

Also provides a command to disconnect/reconnect the USB devices, which is a useful workaround for https://github.com/AsahiLinux/linux/issues/497.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
