### PR TITLE
scoop-installer: init at 0.5.3

### DIFF
--- a/pkgs/by-name/sc/scoop-installer/package.nix
+++ b/pkgs/by-name/sc/scoop-installer/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  makeWrapper,
+  runCommand,
+  powershell,
+  scoop-installer,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "scoop-installer";
+  version = "0.5.3";
+
+  src = fetchFromGitHub {
+    owner = "ScoopInstaller";
+    repo = "Scoop";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-3/fU4UGou2n4wBhj9gqRDrmdbzMd9pWuNn2gZbeCF/0=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/scoop
+    cp -r . $out/share/scoop
+
+    makeWrapper ${lib.getExe powershell} $out/bin/scoop \
+      --run 'export SCOOP="''${SCOOP:-$HOME/scoop}"' \
+      --run 'mkdir -p "$SCOOP/shims" "$SCOOP/buckets"' \
+      --add-flags "-NoLogo -NoProfile -ExecutionPolicy Bypass -File $out/share/scoop/bin/scoop.ps1"
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    tests.help =
+      runCommand "scoop-help-test"
+        {
+          name = "scoop-help-test";
+          nativeBuildInputs = [ scoop-installer ];
+        }
+        ''
+          export HOME="$PWD/home"
+          scoop help > output
+          grep -F "Usage: scoop <command> [<args>]" output
+          touch $out
+        '';
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Command-line installer for Windows";
+    homepage = "https://scoop.sh/";
+    changelog = "https://github.com/ScoopInstaller/Scoop/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [
+      mit
+      unlicense
+    ];
+    maintainers = with lib.maintainers; [ caniko ];
+    mainProgram = "scoop";
+    inherit (powershell.meta) platforms;
+  };
+})

--- a/pkgs/by-name/sc/scoop-installer/package.nix
+++ b/pkgs/by-name/sc/scoop-installer/package.nix
@@ -20,6 +20,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     hash = "sha256-3/fU4UGou2n4wBhj9gqRDrmdbzMd9pWuNn2gZbeCF/0=";
   };
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''


### PR DESCRIPTION
Add ScoopInstaller's Scoop as a new package.

ScoopInstaller's Scoop is exposed as `scoop-installer` to avoid colliding with the existing open PR for Harvard LIL's unrelated `scoop` web-archiving tool. The installed binary is still `scoop`.

Validated locally:

- `nix build .#scoop-installer .#scoop-installer.tests.help --print-build-logs`
- `nix eval --impure --expr 'let pkgs = import ./. { config.allowUnfree = true; }; in pkgs.scoop-installer.updateScript'`
- `printf '\n' | nix-shell maintainers/scripts/update.nix --argstr package scoop-installer`
- `./ci/nixpkgs-vet.sh master https://github.com/NixOS/nixpkgs.git`

`nixpkgs-review-gha` passed on `x86_64-linux`, `aarch64-linux`, `x86_64-darwin`, and `aarch64-darwin`: https://github.com/caniko/nixpkgs-review-gha/actions/runs/26280086317

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


