### PR TITLE
dr14_tmeter: migrate to pyproject

### DIFF
--- a/pkgs/by-name/dr/dr14_tmeter/package.nix
+++ b/pkgs/by-name/dr/dr14_tmeter/package.nix
@@ -2,13 +2,17 @@
   lib,
   fetchFromGitHub,
   python3Packages,
-  pkgs,
+  flac,
+  vorbis-tools,
+  ffmpeg,
+  faad2,
+  lame,
 }:
 
 python3Packages.buildPythonApplication {
   pname = "dr14_tmeter";
   version = "1.0.16-unstable-2025-09-27";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "hboetes";
@@ -17,7 +21,9 @@ python3Packages.buildPythonApplication {
     sha256 = "sha256-3z9Gi32aG6Tk9UHpfT1VqmBZpFJrlKB+NZFu3CH+18U=";
   };
 
-  propagatedBuildInputs = with pkgs; [
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = [
     python3Packages.numpy
     python3Packages.mutagen
     flac

--- a/pkgs/by-name/dr/dr14_tmeter/package.nix
+++ b/pkgs/by-name/dr/dr14_tmeter/package.nix
@@ -13,12 +13,13 @@ python3Packages.buildPythonApplication {
   pname = "dr14_tmeter";
   version = "1.0.16-unstable-2025-09-27";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "hboetes";
     repo = "dr14_t.meter";
     rev = "f9d62f60c30d9404d4c4b644931e76049332310c";
-    sha256 = "sha256-3z9Gi32aG6Tk9UHpfT1VqmBZpFJrlKB+NZFu3CH+18U=";
+    hash = "sha256-3z9Gi32aG6Tk9UHpfT1VqmBZpFJrlKB+NZFu3CH+18U=";
   };
 
   build-system = with python3Packages; [ setuptools ];


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/515974

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
