### PR TITLE
chore: change deprecated `convert` and `magick convert` invocations to just `magick`

### DIFF
--- a/pkgs/applications/editors/jupyter-kernels/clojupyter/default.nix
+++ b/pkgs/applications/editors/jupyter-kernels/clojupyter/default.nix
@@ -53,7 +53,7 @@ let
       dontInstall = true;
 
       buildPhase = ''
-        convert ./resources/clojupyter/assets/logo-64x64.png -resize ${size}x${size} $out
+        magick ./resources/clojupyter/assets/logo-64x64.png -resize ${size}x${size} $out
       '';
 
       inherit meta;

--- a/pkgs/applications/graphics/tesseract/wrapper.nix
+++ b/pkgs/applications/graphics/tesseract/wrapper.nix
@@ -69,7 +69,7 @@ let
       ''
         text="hello nix"
 
-        convert -size 400x40 xc:white -font 'DejaVu-Sans' -pointsize 20 \
+        magick -size 400x40 xc:white -font 'DejaVu-Sans' -pointsize 20 \
           -fill black -annotate +5+20 "$text" /tmp/test-img.png 2>/dev/null
         ocrResult=$(tesseract /tmp/test-img.png - | tr -d "\f")
 

--- a/pkgs/applications/graphics/unigine-sanctuary/default.nix
+++ b/pkgs/applications/graphics/unigine-sanctuary/default.nix
@@ -44,19 +44,19 @@ stdenv.mkDerivation rec {
       --prefix LD_LIBRARY_PATH : ${libPath}:$out/lib/unigine/sanctuary/bin \
       --run "cd $out/lib/unigine/sanctuary"
 
-    convert -size 256x256 xc:Transparent -define gradient:center="128,128" -define gradient:vector="128,128 128,128" \
+    magick -size 256x256 xc:Transparent -define gradient:center="128,128" -define gradient:vector="128,128 128,128" \
       -define gradient:radii="128,128" -fill radial-gradient:'rgb(164,0,0)-rgb(67,1,3)' \
       -draw "roundRectangle 0,0 256,256 50,50" ${pname}-${version}/icon.png
-    convert ${pname}-${version}/icon.png -size 181.991x181.991 -font ${liberation_ttf}/share/fonts/truetype/LiberationSans-Regular.ttf \
+    magick ${pname}-${version}/icon.png -size 181.991x181.991 -font ${liberation_ttf}/share/fonts/truetype/LiberationSans-Regular.ttf \
       -pointsize 181.991 -define gradient:center="128,128" -define gradient:vector="128,128 128,128" \
       -define gradient:radii="46.6974,46.6974" -fill radial-gradient:'rgb(249,197,46)-rgb(218,144,31)' \
       -stroke none -strokewidth 4.54977 -draw 'text 69.3061,194.247 "S"' ${pname}-${version}/icon.png
 
     for RES in 16 24 32 48 64 128 256; do
       mkdir -p $out/share/icons/hicolor/"$RES"x"$RES"/apps
-      convert ${pname}-${version}/icon.png -resize "$RES"x"$RES" $out/share/icons/hicolor/"$RES"x"$RES"/apps/Sanctuary.png
+      magick ${pname}-${version}/icon.png -resize "$RES"x"$RES" $out/share/icons/hicolor/"$RES"x"$RES"/apps/Sanctuary.png
     done
-    convert ${pname}-${version}/icon.png -resize 128x128 $out/share/icons/Sanctuary.png
+    magick ${pname}-${version}/icon.png -resize 128x128 $out/share/icons/Sanctuary.png
 
     runHook postInstall
   '';

--- a/pkgs/applications/graphics/unigine-tropics/default.nix
+++ b/pkgs/applications/graphics/unigine-tropics/default.nix
@@ -46,15 +46,15 @@ stdenv.mkDerivation {
       --prefix LD_LIBRARY_PATH : $libPath:$out/lib/unigine/tropics/bin \
       --run "cd $out/lib/unigine/tropics"
 
-    convert -size 256x256 xc:Transparent -fill gradient:'dodgerblue-white' -stroke Transparent -draw "roundrectangle 0,0 256,256 50,50"  $name/icon.png
-    convert $name/icon.png -fill white -stroke white -draw "polygon  69.2564,84.1261 117.9,84.1261 117.9,206.56 138.1,206.56 138.1,84.1261 186.744,84.1261 186.744,65.9877 69.2564,65.9877 69.2564,84.1261" $name/icon.png
+    magick -size 256x256 xc:Transparent -fill gradient:'dodgerblue-white' -stroke Transparent -draw "roundrectangle 0,0 256,256 50,50"  $name/icon.png
+    magick $name/icon.png -fill white -stroke white -draw "polygon  69.2564,84.1261 117.9,84.1261 117.9,206.56 138.1,206.56 138.1,84.1261 186.744,84.1261 186.744,65.9877 69.2564,65.9877 69.2564,84.1261" $name/icon.png
 
     for RES in 16 24 32 48 64 128 256
     do
         mkdir -p $out/share/icons/hicolor/"$RES"x"$RES"/apps
-        convert $name/icon.png -resize "$RES"x"$RES" $out/share/icons/hicolor/"$RES"x"$RES"/apps/Tropics.png
+        magick $name/icon.png -resize "$RES"x"$RES" $out/share/icons/hicolor/"$RES"x"$RES"/apps/Tropics.png
     done
-    convert $name/icon.png -resize 128x128 $out/share/icons/Tropics.png
+    magick $name/icon.png -resize 128x128 $out/share/icons/Tropics.png
 
     runHook postInstall
   '';

--- a/pkgs/applications/networking/instant-messengers/ripcord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ripcord/default.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
 
     for size in 16 32 48 64 72 96 128 192 256 512 1024; do
       mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
-      convert -resize "$size"x"$size" ${src}/Ripcord_Icon.png $out/share/icons/hicolor/"$size"x"$size"/apps/ripcord.png
+      magick -resize "$size"x"$size" ${src}/Ripcord_Icon.png $out/share/icons/hicolor/"$size"x"$size"/apps/ripcord.png
     done
 
     desktop-file-install --dir $out/share/applications \

--- a/pkgs/applications/office/mendeley/default.nix
+++ b/pkgs/applications/office/mendeley/default.nix
@@ -27,7 +27,7 @@ appimageTools.wrapType2 {
   extraInstallCommands = ''
     mv $out/bin/$pname $out/bin/${executableName}
     install -m 444 -D ${appimageContents}/${executableName}.desktop $out/share/applications/${executableName}.desktop
-    ${imagemagick}/bin/convert ${appimageContents}/${executableName}.png -resize 512x512 ${pname}_512.png
+    ${imagemagick}/bin/magick ${appimageContents}/${executableName}.png -resize 512x512 ${pname}_512.png
     install -m 444 -D ${pname}_512.png $out/share/icons/hicolor/512x512/apps/${executableName}.png
 
     substituteInPlace $out/share/applications/${executableName}.desktop \

--- a/pkgs/build-support/setup-hooks/desktop-to-darwin-bundle.sh
+++ b/pkgs/build-support/setup-hooks/desktop-to-darwin-bundle.sh
@@ -91,7 +91,7 @@ convertIconTheme() {
         local dim=$((iconSize * scale))
 
         echo "desktopToDarwinBundle: resizing icon $in to $out, size $dim" >&2
-        magick convert -scale "${dim}x${dim}" -density "$density" -units PixelsPerInch "$in" "$out"
+        magick -scale "${dim}x${dim}" -density "$density" -units PixelsPerInch "$in" "$out"
         convertIfUnsupportedIcon "$out" "$iconSize" "$scale"
     }
 
@@ -107,7 +107,7 @@ convertIconTheme() {
 
             echo "desktopToDarwinBundle: rasterizing svg $in to $out, size $dim" >&2
             rsvg-convert --keep-aspect-ratio --width "$dim" --height "$dim" "$in" --output "$out"
-            magick convert -density "$density" -units PixelsPerInch "$out" "$out"
+            magick -density "$density" -units PixelsPerInch "$out" "$out"
             convertIfUnsupportedIcon "$out" "$iconSize" "$scale"
         else
             return 1
@@ -167,7 +167,7 @@ convertIconTheme() {
                 case $type in
                     fixed)
                         local density=$((72 * scale))x$((72 * scale))
-                        magick convert -density "$density" -units PixelsPerInch "$icon" "$result"
+                        magick -density "$density" -units PixelsPerInch "$icon" "$result"
                         convertIfUnsupportedIcon "$result" "$iconSize" "$scale"
                         foundIcon=OTHER
                         ;;

--- a/pkgs/by-name/ba/backgroundremover/package.nix
+++ b/pkgs/by-name/ba/backgroundremover/package.nix
@@ -91,7 +91,7 @@ let
               ];
             }
             ''
-              convert ${demoImage} input.png
+              magick ${demoImage} input.png
               export NUMBA_CACHE_DIR=$(mktemp -d)
               backgroundremover -i input.png -o $out
             '';

--- a/pkgs/by-name/ba/ballerburg/package.nix
+++ b/pkgs/by-name/ba/ballerburg/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Generate and install icon files
     for size in 16 32 48 64 72 96 128 192 512 1024; do
       mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
-      convert ${icon} -sample "$size"x"$size" \
+      magick ${icon} -sample "$size"x"$size" \
         -background white -gravity south -extent "$size"x"$size" \
         $out/share/icons/hicolor/"$size"x"$size"/apps/ballerburg.png
     done

--- a/pkgs/by-name/bi/bisq2/package.nix
+++ b/pkgs/by-name/bi/bisq2/package.nix
@@ -161,7 +161,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     for n in 16 24 32 48 64 96 128 256; do
       size=$n"x"$n
-      magick convert opt/bisq2/lib/Bisq2.png -resize $size bisq2.png
+      magick opt/bisq2/lib/Bisq2.png -resize $size bisq2.png
       install -Dm644 -t $out/share/icons/hicolor/$size/apps bisq2.png
     done;
 

--- a/pkgs/by-name/bi/bite/package.nix
+++ b/pkgs/by-name/bi/bite/package.nix
@@ -69,7 +69,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath finalAttrs.runtimeDependencies}"
 
     mkdir -p $out/share/icons/hicolor/64x64/apps
-    convert $src/assets/iconx64.png -background black -alpha remove -alpha off $out/share/icons/hicolor/64x64/apps/bite.png
+    magick $src/assets/iconx64.png -background black -alpha remove -alpha off $out/share/icons/hicolor/64x64/apps/bite.png
   '';
 
   desktopItems = [

--- a/pkgs/by-name/bl/blackvoxel/package.nix
+++ b/pkgs/by-name/bl/blackvoxel/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
   # data/gui/gametype_back.bmp isn't exactly the official icon but since
   # there is no official icon we use that one
   postBuild = ''
-    convert gui/gametype_back.bmp blackvoxel.png
+    magick gui/gametype_back.bmp blackvoxel.png
   '';
 
   installFlags = [

--- a/pkgs/by-name/bl/bluej/package.nix
+++ b/pkgs/by-name/bl/bluej/package.nix
@@ -81,7 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/share/icons/hicolor/{16x16,32x32,48x48,64x64,128x128,256x256}/apps
 
     for dimension in 16x16 32x32 48x48 64x64 128x128 256x256; do
-      magick convert ./icons/bluej-icon-512-embossed.png -geometry $dimension\
+      magick ./icons/bluej-icon-512-embossed.png -geometry $dimension\
         $out/share/icons/hicolor/$dimension/apps/bluej.png
     done
 

--- a/pkgs/by-name/co/coq-kernel/package.nix
+++ b/pkgs/by-name/co/coq-kernel/package.nix
@@ -44,8 +44,8 @@ let
     in
     runCommand "coq-logos" { buildInputs = [ imagemagick ]; } ''
       mkdir -p $out
-      convert ${coq.src}/ide/${dir}/coq.png -resize 32x32 $out/logo-32x32.png
-      convert ${coq.src}/ide/${dir}/coq.png -resize 64x64 $out/logo-64x64.png
+      magick ${coq.src}/ide/${dir}/coq.png -resize 32x32 $out/logo-32x32.png
+      magick ${coq.src}/ide/${dir}/coq.png -resize 64x64 $out/logo-64x64.png
     '';
 
   launcher =

--- a/pkgs/by-name/dd/ddd/package.nix
+++ b/pkgs/by-name/dd/ddd/package.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postInstall = ''
     mv $out/bin/dddexe $out/bin/ddd
-    convert icons/ddd.xbm ddd.png
+    magick icons/ddd.xbm ddd.png
     install -D ddd.png $out/share/icons/hicolor/48x48/apps/ddd.png
   '';
 

--- a/pkgs/by-name/en/ente-desktop/package.nix
+++ b/pkgs/by-name/en/ente-desktop/package.nix
@@ -124,7 +124,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     for size in 16 32 48 64 72 96 128 192 256 512 1024; do
       mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
-      convert -resize "$size"x"$size" build/icon.png $out/share/icons/hicolor/"$size"x"$size"/apps/ente-desktop.png
+      magick -resize "$size"x"$size" build/icon.png $out/share/icons/hicolor/"$size"x"$size"/apps/ente-desktop.png
     done
 
     mkdir -p $out/share/ente-desktop

--- a/pkgs/by-name/ex/exactaudiocopy/package.nix
+++ b/pkgs/by-name/ex/exactaudiocopy/package.nix
@@ -47,7 +47,7 @@ let
       rm cygwin1.tar.xz
       cp -r * $out
       7z x EAC.exe
-      convert .rsrc/1033/ICON/29.ico -thumbnail 128x128 -alpha on -background none -flatten "$out/eac.ico.128.png"
+      magick .rsrc/1033/ICON/29.ico -thumbnail 128x128 -alpha on -background none -flatten "$out/eac.ico.128.png"
     '';
   };
 

--- a/pkgs/by-name/fa/fastqc/package.nix
+++ b/pkgs/by-name/fa/fastqc/package.nix
@@ -54,8 +54,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Create desktop item
     mkdir -p $out/share/{applications,icons}
-    # Freedesktop doesn't support windows ICO files. Use imagemagick to convert it to PNG
-    convert $out/FastQC/fastqc_icon.ico $out/share/icons/fastqc.png
+    # Freedesktop doesn't support windows ICO files. Use imagemagick to magick it to PNG
+    magick $out/FastQC/fastqc_icon.ico $out/share/icons/fastqc.png
 
     runHook postInstall
   '';

--- a/pkgs/by-name/fh/fheroes2/package.nix
+++ b/pkgs/by-name/fh/fheroes2/package.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     for size in 16 24 32 48 64 128; do
       mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
-      convert -resize "$size"x"$size" $PWD/src/resources/fheroes2.png $out/share/icons/hicolor/"$size"x"$size"/apps/fheroes2.png
+      magick -resize "$size"x"$size" $PWD/src/resources/fheroes2.png $out/share/icons/hicolor/"$size"x"$size"/apps/fheroes2.png
     done;
 
     runHook postInstall

--- a/pkgs/by-name/fo/folo/package.nix
+++ b/pkgs/by-name/fo/folo/package.nix
@@ -114,7 +114,7 @@ stdenv.mkDerivation rec {
 
     for size in 16 24 32 48 64 128 256 512; do
       mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
-      convert -background none -resize "$size"x"$size" ${icon} $out/share/icons/hicolor/"$size"x"$size"/apps/follow.png
+      magick -background none -resize "$size"x"$size" ${icon} $out/share/icons/hicolor/"$size"x"$size"/apps/follow.png
     done
 
     runHook postInstall

--- a/pkgs/by-name/fr/freedroid/package.nix
+++ b/pkgs/by-name/fr/freedroid/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     mkdir -p $out/share/icons/hicolor/32x32/apps
-    convert graphics/paraicon.bmp $out/share/icons/hicolor/32x32/apps/freedroid.png
+    magick graphics/paraicon.bmp $out/share/icons/hicolor/32x32/apps/freedroid.png
   '';
 
   desktopItems = [

--- a/pkgs/by-name/go/goattracker/package.nix
+++ b/pkgs/by-name/go/goattracker/package.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    convert goattrk2.bmp goattracker.png
+    magick goattrk2.bmp goattracker.png
     install -Dm644 goattracker.png $out/share/icons/hicolor/32x32/apps/goattracker.png
     ${lib.optionalString (
       !isStereo

--- a/pkgs/by-name/go/gogui/package.nix
+++ b/pkgs/by-name/go/gogui/package.nix
@@ -49,12 +49,12 @@ stdenv.mkDerivation (finalAttrs: {
     sizes=( 16x16 24x24 32x32 48x48 64x64 )
     for i in src/net/sf/gogui/images/*.svg; do
       for j in ''${sizes[@]}; do
-        convert $i -resize $j src/net/sf/gogui/images/$(basename $i .svg)-''${j}.png
+        magick $i -resize $j src/net/sf/gogui/images/$(basename $i .svg)-''${j}.png
       done
     done
 
     for i in src/net/sf/gogui/images/gogui-{black,white,setup}.svg; do
-      convert $i -resize 8x8 src/net/sf/gogui/images/$(basename $i .svg)-8x8.png
+      magick $i -resize 8x8 src/net/sf/gogui/images/$(basename $i .svg)-8x8.png
     done
 
     ant -Ddocbook-xsl.dir=${docbook-xsl-ns}/xml/xsl/docbook

--- a/pkgs/by-name/le/ledger-live-desktop/package.nix
+++ b/pkgs/by-name/le/ledger-live-desktop/package.nix
@@ -27,7 +27,7 @@ appimageTools.wrapType2 rec {
   extraInstallCommands = ''
     install -m 444 -D ${appimageContents}/ledger-live-desktop.desktop $out/share/applications/ledger-live-desktop.desktop
     install -m 444 -D ${appimageContents}/ledger-live-desktop.png $out/share/icons/hicolor/1024x1024/apps/ledger-live-desktop.png
-    ${imagemagick}/bin/convert ${appimageContents}/ledger-live-desktop.png -resize 512x512 ledger-live-desktop_512.png
+    ${imagemagick}/bin/magick ${appimageContents}/ledger-live-desktop.png -resize 512x512 ledger-live-desktop_512.png
     install -m 444 -D ledger-live-desktop_512.png $out/share/icons/hicolor/512x512/apps/ledger-live-desktop.png
 
     wrapProgram "$out/bin/${pname}" \

--- a/pkgs/by-name/lu/lunacy/package.nix
+++ b/pkgs/by-name/lu/lunacy/package.nix
@@ -81,7 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Prepare the desktop icon, the upstream icon is 200x200 but the hicolor theme does not
     # support this resolution. Nearest sizes are 192x192 and 256x256.
-    ${imagemagick}/bin/convert "opt/icons8/lunacy/Assets/LunacyLogo.png" -resize 192x192 lunacy.png
+    ${imagemagick}/bin/magick "opt/icons8/lunacy/Assets/LunacyLogo.png" -resize 192x192 lunacy.png
     install -D lunacy.png "$out/share/icons/hicolor/192x192/apps/lunacy.png"
 
     runHook postInstall

--- a/pkgs/by-name/ma/mars-mips/package.nix
+++ b/pkgs/by-name/ma/mars-mips/package.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
     for size in 16 24 32 48 64 128 256 512
     do
       mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
-      convert -resize "$size"x"$size" images/MarsThumbnail.gif $out/share/icons/hicolor/"$size"x"$size"/apps/mars.png
+      magick -resize "$size"x"$size" images/MarsThumbnail.gif $out/share/icons/hicolor/"$size"x"$size"/apps/mars.png
     done
 
     runHook postInstall

--- a/pkgs/by-name/mq/mqttx/package.nix
+++ b/pkgs/by-name/mq/mqttx/package.nix
@@ -41,7 +41,7 @@ appimageTools.wrapType2 {
     install -m 444 -D ${appimageContents}/${pname}.desktop $out/share/applications/${pname}.desktop
     install -m 444 -D ${appimageContents}/${pname}.png $out/share/icons/hicolor/1024x1024/apps/${pname}.png
 
-    ${imagemagick}/bin/convert ${appimageContents}/mqttx.png -resize 512x512 ${pname}_512.png
+    ${imagemagick}/bin/magick ${appimageContents}/mqttx.png -resize 512x512 ${pname}_512.png
     install -m 444 -D ${pname}_512.png $out/share/icons/hicolor/512x512/apps/${pname}.png
 
     substituteInPlace $out/share/applications/${pname}.desktop \

--- a/pkgs/by-name/ne/netbeans/package.nix
+++ b/pkgs/by-name/ne/netbeans/package.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation {
       then
         mv netbeans_"$size"x"$size"x32.png $out/share/icons/hicolor/"$size"x"$size"/apps/netbeans.png
       else
-        convert -resize "$size"x"$size" netbeans_1024x1024x32.png $out/share/icons/hicolor/"$size"x"$size"/apps/netbeans.png
+        magick -resize "$size"x"$size" netbeans_1024x1024x32.png $out/share/icons/hicolor/"$size"x"$size"/apps/netbeans.png
       fi
     done;
 

--- a/pkgs/by-name/ne/netgen/package.nix
+++ b/pkgs/by-name/ne/netgen/package.nix
@@ -180,7 +180,7 @@ stdenv.mkDerivation (finalAttrs: {
         then
           mv netgen_"$size"x"$size"x32.png $out/share/icons/hicolor/"$size"x"$size"/apps/netgen.png
         else
-          convert -resize "$size"x"$size" netgen_512x512x32.png $out/share/icons/hicolor/"$size"x"$size"/apps/netgen.png
+          magick -resize "$size"x"$size" netgen_512x512x32.png $out/share/icons/hicolor/"$size"x"$size"/apps/netgen.png
         fi
       done;
     '';

--- a/pkgs/by-name/op/optar/package.nix
+++ b/pkgs/by-name/op/optar/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
       --replace /usr/local $out
 
     substituteInPlace pgm2ps \
-      --replace 'convert ' "${lib.getBin imagemagick}/bin/convert "
+      --replace 'magick ' "${lib.getBin imagemagick}/bin/magick "
   '';
 
   env.NIX_CFLAGS_COMPILE = toString [ "-Wno-error=implicit-int" ];

--- a/pkgs/by-name/pl/plezy/package.nix
+++ b/pkgs/by-name/pl/plezy/package.nix
@@ -123,7 +123,7 @@ let
       install -Dm644 assets/plezy.png $out/share/icons/hicolor/128x128/apps/plezy.png
       for size in 16 24 32 48 64 256 512; do
         mkdir -p $out/share/icons/hicolor/''${size}x''${size}/apps
-        convert assets/plezy.png -resize ''${size}x''${size} $out/share/icons/hicolor/''${size}x''${size}/apps/plezy.png
+        magick assets/plezy.png -resize ''${size}x''${size} $out/share/icons/hicolor/''${size}x''${size}/apps/plezy.png
       done
     '';
 

--- a/pkgs/by-name/qu/quark-goldleaf/package.nix
+++ b/pkgs/by-name/qu/quark-goldleaf/package.nix
@@ -60,7 +60,7 @@ maven.buildMavenPackage rec {
 
     for size in 16 24 32 48 64 128; do
       mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
-      convert -resize "$size"x"$size" src/main/resources/Icon.png $out/share/icons/hicolor/"$size"x"$size"/apps/quark-goldleaf.png
+      magick -resize "$size"x"$size" src/main/resources/Icon.png $out/share/icons/hicolor/"$size"x"$size"/apps/quark-goldleaf.png
     done
 
     runHook postInstall

--- a/pkgs/by-name/sp/sparrow/package.nix
+++ b/pkgs/by-name/sp/sparrow/package.nix
@@ -268,7 +268,7 @@ stdenvNoCC.mkDerivation rec {
       for n in 16 24 32 48 64 96 128 256; do
         size=$n"x"$n
         mkdir -p $out/hicolor/$size/apps
-        convert lib/Sparrow.png -resize $size $out/hicolor/$size/apps/sparrow-desktop.png
+        magick lib/Sparrow.png -resize $size $out/hicolor/$size/apps/sparrow-desktop.png
         done;
     '';
   };

--- a/pkgs/by-name/un/unigine-heaven/package.nix
+++ b/pkgs/by-name/un/unigine-heaven/package.nix
@@ -64,11 +64,11 @@ stdenv.mkDerivation {
 
     wrapProgram $out/bin/heaven --prefix LD_LIBRARY_PATH : ${libglvnd}/lib:$out/bin:${openal}/lib --run "cd $out/lib/unigine/heaven/"
 
-    convert $out/lib/unigine/heaven/data/launcher/icon.png -resize 128x128 $out/share/icons/Heaven.png
+    magick $out/lib/unigine/heaven/data/launcher/icon.png -resize 128x128 $out/share/icons/Heaven.png
     for RES in 16 24 32 48 64 128 256
     do
         mkdir -p $out/share/icons/hicolor/"$RES"x"$RES"/apps
-        convert $out/lib/unigine/heaven/data/launcher/icon.png -resize "$RES"x"$RES" $out/share/icons/hicolor/"$RES"x"$RES"/apps/Heaven.png
+        magick $out/lib/unigine/heaven/data/launcher/icon.png -resize "$RES"x"$RES" $out/share/icons/hicolor/"$RES"x"$RES"/apps/Heaven.png
     done
 
     ln -s ${desktopItem}/share/applications/* $out/share/applications

--- a/pkgs/by-name/un/unigine-valley/package.nix
+++ b/pkgs/by-name/un/unigine-valley/package.nix
@@ -109,11 +109,11 @@ stdenv.mkDerivation rec {
       --prefix LD_LIBRARY_PATH : /run/opengl-driver/lib:$instdir/bin:$libPath
 
     # Make desktop Icon
-    convert $out/lib/unigine/valley/data/launcher/icon.png -resize 128x128 $out/share/icons/Valley.png
+    magick $out/lib/unigine/valley/data/launcher/icon.png -resize 128x128 $out/share/icons/Valley.png
     for RES in 16 24 32 48 64 128 256
     do
         mkdir -p $out/share/icons/hicolor/"$RES"x"$RES"/apps
-        convert $out/lib/unigine/valley/data/launcher/icon.png -resize "$RES"x"$RES" $out/share/icons/hicolor/"$RES"x"$RES"/apps/Valley.png
+        magick $out/lib/unigine/valley/data/launcher/icon.png -resize "$RES"x"$RES" $out/share/icons/hicolor/"$RES"x"$RES"/apps/Valley.png
     done
 
     runHook postInstall

--- a/pkgs/by-name/ur/urbanterror/package.nix
+++ b/pkgs/by-name/ur/urbanterror/package.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation {
     for size in 16 24 32 48 64 128 256 512 1024; do
       mkdir -pv $out/share/icons/hicolor/"$size"x"$size"/apps
       if [ ! -e quake3-urt_"$size"x"$size"x32.png ] ; then
-        convert -resize "$size"x"$size" quake3-urt_512x512x32.png quake3-urt_"$size"x"$size"x32.png
+        magick -resize "$size"x"$size" quake3-urt_512x512x32.png quake3-urt_"$size"x"$size"x32.png
       fi
       install -Dm644 quake3-urt_"$size"x"$size"x32.png $out/share/icons/hicolor/"$size"x"$size"/apps/urbanterror.png
     done;

--- a/pkgs/by-name/ut/utsushi/package.nix
+++ b/pkgs/by-name/ut/utsushi/package.nix
@@ -88,10 +88,10 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/etc/{sane.d,udev/rules.d}
     touch $out/etc/sane.d/dll.conf
 
-    # absolute paths to convert & tesseract
+    # absolute paths to magick & tesseract
     sed -i '/\[AC_DEFINE(\[HAVE_IMAGE_MAGICK\], \[1\])/a \ MAGICK_CONVERT="${imagemagick}/bin/convert"' configure.ac
     substituteInPlace filters/magick.cpp \
-      --replace 'convert ' '${imagemagick}/bin/convert '
+      --replace 'magick ' '${imagemagick}/bin/magick '
     substituteInPlace filters/reorient.cpp \
       --replace '"tesseract' '"${tesseract4}/bin/tesseract'
     substituteInPlace filters/get-text-orientation \

--- a/pkgs/by-name/vc/vcv-rack/package.nix
+++ b/pkgs/by-name/vc/vcv-rack/package.nix
@@ -315,7 +315,7 @@ stdenv.mkDerivation (finalAttrs: {
     for size in 16 24 32 48 64 128 256 512 1024; do
       mkdir -pv $out/share/icons/hicolor/"$size"x"$size"/apps
       if [ ! -e icon_"$size"x"$size"x32.png ] ; then
-        convert -resize "$size"x"$size" icon_1024x1024x32.png icon_"$size"x"$size"x32.png
+        magick -resize "$size"x"$size" icon_1024x1024x32.png icon_"$size"x"$size"x32.png
       fi
       install -Dm644 icon_"$size"x"$size"x32.png $out/share/icons/hicolor/"$size"x"$size"/apps/Rack.png
     done;

--- a/pkgs/by-name/we/weka/package.nix
+++ b/pkgs/by-name/we/weka/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
     for n in 16 24 32 48 64 96 128 256; do
       size=$n"x"$n
       mkdir -p $out/share/icons/hicolor/$size/apps
-      magick convert $out/share/weka/weka.gif -resize $size $out/share/icons/hicolor/$size/apps/weka.png
+      magick $out/share/weka/weka.gif -resize $size $out/share/icons/hicolor/$size/apps/weka.png
     done;
 
     runHook postInstall

--- a/pkgs/by-name/xf/xfig/package.nix
+++ b/pkgs/by-name/xf/xfig/package.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/icons/hicolor/{16x16,22x22,48x48,64x64}/apps
 
     for dimension in 16x16 22x22 48x48; do
-      magick convert doc/html/images/xfig-logo.png -geometry $dimension\
+      magick doc/html/images/xfig-logo.png -geometry $dimension\
         $out/share/icons/hicolor/16x16/apps/xfig.png
     done
     install doc/html/images/xfig-logo.png \

--- a/pkgs/by-name/xn/xnconvert/package.nix
+++ b/pkgs/by-name/xn/xnconvert/package.nix
@@ -18,7 +18,7 @@ let
         };
       }
       ''
-        convert $src $out
+        magick $src $out
       '';
   desktopItem = (
     makeDesktopItem {
@@ -58,7 +58,7 @@ appimageTools.wrapType2 {
     longDescription = ''
       XnConvert is a fast, powerful and free cross-platform batch image converter.
       It allows to automate editing of your photo collections: you can rotate,
-      convert and compress your images, photos and pictures easily, and apply over
+      magick and compress your images, photos and pictures easily, and apply over
       80 actions (like resize, crop, color adjustments, filter, ...).
       All common picture and graphics formats are supported (JPEG, TIFF, PNG, GIF,
       WebP, PSD, JPEG2000, JPEG-XL, OpenEXR, camera RAW, HEIC, PDF, DNG, CR2).

--- a/pkgs/by-name/yo/yourkit-java/package.nix
+++ b/pkgs/by-name/yo/yourkit-java/package.nix
@@ -68,7 +68,7 @@ stdenvNoCC.mkDerivation {
     cp ${./forbid-desktop-item-creation} $out/bin/forbid-desktop-item-creation
     mv $out/bin/profiler.sh $out/bin/yourkit-java-profiler
     mkdir -p $out/share/icons
-    convert $out/bin/profiler.ico\[0] \
+    magick $out/bin/profiler.ico\[0] \
             -size 256x256 \
             $out/share/icons/yourkit-java-profiler.png
     rm $out/bin/profiler.ico

--- a/pkgs/kde/plasma/breeze-plymouth/default.nix
+++ b/pkgs/kde/plasma/breeze-plymouth/default.nix
@@ -63,7 +63,7 @@ mkKdeDerivation {
     cp ${logoFile} breeze/images/${resolvedLogoName}.logo.png
 
     # conversion for 16bit taken from the breeze-plymouth readme
-    convert ${logoFile} -alpha Background -background "#000000" -fill "#000000" -flatten tmp.png
+    magick ${logoFile} -alpha Background -background "#000000" -fill "#000000" -flatten tmp.png
     pngtopnm tmp.png | pnmquant 16 | pnmtopng > breeze/images/16bit/${resolvedLogoName}.logo.png
   '';
 }

--- a/pkgs/tools/typesetting/tex/nix/default.nix
+++ b/pkgs/tools/typesetting/tex/nix/default.nix
@@ -252,7 +252,7 @@ rec {
         fi
 
         mkdir -p $out
-        convert -units PixelsPerInch \
+        magick -units PixelsPerInch \
           -density 600 \
           -trim \
           -matte \


### PR DESCRIPTION
Since imagemagick v7, many builds have been printing `WARNING: The convert command is deprecated in IMv7, use "magick" instead of "convert" or "magick convert"`. This change will heed the warning's advice.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
