### PR TITLE
libsvgtiny: vendor patch (no longer on server)

### DIFF
--- a/pkgs/by-name/li/libsvgtiny/fix-calloc-transposed-args.patch
+++ b/pkgs/by-name/li/libsvgtiny/fix-calloc-transposed-args.patch
@@ -1,0 +1,11 @@
+--- a/src/svgtiny.c
++++ b/src/svgtiny.c
+@@ -586,7 +586,7 @@
+ {
+ 	struct svgtiny_diagram *diagram;
+ 
+-	diagram = calloc(sizeof(*diagram), 1);
++	diagram = calloc(1, sizeof(*diagram));
+ 	if (!diagram)
+ 		return 0;
+ 

--- a/pkgs/by-name/li/libsvgtiny/package.nix
+++ b/pkgs/by-name/li/libsvgtiny/package.nix
@@ -24,11 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # fixes libdom build on gcc 14 due to calloc-transposed-args warning
     # remove on next release
-    (fetchpatch {
-      name = "fix-calloc-transposed-args.patch";
-      url = "https://source.netsurf-browser.org/libsvgtiny.git/patch/?id=9d14633496ae504557c95d124b97a71147635f04";
-      hash = "sha256-IRWWjyFXd+lWci/bKR9uPDKbP3ttK6zNB6Cy5bv4huc=";
-    })
+    ./fix-calloc-transposed-args.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
