### PR TITLE
simit: init at 0.8.0

### DIFF
--- a/pkgs/by-name/si/simit/package.nix
+++ b/pkgs/by-name/si/simit/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  fetchCrate,
+  clippy,
+  nix-update-script,
+  rustPlatform,
+  versionCheckHook,
+  git,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "simit";
+  version = "0.8.0";
+
+  src = fetchCrate {
+    pname = "simit";
+    inherit (finalAttrs) version;
+    hash = "sha256-NJou2R+K41JxMqXIbYwiHeoLuhflbN99ksVZgZTkb9I=";
+  };
+
+  cargoHash = "sha256-1BqrVbaa/Calo2T8ktIyYcmS765khQdqkabe7gv9cKw=";
+
+  nativeCheckInputs = [
+    clippy
+    git
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Semver-aware git commit helper for Rust projects";
+    homepage = "https://codeberg.org/caniko/simit";
+    changelog = "https://codeberg.org/caniko/simit/src/tag/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ caniko ];
+    mainProgram = "simit";
+  };
+})


### PR DESCRIPTION
Adds `simit`, a semver-aware git commit helper for Rust projects, packaged from the crates.io release.

Validation performed locally:

- `nix build .#simit`
- `./result/bin/simit --version`
- `nix eval --impure --expr 'let pkgs = import ./. { config.allowUnfree = true; }; in pkgs.simit.updateScript'`
- `nix-shell maintainers/scripts/update.nix --argstr package simit --argstr skip-prompt true`

`nixpkgs-review-gha` has not finished yet; I will update this checklist after it completes.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
