### PR TITLE
minimal-bootstrap: trim static outputs

### DIFF
--- a/pkgs/os-specific/linux/minimal-bootstrap/bash/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/bash/static.nix
@@ -63,6 +63,7 @@ bash.runCommand "${pname}-${version}"
       --host=${hostPlatform.config} \
       --without-bash-malloc \
       --disable-dependency-tracking \
+      --disable-nls \
       --enable-static-link \
       CC=musl-gcc
 
@@ -72,5 +73,6 @@ bash.runCommand "${pname}-${version}"
     # Install
     make -j $NIX_BUILD_CORES install-strip
     rm $out/bin/bashbug
+    rm -rf $out/share
     ln -s $out/bin/bash $out/bin/sh
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/binutils/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/binutils/static.nix
@@ -46,6 +46,8 @@ let
     "--enable-deterministic-archives"
     # depends on bison
     "--disable-gprofng"
+    # unused downstream
+    "--disable-gprof"
 
     # Turn on --enable-new-dtags by default to make the linker set
     # RUNPATH instead of RPATH on binaries.  This is important because
@@ -57,6 +59,8 @@ let
     # path to force users to declare their use of these libraries.
     "--with-lib-path=:"
     "--disable-gold"
+    # unused in the bootstrap path and removed from the output
+    "--disable-libctf"
     "--disable-plugins"
   ];
 in
@@ -83,6 +87,7 @@ bash.runCommand "${pname}-${version}"
       result:
       bash.runCommand "${pname}-get-version-${version}" { } ''
         ${result}/bin/ld --version
+        ${result}/${hostPlatform.config}/bin/ld --version
         mkdir $out
       '';
   }
@@ -106,5 +111,17 @@ bash.runCommand "${pname}-${version}"
 
     # gprof/addr2line/elfedit + man pages are unused downstream.
     rm -f $out/bin/gprof $out/bin/addr2line $out/bin/elfedit
-    rm -rf $out/share/info $out/share/man
+    rm -rf $out/include $out/lib $out/share
+
+    # The target-prefixed tools duplicate the unprefixed tools byte-for-byte.
+    # Keep the conventional target-prefixed paths, but make them symlinks.
+    targetBin=$out/${hostPlatform.config}/bin
+    if [ -d "$targetBin" ]; then
+      for tool in ar as ld ld.bfd nm objcopy objdump ranlib readelf strip; do
+        if [ -e "$targetBin/$tool" ] && cmp -s "$out/bin/$tool" "$targetBin/$tool"; then
+          rm "$targetBin/$tool"
+          ln -s ../../bin/$tool "$targetBin/$tool"
+        fi
+      done
+    fi
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/bzip2/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/bzip2/static.nix
@@ -33,12 +33,28 @@ bash.runCommand "${pname}-${version}"
       gzip
     ];
 
