### PR TITLE
deps-fnl: fix interpreter execution path

### DIFF
--- a/pkgs/by-name/de/deps-fnl/package.nix
+++ b/pkgs/by-name/de/deps-fnl/package.nix
@@ -17,18 +17,21 @@ stdenv.mkDerivation rec {
   };
 
   dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/bin
+    mkdir -p $out/bin $out/libexec
+    cp deps $out/libexec/deps
+
     # deps requires argv0 to be fennel as an executable lua script
     # skipping the luarocks wrapper is fine here
-    fennelLua=$(echo ${luaPackages.fennel}/fennel*/fennel/*/bin/fennel)
-    substitute deps $out/bin/deps \
-      --replace-fail '#!/usr/bin/env fennel' "#!$fennelLua"
-    chmod +x $out/bin/deps
+    fennelCli=$(find "${luaPackages.fennel}" -type f -path "*/bin/fennel" | head -n 1)
+    cat << EOF > $out/bin/deps
+      #!/bin/sh
+      exec "${luaPackages.lua}/bin/lua" "$fennelCli" "$out/libexec/deps" "\$@"
+    EOF
 
+    chmod +x $out/bin/deps
     runHook postInstall
   '';
 


### PR DESCRIPTION
Fixed wrapper script that failed depending on lua environment.

## Things done

Switched to using `makeWrapper` to explicitly invoke the script through the target Fennel binary.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
