### PR TITLE
home-assistant-custom-components.closest_intent: init at 0.1.0

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/closest_intent/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/closest_intent/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  rapidfuzz,
+  # Test dependencies
+  pytestCheckHook,
+  pytest-asyncio,
+  pyyaml,
+}:
+
+buildHomeAssistantComponent (finalAttrs: {
+  owner = "charludo";
+  domain = "closest_intent";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    inherit (finalAttrs) owner;
+    repo = "hass-closest-intent";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8ST+xYqmDwovDqNLnDsoIvIoPIDussAswGOOvMhRQWk=";
+  };
+
+  dependencies = [
+    rapidfuzz
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    pyyaml
+  ];
+
+  meta = {
+    changelog = "https://github.com/charludo/hass-closest-intent/releases/tag/${finalAttrs.src.tag}";
+    description = "Fuzzy intent matcher for Home Assistant; garbled STT output in, actual intent out";
+    homepage = "https://github.com/charludo/hass-closest-intent";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [
+      charludo
+      jpds
+    ];
+  };
+})


### PR DESCRIPTION
https://github.com/charludo/hass-closest-intent

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] Live system
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
