### PR TITLE
haskell.packages.microhs: fix eval after bump to nightly

### DIFF
--- a/pkgs/development/haskell-modules/configuration-microhs.nix
+++ b/pkgs/development/haskell-modules/configuration-microhs.nix
@@ -38,6 +38,7 @@ self: super: {
   Cabal-syntax = doDistribute self.Cabal-syntax_3_16_1_0;
   containers = doDistribute self.containers_0_8;
   exceptions = doDistribute self.exceptions_0_10_12;
+  file-io = markBroken self.file-io_0_2_0;
   filepath = doDistribute self.filepath_1_5_5_0;
   ghc-bignum = null;
   ghc-boot = null;
@@ -49,6 +50,8 @@ self: super: {
   ghc-platform = null;
   ghc-prim = null;
   ghci = null;
+  haddock-api = markBroken self.haddock-api_2_29_1; # depends on ghc
+  haddock-library = markBroken self.haddock-library_1_11_0; # depends on ghc
   haskeline = doDistribute self.haskeline_0_8_4_1;
   hpc = markBroken self.hpc_0_7_0_2;
   integer-gmp = markBroken self.integer-gmp_1_1;
@@ -63,7 +66,7 @@ self: super: {
   system-cxx-std-lib = null;
   template-haskell = null;
   terminfo = doDistribute self.terminfo_0_4_1_7;
-  time = doDistribute self.time_1_15;
+  time = doDistribute self.time_1_16;
   transformers = doDistribute self.transformers_0_6_3_0;
   unix = markBroken self.unix_2_8_8_0;
   xhtml = markBroken self.xhtml_3000_4_0_0;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

cc fyi @AlexandreTunstall 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
