### PR TITLE
jetbrains.*: updater: use channel IDs instead of names

### DIFF
--- a/pkgs/applications/editors/jetbrains/updater/jetbrains_nix_updater/fetcher.py
+++ b/pkgs/applications/editors/jetbrains/updater/jetbrains_nix_updater/fetcher.py
@@ -65,7 +65,7 @@ class VersionFetcher:
                 new_build_number = build["@number"]
             else:
                 new_build_number = build["@fullNumber"]
-            if "EAP" not in channel["@name"]:
+            if "EAP" not in channel["@id"]:
                 version_or_build_number = new_version
             else:
                 version_or_build_number = new_build_number
@@ -111,7 +111,7 @@ class VersionFetcher:
         root = xmltodict.parse(updates_response.text)
         products = root["products"]["product"]
         return {
-            channel["@name"]: channel
+            channel["@id"]: channel
             for product in products
             if "channel" in product
             for channel in one_or_more(product["channel"])

--- a/pkgs/applications/editors/jetbrains/updater/updateInfo.json
+++ b/pkgs/applications/editors/jetbrains/updater/updateInfo.json
@@ -1,6 +1,6 @@
 {
   "clion": {
-    "channel": "CLion RELEASE",
+    "channel": "CL-RELEASE-licensing-RELEASE",
     "urls": {
       "x86_64-linux": "https://download.jetbrains.com/cpp/CLion-{version}.tar.gz",
       "aarch64-linux": "https://download.jetbrains.com/cpp/CLion-{version}-aarch64.tar.gz",
@@ -9,7 +9,7 @@
     }
   },
   "datagrip": {
-    "channel": "DataGrip RELEASE",
+    "channel": "DB-RELEASE-licensing-RELEASE",
     "urls": {
       "x86_64-linux": "https://download.jetbrains.com/datagrip/datagrip-{version}.tar.gz",
       "aarch64-linux": "https://download.jetbrains.com/datagrip/datagrip-{version}-aarch64.tar.gz",
@@ -18,7 +18,7 @@
     }
   },
   "dataspell": {
-    "channel": "DataSpell RELEASE",
+    "channel": "DS-RELEASE-licensing-RELEASE",
     "urls": {
       "x86_64-linux": "https://download.jetbrains.com/python/dataspell-{version}.tar.gz",
       "aarch64-linux": "https://download.jetbrains.com/python/dataspell-{version}-aarch64.tar.gz",
@@ -27,7 +27,7 @@
     }
   },
   "gateway": {
-    "channel": "Gateway RELEASE",
+    "channel": "GW-RELEASE-licensing-RELEASE",
     "urls": {
       "x86_64-linux": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}.tar.gz",
       "aarch64-linux": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}-aarch64.tar.gz",
@@ -36,7 +36,7 @@
     }
   },
   "goland": {
-    "channel": "GoLand RELEASE",
+    "channel": "GO-RELEASE-licensing-RELEASE",
     "urls": {
       "x86_64-linux": "https://download.jetbrains.com/go/goland-{version}.tar.gz",
       "aarch64-linux": "https://download.jetbrains.com/go/goland-{version}-aarch64.tar.gz",
@@ -45,7 +45,7 @@
     }
   },
   "idea": {
-    "channel": "IntelliJ IDEA RELEASE",
+    "channel": "IU-RELEASE-licensing-RELEASE",
     "urls": {
       "x86_64-linux": "https://download.jetbrains.com/idea/ideaIU-{version}.tar.gz",
       "aarch64-linux": "https://download.jetbrains.com/idea/ideaIU-{version}-aarch64.tar.gz",
@@ -54,11 +54,11 @@
     }
   },
   "idea-oss": {
-    "channel": "IntelliJ IDEA RELEASE",
+    "channel": "IU-RELEASE-licensing-RELEASE",
     "urls": {}
   },
   "mps": {
-    "channel": "MPS RELEASE",
+    "channel": "MPS-RELEASE-licensing-RELEASE",
     "urls": {
       "x86_64-linux": "https://download.jetbrains.com/mps/{versionMajorMinor}/MPS-{version}.tar.gz",
       "aarch64-linux": "https://download.jetbrains.com/mps/{versionMajorMinor}/MPS-{version}.tar.gz",
@@ -67,7 +67,7 @@
     }
   },
   "phpstorm": {
-    "channel": "PhpStorm RELEASE",
+    "channel": "PS-RELEASE-licensing-RELEASE",
     "urls": {
       "x86_64-linux": "https://download.jetbrains.com/webide/PhpStorm-{version}.tar.gz",
       "aarch64-linux": "https://download.jetbrains.com/webide/PhpStorm-{version}-aarch64.tar.gz",
@@ -76,7 +76,7 @@
     }
   },
   "pycharm": {
-    "channel": "PyCharm RELEASE",
+    "channel": "PY-RELEASE-licensing-RELEASE",
     "urls": {
       "x86_64-linux": "https://download.jetbrains.com/python/pycharm-{version}.tar.gz",
       "aarch64-linux": "https://download.jetbrains.com/python/pycharm-{version}-aarch64.tar.gz",
@@ -85,11 +85,11 @@
     }
   },
   "pycharm-oss": {
-    "channel": "PyCharm RELEASE",
+    "channel": "PY-RELEASE-licensing-RELEASE",
     "urls": {}
   },
   "rider": {
-    "channel": "Rider RELEASE",
+    "channel": "RD-RELEASE-licensing-RELEASE",
     "urls": {
       "x86_64-linux": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.tar.gz",
       "aarch64-linux": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}-aarch64.tar.gz",
@@ -98,7 +98,7 @@
     }
   },
   "ruby-mine": {
-    "channel": "RubyMine RELEASE",
+    "channel": "RM-RELEASE-licensing-RELEASE",
     "urls": {
       "x86_64-linux": "https://download.jetbrains.com/ruby/RubyMine-{version}.tar.gz",
       "aarch64-linux": "https://download.jetbrains.com/ruby/RubyMine-{version}-aarch64.tar.gz",
@@ -107,7 +107,7 @@
     }
   },
   "rust-rover": {
-    "channel": "RustRover RELEASE",
+    "channel": "RR-RELEASE-licensing-RELEASE",
     "urls": {
       "x86_64-linux": "https://download.jetbrains.com/rustrover/RustRover-{version}.tar.gz",
       "aarch64-linux": "https://download.jetbrains.com/rustrover/RustRover-{version}-aarch64.tar.gz",
@@ -116,7 +116,7 @@
     }
   },
   "webstorm": {
-    "channel": "WebStorm RELEASE",
+    "channel": "WS-RELEASE-licensing-RELEASE",
     "urls": {
       "x86_64-linux": "https://download.jetbrains.com/webstorm/WebStorm-{version}.tar.gz",
       "aarch64-linux": "https://download.jetbrains.com/webstorm/WebStorm-{version}-aarch64.tar.gz",


### PR DESCRIPTION
fixes #522798

The updater (using [updates.xml](https://www.jetbrains.com/updates/updates.xml)) used channel names before, however they are not unique across products. For example, the name "IntelliJ IDEA RELEASE" which was used before existed both in
- "IntelliJ IDEA" as "IU-RELEASE-licensing-RELEASE" (ID) and
- "IntelliJ IDEA Community Edition" as "IC-RELEASE-licensing-RELEASE" (ID)

since the community products aren't updated anymore, the updater got stuck using the versions from the community product. This switches the updater to use the unique IDs instead.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