-    passthru.tests.get-version =
-      result:
-      bash.runCommand "${pname}-get-version-${version}" { } ''
-        ${result}/bin/bzip2 --help
-        mkdir $out
-      '';
+    passthru.tests = {
+      get-version =
+        result:
+        bash.runCommand "${pname}-get-version-${version}" { } ''
+          ${result}/bin/bzip2 --help
+          mkdir $out
+        '';
+
+      compress =
+        result:
+        bash.runCommand "${pname}-compress-${version}" { } ''
+          printf 'bootstrap\n' > input
+          ${result}/bin/bzip2 -k input
+          ${result}/bin/bunzip2 -c input.bz2 > bunzip2-output
+          read -r bunzip2Output < bunzip2-output
+          test "$bunzip2Output" = bootstrap
+          ${result}/bin/bzcat input.bz2 > bzcat-output
+          read -r bzcatOutput < bzcat-output
+          test "$bzcatOutput" = bootstrap
+          mkdir $out
+        '';
+    };
 
     meta = {
       description = "High-quality data compression program";
@@ -58,12 +74,15 @@ bash.runCommand "${pname}-${version}"
       -j $NIX_BUILD_CORES \
       CC=musl-gcc \
       CFLAGS=-static \
-      bzip2 bzip2recover
+      bzip2
 
     # Install
-    make install -j $NIX_BUILD_CORES PREFIX=$out
+    mkdir -p $out/bin
+    cp bzip2 $out/bin/bzip2
+    ln -s bzip2 $out/bin/bunzip2
+    ln -s bzip2 $out/bin/bzcat
 
     # Strip
     # Ignore failures, because strip may fail on non-elf files.
-    find $out/{bin,lib} -type f -exec strip --strip-debug {} + || true
+    strip --strip-debug $out/bin/bzip2 || true
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/coreutils/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/coreutils/static.nix
@@ -80,5 +80,5 @@ bash.runCommand "${pname}-${version}"
     make -j $NIX_BUILD_CORES install-strip
 
     # Remove documentation not needed in the bootstrap chain.
-    rm -rf $out/share/info $out/share/man
+    rm -rf $out/share
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -402,6 +402,7 @@ lib.makeScope
             echo ${bash-static.tests.get-version}
             echo ${binutils-static.tests.get-version}
             echo ${bzip2-static.tests.get-version}
+            echo ${bzip2-static.tests.compress}
             echo ${coreutils-static.tests.get-version}
             echo ${diffutils-static.tests.get-version}
             echo ${findutils-static.tests.get-version}

--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -366,61 +366,82 @@ lib.makeScope
           writeTextFile
           writeText
           ;
-        test = kaem.runCommand "minimal-bootstrap-test" { } (
-          ''
+
+        tests = {
+          bootstrap-chain = kaem.runCommand "minimal-bootstrap-bootstrap-chain-test" { } ''
             echo ${bash.tests.get-version}
-            echo ${bash-static.tests.get-version}
             echo ${bash_2_05.tests.get-version}
             echo ${binutils.tests.get-version}
-            echo ${binutils-static.tests.get-version}
             echo ${bison.tests.get-version}
             echo ${bzip2.tests.get-version}
-            echo ${bzip2-static.tests.get-version}
             echo ${coreutils-musl.tests.get-version}
-            echo ${coreutils-static.tests.get-version}
             echo ${diffutils.tests.get-version}
-            echo ${diffutils-static.tests.get-version}
             echo ${findutils.tests.get-version}
-            echo ${findutils-static.tests.get-version}
             echo ${gawk.tests.get-version}
             echo ${gawk-mes.tests.get-version}
-            echo ${gawk-static.tests.get-version}
-            echo ${gcc46.tests.get-version}
-            echo ${gcc46-cxx.tests.hello-world}
-            echo ${gcc10.tests.hello-world}
-            echo ${gcc-latest.tests.hello-world}
             echo ${gnugrep.tests.get-version}
-            echo ${gnugrep-static.tests.get-version}
             echo ${gnum4.tests.get-version}
             echo ${gnumake-musl.tests.get-version}
-            echo ${gnumake-static.tests.get-version}
-            echo ${gnupatch-static.tests.get-version}
             echo ${gnused.tests.get-version}
             echo ${gnused-mes.tests.get-version}
-            echo ${gnused-static.tests.get-version}
             echo ${gnutar.tests.get-version}
             echo ${gnutar-latest.tests.get-version}
             echo ${gnutar-musl.tests.get-version}
-            echo ${gnutar-static.tests.get-version}
             echo ${gzip.tests.get-version}
-            echo ${gzip-static.tests.get-version}
             echo ${heirloom.tests.get-version}
             echo ${mes.compiler.tests.get-version}
             echo ${musl.tests.hello-world}
-            echo ${patchelf-static.tests.get-version}
             echo ${python.tests.get-version}
             echo ${tinycc-mes.compiler.tests.chain}
             echo ${tinycc-musl.compiler.tests.hello-world}
             echo ${xz.tests.get-version}
-          ''
-          + (lib.strings.optionalString (hostPlatform.libc == "glibc") ''
-            echo ${gcc-glibc.tests.hello-world}
-            echo ${glibc.tests.hello-world}
-          '')
-          + ''
             mkdir ''${out}
-          ''
-        );
+          '';
+
+          static-tools = kaem.runCommand "minimal-bootstrap-static-tools-test" { } ''
+            echo ${bash-static.tests.get-version}
+            echo ${binutils-static.tests.get-version}
+            echo ${bzip2-static.tests.get-version}
+            echo ${coreutils-static.tests.get-version}
+            echo ${diffutils-static.tests.get-version}
+            echo ${findutils-static.tests.get-version}
+            echo ${gawk-static.tests.get-version}
+            echo ${gnugrep-static.tests.get-version}
+            echo ${gnumake-static.tests.get-version}
+            echo ${gnupatch-static.tests.get-version}
+            echo ${gnused-static.tests.get-version}
+            echo ${gnutar-static.tests.get-version}
+            echo ${gzip-static.tests.get-version}
+            echo ${patchelf-static.tests.get-version}
+            echo ${xz-static.tests.get-version}
+            mkdir ''${out}
+          '';
+
+          compiler = kaem.runCommand "minimal-bootstrap-compiler-test" { } (
+            ''
+              echo ${gcc46.tests.get-version}
+              echo ${gcc46-cxx.tests.hello-world}
+              echo ${gcc10.tests.hello-world}
+              echo ${gcc-latest.tests.hello-world}
+            ''
+            + (lib.strings.optionalString (hostPlatform.libc == "glibc") ''
+              echo ${gcc-glibc.tests.hello-world}
+              echo ${glibc.tests.hello-world}
+            '')
+            + ''
+              mkdir ''${out}
+            ''
+          );
+
+          full = kaem.runCommand "minimal-bootstrap-test" { } ''
+            echo ${tests.bootstrap-chain}
+            echo ${tests.static-tools}
+            echo ${tests.compiler}
+            mkdir ''${out}
+          '';
+        };
+
+        test = tests.full;
       }
       // (lib.optionalAttrs (hostPlatform.libc == "glibc")) {
         gcc-glibc = callPackage ./gcc/glibc.nix {

--- a/pkgs/os-specific/linux/minimal-bootstrap/diffutils/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/diffutils/static.nix
@@ -69,6 +69,7 @@ bash.runCommand "${pname}-${version}"
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
       --disable-dependency-tracking \
+      --disable-nls \
       CC=musl-gcc \
       CFLAGS=-static \
       ac_cv_path_PR_PROGRAM=pr
@@ -78,4 +79,7 @@ bash.runCommand "${pname}-${version}"
 
     # Install
     make -j $NIX_BUILD_CORES install-strip
+
+    # Remove documentation not needed in the bootstrap chain.
+    rm -rf $out/share
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/findutils/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/findutils/static.nix
@@ -47,6 +47,7 @@ bash.runCommand "${pname}-${version}"
       result:
       bash.runCommand "${pname}-get-version-${version}" { } ''
         ${result}/bin/find --version
+        ${result}/bin/xargs --version
         mkdir $out
       '';
 
@@ -69,6 +70,7 @@ bash.runCommand "${pname}-${version}"
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
       --disable-dependency-tracking \
+      --disable-nls \
       CC=musl-gcc \
       CFLAGS=-static
 
@@ -77,5 +79,8 @@ bash.runCommand "${pname}-${version}"
 
     # Install
     make -j $NIX_BUILD_CORES install-strip
-    rm $out/bin/updatedb
+
+    # Keep only the bootstrap-relevant find/xargs tools.
+    rm -f $out/bin/locate $out/bin/updatedb
+    rm -rf $out/libexec $out/share $out/var
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/gawk/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gawk/static.nix
@@ -48,6 +48,7 @@ bash.runCommand "${pname}-${version}"
       result:
       bash.runCommand "${pname}-get-version-${version}" { } ''
         ${result}/bin/awk --version
+        ${result}/bin/awk 'BEGIN { if (2 + 2 != 4) exit 1 }'
         mkdir $out
       '';
   }
