### PR TITLE
lib.trivial: more performance improvements

### DIFF
--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -7,7 +7,6 @@ let
     functionArgs
     pathExists
     release
-    setFunctionArgs
     toBaseDigits
     version
     versionSuffix
@@ -1177,7 +1176,10 @@ in
     let
       fArgs = functionArgs f;
     in
-    g: setFunctionArgs g fArgs;
+    g: {
+      __functor = self: g;
+      __functionArgs = fArgs;
+    };
 
   /**
     Turns any non-callable values into constant functions.

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -13,6 +13,7 @@ let
     warn
     ;
   inherit (lib)
+    foldr
     fromJSON
     isString
     readFile
@@ -1047,7 +1048,7 @@ in
 
   info = msg: builtins.trace "INFO: ${msg}";
 
-  showWarnings = warnings: res: lib.foldr (w: x: warn w x) res warnings;
+  showWarnings = warnings: res: foldr warn res warnings;
 
   ## Function annotations
 

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -13,7 +13,9 @@ let
     warn
     ;
   inherit (lib)
+    fromJSON
     isString
+    readFile
     ;
 in
 {
@@ -788,7 +790,7 @@ in
     importJSON :: Path -> Any
     ```
   */
-  importJSON = path: builtins.fromJSON (builtins.readFile path);
+  importJSON = path: fromJSON (readFile path);
 
   /**
     Reads a TOML file.
@@ -835,7 +837,7 @@ in
     importTOML :: Path -> Any
     ```
   */
-  importTOML = path: fromTOML (builtins.readFile path);
+  importTOML = path: fromTOML (readFile path);
 
   /**
     `warn` *`message`* *`value`*

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -1327,11 +1327,11 @@ in
             r = i - ((i / base) * base);
             q = (i - r) / base;
           in
-          [ r ] ++ go q;
+          go q ++ [ r ];
     in
     assert (isInt base);
     assert (isInt i);
     assert (base >= 2);
     assert (i >= 0);
-    lib.reverseList (go i);
+    go i;
 }


### PR DESCRIPTION
Only commit that really matters is the first one, since mirrorFunctionArgs is used in `makeOverridable`. I just saw it as an excuse to look through the file again for free wins.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
