### PR TITLE
git-annex-remote-dbx: switch to pyproject

### DIFF
--- a/pkgs/applications/version-management/git-annex-remote-dbx/default.nix
+++ b/pkgs/applications/version-management/git-annex-remote-dbx/default.nix
@@ -1,23 +1,28 @@
 {
   lib,
   buildPythonApplication,
-  fetchPypi,
+  fetchFromGitHub,
+  setuptools,
   dropbox,
   annexremote,
   humanfriendly,
 }:
 
-buildPythonApplication rec {
+buildPythonApplication (finalAttrs: {
   pname = "git-annex-remote-dbx";
   version = "1.0.3";
-  format = "setuptools";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "5b6f8025ed1e9877f06882ddbd81f701a8e094647ab97595e2afc09016835a7c";
+  src = fetchFromGitHub {
+    owner = "montag451";
+    repo = "git-annex-remote-dbx";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-a1mCLFd9fykzX3BxQBsOe6oPUzQjAzyfxExFlXCOAvQ=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     dropbox
     annexremote
     humanfriendly
@@ -30,4 +35,4 @@ buildPythonApplication rec {
     mainProgram = "git-annex-remote-dbx";
     maintainers = with lib.maintainers; [ matthiasbeyer ];
   };
-}
+})

--- a/pkgs/by-name/gi/git-annex-remote-dbx/package.nix
+++ b/pkgs/by-name/gi/git-annex-remote-dbx/package.nix
@@ -1,14 +1,10 @@
 {
   lib,
-  buildPythonApplication,
+  python3Packages,
   fetchFromGitHub,
-  setuptools,
-  dropbox,
-  annexremote,
-  humanfriendly,
 }:
 
-buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "git-annex-remote-dbx";
   version = "1.0.3";
   pyproject = true;
@@ -20,9 +16,9 @@ buildPythonApplication (finalAttrs: {
     hash = "sha256-a1mCLFd9fykzX3BxQBsOe6oPUzQjAzyfxExFlXCOAvQ=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [ python3Packages.setuptools ];
 
-  dependencies = [
+  dependencies = with python3Packages; [
     dropbox
     annexremote
     humanfriendly

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1156,6 +1156,7 @@ with pkgs;
   git-annex-remote-dbx = callPackage ../applications/version-management/git-annex-remote-dbx {
     inherit (python3Packages)
       buildPythonApplication
+      setuptools
       dropbox
       annexremote
       humanfriendly

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1153,16 +1153,6 @@ with pkgs;
 
   github-cli = gh;
 
-  git-annex-remote-dbx = callPackage ../applications/version-management/git-annex-remote-dbx {
-    inherit (python3Packages)
-      buildPythonApplication
-      setuptools
-      dropbox
-      annexremote
-      humanfriendly
-      ;
-  };
-
   git-credential-manager = callPackage ../applications/version-management/git-credential-manager { };
 
   git-credential-aol = callPackage ../by-name/gi/git-credential-email/git-credential-aol { };


### PR DESCRIPTION
Related to #515974

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
