### PR TITLE
gnat16Packages.{gprbuild{,-boot},gnatcoll-core}: fix build

### DIFF
--- a/pkgs/development/ada-modules/gnatcoll/core.nix
+++ b/pkgs/development/ada-modules/gnatcoll/core.nix
@@ -36,6 +36,12 @@ stdenv.mkDerivation rec {
       url = "https://github.com/AdaCore/gnatcoll-core/commit/515db1c9f1eea8095f2d9ff9570159a78c981ec6.patch";
       sha256 = "1ghnkhp5fncb7qcmf59kyqvy0sd0pzf1phnr2z7b4ljwlkbmcp36";
     })
+    # Fix compilation with GNAT 16
+    (fetchpatch2 {
+      name = "gnatcoll-core-gnat-16.patch";
+      url = "https://github.com/AdaCore/gnatcoll-core/commit/b266466e0a05b30615ec43d72782c345470455b9.patch?full_index=1";
+      hash = "sha256-rG0D1y2dbXA2M2Arnto+f7iAhg3yCfTPDbDRN+pMJKQ=";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/development/ada-modules/gnatcoll/core.nix
+++ b/pkgs/development/ada-modules/gnatcoll/core.nix
@@ -30,12 +30,6 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    # Fix compilation with GNAT 12 https://github.com/AdaCore/gnatcoll-core/issues/88
-    (fetchpatch2 {
-      name = "gnatcoll-core-gnat-12.patch";
-      url = "https://github.com/AdaCore/gnatcoll-core/commit/515db1c9f1eea8095f2d9ff9570159a78c981ec6.patch";
-      sha256 = "1ghnkhp5fncb7qcmf59kyqvy0sd0pzf1phnr2z7b4ljwlkbmcp36";
-    })
     # Fix compilation with GNAT 16
     (fetchpatch2 {
       name = "gnatcoll-core-gnat-16.patch";

--- a/pkgs/development/ada-modules/gnatprove/default.nix
+++ b/pkgs/development/ada-modules/gnatprove/default.nix
@@ -86,6 +86,9 @@ let
       patches = [
         # Disable Coq related targets which are missing in the fsf-15 branch
         ./0001-fix-install-fsf-15.patch
+
+        # Suppress warnings on aarch64: https://github.com/AdaCore/spark2014/issues/54
+        ./0002-mute-aarch64-warnings.patch
       ];
       commit_date = "2025-06-10";
     };

--- a/pkgs/development/ada-modules/gprbuild/boot.nix
+++ b/pkgs/development/ada-modules/gprbuild/boot.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  fetchpatch2,
   gnat,
   which,
   xmlada, # for src
@@ -34,6 +35,20 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     gnat
     which
+  ];
+
+  # Fix compilation with GNAT 16
+  patches = lib.optionals (lib.versionAtLeast gnat.version "16") [
+    # gpr-compilation-process.adb:44:29: error: operator for type "String" is not declared in "Env_Maps"
+    (fetchpatch2 {
+      url = "https://github.com/AdaCore/gprbuild/commit/6421e350274b3018a26bd058b1c90d033b053f71.patch?full_index=1";
+      hash = "sha256-u9bmr8abmthlyHoeqW5nS2CnaxXmbx6WVwhemxVtw+0=";
+    })
+    # gpr-compilation-protocol.adb:981:13: error: "time_t" is undefined
+    (fetchpatch2 {
+      url = "https://github.com/AdaCore/gprbuild/commit/6b6be939d69d534beb7faca17664d7a1ffa9c81e.patch?full_index=1";
+      hash = "sha256-YUjBvA4bBsrCB46o5WVHOZR6qOf2bkMg+A9qlystDbc=";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/development/ada-modules/gprbuild/default.nix
+++ b/pkgs/development/ada-modules/gprbuild/default.nix
@@ -47,11 +47,13 @@ stdenv.mkDerivation {
     NIX_LDFLAGS = "-headerpad_max_install_names";
   };
 
-  # Fixes gprbuild being linked statically always. Based on the AUR's patch:
-  # https://aur.archlinux.org/cgit/aur.git/plain/0001-Makefile-build-relocatable-instead-of-static-binary.patch?h=gprbuild&id=bac524c76cd59c68fb91ef4dfcbe427357b9f850
-  patches = lib.optionals (!stdenv.hostPlatform.isStatic) [
-    ./gprbuild-relocatable-build.patch
-  ];
+  patches =
+    gprbuild-boot.patches
+    # Fixes gprbuild being linked statically always. Based on the AUR's patch:
+    # https://aur.archlinux.org/cgit/aur.git/plain/0001-Makefile-build-relocatable-instead-of-static-binary.patch?h=gprbuild&id=bac524c76cd59c68fb91ef4dfcbe427357b9f850
+    ++ lib.optionals (!stdenv.hostPlatform.isStatic) [
+      ./gprbuild-relocatable-build.patch
+    ];
 
   buildFlags = [
     "all"


### PR DESCRIPTION
https://github.com/AdaCore/gprbuild/commit/6421e350274b3018a26bd058b1c90d033b053f71
https://github.com/AdaCore/gprbuild/commit/6b6be939d69d534beb7faca17664d7a1ffa9c81e
https://github.com/AdaCore/gnatcoll-core/commit/b266466e0a05b30615ec43d72782c345470455b9

Hydra: https://hydra.nixos.org/build/329281640
ZHF: https://github.com/NixOS/nixpkgs/issues/516381

There's also a bump to 26.0.0 in the works (https://github.com/NixOS/nixpkgs/pull/521558), but it seems to be stuck at the moment.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `gnat16Packages.{gprbuild{,-boot},gnatcoll-core}`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
