### PR TITLE
nixos/tests: add simple-container, nixos/release{,-small}: add nixosTests.simple-container

### DIFF
--- a/ci/eval/compare/default.nix
+++ b/ci/eval/compare/default.nix
@@ -188,7 +188,7 @@ let
             kernel: rebuilds: lib.nameValuePair "10.rebuild-${kernel}-stdenv" (lib.elem "stdenv" rebuilds)
           ) rebuildsByKernel
           // {
-            "10.rebuild-nixos-tests" = lib.elem "nixosTests.simple" (extractPackageNames diffAttrs.rebuilds);
+            "10.rebuild-nixos-tests" = lib.elem "nixosTests.simple-vm" (extractPackageNames diffAttrs.rebuilds);
           };
       }
     );

--- a/ci/eval/compare/default.nix
+++ b/ci/eval/compare/default.nix
@@ -172,6 +172,7 @@ let
       rebuildCountByKernel = lib.mapAttrs (
         kernel: kernelRebuilds: lib.length kernelRebuilds
       ) rebuildsByKernel;
+      rebuildNames = extractPackageNames diffAttrs.rebuilds;
     in
     writeText "changed-paths.json" (
       builtins.toJSON {
@@ -188,7 +189,8 @@ let
             kernel: rebuilds: lib.nameValuePair "10.rebuild-${kernel}-stdenv" (lib.elem "stdenv" rebuilds)
           ) rebuildsByKernel
           // {
-            "10.rebuild-nixos-tests" = lib.elem "nixosTests.simple-vm" (extractPackageNames diffAttrs.rebuilds);
+            "10.rebuild-nixos-tests" =
+              lib.elem "nixosTests.simple-container" rebuildNames || lib.elem "nixosTests.simple-vm" rebuildNames;
           };
       }
     );

--- a/ci/eval/outpaths.nix
+++ b/ci/eval/outpaths.nix
@@ -108,6 +108,8 @@ in
 tweak (
   (removeAttrs nixpkgsJobs blacklist)
   // {
-    nixosTests = lib.filterAttrs (name: _: name == "simple-vm") nixosJobs.tests;
+    nixosTests = lib.filterAttrs (
+      name: _: name == "simple-container" || name == "simple-vm"
+    ) nixosJobs.tests;
   }
 )

--- a/ci/eval/outpaths.nix
+++ b/ci/eval/outpaths.nix
@@ -108,6 +108,6 @@ in
 tweak (
   (removeAttrs nixpkgsJobs blacklist)
   // {
-    nixosTests = lib.filterAttrs (name: _: name == "simple") nixosJobs.tests;
+    nixosTests = lib.filterAttrs (name: _: name == "simple-vm") nixosJobs.tests;
   }
 )

--- a/ci/github-script/check-target-branch.js
+++ b/ci/github-script/check-target-branch.js
@@ -99,6 +99,7 @@ async function checkTargetBranch({ github, context, core, dry }) {
     ...Object.values(changed.rebuildCountByKernel),
   )
   const rebuildsAllTests =
+    changed.attrdiff.changed.includes('nixosTests.simple-container') ||
     changed.attrdiff.changed.includes('nixosTests.simple-vm')
 
   // https://github.com/NixOS/nixpkgs/pull/481205#issuecomment-3790123921

--- a/ci/github-script/check-target-branch.js
+++ b/ci/github-script/check-target-branch.js
@@ -99,7 +99,7 @@ async function checkTargetBranch({ github, context, core, dry }) {
     ...Object.values(changed.rebuildCountByKernel),
   )
   const rebuildsAllTests =
-    changed.attrdiff.changed.includes('nixosTests.simple')
+    changed.attrdiff.changed.includes('nixosTests.simple-vm')
 
   // https://github.com/NixOS/nixpkgs/pull/481205#issuecomment-3790123921
   // These should go to staging-nixos instead of master,

