### PR TITLE
fetchFromGitHub: only override fetchzip once

### DIFF
--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -3,7 +3,7 @@
   repoRevToNameMaybe,
   fetchgit,
   fetchzip,
-}:
+}@args:
 let
   # Here defines fetchFromGitHub arguments that determines useFetchGit,
   # The attribute value is their default values.
@@ -37,6 +37,10 @@ let
   adjustFunctionArgs = f: lib.setFunctionArgs f (faUseFetchGit // lib.functionArgs f);
 
   decorate = f: lib.makeOverridable (adjustFunctionArgs f);
+
+  # fetchzip may not be overridable when using external tools, for example nix-prefetch
+  fetchzip =
+    if args.fetchzip ? override then args.fetchzip.override { withUnzip = false; } else args.fetchzip;
 in
 decorate (
   {
@@ -105,14 +109,7 @@ decorate (
     varBase = "NIX${lib.optionalString (varPrefix != null) "_${varPrefix}"}_GITHUB_PRIVATE_";
     # We prefer fetchzip in cases we don't need submodules as the hash
     # is more stable in that case.
-    fetcher =
-      if useFetchGit then
-        fetchgit
-      # fetchzip may not be overridable when using external tools, for example nix-prefetch
-      else if fetchzip ? override then
-        fetchzip.override { withUnzip = false; }
-      else
-        fetchzip;
+    fetcher = if useFetchGit then fetchgit else fetchzip;
     privateAttrs = lib.optionalAttrs private {
       netrcPhase =
         # When using private repos:


### PR DESCRIPTION
Funny bug - we were running a .override on fetchzip on every single call to fetchFromGitHub.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
