### PR TITLE
rhash: disable compile-time SHA-NI for x86_64 compatibility

### DIFF
--- a/pkgs/by-name/rh/rhash/package.nix
+++ b/pkgs/by-name/rh/rhash/package.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   configureFlags = [
     "--ar=${stdenv.cc.targetPrefix}ar"
     "--target=${stdenv.hostPlatform.config}"
+    "--disable-shani"
     (lib.enableFeature enableStatic "static")
     (lib.enableFeature enableStatic "lib-static")
   ];


### PR DESCRIPTION
Since https://github.com/rhash/RHash/commit/e5b0cb6e7092798b14d2e4d85c49e6367a5f7432 rhash, by default, hardcodes SHA-NI instructions at compile time. However, these instructions are not available on older x86_64 CPUs.

In particular, rhash is a dependency of cmake, meaning that no cmake builds can run on CPUs without SHA-NI instructions with the default configuration.

This patch disables SHA-NI in rhash.

Fixes https://github.com/NixOS/nixpkgs/issues/519825.

See also the parallel Debian fix:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1113938


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
