### PR TITLE
alive2: add alive-tv binary

### DIFF
--- a/pkgs/by-name/al/alive2/package.nix
+++ b/pkgs/by-name/al/alive2/package.nix
@@ -34,6 +34,10 @@ clangStdenv.mkDerivation (finalAttrs: {
   ];
   strictDeps = true;
 
+  cmakeFlags = [
+    (lib.cmakeFeature "BUILD_TV" "1")
+  ];
+
   postPatch = ''
     substituteInPlace CMakeLists.txt \
       --replace-fail '-Werror' "" \
@@ -55,6 +59,7 @@ clangStdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/bin
     cp alive $out/bin/
     cp alive-jobserver $out/bin/
+    cp alive-tv $out/bin/
     rm -rf $out/bin/CMakeFiles $out/bin/*.o
     runHook postInstall
   '';


### PR DESCRIPTION
Alive2 also has a standalone translation validation tool named `alive-tv`, which provides slightly different functionality and can be used online [here](https://alive2.llvm.org/ce/).
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
