### PR TITLE
maculay2+dependencies: add meta.platforms

### DIFF
--- a/pkgs/by-name/co/cohomcalg/package.nix
+++ b/pkgs/by-name/co/cohomcalg/package.nix
@@ -49,5 +49,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/BenjaminJurke/cohomCalg";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ coolcuber ];
+    platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/fr/frobby/package.nix
+++ b/pkgs/by-name/fr/frobby/package.nix
@@ -65,5 +65,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/Macaulay2/frobby";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ coolcuber ];
+    platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/ma/macaulay2/package.nix
+++ b/pkgs/by-name/ma/macaulay2/package.nix
@@ -294,5 +294,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://macaulay2.com/";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ coolcuber ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })

--- a/pkgs/by-name/ma/mathic/package.nix
+++ b/pkgs/by-name/ma/mathic/package.nix
@@ -61,5 +61,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/Macaulay2/mathic";
     license = lib.licenses.lgpl2Plus;
     maintainers = with lib.maintainers; [ coolcuber ];
+    platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/ma/mathicgb/package.nix
+++ b/pkgs/by-name/ma/mathicgb/package.nix
@@ -58,5 +58,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/Macaulay2/mathicgb";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ coolcuber ];
+    platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/me/memtailor/package.nix
+++ b/pkgs/by-name/me/memtailor/package.nix
@@ -51,5 +51,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/Macaulay2/memtailor";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ coolcuber ];
+    platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/to/topcom/package.nix
+++ b/pkgs/by-name/to/topcom/package.nix
@@ -79,5 +79,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.wm.uni-bayreuth.de/de/team/rambau_joerg/TOPCOM/index.html";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ coolcuber ];
+    platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
I added the `meta.platforms` attribute for Macaulay2 as well as some of its recently added dependencies, as determined by upstream documentation.  TOPCOM, CohomCalg, Mathic, and MathicGB don't mention anything about supported platforms.  Frobby and Macaulay2 both officially support Linux and Darwin builds (mileage may vary on other Unix platforms).  Although it [does appear](https://hydra.nixos.org/search?query=macaulay) that Hydra is building binaries, the Nixpkgs manual [says](https://nixos.org/manual/nixpkgs/stable/#var-meta-platforms)
> Hydra builds packages according to the platform specified. If no platform is specified, the package does not have prebuilt binaries.

so this seems somewhat important. 

Here are the sources I used:
- [CohomCalg](https://github.com/BenjaminJurke/cohomCalg/blob/master/manual.pdf)
- [Frobby](https://github.com/Macaulay2/frobby)
- [Macaulay2](https://github.com/Macaulay2/M2/wiki)
- [Mathic](https://github.com/Macaulay2/mathic)
- [MathicGB](https://github.com/Macaulay2/mathicgb)
- [Memtailor](https://github.com/Macaulay2/memtailor)
- [TOPCOM](https://www.wm.uni-bayreuth.de/de/team/rambau_joerg/TOPCOM/index.html)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
