### PR TITLE
nixos/foot: fix zsh duplicate precmd functions 

### DIFF
--- a/nixos/modules/programs/foot/zshrc
+++ b/nixos/modules/programs/foot/zshrc
@@ -9,14 +9,11 @@ function chpwd-osc7-pwd() {
     (( ZSH_SUBSHELL )) || osc7-pwd
 }
 
-precmd() {
-    print -Pn "\e]133;A\e\\"
-}
-
 function precmd {
     if ! builtin zle; then
         print -n "\e]133;D\e\\"
     fi
+    print -Pn "\e]133;A\e\\"
 }
 
 function preexec {


### PR DESCRIPTION
Fix the `zshrc` `precmd` function for the `OSC-133;A` prompt marker being overwritten by another `precmd` function for the `OSC-133;D` end pipe marker.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
