### PR TITLE
libdom: vendor patch (no longer exists on server)

### DIFF
--- a/pkgs/by-name/li/libdom/fix-calloc-transposed-args.patch
+++ b/pkgs/by-name/li/libdom/fix-calloc-transposed-args.patch
@@ -1,0 +1,40 @@
+--- a/bindings/xml/expat_xmlparser.c
++++ b/bindings/xml/expat_xmlparser.c
+@@ -484,7 +484,7 @@
+ 
+ 	UNUSED(int_enc);
+ 
+-	parser = calloc(sizeof(*parser), 1);
++	parser = calloc(1, sizeof(*parser));
+ 	if (parser == NULL) {
+ 		msg(DOM_MSG_CRITICAL, mctx, "No memory for parser");
+ 		return NULL;
+--- a/src/core/node.c
++++ b/src/core/node.c
+@@ -2379,7 +2379,7 @@
+ 	if (t == NULL) {
+ 		/* Create the event target list */
+ 		size = 64;
+-		t = calloc(sizeof(*t), size);
++		t = calloc(size, sizeof(*t));
+ 		if (t == NULL) {
+ 			return DOM_NO_MEM_ERR;
+ 		}
+--- a/src/html/html_document.c
++++ b/src/html/html_document.c
+@@ -134,13 +134,12 @@
+ 	doc->cookie = NULL;
+ 	doc->body = NULL;
+ 
+-	doc->memoised = calloc(sizeof(dom_string *), hds_COUNT);
++	doc->memoised = calloc(hds_COUNT, sizeof(dom_string *));
+ 	if (doc->memoised == NULL) {
+ 		error = DOM_NO_MEM_ERR;
+ 		goto out;
+ 	}
+-	doc->elements = calloc(sizeof(dom_string *),
+-			DOM_HTML_ELEMENT_TYPE__COUNT);
++	doc->elements = calloc(DOM_HTML_ELEMENT_TYPE__COUNT, sizeof(dom_string *));
+ 	if (doc->elements == NULL) {
+ 		error = DOM_NO_MEM_ERR;
+ 		goto out;

--- a/pkgs/by-name/li/libdom/package.nix
+++ b/pkgs/by-name/li/libdom/package.nix
@@ -23,11 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # fixes libdom build on gcc 14 due to calloc-transposed-args warning
     # remove on next release
-    (fetchpatch {
-      name = "fix-calloc-transposed-args.patch";
-      url = "https://source.netsurf-browser.org/libdom.git/patch/?id=2687282d56dfef19e26e9639a5c0cd81de957e22";
-      hash = "sha256-1uAdLM9foplCVu8IQlMMlXh6OWHs5eUgsKp+0ZqM9yM=";
-    })
+    ./fix-calloc-transposed-args.patch
   ];
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
