### PR TITLE
python314Packages.scikit-image: update deps to match upstream

### DIFF
--- a/pkgs/development/python-modules/scikit-image/default.nix
+++ b/pkgs/development/python-modules/scikit-image/default.nix
@@ -5,7 +5,6 @@
   buildPythonPackage,
   python,
   astropy,
-  cloudpickle,
   cython,
   dask,
   imageio,
@@ -24,10 +23,8 @@
   pywavelets,
   scikit-learn,
   scipy,
-  setuptools,
   simpleitk,
   tifffile,
-  wheel,
 }:
 
 let
@@ -51,25 +48,20 @@ let
         --replace-fail "version = version_from_init()" "version = \"${version}\""
     '';
 
-    nativeBuildInputs = [
+    build-system = [
       cython
       meson-python
       numpy
-      packaging
       pythran
-      setuptools
-      wheel
     ];
 
-    propagatedBuildInputs = [
+    dependencies = [
       imageio
       lazy-loader
-      matplotlib
       networkx
       numpy
       packaging
       pillow
-      pywavelets
       scipy
       tifffile
     ];
@@ -77,14 +69,17 @@ let
     optional-dependencies = {
       data = [ pooch ];
       optional = [
+        simpleitk
+        scikit-learn
+        pyamg
+      ]
+      ++ self.passthru.optional-dependencies.optional_free_threaded;
+      optional_free_threaded = [
         astropy
-        cloudpickle
         dask
         matplotlib
         pooch
-        pyamg
-        scikit-learn
-        simpleitk
+        pywavelets
       ]
       ++ dask.optional-dependencies.array;
     };
@@ -115,7 +110,7 @@ let
     ];
 
     disabledTestPaths = [
-      # Requires network access (actually some data is loaded via `skimage._shared.testing.fetch` in the global scope, which calls `pytest.skip` when a network is unaccessible, leading to a pytest collection error).
+      # Requires network access (actually some data is loaded via `skimage._shared.testing.fetch` in the global scope, which calls `pytest.skip` when a network is inaccessible, leading to a pytest collection error).
       "${installedPackageRoot}/skimage/filters/rank/tests/test_rank.py"
 
       # These tests require network access


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
