### PR TITLE
fetchurl: performance improvements

### DIFF
--- a/pkgs/build-support/fetchurl/boot.nix
+++ b/pkgs/build-support/fetchurl/boot.nix
@@ -6,7 +6,20 @@ in
   rewriteURL,
   system,
 }:
-
+let
+  handleUrl =
+    if rewriteURL == null then
+      url: url
+    else
+      url:
+      let
+        u = rewriteURL url;
+      in
+      if builtins.isString u then
+        u
+      else
+        throw "rewriteURL deleted the only URL passed to fetchurlBoot (was ${url})";
+in
 {
   url ? builtins.head urls,
   urls ? [ ],
@@ -31,14 +44,7 @@ import <nix/fetchurl.nix> {
     # Handle mirror:// URIs. Since <nix/fetchurl.nix> currently
     # supports only one URI, use the first listed mirror.
     let
-      url_ =
-        let
-          u = rewriteURL url;
-        in
-        if builtins.isString u then
-          u
-        else
-          throw "rewriteURL deleted the only URL passed to fetchurlBoot (was ${url})";
+      url_ = handleUrl url;
       m = builtins.match "mirror://([a-z]+)/(.*)" url_;
     in
     if m == null then url_ else builtins.head (mirrors.${builtins.elemAt m 0}) + (builtins.elemAt m 1);

--- a/pkgs/build-support/fetchurl/boot.nix
+++ b/pkgs/build-support/fetchurl/boot.nix
@@ -53,5 +53,5 @@ import <nix/fetchurl.nix> {
       url_ = handleUrl url;
       m = match "mirror://([a-z]+)/(.*)" url_;
     in
-    if m == null then url_ else head (mirrors.${elemAt m 0}) + (elemAt m 1);
+    if m == null then url_ else head (mirrors.${head m}) + (elemAt m 1);
 }

--- a/pkgs/build-support/fetchurl/boot.nix
+++ b/pkgs/build-support/fetchurl/boot.nix
@@ -1,5 +1,11 @@
 let
   mirrors = import ./mirrors.nix;
+  inherit (builtins)
+    elemAt
+    head
+    isString
+    match
+    ;
 in
 
 {
@@ -15,13 +21,13 @@ let
       let
         u = rewriteURL url;
       in
-      if builtins.isString u then
+      if isString u then
         u
       else
         throw "rewriteURL deleted the only URL passed to fetchurlBoot (was ${url})";
 in
 {
-  url ? builtins.head urls,
+  url ? head urls,
   urls ? [ ],
   sha256 ? "",
   hash ? "",
@@ -45,7 +51,7 @@ import <nix/fetchurl.nix> {
     # supports only one URI, use the first listed mirror.
     let
       url_ = handleUrl url;
-      m = builtins.match "mirror://([a-z]+)/(.*)" url_;
+      m = match "mirror://([a-z]+)/(.*)" url_;
     in
-    if m == null then url_ else builtins.head (mirrors.${builtins.elemAt m 0}) + (builtins.elemAt m 1);
+    if m == null then url_ else head (mirrors.${elemAt m 0}) + (elemAt m 1);
 }

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -278,8 +278,6 @@ lib.extendMkDerivation {
 
       finalHashHasColon = match ".*:.*" finalAttrs.hash != null;
       finalHashColonMatch = match "([^:]+)[:](.*)" finalAttrs.hash;
-
-      resolvedUrl = head (resolveUrl url);
     in
 
     derivationArgs
@@ -382,7 +380,8 @@ lib.extendMkDerivation {
 
       inherit meta;
       passthru = {
-        inherit url resolvedUrl;
+        inherit url;
+        resolvedUrl = head (resolveUrl url);
       }
       // passthru;
     };

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -85,6 +85,22 @@ let
     else
       map (mirror: mirror + elemAt mirrorSplit 1) mirrorList;
 
+  rewriteAllUrls =
+    urls:
+    if rewriteURL == null then
+      urls
+    else
+      let
+        u = concatMap (
+          url:
+          let
+            rewritten = rewriteURL url;
+          in
+          if isString rewritten then [ rewritten ] else [ ]
+        ) urls;
+      in
+      if u == [ ] then throw "urls is empty after rewriteURL (was ${toString urls})" else u;
+
   impureEnvVars =
     lib.fetchers.proxyImpureEnvVars
     ++ [
@@ -210,17 +226,7 @@ lib.extendMkDerivation {
         else
           throw "fetchurl requires either `url` or `urls` to be set: ${lib.generators.toPretty { } args}";
 
-      urls_ =
-        let
-          u = concatMap (
-            url:
-            let
-              rewritten = rewriteURL url;
-            in
-            if isString rewritten then [ rewritten ] else [ ]
-          ) preRewriteUrls;
-        in
-        if u == [ ] then throw "urls is empty after rewriteURL (was ${toString preRewriteUrls})" else u;
+      urls_ = rewriteAllUrls preRewriteUrls;
 
       hash_ =
         if

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -11,6 +11,22 @@
 }:
 
 let
+  inherit (lib)
+    concatMap
+    elemAt
+    fakeHash
+    fakeSha256
+    fakeSha512
+    filter
+    hasPrefix
+    head
+    isList
+    isString
+    length
+    match
+    warn
+    ;
+  nixpkgsVersion = lib.trivial.release;
 
   mirrors = import ./mirrors.nix // {
     inherit hashedMirrors;
@@ -60,14 +76,14 @@ let
   resolveUrl =
     url:
     let
-      mirrorSplit = lib.match "mirror://([[:alpha:]]+)/(.+)" url;
-      mirrorName = lib.head mirrorSplit;
+      mirrorSplit = match "mirror://([[:alpha:]]+)/(.+)" url;
+      mirrorName = head mirrorSplit;
       mirrorList = mirrors."${mirrorName}" or (throw "unknown mirror:// site ${mirrorName}");
     in
     if mirrorSplit == null || mirrorName == null then
       [ url ]
     else
-      map (mirror: mirror + lib.elemAt mirrorSplit 1) mirrorList;
+      map (mirror: mirror + elemAt mirrorSplit 1) mirrorList;
 
   impureEnvVars =
     lib.fetchers.proxyImpureEnvVars
@@ -186,34 +202,28 @@ lib.extendMkDerivation {
     let
       preRewriteUrls =
         if urls != [ ] && url == "" then
-          (
-            if lib.isList urls then urls else throw "`urls` is not a list: ${lib.generators.toPretty { } urls}"
-          )
+          (if isList urls then urls else throw "`urls` is not a list: ${lib.generators.toPretty { } urls}")
         else if urls == [ ] && url != "" then
           (
-            if lib.isString url then
-              [ url ]
-            else
-              throw "`url` is not a string: ${lib.generators.toPretty { } urls}"
+            if isString url then [ url ] else throw "`url` is not a string: ${lib.generators.toPretty { } urls}"
           )
         else
           throw "fetchurl requires either `url` or `urls` to be set: ${lib.generators.toPretty { } args}";
 
       urls_ =
         let
-          u = lib.lists.concatMap (
+          u = concatMap (
             url:
             let
               rewritten = rewriteURL url;
             in
-            if lib.isString rewritten then [ rewritten ] else [ ]
+            if isString rewritten then [ rewritten ] else [ ]
           ) preRewriteUrls;
         in
         if u == [ ] then throw "urls is empty after rewriteURL (was ${toString preRewriteUrls})" else u;
 
       hash_ =
         if
-          with lib.lists;
           length (
             filter (s: s != "") [
               hash
@@ -255,15 +265,15 @@ lib.extendMkDerivation {
         else if cacert != null then
           {
             outputHashAlgo = null;
-            outputHash = lib.fakeHash;
+            outputHash = fakeHash;
           }
         else
           throw "fetchurl requires a hash for fixed-output derivation: ${lib.generators.toPretty { } urls_}";
 
-      finalHashHasColon = lib.match ".*:.*" finalAttrs.hash != null;
-      finalHashColonMatch = lib.match "([^:]+)[:](.*)" finalAttrs.hash;
+      finalHashHasColon = match ".*:.*" finalAttrs.hash != null;
+      finalHashColonMatch = match "([^:]+)[:](.*)" finalAttrs.hash;
 
-      resolvedUrl = lib.head (resolveUrl url);
+      resolvedUrl = head (resolveUrl url);
     in
 
     derivationArgs
@@ -278,7 +288,7 @@ lib.extendMkDerivation {
         else if name != null then
           name
         else
-          baseNameOf (toString (lib.head urls_));
+          baseNameOf (toString (head urls_));
 
       builder = ./builder.sh;
 
@@ -295,17 +305,17 @@ lib.extendMkDerivation {
         if
           hash_.outputHashAlgo == null
           || hash_.outputHash == ""
-          || lib.hasPrefix hash_.outputHashAlgo hash_.outputHash
+          || hasPrefix hash_.outputHashAlgo hash_.outputHash
         then
           hash_.outputHash
         else
           "${hash_.outputHashAlgo}:${hash_.outputHash}";
-      outputHashAlgo = if finalHashHasColon then lib.head finalHashColonMatch else null;
+      outputHashAlgo = if finalHashHasColon then head finalHashColonMatch else null;
       outputHash =
         if finalAttrs.hash == "" then
-          lib.fakeHash
+          fakeHash
         else if finalHashHasColon then
-          lib.elemAt finalHashColonMatch 1
+          elemAt finalHashColonMatch 1
         else
           finalAttrs.hash;
 
@@ -315,9 +325,9 @@ lib.extendMkDerivation {
         if
           (
             hash_.outputHash == ""
-            || hash_.outputHash == lib.fakeSha256
-            || hash_.outputHash == lib.fakeSha512
-            || hash_.outputHash == lib.fakeHash
+            || hash_.outputHash == fakeSha256
+            || hash_.outputHash == fakeSha512
+            || hash_.outputHash == fakeHash
             || netrcPhase != null
           )
         then
@@ -328,8 +338,8 @@ lib.extendMkDerivation {
       outputHashMode = if (recursiveHash || executable) then "recursive" else "flat";
 
       curlOpts =
-        if lib.isList curlOpts then
-          lib.warn (
+        if isList curlOpts then
+          warn (
             let
               url = toString (builtins.head urls_);
               curlOptsRepresentation = lib.generators.toPretty { multiline = false; } curlOpts;
@@ -360,7 +370,7 @@ lib.extendMkDerivation {
 
       impureEnvVars = impureEnvVars ++ netrcImpureEnvVars;
 
-      nixpkgsVersion = lib.trivial.release;
+      inherit nixpkgsVersion;
 
       inherit preferLocalBuild;
 

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -260,7 +260,7 @@ lib.extendMkDerivation {
         else
           throw "fetchurl requires a hash for fixed-output derivation: ${lib.generators.toPretty { } urls_}";
 
-      finalHashHasColon = lib.hasInfix ":" finalAttrs.hash;
+      finalHashHasColon = lib.match ".*:.*" finalAttrs.hash != null;
       finalHashColonMatch = lib.match "([^:]+)[:](.*)" finalAttrs.hash;
 
       resolvedUrl = lib.head (resolveUrl url);

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -11,6 +11,7 @@
 }:
 
 let
+  defaultNativeBuildInputs = [ curl ];
   inherit (lib)
     concatMap
     elemAt
@@ -296,7 +297,7 @@ lib.extendMkDerivation {
 
       builder = ./builder.sh;
 
-      nativeBuildInputs = [ curl ] ++ nativeBuildInputs;
+      nativeBuildInputs = defaultNativeBuildInputs ++ nativeBuildInputs;
 
       urls = urls_;
 

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -433,7 +433,6 @@ let
         The intended use is to allow URL rewriting to insert company-internal mirrors, or work around company firewalls and similar network restrictions.
       '';
       default = null;
-      defaultText = literalExpression "(url: url)";
       example = literalExpression ''
         {
           # Use Nix like it's 2024! ;-)

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -422,7 +422,7 @@ let
     };
 
     rewriteURL = mkOption {
-      type = types.functionTo (types.nullOr types.str);
+      type = types.nullOr (types.functionTo (types.nullOr types.str));
       description = ''
         A hook to rewrite/filter URLs before they are fetched.
 
@@ -432,7 +432,7 @@ let
 
         The intended use is to allow URL rewriting to insert company-internal mirrors, or work around company firewalls and similar network restrictions.
       '';
-      default = lib.id;
+      default = null;
       defaultText = literalExpression "(url: url)";
       example = literalExpression ''
         {


### PR DESCRIPTION
Mostly small things, but we notably change `resolveURL` in nixpkgs config to potentially be null. This allows us to easily detect whether it's set to its default value and avoid a meaningful amount of logic.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
