### PR TITLE
llvmPackages_18.compiler-rt: fix Darwin build

### DIFF
--- a/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
@@ -155,12 +155,28 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals noSanitizers [
     (lib.cmakeBool "COMPILER_RT_BUILD_SANITIZERS" false)
   ]
-  ++ lib.optionals ((useLLVM && !haveLibcxx) || !haveLibc || bareMetal || isMusl || isDarwinStatic) [
-    (lib.cmakeBool "COMPILER_RT_BUILD_XRAY" false)
-    (lib.cmakeBool "COMPILER_RT_BUILD_LIBFUZZER" false)
-    (lib.cmakeBool "COMPILER_RT_BUILD_MEMPROF" false)
-    (lib.cmakeBool "COMPILER_RT_BUILD_ORC" false) # may be possible to build with musl if necessary
-  ]
+  ++
+    lib.optionals
+      (
+        (useLLVM && !haveLibcxx)
+        || !haveLibc
+        || bareMetal
+        || isMusl
+        || isDarwinStatic
+        # On Darwin, `darwin.libcxx` is the libcxx shipped inside the Apple SDK,
+        # so it is bumped together with the SDK. In libcxx 21 (Apple SDK 26.4+),
+        # the fallbacks for `__builtin_ctzg`/`__builtin_clzg` were removed because
+        # clang 18 support was dropped: https://github.com/llvm/llvm-project/pull/133920
+        # Clang 18 itself doesn't recognize those builtins, so the C++ components
+        # of compiler-rt 18 (which include `<algorithm>` etc.) fail to compile.
+        || (lib.versions.major release_version == "18" && stdenv.hostPlatform.isDarwin)
+      )
+      [
+        (lib.cmakeBool "COMPILER_RT_BUILD_XRAY" false)
+        (lib.cmakeBool "COMPILER_RT_BUILD_LIBFUZZER" false)
+        (lib.cmakeBool "COMPILER_RT_BUILD_MEMPROF" false)
+        (lib.cmakeBool "COMPILER_RT_BUILD_ORC" false) # may be possible to build with musl if necessary
+      ]
   ++ lib.optionals (!haveLibc || bareMetal) [
     (lib.cmakeBool "COMPILER_RT_BUILD_PROFILE" false)
     (lib.cmakeBool "CMAKE_C_COMPILER_WORKS" true)


### PR DESCRIPTION
[![](https://hydra-banner.harinn.dev/build/329337675)](https://hydra.nixos.org/build/329337675)

ZHF: #516381

This PR fixes the Darwin build for `llvmPackages_18.compiler-rt` after it was broken by the Apple SDK update #511399 via the staging-next merge #517946. Specifically, llvm/llvm-project#133920 broke the ability to build Clang 18 with libc++ 21, so we add `lib.versions.major release_version == "18" && stdenv.hostPlatform.isDarwin` to the set of conditions to disable things that require libc++.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
