### PR TITLE
markitdown: refactor dependencies

### DIFF
--- a/pkgs/by-name/al/alpaca/package.nix
+++ b/pkgs/by-name/al/alpaca/package.nix
@@ -89,6 +89,10 @@ pythonPackages.buildPythonApplication rec {
       zstandard
       pythonPackages.ollama
     ]
+    ++ markitdown.optional-dependencies.pptx
+    ++ markitdown.optional-dependencies.docx
+    ++ markitdown.optional-dependencies.pdf
+    ++ markitdown.optional-dependencies.youtube-transcription
     ++ lib.concatAttrValues optional-dependencies;
 
   optional-dependencies = with pythonPackages; {

--- a/pkgs/by-name/co/convertx/package.nix
+++ b/pkgs/by-name/co/convertx/package.nix
@@ -125,7 +125,7 @@ stdenvNoCC.mkDerivation {
           pandoc
           perl5Packages.EmailOutlookMessage
           potrace
-          (python3.withPackages (ps: [ ps.markitdown ]))
+          (python3.withPackages (ps: [ ps.markitdown ] ++ ps.markitdown.optional-dependencies.all))
           resvg
           (texliveBasic.withPackages (ps: [
             ps.dvisvgm

--- a/pkgs/by-name/ma/markitdown-mcp/package.nix
+++ b/pkgs/by-name/ma/markitdown-mcp/package.nix
@@ -27,10 +27,13 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "mcp"
   ];
 
-  dependencies = with python3Packages; [
-    markitdown
-    mcp
-  ];
+  dependencies =
+    with python3Packages;
+    [
+      markitdown
+      mcp
+    ]
+    ++ markitdown.optional-dependencies.all;
 
   pythonImportsCheck = [
     "markitdown_mcp"

--- a/pkgs/by-name/sm/smbcrawler/package.nix
+++ b/pkgs/by-name/sm/smbcrawler/package.nix
@@ -36,7 +36,8 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   optional-dependencies = with python3.pkgs; {
     binary-conversion = [
       markitdown
-    ];
+    ]
+    ++ markitdown.optional-dependencies.all;
   };
 
   nativeCheckInputs = with python3.pkgs; [ pytestCheckHook ];

--- a/pkgs/development/python-modules/markitdown/default.nix
+++ b/pkgs/development/python-modules/markitdown/default.nix
@@ -60,27 +60,60 @@ buildPythonPackage (finalAttrs: {
     "mammoth"
     "youtube-transcript-api"
   ];
+
+  optional-dependencies = {
+    all = [
+      python-pptx
+      mammoth
+      pandas
+      openpyxl
+      xlrd
+      lxml
+      pdfminer-six
+      pdfplumber
+      olefile
+      pydub
+      speechrecognition
+      youtube-transcript-api
+      azure-ai-documentintelligence
+      azure-identity
+    ];
+    pptx = [ python-pptx ];
+    docx = [
+      mammoth
+      lxml
+    ];
+    xlsx = [
+      pandas
+      openpyxl
+    ];
+    xls = [
+      pandas
+      xlrd
+    ];
+    pdf = [
+      pdfminer-six
+      pdfplumber
+    ];
+    outlook = [ olefile ];
+    audio-transcription = [
+      pydub
+      speechrecognition
+    ];
+    youtube-transcription = [ youtube-transcript-api ];
+    az-doc-intel = [
+      azure-ai-documentintelligence
+      azure-identity
+    ];
+  };
+
   dependencies = [
-    azure-ai-documentintelligence
-    azure-identity
     beautifulsoup4
+    requests
+    markdownify
+    magika
     charset-normalizer
     defusedxml
-    lxml
-    magika
-    mammoth
-    markdownify
-    olefile
-    openpyxl
-    pandas
-    pdfminer-six
-    pdfplumber
-    pydub
-    python-pptx
-    requests
-    speechrecognition
-    xlrd
-    youtube-transcript-api
   ];
 
   # aarch64-linux fails cpuinfo test, because /sys/devices/system/cpu/ does not exist in the sandbox:
@@ -90,7 +123,7 @@ buildPythonPackage (finalAttrs: {
   pythonImportsCheck = lib.optionals isNotAarch64Linux [ "markitdown" ];
   doCheck = isNotAarch64Linux;
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [ pytestCheckHook ] ++ finalAttrs.passthru.optional-dependencies.all;
 
   disabledTests = [
     # Require network access


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR refactor's `markitdown`'s dependencies to match the optional packages in the original package definition. The options are extensive and the smaller ones avoid unnecessarily heavy packages.

## ⚠️ BREAKING CHANGE ⚠️

Although this does not constitute a breaking change of the python package, it is a breaking change in the assumptions of the nix packaging. the previous default brought in _all_ optional dependencies on including `markitdown`, which would now require `[ markitdown ] ++ markitdown.optional-dependencies.all`. Packages in this repo have been updated accordingly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
