### PR TITLE
validator-nu: 25.12.12 -> 26.9.5

### DIFF
--- a/pkgs/by-name/va/validator-nu/package.nix
+++ b/pkgs/by-name/va/validator-nu/package.nix
@@ -7,6 +7,7 @@
   jdk_headless,
   jre_headless,
   makeWrapper,
+  maven,
   pandoc,
   python3,
   stdenvNoCC,
@@ -16,13 +17,13 @@
 
 let
   pname = "validator-nu";
-  version = "25.12.12";
+  version = "26.7.25";
 
   src = fetchFromGitHub {
     owner = "validator";
     repo = "validator";
-    rev = "7ed7f67468f7f61975dcc78891ea462fce578828";
-    hash = "sha256-cdDmhRyXIdoNWhP4oqu7vRb5abuNXRqvt4P4Dzq48xY=";
+    tag = version;
+    hash = "sha256-mDtITDS+hTqUOaRdx8cp1mjtDstOwit5LDfOZlxeA90=";
   };
 
   deps = stdenvNoCC.mkDerivation {
@@ -33,6 +34,7 @@ let
       ant
       cacert
       jdk_headless
+      maven
       python3
     ];
 
@@ -40,21 +42,47 @@ let
       substituteInPlace build/build.xml \
         --replace-fail \
         'src="https://html.spec.whatwg.org/"' \
-        'src="https://html.spec.whatwg.org/commit-snapshots/0aa021ab4f21a6550f1591a9cc98449aaea9eefa/"'
+        'src="https://html.spec.whatwg.org/commit-snapshots/24c5e48bf66ea61bc199ec6338c81258275ba9c6/"'
     '';
 
     buildPhase = ''
       python checker.py dldeps
+      ant -f build/build.xml dl-html5spec
+      # Pre-download Maven plugins needed for jing-shade
+      export MAVEN_OPTS="-Dmaven.repo.local=$PWD/.m2/repository"
+      cat > $PWD/dummy-pom.xml << EOF
+      <project>
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>dummy</groupId>
+        <artifactId>dummy</artifactId>
+        <version>1.0</version>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-shade-plugin</artifactId>
+              <version>3.5.1</version>
+            </plugin>
+          </plugins>
+        </build>
+      </project>
+      EOF
+      mvn -f $PWD/dummy-pom.xml dependency:resolve-plugins 2>&1 || true
     '';
 
     installPhase = ''
-      mkdir "$out" "$out/build"
+      mkdir -p "$out" "$out/build" "$out/resources"
       mv dependencies extras "$out"
-      mv build/html5spec "$out/build"
+      mv resources/spec "$out/resources/spec"
+      if [ -d "$PWD/.m2" ]; then
+        cp -r "$PWD/.m2" "$out/"
+        # Strip non-deterministic Maven metadata files
+        find "$out/.m2" -type f \( -name "_remote.repositories" -o -name "resolver-status.properties" \) -delete
+      fi
     '';
 
     outputHashMode = "recursive";
-    outputHash = "sha256-8cMoLeOnKNqisezkVS2UeVW11gtkGmhvQWrbSVuqbb8=";
+    outputHash = "sha256-mKEcTHlLvJfnraUj7/q35xAAPRu+A1uIoHiSyX2NUT4=";
   };
 
 in
@@ -66,6 +94,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     installShellFiles
     jdk_headless
     makeWrapper
+    maven
     pandoc
     python3
   ];
@@ -78,7 +107,14 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   buildPhase = ''
     ln -s '${deps}/dependencies' '${deps}/extras' .
