### PR TITLE
geneweb: init 7.1.0-beta2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6142,6 +6142,12 @@
     githubId = 39523942;
     name = "Alex Clarke";
   };
+  darkone = {
+    email = "darkone@darkone.yt";
+    github = "darkone-linux";
+    githubId = 162493435;
+    name = "Guillaume Ponçon";
+  };
   darkonion0 = {
     name = "Alexandre Peruggia";
     email = "darkgenius1@protonmail.com";

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -10,7 +10,7 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- Create the first release note entry in this section!
+- `services.geneweb`, a module for [GeneWeb](https://geneweb.org), an open-source genealogy web server.
 
 ## Backward Incompatibilities {#sec-release-26.11-incompatibilities}
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1656,6 +1656,7 @@
   ./services/web-apps/froide-govplan.nix
   ./services/web-apps/galene.nix
   ./services/web-apps/gancio.nix
+  ./services/web-apps/geneweb.nix
   ./services/web-apps/gerrit.nix
   ./services/web-apps/glance.nix
   ./services/web-apps/glitchtip.nix

--- a/nixos/modules/services/web-apps/geneweb.nix
+++ b/nixos/modules/services/web-apps/geneweb.nix
@@ -1,0 +1,359 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.geneweb;
+  inherit (lib)
+    mkIf
+    mkOption
+    mkEnableOption
+    mkPackageOption
+    types
+    getExe'
+    optional
+    optionals
+    optionalString
+    flatten
+    escapeShellArg
+    escapeShellArgs
+    mapAttrsToList
+    concatStringsSep
+    literalExpression
+    ;
+
+  defaultGwFile = pkgs.writeText "geneweb.gw" "";
+
+  # Shared systemd hardening for both the server and the init service.
+  #
+  # gwd needs AF_UNIX for syslog (logs-syslog) on top of AF_INET/AF_INET6 for the
+  # listener.
+  #
+  # MemoryDenyWriteExecute is intentionally left out: PCRE2 JIT (via the pcre2
+  # dependency) may allocate W+X memory and trip it. UMask is left at the default
+  # 0022: gwd requires its counter dir (<baseDir>/cnt) to be mode 755, and a
+  # stricter umask makes it create that dir as 700 and abort at startup. The data
+  # stays private through baseDir being 0750 (no traversal for "other").
+  hardening = {
+    NoNewPrivileges = true;
+    ProtectSystem = "strict";
+    ProtectHome = true;
+    PrivateTmp = true;
+    PrivateDevices = true;
+    ProtectKernelTunables = true;
+    ProtectKernelModules = true;
+    ProtectKernelLogs = true;
+    ProtectControlGroups = true;
+    ProtectClock = true;
+    ProtectHostname = true;
+    ProtectProc = "invisible";
+    RestrictAddressFamilies = [
+      "AF_INET"
+      "AF_INET6"
+      "AF_UNIX"
+    ];
+    RestrictNamespaces = true;
+    RestrictRealtime = true;
+    RestrictSUIDSGID = true;
+    LockPersonality = true;
+    SystemCallArchitectures = "native";
+    SystemCallFilter = [ "@system-service" ];
+    CapabilityBoundingSet = [ ];
+    RemoveIPC = true;
+  };
+in
+{
+  options.services.geneweb = {
+    enable = mkEnableOption "GeneWeb genealogy web server";
+
+    package = mkPackageOption pkgs "geneweb" { };
+
+    user = mkOption {
+      type = types.str;
+      default = "geneweb";
+      description = "User account under which GeneWeb runs.";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "geneweb";
+      description = "Group account under which GeneWeb runs.";
+    };
+
+    baseDir = mkOption {
+      type = types.path;
+      default = "/var/lib/geneweb";
+      description = "Directory where GeneWeb databases are stored.";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 2317;
+      description = "TCP port for the HTTP server.";
+    };
+
+    interface = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "Network interface to bind to.";
+    };
+
+    defaultLang = mkOption {
+      type = types.str;
+      default = "en";
+      description = "Default language for the web interface.";
+    };
+
+    cacheDatabases = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = "Databases to load in memory before starting the server.";
+    };
+
+    authorizationFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = "Path to authorization file (user:password lines).";
+    };
+
+    wizardPassword = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Password for administrative wizard access. This value ends up
+        world-readable in the Nix store; prefer {option}`wizardPasswordFile`.
+      '';
+    };
+
+    wizardPasswordFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = ''
+        File holding the wizard password, staged through systemd
+        `LoadCredential` and read at service start. Suitable for sops-nix or
+        agenix. Note: gwd only accepts the password on its command line, so it
+        remains visible in the process list, but it never enters the Nix store.
+      '';
+    };
+
+    friendPassword = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Password for friend access. This value ends up world-readable in the
+        Nix store; prefer {option}`friendPasswordFile`.
+      '';
+    };
+
+    friendPasswordFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = ''
+        File holding the friend password. See {option}`wizardPasswordFile` for
+        the staging mechanism and caveats.
+      '';
+    };
+
+    verbosity = mkOption {
+      type = types.int;
+      default = 6;
+      description = "Logging detail level (higher = more verbose).";
+    };
+
+    nWorkers = mkOption {
+      type = types.int;
+      default = 20;
+      description = "Number of worker processes.";
+    };
+
+    banThreshold = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "100,60";
+      description = "Ban threshold: max requests, window in seconds.";
+    };
+
+    extraArgs = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = "Extra command-line arguments passed to gwd.";
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Open the HTTP port in the firewall.";
+    };
+
+    databases = mkOption {
+      default = { };
+      example = literalExpression ''
+        {
+          family = { };
+          imported = { source = ./tree.gw; };
+        }
+      '';
+      description = ''
+        Databases to create declaratively. The attribute name is the base name
+        (served at `?b=<name>`). An existing base is never modified.
+      '';
+      type = types.attrsOf (
+        types.submodule {
+          options.source = mkOption {
+            type = types.nullOr types.path;
+            default = null;
+            description = ''
+              A `.gw` file to import when creating the base. When null, an empty
+              base is created.
+            '';
+          };
+        }
+      );
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !(cfg.wizardPassword != null && cfg.wizardPasswordFile != null);
+        message = "services.geneweb: set either wizardPassword or wizardPasswordFile, not both.";
+      }
+      {
+        assertion = !(cfg.friendPassword != null && cfg.friendPasswordFile != null);
+        message = "services.geneweb: set either friendPassword or friendPasswordFile, not both.";
+      }
+    ];
+
+    users.users.${cfg.user} = {
+      inherit (cfg) group;
+      uid = config.ids.uids.${cfg.user} or null;
+      home = cfg.baseDir;
+      isSystemUser = true;
+    };
+
+    users.groups.${cfg.group} = { };
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.port ];
+    };
+
+    systemd.tmpfiles.settings."10-geneweb".${cfg.baseDir}.d = {
+      inherit (cfg) user group;
+      mode = "0750";
+    };
+
+    systemd.services.geneweb = {
+      description = "GeneWeb genealogy web server";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = hardening // {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        WorkingDirectory = cfg.baseDir;
+        ReadWritePaths = [ cfg.baseDir ];
+        LoadCredential =
+          optional (cfg.wizardPasswordFile != null) "wizard-password:${cfg.wizardPasswordFile}"
+          ++ optional (cfg.friendPasswordFile != null) "friend-password:${cfg.friendPasswordFile}";
+        Restart = "on-failure";
+        RestartSec = "5s";
+        AmbientCapabilities = optional (cfg.port < 1024) "CAP_NET_BIND_SERVICE";
+        CapabilityBoundingSet = optional (cfg.port < 1024) "CAP_NET_BIND_SERVICE";
+      };
+
+      script =
+        let
+          args = [
+            "--base-dir"
+            cfg.baseDir
+            "--port"
+            (toString cfg.port)
+            "--default-lang"
+            cfg.defaultLang
+            "--verbosity"
+            (toString cfg.verbosity)
+            "--n-workers"
+            (toString cfg.nWorkers)
+          ]
+          ++ optionals (cfg.interface != null) [
+            "--interface"
+            cfg.interface
+          ]
+          ++ optionals (cfg.authorizationFile != null) [
+            "--authorization-file"
+            cfg.authorizationFile
+          ]
+          ++ optionals (cfg.wizardPassword != null) [
+            "--wizard-password"
+            cfg.wizardPassword
+          ]
+          ++ optionals (cfg.friendPassword != null) [
+            "--friend-password"
+            cfg.friendPassword
+          ]
+          ++ optionals (cfg.banThreshold != null) [
+            "--ban-threshold"
+            cfg.banThreshold
+          ]
+          ++ flatten (
+            map (db: [
+              "--cache-database"
+              db
+            ]) cfg.cacheDatabases
+          )
+          ++ cfg.extraArgs;
+
+          credentialArgs =
+            optionalString (
+              cfg.wizardPasswordFile != null
+            ) " --wizard-password \"$(cat \"$CREDENTIALS_DIRECTORY/wizard-password\")\""
+            + optionalString (
+              cfg.friendPasswordFile != null
+            ) " --friend-password \"$(cat \"$CREDENTIALS_DIRECTORY/friend-password\")\"";
+        in
+        ''
+          exec ${getExe' cfg.package "gwd"} ${escapeShellArgs args}${credentialArgs}
+        '';
+    };
+
+    systemd.services.geneweb-init = mkIf (cfg.databases != { }) {
+      description = "Create declarative GeneWeb databases";
+      before = [ "geneweb.service" ];
+      requiredBy = [ "geneweb.service" ];
+      after = [ "systemd-tmpfiles-setup.service" ];
+
+      serviceConfig = hardening // {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        User = cfg.user;
+        Group = cfg.group;
+        WorkingDirectory = cfg.baseDir;
+        ReadWritePaths = [ cfg.baseDir ];
+      };
+
+      script =
+        let
+          # gwc looks up particles.txt relative to its own binary, which does
+          # not match the dune-site install layout; point it at the real file.
+          particlesFile = "${cfg.package}/share/geneweb/hd/etc/particles.txt";
+        in
+        concatStringsSep "\n" (
+          mapAttrsToList (
+            name: db:
+            let
+              source = if db.source != null then db.source else defaultGwFile;
+            in
+            ''
+              if [ ! -e ${escapeShellArg "${cfg.baseDir}/${name}.gwb"} ]; then
+                ${getExe' cfg.package "gwc"} -bd ${escapeShellArg cfg.baseDir} -o ${escapeShellArg name} -particles ${escapeShellArg particlesFile} ${escapeShellArg source}
+              fi
+            ''
+          ) cfg.databases
+        );
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -639,6 +639,7 @@ in
   };
   gatus = runTest ./gatus.nix;
   gemstash = import ./gemstash.nix { inherit pkgs runTest; };
+  geneweb = runTest ./geneweb.nix;
   geoclue2 = runTest ./geoclue2.nix;
   geoserver = runTest ./geoserver.nix;
   gerrit = runTest ./gerrit.nix;

--- a/nixos/tests/geneweb.nix
+++ b/nixos/tests/geneweb.nix
@@ -1,0 +1,64 @@
+{ lib, ... }:
+let
+  port = 2318;
+  wizardPass = "s3cret-wizard";
+  friendPass = "s3cret-friend";
+in
+{
+  name = "geneweb";
+  meta.maintainers = [ lib.maintainers.darkone ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.geneweb = {
+        enable = true;
+        inherit port;
+        openFirewall = true;
+        wizardPasswordFile = pkgs.writeText "geneweb-wizard-pw" wizardPass;
+        friendPasswordFile = pkgs.writeText "geneweb-friend-pw" friendPass;
+        databases = {
+          emptybase = { };
+          imported.source = pkgs.writeText "geneweb-sample.gw" ''
+            encoding: utf-8
+
+            fam Smith John + Martin Mary
+            beg
+            - h Paul
+            end
+          '';
+        };
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("geneweb-init.service")
+    machine.wait_for_unit("geneweb.service")
+    machine.wait_for_open_port(${toString port})
+
+    with subtest("HTTP server serves both declarative databases"):
+        machine.succeed("curl -sS -f http://localhost:${toString port}")
+        machine.succeed("curl -sS -f 'http://localhost:${toString port}?b=emptybase'")
+        machine.succeed("curl -sS -f 'http://localhost:${toString port}?b=imported'")
+
+    with subtest("declarative databases were created on disk"):
+        machine.succeed("test -d /var/lib/geneweb/emptybase.gwb")
+        machine.succeed("test -d /var/lib/geneweb/imported.gwb")
+
+    with subtest("openFirewall opens the configured port"):
+        machine.succeed(
+            "iptables -S | grep -q ${toString port} || nft list ruleset | grep -q ${toString port}"
+        )
+
+    with subtest("password files are loaded as credentials and handed to gwd"):
+        machine.succeed("ps -ww -C gwd -o args= | grep -- ${wizardPass}")
+        machine.succeed("ps -ww -C gwd -o args= | grep -- ${friendPass}")
+
+    with subtest("re-running geneweb-init never overwrites an existing base"):
+        before = machine.succeed("stat -c %Y /var/lib/geneweb/imported.gwb").strip()
+        machine.succeed("systemctl restart geneweb-init.service")
+        machine.wait_for_unit("geneweb-init.service")
+        after = machine.succeed("stat -c %Y /var/lib/geneweb/imported.gwb").strip()
+        assert before == after, "imported.gwb was modified by re-running geneweb-init"
+  '';
+}

--- a/pkgs/by-name/ge/geneweb/package.nix
+++ b/pkgs/by-name/ge/geneweb/package.nix
@@ -1,0 +1,153 @@
+{
+  lib,
+  fetchFromGitHub,
+  nixosTests,
+  brotli,
+  not-ocamlfind,
+  ocamlPackages,
+}:
+
+let
+  inherit (ocamlPackages)
+    buildDunePackage
+    ancient
+    benchmark
+    calendars
+    camlp-streams
+    camlp5
+    cmdliner
+    cppo
+    decompress
+    digestif
+    dune-site
+    fmt
+    jingoo
+    logs
+    logs-syslog
+    markup
+    ounit
+    pcre2
+    pp_loc
+    ppx_blob
+    ppx_deriving
+    ppx_import
+    ptime
+    re
+    stdlib-shims
+    unidecode
+    uri
+    uucp
+    uunf
+    uutf
+    yojson
+    zarith
+    ;
+
+  version = "7.1.0-beta2-unstable-2026-05-20";
+  src = fetchFromGitHub {
+    owner = "geneweb";
+    repo = "geneweb";
+    rev = "3e660222f8083a12fc0da725a3ee46840e9d498f";
+    hash = "sha256-jDWioFdKPasXyqBTOgMpAlbn3QdKiK8wdKuGZgXNG9k=";
+  };
+
+  commonMeta = {
+    homepage = "https://geneweb.org";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = [ lib.maintainers.darkone ];
+  };
+
+  geneweb-compat = buildDunePackage {
+    pname = "geneweb-compat";
+    inherit src version;
+
+    meta = commonMeta // {
+      description = "Internal compatibility library for GeneWeb";
+    };
+  };
+
+  geneweb-http = buildDunePackage {
+    pname = "geneweb-http";
+    inherit src version;
+
+    buildInputs = [
+      geneweb-compat
+      camlp-streams
+      logs
+      fmt
+    ];
+
+    meta = commonMeta // {
+      description = "Internal HTTP library for GeneWeb";
+    };
+  };
+
+in
+buildDunePackage {
+  pname = "geneweb";
+  inherit version src;
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    brotli
+    camlp5
+    cppo
+    not-ocamlfind
+  ];
+
+  buildInputs = [
+
+    # Internal workspace libs
+    geneweb-compat
+    geneweb-http
+
+    # External dependencies
+    ancient
+    benchmark
+    calendars
+    camlp-streams
+    camlp5
+    cmdliner
+    decompress
+    digestif
+    dune-site
+    fmt
+    jingoo
+    logs
+    logs-syslog
+    markup
+    ounit
+    pcre2
+    pp_loc
+    ppx_blob
+    ppx_deriving
+    ppx_import
+    ptime
+    re
+    stdlib-shims
+    unidecode
+    uri
+    uucp
+    uunf
+    uutf
+    yojson
+    zarith
+  ];
+
+  doCheck = false;
+
+  passthru.tests = {
+    inherit (nixosTests) geneweb;
+  };
+
+  meta = commonMeta // {
+    description = "Open source genealogy software with a web interface";
+    longDescription = ''
+      GeneWeb is an open source genealogy software written in OCaml.
+      It comes with a Web interface and can be used off-line or as a Web service.
+    '';
+    mainProgram = "gwd";
+  };
+}

