### PR TITLE
libheif: 1.21.2 -> 1.22.2

### DIFF
--- a/pkgs/by-name/li/libheif/package.nix
+++ b/pkgs/by-name/li/libheif/package.nix
@@ -24,7 +24,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libheif";
-  version = "1.21.2";
+  version = "1.22.2";
 
   outputs = [
     "bin"
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "strukturag";
     repo = "libheif";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-odkJ0wZSGoZ7mX9fkaNREDpMvQuQA9HKaf3so1dYrbc=";
+    hash = "sha256-z5vTfZATfwDn8Zwqt3piS7PaOQQ3UG+u20sR6j+dsUg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/pillow-heif/default.nix
+++ b/pkgs/development/python-modules/pillow-heif/default.nix
@@ -77,6 +77,17 @@ buildPythonPackage rec {
   disabledTests = [
     # Time sensitive speed test, not reproducible
     "test_decode_threads"
+    # Tests failing with libheif 1.22.0. To be removed in the next release
+    # https://github.com/bigcat88/pillow_heif/issues/424
+    # these check what happens when the ispe is not valid
+    "test_numpy_array_invalid_ispe"
+    "test_allow_incorrect_headers"
+    "test_invalid_ispe_ok"
+    "test_invalid_ispe_allow"
+    "test_invalid_ispe_stride"
+    "test_invalid_ispe_stride_pillow"
+    # disable version check for libheif
+    "test_libheif_info"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # https://github.com/bigcat88/pillow_heif/issues/89


### PR DESCRIPTION
supersedes: https://github.com/NixOS/nixpkgs/pull/522114

~~pillow-heif still fails its tests. Will continue to investigate.~~
The breakage is only related to tests testing unintended behavior. Everything should work with valid data.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
