### PR TITLE
python3Packages.starlette-testclient: init at 0.4.1

### DIFF
--- a/pkgs/development/python-modules/starlette-testclient/default.nix
+++ b/pkgs/development/python-modules/starlette-testclient/default.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  requests,
+  starlette,
+
+  # tests
+  anyio,
+  dirty-equals,
+  pytestCheckHook,
+  sniffio,
+  trio,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "starlette-testclient";
+  version = "0.4.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "starlette_testclient";
+    inherit (finalAttrs) version;
+    hash = "sha256-npk//hL6tFYGEWJXgTmGYSJi/hXBu23J45zGhpOsH8U=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    requests
+    starlette
+  ];
+
+  nativeCheckInputs = [
+    anyio
+    dirty-equals
+    pytestCheckHook
+    sniffio
+    trio
+  ];
+
+  pytestFlags = [
+    # ResourceWarnings from newer anyio fail the suite due to upstream
+    # filterwarnings = ["error"] in pyproject.toml
+    "-Wignore::ResourceWarning"
+  ];
+
+  pythonImportsCheck = [ "starlette_testclient" ];
+
+  meta = {
+    description = "Backport of Starlette TestClient using requests";
+    homepage = "https://github.com/Kludex/starlette-testclient";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ tembleking ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19595,6 +19595,8 @@ self: super: with self; {
 
   starlette-context = callPackage ../development/python-modules/starlette-context { };
 
+  starlette-testclient = callPackage ../development/python-modules/starlette-testclient { };
+
   starlette-wtf = callPackage ../development/python-modules/starlette-wtf { };
 
   starline = callPackage ../development/python-modules/starline { };


### PR DESCRIPTION
Adds the `starlette-testclient` Python library at 0.4.1. Provides the legacy `requests`-based `TestClient` extracted from Starlette. Required as a transitive dependency for an upcoming `schemathesis` packaging effort.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For new packages: Added a release notes entry if relevant
- [x] Tested, as applicable:
  - [x] `nix-build`
- [x] Tested basic functionality
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)