--- a/pkgs/by-name/no/not-ocamlfind/package.nix
+++ b/pkgs/by-name/no/not-ocamlfind/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  ocamlPackages,
+}:
+
+let
+  inherit (ocamlPackages)
+    ocaml
+    findlib
+    fmt
+    ocamlgraph
+    camlp-streams
+    rresult
+    ;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "not-ocamlfind";
+  version = "0.14";
+
+  src = fetchFromGitHub {
+    owner = "chetmurthy";
+    repo = "not-ocamlfind";
+    rev = finalAttrs.version;
+    hash = "sha256-5hw2oIgZGFVELVgja+vmRx+7vacnFaYDS5FKYe+87nY=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    ocaml
+    findlib
+  ];
+
+  buildInputs = [
+    fmt
+    ocamlgraph
+    camlp-streams
+    rresult
+  ];
+
+  configurePhase = ''
+    ./configure \
+      -bindir $out/bin \
+      -config ${findlib}/etc/findlib.conf
+  '';
+
+  preInstall = ''
+    mkdir -p $out/bin
+    mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib
+  '';
+
+  meta = with lib; {
+    description = "Stub ocamlfind for building camlp5 without findlib dependency";
+    homepage = "https://github.com/chetmurthy/not-ocamlfind";
+    license = licenses.bsd2;
+    platforms = platforms.all;
+    maintainers = [ lib.maintainers.darkone ];
+  };
+})

