### PR TITLE
stm32cubeprogrammer: init at 2.22.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3281,6 +3281,12 @@
     github = "beeb";
     githubId = 703631;
   };
+  beeelias = {
+    name = "Elias Hanelt";
+    email = "elias.hanelt@gmail.com";
+    github = "beeelias";
+    githubId = 236911673;
+  };
   bellackn = {
     name = "Nico Bellack";
     email = "blcknc@pm.me";

--- a/pkgs/by-name/st/stm32cubeprogrammer/package.nix
+++ b/pkgs/by-name/st/stm32cubeprogrammer/package.nix
@@ -288,6 +288,10 @@ in
 buildFHSEnv {
   pname = "stm32cubeprogrammer";
   inherit version;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
   runScript = "${package}/bin/.STM32CubeProgrammer-inner";
 
   extraInstallCommands = ''

--- a/pkgs/by-name/st/stm32cubeprogrammer/package.nix
+++ b/pkgs/by-name/st/stm32cubeprogrammer/package.nix
@@ -1,0 +1,354 @@
+{
+  lib,
+  stdenv,
+  autoPatchelfHook,
+  buildFHSEnv,
+  copyDesktopItems,
+  icoutils,
+  makeDesktopItem,
+  makeWrapper,
+  python3,
+  requireFile,
+  unzip,
+  jdk,
+  zulu21,
+  alsa-lib,
+  fontconfig,
+  freetype,
+  glib,
+  gtk2,
+  gtk3,
+  krb5,
+  libGL,
+  libusb1,
+  libxkbcommon,
+  pcsclite,
+  libx11,
+  libxext,
+  libxi,
+  libxrender,
+  libxtst,
+  libxrandr,
+  libxcursor,
+  libxxf86vm,
+  zlib,
+}:
+
+let
+  version = "2.22.0";
+
+  zulu21WithFx = zulu21.override { enableJavaFX = true; };
+
+  package = stdenv.mkDerivation {
+    pname = "stm32cubeprogrammer-unwrapped";
+    inherit version;
+
+    src = requireFile {
+      name = "SetupSTM32CubeProgrammer_linux_64.zip";
+      sha256 = "fffa017abb4da14582e129aa9a1e4f87e6d0719a3cb950c0184f4cb48ab60aa7";
+      url = "https://www.st.com/en/development-tools/stm32cubeprog.html";
+      message = ''
+        STM32CubeProgrammer must be downloaded manually from STMicroelectronics.
+
+        1. Visit https://www.st.com/en/development-tools/stm32cubeprog.html
+        2. Download "STM32CubeProgrammer for Linux" (you may need an ST account).
+        3. Add the zip to the Nix store:
+
+           nix-store --add-fixed sha256 SetupSTM32CubeProgrammer_linux_64.zip
+      '';
+    };
+
+    nativeBuildInputs = [
+      autoPatchelfHook
+      icoutils
+      makeWrapper
+      jdk
+      python3
+      unzip
+    ];
+
+    buildInputs = [
+      alsa-lib
+      fontconfig
+      freetype
+      glib
+      gtk2
+      gtk3
+      krb5
+      libGL
+      libusb1
+      libxkbcommon
+      pcsclite
+      zlib
+      stdenv.cc.cc.lib
+      libx11
+      libxext
+      libxi
+      libxrender
+      libxtst
+      libxrandr
+      libxcursor
+      libxxf86vm
+    ];
+
+    # libcrypto.so.1.0.0 is wanted by the bundled libssl.so/libstp11_SAM.so
+    # (HSM/smartcard PKCS#11 support — not needed for core flashing). Qt5
+    # references are residual from older libFileManager builds.
+    autoPatchelfIgnoreMissingDeps = [
+      "libjvm.so"
+      "libQt5Core.so.5"
+      "libQt5Network.so.5"
+      "libQt5SerialPort.so.5"
+      "libQt5Widgets.so.5"
+      "libQt5Xml.so.5"
+      "libQt5Gui.so.5"
+      "libcrypto.so.1.0.0"
+    ];
+
+    dontConfigure = true;
+
+    unpackPhase = ''
+      runHook preUnpack
+      unzip -q $src -d unpacked
+      runHook postUnpack
+    '';
+
+    buildPhase = ''
+      runHook preBuild
+
+      install_dir="$PWD/staging"
+
+      # The .exe is an IzPack jar; the .linux ELF wrapper just invokes
+      # `java -jar SetupSTM32CubeProgrammer-${version}.exe`. We drive the
+      # IzPack -console installer with a small Python expect-style helper.
+      cat > drive.py <<'PYEOF'
+      import os, re, select, subprocess, sys, time
+
+      install_dir, jar = sys.argv[1], sys.argv[2]
+      java = os.environ["JAVA_BIN"]
+
+      proc = subprocess.Popen(
+          [java, "-jar", jar, "-console"],
+          stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+          bufsize=0,
+      )
+
+      buf = b""
+      last_input_at = time.time()
+
+      def send(line):
+          global last_input_at
+          sys.stdout.write(f"\n--> [{line!r}]\n"); sys.stdout.flush()
+          proc.stdin.write((line + "\n").encode()); proc.stdin.flush()
+          last_input_at = time.time()
+
+      rules = [
+          (re.compile(rb"to continue, 2 to quit, 3 to redisplay"), lambda: "1"),
+          (re.compile(rb"to accept, 2 to reject, 3 to redisplay"), lambda: "1"),
+          (re.compile(rb"Select the installation path"),           lambda: install_dir),
+          (re.compile(rb"Press Enter to continue, X to exit"),     lambda: ""),
+          (re.compile(rb"Press anything to continue"),             lambda: ""),
+          (re.compile(rb"Enter Y for Yes, N for No"),              lambda: "Y"),
+          # IzPack ExecutableFile post-install script — chmod fails in
+          # the sandbox (no /bin/chmod); say OK so install continues, we
+          # set executable bits ourselves in installPhase.
+          (re.compile(rb"Enter O for OK, C to Cancel"),            lambda: "O"),
+      ]
+
+      fd = proc.stdout.fileno()
+      os.set_blocking(fd, False)
+
+      deadline = time.time() + 1800
+      while True:
+          if proc.poll() is not None:
+              break
+          r, _, _ = select.select([fd], [], [], 1.0)
+          if r:
+              try:
+                  chunk = os.read(fd, 4096)
+              except BlockingIOError:
+                  chunk = b""
+              if not chunk:
+                  if proc.poll() is not None:
+                      break
+                  continue
+              sys.stdout.buffer.write(chunk); sys.stdout.flush()
+              buf += chunk
+
+              for rx, resp in rules:
+                  m = rx.search(buf)
+                  if m:
+                      send(resp())
+                      buf = buf[m.end():]
+                      break
+
+          if time.time() - last_input_at > 20 and proc.poll() is None:
+              sys.stdout.write("\n!!! idle 20s, sending '1'\n")
+              send("1")
+
+          if time.time() > deadline:
+              sys.stdout.write("\n!!! deadline reached\n")
+              proc.kill(); break
+
+      proc.wait()
+      sys.stdout.write(f"\n=== java exited rc={proc.returncode} ===\n")
+      PYEOF
+
+      cd unpacked
+      JAVA_BIN="${jdk}/bin/java" python3 -u ../drive.py \
+        "$install_dir" "SetupSTM32CubeProgrammer-${version}.exe"
+
+      if [ ! -f "$install_dir/bin/STM32_Programmer_CLI" ]; then
+        echo "IzPack install did not produce expected files" >&2
+        exit 1
+      fi
+
+      cd "$NIX_BUILD_TOP"
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      out_root="$out/opt/STM32CubeProgrammer"
+      mkdir -p "$out_root"
+      cp -r "$PWD/staging"/. "$out_root"/
+
+      # IzPack does not preserve executable bits reliably in the sandbox.
+      chmod +x \
+        "$out_root/bin/STM32_Programmer_CLI" \
+        "$out_root/bin/STM32_KeyGen_CLI" \
+        "$out_root/bin/STM32_SigningTool_CLI" \
+        "$out_root/bin/STM32CubeProgrammerLauncher" \
+        "$out_root/bin/STM32_Programmer.sh" \
+        "$out_root/bin/STM32CubeProgrammer" || true
+      find "$out_root" -name '*.so*' -exec chmod +x {} +
+
+      mkdir -p $out/bin
+      makeWrapper "$out_root/bin/STM32_Programmer_CLI" $out/bin/STM32_Programmer_CLI \
+        --prefix LD_LIBRARY_PATH : "$out_root/lib"
+      makeWrapper "$out_root/bin/STM32_KeyGen_CLI" $out/bin/STM32_KeyGen_CLI \
+        --prefix LD_LIBRARY_PATH : "$out_root/lib"
+      makeWrapper "$out_root/bin/STM32_SigningTool_CLI" $out/bin/STM32_SigningTool_CLI \
+        --prefix LD_LIBRARY_PATH : "$out_root/lib"
+
+      # Inner GUI launcher — runs inside the FHS wrapper below so /bin/bash
+      # exists (the Java code Runtime.exec()s /bin/bash). zulu21 with JavaFX
+      # provides the JavaFX modules the JRE 8-built launcher expects.
+      makeWrapper ${zulu21WithFx}/bin/java $out/bin/.STM32CubeProgrammer-inner \
+        --add-flags "-Djdk.gtk.version=3" \
+        --add-flags "-jar $out_root/bin/STM32CubeProgrammerLauncher" \
+        --set GDK_BACKEND x11 \
+        --prefix LD_LIBRARY_PATH : "$out_root/lib"
+
+      # udev rules for ST-LINK / J-Link / DFU
+      mkdir -p $out/lib/udev/rules.d
+      if [ -d "$out_root/Drivers/rules" ]; then
+        for r in "$out_root"/Drivers/rules/*.rules; do
+          cp "$r" "$out/lib/udev/rules.d/"
+        done
+      fi
+
+      # Icon — extract each size of the bundled .ico into hicolor PNGs
+      if [ -f "$out_root/util/Programmer.ico" ]; then
+        icotool -x -o "$NIX_BUILD_TOP" "$out_root/util/Programmer.ico" || true
+        for png in "$NIX_BUILD_TOP"/Programmer_*.png; do
+          [ -f "$png" ] || continue
+          size=$(basename "$png" | sed -E 's/.*_([0-9]+)x[0-9]+x[0-9]+\.png/\1/')
+          [ -n "$size" ] || continue
+          dest=$out/share/icons/hicolor/"$size"x"$size"/apps
+          mkdir -p "$dest"
+          cp "$png" "$dest/stm32cubeprogrammer.png"
+        done
+      fi
+
+      runHook postInstall
+    '';
+  };
+
+  desktopItem = makeDesktopItem {
+    name = "stm32cubeprogrammer";
+    desktopName = "STM32CubeProgrammer";
+    comment = "STMicroelectronics STM32 microcontroller programming software";
+    exec = "STM32CubeProgrammer";
+    icon = "stm32cubeprogrammer";
+    terminal = false;
+    categories = [
+      "Development"
+      "Electronics"
+      "Engineering"
+    ];
+    startupWMClass = "STM32CubeProgrammer";
+  };
+
+in
+buildFHSEnv {
+  pname = "stm32cubeprogrammer";
+  inherit version;
+  runScript = "${package}/bin/.STM32CubeProgrammer-inner";
+
+  extraInstallCommands = ''
+    mv $out/bin/stm32cubeprogrammer $out/bin/STM32CubeProgrammer
+
+    for cli in STM32_Programmer_CLI STM32_KeyGen_CLI STM32_SigningTool_CLI; do
+      ln -sf ${package}/bin/$cli $out/bin/$cli
+    done
+
+    mkdir -p $out/share/applications $out/share/icons $out/lib/udev
+    cp ${desktopItem}/share/applications/*.desktop $out/share/applications/
+    ln -sf ${package}/share/icons/* $out/share/icons/
+    ln -sf ${package}/lib/udev/rules.d $out/lib/udev/rules.d
+  '';
+
+  targetPkgs =
+    pkgs: with pkgs; [
+      alsa-lib
+      cairo
+      dbus
+      expat
+      fontconfig
+      freetype
+      glib
+      gtk3
+      krb5
+      libGL
+      libusb1
+      libxkbcommon
+      pango
+      pcsclite
+      libx11
+      libxcb
+      libxcomposite
+      libxdamage
+      libxext
+      libxfixes
+      libxi
+      libxrandr
+      libxrender
+      libxtst
+      libxxf86vm
+      libxcursor
+      udev
+      zlib
+    ];
+
+  meta = {
+    description = "All-in-one multi-OS software tool for programming STM32 products";
+    longDescription = ''
+      STM32CubeProgrammer (STM32CubeProg) is an all-in-one multi-OS software
+      tool for programming STM32 products. It provides an easy-to-use and
+      efficient environment for reading, writing, and verifying device
+      memory through both the debug interface (JTAG and SWD) and the
+      bootloader interface (UART, USB DFU, I2C, SPI, and CAN).
+      STM32CubeProgrammer offers a wide range of features to program STM32
+      internal memories (such as Flash, RAM, and OTP) as well as external
+      memories.
+    '';
+    homepage = "https://www.st.com/en/development-tools/stm32cubeprog.html";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "STM32CubeProgrammer";
+    maintainers = with lib.maintainers; [ beeelias ];
+  };
+}

--- a/pkgs/by-name/st/stm32cubeprogrammer/package.nix
+++ b/pkgs/by-name/st/stm32cubeprogrammer/package.nix
@@ -43,6 +43,9 @@ let
     pname = "stm32cubeprogrammer-unwrapped";
     inherit version;
 
+    strictDeps = true;
+    __structuredAttrs = true;
+
     src = requireFile {
       name = "SetupSTM32CubeProgrammer_linux_64.zip";
       sha256 = "fffa017abb4da14582e129aa9a1e4f87e6d0719a3cb950c0184f4cb48ab60aa7";


### PR DESCRIPTION
## Description of changes

Adds STM32CubeProgrammer (STM32CubeProg) 2.22.0 — STMicroelectronics' all-in-one multi-OS programming tool for STM32 MCUs/MPUs.

Provides:
- `STM32CubeProgrammer` (JavaFX GUI) — wrapped in `buildFHSEnv` because the Java code `Runtime.exec()`s `/bin/bash` in a few places.
- `STM32_Programmer_CLI`, `STM32_KeyGen_CLI`, `STM32_SigningTool_CLI` (plain autopatchelf'd binaries, no FHS needed).
- udev rules for ST-Link v2 / v2.1 / v3 and Segger J-Link (registers via `services.udev.packages`).
- `.desktop` entry and hicolor PNG icons.

### Notable design choices

- The upstream installer is an IzPack-driven JAR (`SetupSTM32CubeProgrammer_linux_64.zip` → `SetupSTM32CubeProgrammer-2.22.0.exe` is the JAR; the `.linux` ELF is a thin Java launcher). The build drives `java -jar <jar> -console` with a small Python expect-style helper because there is no public `auto-install.xml` and the panels (custom ST-branded analytics + components) make a static input file fragile. IzPack ends up calling `/bin/chmod` on its bundled `util/*.sh` scripts during the *postinstall* `<executable>` actions — those scripts only run in a real install (`util/copy_jre_linux.sh`, etc.), so the helper acks the resulting `Enter O for OK, C to Cancel` prompt and the install phase sets the bits we actually need in `installPhase`.
- The bundled JRE 8 had JavaFX baked in. Modern OpenJDK ships JFX separately and the nixpkgs `openjfx21` is an exploded modular-sdk that can't be loaded via `--module-path`, so the GUI runs against `zulu21.override { enableJavaFX = true; }`.
- Source distribution is gated by an STMicroelectronics account, so `requireFile` is used with the published sha256 and a download message pointing to https://www.st.com/en/development-tools/stm32cubeprog.html .

### Notes

- `meta.license = unfree` (ST proprietary SLA0048).
- Verified on x86_64-linux: GUI launches into the connection screen, `STM32_Programmer_CLI --version` prints `STM32CubeProgrammer version: 2.22.0`, udev rules install under `lib/udev/rules.d/`.
- `auto-patchelf` ignores three deps that aren't required for the core flasher: `libcrypto.so.1.0.0` (wanted only by legacy `libssl.so` / `libstp11_SAM.so` for HSM/PKCS#11) and two `libQt5Core.so.5` references in `libFileManager.so.1` (residual from older Qt5 builds — the bundled Qt6 libs are what's actually used).

---

# Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [x] NixOS test(s) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) — N/A (GUI tool, no automated test)
  - [x] and/or package tests, or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) — manual: GUI launches, CLI `--version` works, udev rules install.
  - [x] made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) and [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc