### PR TITLE
inconsolata-lgc: 1.3 -> 2.200, modernize

### DIFF
--- a/pkgs/by-name/in/inconsolata-lgc/package.nix
+++ b/pkgs/by-name/in/inconsolata-lgc/package.nix
@@ -2,29 +2,48 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fontforge,
+  python3,
   installFonts,
+  ruby,
+  ttfautohint-nox,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "inconsolata-lgc";
-  version = "1.3";
+  version = "2.220";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "MihailJP";
     repo = "Inconsolata-LGC";
-    rev = "8adfef7a7316fcd2e9a5857054c7cdb2babeb35d";
-    sha256 = "0dqjj3mlc28s8ljnph6l086b4j9r5dly4fldq59crycwys72zzai";
+    tag = "LGC-${finalAttrs.version}";
+    hash = "sha256-NNYcLWxWAykcxkRTUS1aE32fFuDJwmycpa9loytSGtw=";
   };
 
   nativeBuildInputs = [
-    fontforge
+    (python3.withPackages (p: [
+      p.fontforge
+      p.fontforge-ref-sel-util
+      p.fontmake
+      p.fonttools
+    ]))
     installFonts
+    ruby
+    ttfautohint-nox
   ];
 
+  postPatch = ''
+    patchShebangs --build *.py *.rb
+  '';
+
+  enableParallelBuilding = true;
+
+  dontInstallWebfonts = true;
   installPhase = ''
     runHook preInstall
-    install -m444 -Dt $out/share/doc/${finalAttrs.pname}-${finalAttrs.version} LICENSE README
+    installFont woff $out/share/fonts/woff
+    installFont woff2 $out/share/fonts/woff2
+    install -m444 -Dt $out/share/doc/${finalAttrs.pname}-${finalAttrs.version} OFL.txt README.md
     runHook postInstall
   '';
 
@@ -53,7 +72,6 @@ stdenv.mkDerivation (finalAttrs: {
       * Straight quotation marks.
     '';
 
-    # See `License.txt' for details.
     license = lib.licenses.ofl;
     homepage = "https://github.com/MihailJP/Inconsolata-LGC";
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/in/inconsolata-lgc/package.nix
+++ b/pkgs/by-name/in/inconsolata-lgc/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   fontforge,
+  installFonts,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -16,12 +17,15 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "0dqjj3mlc28s8ljnph6l086b4j9r5dly4fldq59crycwys72zzai";
   };
 
-  nativeBuildInputs = [ fontforge ];
+  nativeBuildInputs = [
+    fontforge
+    installFonts
+  ];
 
   installPhase = ''
-    find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/truetype {} \;
-    find . -name '*.otf' -exec install -m444 -Dt $out/share/fonts/opentype {} \;
+    runHook preInstall
     install -m444 -Dt $out/share/doc/${finalAttrs.pname}-${finalAttrs.version} LICENSE README
+    runHook postInstall
   '';
 
   meta = {

--- a/pkgs/by-name/in/inconsolata-lgc/package.nix
+++ b/pkgs/by-name/in/inconsolata-lgc/package.nix
@@ -5,7 +5,7 @@
   fontforge,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "inconsolata-lgc";
   version = "1.3";
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/truetype {} \;
     find . -name '*.otf' -exec install -m444 -Dt $out/share/fonts/opentype {} \;
-    install -m444 -Dt $out/share/doc/${pname}-${version} LICENSE README
+    install -m444 -Dt $out/share/doc/${finalAttrs.pname}-${finalAttrs.version} LICENSE README
   '';
 
   meta = {
@@ -56,4 +56,4 @@ stdenv.mkDerivation rec {
       avnik
     ];
   };
-}
+})

--- a/pkgs/by-name/in/inconsolata-lgc/package.nix
+++ b/pkgs/by-name/in/inconsolata-lgc/package.nix
@@ -7,78 +7,98 @@
   ruby,
   ttfautohint-nox,
   nix-update-script,
+  fontFormats ? [ ],
 }:
