### PR TITLE
python3Packages.harfile: init at 0.4.0

### DIFF
--- a/pkgs/development/python-modules/harfile/default.nix
+++ b/pkgs/development/python-modules/harfile/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  hatchling,
+
+  # tests
+  hypothesis,
+  jsonschema,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "harfile";
+  version = "0.4.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-NOLZ7zQQHXaVZr/6s8Qg4Ud3YXQwi+0aA27Y22AMq94=";
+  };
+
+  build-system = [ hatchling ];
+
+  nativeCheckInputs = [
+    hypothesis
+    jsonschema
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "harfile" ];
+
+  meta = {
+    description = "Writer for HTTP Archive (HAR) files";
+    homepage = "https://github.com/schemathesis/harfile";
+    changelog = "https://github.com/schemathesis/harfile/blob/main/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tembleking ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7429,6 +7429,8 @@ self: super: with self; {
 
   hap-python = callPackage ../development/python-modules/hap-python { };
 
+  harfile = callPackage ../development/python-modules/harfile { };
+
   harlequin-bigquery = callPackage ../development/python-modules/harlequin-bigquery { };
 
   harlequin-postgres = callPackage ../development/python-modules/harlequin-postgres { };


### PR DESCRIPTION
Adds the `harfile` Python library at 0.4.0. Required as a transitive dependency for an upcoming `schemathesis` packaging effort.

<https://github.com/schemathesis/harfile>

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For new packages: Added a release notes entry if relevant
- [x] Tested, as applicable:
  - [x] [`nix.conf`](https://nixos.org/manual/nix/stable/command-ref/conf-file.html) configuration changes are tested via `nixos-rebuild build` or `nix-build`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)