### PR TITLE
lib.generators.toGitINI: performance improvements

### DIFF
--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -394,11 +394,10 @@ rec {
           ''${head sections} "${concatStringsSep "." (tail sections)}"'';
 
       mkValueString =
-        v:
         let
-          escapedV = ''"${replaceStrings [ "\n" "	" ''"'' "\\" ] [ "\\n" "\\t" ''\"'' "\\\\" ] v}"'';
+          escape = replaceStrings [ "\n" "	" ''"'' "\\" ] [ "\\n" "\\t" ''\"'' "\\\\" ];
         in
-        mkValueStringDefault { } (if isString v then escapedV else v);
+        v: mkValueStringDefault { } (if isString v then ''"${escape v}"'' else v);
 
       # generation for multiple ini values
       mkKeyValue =

--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -23,8 +23,10 @@
 let
   inherit (lib)
     addErrorContext
+    any
     assertMsg
     attrNames
+    attrValues
     concatLists
     concatMap
     concatMapStringsSep
@@ -53,6 +55,7 @@ let
     isString
     last
     length
+    genAttrs
     mapAttrs
     mapAttrsToList
     optionals
@@ -411,9 +414,10 @@ rec {
       # converts { a.b.c = 5; } to { "a.b".c = 5; } for toINI
       gitFlattenAttrs =
         let
+          isNonDrvAttrs = value: isAttrs value && !isDerivation value;
           recurse =
             path: value:
-            if isAttrs value && !isDerivation value then
+            if isNonDrvAttrs value then
               concatMap (name: recurse ([ name ] ++ path) value.${name}) (attrNames value)
             else if length path > 1 then
               [
@@ -428,7 +432,16 @@ rec {
                 }
               ];
         in
-        attrs: foldl recursiveUpdate { } (recurse [ ] attrs);
+        attrs:
+        let
+          # Filter the names for any that contain nested attrsets. attrs that
+          # don't contain nested attrsets can stay the same =
+          namesToRewrite = filter (
+            name: isAttrs attrs.${name} && any isNonDrvAttrs (attrValues attrs.${name})
+          ) (attrNames attrs);
+          attrsToRewrite = genAttrs namesToRewrite (name: attrs.${name});
+        in
+        removeAttrs attrs namesToRewrite // foldl recursiveUpdate { } (recurse [ ] attrsToRewrite);
 
       toINI_ = toINI { inherit mkKeyValue mkSectionName; };
     in

--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -379,7 +379,6 @@ rec {
       See the [git-config documentation](https://git-scm.com/docs/git-config#_variables) for possible values.
   */
   toGitINI =
-    attrs:
     let
       mkSectionName =
         name:
@@ -427,7 +426,7 @@ rec {
 
       toINI_ = toINI { inherit mkKeyValue mkSectionName; };
     in
-    toINI_ (gitFlattenAttrs attrs);
+    attrs: toINI_ (gitFlattenAttrs attrs);
 
   /**
     `mkKeyValueDefault` wrapper that handles dconf INI quirks.

--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -26,6 +26,7 @@ let
     assertMsg
     attrNames
     concatLists
+    concatMap
     concatMapStringsSep
     concatStrings
     concatStringsSep
@@ -413,17 +414,21 @@ rec {
           recurse =
             path: value:
             if isAttrs value && !isDerivation value then
-              mapAttrsToList (name: value: recurse ([ name ] ++ path) value) value
+              concatMap (name: recurse ([ name ] ++ path) value.${name}) (attrNames value)
             else if length path > 1 then
-              {
-                ${concatStringsSep "." (reverseList (tail path))}.${head path} = value;
-              }
+              [
+                {
+                  ${concatStringsSep "." (reverseList (tail path))}.${head path} = value;
+                }
+              ]
             else
-              {
-                ${head path} = value;
-              };
+              [
+                {
+                  ${head path} = value;
+                }
+              ];
         in
-        attrs: foldl recursiveUpdate { } (flatten (recurse [ ] attrs));
+        attrs: foldl recursiveUpdate { } (recurse [ ] attrs);
 
       toINI_ = toINI { inherit mkKeyValue mkSectionName; };
     in

--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -381,15 +381,17 @@ rec {
   toGitINI =
     let
       mkSectionName =
+        let
+          containsQuote = hasInfix ''"'';
+        in
         name:
         let
-          containsQuote = hasInfix ''"'' name;
           sections = splitString "." name;
-          section = head sections;
-          subsections = tail sections;
-          subsection = concatStringsSep "." subsections;
         in
-        if containsQuote || subsections == [ ] then name else ''${section} "${subsection}"'';
+        if containsQuote name || length sections == 1 then
+          name
+        else
+          ''${head sections} "${concatStringsSep "." (tail sections)}"'';
 
       mkValueString =
         v:

--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -401,11 +401,11 @@ rec {
 
       # generation for multiple ini values
       mkKeyValue =
-        k: v:
         let
-          mkKeyValue = mkKeyValueDefault { inherit mkValueString; } " = " k;
+          mkKeyValue = mkKeyValueDefault { inherit mkValueString; } " = ";
+          attrToString = k: v: "\t" + mkKeyValue k v;
         in
-        concatStringsSep "\n" (map (kv: "\t" + mkKeyValue kv) (toList v));
+        k: v: if isList v then concatStringsSep "\n" (map (attrToString k) v) else attrToString k v;
 
       # converts { a.b.c = 5; } to { "a.b".c = 5; } for toINI
       gitFlattenAttrs =


### PR DESCRIPTION
I use toGitINI in my personal devshell, and while eval profiling, I've noticed it being slower than I expected. The core issue is that rewriting the attributes to use `"a.b".c` syntax performs an expensive recursion over every single attribute - but most gitconfig settings don't have a depth of 3. This means we're performing a lot of redundant computation on attributes that aren't going to change at all. Instead, we now partition the toplevel attributes based on whether they require rewriting, and if they don't, just keep them the same.

Here's a stats diff for all the commits, running `toGitINI` on my personal settings:
```json
{
  "attrset": {
    "lookups": 48,
    "merges": 1,
    "mergeCopies": 21
  },
  "list": {
    "concats": -59
  },
  "parser": {
    "expressions": null
  },
  "memory": {
    "envs": -40696,
    "list": -10088,
    "sets": -11520,
    "symbols": 15,
    "values": false,
    "total": -62289
  },
  "speed": {
    "primops": -1764,
    "functionCalls": -1864,
    "thunksMade": -1578,
    "thunksAvoided": -2778
  }
}
```

These correspond to:

- 55.0% less memory
- 61.8% less function calls
- 46.0% less thunks made
- 63.7% less thunks avoided

Big wins! The real-time win is quite small, because this function isn't _that_ expensive - just more expensive than it needs to be.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
