### PR TITLE
igraph: remove fop dependency and correctly generate HTML doc

### DIFF
--- a/pkgs/by-name/ig/igraph/package.nix
+++ b/pkgs/by-name/ig/igraph/package.nix
@@ -12,6 +12,8 @@
   lapack,
   libxml2,
   libxslt,
+  docbook_xml_dtd_43,
+  docbook_xsl,
   llvmPackages,
   pkg-config,
   plfit,
@@ -49,6 +51,8 @@ stdenv.mkDerivation (finalAttrs: {
     flex
     libxml2
     libxslt
+    docbook_xml_dtd_43
+    docbook_xsl
     pkg-config
     python3
     sourceHighlight
@@ -81,6 +85,11 @@ stdenv.mkDerivation (finalAttrs: {
     "-DIGRAPH_ENABLE_LTO=AUTO"
     "-DIGRAPH_ENABLE_TLS=ON"
     "-DBUILD_SHARED_LIBS=ON"
+  ];
+
+  buildFlags = [
+    "all"
+    "html"
   ];
 
   doCheck = true;

--- a/pkgs/by-name/ig/igraph/package.nix
+++ b/pkgs/by-name/ig/igraph/package.nix
@@ -7,7 +7,6 @@
   blas,
   cmake,
   flex,
-  fop,
   glpk,
   gmp,
   lapack,
@@ -48,7 +47,6 @@ stdenv.mkDerivation (finalAttrs: {
     bison
     cmake
     flex
-    fop
     libxml2
     libxslt
     pkg-config


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

The first commit simply removes the unused input `fop`.

The second commit enables the `html` CMake target and adds dependency needed by DocBook/XSL for generating the HTML documentation.

This first commit could be put in a separate PR if needed.

**Removing the dependency on FOP removes a transitive dependency on `maven` and `openjdk`**


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
