### PR TITLE
vscode-extension-update: skip Marketplace validation-failed versions

### DIFF
--- a/pkgs/by-name/vs/vscode-extension-update/vscode_extension_update.py
+++ b/pkgs/by-name/vs/vscode-extension-update/vscode_extension_update.py
@@ -239,6 +239,21 @@ class VSCodeExtensionUpdater:
             logger.exception(e)
             sys.exit(1)
 
+    def _version_passed_validation(self, version_info: dict) -> bool:
+        """
+        Returns False when the marketplace reports a validation failure for this
+        version (e.g. virus scan). Such versions are hidden from the marketplace
+        UI and have no VsixSignature asset, so we must not select them.
+        """
+        message = version_info.get("validationResultMessage")
+        if not message:
+            return True
+        try:
+            results = json.loads(message).get("results", [])
+        except (json.JSONDecodeError, AttributeError):
+            return False
+        return not any(r.get("status") == "failure" for r in results)
+
     def find_compatible_extension_version(
         self, extension_versions: list, target_platform: str
     ) -> str:
@@ -250,6 +265,12 @@ class VSCodeExtensionUpdater:
             if candidate_platform is not None and candidate_platform != target_platform:
                 continue
             candidate_version = version_info.get("version")
+            if not self._version_passed_validation(version_info):
+                logger.debug(
+                    f"Skipping version {candidate_version} ({candidate_platform}): "
+                    "marketplace validation failed"
+                )
+                continue
             candidate_pre_release = next(
                 (
                     prop.get("value")


### PR DESCRIPTION
## Description of changes

`vscode_extension_update.py` previously selected the newest extension version
satisfying targetPlatform, prerelease, and engine constraints, without
inspecting whether the Marketplace had validated it. Versions that fail
validation (for example virus scan failures) are hidden from the Marketplace
UI and should not be packaged.

This change adds a `_version_passed_validation` helper and filters such
entries in `find_compatible_extension_version`. When the Marketplace API
response sets `validationResultMessage` to a payload whose `results` contain
`status: "failure"`, that version is skipped and the next compatible version
is considered.

Reproduced and verified against `vscode-extensions.anthropic.claude-code`,
where the API was returning a virus-scan-failed 2.1.146 entry while the
Marketplace UI still listed 2.1.145 as current. After the fix, the script
correctly falls back to 2.1.145.

Validation was manual: ran the updater against the affected extension and
confirmed it now selects 2.1.145, then ran `nixos-rebuild switch` against the
branch and built the resulting package successfully. No Nix files were
changed, and the updater has no test suite, so no automated tests apply.

Fixes #522773.
Relates to #482821.
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [ ] NixOS test(s) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/tree/master/nixos/tests))
  - [ ] and/or package tests
  - [ ] or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/tree/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/tree/master/pkgs/test)
  - [ ] made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [ ] 25.11 Release Notes are up to date with package changes in this PR
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)