### PR TITLE
circt: 1.140.0 -> 1.147.0; sv-lang: create versioned packages

### DIFF
--- a/pkgs/by-name/ci/circt/circt-llvm.nix
+++ b/pkgs/by-name/ci/circt/circt-llvm.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation {
 
   requiredSystemFeatures = [ "big-parallel" ];
 
+  __structuredAttrs = true;
+
   nativeBuildInputs = [
     cmake
     ninja
@@ -33,7 +35,7 @@ stdenv.mkDerivation {
     # Based on utils/build-llvm.sh
     (lib.cmakeBool "BUILD_SHARED_LIBS" true)
     (lib.cmakeBool "LLVM_BUILD_EXAMPLES" false)
-    (lib.cmakeBool "LLVM_ENABLE_ASSERTIONS" true)
+    (lib.cmakeBool "LLVM_ENABLE_ASSERTIONS" false) # Conflicts with nixpkgs hardening options
     (lib.cmakeBool "LLVM_ENABLE_BINDINGS" false)
     (lib.cmakeBool "LLVM_ENABLE_OCAMLDOC" false)
     (lib.cmakeFeature "LLVM_ENABLE_PROJECTS" "mlir")

--- a/pkgs/by-name/ci/circt/package.nix
+++ b/pkgs/by-name/ci/circt/package.nix
@@ -9,7 +9,7 @@
   ninja,
   lit,
   z3,
-  sv-lang_9, # update sv-lang version here according to upstream requirements
+  sv-lang_10, # update sv-lang version here according to upstream requirements
   fmt,
   boost,
   mimalloc,
@@ -27,16 +27,18 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "circt";
-  version = "1.140.0";
+  version = "1.147.0";
   src = fetchFromGitHub {
     owner = "llvm";
     repo = "circt";
     tag = "firtool-${finalAttrs.version}";
-    hash = "sha256-oitdYNGsEyraQqouOt9srfbDgVGFOAGZMdcf/rjnx5Q=";
+    hash = "sha256-rtnvahI7EzUJXE80X3XPWjjDD/6f9BPmZ7S97Lstuhw=";
     fetchSubmodules = true;
   };
 
   requiredSystemFeatures = [ "big-parallel" ];
+
+  __structuredAttrs = true;
 
   nativeBuildInputs = [
     cmake
@@ -53,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
     boost
     fmt
     mimalloc
-    sv-lang_9
+    sv-lang_10
   ];
 
   cmakeFlags = [
@@ -110,18 +112,21 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     patchShebangs tools/circt-test
 
+    # Replace slang references to match the package in nixpkgs
     substituteInPlace \
       lib/Tools/circt-verilog-lsp-server/VerilogServerImpl/CMakeLists.txt \
       lib/Conversion/ImportVerilog/CMakeLists.txt \
+      unittests/Conversion/ImportVerilog/CMakeLists.txt \
       --replace-fail "slang_slang" "slang::slang"
-  '';
 
-  preConfigure = ''
+    # Patch shebang in test mlir files
     find ./test -name '*.mlir' -exec sed -i 's|/usr/bin/env|${coreutils}/bin/env|g' {} \;
+
     # circt uses git to check its version, but when cloned on nix it can't access git.
     # So this hard codes the version.
     substituteInPlace cmake/modules/GenVersionFile.cmake \
       --replace-fail "unknown git version" "${finalAttrs.src.rev}"
+
     # Increase timeout on tests because some were failing on hydra.
     # Using `replace-warn` so it doesn't break when upstream changes the timeout.
     substituteInPlace integration_test/CMakeLists.txt \

--- a/pkgs/by-name/ci/circt/package.nix
+++ b/pkgs/by-name/ci/circt/package.nix
@@ -9,7 +9,7 @@
   ninja,
   lit,
   z3,
-  sv-lang,
+  sv-lang_9, # update sv-lang version here according to upstream requirements
   fmt,
   boost,
   mimalloc,
@@ -53,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
     boost
     fmt
     mimalloc
-    sv-lang
+    sv-lang_9
   ];
 
   cmakeFlags = [

--- a/pkgs/by-name/sv/sv-lang_10/package.nix
+++ b/pkgs/by-name/sv/sv-lang_10/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  boost,
+  catch2_3,
+  cmake,
+  ninja,
+  fmt,
+  mimalloc,
+  python3,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sv-lang";
+  version = "10.0";
+
+  src = fetchFromGitHub {
+    owner = "MikePopoloski";
+    repo = "slang";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rw+DztENuY+DiAhQR2oNN/dQJzrcP5neF3LoWnqri+c=";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/MikePopoloski/slang/commit/0e2094e3570f399c4bedff8c7cf342812b50d909.patch";
+      hash = "sha256-Evx5HJk8fH3QoBXM5BE3tmdJVnblVTkxLMTNIRLOt/c=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace external/CMakeLists.txt --replace-fail \
+      'set(mimalloc_min_version "2.2")' \
+      'set(mimalloc_min_version "${lib.versions.majorMinor mimalloc.version}")'
+  '';
+
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DSLANG_INCLUDE_TESTS=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}"
+    # CIRCT disables threading to avoid a race condition in BS::thread_pool:
+    # https://github.com/llvm/circt/blob/firtool-1.147.0/CMakeLists.txt#L579
+    # This may be parameterized if other packages depend on this package.
+    "-DSLANG_USE_THREADS=OFF"
+  ];
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cmake
+    python3
+    ninja
+  ];
+
+  strictDeps = true;
+
+  buildInputs = [
+    boost
+    fmt
+    mimalloc
+    catch2_3
+  ];
+
+  doCheck = !stdenv.hostPlatform.isDarwin;
+
+  meta = {
+    description = "SystemVerilog compiler and language services";
+    homepage = "https://github.com/MikePopoloski/slang";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sharzy ];
+    mainProgram = "slang";
+    platforms = lib.platforms.all;
+    broken = stdenv.hostPlatform.isDarwin;
+  };
+})

