### PR TITLE
nuclear: 0.6.48 -> 1.37.3

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1166,6 +1166,7 @@ in
   ntfy-sh-migration = handleTest ./ntfy-sh-migration.nix { };
   ntpd = runTest ./ntpd.nix;
   ntpd-rs = runTest ./ntpd-rs.nix;
+  nuclear = runTest ./nuclear.nix;
   nvidia-container-toolkit = runTest ./nvidia-container-toolkit.nix;
   nvme-rs = runTest ./nvme-rs.nix;
   nvmetcfg = runTest ./nvmetcfg.nix;

--- a/nixos/tests/nuclear.nix
+++ b/nixos/tests/nuclear.nix
@@ -1,0 +1,48 @@
+{ lib, pkgs, ... }:
+{
+  name = "nuclear";
+
+  nodes.machine =
+    { lib, pkgs, ... }:
+    {
+      imports = [ ./common/wayland-cage.nix ];
+
+      services.cage.program = "${lib.getExe pkgs.nuclear}";
+
+      environment.variables = {
+        GDK_BACKEND = "x11"; # UI is severely broken on VM's wayland
+        # GDK_BACKEND = "wayland";
+        # DISPLAY = "do not use";
+      };
+
+      # Add fonts so text renders properly for OCR
+      fonts.packages = with pkgs; [ dejavu_fonts.minimal ];
+    };
+
+  meta.maintainers = with lib.maintainers; [ NotAShelf ];
+
+  enableOCR = true;
+
+  testScript = ''
+    @polling_condition
+    def nuclear_running():
+        # Use `pgrep -f` as process name longer than 15 characters will result in zero matches
+        # (e.g., nuclear-music-player)
+        machine.succeed('pgrep -f nuclear')
+
+    start_all()
+
+    machine.wait_for_unit('graphical.target')
+
+    nuclear_running.wait()
+    with nuclear_running:
+        with subtest("Check dashboard"):
+            machine.wait_for_text('Welcome to Nuclear')
+            machine.screenshot('nuclear_ui_loaded')
+
+        with subtest("Check version"):
+            machine.send_key('ctrl-comma')
+            machine.wait_for_text('${pkgs.nuclear.version}')
+            machine.screenshot('nuclear_version')
+  '';
+}

--- a/nixos/tests/nuclear.nix
+++ b/nixos/tests/nuclear.nix
@@ -1,5 +1,7 @@
-{ lib, pkgs, ... }:
+{ pkgs, ... }:
 {
+  meta.maintainers = [ ];
+
   name = "nuclear";
 
   nodes.machine =
@@ -18,8 +20,6 @@
       # Add fonts so text renders properly for OCR
       fonts.packages = with pkgs; [ dejavu_fonts.minimal ];
     };
-
-  meta.maintainers = with lib.maintainers; [ NotAShelf ];
 
   enableOCR = true;
 

--- a/nixos/tests/nuclear.nix
+++ b/nixos/tests/nuclear.nix
@@ -12,6 +12,8 @@
       services.cage.program = "${lib.getExe pkgs.nuclear}";
 
       environment.variables = {
+        # We scale nuclear to help OCR find the small semver dot.
+        GDK_DPI_SCALE = 2;
         GDK_BACKEND = "x11"; # UI is severely broken on VM's wayland
         # GDK_BACKEND = "wayland";
         # DISPLAY = "do not use";
@@ -30,14 +32,12 @@
         # (e.g., nuclear-music-player)
         machine.succeed('pgrep -f nuclear')
 
-    start_all()
-
     machine.wait_for_unit('graphical.target')
 
     nuclear_running.wait()
     with nuclear_running:
         with subtest("Check dashboard"):
-            machine.wait_for_text('Welcome to Nuclear')
+            machine.wait_for_text('Welcome')
             machine.screenshot('nuclear_ui_loaded')
 
         with subtest("Check version"):

--- a/pkgs/by-name/nu/nuclear/package.nix
+++ b/pkgs/by-name/nu/nuclear/package.nix
@@ -21,75 +21,81 @@
   # Darwin Dependents
   darwin,
 }:
-rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "nuclear";
-  version = "1.37.3";
+rustPlatform.buildRustPackage (
+  finalAttrs:
+  let
+    version = "1.39.1";
+  in
+  {
+    pname = "nuclear";
+    inherit version;
 
-  src = fetchFromGitHub {
-    owner = "nukeop";
-    repo = "nuclear";
-    tag = "player@1.37.3";
-    hash = "sha256-Ada86CXCrkIaEUKsCrBeji8Su5Bbl1a/ENghO5OJPZc=";
-  };
+    src = fetchFromGitHub {
+      owner = "nukeop";
+      repo = "nuclear";
+      tag = "player@${version}";
+      hash = "sha256-s1D394YRB3sl4q9mqm4gOn4KlPUcQcbNd/XQAvI/xV4=";
+    };
 
-  pnpmDeps = fetchPnpmDeps {
-    inherit (finalAttrs)
-      pname
-      version
-      src
-      patches
-      ;
-    pnpm = pnpm_10;
-    fetcherVersion = 3;
-    hash = "sha256-TeoNYkP6rUfqxtnklcl8wLODesbv1kasKviTspVKKWU=";
-  };
+    pnpmDeps = fetchPnpmDeps {
+      inherit (finalAttrs)
+        pname
+        version
+        src
+        patches
+        ;
+      pnpm = pnpm_10;
+      fetcherVersion = 3;
+      hash = "sha256-nwqUTgcLxEq01Q2vEJNFxBTPH/vi3u+LKADrqE+9cXg=";
+    };
 
-  cargoRoot = "packages/player/src-tauri";
+    cargoRoot = "packages/player/src-tauri";
 
-  postPatch =
-    let
-      tauriConfJson = "${finalAttrs.cargoRoot}/tauri.conf.json";
-    in
-    ''
-      jq '.bundle.createUpdaterArtifacts = false' ${tauriConfJson} | sponge ${tauriConfJson}
-    ''
-    # Disable Tauri's built-in codesigning
-    + lib.optionalString stdenv.hostPlatform.isDarwin ''
-      jq '.bundle.macOS.signingIdentity = null' ${tauriConfJson} | sponge ${tauriConfJson}
-    '';
+    postPatch =
+      let
+        tauriConfJson = "${finalAttrs.cargoRoot}/tauri.conf.json";
+      in
+      ''
+        jq '.bundle.createUpdaterArtifacts = false' ${tauriConfJson} | sponge ${tauriConfJson}
+      ''
+      # Disable Tauri's built-in codesigning
+      + lib.optionalString stdenv.hostPlatform.isDarwin ''
+        jq '.bundle.macOS.signingIdentity = null' ${tauriConfJson} | sponge ${tauriConfJson}
+      '';
 
-  buildAndTestSubdir = finalAttrs.cargoRoot;
+    buildAndTestSubdir = finalAttrs.cargoRoot;
 
-  cargoHash = "sha256-bVioujpKUo3q3pNqFwgPRP+kFRZsNXxALDxXbpV0CjY=";
+    cargoHash = "sha256-GyuVVSBoANqJa+03IY3eOQYv0MiuyMeCXQ2f29lk/kk=";
 
-  tauriBuildFlags = [ "--verbose" ];
+    tauriBuildFlags = [ "--verbose" ];
 
-  nativeBuildInputs = [
-    cargo-tauri.hook
-    jq
-    moreutils
-    nodejs_22
-    pkg-config
-    pnpmConfigHook
-    pnpm_10
-    wrapGAppsHook4
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.autoSignDarwinBinariesHook ];
+    nativeBuildInputs = [
+      cargo-tauri.hook
+      jq
+      moreutils
+      nodejs_22
+      pkg-config
+      pnpmConfigHook
+      pnpm_10
+      wrapGAppsHook4
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.autoSignDarwinBinariesHook ];
 
-  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
-    glib-networking
-    openssl
-    webkitgtk_4_1
-  ];
+    buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+      glib-networking
+      openssl
+      webkitgtk_4_1
+    ];
 
