### PR TITLE
darwin: make static archive fixup deterministic

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -408,6 +408,7 @@ stdenvNoCC.mkDerivation {
     ###
     + optionalString (targetPlatform.isDarwin && !(bintools.isGNU or false)) ''
       echo "export ZERO_AR_DATE=1" >> $out/nix-support/setup-hook
+      echo "export NIX_STRIP_STATIC_ARCHIVE_RANLIB_CMD='ar -s'" >> $out/nix-support/setup-hook
     ''
 
     + ''

--- a/pkgs/build-support/setup-hooks/strip.sh
+++ b/pkgs/build-support/setup-hooks/strip.sh
@@ -96,7 +96,8 @@ stripDirs() {
         # This usually causes linking failures against static libs like:
         #   ld: ...-i686-w64-mingw32-stage-final-gcc-13.0.0-lib/i686-w64-mingw32/lib/libstdc++.dll.a:
         #     error adding symbols: archive has no index; run ranlib to add one
-        # Restore the index by running 'ranlib'.
-        find $paths -name '*.a' -type f -exec $ranlibCmd '{}' \; 2>/dev/null
+        # Restore the index by running 'ranlib', or a platform-specific equivalent.
+        local archiveRanlibCmd="${NIX_STRIP_STATIC_ARCHIVE_RANLIB_CMD:-$ranlibCmd}"
+        find $paths -name '*.a' -type f -exec $archiveRanlibCmd '{}' \; 2>/dev/null
     fi
 }


### PR DESCRIPTION
A follow up on https://github.com/NixOS/nixpkgs/pull/522752 as advised by @RossSmyth 

This change is intended to fix Darwin static archive reproducibility after the generic strip fixup hook runs. I used `unity-test` as a focused reproducer because it builds a static archive and previously failed `--rebuild` due to only the Darwin archive symbol table metadata differing.

Fix: use `ar -s` instead of `ranlib` when restoring static archive indexes after stripping on Darwin.
On Darwin, cctools `ranlib` can rewrite archive symbol tables with sandbox uid/gid metadata, causing non-deterministic outputs. `ar -s` restores the archive index while keeping deterministic archive metadata.

Targets `staging` because it changes generic stripping/bintools setup behavior and causes a broad Darwin rebuild.

Assisted-by: OpenCode (openai/gpt-5.5)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`. 
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

## Testing
On the fixed branch:
- [x] `nix build .#unity-test -L --keep-failed`
- [x] `nix build .#unity-test -L --rebuild --keep-failed`
- [x] `ar -tv ./result/lib/libunity.a`

The final archive now contains deterministic metadata:
```text
---------       0/0          1192 Jan  1 01:00 1970 __.SYMDEF
rw-r--r--       0/0         24696 Jan  1 01:00 1970 src_unity.c.o
```
I attempted targeted `nixpkgs-review` against `staging`, but it failed before giving useful coverage due to dependency failures in the `staging` review environment. That's why I didn't check the `nixpkgs-review` box.
Given that this touches `bintools-wrapper` strip fixup, broader validation seem appropriate for staging/Hydra or reviewer-requested targeted builds (suggestions welcome!).


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
