### PR TITLE
nixos/containers: fix default gateway with privateNetwork

### DIFF
--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -524,6 +524,19 @@ let
     tmpfs = null;
   };
 
+  # Parses an IPv4 address with an optional prefix
+  ipv4FromString =
+    str:
+    let
+      segments = lib.splitString "/" str;
+      prefix = lib.elemAt segments 1;
+      hasPrefix = builtins.length segments == 2;
+    in
+    {
+      address = lib.head segments;
+      prefixLength = if hasPrefix then builtins.fromJSON prefix else 32;
+    };
+
 in
 
 {
@@ -594,6 +607,14 @@ in
                                 boot.isNspawnContainer = true;
                                 networking.hostName = mkDefault name;
                                 networking.useDHCP = false;
+                                networking.interfaces = lib.mkIf config.privateNetwork {
+                                  eth0.ipv4.addresses = lib.optional (config.localAddress != null) (
+                                    ipv4FromString config.localAddress
+                                  );
+                                  eth0.ipv6.addresses = lib.optional (config.localAddress6 != null) (
+                                    lib.network.ipv6.fromString config.localAddress6
+                                  );
+                                };
                                 assertions = [
                                   {
                                     assertion =

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -385,6 +385,7 @@ in
   containers-custom-pkgs = runTest ./containers-custom-pkgs.nix;
   containers-ephemeral = runTest ./containers-ephemeral.nix;
   containers-extra_veth = runTest ./containers-extra_veth.nix;
+  containers-gateway = runTest ./containers-gateway.nix;
   containers-hosts = runTest ./containers-hosts.nix;
   containers-imperative = runTest ./containers-imperative.nix;
   containers-ip = runTest ./containers-ip.nix;

--- a/nixos/tests/containers-gateway.nix
+++ b/nixos/tests/containers-gateway.nix
@@ -1,0 +1,67 @@
+let
+  hostIp4 = "192.168.0.1";
+  containerIp4 = "192.168.0.100/24";
+  hostIp6 = "fc00::1";
+  containerIp6 = "fc00::2/7";
+in
+
+{ lib, ... }:
+{
+  name = "containers-gateway";
+  meta = {
+    maintainers = with lib.maintainers; [
+      rnhmjoj
+    ];
+  };
+
+  nodes.machine = {
+    networking.bridges = {
+      br0.interfaces = [ ];
+    };
+    networking.interfaces = {
+      br0.ipv4.addresses = [
+        {
+          address = hostIp4;
+          prefixLength = 24;
+        }
+      ];
+      br0.ipv6.addresses = [
+        {
+          address = hostIp6;
+          prefixLength = 7;
+        }
+      ];
+    };
+
+    containers.test = {
+      autoStart = true;
+      privateNetwork = true;
+      hostBridge = "br0";
+      localAddress = containerIp4;
+      localAddress6 = containerIp6;
+      config.networking = {
+        defaultGateway.address = hostIp4;
+        defaultGateway6.address = hostIp6;
+      };
+    };
+  };
+
+  testScript = ''
+    def container_succeed(command: str):
+        machine.succeed(f"nixos-container run test -- {command}")
+
+    machine.wait_for_unit("default.target")
+    assert "test" in machine.succeed("nixos-container list")
+
+    with subtest("Container has started"):
+        assert "up" in machine.succeed("nixos-container status test")
+
+    with subtest("Container can ping the host"):
+        container_succeed("ping -n -c 1 ${hostIp4}")
+        container_succeed("ping -n -c 1 ${hostIp6}")
+
+    with subtest("Container default gateways are set"):
+        container_succeed("ip -4 route show default | grep 'via ${hostIp4}'")
+        container_succeed("ip -6 route show default | grep 'via ${hostIp6}'")
+  '';
+}


### PR DESCRIPTION
Fixes issue reported here https://github.com/NixOS/nixpkgs/pull/515773#issuecomment-4501563586

Containers with privateNetwork have an eth0 interface configured imperatively by the container setup script, so the networking-interfaces.nix module doesn't know about it. Specifying the default gateway then fails silently, unless this setup is mirrored in networking.interfaces.eth0 inside the container.


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] nixosTests.containers-bridge
  - [x] nixosTests.containers-custom-pkgs
  - [x] nixosTests.containers-ephemeral
  - [x] nixosTests.containers-extra_veth
  - [x] nixosTests.containers-gateway
  - [x] nixosTests.containers-hosts
  - [x] nixosTests.containers-imperative
  - [x] nixosTests.containers-ip
  - [x] nixosTests.containers-ipv6-slaac
  - [x] nixosTests.containers-macvlans
  - [x] nixosTests.containers-names
  - [x] nixosTests.containers-nested
  - [x] nixosTests.containers-physical_interfaces
  - [x] nixosTests.containers-portforward
  - [x] nixosTests.containers-reloadable
  - [x] nixosTests.containers-require-bind-mounts
  - [x] nixosTests.containers-restart_networking
  - [x] nixosTests.containers-tmpfs
  - [x] nixosTests.containers-unified-hierarchy
  - [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test