### PR TITLE
astal.source: 0-unstable-2025-11-26 -> 0-unstable-2026-06-21

### DIFF
--- a/pkgs/by-name/li/libcava/package.nix
+++ b/pkgs/by-name/li/libcava/package.nix
@@ -8,13 +8,13 @@
 cava.overrideAttrs (old: rec {
   pname = "libcava";
   # fork may not be updated when we update upstream
-  version = "0.10.6";
+  version = "0.10.7";
 
   src = fetchFromGitHub {
     owner = "LukashonakV";
     repo = "cava";
     tag = version;
-    hash = "sha256-63be1wypMiqhPA6sjMebmFE6yKpTj/bUE53sMWun554=";
+    hash = "sha256-zkyj1vBzHtoypX4Bxdh1Vmwh967DKKxN751v79hzmgQ=";
   };
 
   nativeBuildInputs = old.nativeBuildInputs ++ [

--- a/pkgs/by-name/wl/wl-vapi-gen/package.nix
+++ b/pkgs/by-name/wl/wl-vapi-gen/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitea,
+  meson,
+  ninja,
+  python3,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "wl-vapi-gen";
+  version = "1.1.0";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "kotontrion";
+    repo = "wl-vapi-gen";
+    tag = finalAttrs.version;
+    hash = "sha256-Wi6zDrabUjIXJuxRJ9oHYfKF1ULkim/5kHGb+pl0oc4=";
+  };
+
+  postPatch = ''
+    patchShebangs wl-vapi-gen.py
+  '';
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    python3
+  ];
+
+  meta = {
+    description = "Generate vala bindings for wayland protocols";
+    homepage = "https://codeberg.org/kotontrion/wl-vapi-gen";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.PerchunPak ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/development/libraries/astal/default.nix
+++ b/pkgs/development/libraries/astal/default.nix
@@ -9,6 +9,7 @@ self: {
   auth = self.callPackage ./modules/auth.nix { };
   battery = self.callPackage ./modules/battery.nix { };
   bluetooth = self.callPackage ./modules/bluetooth.nix { };
+  brightness = self.callPackage ./modules/brightness.nix { };
   cava = self.callPackage ./modules/cava.nix { };
   gjs = self.callPackage ./modules/gjs.nix { };
   greet = self.callPackage ./modules/greet.nix { };
@@ -18,7 +19,9 @@ self: {
   network = self.callPackage ./modules/network.nix { };
   notifd = self.callPackage ./modules/notifd.nix { };
   powerprofiles = self.callPackage ./modules/powerprofiles.nix { };
+  quarrel = self.callPackage ./modules/quarrel.nix { };
   river = self.callPackage ./modules/river.nix { };
   tray = self.callPackage ./modules/tray.nix { };
   wireplumber = self.callPackage ./modules/wireplumber.nix { inherit wireplumber; };
+  wl = self.callPackage ./modules/wl.nix { };
 }

--- a/pkgs/development/libraries/astal/modules/brightness.nix
+++ b/pkgs/development/libraries/astal/modules/brightness.nix
@@ -1,15 +1,13 @@
 {
   buildAstalModule,
   json-glib,
-  gdk-pixbuf,
   quarrel,
 }:
 buildAstalModule {
-  name = "notifd";
+  name = "brightness";
   buildInputs = [
     json-glib
-    gdk-pixbuf
     quarrel
   ];
-  meta.description = "Astal module for notification daemon";
+  meta.description = "Astal module for brightness devices";
 }

--- a/pkgs/development/libraries/astal/modules/greet.nix
+++ b/pkgs/development/libraries/astal/modules/greet.nix
@@ -1,6 +1,13 @@
-{ buildAstalModule, json-glib }:
+{
+  buildAstalModule,
+  json-glib,
+  quarrel,
+}:
 buildAstalModule {
   name = "greet";
-  buildInputs = [ json-glib ];
+  buildInputs = [
+    json-glib
+    quarrel
+  ];
   meta.description = "Astal module for greetd using IPC";
 }

--- a/pkgs/development/libraries/astal/modules/mpris.nix
+++ b/pkgs/development/libraries/astal/modules/mpris.nix
@@ -2,12 +2,16 @@
   buildAstalModule,
   gvfs,
   json-glib,
+  libsoup_3,
+  quarrel,
 }:
 buildAstalModule {
   name = "mpris";
   buildInputs = [
     gvfs
     json-glib
+    libsoup_3
+    quarrel
   ];
   meta.description = "Astal module for mpris players";
 }

--- a/pkgs/development/libraries/astal/modules/quarrel.nix
+++ b/pkgs/development/libraries/astal/modules/quarrel.nix
@@ -1,0 +1,5 @@
+{ buildAstalModule }:
+buildAstalModule {
+  name = "quarrel";
+  meta.description = "Astal module for command line argument parsing";
+}

--- a/pkgs/development/libraries/astal/modules/river.nix
+++ b/pkgs/development/libraries/astal/modules/river.nix
@@ -3,6 +3,9 @@ buildAstalModule {
   name = "river";
   buildInputs = [ json-glib ];
   meta.description = "Astal module for River using IPC";
+  # needs https://codeberg.org/kotontrion/wl-vapi-gen,
+  # which has 11 commits and needs to be packaged
+  meta.broken = true;
 
   postUnpack = ''
     rm -rf $sourceRoot/subprojects

--- a/pkgs/development/libraries/astal/modules/river.nix
+++ b/pkgs/development/libraries/astal/modules/river.nix
@@ -1,11 +1,17 @@
-{ buildAstalModule, json-glib }:
+{
+  buildAstalModule,
+  json-glib,
+  wl,
+  wl-vapi-gen,
+}:
 buildAstalModule {
   name = "river";
-  buildInputs = [ json-glib ];
+  nativeBuildInputs = [ wl-vapi-gen ];
+  buildInputs = [
+    json-glib
+    wl
+  ];
   meta.description = "Astal module for River using IPC";
-  # needs https://codeberg.org/kotontrion/wl-vapi-gen,
-  # which has 11 commits and needs to be packaged
-  meta.broken = true;
 
   postUnpack = ''
     rm -rf $sourceRoot/subprojects

--- a/pkgs/development/libraries/astal/modules/wl.nix
+++ b/pkgs/development/libraries/astal/modules/wl.nix
@@ -1,0 +1,9 @@
+{ buildAstalModule }:
+buildAstalModule {
+  name = "wl";
+  buildInputs = [ ];
+  meta.description = "Central wayland connection manager";
+  # needs https://codeberg.org/kotontrion/wl-vapi-gen,
+  # which has 11 commits and needs to be packaged
+  meta.broken = true;
+}

--- a/pkgs/development/libraries/astal/modules/wl.nix
+++ b/pkgs/development/libraries/astal/modules/wl.nix
@@ -1,9 +1,6 @@
-{ buildAstalModule }:
+{ buildAstalModule, wl-vapi-gen }:
 buildAstalModule {
   name = "wl";
-  buildInputs = [ ];
+  nativeBuildInputs = [ wl-vapi-gen ];
   meta.description = "Central wayland connection manager";
-  # needs https://codeberg.org/kotontrion/wl-vapi-gen,
-  # which has 11 commits and needs to be packaged
-  meta.broken = true;
 }

--- a/pkgs/development/libraries/astal/source.nix
+++ b/pkgs/development/libraries/astal/source.nix
@@ -7,15 +7,15 @@ let
   originalDrv = fetchFromGitHub {
     owner = "Aylur";
     repo = "astal";
-    rev = "7d1fac8a4b2a14954843a978d2ddde86168c75ef";
-    hash = "sha256-Jh4VtPcK2Ov+RTcV9FtyQRsxiJmXFQGfqX6jjM7/mgc=";
+    rev = "11842ae3045c1367fb3a62a2302dba0d9ccb4a33";
+    hash = "sha256-FGZHls4eQJ8y3pvf5h3b83PfXlve3vD/Gj3g1qoAK6o=";
   };
 in
 originalDrv.overrideAttrs (
   final: prev: {
     name = "${final.pname}-${final.version}"; # fetchFromGitHub already defines name
     pname = "astal-source";
-    version = "0-unstable-2025-11-26";
+    version = "0-unstable-2026-06-21";
 
     meta = prev.meta // {
       description = "Building blocks for creating custom desktop shells (source)";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Diff: https://github.com/Aylur/astal/compare/7d1fac8a4b2a14954843a978d2ddde86168c75ef...d8738f97ed01f4d87f668df35fa7bbad795c9e49
Superseds https://github.com/NixOS/nixpkgs/pull/486571
Must be merged with https://github.com/NixOS/nixpkgs/pull/500631 to fix the build failures

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
