### PR TITLE
esphome: 2026.4.5 -> 2026.5.0

### DIFF
--- a/pkgs/by-name/es/esphome/dashboard.nix
+++ b/pkgs/by-name/es/esphome/dashboard.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "esphome-dashboard";
-  version = "20260408.1";
+  version = "20260425.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "esphome";
     repo = "dashboard";
     tag = finalAttrs.version;
-    hash = "sha256-OY7s/b0rWmjI9QfmEwj3VxbTFrj99fyf9x1tPl24RbI=";
+    hash = "sha256-OhvRPIvytLmWkIvO45arikC3+7WCTdsEOwswuSAx0XA=";
   };
 
   npmDeps = fetchNpmDeps {

--- a/pkgs/by-name/es/esphome/package.nix
+++ b/pkgs/by-name/es/esphome/package.nix
@@ -33,14 +33,14 @@ let
 in
 python.pkgs.buildPythonApplication (finalAttrs: {
   pname = "esphome";
-  version = "2026.4.5";
+  version = "2026.5.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "esphome";
     repo = "esphome";
     tag = finalAttrs.version;
-    hash = "sha256-uMlkrHg4cZYsdSv8D8U57mEZnjwcRkJe2zKI8VFsTRk=";
+    hash = "sha256-oWlzpBzDOSrXv+gOnFSL7TQqDZJc3oN2RoAW2ywFCGo=";
   };
 
   patches = [
@@ -73,7 +73,7 @@ python.pkgs.buildPythonApplication (finalAttrs: {
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail "setuptools==82.0.1" "setuptools" \
-      --replace-fail "wheel>=0.43,<0.47" "wheel"
+      --replace-fail "wheel>=0.43,<0.48" "wheel"
   '';
 
   # Remove esptool and platformio from requirements
@@ -189,6 +189,7 @@ python.pkgs.buildPythonApplication (finalAttrs: {
     # Patched to run platformio without the esphome wrapper
     "test_run_platformio_cli_strips_win_long_path_prefix"
     "test_run_platformio_cli_does_not_set_pythonexepath_without_strip"
+    "test_patch_file_downloader_recovers_against_real_server"
   ];
 
   passthru = {

--- a/pkgs/by-name/es/esphome/platformio-binary-reference.patch
+++ b/pkgs/by-name/es/esphome/platformio-binary-reference.patch
@@ -1,12 +1,12 @@
-diff --git a/esphome/platformio_api.py b/esphome/platformio_api.py
-index 81ff01306..2dfa523dd 100644
---- a/esphome/platformio_api.py
-+++ b/esphome/platformio_api.py
+diff --git a/esphome/platformio/toolchain.py b/esphome/platformio/toolchain.py
+index 073e134ac4..2dfa523ddc 100644
+--- a/esphome/platformio/toolchain.py
++++ b/esphome/platformio/toolchain.py
 @@ -64,7 +64,7 @@ def run_platformio_cli(*args, **kwargs) -> str | int:
          # a user-provided value (or the unmodified path on platforms that
          # don't need the strip).
          os.environ["PYTHONEXEPATH"] = python_exe
--    cmd = [python_exe, "-m", "esphome.platformio_runner"] + list(args)
+-    cmd = [python_exe, "-m", "esphome.platformio.runner"] + list(args)
 +    cmd = ["platformio"] + list(args)
  
      return run_external_process(*cmd, **kwargs)


### PR DESCRIPTION
https://esphome.io/changelog/2026.5.0/

Untested

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
