### PR TITLE
adw-bluetooth: 1.0.0 -> 1.1.0, init NixOS module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -77,6 +77,8 @@
 
 - [ImmichFrame](https://immichframe.dev/), display your photos from Immich as a digital photo frame. Available as [services.immichframe](#opt-services.immichframe.enable).
 
+- [adw-bluetooth](https://github.com/ezratweaver/adw-bluetooth), a GNOME-inspired LibAdwaita Bluetooth applet. Available as [services.adw-bluetooth](#opt-services.adw-bluetooth.enable).
+
 - [PdfDing](https://www.pdfding.com/), manage, view and edit your PDFs seamlessly on all your devices wherever you are. Available as [services.pdfding](#opt-services.pdfding.enable).
 
 - [mangowc](https://github.com/DreamMaoMao/mangowc), a lightweight and feature-rich Wayland compositor based on dwl. Available as [programs.mangowc](#opt-programs.mangowc.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -557,6 +557,7 @@
   ./services/databases/victoriametrics.nix
   ./services/databases/victoriatraces.nix
   ./services/desktops/accountsservice.nix
+  ./services/desktops/adw-bluetooth.nix
   ./services/desktops/ayatana-indicators.nix
   ./services/desktops/bamf.nix
   ./services/desktops/blueman.nix

--- a/nixos/modules/services/desktops/adw-bluetooth.nix
+++ b/nixos/modules/services/desktops/adw-bluetooth.nix
@@ -13,11 +13,12 @@ in
 
   options.services.adw-bluetooth = {
     enable = lib.mkEnableOption "Adwaita Bluetooth daemon";
+    package = lib.mkPackageOption pkgs "adw-bluetooth" { };
   };
 
   config = lib.mkIf cfg.enable {
-    environment.systemPackages = [ pkgs.adw-bluetooth ];
-    services.dbus.packages = [ pkgs.adw-bluetooth ];
+    environment.systemPackages = [ cfg.package ];
+    services.dbus.packages = [ cfg.package ];
 
     systemd.user.services.adw-bluetooth-daemon = {
       description = "AdwBluetooth Daemon";
@@ -26,7 +27,7 @@ in
       serviceConfig = {
         Type = "dbus";
         BusName = "com.ezratweaver.AdwBluetoothDaemon";
-        ExecStart = "${pkgs.adw-bluetooth}/libexec/adw-bluetooth-daemon";
+        ExecStart = "${cfg.package}/libexec/adw-bluetooth-daemon";
       };
     };
   };

--- a/nixos/modules/services/desktops/adw-bluetooth.nix
+++ b/nixos/modules/services/desktops/adw-bluetooth.nix
@@ -1,0 +1,33 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.adw-bluetooth;
+in
+{
+  meta.maintainers = with lib.maintainers; [ ezratweaver ];
+
+  options.services.adw-bluetooth = {
+    enable = lib.mkEnableOption "Adwaita Bluetooth daemon";
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.adw-bluetooth ];
+    services.dbus.packages = [ pkgs.adw-bluetooth ];
+
+    systemd.user.services.adw-bluetooth-daemon = {
+      description = "AdwBluetooth Daemon";
+      wantedBy = [ "default.target" ];
+      after = [ "bluetooth.target" ];
+      serviceConfig = {
+        Type = "dbus";
+        BusName = "com.ezratweaver.AdwBluetoothDaemon";
+        ExecStart = "${pkgs.adw-bluetooth}/libexec/adw-bluetooth-daemon";
+      };
+    };
+  };
+}

--- a/pkgs/by-name/ad/adw-bluetooth/package.nix
+++ b/pkgs/by-name/ad/adw-bluetooth/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  buildGoModule,
   meson,
   ninja,
   pkg-config,
@@ -13,16 +14,26 @@
   libadwaita,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
-  pname = "adw-bluetooth";
-  version = "1.0.0";
+let
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "ezratweaver";
     repo = "adw-bluetooth";
-    tag = finalAttrs.version;
-    hash = "sha256-/KJpB9i6tFDnB3C0tPtJtt8tTDfNftIkHmP1JSVSZNY=";
+    tag = version;
+    hash = "sha256-h3cHtecwBsx3j33qXVn/zaq4FZext71P7flzunCHqHg=";
   };
+
+  daemon = buildGoModule {
+    pname = "adw-bluetooth-daemon";
+    inherit version;
+    src = src + "/daemon";
+    vendorHash = "sha256-7tiSwNhq6e4LEh4lUkfh2i4tEdWWL6TxQpYYwYKsfog=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "adw-bluetooth";
+  inherit version src;
 
   nativeBuildInputs = [
     meson
@@ -38,6 +49,13 @@ stdenv.mkDerivation (finalAttrs: {
     gjs
     libadwaita
   ];
+
+  mesonFlags = [ "-Dbuild_daemon=false" ];
+
+  postInstall = ''
+    mkdir -p $out/libexec
+    ln -s ${daemon}/bin/daemon $out/libexec/adw-bluetooth-daemon
+  '';
 
   meta = {
     description = "GNOME Inspired LibAdwaita Bluetooth Applet";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bumps adw-bluetooth to 1.1.0, which adds a Go-based D-Bus daemon. Also adds a NixOS module (services.adw-bluetooth) to manage the daemon as a systemd user service.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