--- a/pkgs/development/ocaml-modules/calendars/default.nix
+++ b/pkgs/development/ocaml-modules/calendars/default.nix
@@ -1,0 +1,25 @@
+{
+  buildDunePackage,
+  fetchFromGitHub,
+  lib,
+}:
+
+buildDunePackage {
+  pname = "calendars";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "geneweb";
+    repo = "calendars";
+    rev = "v2.0.0";
+    hash = "sha256-bDTQr/uG3Yv1dNC10QpbBKPXAgT7p8TkUAx3dALKKpk=";
+  };
+
+  meta = with lib; {
+    description = "Calendar conversions handling Gregorian, Julian, French Republican and Hebrew";
+    homepage = "https://github.com/geneweb/calendars";
+    license = licenses.isc;
+    platforms = platforms.linux ++ platforms.darwin;
+    maintainers = [ lib.maintainers.darkone ];
+  };
+}

--- a/pkgs/development/ocaml-modules/unidecode/default.nix
+++ b/pkgs/development/ocaml-modules/unidecode/default.nix
@@ -1,0 +1,25 @@
+{
+  buildDunePackage,
+  fetchFromGitHub,
+  lib,
+}:
+
+buildDunePackage {
+  pname = "unidecode";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "geneweb";
+    repo = "unidecode";
+    rev = "v0.5.0";
+    hash = "sha256-lz58gNITK9IG44pvoIVaMBt21mjDXA2avaL8Wmp/z8s=";
+  };
+
+  meta = with lib; {
+    description = "Unicode transliteration library";
+    homepage = "https://github.com/geneweb/unidecode";
+    license = licenses.lgpl21Only;
+    platforms = platforms.linux ++ platforms.darwin;
+    maintainers = [ lib.maintainers.darkone ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -2197,6 +2197,8 @@ let
 
         ulex = callPackage ../development/ocaml-modules/ulex { };
 
+        unidecode = callPackage ../development/ocaml-modules/unidecode { };
+
         unionFind = callPackage ../development/ocaml-modules/unionFind { };
 
         unisim_archisec = callPackage ../development/ocaml-modules/unisim_archisec { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -178,6 +178,8 @@ let
 
         calendar = callPackage ../development/ocaml-modules/calendar { };
 
+        calendars = callPackage ../development/ocaml-modules/calendars { };
+
         callipyge = callPackage ../development/ocaml-modules/callipyge { };
 
         camlgpc = callPackage ../development/ocaml-modules/camlgpc { };


### PR DESCRIPTION
## Summary

[GeneWeb](https://geneweb.org) ([github](https://github.com/geneweb/geneweb)) is open source genealogy software with a web interface, written in OCaml. This PR adds the server, its missing OCaml dependencies and a NixOS module.

**Packages**

- **geneweb** (`pkgs/servers/geneweb`) — the server, exposed at top level. Builds `gwd` (the web daemon, `mainProgram`) plus 13 companion CLI tools (`gwc`, `gwu`, `gwb2ged`, `ged2gwb`, `consang`, `gwfixbase`, `gwsetup`, `connex`, `gwdiff`, `gwgc`, `gwrobot`, `update_nldb`, `cache_files`). GPL-2.0-only

**OCaml libraries** (`pkgs/development/ocaml-modules/`, registered in `ocaml-packages.nix`):

- **not-ocamlfind** 0.14 — stub `ocamlfind` to build camlp5 without a findlib dependency; build-time only. BSD-2
- **calendars** 2.0.0 — calendar conversions (Gregorian, Julian, French Republican, Hebrew). ISC
- **unidecode** 0.5.0 — Unicode transliteration. LGPL-2.1-only

**NixOS module** — **services.geneweb** (`nixos/modules/services/web-apps/geneweb.nix`):

- Systemd service for `gwd` with extended hardening (`ProtectSystem=strict`, `ProtectProc=invisible`, empty `CapabilityBoundingSet`, restricted address families/namespaces/syscalls, etc.); `CAP_NET_BIND_SERVICE` is granted only when `port < 1024`.
- Declarative, **idempotent** database creation via `gwc` (a `geneweb-init` oneshot unit) — an existing base is never modified; bases can be empty or imported from a `.gw` file.
- Secrets via systemd `LoadCredential` (`wizardPasswordFile` / `friendPasswordFile`), so passwords never enter the Nix store. Note: `gwd` only accepts these on its command line, so they remain visible in the process list (documented in the option).
- `openFirewall` option.

## Things done

- Built on platform(s):
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: provided `nix path-info -S` before/after: n/a
- Tested, as applicable:
  - [x] NixOS test in `nixos/tests/geneweb.nix` (server up, both declarative bases served, firewall port open, credentials passed to `gwd`, init idempotent across restart).
  - [x] Package tests at `passthru.tests` (`nixosTests.geneweb`).
  - [ ] Tests in `lib/tests` or `pkgs/test` for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR — to be run with `nixpkgs-review pr <num>` once the PR is open. Instead, built all changed attributes directly: `geneweb` (which pulls its new OCaml deps `not-ocamlfind`, `calendars`, `unidecode`) and `nixosTests.geneweb`. These are brand-new packages with no reverse dependencies, so the rebuild set is exactly those attributes.
- [x] Tested basic functionality of all binary files in `./result/bin/`: the 14 installed binaries each return successfully on `--help`.
- Nixpkgs Release Notes
  - [ ] Package update (major or breaking change).
- NixOS Release Notes
  - [x] Module addition — new NixOS module.
  - [ ] Module update.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.
- [x] Follows the automation/AI policy.
