### PR TITLE
Fix FreeBSD bootstrap for 15

### DIFF
--- a/pkgs/by-name/gi/git/package.nix
+++ b/pkgs/by-name/gi/git/package.nix
@@ -577,6 +577,15 @@ stdenv.mkDerivation (finalAttrs: {
     # Fails largely due to assumptions about BOM
     # Tested to fail: 2.18.0
     disable_test t0028-working-tree-encoding
+  ''
+  + lib.optionalString stdenv.hostPlatform.isFreeBSD ''
+    # Time zones are not available in the build sandbox.
+    # This can be fixed if/when we decide on how the hardcoded libc paths should look
+    disable_test t0006-date
+    # Kernel bug (?) related to confusion over whether ulimit -n should set max fd or num files
+    disable_test t5324-split-commit-graph
+    # known breakage vanished?
+    disable_test t7815-grep-binary
   '';
 
   stripDebugList = [

--- a/pkgs/by-name/li/libarchive/package.nix
+++ b/pkgs/by-name/li/libarchive/package.nix
@@ -65,6 +65,11 @@ stdenv.mkDerivation (finalAttrs: {
         #   bsdcpio: linkfile: large inode number truncated: Numerical result out of range
         "cpio/test/test_basic.c"
         "cpio/test/test_format_newc.c"
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isFreeBSD [
+        # Locales are broken while building FreeBSD stdenv
+        # Optimally they would be fixed, but it is challenging to debug.
+        "libarchive/test/test_archive_string_conversion.c"
       ];
       removeTest = testPath: ''
         substituteInPlace Makefile.am --replace-fail "${testPath}" ""

--- a/pkgs/by-name/li/libuv/package.nix
+++ b/pkgs/by-name/li/libuv/package.nix
@@ -130,6 +130,10 @@ stdenv.mkDerivation (finalAttrs: {
         "shutdown_close_pipe"
       ]
       ++ lib.optionals stdenv.hostPlatform.isFreeBSD [
+        # ENETUNREACH when performed in jailed build env
+        "tcp_connect"
+        "udp_connect"
+        "connect_unspecified"
         # EOPNOTSUPP when performed in jailed build env
         "tcp_reuseport"
         "udp_reuseport"

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -103,6 +103,13 @@ let
           ''
       + lib.optionalString stdenv.hostPlatform.isCygwin ''
         rm test/recipes/01-test_symbol_presence.t
+      ''
+      # this test has inconsistent behavior in the freebsd sandbox
+      # (binds to only ipv6 and connects on only ipv4)
+      + lib.optionalString stdenv.hostPlatform.isFreeBSD ''
+        substituteInPlace test/recipes/82-test_ocsp_cert_chain.t \
+          --replace-fail '"-accept",' '"-4", "-accept",' \
+          --replace-fail '"-connect",' '"-4", "-connect",'
       '';
 
       outputs = [

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -99,12 +99,11 @@ let
           "lib/clang"
         ];
         # SYNCME: this version number must be synced with the one in make-bootstrap-tools.nix
-        version = "18";
+        version = "21";
       };
       libunwind = linkBootstrap {
         name = "libunwind";
         paths = [
-          "lib/libunwind.a"
           "lib/libunwind.so"
           "lib/libunwind.so.1"
           "lib/libunwind.so.1.0"
@@ -291,6 +290,7 @@ let
     };
     freebsd = {
       locales = linkBootstrap { paths = [ "share/locale" ]; };
+      libiconvModules = linkBootstrap { paths = [ "lib/i18n" ]; };
       libc = linkBootstrap {
         name = "bootstrapLibs";
         paths = [
@@ -303,16 +303,12 @@ let
           "lib/crtendS.o"
           "lib/crti.o"
           "lib/crtn.o"
-          "lib/libc++.a"
           "lib/libc++.so"
           "lib/libc++.so.1"
-          "lib/libc.a"
           "lib/libc.so"
           "lib/libc.so.7"
-          "lib/libc_nonshared.a"
           "lib/libcrypt.so"
           "lib/libcrypt.so.5"
-          "lib/libcxxrt.a"
           "lib/libcxxrt.so"
           "lib/libcxxrt.so.1"
           "lib/libdevstat.so"
@@ -329,11 +325,10 @@ let
           "lib/libgcc_s.so.1"
           "lib/libkvm.so"
           "lib/libkvm.so.7"
-          "lib/libm.a"
           "lib/libm.so"
           "lib/libm.so.5"
           "lib/libmd.so"
-          "lib/libmd.so.6"
+          "lib/libmd.so.7"
           "lib/libncurses.so"
           "lib/libncurses.so.6"
           "lib/libncursesw.so"
@@ -344,7 +339,7 @@ let
           "lib/libthr.so"
           "lib/libthr.so.3"
           "lib/libutil.so"
-          "lib/libutil.so.9"
+          "lib/libutil.so.10"
           "lib/libxnet.so"
           "include"
           "share"
@@ -459,8 +454,6 @@ let
           export NIX_ENFORCE_PURITY="''${NIX_ENFORCE_PURITY-1}"
           export NIX_ENFORCE_NO_NATIVE="''${NIX_ENFORCE_NO_NATIVE-1}"
           export PATH_LOCALE=${prevStage.freebsd.localesReal or prevStage.freebsd.locales}/share/locale
-        ''
-        + lib.optionalString (prevStage.freebsd ? libiconvModules) ''
           export PATH_I18NMODULE=${prevStage.freebsd.libiconvModules}/lib/i18n
         '';
       };
@@ -589,7 +582,10 @@ in
       __bootstrapArchive = bootstrapArchive;
       fetchurl = prevStage.fetchurlReal;
       freebsd = super.freebsd.overrideScope (
-        self': super': { localesPrev = prevStage.freebsd.localesReal; }
+        self': super': {
+          inherit (prevStage.freebsd) libc;
+          localesPrev = prevStage.freebsd.localesReal;
+        }
       );
     };
   })

--- a/pkgs/stdenv/freebsd/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/freebsd/make-bootstrap-tools.nix
@@ -46,6 +46,8 @@ let
   mkdir = runCommand "mkdir" { coreutils = coreutils-big; } ''
     mkdir -p $out/bin
     cp $coreutils/bin/mkdir $out/bin
+    cp $coreutils/bin/cp $out/bin
+    cp $coreutils/bin/mv $out/bin
   '';
 in
 rec {
@@ -58,13 +60,13 @@ rec {
         gnutar
       ])
       ''
-        rm -rf include lib/*.a lib/i18n lib/bash share
+        rm -rf include lib/*.a lib/bash share
       '';
   bootstrap-tools = tar-all "bootstrap-tools.tar.xz" (
     with pkgs;
     # SYNCME: this version number must be synced with the one in default.nix
     let
-      llvmPackages = llvmPackages_18;
+      llvmPackages = llvmPackages_21;
     in
     [
       (runCommand "bsdcp" { } "mkdir -p $out/bin; cp ${freebsd.cp}/bin/cp $out/bin/bsdcp")
@@ -84,14 +86,16 @@ rec {
       gzip
       bzip2
       bzip2.dev
-      curl
+      # We don't use wcurl, and it uses shebangs for the build system when cross-compiling.
+      # That pollutes the bootstrap tarballs and prevents it from working.
+      (curl.overrideAttrs (old: {
+        postFixup = "rm $bin/bin/wcurl";
+      }))
       expand-response-params
       binutils-unwrapped
       freebsd.libc
-      llvmPackages.libcxx
-      llvmPackages.libcxx.dev
-      llvmPackages.compiler-rt
-      llvmPackages.compiler-rt.dev
+      stdenv.cc.libcxx
+      stdenv.cc.libcxx.dev
       llvmPackages.clang-unwrapped
       (freebsd.locales.override { locales = [ "C.UTF-8" ]; })
     ]

--- a/pkgs/stdenv/freebsd/unpack-bootstrap-files.sh
+++ b/pkgs/stdenv/freebsd/unpack-bootstrap-files.sh
@@ -6,7 +6,9 @@ BADLIST=ld-elf.so.1
 
 oobpatch() {
     $out/libexec/ld-elf.so.1 $src/bin/cp $1 ./tmp
-    $out/libexec/ld-elf.so.1 $out/bin/patchelf --set-rpath $out/lib --set-interpreter $out/libexec/ld-elf.so.1 ./tmp
+    $out/libexec/ld-elf.so.1 $out/bin/patchelf --set-rpath $out/lib ./tmp
+    # This will fail for libraries, but we don't have set -e so it's fine
+    $out/libexec/ld-elf.so.1 $out/bin/patchelf --set-interpreter $out/libexec/ld-elf.so.1 ./tmp
     $out/libexec/ld-elf.so.1 $src/bin/mv ./tmp $1
     BADLIST="$BADLIST|${1##*/}"
 }
@@ -14,6 +16,9 @@ oobpatch() {
 oobpatch $out/bin/patchelf
 oobpatch $out/lib/libthr.so.3
 oobpatch $out/lib/libc.so.7
+oobpatch $out/lib/libgmp.so.10
+oobpatch $out/lib/librt.so.1
+oobpatch $out/lib/libsys.so.7
 
 for f in $($out/libexec/ld-elf.so.1 $out/bin/find $out/lib -type f); do
     $out/libexec/ld-elf.so.1 $out/bin/grep -E "$BADLIST" <<<"$f" && continue

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1141,6 +1141,7 @@ with pkgs;
     perlSupport = false;
     rustSupport = false; # Needed for bootstrap
     withpcre2 = false;
+    curl = if stdenv.hostPlatform.isFreeBSD then curlMinimal else curl; # Needed for FreeBSD bootstrap
   };
 
   bump2version = with python3Packages; toPythonApplication bump2version;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
FreeBSD native build has been broken since the fix to FreeBSD 15 due to changes in the required bootstrap tarball files.

In the ensuing months, several packages have also started failing tests in the sandbox. I do not believe they are nix builder bugs, but it is possible. At least temporary, add some FreeBSD-specific fixes.

This will require someone to generate and upload bootstrap tarballs with `refresh-tarballs.bash` for the target `x86_64-unknown-freebsd`, I do not have access.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
