### PR TITLE
vkquake: 1.32.3.1 -> 1.34.1

### DIFF
--- a/pkgs/by-name/vk/vkquake/package.nix
+++ b/pkgs/by-name/vk/vkquake/package.nix
@@ -1,7 +1,6 @@
 {
   SDL2,
   fetchFromGitHub,
-  fetchpatch2,
   flac,
   glslang,
   gzip,
@@ -25,13 +24,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "vkquake";
-  version = "1.32.3.1";
+  version = "1.34.1";
 
   src = fetchFromGitHub {
     owner = "Novum";
     repo = "vkQuake";
     tag = finalAttrs.version;
-    hash = "sha256-Hsj6LgxlEICI3MMDMCE1KvslYrsYfQPhShpP5kzLCTI=";
+    hash = "sha256-vCjL8zDf+VJjYHQoXPY9kqrAiU7HA7avJcOx6v2Jujg=";
   };
 
   nativeBuildInputs = [
@@ -58,14 +57,6 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     moltenvk
     vulkan-headers
-  ];
-
-  patches = [
-    (fetchpatch2 {
-      # https://github.com/Novum/vkQuake/pull/809
-      url = "https://github.com/Novum/vkQuake/commit/85ddf2386f15944c26317a763d4044077fc8731f.patch?full_index=1";
-      hash = "sha256-t+atA+ilCwGwLpql5BZO2OF4Xh1KdzRFjOpglTIA/KY=";
-    })
   ];
 
   mesonFlags = [ "-Ddo_userdirs=enabled" ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/Novum/vkQuake/releases/tag/1.34.1
https://github.com/Novum/vkQuake/compare/1.32.3.1...1.34.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
