### PR TITLE
ip2unix: 2.2.1 -> 2.2.2

### DIFF
--- a/pkgs/by-name/ip/ip2unix/package.nix
+++ b/pkgs/by-name/ip/ip2unix/package.nix
@@ -20,23 +20,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ip2unix";
-  version = "2.2.1";
+  version = "2.2.2";
 
   src = fetchFromGitHub {
     owner = "nixcloud";
     repo = "ip2unix";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-+p5wQbX35LAjZ4vIE4AhI4M6gQ7gVviqf9jJDAr9xg8";
+    hash = "sha256-QWhOO2tHl8fwXy0k9W+I/XHPJI8OJyexMsgOSJes37s";
   };
-
-  patches = [
-    # https://github.com/nixcloud/ip2unix/pull/35
-    # fix out of range string_view access
-    (fetchpatch {
-      url = "https://github.com/nixcloud/ip2unix/commit/050ddf76b4b925f27e255fbb820b0700407ceb2b.patch";
-      hash = "sha256-5vaLmZmwuiMGV4KnVhuDSnXG1a390aBU51TShwpaMLs=";
-    })
-  ];
 
   nativeBuildInputs = [
     meson


### PR DESCRIPTION
This update comes with a bunch of fixes:

  * Out of range `string_view` access in `globpath`. Thanks to Adam Mizerski. This patch was already in nixpkgs because it led to a test failure.
  * Typo in README and manpage.
  * Invalid use of PROVIDE in linker script. This was the reason why ip2unix failed to build on `x86_64-linux` after our binutils upgrade.
  * `reject` rule not working with `sendto`/`sendmsg`.
  * Bug in `accept` if `stdin` was closed and `accept` would return FD 0.
  * Broken abstract socket support if used with `from-abstract`.
  * Race condition if the program uses library calls wrapped by ip2unix before initialisation was done. This fixes the integration tests on `aarch64-linux`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test