### PR TITLE
vouch-proxy: 0.45.1 -> 0.47.2

### DIFF
--- a/pkgs/by-name/vo/vouch-proxy/package.nix
+++ b/pkgs/by-name/vo/vouch-proxy/package.nix
@@ -6,16 +6,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "vouch-proxy";
-  version = "0.45.1";
+  version = "0.47.2";
 
   src = fetchFromGitHub {
     owner = "vouch";
     repo = "vouch-proxy";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-xI9xucRb2D2a1Fvp5DetB4ln3C020qSGEVnuIpy1TMI=";
+    hash = "sha256-BdqdJosX1Z1CsPDW65ybk6oGdSk/RXHPaEJuuIedNJ4=";
   };
 
-  vendorHash = "sha256-hieN3RJA0eBqlYxJj6hKgpQhq8s3vg/fPzxW0XSrlPA=";
+  vendorHash = "sha256-Ma5/S2PXQ9lByIpIfkkLeiw/9rvmasSMElE1VoGIEHc=";
 
   ldflags = [
     "-s"
@@ -26,6 +26,9 @@ buildGoModule (finalAttrs: {
   preCheck = ''
     export VOUCH_ROOT=$PWD
   '';
+
+  # TestClaimsHMAC requires network access to validate HMAC signatures
+  checkFlags = [ "-skip=TestClaimsHMAC" ];
 
   meta = {
     homepage = "https://github.com/vouch/vouch-proxy";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/vouch/vouch-proxy/releases/tag/v0.47.2
https://github.com/vouch/vouch-proxy/compare/v0.45.1...v0.47.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
