### PR TITLE
frei0r: 2.5.1 -> 3.1.3, gavl: init at 2.0.1

### DIFF
--- a/pkgs/by-name/fr/frei0r/package.nix
+++ b/pkgs/by-name/fr/frei0r/package.nix
@@ -7,20 +7,26 @@
   cmake,
   opencv,
   pkg-config,
+  gavl,
   cudaSupport ? config.cudaSupport,
   cudaPackages,
+  testers,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "frei0r-plugins";
-  version = "2.5.1";
+  version = "3.1.3";
 
   src = fetchFromGitHub {
     owner = "dyne";
     repo = "frei0r";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-3gUWvO5izOrJt+XwcNBNiLfu+iMqo4nuPbx++TYzao0=";
+    hash = "sha256-D00sxSTnv4oqxhKYKayJPs5uWYW4HosEp2StuCVmGFY=";
   };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+  enableParallelBuilding = true;
 
   nativeBuildInputs = [
     cmake
@@ -30,10 +36,18 @@ stdenv.mkDerivation (finalAttrs: {
     cairo
     opencv
   ]
+  ++ lib.optional (!stdenv.hostPlatform.isDarwin) gavl
   ++ lib.optionals cudaSupport [
     cudaPackages.cuda_cudart
     cudaPackages.cuda_nvcc
   ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "WITHOUT_GAVL" stdenv.hostPlatform.isDarwin)
+    (lib.cmakeFeature "FREI0R_VERSION" finalAttrs.version)
+  ];
+
+  doCheck = true;
 
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     for f in $out/lib/frei0r-1/*.so* ; do
@@ -41,11 +55,17 @@ stdenv.mkDerivation (finalAttrs: {
     done
   '';
 
+  passthru.tests.pkg-config = testers.hasPkgConfigModules {
+    package = finalAttrs.finalPackage;
+    versionCheck = true;
+  };
+
   meta = {
     homepage = "https://frei0r.dyne.org";
     description = "Minimalist, cross-platform, shared video plugins";
     license = lib.licenses.gpl2Plus;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.christoph-heiss ];
     platforms = lib.platforms.unix;
+    pkgConfigModules = [ "frei0r" ];
   };
 })

--- a/pkgs/by-name/ga/gavl/package.nix
+++ b/pkgs/by-name/ga/gavl/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  nettle,
+  gnutls,
+  libdrm,
+  libGL,
+  libpng,
+  testers,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gavl";
+  version = "2.0.1";
+
+  src = fetchFromGitHub {
+    owner = "bplaum";
+    repo = "gavl";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-nvgBsUiSF6+voMzo5XRWHig2Iq8DD2hVV5hWodGxgQo=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+  enableParallelBuilding = true;
+
+  configureFlags = [
+    # disable -march=native
+    (lib.withFeatureAs true "cpuflags" "none")
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    nettle
+    gnutls
+    libdrm
+    libGL
+    libpng
+  ];
+
+  doCheck = true;
+
+  passthru.tests.pkg-config = testers.hasPkgConfigModules {
+    package = finalAttrs.finalPackage;
+    versionCheck = true;
+  };
+
+  meta = {
+    homepage = "https://github.com/bplaum/gavl";
+    description = "Support library for other packages of the gmerlin project";
+    license = lib.licenses.gpl2Plus;
+    maintainers = [ lib.maintainers.christoph-heiss ];
+    platforms = lib.platforms.linux;
+    pkgConfigModules = [ "gavl" ];
+  };
+})


### PR DESCRIPTION
`gavl` is needed by the newer `frei0r`, it's a simple library though.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
