### PR TITLE
gnome-remote-desktop: allow configuration from GNOME Settings

### DIFF
--- a/nixos/modules/services/desktops/gnome/gnome-remote-desktop.nix
+++ b/nixos/modules/services/desktops/gnome/gnome-remote-desktop.nix
@@ -5,7 +5,9 @@
   pkgs,
   ...
 }:
-
+let
+  cfg = config.services.gnome.gnome-remote-desktop;
+in
 {
   meta = {
     teams = [ lib.teams.gnome ];
@@ -15,11 +17,12 @@
   options = {
     services.gnome.gnome-remote-desktop = {
       enable = lib.mkEnableOption "Remote Desktop support using Pipewire";
+      openFirewall = lib.mkEnableOption "opening the default RDP port (3389) in the firewall";
     };
   };
 
   ###### implementation
-  config = lib.mkIf config.services.gnome.gnome-remote-desktop.enable {
+  config = lib.mkIf cfg.enable {
     services.pipewire.enable = true;
     services.dbus.packages = [ pkgs.gnome-remote-desktop ];
 
@@ -36,6 +39,11 @@
         home = "/var/lib/gnome-remote-desktop";
       };
       groups.gnome-remote-desktop = { };
+    };
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [ 3389 ];
+      allowedUDPPorts = [ 3389 ];
     };
   };
 }

--- a/pkgs/by-name/gn/gnome-control-center/package.nix
+++ b/pkgs/by-name/gn/gnome-control-center/package.nix
@@ -90,6 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
       inherit glibc tzdata shadow;
       inherit cups networkmanagerapplet;
     })
+    ./treat-linked-services-as-enabled.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-control-center/treat-linked-services-as-enabled.patch
+++ b/pkgs/by-name/gn/gnome-control-center/treat-linked-services-as-enabled.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: winston <hey@winston.sh>
+Date: Tue, 19 May 2026 22:21:23 +0200
+Subject: [PATCH] system: treat "linked" services as enabled
+
+This will enable the "Remote Desktop" panel.
+---
+ panels/system/cc-systemd-service.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/panels/system/cc-systemd-service.c b/panels/system/cc-systemd-service.c
+index 841f10f32..2cf7f9127 100644
+--- a/panels/system/cc-systemd-service.c
++++ b/panels/system/cc-systemd-service.c
+@@ -58,7 +58,7 @@ cc_get_service_state (const char *service,
+   }
+ 
+   g_variant_get_child (unit_path_variant, 0, "&s", &state);
+-  if (g_strcmp0 (state, "enabled") == 0)
++  if (g_strcmp0 (state, "enabled") == 0 || g_strcmp0 (state, "linked") == 0)
+     return CC_SERVICE_STATE_ENABLED;
+   if (g_strcmp0 (state, "disabled") == 0)
+     return CC_SERVICE_STATE_DISABLED;

