### PR TITLE
[25.11] docker_28: mark as vulnerable

### DIFF
--- a/nixos/tests/docker.nix
+++ b/nixos/tests/docker.nix
@@ -15,7 +15,7 @@
       {
         virtualisation.docker.enable = true;
         virtualisation.docker.autoPrune.enable = true;
-        virtualisation.docker.package = pkgs.docker;
+        virtualisation.docker.package = pkgs.docker_29;
 
         users.users = {
           noprivs = {
@@ -48,7 +48,7 @@
     docker.succeed("docker stop sleeping")
 
     # Must match version 4 times to ensure client and server git commits and versions are correct
-    docker.succeed('[ $(docker version | grep ${pkgs.docker.version} | wc -l) = "4" ]')
+    docker.succeed('[ $(docker version | grep ${pkgs.docker_29.version} | wc -l) = "4" ]')
     docker.succeed("systemctl restart systemd-sysctl")
     docker.succeed("grep 1 /proc/sys/net/ipv4/conf/all/forwarding")
     docker.succeed("grep 1 /proc/sys/net/ipv4/conf/default/forwarding")

--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -430,6 +430,9 @@ in
       containerdHash = "sha256-vz7RFJkFkMk2gp7bIMx1kbkDFUMS9s0iH0VoyD9A21s=";
       tiniRev = "369448a167e8b3da4ca5bca0b3307500c3371828";
       tiniHash = "sha256-jCBNfoJAjmcTJBx08kHs+FmbaU82CbQcf0IVjd56Nuw=";
+      knownVulnerabilities = [
+        "docker_28 has been unmaintained since November 2025, use docker_29 or newer instead"
+      ];
     };
 
   docker_29 =


### PR DESCRIPTION
Manual backport of #521611. Marking as vulnerable instead of dropping the package.

docker 28.x is no longer maintained since November 2025[1].

[1] https://github.com/moby/moby/commit/941805303910a3749ed8fa9669d078015f6f268c

Trying to build this package after this commit will show this message:

```
       error: Package ‘docker-28.5.2’ in NixOS/nixpkgs/pkgs/applications/virtualization/docker/default.nix:372 is marked as insecure, refusing to evaluate.


       Known issues:
        - docker_28 has been unmaintained since November 2025, use docker_29 or newer instead

       You can install it anyway by allowing this package, using the
       following methods:

       a) To temporarily allow all insecure packages, you can use an environment
          variable for a single invocation of the nix tools:

            $ export NIXPKGS_ALLOW_INSECURE=1

          Note: When using `nix shell`, `nix build`, `nix develop`, etc with a flake,
                then pass `--impure` in order to allow use of environment variables.

       b) for `nixos-rebuild` you can add ‘docker-28.5.2’ to
          `nixpkgs.config.permittedInsecurePackages` in the configuration.nix,
          like so:

            {
              nixpkgs.config.permittedInsecurePackages = [
                "docker-28.5.2"
              ];
            }

       c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
          ‘docker-28.5.2’ to `permittedInsecurePackages` in
          ~/.config/nixpkgs/config.nix, like so:

            {
              permittedInsecurePackages = [
                "docker-28.5.2"
              ];
            }
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
