### PR TITLE
libinput: luaSupport flag

### DIFF
--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -7,7 +7,6 @@
   meson,
   ninja,
   libevdev,
-  lua5_4,
   mtdev,
   udev,
   wacomSupport ? stdenv.hostPlatform.isLinux,
@@ -20,6 +19,8 @@
   cairo,
   glib,
   gtk3,
+  luaSupport ? true,
+  lua5_4,
   testsSupport ? false,
   check,
   valgrind,
@@ -82,7 +83,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     libevdev
-    lua5_4
     mtdev
     (python3.withPackages (
       pp: with pp; [
@@ -98,6 +98,9 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optionals wacomSupport [
     libwacom
+  ]
+  ++ lib.optionals luaSupport [
+    lua5_4
   ]
   ++ lib.optionals eventGUISupport [
     # GUI event viewer
@@ -121,6 +124,7 @@ stdenv.mkDerivation rec {
     (lib.mesonBool "debug-gui" eventGUISupport)
     (lib.mesonBool "tests" testsSupport)
     (lib.mesonBool "libwacom" wacomSupport)
+    (lib.mesonEnable "lua-plugins" luaSupport)
     "--sysconfdir=/etc"
     "--libexecdir=${placeholder "bin"}/libexec"
   ]

--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -32,8 +32,6 @@
 }:
 
 let
-  mkFlag = optSet: flag: "-D${flag}=${lib.boolToString optSet}";
-
   sphinx-build =
     let
       env = python3.withPackages (
@@ -119,10 +117,10 @@ stdenv.mkDerivation rec {
   ];
 
   mesonFlags = [
-    (mkFlag documentationSupport "documentation")
-    (mkFlag eventGUISupport "debug-gui")
-    (mkFlag testsSupport "tests")
-    (mkFlag wacomSupport "libwacom")
+    (lib.mesonBool "documentation" documentationSupport)
+    (lib.mesonBool "debug-gui" eventGUISupport)
+    (lib.mesonBool "tests" testsSupport)
+    (lib.mesonBool "libwacom" wacomSupport)
     "--sysconfdir=/etc"
     "--libexecdir=${placeholder "bin"}/libexec"
   ]


### PR DESCRIPTION
Especially in constrained environments such as mobile and embedded devices the addition of Lua plugins may be undesirable due to the size of the resulting derivation.
Allowing this feature to be easily disabled reduces boilerplate for downstream projects (such as *mobile-nixos*) significantly at little to no cost to *nixpkgs*.

This change does cause rebuilds due to changes in the order of packages, however it does not constitute a breaking change as the default result is unchanged in terms of build results.

---

Above is the relevant commit message verbatim.

Personally I don't mind if this PR isn't merged, however I would recommend taking a look at 3b64986111a59fddd46c35357916f696bb79afba since that one is probably a good (cherry) pick, feel free to take that and close this PR if you don't think the relevant change isn't a good fit for *nixpkgs*.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
