### PR TITLE
debian-devscripts: vendor patches

### DIFF
--- a/pkgs/by-name/de/debian-devscripts/hardening-check-obey-binutils-env-vars.patch
+++ b/pkgs/by-name/de/debian-devscripts/hardening-check-obey-binutils-env-vars.patch
@@ -1,0 +1,72 @@
+From c6a018e0ef50a1b0cb4962a2f96dae7c6f21f1d4 Mon Sep 17 00:00:00 2001
+From: Robert Scott <code@humanleg.org.uk>
+Date: Sun, 12 Feb 2023 23:04:15 +0000
+Subject: [PATCH] hardening-check: obey READELF, LDD & OBJDUMP env vars for
+ tool names
+
+this is useful on e.g. cross-build systems where the desired
+tools may have platform-denoting prefixes
+---
+ scripts/hardening-check.pl | 17 ++++++++++-------
+ 1 file changed, 10 insertions(+), 7 deletions(-)
+
+diff --git a/scripts/hardening-check.pl b/scripts/hardening-check.pl
+index ad7f4e43..d4b1f79e 100755
+--- a/scripts/hardening-check.pl
++++ b/scripts/hardening-check.pl
+@@ -47,6 +47,9 @@
+ pod2usage(1)                                                if $help;
+ pod2usage(-exitstatus => 0, -verbose => 2, -noperldoc => 1) if $man;
+ 
++my $ldd     = $ENV{'LDD'} || "ldd";
++my $objdump = $ENV{'OBJDUMP'} || "objdump";
++my $readelf = $ENV{'READELF'} || "readelf";
+ my $overall = 0;
+ my $rc      = 0;
+ my $report  = "";
+@@ -220,8 +223,8 @@ (@)
+ # Find the libc used in this executable, if any.
+ sub find_libc($) {
+     my ($file) = @_;
+-    my $ldd = output("ldd", $file);
+-    $ldd =~ /^\s*libc\.so\.\S+\s+\S+\s+(\S+)/m;
++    my $ldd_out = output($ldd, $file);
++    $ldd_out =~ /^\s*libc\.so\.\S+\s+\S+\s+(\S+)/m;
+     return $1 || "";
+ }
+ 
+@@ -232,7 +235,7 @@ ($$)
+     # Catch "NOTYPE" for object archives.
+     my $func_regex = " (I?FUNC|NOTYPE) ";
+ 
+-    my $relocs = output("readelf", "-sW", $file);
++    my $relocs = output($readelf, "-sW", $file);
+     for my $line (split("\n", $relocs)) {
+         next if ($line               !~ /$func_regex/);
+         next if ($undefined && $line !~ /$func_regex.* UND /);
+@@ -271,21 +274,21 @@ ($$)
+     @tags   = ();
+ 
+     # Get program headers.
+-    my $PROG_REPORT = output("readelf", "-lW", $file);
++    my $PROG_REPORT = output($readelf, "-lW", $file);
+     if (length($PROG_REPORT) == 0) {
+         $overall = 1;
+         next;
+     }
+ 
+     # Get ELF headers.
+-    my $DYN_REPORT = output("readelf", "-dW", $file);
++    my $DYN_REPORT = output($readelf, "-dW", $file);
+ 
+     # Get disassembly
+     my $DISASM
+-      = output("objdump", "-d", "--no-show-raw-insn", "-M", "intel", $file);
++      = output($objdump, "-d", "--no-show-raw-insn", "-M", "intel", $file);
+ 
+     # Get notes
+-    my $NOTES = output("readelf", "-n", $file);
++    my $NOTES = output($readelf, "-n", $file);
+ 
+     # Get list of all symbols needing external resolution.
+     my $functions = find_functions($file, 1);

--- a/pkgs/by-name/de/debian-devscripts/package.nix
+++ b/pkgs/by-name/de/debian-devscripts/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitLab,
-  fetchpatch,
   xz,
   dpkg,
   libxslt,
@@ -44,17 +43,13 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [
-    (fetchpatch {
-      name = "hardening-check-obey-binutils-env-vars.patch";
-      url = "https://github.com/Debian/devscripts/pull/2/commits/c6a018e0ef50a1b0cb4962a2f96dae7c6f21f1d4.patch";
-      hash = "sha256-UpS239JiAM1IYxNuJLdILq2h0xlR5t0Tzhj47xiMHww=";
-    })
+    # hardening-check: obey READELF, LDD & OBJDUMP env vars for tool names
+    # https://github.com/Debian/devscripts/pull/2
+    ./hardening-check-obey-binutils-env-vars.patch
+
     # Write to stdout and exit 0 for --help, --version
     # https://salsa.debian.org/debian/devscripts/-/merge_requests/637
-    (fetchpatch {
-      url = "https://salsa.debian.org/debian/devscripts/-/commit/dbb258ea17749e2d102d4d181fe2709bda5584e7.patch";
-      hash = "sha256-+/E1UhxKk4PYD1bO1kI0qjfBpcMoFbo3xiY45IQ/FWU=";
-    })
+    ./write-to-stdout-and-exit-0.patch
   ];
 
   postPatch = ''

--- a/pkgs/by-name/de/debian-devscripts/write-to-stdout-and-exit-0.patch
+++ b/pkgs/by-name/de/debian-devscripts/write-to-stdout-and-exit-0.patch
@@ -1,0 +1,212 @@
+From d76aaa05cb44a6ba741c74a83a319fcabf493865 Mon Sep 17 00:00:00 2001
+From: Anders Kaseorg <andersk@mit.edu>
+Date: Mon, 20 Apr 2026 13:59:02 -0700
+Subject: [PATCH 1/5] dpkg-genbuilddeps: exit 0 for --help, --version
+
+Signed-off-by: Anders Kaseorg <andersk@mit.edu>
+---
+ scripts/dpkg-genbuilddeps.sh | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/scripts/dpkg-genbuilddeps.sh b/scripts/dpkg-genbuilddeps.sh
+index 04cb048d..dd140ea7 100755
+--- a/scripts/dpkg-genbuilddeps.sh
++++ b/scripts/dpkg-genbuilddeps.sh
+@@ -14,12 +14,12 @@ Options:
+    -h, --help     This help
+    -v, --version  Report version and exit
+ EOF
+-	    exit 1
++	    exit 0
+ 	    ;;
+ 	-v|--version)
+ 	    echo "$PROGNAME wrapper for dpkg-depcheck:"
+ 	    dpkg-depcheck --version
+-	    exit 1
++	    exit 0
+ 	    ;;
+     esac
+ fi
+-- 
+GitLab
+
+
+From 183ed0a70f6f72dc6bf4d9765285c62b8c7e8629 Mon Sep 17 00:00:00 2001
+From: Anders Kaseorg <andersk@mit.edu>
+Date: Mon, 20 Apr 2026 14:04:43 -0700
+Subject: [PATCH 2/5] debchange: Use ###VERSION###
+
+Signed-off-by: Anders Kaseorg <andersk@mit.edu>
+---
+ scripts/debchange.pl | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scripts/debchange.pl b/scripts/debchange.pl
+index adae33d9..0b60b0b2 100755
+--- a/scripts/debchange.pl
++++ b/scripts/debchange.pl
+@@ -250,7 +250,7 @@ EOF
+ 
+ sub version () {
+     print <<"EOF";
+-This is $progname, from the Debian devscripts package, version 2.17.10
++This is $progname, from the Debian devscripts package, version ###VERSION###
+ This code is copyright 1999-2003 by Julian Gilbey, all rights reserved.
+ Based on code by Christoph Lameter.
+ This program comes with ABSOLUTELY NO WARRANTY.
+-- 
+GitLab
+
+
+From 73625a57909ea3fd7c5cdea3115c9d16f87668a9 Mon Sep 17 00:00:00 2001
+From: Anders Kaseorg <andersk@mit.edu>
+Date: Mon, 20 Apr 2026 14:12:18 -0700
+Subject: [PATCH 3/5] hardening-check: exit 0 for --help
+
+Signed-off-by: Anders Kaseorg <andersk@mit.edu>
+---
+ scripts/hardening-check.pl | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scripts/hardening-check.pl b/scripts/hardening-check.pl
+index 1a2b2dfa..433c1ca6 100755
+--- a/scripts/hardening-check.pl
++++ b/scripts/hardening-check.pl
+@@ -46,7 +46,7 @@ GetOptions(
+     "help|h|?"               => \$help,
+     "man|H"                  => \$man,
+ ) or pod2usage(2);
+-pod2usage(1)                                                if $help;
++pod2usage(0)                                                if $help;
+ pod2usage(-exitstatus => 0, -verbose => 2, -noperldoc => 1) if $man;
+ 
+ my $overall = 0;
+-- 
+GitLab
+
+
+From e8fb22f6d8d7a916f66ca87fa252d03af6270105 Mon Sep 17 00:00:00 2001
+From: Anders Kaseorg <andersk@mit.edu>
+Date: Mon, 20 Apr 2026 14:46:50 -0700
+Subject: [PATCH 4/5] who-permits-upload: Write to stdout, exit 0 for --help
+
+Signed-off-by: Anders Kaseorg <andersk@mit.edu>
+---
+ scripts/who-permits-upload.pl | 44 ++++++++++++++++++-----------------
+ 1 file changed, 23 insertions(+), 21 deletions(-)
+
+diff --git a/scripts/who-permits-upload.pl b/scripts/who-permits-upload.pl
+index 99e3e1df..60b4a1f9 100755
+--- a/scripts/who-permits-upload.pl
++++ b/scripts/who-permits-upload.pl
+@@ -189,39 +189,41 @@ if ($TYPE eq 'package') {
+ } elsif ($TYPE eq 'sponsor') {
+     $TYPE = TYPE_SPONSOR;
+ } else {
+-    usage();
++    usage(*STDERR);
++    exit 2;
+ }
+ 
+ if ($HELP) {
+-    usage();
++    usage(*STDOUT);
++    exit 0;
+ }
+ 
+ if (not @ARGUMENTS) {
+-    usage();
++    usage(*STDERR);
++    exit 2;
+ }
+ 
+ sub usage {
+-    print STDERR (
++    my ($fh) = @_;
++    print $fh (
+ "Usage: $0 [-h][-s KEYRING][-d DM_URL][-s SEARCH_TYPE] QUERY [QUERY ...]\n"
+     );
+-    print STDERR "Retrieve permissions granted to Debian Maintainers (DM)\n";
+-    print STDERR "\n";
+-    print STDERR "-h, --help\n";
+-    print STDERR "\t\t\tDisplay this usage summary and exit\n";
+-    print STDERR "-k, --keyring=KEYRING\n";
+-    print STDERR
++    print $fh "Retrieve permissions granted to Debian Maintainers (DM)\n";
++    print $fh "\n";
++    print $fh "-h, --help\n";
++    print $fh "\t\t\tDisplay this usage summary and exit\n";
++    print $fh "-k, --keyring=KEYRING\n";
++    print $fh
+       "\t\t\tUse the supplied keyring file(s) instead of the default\n";
+-    print STDERR "\t\t\tkeyring. Separate arguments by a colon (\":\")\n";
+-    print STDERR "-d, --dmfile=DM_URL\n";
+-    print STDERR "\t\t\tRetrieve DM permissions from the supplied URL.\n";
+-    print STDERR "\t\t\tDefault is https://ftp-master.debian.org/dm.txt\n";
+-    print STDERR "-s, --search=SEARCH_TYPE\n";
+-    print STDERR "\t\t\tSupplied QUERY arguments are interpreted as:\n";
+-    print STDERR
+-      "\t\t\tpackage name when SEARCH_TYPE is \"package\" (default)\n";
+-    print STDERR "\t\t\tDM user name id when SEARCH_TYPE is \"uid\"\n";
+-    print STDERR "\t\t\tsponsor user id when SEARCH_TYPE is \"sponsor\"\n";
+-    exit 2;
++    print $fh "\t\t\tkeyring. Separate arguments by a colon (\":\")\n";
++    print $fh "-d, --dmfile=DM_URL\n";
++    print $fh "\t\t\tRetrieve DM permissions from the supplied URL.\n";
++    print $fh "\t\t\tDefault is https://ftp-master.debian.org/dm.txt\n";
++    print $fh "-s, --search=SEARCH_TYPE\n";
++    print $fh "\t\t\tSupplied QUERY arguments are interpreted as:\n";
++    print $fh "\t\t\tpackage name when SEARCH_TYPE is \"package\" (default)\n";
++    print $fh "\t\t\tDM user name id when SEARCH_TYPE is \"uid\"\n";
++    print $fh "\t\t\tsponsor user id when SEARCH_TYPE is \"sponsor\"\n";
+ }
+ 
+ sub leave {
+-- 
+GitLab
+
+
+From d91e190604da139b2b492efcdeb55a099467dd03 Mon Sep 17 00:00:00 2001
+From: Anders Kaseorg <andersk@mit.edu>
+Date: Mon, 20 Apr 2026 15:36:22 -0700
+Subject: [PATCH 5/5] cowpoke: Write to stdout for --help
+
+Signed-off-by: Anders Kaseorg <andersk@mit.edu>
+---
+ scripts/cowpoke.sh | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/scripts/cowpoke.sh b/scripts/cowpoke.sh
+index 54dd9fc2..f7756322 100755
+--- a/scripts/cowpoke.sh
++++ b/scripts/cowpoke.sh
+@@ -111,7 +111,7 @@ GNU General Public License."
+ }
+ 
+ usage() {
+-    cat 1>&2 <<EOF
++    cat <<EOF
+ 
+ cowpoke [options] package.dsc
+ 
+@@ -258,7 +258,7 @@ for arg; do
+ 
+ 	*)
+ 	    echo "ERROR: unrecognised option '$arg'"
+-	    usage 1
++	    usage 1 >&2
+ 	    ;;
+     esac
+ done
+@@ -269,7 +269,7 @@ if [ -z "$REMOTE_SCRIPT" ]; then
+ fi
+ if [ -z "$DSC" ]; then
+     echo "ERROR: No package .dsc specified"
+-    usage 1
++    usage 1 >&2
+ fi
+ if ! [ -r "$DSC" ]; then
+     echo "ERROR: '$DSC' not found."
+-- 
+GitLab
+


### PR DESCRIPTION
Both patches are from unmerged PRs and the commit corresponding to the second patch has already been garbage-collected, causing the build of debian-devscripts to fail.

- The first vendored patch corresponds to
https://github.com/Debian/devscripts/commit/c6a018e0ef50a1b0cb4962a2f96dae7c6f21f1d4.patch from https://github.com/Debian/devscripts/pull/2.
- The second vendored patch corresponds to
https://salsa.debian.org/debian/devscripts/-/merge_requests/637.patch from https://salsa.debian.org/debian/devscripts/-/merge_requests/637.
- You can verify that the second vendored patch matches the patch that was previously fetched by fetching https://salsa.debian.org/debian/devscripts/-/merge_requests/637.patch using `fetchpatch` instead of the garbage-collected commit — the hash is the same (at the time of writing).
  - (I found out that this was the PR patch by consulting an [OfBorg build](https://logs.ofborg.org/?key=nixos/nixpkgs.511906&attempt_id=f424b048-f71e-4507-86fc-9a9366137ad7) for https://github.com/NixOS/nixpkgs/pull/511906, whose logs list the names of the patched files.)

Hydra: https://hydra.nixos.org/build/329270098
ZHF: https://github.com/NixOS/nixpkgs/issues/516381
Tracking: https://github.com/NixOS/nixpkgs/issues/476406

Fixes https://github.com/NixOS/nixpkgs/issues/522890

cc @andersk 


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`. — fails due to a `TabError` when importing `python3Packages.magic`
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
