### PR TITLE
kristall: 0.3 -> 0.4

### DIFF
--- a/pkgs/by-name/kr/kristall/package.nix
+++ b/pkgs/by-name/kr/kristall/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "kristall";
-  version = "0.3";
+  version = "0.4";
 
   src = fetchFromGitHub {
     owner = "MasterQ32";
     repo = "kristall";
     rev = "V${version}";
-    sha256 = "07nf7w6ilzs5g6isnvsmhh4qa1zsprgjyf0zy7rhpx4ikkj8c8zq";
+    hash = "sha256-zTO55xTc7hXlqVUVlx921+LalKj/yQwjEgXW2YUdG70=";
   };
 
   postPatch = lib.optionalString stdenv.cc.isClang ''
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     libsForQt5.wrapQtAppsHook
     libsForQt5.qmake
+    libsForQt5.qttools
   ];
 
   buildInputs = [ libsForQt5.qtmultimedia ];


### PR DESCRIPTION
update to 0.4



## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
