### PR TITLE
python3Packages.crossandra: 2.2.1 -> 2.3.0

### DIFF
--- a/pkgs/development/python-modules/crossandra/default.nix
+++ b/pkgs/development/python-modules/crossandra/default.nix
@@ -2,35 +2,34 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  setuptools,
+  hatchling,
+  hatch-mypyc,
+  pytestCheckHook,
   result,
-  mypy,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "crossandra";
-  version = "2.2.1";
+  version = "2.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "trag1c";
     repo = "crossandra";
     tag = finalAttrs.version;
-    hash = "sha256-/JhrjXRH7Rs2bUil9HRneBC9wlVYEyfwivjzb+eyRv8=";
+    hash = "sha256-xKMySbt+Bf+6BGyIKsmYHTZTl25HxlG8hY/HuUtDjSM=";
   };
 
   build-system = [
-    setuptools
-    mypy
+    hatchling
+    hatch-mypyc
   ];
+
   dependencies = [ result ];
 
+  nativeCheckInputs = [ pytestCheckHook ];
+
   pythonImportsCheck = [ "crossandra" ];
-  prePatch = ''
-    # pythonRelaxDepsHook did not work
-    substituteInPlace pyproject.toml \
-      --replace-fail "result ~= 0.9.0" "result >= 0.9.0"
-  '';
 
   meta = {
     changelog = "https://github.com/trag1c/crossandra/blob/${finalAttrs.src.tag}/CHANGELOG.md";


### PR DESCRIPTION
changelog: https://github.com/trag1c/crossandra/blob/2.3.0/CHANGELOG.md
diff: https://github.com/trag1c/crossandra/compare/2.2.1...2.3.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
