### PR TITLE
vte: fix build for x86_64-linux

### DIFF
--- a/pkgs/applications/terminal-emulators/termite/vte-ng-modified-patches/vte-0005-expose-function-for-getting-the-selected-text.patch
+++ b/pkgs/applications/terminal-emulators/termite/vte-ng-modified-patches/vte-0005-expose-function-for-getting-the-selected-text.patch
@@ -21,7 +21,7 @@
 +vte_terminal_get_selection(VteTerminal *terminal) noexcept
 +{
 +	g_return_val_if_fail(VTE_IS_TERMINAL(terminal), NULL);
-+	return g_strdup (IMPL(terminal)->m_selection[vte::to_integral(vte::platform::ClipboardType::PRIMARY)]->str);
++	return g_strdup (IMPL(terminal)->m_selection[std::to_underlying(vte::platform::ClipboardType::PRIMARY)]->str);
 +}
 +
  /**


### PR DESCRIPTION
Assisted-by: Claude (Opus 4.7)

ZHF: #516381


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
