### PR TITLE
ndg: init at 2.8.0

### DIFF
--- a/pkgs/by-name/nd/ndg/package.nix
+++ b/pkgs/by-name/nd/ndg/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  installShellFiles,
+  stdenv,
+  nix-update-script,
+  buildPackages,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ndg";
+  version = "2.8.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "feel-co";
+    repo = "ndg";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-YIKEyzh0NFQlD0O92LQQNMoVCDwV8yw1Xz0Iu+4ZC5U=";
+  };
+
+  cargoHash = "sha256-r4lNSZuGFtNTOkIyd7skdEmA61lfbetI03tIUD+MO+Y=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  cargoBuildFlags = [
+    "-p"
+    "ndg"
+    "-p"
+    "xtask"
+  ];
+
+  checkFlags = [
+    "--skip"
+    "test_js_commonjs_syntax"
+  ];
+
+  postInstall =
+    lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
+      let
+        emulator = stdenv.hostPlatform.emulator buildPackages;
+      in
+      ''
+        ${emulator} $out/bin/xtask dist
+
+        installManPage dist/man/*
+        installShellCompletion --cmd ${finalAttrs.meta.mainProgram} dist/completions/*.{bash,fish,zsh}
+      ''
+    )
+    + ''
+      rm $out/bin/xtask
+    '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Not A Docs Generator";
+    homepage = "https://github.com/feel-co/ndg";
+    changelog = "https://github.com/feel-co/ndg/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mpl20;
+    maintainers = [ lib.teams.feel-co ];
+    mainProgram = "ndg";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

like many others i found this tool to be immensely useful - thank you @NotAShelf for your efforts :bowing_man:

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
