### PR TITLE
libmamba: 2.4.0 -> 2.6.2

### DIFF
--- a/pkgs/by-name/li/libmamba/package.nix
+++ b/pkgs/by-name/li/libmamba/package.nix
@@ -12,6 +12,7 @@
   reproc,
   libsolv,
   curl,
+  msgpack-c,
   libarchive,
   zstd,
   nix-update-script,
@@ -21,13 +22,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libmamba";
-  version = "2.4.0";
+  version = "2.6.2";
 
   src = fetchFromGitHub {
     owner = "mamba-org";
     repo = "mamba";
     tag = finalAttrs.version;
-    hash = "sha256-ojcAS5NYAhklACrBkmSHRPNiVLjUR/umll0vhoFnFBs=";
+    hash = "sha256-qvUo2OD+vh5oXF/ckz9vJyiQ9wpEbTrC+C4oYXOGFAU=";
   };
 
   nativeBuildInputs = [
@@ -45,6 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     reproc
     libsolv
     curl
+    msgpack-c
     libarchive
     zstd
     bzip2
@@ -52,6 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "BUILD_LIBMAMBA" true)
+    (lib.cmakeBool "BUILD_LIBMAMBA_SPDLOG" true)
     (lib.cmakeBool "BUILD_SHARED" true)
   ];
 

--- a/pkgs/by-name/li/libmamba/package.nix
+++ b/pkgs/by-name/li/libmamba/package.nix
@@ -1,23 +1,23 @@
 {
-  fetchFromGitHub,
-  lib,
-  stdenv,
-  cmake,
-  fmt,
-  spdlog,
-  tl-expected,
-  nlohmann_json,
-  yaml-cpp,
-  simdjson,
-  reproc,
-  libsolv,
-  curl,
-  msgpack-c,
-  libarchive,
-  zstd,
-  nix-update-script,
   bzip2,
+  cmake,
+  curl,
+  fetchFromGitHub,
+  fmt,
+  lib,
+  libarchive,
+  libsolv,
+  msgpack-c,
+  nix-update-script,
+  nlohmann_json,
   python3,
+  reproc,
+  simdjson,
+  spdlog,
+  stdenv,
+  tl-expected,
+  yaml-cpp,
+  zstd,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -37,19 +37,19 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    bzip2
+    curl
     fmt
+    libarchive
+    libsolv
+    msgpack-c
+    nlohmann_json
+    reproc
+    simdjson
     spdlog
     tl-expected
-    nlohmann_json
     yaml-cpp
-    simdjson
-    reproc
-    libsolv
-    curl
-    msgpack-c
-    libarchive
     zstd
-    bzip2
   ];
 
   cmakeFlags = [
@@ -57,6 +57,9 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "BUILD_LIBMAMBA_SPDLOG" true)
     (lib.cmakeBool "BUILD_SHARED" true)
   ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/ma/mamba-cpp/package.nix
