### PR TITLE
balls: 5.4.0 -> 6.0.1

### DIFF
--- a/pkgs/by-name/ba/balls/lock.json
+++ b/pkgs/by-name/ba/balls/lock.json
@@ -2,110 +2,146 @@
   "depends": [
     {
       "method": "fetchzip",
-      "path": "/nix/store/zjgvbd2l57kn33qnngr17qdqsinwqhzl-source",
-      "rev": "46ecdd598dbafeb0e0ba38e87e6bc98b4637cd13",
-      "sha256": "1rsl8z2gsa0pqh4wx8dvdjf94b0wn4bfbvcq9bfcvc7qkmn96mkg",
-      "url": "https://github.com/disruptek/ups/archive/46ecdd598dbafeb0e0ba38e87e6bc98b4637cd13.tar.gz",
-      "ref": "0.4.0",
       "packages": [
         "ups"
       ],
-      "srcDir": ""
+      "path": "/nix/store/zjgvbd2l57kn33qnngr17qdqsinwqhzl-source",
+      "ref": "0.4.0",
+      "rev": "46ecdd598dbafeb0e0ba38e87e6bc98b4637cd13",
+      "sha256": "1rsl8z2gsa0pqh4wx8dvdjf94b0wn4bfbvcq9bfcvc7qkmn96mkg",
+      "srcDir": "",
+      "url": "https://github.com/disruptek/ups/archive/46ecdd598dbafeb0e0ba38e87e6bc98b4637cd13.tar.gz"
     },
     {
       "method": "fetchzip",
-      "path": "/nix/store/sh8prqisw6dmi91hbi7c4x934vvgy46p-source",
-      "rev": "64f71af2fa4572c2bdf8987a56a427c1d88fc34f",
-      "sha256": "1slqsl9gj782hlfzpklxwdy0hip6hhykrk226xzq31sg40nfh9r6",
-      "url": "https://github.com/haltcase/glob/archive/64f71af2fa4572c2bdf8987a56a427c1d88fc34f.tar.gz",
       "packages": [
         "glob"
       ],
-      "srcDir": "src"
+      "path": "/nix/store/sh8prqisw6dmi91hbi7c4x934vvgy46p-source",
+      "rev": "64f71af2fa4572c2bdf8987a56a427c1d88fc34f",
+      "sha256": "1slqsl9gj782hlfzpklxwdy0hip6hhykrk226xzq31sg40nfh9r6",
+      "srcDir": "src",
+      "url": "https://github.com/haltcase/glob/archive/64f71af2fa4572c2bdf8987a56a427c1d88fc34f.tar.gz"
     },
     {
       "method": "fetchzip",
-      "path": "/nix/store/z211zbzrd1808rpr5j8lgfzc7rqwqpbr-source",
-      "rev": "358c8969183dcf365cbc34f9c9c035da0f8c60c7",
-      "sha256": "1x2rp0wj048hvbrj7xkdm408adj16rr8wg4wdfynxxryl08vl30l",
-      "url": "https://github.com/disruptek/insideout/archive/358c8969183dcf365cbc34f9c9c035da0f8c60c7.tar.gz",
-      "ref": "0.1.0",
       "packages": [
         "insideout"
       ],
-      "srcDir": ""
+      "path": "/nix/store/q62rizai2nwm1x8skld29b2i7g9rad9h-source",
+      "ref": "1.0.9",
+      "rev": "7c8f2730df0c4efad1b18cd12f967dc823543aa0",
+      "sha256": "0akfhi59vmy9sqwx508p3d6bfx7px5aqmb4qzhb48f5b9klp7vvz",
+      "srcDir": "",
+      "url": "https://github.com/disruptek/insideout/archive/7c8f2730df0c4efad1b18cd12f967dc823543aa0.tar.gz"
     },
     {
       "method": "fetchzip",
-      "path": "/nix/store/xpn694ibgipj8xak3j4bky6b3k0vp7hh-source",
-      "rev": "ec0cc6e64ea4c62d2aa382b176a4838474238f8d",
-      "sha256": "1fi9ls3xl20bmv1ikillxywl96i9al6zmmxrbffx448gbrxs86kg",
-      "url": "https://github.com/zevv/npeg/archive/ec0cc6e64ea4c62d2aa382b176a4838474238f8d.tar.gz",
-      "ref": "1.2.2",
-      "packages": [
-        "npeg"
-      ],
-      "srcDir": "src"
-    },
-    {
-      "method": "fetchzip",
-      "path": "/nix/store/fclb7r25h7ldq4k8lrc9mc614nihyhp7-source",
-      "rev": "667736f52983239aa6b76a07605add23598362ca",
-      "sha256": "0y1a9p21hclrm2p3x018idrh4sk09hpr6csvcrnh5ka6baj6wj3k",
-      "url": "https://github.com/nim-works/cps/archive/667736f52983239aa6b76a07605add23598362ca.tar.gz",
-      "ref": "0.11.1",
       "packages": [
         "cps"
       ],
-      "srcDir": ""
+      "path": "/nix/store/hfzhrr71gq66dg8mbdqsfvikp134vc9c-source",
+      "ref": "0.11.4",
+      "rev": "f0ffe895d5cf5615228a2119444e23c3434217f6",
+      "sha256": "0xqqs2xf10c4pxmah3yaqchqm1mygqjb13i38yswq42ir0xsdjv2",
+      "srcDir": "",
+      "url": "https://github.com/nim-works/cps/archive/f0ffe895d5cf5615228a2119444e23c3434217f6.tar.gz"
     },
     {
       "method": "fetchzip",
-      "path": "/nix/store/y6w1gzbf6i691z35rbn6kzrmf1n5bmdc-source",
-      "rev": "cb8b7bfdcdc2272aadf92153c668acd3c901bd6b",
-      "sha256": "1ggp5rvs217dv2n0p5ddm5h17pv2mc7724n8cd0b393kmsjiykhz",
-      "url": "https://github.com/nitely/nim-regex/archive/cb8b7bfdcdc2272aadf92153c668acd3c901bd6b.tar.gz",
-      "ref": "v0.25.0",
+      "packages": [
+        "loony"
+      ],
+      "path": "/nix/store/ngxw7vd9y8s7r3sv0yzs20iwncfr2f76-source",
+      "ref": "0.3.1",
+      "rev": "cc65bd51c2ddde2578959f57c933efde106cfeeb",
+      "sha256": "16vr1sl4bql16bicqkq177lx73jc8lhl89nvm85lb4c4cz3s05zm",
+      "srcDir": "",
+      "url": "https://github.com/nim-works/loony/archive/cc65bd51c2ddde2578959f57c933efde106cfeeb.tar.gz"
+    },
+    {
+      "method": "fetchzip",
+      "packages": [
+        "trees"
+      ],
+      "path": "/nix/store/l1zsa6n0vs4rsq1j6r126csb50m151dk-source",
+      "ref": "1.0.0",
+      "rev": "5f5152bea815a28e32133b16be92ba03ce878f42",
+      "sha256": "0xdiy1q2363ahpbfdh5bj4m85c3zh55drn6sdps379hhsf98w107",
+      "srcDir": "",
+      "url": "https://github.com/disruptek/trees/archive/5f5152bea815a28e32133b16be92ba03ce878f42.tar.gz"
+    },
+    {
+      "method": "fetchzip",
+      "packages": [
+        "arc"
+      ],
+      "path": "/nix/store/9x9b9nvm9zxw6lrrbfyif258pm423j9l-source",
+      "ref": "0.0.4",
+      "rev": "6be4911be5cb877d30a8e71ed86c8d8035c3ebb9",
+      "sha256": "1wh4k9z8gv6510wyg0js1gg7dlr19dvwdi7bjyxp1kz4xpcc4j0b",
+      "srcDir": "",
+      "url": "https://github.com/nim-works/arc/archive/6be4911be5cb877d30a8e71ed86c8d8035c3ebb9.tar.gz"
+    },
+    {
+      "method": "fetchzip",
+      "packages": [
+        "npeg"
+      ],
+      "path": "/nix/store/4gpjryla9dlnb899jjx3cqp99z3h4a83-source",
+      "ref": "1.3.0",
+      "rev": "409f6796d0e880b3f0222c964d1da7de6e450811",
+      "sha256": "1h2f5znbpa3svk7wsw2axn8f7f59d23xq85z148kiv6fqh0ffwbm",
+      "srcDir": "src",
+      "url": "https://github.com/zevv/npeg/archive/409f6796d0e880b3f0222c964d1da7de6e450811.tar.gz"
+    },
+    {
+      "method": "fetchzip",
       "packages": [
         "regex"
       ],
-      "srcDir": "src"
+      "path": "/nix/store/73h80vbxzpffpywzdjycak8a1y7cdqdb-source",
+      "ref": "v0.26.3",
+      "rev": "4593305ed1e49731fc75af1dc572dd2559aad19c",
+      "sha256": "1b666qws5sva3n5allin0ycvnqlzdjd7xzprpdvv632ccqddzcl9",
+      "srcDir": "src",
+      "url": "https://github.com/nitely/nim-regex/archive/4593305ed1e49731fc75af1dc572dd2559aad19c.tar.gz"
     },
     {
       "method": "fetchzip",
-      "path": "/nix/store/1mcck56sr1h1sf8gv87m761x6f3d1k0l-source",
-      "rev": "7c6ee4bfc184d7121896a098d68b639a96df7af1",
-      "sha256": "06j8d0bjbpv1iibqlmrac4qb61ggv17hvh6nv4pbccqk1rlpxhsq",
-      "url": "https://github.com/nitely/nim-unicodedb/archive/7c6ee4bfc184d7121896a098d68b639a96df7af1.tar.gz",
-      "ref": "v0.9.0",
       "packages": [
         "unicodedb"
       ],
-      "srcDir": "src"
+      "path": "/nix/store/1mcck56sr1h1sf8gv87m761x6f3d1k0l-source",
+      "ref": "v0.13.2",
+      "rev": "66f2458710dc641dd4640368f9483c8a0ec70561",
+      "sha256": "092z3glgdb7rmwajm7dmqzvralkm7ixighixk8ycf8sf17zm72ck",
+      "srcDir": "src",
+      "url": "https://github.com/nitely/nim-unicodedb/archive/66f2458710dc641dd4640368f9483c8a0ec70561.tar.gz"
     },
     {
       "method": "fetchzip",
-      "path": "/nix/store/16fm03dql3pplz3ip40k0nbxw1gc0880-source",
-      "rev": "f5d50197b266173dd4ca4c6fdd30361398433bb4",
-      "sha256": "1cd3n9l45z60gpv0rc84v1ngkjxn0i45vz0lzy63052m7m0j2rks",
-      "url": "https://github.com/nitely/nim-unicodeplus/archive/f5d50197b266173dd4ca4c6fdd30361398433bb4.tar.gz",
-      "ref": "v0.9.1",
       "packages": [
         "unicodeplus"
       ],
-      "srcDir": "src"
+      "path": "/nix/store/16fm03dql3pplz3ip40k0nbxw1gc0880-source",
+      "ref": "v0.14.2",
+      "rev": "f802d012290c32a69a774f2e7ea889546c1132e7",
+      "sha256": "0qi653q19340hnay17s8zm4qy058rl474cpw7mifqaxk9ac2dhi5",
+      "srcDir": "src",
+      "url": "https://github.com/nitely/nim-unicodeplus/archive/f802d012290c32a69a774f2e7ea889546c1132e7.tar.gz"
     },
     {
       "method": "fetchzip",
-      "path": "/nix/store/c4c1bbxd29gmjj543wma2sbya5wvw5yg-source",
-      "rev": "6845c68cf00c1546f49d628ae11334acba966bfb",
-      "sha256": "007bkx8dwy8n340zbp6wyqfsq9bh6q5ykav1ywdlwykyp1n909bh",
-      "url": "https://github.com/nitely/nim-segmentation/archive/6845c68cf00c1546f49d628ae11334acba966bfb.tar.gz",
-      "ref": "v0.1.0",
       "packages": [
         "segmentation"
       ],
-      "srcDir": "src"
+      "path": "/nix/store/c4c1bbxd29gmjj543wma2sbya5wvw5yg-source",
+      "ref": "v0.1.0",
+      "rev": "6845c68cf00c1546f49d628ae11334acba966bfb",
+      "sha256": "007bkx8dwy8n340zbp6wyqfsq9bh6q5ykav1ywdlwykyp1n909bh",
+      "srcDir": "src",
+      "url": "https://github.com/nitely/nim-segmentation/archive/6845c68cf00c1546f49d628ae11334acba966bfb.tar.gz"
     }
   ]
 }

