### PR TITLE
unity-test: fix non-deterministic Darwin build

### DIFF
--- a/pkgs/by-name/un/unity-test/package.nix
+++ b/pkgs/by-name/un/unity-test/package.nix
@@ -71,6 +71,11 @@ stdenv.mkDerivation (finalAttrs: {
     validatePkgConfig
   ];
 
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    AR = "llvm-ar";
+    RANLIB = "llvm-ranlib";
+  };
+
   # For the helper shebangs
   buildInputs = [
     python3


### PR DESCRIPTION
Use LLVM archive tools on Darwin so libunity.a does not include non-deterministic archive metadata.

Assisted-by: OpenCode (openai/gpt-5.5)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
   nixpkgs-review result on aarch64-darwin:
   7 packages built:
   `cava`, `cavalcade`, `cavalcade.dist`, `iniparser`, `libcava`, `unity-test`, `unity-test.dev`
    2 reverse dependencies failed and are unrelated:
    `cavasik` failed via `appstream`, and `isle-portable` failed via `LEGO_ISLANDI.ISO`.
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

## Testing
- `nix build .#corkscrew -L`
- `ar -tv ./result/lib/libunity.a`

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
