### PR TITLE
workflows/periodic-merge: update haskell-updates PR's base branch

### DIFF
--- a/.github/workflows/periodic-merge-24h.yml
+++ b/.github/workflows/periodic-merge-24h.yml
@@ -22,7 +22,7 @@ defaults:
 
 jobs:
   periodic-merge:
-    if: github.repository_owner == 'NixOS'
+    if: github.repository_owner == 'NixOS' || github.event_name == 'workflow_dispatch'
     strategy:
       # don't fail fast, so that all pairs are tried
       fail-fast: false

--- a/.github/workflows/periodic-merge-24h.yml
+++ b/.github/workflows/periodic-merge-24h.yml
@@ -49,3 +49,34 @@ jobs:
     name: ${{ matrix.pairs.name || format('{0} → {1}', matrix.pairs.from, matrix.pairs.into) }}
     secrets:
       NIXPKGS_CI_APP_PRIVATE_KEY: ${{ secrets.NIXPKGS_CI_APP_PRIVATE_KEY }}
+
+  # Resets the target branch of the current haskell-updates PR.
+  # This makes GitHub hide all the commits that are already part of staging and gives us a much clearer PR view.
+  haskell-updates:
+    needs: periodic-merge
+    runs-on: ubuntu-slim
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Find PR and update target branch
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            // There will at most be a single haskell-updates PR anyway, so no need to paginate.
+            await Promise.all(
+              (
+                await github.rest.pulls.list({
+                  ...context.repo,
+                  state: 'open',
+                  head: `${context.repo.owner}:haskell-updates`,
+                })
+              ).data.map((pr) =>
+                github.rest.pulls.update({
+                  ...context.repo,
+                  pull_number: pr.number,
+                  // Just updating to the same branch to trigger a UI update.
+                  // This is staging most of the time, but could be staging-next in rare cases.
+                  base: pr.base.ref,
+                }),
+              ),
+            )

--- a/.github/workflows/periodic-merge-6h.yml
+++ b/.github/workflows/periodic-merge-6h.yml
@@ -22,7 +22,7 @@ defaults:
 
 jobs:
   periodic-merge:
-    if: github.repository_owner == 'NixOS'
+    if: github.repository_owner == 'NixOS' || github.event_name == 'workflow_dispatch'
     strategy:
       # don't fail fast, so that all pairs are tried
       fail-fast: false


### PR DESCRIPTION
This gives us better UI in the PR by hiding the commits that are already on the base branch (mostly staging) after the periodic merge. Without this, the PR has 100s of commits listed after a few days.

Resolves / based on https://github.com/NixOS/nixpkgs/pull/521260#issuecomment-4496394793

## Things done

- [x] Tested in my fork, seems to work as expected.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