--- a/pkgs/by-name/ba/balls/package.nix
+++ b/pkgs/by-name/ba/balls/package.nix
@@ -1,49 +1,135 @@
 {
   lib,
+  stdenv,
   buildNimPackage,
   fetchFromGitHub,
+  fetchzip,
   nim,
   makeWrapper,
 }:
 
+let
+  insideout-src = fetchzip {
+    url = "https://github.com/disruptek/insideout/archive/7c8f2730df0c4efad1b18cd12f967dc823543aa0.tar.gz";
+    sha256 = "0akfhi59vmy9sqwx508p3d6bfx7px5aqmb4qzhb48f5b9klp7vvz";
+  };
+  # insideout exports posix signals to be compile time constats, but in nim they are not on aarch64
+  insideout-patched = stdenv.mkDerivation {
+    name = "insideout-patched";
+    src = insideout-src;
+    dontBuild = true;
+    dontConfigure = true;
+    installPhase = ''
+            mkdir -p $out
+            cp -r * $out/
+            substituteInPlace $out/insideout/futexes.nim \
+              --replace 'import std/posix' \
+                        'import std/posix
+      when compiles((const x = posix.EINTR)):
+        const EINTR = posix.EINTR
+      else:
+        const EINTR = cint(4)
+      when compiles((const x = posix.EAGAIN)):
+        const EAGAIN = posix.EAGAIN
+      else:
+        const EAGAIN = cint(11)
+      when compiles((const x = posix.ETIMEDOUT)):
+        const ETIMEDOUT = posix.ETIMEDOUT
+      else:
+        const ETIMEDOUT = cint(110)'
+
+            substituteInPlace $out/insideout/mailboxes.nim \
+              --replace 'import std/posix' \
+                        'import std/posix
+      when compiles((const x = posix.EINTR)):
+        const EINTR = posix.EINTR
+      else:
+        const EINTR = cint(4)'
+
+            substituteInPlace $out/insideout/runtimes.nim \
+              --replace 'import std/posix' \
+                        'import std/posix
+      when compiles((const x = posix.EINTR)):
+        const EINTR = posix.EINTR
+      else:
+        const EINTR = cint(4)
+      when compiles((const x = posix.EAGAIN)):
+        const EAGAIN = posix.EAGAIN
+      else:
+        const EAGAIN = cint(11)
+      when compiles((const x = posix.ETIMEDOUT)):
+        const ETIMEDOUT = posix.ETIMEDOUT
+      else:
+        const ETIMEDOUT = cint(110)
+      when compiles((const x = posix.SIGINT)):
+        const SIGINT = posix.SIGINT
+      else:
+        const SIGINT = cint(2)
+      when compiles((const x = posix.SIGTERM)):
+        const SIGTERM = posix.SIGTERM
+      else:
+        const SIGTERM = cint(15)
+      when compiles((const x = posix.SIGQUIT)):
+        const SIGQUIT = posix.SIGQUIT
+      else:
+        const SIGQUIT = cint(3)
+      when compiles((const x = posix.SIGCONT)):
+        const SIGCONT = posix.SIGCONT
+      else:
+        const SIGCONT = cint(18)'
+    '';
+  };
+
+  lockAttrs = builtins.fromJSON (builtins.readFile ./lock.json);
+
+  dependencies = map (
+    dep:
+    let
+      fod =
+        if (builtins.elem "insideout" dep.packages) then
+          insideout-patched
+        else
+          fetchzip {
+            url = dep.url;
+            sha256 = dep.sha256;
+          };
+      srcDir = if dep ? srcDir && dep.srcDir != "" then "/${dep.srcDir}" else "";
+    in
+    "--path:${fod}${srcDir}"
+  ) lockAttrs.depends;
+in
 buildNimPackage (finalAttrs: {
   pname = "balls";
-  version = "5.4.0";
+  version = "6.0.1";
 
   src = fetchFromGitHub {
     owner = "disruptek";
     repo = "balls";
     rev = finalAttrs.version;
-    hash = "sha256-CMYkMkekVI0C1WUds+KBbRfjMte42kBAB2ddtQp8d+k=";
+    hash = "sha256-YmP4ODQwvvQ74+LLnQGkYOnFP7ONjUP6RONRpEgZl2k=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
 
-  lockFile = ./lock.json;
+  nimFlags = dependencies;
 
   postPatch =
     # Trim comments from the Nimble file.
     ''
       sed \
         -e 's/[[:space:]]* # .*$//g' \
-       -i balls.nimble
+        -i balls.nimble
     '';
 
   preCheck = ''
     echo 'path:"$projectDir/.."' > tests/nim.cfg
   '';
 
-  postFixup =
-    let
-      lockAttrs = builtins.fromJSON (builtins.readFile finalAttrs.lockFile);
-      pathFlagOfFod = { path, srcDir, ... }: ''"--path:${path}/${srcDir}"'';
-      pathFlags = map pathFlagOfFod lockAttrs.depends;
-    in
-    ''
-      wrapProgram $out/bin/balls \
-        --suffix PATH : ${lib.makeBinPath [ nim ]} \
-        --append-flags '--path:"${finalAttrs.src}" ${toString pathFlags}'
-    '';
+  postFixup = ''
+    wrapProgram $out/bin/balls \
+      --suffix PATH : ${lib.makeBinPath [ nim ]} \
+      --append-flags "${lib.escapeShellArgs finalAttrs.nimFlags} --path:${finalAttrs.src}"
+  '';
 
   meta = finalAttrs.src.meta // {
     description = "Testing framework with balls";


### PR DESCRIPTION
Update to 6.0.1

update lock.json
patched insideout dependency by adding compile time constants on aarch64-linux

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
