### PR TITLE
callSimplePackage: init

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -34,6 +34,44 @@ let
     ;
   inherit (lib.strings) levenshtein levenshteinAtMost;
 
+  makeErrorMessage =
+    autoArgs: fn: args: fargs: unpassedArgs:
+    let
+      # The first missing arg
+      arg = head (
+        # Filter out the default args. We did a similar computation in the
+        # happy path, but we're okay recomputing it in an error case
+        filter (name: !fargs.${name}) (attrNames unpassedArgs)
+      );
+      # Get a list of suggested argument names for a given missing one
+      getSuggestions =
+        arg:
+        pipe (autoArgs // args) [
+          attrNames
+          # Only use ones that are at most 2 edits away. While mork would work,
+          # levenshteinAtMost is only fast for 2 or less.
+          (filter (levenshteinAtMost 2 arg))
+          # Put strings with shorter distance first
+          (sortOn (levenshtein arg))
+          # Only take the first couple results
+          (take 3)
+          # Quote all entries
+          (map (x: "\"" + x + "\""))
+        ];
+
+      prettySuggestions =
+        suggestions:
+        if suggestions == [ ] then
+          ""
+        else if length suggestions == 1 then
+          ", did you mean ${elemAt suggestions 0}?"
+        else
+          ", did you mean ${concatStringsSep ", " (lib.init suggestions)} or ${lib.last suggestions}?";
+
+      loc = unsafeGetAttrPos arg fargs;
+      loc' = if loc != null then loc.file + ":" + toString loc.line else "<unknown location>";
+    in
+    "lib.customisation.callPackageWith: Function called without required argument \"${arg}\" at ${loc'}${prettySuggestions (getSuggestions arg)}";
 in
 rec {
 
@@ -215,6 +253,29 @@ rec {
     else
       mirrorArgs f';
 
+  callSimplePackageWith =
+    autoArgs: filepath:
+    let
+      fn = import filepath;
+      fargs = functionArgs fn;
+
+      # All arguments that will be passed to the function
+      allArgs = intersectAttrs fargs autoArgs;
+
+      # arguments that weren't passed automatically to the function
+      unpassedArgs = removeAttrs fargs (attrNames allArgs);
+    in
+    # if nonempty, check if the function has defaults for those other args
+    if unpassedArgs == { } || all (value: value) (attrValues unpassedArgs) then
+      makeOverridable fn allArgs
+    else
+      # Only show the error for the first missing argument
+      # This needs to be an abort so it can't be caught with `builtins.tryEval`,
+      # which is used by nix-env and ofborg to filter out packages that don't evaluate.
+      # This way we're forced to fix such errors in Nixpkgs,
+      # which is especially relevant with allowAliases = false
+      abort (makeErrorMessage autoArgs fn { } fargs unpassedArgs);
+
   /**
     Call the package function in the file `fn` with the required
     arguments automatically.  The function is called with the
@@ -264,46 +325,6 @@ rec {
     ```
   */
   callPackageWith =
-    let
-      makeErrorMessage =
-        autoArgs: fn: args: fargs: unpassedArgs:
-        let
-          # The first missing arg
-          arg = head (
-            # Filter out the default args. We did a similar computation in the
-            # happy path, but we're okay recomputing it in an error case
-            filter (name: !fargs.${name}) (attrNames unpassedArgs)
-          );
-          # Get a list of suggested argument names for a given missing one
-          getSuggestions =
-            arg:
-            pipe (autoArgs // args) [
-              attrNames
-              # Only use ones that are at most 2 edits away. While mork would work,
-              # levenshteinAtMost is only fast for 2 or less.
-              (filter (levenshteinAtMost 2 arg))
-              # Put strings with shorter distance first
-              (sortOn (levenshtein arg))
-              # Only take the first couple results
-              (take 3)
-              # Quote all entries
-              (map (x: "\"" + x + "\""))
-            ];
-
-          prettySuggestions =
-            suggestions:
-            if suggestions == [ ] then
-              ""
-            else if length suggestions == 1 then
-              ", did you mean ${elemAt suggestions 0}?"
-            else
-              ", did you mean ${concatStringsSep ", " (lib.init suggestions)} or ${lib.last suggestions}?";
-
-          loc = unsafeGetAttrPos arg fargs;
-          loc' = if loc != null then loc.file + ":" + toString loc.line else "<unknown location>";
-        in
-        "lib.customisation.callPackageWith: Function called without required argument \"${arg}\" at ${loc'}${prettySuggestions (getSuggestions arg)}";
-    in
     autoArgs: fn: args:
     let
       f = if isFunction fn then fn else import fn;

--- a/pkgs/top-level/by-name-overlay.nix
+++ b/pkgs/top-level/by-name-overlay.nix
@@ -49,6 +49,7 @@ self: super:
   # and whether it's defined by this file here or `all-packages.nix`.
   # TODO: This can be removed once `pkgs/by-name` can handle custom `callPackage` arguments without `all-packages.nix` (or any other way of achieving the same result).
   # Because at that point the code in ./stage.nix can be changed to not allow definitions in `all-packages.nix` to override ones from `pkgs/by-name` anymore and throw an error if that happens instead.
-  _internalCallByNamePackageFile = file: self.callPackage file { };
+  _internalCallByNamePackageFile =
+    if self ? callSimplePackage then self.callSimplePackage else file: self.callPackage file { };
 }
 // mapAttrs (name: self._internalCallByNamePackageFile) packageFiles

--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -119,6 +119,11 @@ in
   # Use `newScope' for sets of packages in `pkgs' (see e.g. `gnome' below).
   callPackage = pkgs.newScope { };
 
+  # callPackage with more invariants (must be passed a filepath instead of a
+  # function, no injecting other args). Good for performance-critical places
+  # like the by-name-overlay
+  callSimplePackage = lib.customisation.callSimplePackageWith pkgsForCall;
+
   callPackages = lib.callPackagesWith pkgsForCall;
 
   newScope = extra: lib.callPackageWith (pkgsForCall // extra);


### PR DESCRIPTION
All the files in by-name get called with `callPackage`. However, this by-name usage follows some extra invariants that aren't assumed for the generalized `callPackage`:
- we're always calling with a filepath
- we never pass extra args to the file

By using a custom variant of callPackage that assumes these invariants, we can improve performance. This seems to be a more minor improvement than I expected, but CI might like it.

~~This might hypothetically cause issues for the injection into _internalCallByNamePackageFile that's supposedly 's supposedly done by CI:~~
Nevermind, I found where the injection is done [here](https://github.com/llakala/nixpkgs/blob/ad4753a1b6d2bd01cbe7026615b79898ab9d1771/maintainers/scripts/build.nix#L29), and this shouldn't cause any issues.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - x ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
