### PR TITLE
chatzone-desktop: migrate from bundled Electron to packaged

### DIFF
--- a/pkgs/by-name/ch/chatzone-desktop/package.nix
+++ b/pkgs/by-name/ch/chatzone-desktop/package.nix
@@ -1,30 +1,29 @@
 {
   lib,
-  appimageTools,
   fetchurl,
+  appimageTools,
+  electron,
   stdenvNoCC,
   makeDesktopItem,
   copyDesktopItems,
-  makeWrapper,
+  makeBinaryWrapper,
 }:
 
-let
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "chatzone-desktop";
   version = "5.6.2";
-  src = fetchurl {
-    url = "https://ir.ozone.ru/s3/chatzone-clients/ci/5.6.2/1175/chatzone-desktop-linux-5.6.2.AppImage";
-    hash = "sha256-2t3mp0snHn2NxVFCcU1XQ5h3rUCb4gXjKbF43p9W8ZU=";
-  };
-  appimageContents = appimageTools.extract { inherit pname version src; };
-in
-stdenvNoCC.mkDerivation {
-  inherit pname version;
 
-  src = appimageTools.wrapType2 { inherit pname version src; };
+  src = appimageTools.extract {
+    inherit (finalAttrs) pname version;
+    src = fetchurl {
+      url = "https://ir.ozone.ru/s3/chatzone-clients/ci/5.6.2/1175/chatzone-desktop-linux-5.6.2.AppImage";
+      hash = "sha256-2t3mp0snHn2NxVFCcU1XQ5h3rUCb4gXjKbF43p9W8ZU=";
+    };
+  };
 
   nativeBuildInputs = [
     copyDesktopItems
-    makeWrapper
+    makeBinaryWrapper
   ];
 
   desktopItems = [
@@ -49,15 +48,16 @@ stdenvNoCC.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/
-    cp -r bin $out/bin
+    mkdir -p "$out/opt/chatzone-desktop" "$out/bin"
 
-    mkdir -p $out/share/chatzone-desktop/
-    cp ${appimageContents}/app_icon.png $out/share/chatzone-desktop/
-    cp -r ${appimageContents}/usr/share/icons $out/share
+    cp -r --no-preserve=mode resources "$out/opt/chatzone-desktop/"
 
-    wrapProgram $out/bin/chatzone-desktop \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+    cp -r --no-preserve=mode usr/share/icons "$out/share"
+
+    makeWrapper "${electron}/bin/electron" "$out/bin/chatzone-desktop" \
+      --add-flags "$out/opt/chatzone-desktop/resources/app.asar" \
+      --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
+      --inherit-argv0
 
     runHook postInstall
   '';
@@ -72,4 +72,4 @@ stdenvNoCC.mkDerivation {
     maintainers = [ lib.maintainers.progrm_jarvis ];
     platforms = [ "x86_64-linux" ];
   };
-}
+})


### PR DESCRIPTION
Switch `chatzone-desktop` from using bundled Electron to the one provided in nixpkgs.

This is explicitly assisted by `OpenCode 1.14.48 opencode/big-pickle` (which is also referenced in Git trailer) which is part of my personal experiment to use it for generating non-trivial Nix changes.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
