### PR TITLE
nixos/security/pam: install unix_chkpwd wrapper with capabilities instead of setuid

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -2551,7 +2551,7 @@ in
 
     security.wrappers = {
       unix_chkpwd = {
-        setuid = true;
+        capabilities = "cap_dac_read_search,cap_audit_write=ep";
         owner = "root";
         group = "root";
         source = "${package}/bin/unix_chkpwd";


### PR DESCRIPTION
The `pam_unix` module unconditionally relies on a helper binary, `unix_chkpwd`, to read "shadow password" records from `/etc/shadow`.

The most important thing in a shadow password record is of course the user's hashed password, if any, but there are also several other fields, including some that can affect whether the user is allowed to log in at all.  (See the [`shadow(5)`](https://man7.org/linux/man-pages/man5/shadow.5.html) manpage for full detail.)  Therefore, unless the system’s PAM configuration has been radically modified, `unix_chkpwd` is needed *even if* access to accounts is entirely via means other than passwords (e.g. SSH key only).

However, `unix_chkpwd` does not need to be installed setuid root.  The only special privileges it needs are the ability to read `/etc/shadow` and the ability to write audit logs.  This can be expressed using capability bits: `CAP_DAC_READ_SEARCH` + `CAP_AUDIT_WRITE` is sufficient.  Make that change to the wrapper configuration.

(`CAP_DAC_READ_SEARCH` gives read access to *all files on the system*, which is still a lot more than what’s *necessary*, but substantially narrower than full root privileges.  One could instead make `/etc/shadow` group-readable and have `unix_chkpwd` be setgid to the relevant group, but that wouldn’t be a two-line change anymore.)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
