### PR TITLE
cadence-allegro-free: init at 25.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3206,6 +3206,12 @@
     github = "beeb";
     githubId = 703631;
   };
+  beeelias = {
+    name = "Elias Hanelt";
+    email = "elias.hanelt@gmail.com";
+    github = "beeelias";
+    githubId = 236911673;
+  };
   bellackn = {
     name = "Nico Bellack";
     email = "blcknc@pm.me";

--- a/pkgs/by-name/ca/cadence-allegro-free/package.nix
+++ b/pkgs/by-name/ca/cadence-allegro-free/package.nix
@@ -16,7 +16,8 @@ let
   wineEnv = ''
     export WINEPREFIX="${winePrefix}"
     export WINEARCH=win64
-    export WINEDLLOVERRIDES="mscoree=n;mshtml=n"
+    export WINEDLLOVERRIDES="mscoree=n;mshtml=n;cryptbase=b"
+    export WINEDEBUG="''${WINEDEBUG:--all,err+seh,err+module}"
     export PATH="${wine}/bin:$PATH"
   '';
 

--- a/pkgs/by-name/ca/cadence-allegro-free/package.nix
+++ b/pkgs/by-name/ca/cadence-allegro-free/package.nix
@@ -3,7 +3,6 @@
   symlinkJoin,
   writeShellScriptBin,
   makeDesktopItem,
-  copyDesktopItems,
   wineWow64Packages,
   winetricks,
 }:
@@ -46,6 +45,12 @@ let
       ${wine}/bin/wineboot --init
       ${winetricks}/bin/winetricks -q corefonts vcrun2019 dotnet48
       echo "==> Wine prefix ready."
+    else
+      # Refresh prefix DLLs from the current wine. Old prefixes can be
+      # missing files like cryptbase.dll after a wine upgrade, which makes
+      # advapi32's SystemFunction036 forward fail at startup.
+      echo "==> Refreshing Wine prefix DLLs..."
+      ${wine}/bin/wineboot --update
     fi
 
     echo "==> Running installer: $installer"
