### PR TITLE
dkimpy: migrate to pyproject, modernize

### DIFF
--- a/pkgs/development/python-modules/dkimpy/default.nix
+++ b/pkgs/development/python-modules/dkimpy/default.nix
@@ -4,11 +4,10 @@
   openssl,
   buildPythonPackage,
   setuptools,
-  pytest,
+  pytestCheckHook,
   dnspython,
   pynacl,
   authres,
-  python,
 }:
 
 buildPythonPackage rec {
@@ -20,8 +19,6 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-tfYPtHu/XY12LxNLzqDDiOumtJg0KmgqIfFoZUUJS3c=";
   };
-
-  nativeCheckInputs = [ pytest ];
 
   build-system = [ setuptools ];
 
@@ -37,9 +34,7 @@ buildPythonPackage rec {
       /usr/bin/openssl ${openssl}/bin/openssl
   '';
 
-  checkPhase = ''
-    ${python.interpreter} ./test.py
-  '';
+  nativeCheckInputs = [ pytestCheckHook ];
 
   meta = {
     description = "DKIM + ARC email signing/verification tools + Python module";

--- a/pkgs/development/python-modules/dkimpy/default.nix
+++ b/pkgs/development/python-modules/dkimpy/default.nix
@@ -10,13 +10,13 @@
   authres,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "dkimpy";
   version = "1.1.8";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-tfYPtHu/XY12LxNLzqDDiOumtJg0KmgqIfFoZUUJS3c=";
   };
 
@@ -29,10 +29,12 @@ buildPythonPackage rec {
     authres
   ];
 
-  patchPhase = ''
-    substituteInPlace dkim/dknewkey.py --replace \
-      /usr/bin/openssl ${openssl}/bin/openssl
+  postPatch = ''
+    substituteInPlace dkim/dknewkey.py --replace-fail \
+      /usr/bin/openssl ${lib.getExe openssl}
   '';
+
+  pythonImportsCheck = [ "dkim" ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 
@@ -48,4 +50,4 @@ buildPythonPackage rec {
     homepage = "https://launchpad.net/dkimpy";
     license = lib.licenses.bsd3;
   };
-}
+})

--- a/pkgs/development/python-modules/dkimpy/default.nix
+++ b/pkgs/development/python-modules/dkimpy/default.nix
@@ -3,6 +3,7 @@
   fetchPypi,
   openssl,
   buildPythonPackage,
+  setuptools,
   pytest,
   dnspython,
   pynacl,
@@ -13,7 +14,7 @@
 buildPythonPackage rec {
   pname = "dkimpy";
   version = "1.1.8";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
@@ -21,7 +22,10 @@ buildPythonPackage rec {
   };
 
   nativeCheckInputs = [ pytest ];
-  propagatedBuildInputs = [
+
+  build-system = [ setuptools ];
+
+  dependencies = [
     openssl
     dnspython
     pynacl


### PR DESCRIPTION
- #515974

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
