### PR TITLE
systemd: fix tmpfiles errors when mount is noatime

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -5,6 +5,7 @@
   pkgsCross,
   testers,
   fetchFromGitHub,
+  fetchpatch,
   buildPackages,
   makeBinaryWrapper,
   ninja,
@@ -237,6 +238,13 @@ stdenv.mkDerivation (finalAttrs: {
     ./0003-add-rootprefix-to-lookup-dir-paths.patch
     ./0004-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
     ./0005-core-don-t-taint-on-unmerged-usr.patch
+
+    # TODO: remove the following patch when systemd v261 is released.
+    # see upstream PR: https://github.com/systemd/systemd/pull/41232
+    (fetchpatch {
+      url = "https://github.com/systemd/systemd/commit/df45055942330fcd2b77389e449905e7f6ca34ec.patch";
+      hash = "sha256-PDh4mP9rYGCglp25346nExU2v6P0WYPfLZgu+YwzZ9c=";
+    })
   ]
   ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isGnu) [
     ./0006-timesyncd-disable-NSCD-when-DNSSEC-validation-is-dis.patch


### PR DESCRIPTION
fixes #520485

I followed the instructions of the "PATCH POLICY" so the patch should be formatted as expected.


I added a small comment as recommended by @nikstur .

I guess it'll only go to 26.11 now, what about 26.05? Should I open another PR or could you add the `backport` label?