### PR TITLE
python3Packages.hypothesis-jsonschema: init at 0.23.1

### DIFF
--- a/pkgs/development/python-modules/hypothesis-jsonschema/default.nix
+++ b/pkgs/development/python-modules/hypothesis-jsonschema/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  hypothesis,
+  jsonschema,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "hypothesis-jsonschema";
+  version = "0.23.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-9KwDICQ0KkFJoQJTmE9aVza4Kz/ir7CIjzg0oxFT8hU=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    hypothesis
+    jsonschema
+  ];
+
+  # Tests require a `gen_schemas` helper module and a JSON Schema corpus that
+  # are not shipped in the PyPI sdist.
+  doCheck = false;
+
+  pythonImportsCheck = [ "hypothesis_jsonschema" ];
+
+  meta = {
+    description = "Hypothesis strategies for JSON-Schema-based property testing";
+    homepage = "https://github.com/python-jsonschema/hypothesis-jsonschema";
+    changelog = "https://github.com/python-jsonschema/hypothesis-jsonschema/blob/master/CHANGELOG.md";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ tembleking ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7399,6 +7399,8 @@ self: super: with self; {
 
   hypothesis-auto = callPackage ../development/python-modules/hypothesis-auto { };
 
+  hypothesis-jsonschema = callPackage ../development/python-modules/hypothesis-jsonschema { };
+
   hypothesis_6_136 = callPackage ../development/python-modules/hypothesis/hypothesis_6_136.nix { };
 
   hypothesmith = callPackage ../development/python-modules/hypothesmith { };


### PR DESCRIPTION
Adds the `hypothesis-jsonschema` Python library at 0.23.1. Hypothesis strategies for JSON-Schema-based property testing. Required as a transitive dependency for an upcoming `schemathesis` packaging effort.

<https://github.com/python-jsonschema/hypothesis-jsonschema>

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For new packages: Added a release notes entry if relevant
- [x] Tested, as applicable:
  - [x] `nix-build`
- [x] Tested basic functionality
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)