### PR TITLE
git-bars: 0-unstable-2023-08-08 -> 0-unstable-2023-08-20

### DIFF
--- a/pkgs/by-name/gi/git-bars/package.nix
+++ b/pkgs/by-name/gi/git-bars/package.nix
@@ -7,17 +7,19 @@
 
 python3Packages.buildPythonApplication {
   pname = "git-bars";
-  version = "0-unstable-2023-08-08";
-  format = "setuptools";
+  version = "0-unstable-2023-08-20";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "knadh";
     repo = "git-bars";
-    rev = "f15fbc15345d9ef021e5a9b278e352bb532dcee8";
-    hash = "sha256-jHP6LqhUQv6hh97tSXAdOruWdtp2FXM6ANlpWoA+fHQ=";
+    rev = "8c935c75844512553ae50e396181c422504516d7";
+    hash = "sha256-aGvioTurv0OPwpBib5O+Nytt6WZqwylhTZHYk5qmCEo=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ python3Packages.setuptools ];
+
+  dependencies = [
     git
     python3Packages.setuptools
   ];


### PR DESCRIPTION
Related to #515974

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
