### PR TITLE
antigravity-cli: init at 1.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3206,6 +3206,12 @@
     github = "beeb";
     githubId = 703631;
   };
+  beeelias = {
+    name = "Elias Hanelt";
+    email = "elias.hanelt@gmail.com";
+    github = "beeelias";
+    githubId = 236911673;
+  };
   bellackn = {
     name = "Nico Bellack";
     email = "blcknc@pm.me";

--- a/pkgs/by-name/an/antigravity-cli/package.nix
+++ b/pkgs/by-name/an/antigravity-cli/package.nix
@@ -72,6 +72,6 @@ stdenv.mkDerivation {
       "x86_64-darwin"
       "x86_64-linux"
     ];
-    sourceProvenance = with lib.sourceTypes; [binaryNativeCode];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
 }

--- a/pkgs/by-name/an/antigravity-cli/package.nix
+++ b/pkgs/by-name/an/antigravity-cli/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  glibc,
+}:
+
+let
+  version = "1.0.1";
+  buildId = "5826024320139264";
+
+  sources = {
+    x86_64-linux = {
+      url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/${version}-${buildId}/linux-x64/cli_linux_x64.tar.gz";
+      hash = "sha512-vhF0oWXQa/Qf+3yxMAABRncfOEhrAFpopDxeYJH6gDIbOovNXTJeGJgftkiHC1lf9WMQgC1/kbsO2OdDJmhFOg==";
+    };
+    aarch64-linux = {
+      url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/${version}-${buildId}/linux-arm/cli_linux_arm64.tar.gz";
+      hash = "sha512-pVxabP+Xlpl9EEtxMPw7K59PAc9hvmBrbNGSnknSIfLaMmWRUuE720cH/X0cUB0q1y4RwImn6niHzNHGW+sGcg==";
+    };
+    x86_64-darwin = {
+      url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/${version}-${buildId}/darwin-x64/cli_mac_x64.tar.gz";
+      hash = "sha512-14L4wyJYIQlEBQeQjDoRJCDmH+3FZ+2ATyDyOcLzNkEFMmwIzK2f5ubuqWHB8PHkLrfQaAd9Dc06820XSISbmw==";
+    };
+    aarch64-darwin = {
+      url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/${version}-${buildId}/darwin-arm/cli_mac_arm64.tar.gz";
+      hash = "sha512-bgvIqJlmgNBvtwz25S07jA2ga87ulxBsPXZybq7oyU7AOFeY68hf4AGAiMlP483SP7YfvTnsIHq5WJgMmF0O8A==";
+    };
+  };
+in
+stdenv.mkDerivation {
+  pname = "antigravity-cli";
+  inherit version;
+
+  src = fetchurl (
+    sources.${stdenv.hostPlatform.system}
+      or (throw "antigravity-cli: unsupported system ${stdenv.hostPlatform.system}")
+  );
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    glibc
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 antigravity $out/bin/antigravity
+    ln -s antigravity $out/bin/agy
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Google's agentic development platform CLI, bringing multi-step reasoning and tool calling to the terminal";
+    homepage = "https://antigravity.google";
+    license = lib.licenses.unfree;
+    mainProgram = "antigravity";
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/by-name/an/antigravity-cli/package.nix
+++ b/pkgs/by-name/an/antigravity-cli/package.nix
@@ -40,6 +40,9 @@ stdenv.mkDerivation {
 
   sourceRoot = ".";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     autoPatchelfHook
   ];
@@ -53,13 +56,13 @@ stdenv.mkDerivation {
 
   installPhase = ''
     runHook preInstall
-    install -Dm755 antigravity $out/bin/antigravity
-    ln -s antigravity $out/bin/agy
+    install -Dm755 antigravity "$out/bin/antigravity"
+    ln -s antigravity "$out/bin/agy"
     runHook postInstall
   '';
 
   meta = {
-    description = "Google's agentic development platform CLI, bringing multi-step reasoning and tool calling to the terminal";
+    description = "Google's agentic development platform CLI";
     homepage = "https://antigravity.google";
     license = lib.licenses.unfree;
     mainProgram = "antigravity";
@@ -69,6 +72,6 @@ stdenv.mkDerivation {
       "x86_64-darwin"
       "x86_64-linux"
     ];
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    sourceProvenance = with lib.sourceTypes; [binaryNativeCode];
   };
 }

--- a/pkgs/by-name/an/antigravity-cli/package.nix
+++ b/pkgs/by-name/an/antigravity-cli/package.nix
@@ -65,6 +65,7 @@ stdenv.mkDerivation {
     description = "Google's agentic development platform CLI";
     homepage = "https://antigravity.google";
     license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ beeelias ];
     mainProgram = "antigravity";
     platforms = [
       "aarch64-darwin"


### PR DESCRIPTION
## Summary

- Adds `antigravity-cli` package at version 1.0.1 — Google's new agentic development platform CLI (successor to Gemini CLI), announced at Google I/O 2026
- Packages prebuilt binaries for x86_64-linux, aarch64-linux, x86_64-darwin, aarch64-darwin
- Uses `autoPatchelfHook` on Linux to patch the dynamically-linked Go binary (glibc dependencies)
- Installs the binary as `antigravity` with an `agy` symlink (both names are in common use)

## Context

Google Antigravity CLI brings multi-step reasoning, multi-file editing, tool calling, and persistent history to the terminal. It was [released on May 19, 2026](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/) as the successor to Gemini CLI.

The existing `antigravity` package in nixpkgs is for the desktop app. This is the standalone CLI tool, distributed separately.

Download URLs and SHA-512 hashes are sourced from the official auto-updater manifests at `antigravity-cli-auto-updater-974169037036.us-central1.run.app`.

## Things done

- [x] Built on x86_64-linux
- [x] Tested on aarch64-linux
- [x] Tested on x86_64-darwin
- [x] Tested on aarch64-darwin
- [x] `meta.mainProgram` set to `antigravity`
- [x] `meta.sourceProvenance` set to `binaryNativeCode`
- [x] `meta.license` set to `unfree`

## Notes for maintainers

- The `maintainers` list is empty — happy to add myself or another volunteer
- The build ID `5826024320139264` is part of the download URL versioning scheme used by Google's release infrastructure