### PR TITLE
importNpmLock: workspace support

### DIFF
--- a/pkgs/build-support/node/import-npm-lock/default.nix
+++ b/pkgs/build-support/node/import-npm-lock/default.nix
@@ -190,6 +190,7 @@ lib.fix (self: {
       # Backwards compatibility: if derivationArgs contains passAsFile,
       # we can't force structuredAttrs here yet.
       __structuredAttrs = !(derivationArgs ? passAsFile);
+      workspaces = lib.optionals (npmRoot != null) (package.workspaces or [ ]);
     in
     stdenv.mkDerivation (
       {
@@ -210,6 +211,7 @@ lib.fix (self: {
           mkdir $out
           cp package.json $out/
           cp package-lock.json $out/
+          ${lib.concatMapStringsSep "\n" (w: "cp -R ${w} $out/") workspaces}
           [[ -d node_modules ]] && mv node_modules $out/
           runHook postInstall
         '';
@@ -237,6 +239,11 @@ lib.fix (self: {
                 cp --no-preserve=mode "$packageLockPath" package-lock.json
               ''
           )
+          + ''
+            ${lib.concatMapStringsSep "\n" (
+              w: "install --mode ugo=r -Dt ${w} ${npmRoot}/${w}/package.json"
+            ) workspaces}
+          ''
           + derivationArgs.postPatch or "";
 
         inherit __structuredAttrs;

--- a/pkgs/build-support/node/import-npm-lock/hooks/link-node-modules.js
+++ b/pkgs/build-support/node/import-npm-lock/hooks/link-node-modules.js
@@ -14,88 +14,127 @@ async function asyncFilter(arr, pred) {
   return filtered;
 }
 
+async function isSymlinkWithTargetPathPrefix(path, targetPathPrefix) {
+  const stat = await fs.promises.lstat(path);
+  if (!stat.isSymbolicLink()) {
+    return false;
+  }
+  const targetPath = await fs.promises.readlink(path);
+  return targetPath.startsWith(targetPathPrefix);
+}
+
 // Get a list of all _unmanaged_ files in node_modules.
 // This means every file in node_modules that is _not_ a symlink to the Nix store.
-async function getUnmanagedFiles(storePrefix, files) {
+async function getUnmanagedFiles(storePrefix, dir, files) {
   return await asyncFilter(files, async (file) => {
-    const filePath = path.join(node_modules, file);
-
-    // Is file a symlink
-    const stat = await fs.promises.lstat(filePath);
-    if (!stat.isSymbolicLink()) {
-      return true;
-    }
-
-    // Is file in the store
-    const linkTarget = await fs.promises.readlink(filePath);
-    return !linkTarget.startsWith(storePrefix);
+    const filePath = path.join(dir, file);
+    return !await isSymlinkWithTargetPathPrefix(filePath, storePrefix);
   });
 }
 
-async function main() {
-  const args = process.argv.slice(2);
-  const storePrefix = args[0];
-  const sourceModules = args[1];
+async function replaceFile(targetPath, createFile) {
+  const tmpPath = `${targetPath}.tmp.${process.pid}`
+  await createFile(tmpPath);
+  await fs.promises.rename(tmpPath, targetPath);
+}
 
-  // Ensure node_modules exists
+async function replaceSymlink(targetPath, linkPath, createSymlink) {
+  // No need to replace the symlink if it already points to the right target
   try {
-    await fs.promises.mkdir(node_modules);
+    if (await fs.promises.readlink(linkPath) === targetPath) {
+      return;
+    }
+  } catch (err) {
+    // If the symlink doesn't already exist, keep going. If we get a
+    // different error trying to read it, fail.
+    if (err.code !== "ENOENT") {
+      throw err;
+    }
+  }
+  // Replace the link, if it exists, atomically.
+  await replaceFile(linkPath, (tmpPath) => createSymlink(targetPath, tmpPath));
+}
+
+async function ensureSymlink(targetPath, linkPath) {
+  replaceSymlink(targetPath, linkPath, fs.promises.symlink);
+}
+
+// Works like `cp --no-dereference`
+async function copySymlink(source, target) {
+  const sourceTarget = await fs.promises.readlink(source);
+  await fs.promises.symlink(sourceTarget, target);
+}
+
+async function ensureCopySymlink(targetPath, linkPath) {
+  await replaceSymlink(targetPath, linkPath, copySymlink);
+}
+
+async function relinkModulesDir(sourceDir, targetDir, storePrefix, workspaceLinkTargetPathPrefix = "../") {
+  // Ensure directory exists
+  try {
+    await fs.promises.mkdir(targetDir);
   } catch (err) {
     if (err.code !== "EEXIST") {
       throw err;
     }
   }
 
-  const files = await fs.promises.readdir(node_modules);
+  const files = await fs.promises.readdir(targetDir);
 
   // Get deny list of files that we don't manage.
   // We do manage nix store symlinks, but not other files.
   // For example: If a .vite was present in both our
   // source node_modules and the non-store node_modules we don't want to overwrite
   // the non-store one.
-  const unmanaged = await getUnmanagedFiles(storePrefix, files);
+  const unmanaged = await getUnmanagedFiles(storePrefix, targetDir, files);
   const managed = new Set(files.filter((file) => ! unmanaged.includes(file)));
 
-  const sourceFiles = await fs.promises.readdir(sourceModules);
+  const sourceFiles = await fs.promises.readdir(sourceDir);
   await Promise.all(
     sourceFiles.map(async (file) => {
-      const sourcePath = path.join(sourceModules, file);
-      const targetPath = path.join(node_modules, file);
+      const sourcePath = path.join(sourceDir, file);
+      const targetPath = path.join(targetDir, file);
+      // Is this a scoped directory?
+      if (file[0] === "@") {
+        // If so, walk it because it might also contain symlinks to workspace source directories (see below)
+        await relinkModulesDir(sourcePath, targetPath, storePrefix, path.join(workspaceLinkTargetPathPrefix, "../"));
+      } else {
+        // Is this a relative symlink, potentially pointing to a workspace source directory?
+        if (await isSymlinkWithTargetPathPrefix(sourcePath, workspaceLinkTargetPathPrefix)) {
+          // If so, copy it instead of linking to it so that it points to the local workspace source
+          // directory rather than the one in the nix store. This allows working on the workspace
+          // code without having to rebuild node_modules for every change.
+          await ensureCopySymlink(sourcePath, targetPath);
+        } else {
+          // Skip file if it's not a symlink to a store path
+          if (unmanaged.includes(file)) {
+            console.log(`'${targetPath}' exists, cowardly refusing to link.`);
+            return;
+          }
 
-      // Skip file if it's not a symlink to a store path
-      if (unmanaged.includes(file)) {
-        console.log(`'${targetPath}' exists, cowardly refusing to link.`);
-        return;
-      }
+          // Otherwise, link it
+          await ensureSymlink(sourcePath, targetPath);
 
-      // Don't unlink this file, we just wrote it.
-      managed.delete(file);
-
-      // No need to replace the symlink if it already points to the right target
-      try {
-        if (await fs.promises.readlink(targetPath) === sourcePath) {
-          return
+          // Don't unlink this file, we just wrote it.
+          managed.delete(file);
         }
-      } catch (err) {
-        // If the symlink doesn't already exist, keep going. If we get a
-        // different error trying to stat it, fail.
-        if (err.code !== "ENOENT") {
-          throw err;
-        }
       }
-      // Replace the link, if it exists, atomically.
-      const tmpPath = `${targetPath}.tmp.${process.pid}`
-      await fs.promises.symlink(sourcePath, tmpPath);
-      await fs.promises.rename(tmpPath, targetPath);
     })
   );
 
   // Clean up store symlinks not included in this generation of node_modules
   await Promise.all(
     Array.from(managed).map((file) =>
-      fs.promises.unlink(path.join(node_modules, file)),
+      fs.promises.unlink(path.join(targetDir, file)),
     )
   );
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const storePrefix = args[0];
+  const sourceModules = args[1];
+  await relinkModulesDir(sourceModules, node_modules, storePrefix);
 }
 
 main();


### PR DESCRIPTION
This change adds support for [npm workspaces](https://docs.npmjs.com/cli/v11/using-npm/workspaces) to `importNpmLock.buildNodeModules` and `importNpmLock.linkNodeModulesHook` so that the linked `node_modules` directory can be used when working on projects with workspaces. It consists of two parts:

1. When building the `node_modules` derivation (via `buildNodeModules`), we now also carry over all workspaces' `package.json` files. This has two effects:
    1. For every workspace, there will be a (relative) symlink which points to the workspace's source directory, allowing for inter-workspace dependencies.
    2. Programs provided by dependencies which are only declared in a workspace's `package.json` (i.e. not in the top-level `package.json`) will be symlinked in `node_modules/.bin` (mostly relevant for dev tooling)
2. When `node_modules` for a dev shell (via `linkNodeModulesHook`), we now preserve these relative workspace symlinks so that they point to the project's working directory rather than the nix store.

Hope it makes sense!

FTR: This is patch set 100% brain-coded :100: :brain: :smile: 


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