--- a/pkgs/by-name/gn/gnome-remote-desktop/0001-pkexec-path.patch
+++ b/pkgs/by-name/gn/gnome-remote-desktop/0001-pkexec-path.patch
@@ -1,0 +1,26 @@
+diff --git a/src/grd-ctl.c b/src/grd-ctl.c
+index 8bb1697..6d2c042 100644
+--- a/src/grd-ctl.c
++++ b/src/grd-ctl.c
+@@ -1115,7 +1115,7 @@ main (int   argc,
+
+       builder = g_strv_builder_new ();
+
+-      g_strv_builder_add (builder, "pkexec");
++      g_strv_builder_add (builder, "/run/wrappers/bin/pkexec");
+       g_strv_builder_add (builder, "--user");
+       g_strv_builder_add (builder, GRD_USERNAME);
+       g_strv_builder_add (builder, argv[0]);
+diff --git a/src/grd-utils.c b/src/grd-utils.c
+index e082fcf..2fb2faa 100644
+--- a/src/grd-utils.c
++++ b/src/grd-utils.c
+@@ -363,7 +363,7 @@ grd_toggle_systemd_unit (GrdRuntimeMode   runtime_mode,
+   builder = g_strv_builder_new ();
+
+   if (runtime_mode == GRD_RUNTIME_MODE_SYSTEM)
+-    g_strv_builder_add (builder, "pkexec");
++    g_strv_builder_add (builder, "/run/wrappers/bin/pkexec");
+
+   g_strv_builder_add (builder,
+                       GRD_LIBEXEC_DIR "/gnome-remote-desktop-enable-service");

--- a/pkgs/by-name/gn/gnome-remote-desktop/0002-immutable-systemd.patch
+++ b/pkgs/by-name/gn/gnome-remote-desktop/0002-immutable-systemd.patch
@@ -1,0 +1,62 @@
+diff --git a/src/grd-configuration.c b/src/grd-configuration.c
+index d48b40c..aac8aed 100644
+--- a/src/grd-configuration.c
++++ b/src/grd-configuration.c
+@@ -191,6 +191,7 @@ on_handle_enable (GrdDBusRemoteDesktopConfigurationRdpServer *configuration_rdp_
+ {
+   g_autoptr (GError) error = NULL;
+
++#if 0 // skip the attempt to modify `/etc/systemd/system` when running on NixOS
+   if (!grd_toggle_systemd_unit (GRD_RUNTIME_MODE_SYSTEM, TRUE, &error))
+     {
+       g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR,
+@@ -200,6 +201,7 @@ on_handle_enable (GrdDBusRemoteDesktopConfigurationRdpServer *configuration_rdp_
+                                              error->message);
+       return G_DBUS_METHOD_INVOCATION_HANDLED;
+     }
++#endif
+
+   g_object_set (G_OBJECT (configuration->settings), "rdp-enabled", TRUE, NULL);
+
+@@ -217,6 +219,7 @@ on_handle_disable (GrdDBusRemoteDesktopConfigurationRdpServer *configuration_rdp
+ {
+   g_autoptr (GError) error = NULL;
+
++#if 0 // skip the attempt to modify `/etc/systemd/system` when running on NixOS
+   if (!grd_toggle_systemd_unit (GRD_RUNTIME_MODE_SYSTEM, FALSE, &error))
+     {
+       g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR,
+@@ -226,6 +229,7 @@ on_handle_disable (GrdDBusRemoteDesktopConfigurationRdpServer *configuration_rdp
+                                              error->message);
+       return G_DBUS_METHOD_INVOCATION_HANDLED;
+     }
++#endif
+
+   g_object_set (G_OBJECT (configuration->settings), "rdp-enabled", FALSE, NULL);
+
+diff --git a/src/grd-enable-service.c b/src/grd-enable-service.c
+index 5c98c71..bca8169 100644
+--- a/src/grd-enable-service.c
++++ b/src/grd-enable-service.c
+@@ -111,6 +111,10 @@ enable_systemd_unit (GrdRuntimeMode   runtime_mode,
+   GBusType bus_type;
+   const char *unit;
+
++  // skip the attempt to modify `/etc/systemd/system` when running on NixOS
++  if (runtime_mode == GRD_RUNTIME_MODE_SYSTEM)
++    return TRUE;
++
+   get_systemd_unit_info (runtime_mode, &bus_type, &unit);
+
+   connection = g_bus_get_sync (bus_type, NULL, error);
+@@ -157,6 +161,10 @@ disable_systemd_unit (GrdRuntimeMode   runtime_mode,
+   GBusType bus_type;
+   const char *unit;
+
++  // skip the attempt to modify `/etc/systemd/system` when running on NixOS
++  if (runtime_mode == GRD_RUNTIME_MODE_SYSTEM)
++    return TRUE;
++
+   get_systemd_unit_info (runtime_mode, &bus_type, &unit);
+
+   connection = g_bus_get_sync (bus_type, NULL, error);

--- a/pkgs/by-name/gn/gnome-remote-desktop/package.nix
+++ b/pkgs/by-name/gn/gnome-remote-desktop/package.nix
@@ -42,6 +42,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-CJBJEZ4fJEL+l3PwKFNlztwgf0y8fOmvOI4VNmjisXE=";
   };
 
+  patches = [
+    ./0001-pkexec-path.patch
+    ./0002-immutable-systemd.patch
+  ];
+
   nativeBuildInputs = [
     meson
     ninja


### PR DESCRIPTION
A few patches to allow users to configure gnome-remote-desktop via the GNOME Settings app.
This also fixes `grdctl` being able to edit `/etc/gnome-remote-desktop/grd.conf` with `grd --system {enable,disable}`, as it no longer errors while trying to edit `/etc/systemd/system`; if a user wants to fully disable the service, they can make use the NixOS module.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
