### PR TITLE
embedxpl: init at 3.1.0

### DIFF
--- a/pkgs/by-name/em/embedxpl/package.nix
+++ b/pkgs/by-name/em/embedxpl/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonApplication (finalAttrs: {
+  pname = "embedxpl";
+  version = "3.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mrhenrike";
+    repo = "EmbedXPL-Forge";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-C7BTFRvhIjUePXxVmUbZXN2EKi+D/nE220/6ms30yAs=";
+  };
+
+  __structuredAttrs = true;
+
+  build-system = with python3.pkgs; [ setuptools ];
+
+  dependencies = with python3.pkgs; [
+    aiohttp
+    colorama
+    paramiko
+    psutil
+    pycryptodome
+    pysnmp
+    python-nmap
+    requests
+    rich
+    scapy
+    telnetlib3
+  ];
+
+  optional-dependencies = with python3.pkgs; {
+    all = [
+      numpy
+      pymodbus
+      python-can
+      python-nmap
+      scikit-learn
+    ];
+    at = [ python-can ];
+    hvac = [ pymodbus ];
+    iiot = [ pymodbus ];
+    ml = [
+      numpy
+      scikit-learn
+    ];
+    ml-gpu = [
+      numpy
+      torch
+    ];
+    nse = [ python-nmap ];
+    ot = [ pymodbus ];
+    specialized = [ python-can ];
+    vehicles = [ python-can ];
+  };
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "embedxpl" ];
+
+  meta = {
+    description = "Embedded Device Security Assessment Framework";
+    homepage = "https://github.com/mrhenrike/EmbedXPL-Forge";
+    changelog = "https://github.com/mrhenrike/EmbedXPL-Forge/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "exf";
+  };
+})


### PR DESCRIPTION
Embedded Device Security Assessment Framework

https://github.com/mrhenrike/EmbedXPL-Forge

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
