### PR TITLE
x3270: 4.4ga6 -> 4.5ga5

### DIFF
--- a/pkgs/by-name/x3/x3270/package.nix
+++ b/pkgs/by-name/x3/x3270/package.nix
@@ -50,6 +50,8 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-tcl3270"
   ];
 
+  enableParallelBuilding = true;
+
   preBuild = ''
     if [ -n "$SOURCE_DATE_EPOCH" ]; then
       export SOURCE_DATE_EPOCH="$(date -u -d "@$SOURCE_DATE_EPOCH" '+%a %b %d %H:%M:%S UTC %Y')"

--- a/pkgs/by-name/x3/x3270/package.nix
+++ b/pkgs/by-name/x3/x3270/package.nix
@@ -24,8 +24,8 @@
 }:
 let
   majorVersion = "4";
-  minorVersion = "4";
-  versionSuffix = "ga6";
+  minorVersion = "5";
+  versionSuffix = "ga5";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "x3270";
@@ -33,11 +33,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://x3270.bgp.nu/download/0${majorVersion}.0${minorVersion}/suite3270-${finalAttrs.version}-src.tgz";
-    hash = "sha256-hDju5ZeVzTv78ZYwUzabmqMK9rheTZJ7clTSTpkkM7E=";
+    hash = "sha256-AVdvpYWYzN09Nm/r+u9h49Hek+tgqT+axrpfr4QUTG8=";
   };
 
   postPatch = ''
     patchShebangs .
+    substituteInPlace Common/mkversion.py --replace-fail "int(os.environ['SOURCE_DATE_EPOCH'])" "1"
   '';
 
   buildFlags = lib.optional stdenv.hostPlatform.isLinux "unix";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
