### PR TITLE
home-assistant: 2026.5.3 -> 2026.5.4

### DIFF
--- a/pkgs/development/python-modules/aiolyric/default.nix
+++ b/pkgs/development/python-modules/aiolyric/default.nix
@@ -4,7 +4,7 @@
   aioresponses,
   buildPythonPackage,
   fetchFromGitHub,
-  incremental,
+  packaging,
   pytest-asyncio,
   pytestCheckHook,
   setuptools,
@@ -12,24 +12,27 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "aiolyric";
-  version = "2.1.0";
+  version = "2.1.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "timmo001";
     repo = "aiolyric";
     tag = finalAttrs.version;
-    hash = "sha256-kLsq1pBRWz49DZgX47k132OipDcfn+kby6/GYDL3pPc=";
+    hash = "sha256-+OYMe63sX5TtvJpNn6dzvnephlhS/MyFXmUerYZqF5A=";
   };
 
   build-system = [
-    incremental
     setuptools
+  ];
+
+  pythonRelaxDeps = [
+    "packaging"
   ];
 
   dependencies = [
     aiohttp
-    incremental
+    packaging
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/ha-garmin/default.nix
+++ b/pkgs/development/python-modules/ha-garmin/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "ha-garmin";
-  version = "0.1.22";
+  version = "0.1.23";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "cyberjunky";
     repo = "ha-garmin";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-q5bNa6HT2GeqdElsSG7Rgk3a14GsjGyLkHWVrg3CTYs=";
+    hash = "sha256-0x7+pABt0i9QFty/i8IeU2CLmDUQiw16pYZ1Wr7CARI=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/python-backoff/default.nix
+++ b/pkgs/development/python-modules/python-backoff/default.nix
@@ -1,0 +1,42 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  lib,
+  pytest-asyncio,
+  pytestCheckHook,
+  requests,
+  responses,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "python-backoff";
+  version = "2.3.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "python-backoff";
+    repo = "backoff";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Os20Gz+uWaEdUPPF9/tT7LNxbmN0W/tuzVZa3H+ZG2A=";
+  };
+
+  build-system = [ hatchling ];
+
+  pythonImportsCheck = [ "backoff" ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+    requests
+    responses
+  ];
+
+  meta = {
+    changelog = "https://github.com/python-backoff/backoff/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    description = "Python library providing function decorators for configurable backoff and retry";
+    homepage = "https://github.com/python-backoff/backoff";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.dotlambda ];
+  };
+})

--- a/pkgs/development/python-modules/python-roborock/default.nix
+++ b/pkgs/development/python-modules/python-roborock/default.nix
@@ -24,14 +24,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "python-roborock";
-  version = "5.5.1";
+  version = "5.12.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Python-roborock";
     repo = "python-roborock";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-2ShXt2mtMhMugzqOHhY1GT7cQ0K78k/4/bPmmP/uheI=";
+    hash = "sha256-v4hONQ3EmpenjnAVKm8YMrynVyxtduefN5oqGW9MoE0=";
   };
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/renault-api/default.nix
+++ b/pkgs/development/python-modules/renault-api/default.nix
@@ -19,14 +19,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "renault-api";
-  version = "0.5.8";
+  version = "0.5.10";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "hacf-fr";
     repo = "renault-api";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/ZvMrEe3qgtMpg49OLZH1YTXQKSGR8e3yaShghnyMv4=";
+    hash = "sha256-1ym2xDJo8Ax76jC7rvVYI+EADKkdjGiKKvtiyE/rk/4=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/wled/default.nix
+++ b/pkgs/development/python-modules/wled/default.nix
@@ -3,9 +3,7 @@
   aiohttp,
   aioresponses,
   awesomeversion,
-  backoff,
   buildPythonPackage,
-  cachetools,
   fetchFromGitHub,
   mashumaro,
   orjson,
@@ -14,6 +12,7 @@
   pytest-cov-stub,
   pytest-xdist,
   pytestCheckHook,
+  python-backoff,
   syrupy,
   typer,
   yarl,
@@ -22,14 +21,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "wled";
-  version = "0.22.0";
+  version = "0.23.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "frenck";
     repo = "python-wled";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-CUTuIQf6gj9teLicIOtu1FUsYiYXtKeLNuDbNh/21sc=";
+    hash = "sha256-1JLW3wze4W3Uva9xIeSAmYw8f9tDfGxe9rueixVedms=";
   };
 
   postPatch = ''
