### PR TITLE
libaec: switch source to github

### DIFF
--- a/pkgs/by-name/li/libaec/package.nix
+++ b/pkgs/by-name/li/libaec/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitLab,
+  fetchFromGitHub,
   cmake,
 }:
 
@@ -9,9 +9,8 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "libaec";
   version = "1.1.6";
 
-  src = fetchFromGitLab {
-    domain = "gitlab.dkrz.de";
-    owner = "k202009";
+  src = fetchFromGitHub {
+    owner = "Deutsches-Klimarechenzentrum";
     repo = "libaec";
     tag = "v${finalAttrs.version}";
     hash = "sha256-cxDP+JNwokxgzH9hO2zw+rIcz8XG7E8ujbAbWpgUEW8=";
@@ -24,7 +23,8 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
 
   meta = {
-    homepage = "https://gitlab.dkrz.de/k202009/libaec";
+    changelog = "https://github.com/Deutsches-Klimarechenzentrum/libaec/blob/v${finalAttrs.version}/CHANGELOG.md";
+    homepage = "https://github.com/Deutsches-Klimarechenzentrum/libaec";
     description = "Adaptive Entropy Coding library";
     license = lib.licenses.bsd2;
     maintainers = [ ];


### PR DESCRIPTION
The old source, https://gitlab.dkrz.de/k202009/libaec, is now a redirect to https://gitlab.dkrz.de/dkrz-sw/libaec, and the top of this README links to https://github.com/Deutsches-Klimarechenzentrum/libaec as the source before the GitLab. Additionally, pull requests are being made on GitHub (https://github.com/Deutsches-Klimarechenzentrum/libaec/pulls) and commits seem to be mirrored to GitLab. Thus, it seems like the GitHub is now the primary development repository, so we fetch the source from there instead.

Found in #522876.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
