### PR TITLE
schemathesis: init at 4.19.0

### DIFF
--- a/pkgs/by-name/sc/schemathesis/package.nix
+++ b/pkgs/by-name/sc/schemathesis/package.nix
@@ -1,0 +1,3 @@
+{ python3Packages }:
+
+python3Packages.toPythonApplication python3Packages.schemathesis

--- a/pkgs/development/python-modules/schemathesis/default.nix
+++ b/pkgs/development/python-modules/schemathesis/default.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  click,
+  harfile,
+  httpx,
+  hypothesis,
+  hypothesis-graphql,
+  hypothesis-jsonschema,
+  jsonschema-rs,
+  junit-xml,
+  pyrate-limiter,
+  pytest,
+  pyyaml,
+  requests,
+  rich,
+  starlette-testclient,
+  tenacity,
+  tomli,
+  typing-extensions,
+  werkzeug,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "schemathesis";
+  version = "4.19.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-FfNIFmMEOPR7Pi+KcfIYHBAjqkWNQUMX4B/OQAAdAGY=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    click
+    harfile
+    httpx
+    hypothesis
+    hypothesis-graphql
+    hypothesis-jsonschema
+    jsonschema-rs
+    junit-xml
+    pyrate-limiter
+    pytest
+    pyyaml
+    requests
+    rich
+    starlette-testclient
+    tenacity
+    typing-extensions
+    werkzeug
+  ]
+  ++ lib.optionals (pythonOlder "3.11") [ tomli ];
+
+  # Test suite requires `hypothesis-openapi` (not packaged) plus a large
+  # network/property-based fixture set. Rely on the smoke check below.
+  doCheck = false;
+
+  pythonImportsCheck = [ "schemathesis" ];
+
+  meta = {
+    description = "Adaptive API testing for OpenAPI and GraphQL";
+    homepage = "https://github.com/schemathesis/schemathesis";
+    changelog = "https://github.com/schemathesis/schemathesis/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tembleking ];
+    mainProgram = "schemathesis";
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17531,6 +17531,8 @@ self: super: with self; {
 
   schema-salad = callPackage ../development/python-modules/schema-salad { };
 
+  schemathesis = callPackage ../development/python-modules/schemathesis { };
+
   schemdraw = callPackage ../development/python-modules/schemdraw { };
 
   schiene = callPackage ../development/python-modules/schiene { };


### PR DESCRIPTION
Adds `schemathesis` 4.19.0 — adaptive API testing for OpenAPI and GraphQL. Packaged both as a Python library (`python3Packages.schemathesis`) and as a CLI application (`schemathesis`, alias `st`) using `toPythonApplication`, per the nixpkgs Python guide for packages used as both library and app.

**Blocked on these prerequisite PRs:**

- [ ] #522950 `python3Packages.harfile: init at 0.4.0`
- [ ] #522951 `python3Packages.hypothesis-jsonschema: init at 0.23.1`
- [ ] #522953 `python3Packages.starlette-testclient: init at 0.4.1`
- [ ] #522955 `python3Packages.hypothesis-graphql: init at 0.12.0`
- [ ] #522966 `python3Packages.jsonschema-rs: 0.39.0 -> 0.46.5`

Marked draft until those merge. Build verified locally with the five branches applied; both `schemathesis --version` and `st --version` report `4.19.0`.

Tests disabled (`doCheck = false`): the suite (~288 files) requires `hypothesis-openapi` which isn't in nixpkgs, plus heavy network/property-based fixtures. `pythonImportsCheck` and the CLI smoke test cover the basics; tests can be enabled in a follow-up.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested via `nix-build`
- [x] CLI smoke test (`schemathesis --version`, `st --version`) passes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)