### PR TITLE
nixos/starship: fix '$' escaping for bash and zsh

### DIFF
--- a/nixos/modules/programs/starship.nix
+++ b/nixos/modules/programs/starship.nix
@@ -116,7 +116,7 @@ in
         # config file.  starship appears to use a hardcoded config location
         # rather than one inside an XDG folder:
         # https://github.com/starship/starship/blob/686bda1706e5b409129e6694639477a0f8a3f01b/src/configure.rs#L651
-        if [[ ! -f "$${STARSHIP_CONFIG:-$HOME/.config/starship.toml}" ]]; then
+        if [[ ! -f "''${STARSHIP_CONFIG:-$HOME/.config/starship.toml}" ]]; then
           export STARSHIP_CONFIG=${settingsFile}
         fi
         eval "$(${cfg.package}/bin/starship init bash --print-full-init)"
@@ -154,7 +154,7 @@ in
         # config file.  starship appears to use a hardcoded config location
         # rather than one inside an XDG folder:
         # https://github.com/starship/starship/blob/686bda1706e5b409129e6694639477a0f8a3f01b/src/configure.rs#L651
-        if [[ ! -f "$${STARSHIP_CONFIG:-$HOME/.config/starship.toml}" ]]; then
+        if [[ ! -f "''${STARSHIP_CONFIG:-$HOME/.config/starship.toml}" ]]; then
           export STARSHIP_CONFIG=${settingsFile}
         fi
         eval "$(${cfg.package}/bin/starship init zsh)"


### PR DESCRIPTION
Fix the escaping of the '$' symbol for bash and zsh initOption scripts.  
Current scripts result in:
```bash 
if [[ ! -f "$${STARSHIP_CONFIG:-$HOME/.config/starship.toml}" ]]; then
```

Where the `$$` is expanded to the PID of the current script.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