-    ln -s '${deps}/build/html5spec' build/
+    mkdir -p resources
+    ln -s '${deps}/resources/spec' resources/spec
+    if [ -d "${deps}/.m2" ]; then
+      mkdir -p "$PWD/.m2"
+      cp -r "${deps}/.m2"/* "$PWD/.m2/"
+      chmod -R +w "$PWD/.m2"
+      export MAVEN_OPTS="-Dmaven.repo.local=$PWD/.m2/repository"
+    fi
     JAVA_HOME='${jdk_headless}' python checker.py --offline build
     make -C docs VNU_VERSION='${finalAttrs.version}' DATE='date -d @$(SOURCE_DATE_EPOCH)'
   '';

--- a/pkgs/by-name/va/validator-nu/package.nix
+++ b/pkgs/by-name/va/validator-nu/package.nix
@@ -7,6 +7,7 @@
   jdk_headless,
   jre_headless,
   makeWrapper,
+  maven,
   pandoc,
   python3,
   stdenvNoCC,
@@ -16,13 +17,13 @@
 
 let
   pname = "validator-nu";
-  version = "25.12.12";
+  version = "26.9.5";
 
   src = fetchFromGitHub {
     owner = "validator";
     repo = "validator";
-    rev = "7ed7f67468f7f61975dcc78891ea462fce578828";
-    hash = "sha256-cdDmhRyXIdoNWhP4oqu7vRb5abuNXRqvt4P4Dzq48xY=";
+    tag = version;
+    hash = "sha256-pxILjdrrzu5358/wIUMvXeyqy8eH3EQeCkXjsdqYdWE=";
   };
 
   deps = stdenvNoCC.mkDerivation {
@@ -33,6 +34,7 @@ let
       ant
       cacert
       jdk_headless
+      maven
       python3
     ];
 
@@ -40,21 +42,47 @@ let
       substituteInPlace build/build.xml \
         --replace-fail \
         'src="https://html.spec.whatwg.org/"' \
-        'src="https://html.spec.whatwg.org/commit-snapshots/0aa021ab4f21a6550f1591a9cc98449aaea9eefa/"'
+        'src="https://html.spec.whatwg.org/commit-snapshots/24c5e48bf66ea61bc199ec6338c81258275ba9c6/"'
     '';
 
     buildPhase = ''
       python checker.py dldeps
+      ant -f build/build.xml dl-html5spec
+      # Pre-download Maven plugins needed for jing-shade
+      export MAVEN_OPTS="-Dmaven.repo.local=$PWD/.m2/repository"
+      cat > $PWD/dummy-pom.xml << EOF
+      <project>
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>dummy</groupId>
+        <artifactId>dummy</artifactId>
+        <version>1.0</version>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-shade-plugin</artifactId>
+              <version>3.5.1</version>
+            </plugin>
+          </plugins>
+        </build>
+      </project>
+      EOF
+      mvn -f $PWD/dummy-pom.xml dependency:resolve-plugins 2>&1 || true
     '';
 
     installPhase = ''
-      mkdir "$out" "$out/build"
+      mkdir -p "$out" "$out/build" "$out/resources"
       mv dependencies extras "$out"
-      mv build/html5spec "$out/build"
+      mv resources/spec "$out/resources/spec"
+      if [ -d "$PWD/.m2" ]; then
+        cp -r "$PWD/.m2" "$out/"
+        # Strip non-deterministic Maven metadata files
+        find "$out/.m2" -type f \( -name "_remote.repositories" -o -name "resolver-status.properties" \) -delete
+      fi
     '';
 
     outputHashMode = "recursive";
-    outputHash = "sha256-8cMoLeOnKNqisezkVS2UeVW11gtkGmhvQWrbSVuqbb8=";
+    outputHash = "sha256-wbbXIN3rRkGIrjz1R9TLXt9xYW5qzR2OI0OwCrZUcNI=";
   };
 
 in
@@ -66,6 +94,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     installShellFiles
     jdk_headless
     makeWrapper
+    maven
     pandoc
     python3
   ];
@@ -78,7 +107,14 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   buildPhase = ''
     ln -s '${deps}/dependencies' '${deps}/extras' .
-    ln -s '${deps}/build/html5spec' build/
+    mkdir -p resources
+    ln -s '${deps}/resources/spec' resources/spec
+    if [ -d "${deps}/.m2" ]; then
+      mkdir -p "$PWD/.m2"
+      cp -r "${deps}/.m2"/* "$PWD/.m2/"
+      chmod -R +w "$PWD/.m2"
+      export MAVEN_OPTS="-Dmaven.repo.local=$PWD/.m2/repository"
+    fi
     JAVA_HOME='${jdk_headless}' python checker.py --offline build
     make -C docs VNU_VERSION='${finalAttrs.version}' DATE='date -d @$(SOURCE_DATE_EPOCH)'
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/validator/validator/releases/tag/26.9.5

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
