### PR TITLE
python3Packages.sphinx-toolbox: relax ruamel.yaml and sphinx-tabs

### DIFF
--- a/pkgs/development/python-modules/sphinx-toolbox/default.nix
+++ b/pkgs/development/python-modules/sphinx-toolbox/default.nix
@@ -35,7 +35,8 @@ buildPythonPackage (finalAttrs: {
   postPatch = ''
     substituteInPlace \
       requirements.txt PKG-INFO pyproject.toml \
-      --replace-fail "sphinx-tabs<3.4.7,>=1.2.1" "sphinx-tabs<=3.4.7,>=1.2.1"
+      --replace-fail "sphinx-tabs<3.4.7,>=1.2.1" "sphinx-tabs<=3.5.0,>=1.2.1" \
+      --replace-fail "ruamel.yaml<=0.18.16,>=0.16.12" "ruamel.yaml<=0.19.1,>=0.16.12"
   '';
 
   build-system = [ whey ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Assisted-by: OpenAI (GPT 4.5)

ZHF: https://github.com/NixOS/nixpkgs/issues/516381

I intentionally chose `substituteInPlace` (like it already was there) in the `postPatch` instead of `pythonRelaxDeps`. Because it fails as soon as upstream changes and thus prompts future PRs to remove the substitution again if it is not necessary anymore.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
