### PR TITLE
chocolatey: init at 2.7.2

### DIFF
--- a/pkgs/by-name/ch/chocolatey/package.nix
+++ b/pkgs/by-name/ch/chocolatey/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  coreutils,
+  fetchurl,
+  makeWrapper,
+  mono,
+  testers,
+  chocolatey,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "chocolatey";
+  version = "2.7.2";
+
+  src = fetchurl {
+    url = "https://github.com/chocolatey/choco/releases/download/${finalAttrs.version}/chocolatey.v${finalAttrs.version}.tar.gz";
+    hash = "sha256-x29mz/qyQqWb3PaciOBb9MjWQw9OX5yfXEXZdz/1v3s=";
+  };
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontStrip = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/chocolatey
+    cp -r . $out/share/chocolatey
+    makeWrapper ${lib.getExe mono} $out/bin/choco \
+      --prefix PATH : ${lib.makeBinPath [ coreutils ]} \
+      --run 'runtimeDir="''${CHOCOLATEY_NIX_STATE:-''${XDG_CACHE_HOME:-$HOME/.cache}/chocolatey-nix/${finalAttrs.version}}"' \
+      --run 'if [ ! -e "$runtimeDir/choco.exe" ]; then rm -rf "$runtimeDir"; mkdir -p "$runtimeDir"; cp -R '"$out"'/share/chocolatey/. "$runtimeDir/"; chmod -R u+w "$runtimeDir"; fi' \
+      --run 'cd "$runtimeDir"' \
+      --add-flags "choco.exe"
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    tests.version = testers.testVersion {
+      package = chocolatey;
+      command = "HOME=$(mktemp -d) choco --version";
+      version = finalAttrs.version;
+    };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Package manager for Windows";
+    homepage = "https://chocolatey.org/";
+    changelog = "https://github.com/chocolatey/choco/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ caniko ];
+    mainProgram = "choco";
+    inherit (mono.meta) platforms;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+  };
+})

--- a/pkgs/by-name/ch/chocolatey/package.nix
+++ b/pkgs/by-name/ch/chocolatey/package.nix
@@ -21,6 +21,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   sourceRoot = ".";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   nativeBuildInputs = [ makeWrapper ];
 
   dontStrip = true;


### PR DESCRIPTION
Add Chocolatey as a new package.

Chocolatey is packaged from the upstream release tarball and wrapped with Mono. Since Chocolatey expects a writable install directory, the wrapper copies the bundled CLI to a per-user cache directory before execution.

Validated locally:

- `nix build .#chocolatey .#chocolatey.tests.version --print-build-logs`
- `nix eval --impure --expr 'let pkgs = import ./. { config.allowUnfree = true; }; in pkgs.chocolatey.updateScript'`
- `printf '\n' | nix-shell maintainers/scripts/update.nix --argstr package chocolatey`
- `./ci/nixpkgs-vet.sh master https://github.com/NixOS/nixpkgs.git`

`nixpkgs-review-gha` passed on `x86_64-linux`, `aarch64-linux`, `x86_64-darwin`, and `aarch64-darwin`: https://github.com/caniko/nixpkgs-review-gha/actions/runs/26280086350

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