@@ -62,6 +63,10 @@ bash.runCommand "${pname}-${version}"
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
       --disable-dependency-tracking \
+      --disable-extensions \
+      --disable-mpfr \
+      --disable-nls \
+      --disable-pma \
       CC=musl-gcc \
       CFLAGS=-static
 
@@ -71,4 +76,6 @@ bash.runCommand "${pname}-${version}"
     # Install
     make -j $NIX_BUILD_CORES install-strip
     rm $out/bin/gawkbug
+    rm -rf $out/etc $out/include $out/lib $out/libexec
+    rm -rf $out/share
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnugrep/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnugrep/static.nix
@@ -70,6 +70,7 @@ bash.runCommand "${pname}-${version}"
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
       --disable-dependency-tracking \
+      --disable-nls \
       CC=musl-gcc \
       CFLAGS=-static
 
@@ -79,4 +80,7 @@ bash.runCommand "${pname}-${version}"
     # Install
     make -j $NIX_BUILD_CORES install-strip
     rm $out/bin/{egrep,fgrep}
+
+    # Remove documentation not needed in the bootstrap chain.
+    rm -rf $out/share
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnumake/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnumake/static.nix
@@ -79,6 +79,7 @@ bash.runCommand "${pname}-${version}"
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
       --disable-dependency-tracking \
