### PR TITLE
linux: publish nix packaging for 7.0

### DIFF
--- a/pkgs/by-name/wi/wireshare/package.nix
+++ b/pkgs/by-name/wi/wireshare/package.nix
@@ -1,0 +1,40 @@
+{ lib
+, stdenv
+, fetchurl
+, jdk21
+, gradle
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wireshare";
+  version = "7.0";
+
+  src = fetchurl {
+    url = "https://github.com/nmatavka/hermes-wireshare/releases/download/release/7.0/WireShare-7.0-source.tar.gz";
+    sha256 = "19rgqx0i8csz8sadwhv3f7mc6gknbmw2n0xxv4dgymy1zwc7rjzk";
+  };
+
+  nativeBuildInputs = [ gradle jdk21 ];
+
+  buildPhase = ''
+    export JAVA_HOME=${jdk21}
+    ./gradlew --no-daemon wireShareJar
+  '';
+
+  installPhase = ''
+    install -d $out/bin $out/share/wireshare
+    install -m755 packaging/common/launchers/WireShare $out/bin/WireShare
+    install -m644 WireShare.jar $out/share/wireshare/WireShare.jar
+    install -Dm644 packaging/common/app/cx.hermes.WireShare.desktop $out/share/applications/cx.hermes.WireShare.desktop
+    install -Dm644 packaging/common/app/cx.hermes.WireShare.metainfo.xml $out/share/metainfo/cx.hermes.WireShare.metainfo.xml
+    cp -a packaging/common/icons $out/share/
+  '';
+
+  meta = with lib; {
+    description = "Peer-to-peer sharing for Gnutella, BitTorrent, magnet, and eD2k";
+    homepage = "https://github.com/nmatavka/hermes-wireshare";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    mainProgram = "WireShare";
+  };
+}


### PR DESCRIPTION
Prepared by the local WireShare Linux rollout orchestrator.

- Target: `nix`
- Unit: `nix`
- Submission mode: `github_pr`