### PR TITLE
lib.lists: performance improvements

### DIFF
--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -1581,7 +1581,12 @@ rec {
 
     :::
   */
-  drop = count: list: sublist count (length list) list;
+  drop =
+    count: list:
+    let
+      len = length list;
+    in
+    genList (n: elemAt list (n + count)) (if count > len then 0 else len - count);
 
   /**
     Remove the last (at most) N elements of a list.

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -1508,7 +1508,12 @@ rec {
 
     :::
   */
-  take = count: sublist 0 count;
+  take =
+    count: list:
+    let
+      len = length list;
+    in
+    genList (elemAt list) (if count > len then len else count);
 
   /**
     Returns the last (at most) N elements of a list.

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -6,8 +6,9 @@ let
   inherit (lib.strings) toInt;
   inherit (lib.trivial)
     compare
-    min
     id
+    min
+    seq
     warn
     ;
   inherit (lib.attrsets) mapAttrs attrNames attrValues;
@@ -276,11 +277,14 @@ rec {
     :::
   */
   foldl' =
+    let
+      inherit (builtins) foldl';
+    in
     op: acc:
     # The builtin `foldl'` is a bit lazier than one might expect.
     # See https://github.com/NixOS/nix/pull/7158.
     # In particular, the initial accumulator value is not forced before the first iteration starts.
-    builtins.seq acc (builtins.foldl' op acc);
+    seq acc (foldl' op acc);
 
   /**
     Map with index starting from 0

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -445,7 +445,7 @@ rec {
 
     :::
   */
-  flatten = x: if isList x then concatMap (y: flatten y) x else [ x ];
+  flatten = x: if isList x then concatMap flatten x else [ x ];
 
   /**
     Remove elements equal to `e` from a list.  Useful for `buildInputs`.

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -1547,7 +1547,13 @@ rec {
 
     :::
   */
-  takeEnd = n: xs: drop (max 0 (length xs - n)) xs;
+  takeEnd =
+    count: list:
+    let
+      len = length list;
+      start = if count > len then 0 else len - count;
+    in
+    genList (i: elemAt list (start + i)) (if start > len then 0 else len - start);
 
   /**
     Remove the first (at most) N elements of a list.

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -12,7 +12,6 @@ let
     warn
     ;
   inherit (lib.attrsets) mapAttrs attrNames attrValues;
-  inherit (lib) max;
 in
 rec {
 
@@ -1626,7 +1625,19 @@ rec {
     ```
     :::
   */
-  dropEnd = n: xs: take (max 0 (length xs - n)) xs;
+  dropEnd =
+    n: list:
+    let
+      len = length list;
+    in
+    genList (elemAt list) (
+      if n > len then
+        0
+      else if n < 0 then
+        len
+      else
+        len - n
+    );
 
   /**
     Whether the first list is a prefix of the second list.

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -1184,13 +1184,13 @@ rec {
           c = filter (x: before x us) visited;
           b = partition (x: before x us) rest;
         in
-        if stopOnCycles && (length c > 0) then
+        if stopOnCycles && c != [ ] then
           {
             cycle = us;
             loops = c;
             inherit visited rest;
           }
-        else if length b.right == 0 then
+        else if b.right == [ ] then
           # nothing is before us
           {
             minimal = us;

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -1247,27 +1247,33 @@ rec {
     :::
   */
   toposort =
-    before: list:
+    before:
     let
-      dfsthis = listDfs true before list;
-      toporest = toposort before (dfsthis.visited ++ dfsthis.rest);
+      dfs = listDfs true before;
+      recurse =
+        list:
+        let
+          dfsthis = dfs list;
+          toporest = recurse (dfsthis.visited ++ dfsthis.rest);
+        in
+        if length list < 2 then
+          # finish
+          { result = list; }
+        else if dfsthis ? cycle then
+          # there's a cycle, starting from the current vertex, return it
+          {
+            cycle = reverseList ([ dfsthis.cycle ] ++ dfsthis.visited);
+            inherit (dfsthis) loops;
+          }
+        else if toporest ? cycle then
+          # there's a cycle somewhere else in the graph, return it
+          toporest
+        # Slow, but short. Can be made a bit faster with an explicit stack.
+        else
+          # there are no cycles
+          { result = [ dfsthis.minimal ] ++ toporest.result; };
     in
-    if length list < 2 then
-      # finish
-      { result = list; }
-    else if dfsthis ? cycle then
-      # there's a cycle, starting from the current vertex, return it
-      {
-        cycle = reverseList ([ dfsthis.cycle ] ++ dfsthis.visited);
-        inherit (dfsthis) loops;
-      }
-    else if toporest ? cycle then
-      # there's a cycle somewhere else in the graph, return it
-      toporest
-    # Slow, but short. Can be made a bit faster with an explicit stack.
-    else
-      # there are no cycles
-      { result = [ dfsthis.minimal ] ++ toporest.result; };
+    recurse;
 
   /**
     Sort a list based on a comparator function which compares two

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -1875,7 +1875,7 @@ rec {
   init =
     list:
     assert lib.assertMsg (list != [ ]) "lists.init: list must not be empty!";
-    take (length list - 1) list;
+    genList (elemAt list) (length list - 1);
 
   /**
     Returns the image of the cross product of some lists by a function.

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -1262,7 +1262,7 @@ rec {
         else if dfsthis ? cycle then
           # there's a cycle, starting from the current vertex, return it
           {
-            cycle = reverseList ([ dfsthis.cycle ] ++ dfsthis.visited);
+            cycle = reverseList dfsthis.visited ++ [ dfsthis.cycle ];
             inherit (dfsthis) loops;
           }
         else if toporest ? cycle then

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -1125,9 +1125,10 @@ rec {
   reverseList =
     xs:
     let
-      l = length xs;
+      # subtract one to save an __sub call on every element
+      lastIndex = length xs - 1;
     in
-    genList (n: elemAt xs (l - n - 1)) l;
+    genList (n: elemAt xs (lastIndex - n)) (lastIndex + 1);
 
   /**
     Depth-First Search (DFS) for lists `list != []`.


### PR DESCRIPTION
`lib.take` and `lib.drop` are used somewhat frequently in-tree, but they're currently written in terms of `sublist`, which results in some unnecessary extra computations being performed. Rewriting these to use `genList` directly should give some nice results. I also rewrote some more niche functions like `dropEnd` to use their own logic. These functions only have a few usages in-tree, so I can drop those commits if we prefer a simpler implementation over a slight speedup.

The last commit will probably break CI - I'm sure that someone is stupid enough to use `flatten` on a non-list. But we'll see.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
