### PR TITLE
libcss: vendor patches (no longer exist on server)

### DIFF
--- a/pkgs/by-name/li/libcss/fix-calloc-transposed-args-computed.patch
+++ b/pkgs/by-name/li/libcss/fix-calloc-transposed-args-computed.patch
@@ -1,0 +1,11 @@
+--- a/src/select/computed.c
++++ b/src/select/computed.c
+@@ -73,7 +73,7 @@
+ 	if (result == NULL)
+ 		return CSS_BADPARM;
+ 
+-	s = calloc(sizeof(css_computed_style), 1);
++	s = calloc(1, sizeof(css_computed_style));
+ 	if (s == NULL)
+ 		return CSS_NOMEM;
+ 

--- a/pkgs/by-name/li/libcss/fix-calloc-transposed-args-select.patch
+++ b/pkgs/by-name/li/libcss/fix-calloc-transposed-args-select.patch
@@ -1,0 +1,29 @@
+--- a/src/select/select.c
++++ b/src/select/select.c
+@@ -138,7 +138,7 @@
+ {
+ 	struct css_node_data *nd;
+ 
+-	nd = calloc(sizeof(struct css_node_data), 1);
++	nd = calloc(1, sizeof(struct css_node_data));
+ 	if (nd == NULL) {
+ 		return CSS_NOMEM;
+ 	}
+@@ -234,7 +234,7 @@
+ 	if (result == NULL)
+ 		return CSS_BADPARM;
+ 
+-	c = calloc(sizeof(css_select_ctx), 1);
++	c = calloc(1, sizeof(css_select_ctx));
+ 	if (c == NULL)
+ 		return CSS_NOMEM;
+ 
+@@ -613,7 +613,7 @@
+ 	*node_bloom = NULL;
+ 
+ 	/* Create the node's bloom */
+-	bloom = calloc(sizeof(css_bloom), CSS_BLOOM_SIZE);
++	bloom = calloc(CSS_BLOOM_SIZE, sizeof(css_bloom));
+ 	if (bloom == NULL) {
+ 		return CSS_NOMEM;
+ 	}

--- a/pkgs/by-name/li/libcss/package.nix
+++ b/pkgs/by-name/li/libcss/package.nix
@@ -22,18 +22,10 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # select: computed: Squash -Wcalloc-transposed-args (gcc-14)
     # remove on next release
-    (fetchpatch {
-      name = "fix-calloc-transposed-args-computed.patch";
-      url = "https://source.netsurf-browser.org/libcss.git/patch/?id=0541e18b442d2f46abc0f0b09e0db950e1b657e5";
-      hash = "sha256-6nrT1S1E+jU6UDr3BZo9GH8jcSiIwTNLnmI1rthhhws=";
-    })
+    ./fix-calloc-transposed-args-computed.patch
     # select: select: Squash -Wcalloc-transposed-args (gcc-14)
     # remove on next release
-    (fetchpatch {
-      name = "fix-calloc-transposed-args-select.patch";
-      url = "https://source.netsurf-browser.org/libcss.git/patch/?id=8619d09102d6cc34d63fe87195c548852fc93bf4";
-      hash = "sha256-Clkhw/n/+NQR/T8Gi+2Lc1Neq5dWsNKM8RqieYuTnzQ=";
-    })
+    ./fix-calloc-transposed-args-select.patch
   ];
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