+      --disable-nls \
       CC=musl-gcc \
       CFLAGS="-static -std=gnu17"
 
@@ -87,4 +88,7 @@ bash.runCommand "${pname}-${version}"
 
     # Install
     make -j $NIX_BUILD_CORES install-strip
+
+    # Remove files not needed to execute make in the bootstrap chain.
+    rm -rf $out/include $out/share
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnupatch/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnupatch/static.nix
@@ -78,4 +78,5 @@ bash.runCommand "${pname}-${version}"
 
     # Install
     make -j $NIX_BUILD_CORES install-strip
+    rm -rf $out/share
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnused/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnused/static.nix
@@ -62,6 +62,7 @@ bash.runCommand "${pname}-${version}"
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
       --disable-dependency-tracking \
+      --disable-nls \
       CC=musl-gcc \
       CFLAGS=-static
 
@@ -70,4 +71,5 @@ bash.runCommand "${pname}-${version}"
 
     # Install
     make -j $NIX_BUILD_CORES install-strip
+    rm -rf $out/share
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnutar/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnutar/static.nix
@@ -62,6 +62,7 @@ bash.runCommand "${pname}-${version}"
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
       --disable-dependency-tracking \
+      --disable-nls \
       CC=musl-gcc \
       CFLAGS=-static
 
@@ -70,4 +71,5 @@ bash.runCommand "${pname}-${version}"
 
     # Install
     make -j $NIX_BUILD_CORES install-strip
+    rm -rf $out/libexec $out/share
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/gzip/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gzip/static.nix
@@ -77,4 +77,5 @@ bash.runCommand "${pname}-${version}"
 
     # Install
     make -j $NIX_BUILD_CORES bin_SCRIPTS= install-strip
+    rm -rf $out/share
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/patchelf/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/patchelf/static.nix
@@ -43,6 +43,8 @@ bash.runCommand "${pname}-${version}"
       gzip
     ];
 
+    disallowedReferences = [ gcc ];
+
     passthru.tests.get-version =
       result:
       bash.runCommand "${pname}-get-version-${version}" { } ''
@@ -70,7 +72,7 @@ bash.runCommand "${pname}-${version}"
       --host=${hostPlatform.config} \
       --disable-dependency-tracking \
       CC=musl-gcc \
-      CXXFLAGS=-static
+      CXXFLAGS="-static -g0 -O2 -DNDEBUG -ffile-prefix-map=${gcc}=. -fmacro-prefix-map=${gcc}=."
 
     # Build
     make -j $NIX_BUILD_CORES

--- a/pkgs/os-specific/linux/minimal-bootstrap/patchelf/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/patchelf/static.nix
@@ -79,4 +79,5 @@ bash.runCommand "${pname}-${version}"
 
     # Install
     make -j $NIX_BUILD_CORES install-strip
+    rm -rf $out/share
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/xz/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/xz/static.nix
@@ -39,10 +39,12 @@ bash.runCommand "${pname}-${version}"
       gzip
     ];
 
+    disallowedReferences = [ musl ];
+
     passthru.tests.get-version =
       result:
       bash.runCommand "${pname}-get-version-${version}" { } ''
-        ${lib.getExe result} --version
+        ${result}/bin/xz --version
         mkdir $out
       '';
 
@@ -65,8 +67,8 @@ bash.runCommand "${pname}-${version}"
 
     # Configure
     export CC=musl-gcc