--- a/pkgs/by-name/sv/sv-lang_9/package.nix
+++ b/pkgs/by-name/sv/sv-lang_9/package.nix
@@ -13,14 +13,20 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sv-lang";
-  version = "11.0";
+  version = "9.1";
 
   src = fetchFromGitHub {
     owner = "MikePopoloski";
     repo = "slang";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-popHzwX0qwv2POAl7/qX3e//OwJRXGtSl9xogpSn2LI=";
+    hash = "sha256-IfRh6F6vA+nFa+diPKD2aMv9kRbvVIY80IqX0d+d5JA=";
   };
+
+  postPatch = ''
+    substituteInPlace external/CMakeLists.txt --replace-fail \
+      'set(mimalloc_min_version "2.2")' \
+      'set(mimalloc_min_version "${lib.versions.majorMinor mimalloc.version}")'
+  '';
 
   cmakeFlags = [
     # fix for https://github.com/NixOS/nixpkgs/issues/144170

--- a/pkgs/by-name/ve/veridian/package.nix
+++ b/pkgs/by-name/ve/veridian/package.nix
@@ -10,7 +10,7 @@
   boost,
   fmt,
   openssl,
-  sv-lang,
+  sv-lang_9, # update sv-lang version here according to upstream requirements
   mimalloc,
 
   verible,
@@ -43,7 +43,7 @@ rustPlatform.buildRustPackage {
     boost
     fmt
     openssl
-    sv-lang
+    sv-lang_9
     mimalloc
   ];
 
@@ -69,7 +69,7 @@ rustPlatform.buildRustPackage {
     OPENSSL_NO_VENDOR = "1";
     RUSTFLAGS = "-C link-args=-lmimalloc";
     # this is needed so that veridian doesn't try to build the sv-lang package itself
-    SLANG_INSTALL_PATH = sv-lang;
+    SLANG_INSTALL_PATH = sv-lang_9;
   };
 
   passthru = {


### PR DESCRIPTION
This PR does the following:

- Updates circt
- Updates sv-lang and creates versioned packages
- Pins sv-lang version for depending packages
- Enable structuredAttrs for circt and sv-lang

## Why I have created versiond packages for sv-lang
In this PR I have updated sv-lang and created _9 and _10 variants.
This was done because each version in incompatible with each other and the packages that use sv-lang (circt and veridian) have different requirements.
I have thought about removing the plain sv-lang without version, but since it provides bin files, I think it makes sence to keep the latest version in nixpkgs.
@SharzyL  Let me know if you have any thoughts around this.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