@@ -146,6 +151,9 @@ symlinkJoin {
     allegro-winecfg
     desktopItem
   ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   meta = {
     description = "Wine wrapper scripts for Cadence Allegro X Free PCB Viewer";

--- a/pkgs/by-name/ca/cadence-allegro-free/package.nix
+++ b/pkgs/by-name/ca/cadence-allegro-free/package.nix
@@ -1,0 +1,155 @@
+{
+  lib,
+  symlinkJoin,
+  writeShellScriptBin,
+  wineWowPackages,
+  winetricks,
+}:
+
+let
+  version = "25.1";
+  wine = wineWowPackages.full;
+  winePrefix = "$HOME/.local/share/cadence-allegro";
+
+  wineEnv = ''
+    export WINEPREFIX="${winePrefix}"
+    export WINEARCH=win64
+    export WINEDLLOVERRIDES="mscoree=n;mshtml=n"
+    export PATH="${wine}/bin:$PATH"
+  '';
+
+  allegro-install = writeShellScriptBin "allegro-install" ''
+    set -euo pipefail
+    ${wineEnv}
+
+    installer="''${1:-}"
+    if [ -z "$installer" ]; then
+      echo "Usage: allegro-install <path-to-installer.exe>"
+      echo ""
+      echo "Download the Allegro X Free Viewer installer from:"
+      echo "  https://www.cadence.com/en_US/home/tools/pcb-design-and-analysis/allegro-downloads-start.html"
+      exit 1
+    fi
+
+    if [ ! -f "$installer" ]; then
+      echo "Error: file not found: $installer"
+      exit 1
+    fi
+
+    echo "==> Wine prefix: $WINEPREFIX"
+
+    if [ ! -d "$WINEPREFIX" ]; then
+      echo "==> Initializing Wine prefix..."
+      ${wine}/bin/wineboot --init
+      ${winetricks}/bin/winetricks -q corefonts vcrun2019 dotnet48
+      echo "==> Wine prefix ready."
+    fi
+
+    echo "==> Running installer: $installer"
+    ${wine}/bin/wine "$installer"
+    echo "==> Done. Run 'allegro-run' to launch the viewer."
+  '';
+
+  allegro-run = writeShellScriptBin "allegro-run" ''
+    set -euo pipefail
+    ${wineEnv}
+
+    if [ ! -d "$WINEPREFIX" ]; then
+      echo "Error: Wine prefix not found at $WINEPREFIX"
+      echo "Run 'allegro-install <installer.exe>' first."
+      exit 1
+    fi
+
+    cadence_root="$WINEPREFIX/drive_c"
+    exe=""
+
+    for candidate in \
+      "$cadence_root/Cadence/"*/tools/bin/allegro_free_viewer.exe \
+      "$cadence_root/Cadence/"*/tools/bin/allegro_free_viewer_classic.exe \
+      "$cadence_root/Cadence/"*/tools/bin/allegro.exe \
+      "$cadence_root/Cadence/Allegro_X_Free_Viewer"*/tools/bin/allegro.exe \
+      "$cadence_root/Cadence/Allegro"*/tools/bin/allegro.exe \
+      "$cadence_root/Cadence/"*/tools/pcb/bin/allegro.exe \
+      "$cadence_root/Program Files/Cadence/"*/tools/bin/allegro_free_viewer.exe \
+      "$cadence_root/Program Files/Cadence/"*/tools/bin/allegro.exe \
+      "$cadence_root/Program Files/Cadence/"*/tools/pcb/bin/allegro.exe \
+      "$cadence_root/Cadence/SPB_"*/tools/bin/allegro.exe \
+    ; do
+      if [ -f "$candidate" ]; then
+        exe="$candidate"
+        break
+      fi
+    done
+
+    if [ -z "$exe" ]; then
+      echo "Could not find allegro.exe in the Wine prefix."
+      echo "Searching for any Cadence executables..."
+      find "$cadence_root" -iname '*.exe' -path '*/Cadence/*' 2>/dev/null | head -20
+      echo ""
+      echo "You can run a specific exe with: allegro-exec <path-to-exe>"
+      exit 1
+    fi
+
+    echo "==> Launching: $exe"
+    ${wine}/bin/wine "$exe" "$@"
+  '';
+
+  allegro-exec = writeShellScriptBin "allegro-exec" ''
+    set -euo pipefail
+    ${wineEnv}
+
+    exe="''${1:-}"
+    if [ -z "$exe" ]; then
+      echo "Usage: allegro-exec <path-to-exe> [args...]"
+      exit 1
+    fi
+    shift
+    ${wine}/bin/wine "$exe" "$@"
+  '';
+
+  allegro-winetricks = writeShellScriptBin "allegro-winetricks" ''
+    set -euo pipefail
+    ${wineEnv}
+    ${winetricks}/bin/winetricks "$@"
+  '';
+
+  allegro-winecfg = writeShellScriptBin "allegro-winecfg" ''
+    set -euo pipefail
+    ${wineEnv}
+    ${wine}/bin/winecfg "$@"
+  '';
+in
+symlinkJoin {
+  name = "cadence-allegro-free-${version}";
+
+  paths = [
+    allegro-install
+    allegro-run
+    allegro-exec
+    allegro-winetricks
+    allegro-winecfg
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Wine wrapper scripts for Cadence Allegro X Free PCB Viewer";
+    longDescription = ''
+      Provides wrapper scripts to install and run the Cadence Allegro X Free
+      Viewer under Wine on Linux. The viewer itself is proprietary and must be
+      downloaded separately from Cadence's website.
+
+      Usage:
+        1. Download the installer from:
+           https://www.cadence.com/en_US/home/tools/pcb-design-and-analysis/allegro-downloads-start.html
+        2. Run: allegro-install <path-to-installer.exe>
+        3. Run: allegro-run
+    '';
+    homepage = "https://www.cadence.com/en_US/home/tools/pcb-design-and-analysis/allegro-downloads-start.html";
+    license = lib.licenses.unfree;
+    mainProgram = "allegro-run";
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/by-name/ca/cadence-allegro-free/package.nix
+++ b/pkgs/by-name/ca/cadence-allegro-free/package.nix
@@ -2,6 +2,8 @@
   lib,
   symlinkJoin,
   writeShellScriptBin,
+  makeDesktopItem,
+  copyDesktopItems,
   wineWow64Packages,
   winetricks,
 }:
@@ -118,6 +120,15 @@ let
     ${wineEnv}
     ${wine}/bin/winecfg "$@"
   '';
+  desktopItem = makeDesktopItem {
+    name = "cadence-allegro-free";
+    desktopName = "Cadence Allegro Viewer";
+    comment = "Cadence Allegro X Free PCB Viewer (Wine)";
+    exec = "allegro-run";
+    icon = "applications-engineering";
+    categories = [ "Electronics" "Engineering" "Science" ];
+    terminal = false;
+  };
 in
 symlinkJoin {
   name = "cadence-allegro-free-${version}";
@@ -128,10 +139,8 @@ symlinkJoin {
     allegro-exec
     allegro-winetricks
     allegro-winecfg
+    desktopItem
   ];
-
-  strictDeps = true;
-  __structuredAttrs = true;
 
   meta = {
     description = "Wine wrapper scripts for Cadence Allegro X Free PCB Viewer";

--- a/pkgs/by-name/ca/cadence-allegro-free/package.nix
+++ b/pkgs/by-name/ca/cadence-allegro-free/package.nix
@@ -2,13 +2,13 @@
   lib,
   symlinkJoin,
   writeShellScriptBin,
-  wineWowPackages,
+  wineWow64Packages,
   winetricks,
 }:
 
 let
   version = "25.1";
-  wine = wineWowPackages.full;
+  wine = wineWow64Packages.full;
   winePrefix = "$HOME/.local/share/cadence-allegro";
 
   wineEnv = ''

--- a/pkgs/by-name/ca/cadence-allegro-free/package.nix
+++ b/pkgs/by-name/ca/cadence-allegro-free/package.nix
@@ -126,7 +126,11 @@ let
     comment = "Cadence Allegro X Free PCB Viewer (Wine)";
     exec = "allegro-run";
     icon = "applications-engineering";
-    categories = [ "Electronics" "Engineering" "Science" ];
+    categories = [
+      "Electronics"
+      "Engineering"
+      "Science"
+    ];
     terminal = false;
   };
 in

--- a/pkgs/by-name/ca/cadence-allegro-free/package.nix
+++ b/pkgs/by-name/ca/cadence-allegro-free/package.nix
@@ -171,6 +171,7 @@ symlinkJoin {
     homepage = "https://www.cadence.com/en_US/home/tools/pcb-design-and-analysis/allegro-downloads-start.html";
     license = lib.licenses.unfree;
     mainProgram = "allegro-run";
+    maintainers = with lib.maintainers; [ beeelias ];
     platforms = [ "x86_64-linux" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };


### PR DESCRIPTION
## Summary

- Adds `cadence-allegro-free` — Wine wrapper scripts for the Cadence Allegro X Free PCB Viewer on Linux
- Provides 5 commands: `allegro-install`, `allegro-run`, `allegro-exec`, `allegro-winetricks`, `allegro-winecfg`
- Uses `wineWowPackages.full` and `winetricks` to manage a dedicated Wine prefix at `~/.local/share/cadence-allegro`
- x86_64-linux only (Wine requirement)

## How it works

The Allegro Free Viewer is proprietary and requires downloading the installer from Cadence's website (free registration). This package provides the infrastructure to run it under Wine:

1. User downloads the installer `.exe` from https://www.cadence.com/en_US/home/tools/pcb-design-and-analysis/allegro-downloads-start.html
2. `allegro-install <installer.exe>` — sets up Wine prefix with required dependencies (corefonts, vcrun2019, dotnet48) and runs the installer
3. `allegro-run` — auto-discovers and launches the viewer from the Wine prefix

This follows the same pattern as other proprietary packages in nixpkgs that require user-provided installers.

## Things done

- [x] Built on x86_64-linux
- [x] Tested full install + launch workflow
- [x] `meta.mainProgram` set to `allegro-run`
- [x] `meta.sourceProvenance` set to `binaryNativeCode`
- [x] `meta.license` set to `unfree`
- [x] `strictDeps` and `__structuredAttrs` enabled