### PR TITLE
prettier-java: init at 2.9.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18133,6 +18133,12 @@
     githubId = 20436235;
     name = "Billy Zaelani Malik";
   };
+  minksd = {
+    email = "danielminks1230@gmail.com";
+    github = "minksd";
+    githubId = 157417909;
+    name = "Daniel Minks";
+  };
   mio = {
     name = "Mio";
     email = "mio@mio19.uk";

--- a/pkgs/by-name/pr/prettier-java/package.nix
+++ b/pkgs/by-name/pr/prettier-java/package.nix
@@ -9,61 +9,61 @@
   makeBinaryWrapper,
   nodejs,
   prettier,
-}: stdenv.mkDerivation
-  (finalAttrs: {
-    pname = "prettier-java";
-    version = "2.9.2";
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "prettier-java";
+  version = "2.9.2";
 
-    src = fetchFromGitHub {
-      owner = "jhipster";
-      repo = "prettier-java";
-      tag = "prettier-plugin-java@${finalAttrs.version}";
-      hash = "sha256-Sdd7nE1mgz05W6FF8BSTPbuhcJCnV/rGzrySJSLAT7w=";
-    };
+  src = fetchFromGitHub {
+    owner = "jhipster";
+    repo = "prettier-java";
+    tag = "prettier-plugin-java@${finalAttrs.version}";
+    hash = "sha256-Sdd7nE1mgz05W6FF8BSTPbuhcJCnV/rGzrySJSLAT7w=";
+  };
 
-    # NPV-164 and NPV-166
-    __structuredAttrs = true;
-    strictDeps = true;
+  # NPV-164 and NPV-166
+  __structuredAttrs = true;
+  strictDeps = true;
 
-    yarnOfflineCache = fetchYarnDeps {
-      yarnLock = finalAttrs.src + "/yarn.lock";
-      hash = "sha256-Y3QCh9Dv17eROlZB7Fd8z0io7cbgHasBbK+IgrCCWkY=";
-    };
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = finalAttrs.src + "/yarn.lock";
+    hash = "sha256-Y3QCh9Dv17eROlZB7Fd8z0io7cbgHasBbK+IgrCCWkY=";
+  };
 
-    nativeBuildInputs = [
-      yarnConfigHook
-      yarnBuildHook
-      yarnInstallHook
-      # Needed for executing package.json scripts
-      nodejs
+  nativeBuildInputs = [
+    yarnConfigHook
+    yarnBuildHook
+    yarnInstallHook
+    # Needed for executing package.json scripts
+    nodejs
+  ];
+
+  buildInputs = [
+    makeBinaryWrapper
+  ];
+
+  installPhase = ''
+    runHook yarnInstall
+
+    #Dependancies
+    mkdir -p $out/lib
+    cp -r ./node_modules $out/lib
+
+    #Out File
+    cp -r dist $out/
+
+    makeBinaryWrapper "${lib.getExe prettier}" "$out/bin/prettier-java" \
+      --set NODE_PATH "$out/lib/node_modules" \
+      --add-flags "--plugin" \
+      --add-flags "$out/dist/index.cjs"
+  '';
+
+  meta = {
+    description = "Prettier with prettier-java preloaded";
+    license = lib.licensesSpdx."Apache-2.0";
+    mainProgram = "prettier-java";
+    maintainers = [
+      lib.maintainers.minksd
     ];
-
-    buildInputs = [
-      makeBinaryWrapper
-    ];
-
-    installPhase = ''
-      runHook yarnInstall
-
-      #Dependancies
-      mkdir -p $out/lib
-      cp -r ./node_modules $out/lib
-
-      #Out File
-      cp -r dist $out/
-
-      makeBinaryWrapper "${lib.getExe prettier}" "$out/bin/prettier-java" \
-        --set NODE_PATH "$out/lib/node_modules" \
-        --add-flags "--plugin" \
-        --add-flags "$out/dist/index.cjs"
-    '';
-    
-    meta = {
-      description = "Prettier with prettier-java preloaded";
-      license = lib.licensesSpdx."Apache-2.0";
-      mainProgram = "prettier-java";
-      maintainers = [
-        lib.maintainers.minksd
-      ];
-    };
-  })
+  };
+})

--- a/pkgs/by-name/pr/prettier-java/package.nix
+++ b/pkgs/by-name/pr/prettier-java/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  yarnConfigHook,
+  yarnBuildHook,
+  yarnInstallHook,
+  fetchYarnDeps,
+  makeBinaryWrapper,
+  nodejs,
+  prettier,
+}: stdenv.mkDerivation
+  (finalAttrs: {
+    pname = "prettier-java";
+    version = "2.9.2";
+
+    src = fetchFromGitHub {
+      owner = "jhipster";
+      repo = "prettier-java";
+      tag = "prettier-plugin-java@${finalAttrs.version}";
+      hash = "sha256-Sdd7nE1mgz05W6FF8BSTPbuhcJCnV/rGzrySJSLAT7w=";
+    };
+
+    yarnOfflineCache = fetchYarnDeps {
+      yarnLock = finalAttrs.src + "/yarn.lock";
+      hash = "sha256-Y3QCh9Dv17eROlZB7Fd8z0io7cbgHasBbK+IgrCCWkY=";
+    };
+
+    nativeBuildInputs = [
+      yarnConfigHook
+      yarnBuildHook
+      yarnInstallHook
+      # Needed for executing package.json scripts
+      nodejs
+    ];
+
+    buildInputs = [
+      makeBinaryWrapper
+    ];
+
+    installPhase = ''
+      runHook yarnInstall
+
+      #Dependancies
+      mkdir -p $out/lib
+      cp -r ./node_modules $out/lib
+
+      #Out File
+      cp -r dist $out/
+
+      makeBinaryWrapper "${lib.getExe prettier}" "$out/bin/prettier-java" \
+        --set NODE_PATH "$out/lib/node_modules" \
+        --add-flags "--plugin" \
+        --add-flags "$out/dist/index.cjs"
+    '';
+    
+    meta = {
+      description = "Prettier with prettier-java preloaded";
+      license = lib.licensesSpdx."Apache-2.0";
+      mainProgram = "prettier-java";
+      maintainers = [
+        lib.maintainers.minksd
+      ];
+    };
+  })

--- a/pkgs/by-name/pr/prettier-java/package.nix
+++ b/pkgs/by-name/pr/prettier-java/package.nix
@@ -21,6 +21,10 @@
       hash = "sha256-Sdd7nE1mgz05W6FF8BSTPbuhcJCnV/rGzrySJSLAT7w=";
     };
 
+    # NPV-164 and NPV-166
+    __structuredAttrs = true;
+    strictDeps = true;
+
     yarnOfflineCache = fetchYarnDeps {
       yarnLock = finalAttrs.src + "/yarn.lock";
       hash = "sha256-Y3QCh9Dv17eROlZB7Fd8z0io7cbgHasBbK+IgrCCWkY=";


### PR DESCRIPTION
[prettier-java](https://github.com/jhipster/prettier-java) is a prettier plugin for java code. This package provides a binary with prettier-java pre-added to be used as a standalone code formatter.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
