### PR TITLE
python3Packages.wasmtime: don't run mypy via pytest-mypy

### DIFF
--- a/pkgs/development/python-modules/wasmtime/default.nix
+++ b/pkgs/development/python-modules/wasmtime/default.nix
@@ -5,7 +5,6 @@
   python,
   pkgs,
   pycparser,
-  pytest-mypy,
   pytestCheckHook,
   setuptools-git-versioning,
   setuptools,
@@ -32,6 +31,10 @@ buildPythonPackage (finalAttrs: {
     substituteInPlace ci/cbindgen.py \
       --replace-fail "'-D__builtin_va_list=int'," "'-D__builtin_va_list=int', '-Dnullptr_t=void*',"
 
+    # Don't run mypy via pytest-mypy (type checking breaks easily)
+    substituteInPlace pytest.ini \
+      --replace-fail 'addopts = --doctest-modules --mypy' 'addopts = --doctest-modules'
+
     sed -i '/^backend-path = \[/,/^\]/d' pyproject.toml
 
     # Use nixpkgs' wasmtime instead of downloading prebuilt C API artifacts.
@@ -57,7 +60,6 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [
     pycparser
-    pytest-mypy
     pytestCheckHook
     writableTmpDirAsHomeHook
   ];


### PR DESCRIPTION
Type checking breaks easily and we're not interested in type checking results (see the [manual](https://nixos.org/manual/nixpkgs/unstable/#testing-python-packages)).

Hydra: https://hydra.nixos.org/build/329220521
ZHF: https://github.com/NixOS/nixpkgs/issues/516381

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `python3{13,14}Packages.wasmtime`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
