### PR TITLE
happ: init at 2.15.0

### DIFF
--- a/nixos/modules/services/networking/happd.nix
+++ b/nixos/modules/services/networking/happd.nix
@@ -1,0 +1,38 @@
+{
+  config,
+  lib,
+  pkgs,
+}:
+let
+  cfg = config.services.happd;
+in
+{
+  options.services.happd = {
+    enable = lib.mkEnableOption "happd, Happ Process Control Daemon";
+    package = lib.mkPackageOption pkgs "happ" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.services.happd = {
+      description = "Happ Control Process Daemon";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        User = "root";
+        Group = "root";
+        ExecStart = "${cfg.package}/bin/happd";
+        Restart = "on-failure";
+        RestartSec = 5;
+        NoNewPrivileges = false;
+        TimeoutStopSec = 10;
+        KillMode = "mixed";
+        KillSignal = "SIGTERM";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ nekitdev ];
+}

--- a/pkgs/tools/networking/happ/default.nix
+++ b/pkgs/tools/networking/happ/default.nix
@@ -1,0 +1,106 @@
+{
+  autoPatchelfHook,
+  dpkg,
+  e2fsprogs,
+  fetchurl,
+  fontconfig,
+  freetype,
+  lib,
+  libGL,
+  libffi,
+  libgpg-error,
+  openssl,
+  qtbase,
+  stdenv,
+  wrapQtAppsHook,
+  zlib,
+}:
+
+let
+  deps = [
+    stdenv.cc.cc.lib
+    e2fsprogs
+    freetype
+    fontconfig
+    libffi
+    libGL
+    libgpg-error
+    qtbase
+    zlib
+    openssl
+  ];
+
+  version = "2.15.0";
+
+  hostSystem = stdenv.hostPlatform.system;
+
+  selectSystem = attrs: attrs.${hostSystem} or (throw "unsupported system: ${hostSystem}");
+
+  platform = selectSystem {
+    x86_64-linux = "x64";
+    aarch64-linux = "arm64";
+  };
+
+  hash = selectSystem {
+    x86_64-linux = "sha256-Xjo5LByAx2ME+RMqfshhFx6st5NehDdYrrZ/pksSOW4=";
+    aarch64-linux = "sha256-CETIXElIlGHEIitFp9dj0QE/u6/w4GNFK3NYEof+rL4=";
+  };
+
+  libraryPath = lib.makeLibraryPath [ openssl ];
+
+in
+
+stdenv.mkDerivation {
+  __structuredAttrs = true;
+
+  strictDeps = true;
+
+  pname = "happ";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/Happ-proxy/happ-desktop/releases/download/${version}/Happ.linux.${platform}.deb";
+    inherit hash;
+  };
+
+  buildInputs = deps;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    wrapQtAppsHook
+    dpkg
+  ];
+
+  qtWrapperArgs = [
+    "--prefix LD_LIBRARY_PATH : ${libraryPath}"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/happ $out/bin
+
+    mv usr/share/* $out/share
+    mv usr/bin/* $out/bin
+
+    mv opt/happ/* $out/share/happ
+
+    ln -s $out/share/happ/bin/Happ $out/bin
+    ln -s $out/share/happ/bin/happd $out/bin
+
+    sed -i "s|Exec.*$|Exec=$out/bin/Happ %f|" $out/share/applications/Happ.desktop
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://happ.su/";
+    description = "Happ Proxy Utility";
+    changelog = "https://github.com/Happ-proxy/happ-desktop/releases/tag/${version}";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfree;
+    mainProgram = "Happ";
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.nekitdev ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3311,6 +3311,8 @@ with pkgs;
 
   vpn-slice = python3Packages.callPackage ../tools/networking/vpn-slice { };
 
+  happ = qt6Packages.callPackage ../tools/networking/happ { };
+
   openconnectPackages = callPackage ../tools/networking/openconnect { };
 
   inherit (openconnectPackages) openconnect openconnect_openssl;


### PR DESCRIPTION
# `happ`

In this PR I have packaged Happ Proxy Utility for nixpkgs.

`happ` allows connecting to various proxy servers, supporting various protocols (for instance, VLESS).
For more information see the [website](https://happ.su/).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin (not packaged)
  - [ ] aarch64-darwin (not packaged)
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