+++ b/pkgs/by-name/ma/mamba-cpp/package.nix
@@ -1,19 +1,19 @@
 {
-  lib,
-  stdenv,
   bzip2,
-  cmake,
   cli11,
+  cmake,
+  lib,
+  libmamba,
   msgpack-c,
-  yaml-cpp,
   nlohmann_json,
-  zstd,
+  python3,
   reproc,
   spdlog,
+  stdenv,
   tl-expected,
-  libmamba,
-  python3,
   versionCheckHook,
+  yaml-cpp,
+  zstd,
 }:
 stdenv.mkDerivation {
   pname = "mamba-cpp";
@@ -22,17 +22,17 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [
+    bzip2
+    cli11
+    libmamba
+    msgpack-c
+    nlohmann_json
     python3
     reproc
     spdlog
-    nlohmann_json
     tl-expected
-    zstd
-    bzip2
-    cli11
-    msgpack-c
     yaml-cpp
-    libmamba
+    zstd
   ];
 
   cmakeFlags = [
@@ -42,6 +42,9 @@ stdenv.mkDerivation {
   ];
 
   nativeInstallCheckInputs = [ versionCheckHook ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   meta = {
     description = "Reimplementation of the conda package manager";

--- a/pkgs/by-name/ma/mamba-cpp/package.nix
+++ b/pkgs/by-name/ma/mamba-cpp/package.nix
@@ -4,6 +4,7 @@
   cmake,
   lib,
   libmamba,
+  makeWrapper,
   msgpack-c,
   nlohmann_json,
   python3,
@@ -14,12 +15,19 @@
   versionCheckHook,
   yaml-cpp,
   zstd,
+  # runtime options
+  defaultEnvPath ? "~/.mamba/envs",
+  defaultPkgPath ? "~/.mamba/pkgs",
+  defaultRootPath ? "~/.mamba",
 }:
 stdenv.mkDerivation {
   pname = "mamba-cpp";
   inherit (libmamba) version src;
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+  ];
 
   buildInputs = [
     bzip2
@@ -42,6 +50,13 @@ stdenv.mkDerivation {
   ];
 
   nativeInstallCheckInputs = [ versionCheckHook ];
+
+  postInstall = ''
+    wrapProgram $out/bin/mamba \
+      --set-default CONDA_ENVS_PATH '${defaultEnvPath}' \
+      --set-default CONDA_PKGS_DIRS '${defaultPkgPath}' \
+      --set-default MAMBA_ROOT_PREFIX '${defaultRootPath}'
+  '';
 
   __structuredAttrs = true;
   strictDeps = true;

--- a/pkgs/by-name/ma/mamba-cpp/package.nix
+++ b/pkgs/by-name/ma/mamba-cpp/package.nix
@@ -4,6 +4,7 @@
   bzip2,
   cmake,
   cli11,
+  msgpack-c,
   yaml-cpp,
   nlohmann_json,
   zstd,
@@ -29,6 +30,7 @@ stdenv.mkDerivation {
     zstd
     bzip2
     cli11
+    msgpack-c
     yaml-cpp
     libmamba
   ];

--- a/pkgs/development/python-modules/conda-libmamba-solver/default.nix
+++ b/pkgs/development/python-modules/conda-libmamba-solver/default.nix
@@ -1,25 +1,24 @@
 {
-  lib,
+  boltons,
   buildPythonPackage,
   fetchFromGitHub,
   hatchling,
   hatch-vcs,
-  boltons,
+  lib,
   libmambapy,
   msgpack,
   requests,
   zstandard,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "conda-libmamba-solver";
   version = "26.4.2";
   pyproject = true;
 
   src = fetchFromGitHub {
-    inherit pname version;
     owner = "conda";
     repo = "conda-libmamba-solver";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-8+BIUQp2tg50P0UDjzBvywg8/mDelDYMtp/ejEcMH20=";
   };
 
@@ -47,4 +46,4 @@ buildPythonPackage rec {
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.ericthemagician ];
   };
-}
+})

--- a/pkgs/development/python-modules/conda-libmamba-solver/default.nix
+++ b/pkgs/development/python-modules/conda-libmamba-solver/default.nix
@@ -12,7 +12,7 @@
 }:
 buildPythonPackage rec {
   pname = "conda-libmamba-solver";
-  version = "25.11.0";
+  version = "26.4.2";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "conda";
     repo = "conda-libmamba-solver";
     tag = version;
-    hash = "sha256-t4mwQ9nsduicT1sL1TQLbuCoS4r7K/GaXyBFOO+3/m8=";
+    hash = "sha256-8+BIUQp2tg50P0UDjzBvywg8/mDelDYMtp/ejEcMH20=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/conda/default.nix
+++ b/pkgs/development/python-modules/conda/default.nix
@@ -28,7 +28,7 @@
 buildPythonPackage rec {
   __structuredAttrs = true;
   pname = "conda";
-  version = "26.1.0";
+  version = "26.5.0";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -36,13 +36,15 @@ buildPythonPackage rec {
     owner = "conda";
     repo = "conda";
     tag = version;
-    hash = "sha256-u3xxaSNfPocAjzvzEhKNijsa2lR4xiMSpWHP4MTnBzQ=";
+    hash = "sha256-x6p9CaityAO8NYiKLGUbu3Lk5C/mVmMmdqP4OpfSkNs=";
   };
 
   build-system = [
     hatchling
     hatch-vcs
   ];
+
+  pythonRelaxDeps = [ "ruamel-yaml" ];
 
   dependencies = [
     archspec

--- a/pkgs/development/python-modules/libmambapy/default.nix
+++ b/pkgs/development/python-modules/libmambapy/default.nix
@@ -1,23 +1,23 @@
 {
-  lib,
-  python,
-  buildPythonPackage,
+  bzip2,
   cmake,
+  curl,
+  buildPythonPackage,
+  fmt,
+  lib,
+  libmamba,
+  libsolv,
   msgpack-c,
   ninja,
-  libmamba,
+  nlohmann_json,
   pybind11,
+  python,
+  reproc,
   scikit-build-core,
-  fmt,
   spdlog,
   tl-expected,
-  nlohmann_json,
   yaml-cpp,
-  reproc,
-  libsolv,
-  curl,
   zstd,
-  bzip2,
 }:
 
 buildPythonPackage rec {
@@ -39,17 +39,17 @@ buildPythonPackage rec {
 
   buildInputs = [
     (libmamba.override { python3 = python; })
-    curl
-    zstd
     bzip2
-    spdlog
+    curl
     fmt
-    msgpack-c
-    tl-expected
-    nlohmann_json
-    yaml-cpp
-    reproc
     libsolv
+    msgpack-c
+    nlohmann_json
+    reproc
+    spdlog
+    tl-expected
+    yaml-cpp
+    zstd
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/libmambapy/default.nix
+++ b/pkgs/development/python-modules/libmambapy/default.nix
@@ -3,6 +3,7 @@
   python,
   buildPythonPackage,
   cmake,
+  msgpack-c,
   ninja,
   libmamba,
   pybind11,
@@ -43,6 +44,7 @@ buildPythonPackage rec {
     bzip2
     spdlog
     fmt
+    msgpack-c
     tl-expected
     nlohmann_json
     yaml-cpp


### PR DESCRIPTION
changelog: https://github.com/mamba-org/mamba/blob/2.6.2/CHANGELOG.md
diff: https://github.com/mamba-org/mamba/compare/2.4.0...2.6.2

Also contains some fixes for `conda` related packages since those are broken too otherwise. Some commit messages aren't accurate since I couldn't fit all of the package names in them.

Supersedes #479361
Supersedes #492950
Supersedes #504619

ZHF: #516381

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
