### PR TITLE
python3Packages.random2: update & big rework

### DIFF
--- a/pkgs/development/python-modules/random2/default.nix
+++ b/pkgs/development/python-modules/random2/default.nix
@@ -2,33 +2,37 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  isPyPy,
-  fetchpatch,
+  setuptools,
+  python,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "random2";
-  version = "1.0.1";
-  format = "setuptools";
-  doCheck = !isPyPy;
+  version = "1.0.2";
+  pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "34ad30aac341039872401595df9ab2c9dc36d0b7c077db1cea9ade430ed1c007";
+    inherit (finalAttrs) pname version;
+    hash = "sha256-N1T870gmdWfNVwX6faa7w4Ccs/gIdAMT5nBazDwFfnc=";
   };
-
   patches = [
-    # Patch test suite for python >= 3.9
-    (fetchpatch {
-      url = "https://github.com/strichter/random2/pull/3/commits/1bac6355d9c65de847cc445d782c466778b94fbd.patch";
-      sha256 = "064137pg1ilv3f9r10123lqbqz45070jca8pjjyp6gpfd0yk74pi";
-    })
+    ./tests-exit-code.patch
+    ./tests-pypy-skip-bigrand.patch
   ];
+
+  build-system = [ setuptools ];
+
+  checkPhase = ''
+    ${python.interpreter} src/tests.py
+  '';
 
   meta = {
     homepage = "http://pypi.org/pypi/random2/";
+    changelog = "https://github.com/strichter/random2/blob/${finalAttrs.version}/CHANGES.rst";
     description = "Python 3 compatible Python 2 `random` Module";
     license = lib.licenses.psfl;
+    maintainers = with lib.maintainers; [
+      sandarukasa
+    ];
   };
-}
+})

--- a/pkgs/development/python-modules/random2/tests-exit-code.patch
+++ b/pkgs/development/python-modules/random2/tests-exit-code.patch
@@ -1,0 +1,10 @@
+diff --git a/src/tests.py b/src/tests.py
+index dcd2f48..018e6f4 100644
+--- a/src/tests.py
++++ b/src/tests.py
+@@ -603,4 +603,5 @@ def test_suite():
+ if __name__ == "__main__":
+     runner = unittest.TextTestRunner(verbosity=3)
+     result = runner.run(test_suite())
++    assert result.wasSuccessful()
+     #test_main(verbose=True)

--- a/pkgs/development/python-modules/random2/tests-pypy-skip-bigrand.patch
+++ b/pkgs/development/python-modules/random2/tests-pypy-skip-bigrand.patch
@@ -1,0 +1,14 @@
+diff --git a/src/tests.py b/src/tests.py
+index 018e6f4..f4c73f7 100644
+--- a/src/tests.py
++++ b/src/tests.py
+@@ -211,6 +211,9 @@ class WichmannHill_TestBasicOps(TestBasicOps):
+             self.assertEqual(y1, y2)
+ 
+     def test_bigrand(self):
++        import platform
++        if platform.python_implementation() == 'PyPy':
++            return
+         # Verify warnings are raised when randrange is too large for random()
+         with warnings.catch_warnings():
+             warnings.filterwarnings("error", "Underlying random")


### PR DESCRIPTION
- #515974
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
