### PR TITLE
runit: fix patch

### DIFF
--- a/pkgs/by-name/ru/runit/fix-ar-ranlib.patch
+++ b/pkgs/by-name/ru/runit/fix-ar-ranlib.patch
@@ -1,5 +1,5 @@
---- runit-2.1.2/src/print-ar.sh
-+++ runit-2.1.2/src/print-ar.sh
+--- a/src/print-ar.sh
++++ b/src/print-ar.sh
 @@ -1,7 +1,7 @@
  cat warn-auto.sh
  echo 'main="$1"; shift'

--- a/pkgs/by-name/ru/runit/package.nix
+++ b/pkgs/by-name/ru/runit/package.nix
@@ -44,6 +44,8 @@ stdenv.mkDerivation rec {
     sed -i 's,-static,,g' src/Makefile
   '';
 
+  enableParallelBuilding = true;
+
   preBuild = ''
     cd src
 

--- a/pkgs/by-name/ru/runit/package.nix
+++ b/pkgs/by-name/ru/runit/package.nix
@@ -7,13 +7,13 @@
   static ? false,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "runit";
   version = "2.3.1";
 
   src = fetchurl {
-    url = "https://smarden.org/runit/${pname}-${version}.tar.gz";
-    sha256 = "sha256-Y08jyMTR1EAEO+D+ko3fkEYmKJ6Xv+fFgm6TqvLMb+k=";
+    url = "https://smarden.org/runit/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
+    hash = "sha256-Y08jyMTR1EAEO+D+ko3fkEYmKJ6Xv+fFgm6TqvLMb+k=";
   };
 
   patches = [
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     "man"
   ];
 
-  sourceRoot = "admin/${pname}-${version}";
+  sourceRoot = "admin/${finalAttrs.pname}-${finalAttrs.version}";
 
   doCheck = true;
 
@@ -70,4 +70,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     mainProgram = "runit";
   };
-}
+})

--- a/pkgs/by-name/ru/runit/package.nix
+++ b/pkgs/by-name/ru/runit/package.nix
@@ -68,5 +68,6 @@ stdenv.mkDerivation rec {
     homepage = "http://smarden.org/runit";
     maintainers = [ ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    mainProgram = "runit";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
