### PR TITLE
wayback-machine-archiver: 1.9.1 -> 3.5.0

### DIFF
--- a/pkgs/by-name/wa/wayback-machine-archiver/package.nix
+++ b/pkgs/by-name/wa/wayback-machine-archiver/package.nix
@@ -6,32 +6,30 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "wayback-machine-archiver";
-  version = "1.9.1";
+  version = "3.5.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "agude";
     repo = "wayback-machine-archiver";
-    rev = "v${finalAttrs.version}";
-    sha256 = "0dnnqx507gpj8wsx6f2ivfmha969ydayiqsvxh23p9qcixw9257x";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-gowktQvJg09iD+6KhP/EpYXOGMXXWy4nAaxvEc2sh3o=";
   };
 
   build-system = with python3.pkgs; [
     setuptools
-    pypandoc
   ];
 
-  dependencies = with python3.pkgs; [ requests ];
+  dependencies = with python3.pkgs; [
+    requests
+    python-dotenv
+    urllib3
+  ];
 
   nativeCheckInputs = with python3.pkgs; [
     pytestCheckHook
     requests-mock
   ];
-
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace-fail \"pytest-runner\", ""
-  '';
 
   pythonImportsCheck = [ "wayback_machine_archiver" ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/agude/wayback-machine-archiver/releases/tag/v3.5.0
https://github.com/agude/wayback-machine-archiver/compare/v1.9.1...v3.5.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
