### PR TITLE
python313Packages.jedi-language-server: relax jedi dependency constraint

### DIFF
--- a/pkgs/development/python-modules/jedi-language-server/default.nix
+++ b/pkgs/development/python-modules/jedi-language-server/default.nix
@@ -6,6 +6,7 @@
 
   # build-system
   poetry-core,
+  pythonRelaxDepsHook,
 
   # dependencies
   docstring-to-markdown,
@@ -35,7 +36,10 @@ buildPythonPackage rec {
 
   build-system = [
     poetry-core
+    pythonRelaxDepsHook
   ];
+
+  pythonRelaxDeps = [ "jedi" ];
 
   dependencies = [
     docstring-to-markdown


### PR DESCRIPTION
Fixes #523129


<!--
Fixes #523129

Relax the upper bound dependency constraint on `jedi` (`<0.20`) using `pythonRelaxDepsHook`. This allows `jedi-language-server` to build successfully with the newer `jedi` version (`0.20.0`) currently available in nixpkgs.

All 104 internal tests passed successfully during `pytestCheckPhase` using Python 3.13, confirming full compatibility with the new `jedi` version.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
