### PR TITLE
libagar: fix conflicting types compilation error

### DIFF
--- a/pkgs/by-name/li/libagar/fix-conflicting-types.patch
+++ b/pkgs/by-name/li/libagar/fix-conflicting-types.patch
@@ -1,0 +1,26 @@
+--- a/math/m_sparse_factor.c
++++ b/math/m_sparse_factor.c
+@@ -1236,7 +1236,6 @@ int  I, NumberOfTies = 0;
+ ElementPtr  ChosenPivot, TiedElements[MAX_MARKOWITZ_TIES + 1];
+ RealNumber  Magnitude, LargestInCol, Ratio, MaxRatio;
+ RealNumber  LargestOffDiagonal;
+-RealNumber  FindBiggestInColExclude();
+ 
+ /* Begin `QuicklySearchDiagonal'. */
+     NumberOfTies = -1;
+@@ -1434,7 +1433,6 @@ register  ElementPtr  pDiag;
+ int  I;
+ ElementPtr  ChosenPivot, pOtherInRow, pOtherInCol;
+ RealNumber  Magnitude, LargestInCol, LargestOffDiagonal;
+-RealNumber  FindBiggestInColExclude();
+ 
+ /* Begin `QuicklySearchDiagonal'. */
+     ChosenPivot = NULL;
+@@ -1601,7 +1599,6 @@ register  ElementPtr  pDiag;
+ int  NumberOfTies = 0, Size = Matrix->Size;
+ ElementPtr  ChosenPivot;
+ RealNumber  Magnitude, Ratio, RatioOfAccepted = 0.0, LargestInCol;
+-RealNumber  FindBiggestInColExclude();
+ 
+ /* Begin `SearchDiagonal'. */
+     ChosenPivot = NULL;

--- a/pkgs/by-name/li/libagar/package.nix
+++ b/pkgs/by-name/li/libagar/package.nix
@@ -29,6 +29,10 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "001wcqk5z67qg0raw9zlwmv62drxiwqykvsbk10q2mrc6knjsd42";
   };
 
+  patches = [
+    ./fix-conflicting-types.patch
+  ];
+
   preConfigure = ''
     substituteInPlace configure.in \
       --replace '_BSD_SOURCE' '_DEFAULT_SOURCE'


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
