### PR TITLE
WIP/Test: fix kotlin-interactive-shell build for Maven 3.9.16

### DIFF
--- a/pkgs/by-name/ko/kotlin-interactive-shell/package.nix
+++ b/pkgs/by-name/ko/kotlin-interactive-shell/package.nix
@@ -17,7 +17,7 @@ maven.buildMavenPackage rec {
     hash = "sha256-3DTyo7rPswpEVzFkcprT6FD+ITGJ+qCXFKXEGoCK+oE=";
   };
 
-  mvnHash = "sha256-UHtvBVw35QBwgCD+nSduR0924ANAOfwrr/a4qPEYsrM=";
+  mvnHash = "sha256-qGxpeb+8hP0ljbI0+aHnuO5efzXvVQWo8VFYMuRzYck=";
   mvnParameters = "compile";
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/by-name/ma/maven/package.nix
+++ b/pkgs/by-name/ma/maven/package.nix
@@ -9,11 +9,11 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "maven";
-  version = "3.9.12";
+  version = "3.9.16";
 
   src = fetchurl {
     url = "mirror://apache/maven/maven-3/${finalAttrs.version}/binaries/apache-maven-${finalAttrs.version}-bin.tar.gz";
-    hash = "sha256-+iyZSHKSlsI6/Rj9AakPYs3aCaRhkbVKi8N2TC7ugS4=";
+    hash = "sha256-gP/KIq7Z6LlxOiMvM5T9gdfyAyLfde/bKwR9vT46I7s=";
   };
 
   sourceRoot = ".";


### PR DESCRIPTION
This is an experiment that updates the `mvnHash` for ~~`fop` and~~ `kotlin-interactive-shell` to work with the updated `maven` package for release 3.9.16.

This PR adds ~~two~~ one commit on top of PR #497416 

~~Update: I also cherry-picked 0a4c158427a9f0ff08d6bb46d9d133be1093ae84~~ (That commit was merged and now this PR is rebased)