-  passthru.updateScript = nix-update-script { };
+    passthru.updateScript = nix-update-script { };
 
-  meta = {
-    description = "Streaming music player that finds free music for you";
-    homepage = "https://nuclear.js.org/";
-    license = lib.licenses.agpl3Plus;
-    maintainers = [ ];
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
-    mainProgram = "nuclear-music-player";
-  };
-})
+    meta = {
+      description = "Streaming music player that finds free music for you";
+      homepage = "https://nuclear.js.org/";
+      license = lib.licenses.agpl3Plus;
+      maintainers = [ ];
+      platforms = lib.platforms.linux ++ lib.platforms.darwin;
+      mainProgram = "nuclear-music-player";
+    };
+  }
+)

--- a/pkgs/by-name/nu/nuclear/package.nix
+++ b/pkgs/by-name/nu/nuclear/package.nix
@@ -3,19 +3,23 @@
   fetchPnpmDeps,
   lib,
   rustPlatform,
+  # Common
   cargo-tauri,
-  glib-networking,
   jq,
   moreutils,
   nix-update-script,
   nodejs_22,
-  openssl,
   pkg-config,
   pnpmConfigHook,
   pnpm_10,
   stdenv,
+  # Linux Dependents
+  glib-networking,
+  openssl,
   webkitgtk_4_1,
   wrapGAppsHook4,
+  # Darwin Dependents
+  darwin,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nuclear";
@@ -42,17 +46,37 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoRoot = "packages/player/src-tauri";
 
+  preBuild = lib.optionals stdenv.hostPlatform.isDarwin ''
+    mkdir -p $TMPDIR/mock_bin
+
+    # Create a fake `xattr` that simply exits with 0 (success)
+    cat << 'EOF' > $TMPDIR/mock_bin/xattr
+    #!/usr/bin/env bash
+    exit 0
+    EOF
+
+    chmod +x $TMPDIR/mock_bin/xattr
+
+    export PATH="$TMPDIR/mock_bin:$PATH"
+  '';
+
   postPatch =
     let
       tauriConfJson = "${finalAttrs.cargoRoot}/tauri.conf.json";
     in
     ''
       jq '.bundle.createUpdaterArtifacts = false' ${tauriConfJson} | sponge ${tauriConfJson}
+    ''
+    # disable Tauri's built-in codesigning
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      jq '.bundle.macOS.signingIdentity = null' ${tauriConfJson} | sponge ${tauriConfJson}
     '';
 
   buildAndTestSubdir = finalAttrs.cargoRoot;
 
   cargoHash = "sha256-bVioujpKUo3q3pNqFwgPRP+kFRZsNXxALDxXbpV0CjY=";
+
+  tauriBuildFlags = [ "--verbose" ];
 
   nativeBuildInputs = [
     cargo-tauri.hook
@@ -63,7 +87,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     pnpmConfigHook
     pnpm_10
     wrapGAppsHook4
-  ];
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.autoSignDarwinBinariesHook ];
 
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     glib-networking
@@ -78,7 +103,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://nuclear.js.org/";
     license = lib.licenses.agpl3Plus;
     maintainers = [ lib.maintainers.NotAShelf ];
-    platforms = with lib.platforms; linux ++ darwin;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     mainProgram = "nuclear-music-player";
   };
 })

