### PR TITLE
mattermost: add .patch files for user limit and banner removal

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -220,6 +220,17 @@
 
 - `services.mattermost` now defaults to version 11, which has dropped support for MySQL in favor of Postgres. As a result, all support for MySQL has been removed from the module.
   See the [migration steps](https://docs.mattermost.com/deployment-guide/manual-postgres-migration.html) if you were not running Postgres.
+  Note that version 11 also restricts the user limit to 250 [by default](https://forum.mattermost.com/t/clarification-request-on-user-limits-max-250-user-server-v-11/25309);
+  see the `pkgs.mattermost` removeUserLimit and removeFreeBadge options combined with `services.mattermost.package` to change this behavior. For example:
+
+```nix
+{
+  services.mattermost.package = pkgs.mattermost.override {
+    removeUserLimit = true;
+    removeFreeBadge = true;
+  };
+}
+```
 
 - `post-resume.target` has been removed. See {manpage}`systemd.special(7)` about `sleep.target` for instructions on ordering a process after resume with `ExecStop=`.
 

--- a/nixos/tests/mattermost/default.nix
+++ b/nixos/tests/mattermost/default.nix
@@ -58,11 +58,20 @@ import ../make-test-python.nix (
                   UserNoticesEnabled = false;
                 };
               };
+              package = pkgs.mattermost.override {
+                removeFreeBadge = true;
+                removeUserLimit = true;
+              };
             } mattermostConfig;
 
             # Upgrade to the latest Mattermost.
             specialisation.latest.configuration = {
-              services.mattermost.package = lib.mkForce pkgs.mattermostLatest;
+              services.mattermost.package = lib.mkForce (
+                pkgs.mattermostLatest.override {
+                  removeFreeBadge = true;
+                  removeUserLimit = true;
+                }
+              );
               system.stateVersion = lib.mkVMOverride (lib.versions.majorMinor lib.version);
             };
           }

--- a/pkgs/by-name/ma/mattermost/mattermost-remove-free-banner.patch
+++ b/pkgs/by-name/ma/mattermost/mattermost-remove-free-banner.patch
@@ -1,0 +1,85 @@
+diff --git a/webapp/channels/src/components/global_header/left_controls/product_menu/product_branding_team_edition/product_branding_free_edition.tsx b/webapp/channels/src/components/global_header/left_controls/product_menu/product_branding_team_edition/product_branding_free_edition.tsx
+index 93cb8ab263..3d12cd5e54 100644
+--- a/webapp/channels/src/components/global_header/left_controls/product_menu/product_branding_team_edition/product_branding_free_edition.tsx
++++ b/webapp/channels/src/components/global_header/left_controls/product_menu/product_branding_team_edition/product_branding_free_edition.tsx
+@@ -57,7 +57,6 @@ const ProductBrandingFreeEdition = (): JSX.Element => {
+                 width={116}
+                 height={20}
+             />
+-            <Badge>{badgeText}</Badge>
+         </ProductBrandingFreeEditionContainer>
+     );
+ };
+diff --git a/webapp/channels/src/components/header_footer_route/header.scss b/webapp/channels/src/components/header_footer_route/header.scss
+index c2e6fbd187..bc1cedcff1 100644
+--- a/webapp/channels/src/components/header_footer_route/header.scss
++++ b/webapp/channels/src/components/header_footer_route/header.scss
+@@ -47,20 +47,7 @@
+             }
+ 
+             .freeBadge {
+-                position: relative;
+-                top: 1px;
+-                display: flex;
+-                align-self: center;
+-                padding: 2px 6px;
+-                border-radius: var(--radius-s);
+-                margin-left: 12px;
+-                background: rgba(var(--center-channel-color-rgb), 0.08);
+-                color: rgba(var(--center-channel-color-rgb), 0.75);
+-                font-family: 'Open Sans', sans-serif;
+-                font-size: 10px;
+-                font-weight: 600;
+-                letter-spacing: 0.025em;
+-                line-height: 16px;
++                display: none !important;
+             }
+         }
+     }
+@@ -83,12 +70,6 @@
+             margin-top: 12px;
+         }
+     }
+-
+-    &.has-free-banner.has-custom-site-name {
+-        .header-back-button {
+-            bottom: -20px;
+-        }
+-    }
+ }
+ 
+ @media screen and (max-width: 699px) {
+diff --git a/webapp/channels/src/components/widgets/menu/menu_items/menu_item.scss b/webapp/channels/src/components/widgets/menu/menu_items/menu_item.scss
+index dee9b57f8c..8ef4aa073a 100644
+--- a/webapp/channels/src/components/widgets/menu/menu_items/menu_item.scss
++++ b/webapp/channels/src/components/widgets/menu/menu_items/menu_item.scss
+@@ -316,14 +316,7 @@
+     }
+ 
+     .MenuStartTrial {
+-        display: flex;
+-        flex-direction: column;
+-        align-items: flex-start;
+-        padding: 8px 20px;
+-        border-radius: 4px;
+-        margin-top: 0;
+-        font-size: 12px;
+-        line-height: 16px;
++        display: none !important;
+ 
+         button {
+             padding: 3px 0;
+diff --git a/webapp/channels/webpack.config.js b/webapp/channels/webpack.config.js
+index f29f19f9ab..ab85fc3b86 100644
+--- a/webapp/channels/webpack.config.js
++++ b/webapp/channels/webpack.config.js
+@@ -469,6 +469,9 @@ if (targetIsDevServer) {
+             historyApiFallback: {
+                 index: '/static/root.html',
+             },
++            client: {
++                overlay: false,
++            },
+         },
+         performance: false,
+         optimization: {

--- a/pkgs/by-name/ma/mattermost/mattermost-remove-user-limit.patch
+++ b/pkgs/by-name/ma/mattermost/mattermost-remove-user-limit.patch
@@ -1,0 +1,16 @@
+diff --git a/server/channels/app/limits.go b/server/channels/app/limits.go
+index 4c88c1f049..3c1af8d02f 100644
+--- a/server/channels/app/limits.go
++++ b/server/channels/app/limits.go
+@@ -10,8 +10,8 @@ import (
+ )
+ 
+ const (
+-	maxUsersLimit     = 200
+-	maxUsersHardLimit = 250
++	maxUsersLimit     = 10000000
++	maxUsersHardLimit = 10000000
+ )
+ 
+ func (a *App) GetServerLimits() (*model.ServerLimits, *model.AppError) {
+    

--- a/pkgs/by-name/ma/mattermost/package.nix
+++ b/pkgs/by-name/ma/mattermost/package.nix
@@ -13,6 +13,8 @@
   nixosTests,
 
   latestVersionInfo ? null,
+  removeUserLimit ? false,
+  removeFreeBadge ? false,
   versionInfo ? {
     # ESR releases only. Note: if NixOS would release with an ESR that goes out
     # of support during the lifetime of the NixOS release, it is acceptable
@@ -135,6 +137,14 @@ buildMattermost rec {
       mv package-lock.fixed.json package-lock.json
     '';
   };
+
+  patches =
+    lib.optionals removeFreeBadge [
+      ./mattermost-remove-free-banner.patch
+    ]
+    ++ lib.optionals removeUserLimit [
+      ./mattermost-remove-user-limit.patch
+    ];
 
   # Needed because buildGoModule does not support go workspaces yet.
   # We use go 1.22's workspace vendor command, which is not yet available


### PR DESCRIPTION
Patches for user limit (set at 200 users) and for free banner removal

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].