### PR TITLE
 lauti: 1.1.0 -> 1.2.0 

### DIFF
--- a/pkgs/by-name/la/lauti/frontend.nix
+++ b/pkgs/by-name/la/lauti/frontend.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   offlineCache = fetchYarnDeps {
     yarnLock = "${finalAttrs.src}/yarn.lock";
-    hash = "sha256-8+bAqWg6sqWQcjEdhS/tDZ1farY6VQ++lvbAfpwOeRE=";
+    hash = "sha256-RKalgQ6dXNOxMeC6pSKe9Lo0KXN0gfeX0I/pkcv2FXs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/la/lauti/package.nix
+++ b/pkgs/by-name/la/lauti/package.nix
@@ -7,12 +7,12 @@
 }:
 
 let
-  version = "1.1.0";
+  version = "1.2.0";
   src = fetchFromCodeberg {
     owner = "Klasse-Methode";
     repo = "lauti";
     tag = "v${version}";
-    hash = "sha256-eYIKVQG+Vj2qld/xKbxx0JpNqKhnGSjIOXXc7400BYo=";
+    hash = "sha256-llmXXaCy6V4DE0B1a0K0rRCb6XSvC1+EaG9legx0u4I=";
   };
   frontend = callPackage ./frontend.nix { inherit src version; };
 in
@@ -21,7 +21,7 @@ buildGoModule rec {
   pname = "lauti";
   inherit version src;
 
-  vendorHash = "sha256-4LQ3PvwWAg+/KBQHroj2ZVQZst7jPq99XwLTHClDPCU=";
+  vendorHash = "sha256-XO2Fo4rH6YDlj8x9f0847OEBLLpLlzFpK72uOEgW65o=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
changelogs:

- https://codeberg.org/Klasse-Methode/lauti/releases/tag/v1.1.1
- https://codeberg.org/Klasse-Methode/lauti/releases/tag/v1.2.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
