### PR TITLE
wayfarer: 1.2.4-unstable-2025-04-12 -> 1.4.0

### DIFF
--- a/pkgs/by-name/wa/wayfarer/package.nix
+++ b/pkgs/by-name/wa/wayfarer/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
+  fetchFromCodeberg,
   blueprint-compiler,
   desktop-file-utils,
   gst_all_1,
@@ -17,14 +17,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wayfarer";
-  version = "1.2.4-unstable-2025-04-12";
+  version = "1.4.0";
 
-  src = fetchFromGitHub {
+  src = fetchFromCodeberg {
     owner = "stronnag";
     repo = "wayfarer";
-    # branch development - has new gtk4 code
-    rev = "2517004bb3c48653100f0c6a6da16fde7927755e";
-    hash = "sha256-ULmkjyBuqVwsFbLOdvqxvsAH1EF7zXFEBhU//nsV5sU=";
+    tag = finalAttrs.version;
+    hash = "sha256-+DKPRZjJ2Gg2TdoTk8LFsQlI3ecitLOGouVFEexwjkQ=";
   };
 
   postPatch = ''
@@ -57,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Screen recorder for GNOME / Wayland / pipewire";
-    homepage = "https://github.com/stronnag/wayfarer";
+    homepage = "https://codeberg.org/stronnag/wayfarer";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ fgaz ];
     mainProgram = "wayfarer";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://codeberg.org/stronnag/wayfarer/src/tag/1.4.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
