### PR TITLE
python3Packages.pygdbmi: modernize and migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/pygdbmi/default.nix
+++ b/pkgs/development/python-modules/pygdbmi/default.nix
@@ -39,6 +39,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Parse gdb machine interface output with Python";
     homepage = "https://github.com/cs01/pygdbmi";
+    changelog = "https://github.com/cs01/pygdbmi/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.mic92 ];
   };

--- a/pkgs/development/python-modules/pygdbmi/default.nix
+++ b/pkgs/development/python-modules/pygdbmi/default.nix
@@ -8,7 +8,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pygdbmi";
   version = "0.11.0.0";
   pyproject = true;
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "cs01";
     repo = "pygdbmi";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-JqEDN8Pg/JttyYQbwkxKkLYuxVnvV45VlClD23eaYyc=";
   };
 
@@ -42,4 +42,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.mic92 ];
   };
-}
+})

--- a/pkgs/development/python-modules/pygdbmi/default.nix
+++ b/pkgs/development/python-modules/pygdbmi/default.nix
@@ -5,12 +5,13 @@
   fetchFromGitHub,
   gdb,
   pytest,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "pygdbmi";
   version = "0.11.0.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "cs01";
@@ -18,6 +19,8 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-JqEDN8Pg/JttyYQbwkxKkLYuxVnvV45VlClD23eaYyc=";
   };
+
+  build-system = [ setuptools ];
 
   nativeCheckInputs = [
     gdb
@@ -27,7 +30,7 @@ buildPythonPackage rec {
   # tests require gcc for some reason
   doCheck = !stdenv.hostPlatform.isDarwin;
 
-  postPatch = ''
+  preCheck = ''
     # tries to execute flake8,
     # which is likely to break on flake8 updates
     echo "def main(): return 0" > tests/static_tests.py


### PR DESCRIPTION
- #515974
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