--- a/pkgs/by-name/nu/nuclear/package.nix
+++ b/pkgs/by-name/nu/nuclear/package.nix
@@ -1,39 +1,84 @@
 {
-  appimageTools,
+  fetchFromGitHub,
+  fetchPnpmDeps,
   lib,
-  fetchurl,
+  rustPlatform,
+  cargo-tauri,
+  glib-networking,
+  jq,
+  moreutils,
+  nix-update-script,
+  nodejs_22,
+  openssl,
+  pkg-config,
+  pnpmConfigHook,
+  pnpm_10,
+  stdenv,
+  webkitgtk_4_1,
+  wrapGAppsHook4,
 }:
-let
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nuclear";
-  version = "0.6.48";
+  version = "1.37.3";
 
-  src = fetchurl {
-    # Nuclear currently only publishes AppImage releases for x86_64, which is hardcoded in
-    # the package name. We also hardcode the host arch in the release name, but should upstream
-    # provide more arches, we should use stdenv.hostPlatform to determine the arch and choose
-    # source URL accordingly.
-    url = "https://github.com/nukeop/nuclear/releases/download/v${version}/${pname}-v${version}-x86_64.AppImage";
-    hash = "sha256-k3qGWPn+O4kazsrrZAYHIvSrrix9LNnnJgZGJqlJbJE=";
+  src = fetchFromGitHub {
+    owner = "nukeop";
+    repo = "nuclear";
+    tag = "player@1.37.3";
+    hash = "sha256-Ada86CXCrkIaEUKsCrBeji8Su5Bbl1a/ENghO5OJPZc=";
   };
 
-  appimageContents = appimageTools.extract { inherit pname version src; };
-in
-appimageTools.wrapType2 {
-  inherit pname version src;
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      patches
+      ;
+    pnpm = pnpm_10;
+    fetcherVersion = 3;
+    hash = "sha256-TeoNYkP6rUfqxtnklcl8wLODesbv1kasKviTspVKKWU=";
+  };
 
-  extraInstallCommands = ''
-    install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
-    substituteInPlace $out/share/applications/${pname}.desktop \
-      --replace-fail 'Exec=AppRun' 'Exec=${pname}'
-    cp -r ${appimageContents}/usr/share/icons $out/share
-  '';
+  cargoRoot = "packages/player/src-tauri";
+
+  postPatch =
+    let
+      tauriConfJson = "${finalAttrs.cargoRoot}/tauri.conf.json";
+    in
+    ''
+      jq '.bundle.createUpdaterArtifacts = false' ${tauriConfJson} | sponge ${tauriConfJson}
+    '';
+
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+
+  cargoHash = "sha256-bVioujpKUo3q3pNqFwgPRP+kFRZsNXxALDxXbpV0CjY=";
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    jq
+    moreutils
+    nodejs_22
+    pkg-config
+    pnpmConfigHook
+    pnpm_10
+    wrapGAppsHook4
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    glib-networking
+    openssl
+    webkitgtk_4_1
+  ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Streaming music player that finds free music for you";
     homepage = "https://nuclear.js.org/";
     license = lib.licenses.agpl3Plus;
     maintainers = [ lib.maintainers.NotAShelf ];
-    platforms = [ "x86_64-linux" ];
-    mainProgram = "nuclear";
+    platforms = with lib.platforms; linux ++ darwin;
+    mainProgram = "nuclear-music-player";
   };
-}
+})

--- a/pkgs/by-name/nu/nuclear/package.nix
+++ b/pkgs/by-name/nu/nuclear/package.nix
@@ -46,20 +46,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoRoot = "packages/player/src-tauri";
 
-  preBuild = lib.optionals stdenv.hostPlatform.isDarwin ''
-    mkdir -p $TMPDIR/mock_bin
-
-    # Create a fake `xattr` that simply exits with 0 (success)
-    cat << 'EOF' > $TMPDIR/mock_bin/xattr
-    #!/usr/bin/env bash
-    exit 0
-    EOF
-
-    chmod +x $TMPDIR/mock_bin/xattr
-
-    export PATH="$TMPDIR/mock_bin:$PATH"
-  '';
-
   postPatch =
     let
       tauriConfJson = "${finalAttrs.cargoRoot}/tauri.conf.json";

