### PR TITLE
v4l2-relayd: 0.1.5 -> 0.2.0

### DIFF
--- a/pkgs/by-name/v4/v4l2-relayd/package.nix
+++ b/pkgs/by-name/v4/v4l2-relayd/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchgit,
+  fetchFromGitLab,
   autoreconfHook,
   glib,
   gst_all_1,
@@ -12,12 +12,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "v4l2-relayd";
-  version = "0.1.5";
+  version = "0.2.0";
 
-  src = fetchgit {
-    url = "https://git.launchpad.net/v4l2-relayd";
+  src = fetchFromGitLab {
+    owner = "vicamo";
+    repo = "v4l2-relayd";
     tag = "upstream/${finalAttrs.version}";
-    hash = "sha256-D+OWkny+TYNJt08X+nl7EYs5tp51vjvig/vuID6lkmg=";
+    hash = "sha256-kgCVuUvgS7yXEh7DRcZUI0gfuHKwLgUS+FDxR8u//U0=";
   };
 
   nativeBuildInputs = [
@@ -42,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Streaming relay for v4l2loopback using GStreamer";
     mainProgram = "v4l2-relayd";
-    homepage = "https://git.launchpad.net/v4l2-relayd";
+    homepage = "https://gitlab.com/vicamo/v4l2-relayd";
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ betaboon ];
     platforms = [ "x86_64-linux" ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://gitlab.com/vicamo/v4l2-relayd/-/tags/upstream%2F0.2.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