@@ -43,10 +42,9 @@ buildPythonPackage (finalAttrs: {
   dependencies = [
     aiohttp
     awesomeversion
-    backoff
-    cachetools
     mashumaro
     orjson
+    python-backoff
     yarl
   ];
 
@@ -70,6 +68,8 @@ buildPythonPackage (finalAttrs: {
   disabledTests = [
     # wled release table rendering is inconsistent
     "test_releases_command"
+    # outdated snapshots
+    "test_device_version_fixture"
   ];
 
   pythonImportsCheck = [ "wled" ];

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2026.5.3";
+  version = "2026.5.4";
   components = {
     "3_day_blinds" =
       ps: with ps; [

--- a/pkgs/servers/home-assistant/custom-components/alarmo/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/alarmo/package.nix
@@ -7,13 +7,13 @@
 buildHomeAssistantComponent rec {
   owner = "nielsfaber";
   domain = "alarmo";
-  version = "1.10.17";
+  version = "1.10.18";
 
   src = fetchFromGitHub {
     owner = "nielsfaber";
     repo = "alarmo";
     tag = "v${version}";
-    hash = "sha256-LVTwqJsuFvAGUgZDq6lkUUI/Ch0Ex+ApNxsyuUbDz14=";
+    hash = "sha256-SBR/NVz7E+gsVLnEO3o30irNeFnnBZb5YVJImWHLk2Y=";
   };
 
   postPatch = ''

--- a/pkgs/servers/home-assistant/custom-components/entity-notes/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/entity-notes/package.nix
@@ -8,13 +8,13 @@
 buildHomeAssistantComponent rec {
   owner = "martindell";
   domain = "entity_notes";
-  version = "3.3.4";
+  version = "3.3.10";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "ha-entity-notes";
     tag = "v${version}";
-    hash = "sha256-5JKZ/KC2sSDQQeg3taLyuZdF6QJHdc7pJ1jaFD9S3kc=";
+    hash = "sha256-2ZwIqqF3OQ6wjfi5c3cV8NyJNcucd95Nkrs/OimHrb0=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/garmin_connect/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/garmin_connect/package.nix
@@ -8,13 +8,13 @@
 buildHomeAssistantComponent rec {
   owner = "cyberjunky";
   domain = "garmin_connect";
-  version = "3.0.7";
+  version = "3.0.8";
 
   src = fetchFromGitHub {
     owner = "cyberjunky";
     repo = "home-assistant-garmin_connect";
     tag = version;
-    hash = "sha256-qCpUMmxH/Fjm2vlC9o5IUuip8QvOUGuPCZTZOnC/uuM=";
+    hash = "sha256-F/zMwaGt9lbMzhgy3Jk23ylalMJqMT5xf90YUeH0Fv4=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/mypyllant/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/mypyllant/package.nix
@@ -19,13 +19,13 @@
 buildHomeAssistantComponent rec {
   owner = "signalkraft";
   domain = "mypyllant";
-  version = "0.9.12";
+  version = "0.9.13";
 
   src = fetchFromGitHub {
     owner = "signalkraft";
     repo = "mypyllant-component";
     tag = "v${version}";
-    hash = "sha256-vXzcVua2cGQXXeug6Zy4AAeTok+BLH5k+krq3UBuQjw=";
+    hash = "sha256-ydayYZjebVQULYyF3KWJHuSg89dY+bGYe+5zHGxfnEw=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/oref_alert/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/oref_alert/package.nix
@@ -15,13 +15,13 @@
 buildHomeAssistantComponent rec {
   owner = "amitfin";
   domain = "oref_alert";
-  version = "6.18.2";
+  version = "6.18.3";
 
   src = fetchFromGitHub {
     owner = "amitfin";
     repo = "oref_alert";
     tag = "v${version}";
-    hash = "sha256-1z/0nvwQ0cyYWl+LDhCTZQhEzKU/RgSbHejqoZLDRSo=";
+    hash = "sha256-gF8JemhOxnwDHoMcC3Znp9lx92bPdRk/a8e3Upbhb+o=";
   };
 
   # Do not publish cards, currently broken, attempting to write to nix store.

--- a/pkgs/servers/home-assistant/custom-components/yandex-station/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/yandex-station/package.nix
@@ -10,13 +10,13 @@
 buildHomeAssistantComponent rec {
   owner = "AlexxIT";
   domain = "yandex_station";
-  version = "3.20.3";
+  version = "3.21.1";
 
   src = fetchFromGitHub {
     owner = "AlexxIT";
     repo = "YandexStation";
     tag = "v${version}";
-    hash = "sha256-odI16EkIqQ6tubr0BZHwRWwnAC7816DezNA8FoRcwyc=";
+    hash = "sha256-5a+631Gu7xaPq8EF+34bybm40YVTXPA/ylq6k8LPBNU=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -4,6 +4,7 @@
   callPackage,
   fetchFromGitHub,
   fetchPypi,
+  fetchpatch,
   python314,
   replaceVars,
   ffmpeg-headless,
@@ -262,7 +263,7 @@ let
   extraBuildInputs = extraPackages python.pkgs;
 
   # Don't forget to run update-component-packages.py after updating
-  hassVersion = "2026.5.3";
+  hassVersion = "2026.5.4";
 
 in
 python.pkgs.buildPythonApplication rec {
@@ -283,13 +284,13 @@ python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     tag = version;
-    hash = "sha256-U3P97V/3+4eKMPyT6JzqLiDgei84iEOyWdknFvJBn1o=";
+    hash = "sha256-Z5FUkljaWRr9tfBb6RXJCC86ZbyNkw0PvUcOl+bZ2cc=";
   };
 
   # Secondary source is pypi sdist for translations
   sdist = fetchPypi {
     inherit pname version;
-    hash = "sha256-SAeqGo+fTQG//Abix+6pjHKQJY1XBrNL7IexgqoXsYc=";
+    hash = "sha256-o5S6rnOTqzPLZpMBxgmp9IpmLlEHLvHTH68ql2EkVbI=";
   };
 
   build-system = with python.pkgs; [
@@ -317,6 +318,19 @@ python.pkgs.buildPythonApplication rec {
     # Patch path to ffmpeg binary
     (replaceVars ./patches/ffmpeg-path.patch {
       ffmpeg = "${lib.getExe ffmpeg-headless}";
+    })
+
+    (fetchpatch {
+      name = "2026.5.4-shelly-tests-fix.patch";
+      url = "https://github.com/home-assistant/core/commit/072e9b51a2321b0d4489bae6f1e04f7ed845222f.patch";
+      includes = [ "tests/components/shelly/test_coordinator.py" ];
+      hash = "sha256-0XQdw2MnwzrHKYY06TotfJJem0bqremmi7k8SyVQVGA=";
+    })
+
+    (fetchpatch {
+      name = "2026.5.4-homewizard-tests-fix.patch";
+      url = "https://github.com/home-assistant/core/commit/e796d9c46744097585bfada483108a55ae16344a.patch";
+      hash = "sha256-T0Nb6LcL/21WdUm8RmczhHaVX92n5O/rpMdpqDVQ2VU=";
     })
   ];
 

--- a/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
+++ b/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "pytest-homeassistant-custom-component";
-  version = "0.13.332";
+  version = "0.13.333";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "MatthewFlamm";
     repo = "pytest-homeassistant-custom-component";
     tag = version;
-    hash = "sha256-zkRmuNUmRVvnIwIx494xzFKT0/00GZzkVo6cva9tut4=";
+    hash = "sha256-zSssvqYxgGguKUanzpAYzammeWrBOi0bZrLIfg8NwC0=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "homeassistant-stubs";
-  version = "2026.5.3";
+  version = "2026.5.4";
   pyproject = true;
 
   disabled = python.version != home-assistant.python.version;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "KapJI";
     repo = "homeassistant-stubs";
     tag = version;
-    hash = "sha256-kgfnT+qTsbB3T8PPsSA698QcxcM1o1QW8hLnfXjGm5M=";
+    hash = "sha256-AMJZxGN/asXcWbT/X92tQQ82/f8vI8MYft/Xx43GInc=";
   };
 
   build-system = [

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -142,6 +142,11 @@ let
       # [2026.5.2] Failed: Description not found for placeholder `modulation` in component.honeywell_string_lights.config.abort.no_compatible_transmitters"
       "test_no_compatible_transmitters"
     ];
+    lutron_caseta = [
+      # [2026.5.4] creates binary_sensor.basement_bedroom_left_shade_battery
+      #            expects binary_sensor.basement_bedroom_basement_bedroom_left_shade_battery
+      "test_battery_sensor_handles_bridge_response_error"
+    ];
     novy_cooker_hood = [
       # [2026.5.2] Failed: Description not found for placeholder `modulation` in component.novy_cooker_hood.config.abort.no_compatible_transmitters
       "test_no_compatible_transmitters"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15756,6 +15756,8 @@ self: super: with self; {
 
   python-axolotl-curve25519 = callPackage ../development/python-modules/python-axolotl-curve25519 { };
 
+  python-backoff = callPackage ../development/python-modules/python-backoff { };
+
   python-barbicanclient = callPackage ../development/python-modules/python-barbicanclient { };
 
   python-barcode = callPackage ../development/python-modules/python-barcode { };


### PR DESCRIPTION
Diff: https://github.com/home-assistant/core/compare/2026.5.3...2026.5.4

Changelog: https://github.com/home-assistant/core/releases/tag/2026.5.4

closes https://github.com/NixOS/nixpkgs/pull/522206
closes https://github.com/NixOS/nixpkgs/pull/520217
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