--- a/pkgs/by-name/nu/nuclear/package.nix
+++ b/pkgs/by-name/nu/nuclear/package.nix
@@ -53,7 +53,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     ''
       jq '.bundle.createUpdaterArtifacts = false' ${tauriConfJson} | sponge ${tauriConfJson}
     ''
-    # disable Tauri's built-in codesigning
+    # Disable Tauri's built-in codesigning
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
       jq '.bundle.macOS.signingIdentity = null' ${tauriConfJson} | sponge ${tauriConfJson}
     '';
@@ -88,7 +88,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "Streaming music player that finds free music for you";
     homepage = "https://nuclear.js.org/";
     license = lib.licenses.agpl3Plus;
-    maintainers = [ lib.maintainers.NotAShelf ];
+    maintainers = [ ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     mainProgram = "nuclear-music-player";
   };


### PR DESCRIPTION
This PR updates Nuclear to version 1.37.3 and fundamentally overhauls how the application is packaged in Nixpkgs.  Which has new UI design and MCP support.

**Key Changes:**
- **Built from Source (Tauri):**  The package has been rewritten to build directly from source using `rustPlatform.buildRustPackage` and `fetchPnpmDeps` according to the Nixpkgs Manual, moving away from wrapping a pre-built x86-only AppImage.
- **Expanded Platform Support:** Because it's now built from source, platform support has been successfully expanded from `x86_64-linux` only to all Linux and Darwin architectures supported by the dependencies.
- **Tauri Configuration Adjustments:** Disabled Tauri's built-in updater and macOS codesigning inside `tauri.conf.json` using `jq` during the `postPatch` phase to adhere to Nixpkgs build standards. (Ref: [pkg/gale#L62-63](https://github.com/NixOS/nixpkgs/blob/8d0a7d4c0437cc1e5349d3dabde379c5e2a66305/pkgs/by-name/ga/gale/package.nix#L62-L63), [pkg/dorion#L133-L137](https://github.com/NixOS/nixpkgs/blob/5c7be848cb14e999948350839a2d9b28eb1133b2/pkgs/by-name/do/dorion/package.nix#L133-L137))
- **Executable Name Change:** Updated `meta.mainProgram` from `nuclear` to `nuclear-music-player` to correctly reflect the new binary output.
- **Automation:** Added `nix-update-script` to `passthru.updateScript` for easier future maintenance.

Previous:
TBD
Current:
<img width="3416" height="1363" alt="image" src="https://github.com/user-attachments/assets/696b4729-e915-48cc-8f1d-cdd9ab8fe5f6" />

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `9b019f85ec3c3458d5bd9421b7a86fc2d355626f`

## References

- [nixos/tests/stirling-pdf-desktop.nix](https://github.com/NixOS/nixpkgs/blob/07edef9b4d7e12a3af5af4eec4075cd52d7ef85a/nixos/tests/stirling-pdf-desktop.nix)
- https://nixos.org/manual/nixpkgs/stable/#tauri-hook
- [pkgs/by-name/ga/gale/package.nix](https://github.com/NixOS/nixpkgs/blob/07edef9b4d7e12a3af5af4eec4075cd52d7ef85a/pkgs/by-name/ga/gale/package.nix#L63)
- [pkgs/by-name/do/dorion/package.nix](https://github.com/NixOS/nixpkgs/commit/687fe3c6346172edb78fa0116860c4af1109b5fc)

## AI Disclosure

I used Claude Sonnet 4.6 to assist in

- Generating the commit messages

I used Gemini 3.1 Pro to assist in

- Generating the PR messages
- First version of rewrite to build from source.
- Ideas of mock `xattrs`
- Preliminary version of the test unit, referencing the existing nixos/tests/vscodium.nix

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>nuclear</li>
  </ul>
</details>
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