--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -202,6 +202,7 @@ rec {
         (onFullSupported "nixos.tests.proxy")
         (onFullSupported "nixos.tests.sddm.default")
         (onFullSupported "nixos.tests.shadow")
+        (onFullSupported "nixos.tests.simple-container")
         (onFullSupported "nixos.tests.simple-vm")
         (onFullSupported "nixos.tests.sway")
         (onFullSupported "nixos.tests.switchTest")

--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -202,7 +202,7 @@ rec {
         (onFullSupported "nixos.tests.proxy")
         (onFullSupported "nixos.tests.sddm.default")
         (onFullSupported "nixos.tests.shadow")
-        (onFullSupported "nixos.tests.simple")
+        (onFullSupported "nixos.tests.simple-vm")
         (onFullSupported "nixos.tests.sway")
         (onFullSupported "nixos.tests.switchTest")
         (onFullSupported "nixos.tests.udisks2")

--- a/nixos/release-small.nix
+++ b/nixos/release-small.nix
@@ -67,6 +67,7 @@ rec {
         php
         predictable-interface-names
         proxy
+        simple-container
         simple-vm
         ;
       latestKernel = {
@@ -165,6 +166,7 @@ rec {
           "nixos.tests.predictable-interface-names.unpredictable"
           "nixos.tests.predictable-interface-names.unpredictableNetworkd"
           "nixos.tests.proxy"
+          "nixos.tests.simple-container"
           "nixos.tests.simple-vm"
           "nixpkgs.jdk"
           "nixpkgs.tests.stdenv.tests-stdenv-gcc-stageCompare"

--- a/nixos/release-small.nix
+++ b/nixos/release-small.nix
@@ -67,7 +67,7 @@ rec {
         php
         predictable-interface-names
         proxy
-        simple
+        simple-vm
         ;
       latestKernel = {
         inherit (nixos'.tests.latestKernel)
@@ -165,7 +165,7 @@ rec {
           "nixos.tests.predictable-interface-names.unpredictable"
           "nixos.tests.predictable-interface-names.unpredictableNetworkd"
           "nixos.tests.proxy"
-          "nixos.tests.simple"
+          "nixos.tests.simple-vm"
           "nixpkgs.jdk"
           "nixpkgs.tests.stdenv.tests-stdenv-gcc-stageCompare"
           "nixpkgs.opensshTest"

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1508,6 +1508,7 @@ in
   shoko = import ./shoko.nix { inherit runTest; };
   signal-desktop = runTest ./signal-desktop.nix;
   silverbullet = runTest ./silverbullet.nix;
+  simple-container = runTest ./simple-container.nix;
   simple-vm = runTest ./simple-vm.nix;
   sing-box = runTest ./sing-box.nix;
   sks = runTest ./sks.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1508,7 +1508,7 @@ in
   shoko = import ./shoko.nix { inherit runTest; };
   signal-desktop = runTest ./signal-desktop.nix;
   silverbullet = runTest ./silverbullet.nix;
-  simple = runTest ./simple.nix;
+  simple-vm = runTest ./simple-vm.nix;
   sing-box = runTest ./sing-box.nix;
   sks = runTest ./sks.nix;
   slimserver = runTest ./slimserver.nix;

--- a/nixos/tests/nixos-test-driver/skip-typecheck.nix
+++ b/nixos/tests/nixos-test-driver/skip-typecheck.nix
@@ -1,5 +1,5 @@
 /**
-  nixosTests.simple, but with skipTypeCheck.
+  nixosTests.simple-vm, but with skipTypeCheck.
   This catches regressions in the wiring, e.g.
   https://github.com/NixOS/nixpkgs/pull/511225
 */

--- a/nixos/tests/simple-container.nix
+++ b/nixos/tests/simple-container.nix
@@ -1,0 +1,11 @@
+{
+  name = "simple-container";
+
+  containers.machine = { };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("multi-user.target")
+    machine.shutdown()
+  '';
+}

--- a/nixos/tests/simple-vm.nix
+++ b/nixos/tests/simple-vm.nix
@@ -1,5 +1,5 @@
 {
-  name = "simple";
+  name = "simple-vm";
 
   nodes.machine = { };
 


### PR DESCRIPTION
nixosTests.simple but using an nspawn container

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