-stdenv.mkDerivation (finalAttrs: {
-  pname = "inconsolata-lgc";
-  version = "2.220";
+let
+  elemOrEmpty = item: list: builtins.elem item list || list == [ ];
+in
+lib.checkListOfEnum "fontFormats"
+  [
+    "ttf"
+    "hintedttf"
+    "otf"
+    "ttc"
+    "woff"
+    "woff2"
+    "variable"
+  ]
+  fontFormats
+  stdenv.mkDerivation
+  (finalAttrs: {
+    pname = "inconsolata-lgc";
+    version = "2.220";
 
-  __structuredAttrs = true;
+    __structuredAttrs = true;
 
-  src = fetchFromGitHub {
-    owner = "MihailJP";
-    repo = "Inconsolata-LGC";
-    tag = "LGC-${finalAttrs.version}";
-    hash = "sha256-NNYcLWxWAykcxkRTUS1aE32fFuDJwmycpa9loytSGtw=";
-  };
+    src = fetchFromGitHub {
+      owner = "MihailJP";
+      repo = "Inconsolata-LGC";
+      tag = "LGC-${finalAttrs.version}";
+      hash = "sha256-NNYcLWxWAykcxkRTUS1aE32fFuDJwmycpa9loytSGtw=";
+    };
 
-  nativeBuildInputs = [
-    (python3.withPackages (p: [
-      p.fontforge
-      p.fontforge-ref-sel-util
-      p.fontmake
-      p.fonttools
-    ]))
-    installFonts
-    ruby
-    ttfautohint-nox
-  ];
+    nativeBuildInputs = [
+      (python3.withPackages (
+        p:
+        [
+          p.fontforge
+          p.fontforge-ref-sel-util
+        ]
+        ++ lib.optionals (elemOrEmpty "variable" fontFormats) [ p.fontmake ]
+        ++ lib.optionals (elemOrEmpty "ttc" fontFormats) [ p.fonttools ]
+      ))
+      installFonts
+      ruby
+      ttfautohint-nox
+    ];
 
-  postPatch = ''
-    patchShebangs --build *.py *.rb
-  '';
-
-  enableParallelBuilding = true;
-
-  dontInstallWebfonts = true;
-  installPhase = ''
-    runHook preInstall
-    installFont woff $out/share/fonts/woff
-    installFont woff2 $out/share/fonts/woff2
-    install -m444 -Dt $out/share/doc/${finalAttrs.pname}-${finalAttrs.version} OFL.txt README.md
-    runHook postInstall
-  '';
-
-  passthru.updateScript = nix-update-script { };
-
-  meta = {
-    description = "Fork of Inconsolata font, with proper support of Cyrillic and Greek";
-    longDescription = ''
-      Inconsolata is one of the most suitable font for programmers created by Raph
-      Levien. Since the original Inconsolata does not contain Cyrillic alphabet,
-      it was slightly inconvenient for not a few programmers from Russia.
-
-      Inconsolata LGC is a modified version of Inconsolata with added the Cyrillic
-      alphabet which directly descends from Inconsolata Hellenic supporting modern
-      Greek.
-
-      Inconsolata LGC is licensed under SIL OFL.
-
-
-      Inconsolata LGC changes:
-      * Cyrillic glyphs added.
-      * Italic and Bold font added.
-
-      Changes inherited from Inconsolata Hellenic:
-      * Greek glyphs.
-
-      Changes inherited from Inconsolata-dz:
-      * Straight quotation marks.
+    postPatch = ''
+      patchShebangs --build *.py *.rb
     '';
 
-    license = lib.licenses.ofl;
-    homepage = "https://github.com/MihailJP/Inconsolata-LGC";
-    maintainers = with lib.maintainers; [
-      avnik
-    ];
-  };
-})
+    enableParallelBuilding = true;
+    buildFlags = fontFormats;
+
+    dontInstallWebfonts = true;
+    installPhase = ''
+      runHook preInstall
+      installFont woff $out/share/fonts/woff
+      installFont woff2 $out/share/fonts/woff2
+      install -m444 -Dt $out/share/doc/${finalAttrs.pname}-${finalAttrs.version} OFL.txt README.md
+      runHook postInstall
+    '';
+
+    passthru.updateScript = nix-update-script { };
+
+    meta = {
+      description = "Fork of Inconsolata font, with proper support of Cyrillic and Greek";
+      longDescription = ''
+        Inconsolata is one of the most suitable font for programmers created by Raph
+        Levien. Since the original Inconsolata does not contain Cyrillic alphabet,
+        it was slightly inconvenient for not a few programmers from Russia.
+
+        Inconsolata LGC is a modified version of Inconsolata with added the Cyrillic
+        alphabet which directly descends from Inconsolata Hellenic supporting modern
+        Greek.
+
+        Inconsolata LGC is licensed under SIL OFL.
+
+
+        Inconsolata LGC changes:
+        * Cyrillic glyphs added.
+        * Italic and Bold font added.
+
+        Changes inherited from Inconsolata Hellenic:
+        * Greek glyphs.
+
+        Changes inherited from Inconsolata-dz:
+        * Straight quotation marks.
+      '';
+
+      license = lib.licenses.ofl;
+      homepage = "https://github.com/MihailJP/Inconsolata-LGC";
+      maintainers = with lib.maintainers; [
+        avnik
+      ];
+    };
+  })

--- a/pkgs/by-name/in/inconsolata-lgc/package.nix
+++ b/pkgs/by-name/in/inconsolata-lgc/package.nix
@@ -6,6 +6,7 @@
   installFonts,
   ruby,
   ttfautohint-nox,
+  nix-update-script,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "inconsolata-lgc";
@@ -46,6 +47,8 @@ stdenv.mkDerivation (finalAttrs: {
     install -m444 -Dt $out/share/doc/${finalAttrs.pname}-${finalAttrs.version} OFL.txt README.md
     runHook postInstall
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Fork of Inconsolata font, with proper support of Cyrillic and Greek";

--- a/pkgs/development/python-modules/fontforge-ref-sel-util/default.nix
+++ b/pkgs/development/python-modules/fontforge-ref-sel-util/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  nix-update-script,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "fontforge-ref-sel-util";
+  version = "0.1.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mihailjp";
+    repo = "fontforge-ref-sel-util";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qMwrcnt6LNEzOPDfibXkN5CYnkboMes4W9oHX9bTSBA=";
+  };
+
+  build-system = [ setuptools ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "FontForge utility plugin on references and selections";
+    homepage = "https://github.com/MihailJP/fontforge-ref-sel-util";
+    changelog = "https://github.com/MihailJP/fontforge-ref-sel-util/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      acidbong
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5928,6 +5928,8 @@ self: super: with self; {
     }
   );
 
+  fontforge-ref-sel-util = callPackage ../development/python-modules/fontforge-ref-sel-util { };
+
   fontmake = callPackage ../development/python-modules/fontmake { };
 
   fontmath = callPackage ../development/python-modules/fontmath { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
