### PR TITLE
nixos/i18n.spellcheck: init

### DIFF
--- a/nixos/modules/i18n/spellcheck.nix
+++ b/nixos/modules/i18n/spellcheck.nix
@@ -1,0 +1,29 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+{
+  options.i18n.spellcheck = {
+    enable = lib.mkEnableOption "additional packages for spellchecking";
+  };
+
+  config = lib.mkIf config.i18n.spellcheck.enable {
+    environment.systemPackages = [
+      pkgs.hunspellWithDicts
+      (
+        dicts:
+        lib.remove null (
+          lib.map (
+            locale:
+            let
+              attr = lib.head (lib.splitString "." locale);
+            in
+            dicts."${attr}-large" or dicts.${attr} or null
+          ) config.i18n.supportedLocales
+        )
+      )
+    ];
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -140,6 +140,7 @@
   ./i18n/input-method/kime.nix
   ./i18n/input-method/nabi.nix
   ./i18n/input-method/uim.nix
+  ./i18n/spellcheck.nix
   ./image/images.nix
   ./installer/tools/tools.nix
   ./misc/assertions.nix

--- a/nixos/modules/services/desktop-managers/budgie.nix
+++ b/nixos/modules/services/desktop-managers/budgie.nix
@@ -229,6 +229,7 @@ in
       sansSerif = mkDefault [ "Noto Sans" ];
       monospace = mkDefault [ "Hack" ];
     };
+    i18n.spellcheck.enable = mkDefault true;
 
     environment.pathsToLink = [
       "/share" # TODO: https://github.com/NixOS/nixpkgs/issues/47173

--- a/nixos/modules/services/desktop-managers/cosmic.nix
+++ b/nixos/modules/services/desktop-managers/cosmic.nix
@@ -140,6 +140,7 @@ in
       noto-fonts
       open-sans
     ];
+    i18n.spellcheck.enable = lib.mkDefault true;
 
     # Required options for the COSMIC DE
     environment.sessionVariables.X11_BASE_RULES_XML = "${config.services.xserver.xkb.dir}/rules/base.xml";

--- a/nixos/modules/services/desktop-managers/gnome.nix
+++ b/nixos/modules/services/desktop-managers/gnome.nix
@@ -425,6 +425,7 @@ in
       fonts.packages = removeExcluded [
         pkgs.adwaita-fonts
       ];
+      i18n.spellcheck.enable = mkDefault true;
 
       # Adapt from https://gitlab.gnome.org/GNOME/gnome-build-meta/blob/gnome-48/elements/core/meta-gnome-core-shell.bst
       environment.systemPackages =

--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -68,6 +68,7 @@ in
       fonts.packages = with pkgs; [
         ubuntu-classic # Ubuntu is default font
       ];
+      i18n.spellcheck.enable = lib.mkDefault true;
 
       # Xwayland is partly hardcoded in Mir so it can't really be fully turned off, and it must be on PATH for X11 apps *and Lomiri's web browser* to work.
       # Until Mir/Lomiri can be properly used without it, force it on so everything behaves as expected.

--- a/nixos/modules/services/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/desktop-managers/pantheon.nix
@@ -315,6 +315,8 @@ in
         monospace = [ "Roboto Mono" ];
         sansSerif = [ "Inter" ];
       };
+
+      i18n.spellcheck.enable = mkDefault true;
     })
 
     (mkIf serviceCfg.apps.enable {

--- a/nixos/modules/services/desktop-managers/plasma6.nix
+++ b/nixos/modules/services/desktop-managers/plasma6.nix
@@ -257,6 +257,8 @@ in
       serif = [ "Noto Serif" ];
     };
 
+    i18n.spellcheck.enable = mkDefault true;
+
     programs.gnupg.agent.pinentryPackage = mkDefault pkgs.pinentry-qt;
     programs.kde-pim.enable = mkDefault true;
     programs.ssh.askPassword = mkDefault "${kdePackages.ksshaskpass.out}/bin/ksshaskpass";


### PR DESCRIPTION
Closes #312595

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