-    export CFLAGS=-static
-    export CXXFLAGS=-static
+    export CFLAGS="-g0 -O2 -DNDEBUG"
+    export CXXFLAGS="$CFLAGS"
     export LDFLAGS=-static
     bash ./configure \
       --prefix=$out \
@@ -78,11 +80,16 @@ bash.runCommand "${pname}-${version}"
       --disable-nls \
       --disable-shared \
       --disable-scripts \
+      --disable-doc \
+      --disable-xzdec \
+      --disable-lzmadec \
+      --disable-lzmainfo \
       --disable-assembler
 
     # Build
-    make -j $NIX_BUILD_CORES
+    make -j $NIX_BUILD_CORES LDFLAGS=-all-static
 
     # Install
     make -j $NIX_BUILD_CORES install-strip
+    rm -rf $out/include $out/lib $out/share
   ''


### PR DESCRIPTION
Assisted-by: codex with gpt-5.5-high. Follow up to #514298

Trim the static tool outputs used by `minimal-bootstrap` and split the aggregate test so static-tool changes can be verified without always rebuilding unrelated compiler checks.

The static bootstrap tools were carrying unused installed files and, in a few cases, large build/runtime references that are not consumed by the stage0 bootstrap path. This PR prunes documentation, locale data, headers, libraries, helper binaries, and duplicate binaries where they are not needed; makes `xz-static` actually static; prevents `patchelf-static` from retaining the bootstrap compiler reference; and removes the empty `coreutils-static` `share` directory left after documentation pruning.

Measured against `upstream/staging` on `x86_64-linux`:

| measurement | before | after | reduction |
|---|---:|---:|---:|
| stage0 `initialPath` unique NAR-size closure | 395.250 MiB | 212.709 MiB | -182.541 MiB (-46.2%) |

The aggregate row was measured by realizing the direct `pkgs/stdenv/linux/stage0.nix` import and summing the NAR sizes of the recursive closure:

```sh
nix path-info -rs $(nix build --no-link --print-out-paths --impure --expr 'let pkgs = import ./. { system = "x86_64-linux"; }; stage0 = import ./pkgs/stdenv/linux/stage0.nix { localSystem = pkgs.stdenv.hostPlatform; inherit (pkgs) config lib; bootstrapFiles = null; }; in stage0.initialPath') | awk '{s += $2} END {printf "%.3f MiB\n", s / 1024 / 1024}'
```

That aggregate value was reproduced at PR head `0e0ec4db091a`. The current package table below includes the later small direct-output trims as well; re-running the aggregate measurement at the current head would require realizing `compilerPackage` from `stage0.initialPath`.

Per-package closure deltas:

| package | before | after | reduction |
|---|---:|---:|---:|
| `patchelf-static` | 167.634 MiB | 1.225 MiB | -166.409 MiB |
| `xz-static` | 26.517 MiB | 0.277 MiB | -26.239 MiB |
| `bash-static` | 9.643 MiB | 1.333 MiB | -8.310 MiB |
| `binutils-static` | 42.482 MiB | 21.093 MiB | -21.389 MiB |
| `gawk-static` | 6.001 MiB | 1.549 MiB | -4.453 MiB |
| `findutils-static` | 2.830 MiB | 0.592 MiB | -2.237 MiB |
| `gnumake-static` | 0.963 MiB | 0.325 MiB | -0.638 MiB |
| `diffutils-static` | 0.896 MiB | 0.661 MiB | -0.235 MiB |
| `gnugrep-static` | 0.546 MiB | 0.381 MiB | -0.165 MiB |
| `bzip2-static` | 0.665 MiB | 0.159 MiB | -0.505 MiB |
| `gnutar-static` | 3.772 MiB | 0.826 MiB | -2.946 MiB |
| `gzip-static` | 0.249 MiB | 0.175 MiB | -0.073 MiB |
| `gnused-static` | 0.480 MiB | 0.276 MiB | -0.204 MiB |
| `gnupatch-static` | 0.273 MiB | 0.241 MiB | -0.032 MiB |
| `coreutils-static` | 2,250,112 B | 2,249,944 B | -168 B |

Validation performed:

- [x] `nix-build -A minimal-bootstrap.test`
- [x] `nix-build -A minimal-bootstrap.test --argstr system i686-linux`
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] i686-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
