### PR TITLE
nixos/phosh: move out of x11

### DIFF
--- a/nixos/modules/services/desktop-managers/phosh.nix
+++ b/nixos/modules/services/desktop-managers/phosh.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  cfg = config.services.xserver.desktopManager.phosh;
+  cfg = config.services.desktopManager.phosh;
 
   phocConfigType = lib.types.submodule {
     options = {
@@ -21,13 +21,6 @@ let
           "immediate"
         ];
         default = "false";
-      };
-      cursorTheme = lib.mkOption {
-        description = ''
-          Cursor theme to use in Phosh.
-        '';
-        type = lib.types.str;
-        default = "default";
       };
       outputs = lib.mkOption {
         description = ''
@@ -120,8 +113,6 @@ let
       [core]
       xwayland = ${phoc.xwayland}
       ${lib.concatStringsSep "\n" outputs}
-      [cursor]
-      theme = ${phoc.cursorTheme}
     '';
 in
 
@@ -131,8 +122,31 @@ in
     maintainers = with lib.maintainers; [ armelclo ];
   };
 
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "services" "xserver" "desktopManager" "phosh" "enable" ]
+      [ "services" "desktopManager" "phosh" "enable" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "xserver" "desktopManager" "phosh" "package" ]
+      [ "services" "desktopManager" "phosh" "package" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "xserver" "desktopManager" "phosh" "user" ]
+      [ "services" "desktopManager" "phosh" "user" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "xserver" "desktopManager" "phosh" "group" ]
+      [ "services" "desktopManager" "phosh" "group" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "xserver" "desktopManager" "phosh" "phocConfig" ]
+      [ "services" "desktopManager" "phosh" "phocConfig" ]
+    )
+  ];
+
   options = {
-    services.xserver.desktopManager.phosh = {
+    services.desktopManager.phosh = {
       enable = lib.mkOption {
         type = lib.types.bool;
         default = false;

--- a/nixos/modules/services/desktop-managers/phosh.nix
+++ b/nixos/modules/services/desktop-managers/phosh.nix
@@ -241,6 +241,7 @@ in
       pkgs.phoc
       cfg.package
       pkgs.stevia
+      pkgs.phosh-mobile-settings
     ];
 
     systemd.packages = [ cfg.package ];

--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -24,7 +24,7 @@ in
   imports = [
     ./none.nix
     ./xterm.nix
-    ./phosh.nix
+    ../../desktop-managers/phosh.nix
     ./xfce.nix
     ../../desktop-managers/plasma6.nix
     ./lumina.nix

--- a/nixos/tests/phosh.nix
+++ b/nixos/tests/phosh.nix
@@ -17,7 +17,7 @@ in
           password = pin;
         };
 
-        services.xserver.desktopManager.phosh = {
+        services.desktopManager.phosh = {
           enable = true;
           user = "nixos";
           group = "users";


### PR DESCRIPTION
Phosh was always using Wayland, putting it under `services.xserver` is misleading.

I have follow the Gnome own migration #392804.

Removed the cursor theme config entry that was removed multiple versions ago in Phosh. (Replaced by `gsettings set org.gnome.desktop.interface cursor-theme 'name'`)

fix: #499593


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
