### PR TITLE
treewide: resolve pypi.org and related redirects

### DIFF
--- a/pkgs/by-name/rs/rss2email/package.nix
+++ b/pkgs/by-name/rs/rss2email/package.nix
@@ -73,7 +73,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   meta = {
     description = "Tool that converts RSS/Atom newsfeeds to email";
-    homepage = "https://pypi.python.org/pypi/rss2email";
+    homepage = "https://pypi.org/project/rss2email/";
     license = lib.licenses.gpl2;
     mainProgram = "r2e";
   };

--- a/pkgs/development/misc/resholve/deps.nix
+++ b/pkgs/development/misc/resholve/deps.nix
@@ -54,7 +54,7 @@ rec {
 
     meta = {
       description = "Python 2 and 3 compatibility library";
-      homepage = "https://pypi.python.org/pypi/six/";
+      homepage = "https://pypi.org/project/six/";
       license = lib.licenses.mit;
     };
   };

--- a/pkgs/development/python-modules/atomicwrites/default.nix
+++ b/pkgs/development/python-modules/atomicwrites/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Atomic file writes on POSIX";
-    homepage = "https://pypi.python.org/pypi/atomicwrites";
+    homepage = "https://pypi.org/project/atomicwrites/";
     maintainers = with lib.maintainers; [ matthiasbeyer ];
     license = lib.licenses.mit;
   };

--- a/pkgs/development/python-modules/avro-python3/default.nix
+++ b/pkgs/development/python-modules/avro-python3/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   meta = {
     description = "Serialization and RPC framework";
     mainProgram = "avro";
-    homepage = "https://pypi.python.org/pypi/avro-python3/";
+    homepage = "https://pypi.org/project/avro-python3/";
     license = lib.licenses.asl20;
 
     maintainers = [

--- a/pkgs/development/python-modules/avro3k/default.nix
+++ b/pkgs/development/python-modules/avro3k/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
   meta = {
     description = "Serialization and RPC framework";
     mainProgram = "avro";
-    homepage = "https://pypi.python.org/pypi/avro3k/";
+    homepage = "https://pypi.org/project/avro3k/";
     license = lib.licenses.asl20;
   };
 }

--- a/pkgs/development/python-modules/csscompressor/default.nix
+++ b/pkgs/development/python-modules/csscompressor/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Python port of YUI CSS Compressor";
-    homepage = "https://pypi.python.org/pypi/csscompressor";
+    homepage = "https://pypi.org/project/csscompressor/";
     license = lib.licenses.bsd3;
     maintainers = [ ];
   };

--- a/pkgs/development/python-modules/filebrowser-safe/default.nix
+++ b/pkgs/development/python-modules/filebrowser-safe/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
       dependency for the Mezzanine CMS for Django.
     '';
     homepage = "https://github.com/stephenmcd/filebrowser-safe";
-    downloadPage = "https://pypi.python.org/pypi/filebrowser_safe/";
+    downloadPage = "https://pypi.org/project/filebrowser_safe/";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ prikhi ];
     platforms = lib.platforms.unix;

--- a/pkgs/development/python-modules/grappelli-safe/default.nix
+++ b/pkgs/development/python-modules/grappelli-safe/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
       address these specific issues.
     '';
     homepage = "https://github.com/stephenmcd/grappelli-safe";
-    downloadPage = "http://pypi.python.org/pypi/grappelli_safe/";
+    downloadPage = "http://pypi.org/pypi/grappelli_safe/";
     changelog = "https://github.com/stephenmcd/grappelli-safe/releases/tag/v${version}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ prikhi ];

--- a/pkgs/development/python-modules/jsonrpclib-pelix/default.nix
+++ b/pkgs/development/python-modules/jsonrpclib-pelix/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "JSON RPC client library - Pelix compatible fork";
-    homepage = "https://pypi.python.org/pypi/jsonrpclib-pelix/";
+    homepage = "https://pypi.org/project/jsonrpclib-pelix/";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };

--- a/pkgs/development/python-modules/manuel/default.nix
+++ b/pkgs/development/python-modules/manuel/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Documentation builder";
-    homepage = "https://pypi.python.org/pypi/manuel";
+    homepage = "https://pypi.org/project/manuel/";
     license = lib.licenses.zpl20;
   };
 }

--- a/pkgs/development/python-modules/memory-profiler/default.nix
+++ b/pkgs/development/python-modules/memory-profiler/default.nix
@@ -27,7 +27,7 @@ python.pkgs.buildPythonPackage rec {
       This is a python module for monitoring memory consumption of a process as
       well as line-by-line analysis of memory consumption for python programs.
     '';
-    homepage = "https://pypi.python.org/pypi/memory_profiler";
+    homepage = "https://pypi.org/project/memory_profiler/";
     license = lib.licenses.bsd3;
   };
 }

--- a/pkgs/development/python-modules/minimock/default.nix
+++ b/pkgs/development/python-modules/minimock/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Minimalistic mocking library";
-    homepage = "https://pypi.python.org/pypi/MiniMock";
+    homepage = "https://pypi.org/project/MiniMock/";
     license = lib.licenses.mit;
     maintainers = [ ];
   };

--- a/pkgs/development/python-modules/numericalunits/default.nix
+++ b/pkgs/development/python-modules/numericalunits/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage (finalAttrs: {
   ];
 
   meta = {
-    homepage = "http://pypi.python.org/pypi/numericalunits";
+    homepage = "http://pypi.org/pypi/numericalunits/";
     description = "Package that lets you define quantities with unit";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ nickcao ];

--- a/pkgs/development/python-modules/pdfkit/default.nix
+++ b/pkgs/development/python-modules/pdfkit/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = {
-    homepage = "https://pypi.python.org/pypi/pdfkit";
+    homepage = "https://pypi.org/project/pdfkit/";
     description = "Wkhtmltopdf python wrapper to convert html to pdf using the webkit rendering engine and qt";
     license = lib.licenses.mit;
   };

--- a/pkgs/development/python-modules/progressbar/default.nix
+++ b/pkgs/development/python-modules/progressbar/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage (finalAttrs: {
   doCheck = false;
 
   meta = {
-    homepage = "https://pypi.python.org/pypi/progressbar";
+    homepage = "https://pypi.org/project/progressbar/";
     description = "Text progressbar library for python";
     license = lib.licenses.lgpl3Plus;
     maintainers = [ ];

--- a/pkgs/development/python-modules/progressbar33/default.nix
+++ b/pkgs/development/python-modules/progressbar33/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = {
-    homepage = "https://pypi.python.org/pypi/progressbar33";
+    homepage = "https://pypi.org/project/progressbar33/";
     description = "Text progressbar library for python";
     license = lib.licenses.lgpl3Plus;
     maintainers = with lib.maintainers; [ twey ];

--- a/pkgs/development/python-modules/ptest/default.nix
+++ b/pkgs/development/python-modules/ptest/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Test classes and test cases using decorators, execute test cases by command line, and get clear reports";
-    homepage = "https://pypi.python.org/pypi/ptest";
+    homepage = "https://pypi.org/project/ptest/";
     license = lib.licenses.asl20;
     mainProgram = "ptest";
   };

--- a/pkgs/development/python-modules/pymysqlsa/default.nix
+++ b/pkgs/development/python-modules/pymysqlsa/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "PyMySQL dialect for SQL Alchemy";
-    homepage = "https://pypi.python.org/pypi/pymysql_sa";
+    homepage = "https://pypi.org/project/pymysql_sa/";
     license = lib.licenses.mit;
   };
 }

--- a/pkgs/development/python-modules/pync/default.nix
+++ b/pkgs/development/python-modules/pync/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Python Wrapper for Mac OS 10.8 Notification Center";
-    homepage = "https://pypi.python.org/pypi/pync";
+    homepage = "https://pypi.org/project/pync/";
     license = lib.licenses.mit;
     platforms = lib.platforms.darwin;
     maintainers = [ ];

--- a/pkgs/development/python-modules/pytest-catchlog/default.nix
+++ b/pkgs/development/python-modules/pytest-catchlog/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   meta = {
     license = lib.licenses.mit;
-    homepage = "https://pypi.python.org/pypi/pytest-catchlog/";
+    homepage = "https://pypi.org/project/pytest-catchlog/";
     description = "py.test plugin to catch log messages. This is a fork of pytest-capturelog";
   };
 }

--- a/pkgs/development/python-modules/pytest-flakes/default.nix
+++ b/pkgs/development/python-modules/pytest-flakes/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     license = lib.licenses.mit;
-    homepage = "https://pypi.python.org/pypi/pytest-flakes";
+    homepage = "https://pypi.org/project/pytest-flakes/";
     description = "Pytest plugin to check source code with pyflakes";
   };
 })

--- a/pkgs/development/python-modules/pytest-postgresql/default.nix
+++ b/pkgs/development/python-modules/pytest-postgresql/default.nix
@@ -70,7 +70,7 @@ buildPythonPackage rec {
   doCheck = !stdenv.buildPlatform.isDarwin;
 
   meta = {
-    homepage = "https://pypi.python.org/pypi/pytest-postgresql";
+    homepage = "https://pypi.org/project/pytest-postgresql/";
     description = "Pytest plugin that enables you to test code on a temporary PostgreSQL database";
     changelog = "https://github.com/dbfixtures/pytest-postgresql/blob/v${version}/CHANGES.rst";
     license = lib.licenses.lgpl3Plus;

--- a/pkgs/development/python-modules/pytest-quickcheck/default.nix
+++ b/pkgs/development/python-modules/pytest-quickcheck/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   meta = {
     license = lib.licenses.asl20;
-    homepage = "https://pypi.python.org/pypi/pytest-quickcheck";
+    homepage = "https://pypi.org/project/pytest-quickcheck/";
     description = "Pytest plugin to generate random data inspired by QuickCheck";
     maintainers = with lib.maintainers; [ onny ];
   };

--- a/pkgs/development/python-modules/pytestcache/default.nix
+++ b/pkgs/development/python-modules/pytestcache/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
 
   meta = {
     license = lib.licenses.mit;
-    homepage = "https://pypi.python.org/pypi/pytest-cache/";
+    homepage = "https://pypi.org/project/pytest-cache/";
     description = "Pytest plugin with mechanisms for caching across test runs";
   };
 }

--- a/pkgs/development/python-modules/python-jenkins/default.nix
+++ b/pkgs/development/python-modules/python-jenkins/default.nix
@@ -63,7 +63,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Python bindings for the remote Jenkins API";
-    homepage = "https://pypi.python.org/pypi/python-jenkins";
+    homepage = "https://pypi.org/project/python-jenkins/";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ gador ];
   };

--- a/pkgs/development/python-modules/random2/default.nix
+++ b/pkgs/development/python-modules/random2/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    homepage = "http://pypi.python.org/pypi/random2";
+    homepage = "http://pypi.org/pypi/random2/";
     description = "Python 3 compatible Python 2 `random` Module";
     license = lib.licenses.psfl;
   };

--- a/pkgs/development/python-modules/requestsexceptions/default.nix
+++ b/pkgs/development/python-modules/requestsexceptions/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Import exceptions from potentially bundled packages in requests";
-    homepage = "https://pypi.python.org/pypi/requestsexceptions";
+    homepage = "https://pypi.org/project/requestsexceptions/";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ makefu ];
     platforms = lib.platforms.all;

--- a/pkgs/development/python-modules/rfc3987/default.nix
+++ b/pkgs/development/python-modules/rfc3987/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   doCheck = false;
   meta = {
-    homepage = "https://pypi.python.org/pypi/rfc3987";
+    homepage = "https://pypi.org/project/rfc3987/";
     license = lib.licenses.gpl3Plus;
     description = "Parsing and validation of URIs (RFC 3986) and IRIs (RFC 3987)";
     maintainers = with lib.maintainers; [ vanschelven ];

--- a/pkgs/development/python-modules/roman/default.nix
+++ b/pkgs/development/python-modules/roman/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Integer to Roman numerals converter";
     changelog = "https://github.com/zopefoundation/roman/blob/${finalAttrs.version}/CHANGES.rst";
-    homepage = "https://pypi.python.org/pypi/roman";
+    homepage = "https://pypi.org/project/roman/";
     license = lib.licenses.psfl;
     maintainers = with lib.maintainers; [ sigmanificient ];
     mainProgram = "roman";

--- a/pkgs/development/python-modules/sh/default.nix
+++ b/pkgs/development/python-modules/sh/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Python subprocess interface";
-    homepage = "https://pypi.python.org/pypi/sh/";
+    homepage = "https://pypi.org/project/sh/";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ siriobalmelli ];
   };

--- a/pkgs/development/python-modules/termstyle/default.nix
+++ b/pkgs/development/python-modules/termstyle/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Console colouring for python";
-    homepage = "https://pypi.python.org/pypi/python-termstyle/0.1.10";
+    homepage = "https://pypi.org/project/python-termstyle/";
     license = lib.licenses.bsdOriginal;
   };
 }

--- a/pkgs/development/python-modules/testrepository/default.nix
+++ b/pkgs/development/python-modules/testrepository/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
   meta = {
     description = "Database of test results which can be used as part of developer workflow";
     mainProgram = "testr";
-    homepage = "https://pypi.python.org/pypi/testrepository";
+    homepage = "https://pypi.org/project/testrepository/";
     license = lib.licenses.bsd2;
   };
 }

--- a/pkgs/development/python-modules/tlslite/default.nix
+++ b/pkgs/development/python-modules/tlslite/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Pure Python implementation of SSL and TLS";
-    homepage = "https://pypi.python.org/pypi/tlslite";
+    homepage = "https://pypi.org/project/tlslite/";
     license = lib.licenses.bsd3;
   };
 }

--- a/pkgs/development/python-modules/toposort/default.nix
+++ b/pkgs/development/python-modules/toposort/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Topological sort algorithm";
-    homepage = "https://pypi.python.org/pypi/toposort/";
+    homepage = "https://pypi.org/project/toposort/";
     maintainers = [ ];
     platforms = lib.platforms.unix;
     license = lib.licenses.asl20;

--- a/pkgs/development/python-modules/traceback2/default.nix
+++ b/pkgs/development/python-modules/traceback2/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Backport of traceback to older supported Pythons";
-    homepage = "https://pypi.python.org/pypi/traceback2/";
+    homepage = "https://pypi.org/project/traceback2/";
     license = lib.licenses.psfl;
   };
 }

--- a/pkgs/development/python-modules/traits/default.nix
+++ b/pkgs/development/python-modules/traits/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Explicitly typed attributes for Python";
-    homepage = "https://pypi.python.org/pypi/traits";
+    homepage = "https://pypi.org/project/traits/";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ bot-wxt1221 ];
   };

--- a/pkgs/development/python-modules/zope-exceptions/default.nix
+++ b/pkgs/development/python-modules/zope-exceptions/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Exception interfaces and implementations";
-    homepage = "https://pypi.python.org/pypi/zope.exceptions";
+    homepage = "https://pypi.org/project/zope.exceptions/";
     changelog = "https://github.com/zopefoundation/zope.exceptions/blob/${version}/CHANGES.rst";
     license = lib.licenses.zpl21;
     maintainers = with lib.maintainers; [ nickcao ];

--- a/pkgs/development/python2-modules/setuptools/default.nix
+++ b/pkgs/development/python2-modules/setuptools/default.nix
@@ -77,7 +77,7 @@ buildPythonPackage {
 
   meta = {
     description = "Utilities to facilitate the installation of Python packages";
-    homepage = "https://pypi.python.org/pypi/setuptools";
+    homepage = "https://pypi.org/project/setuptools/";
     license = with lib.licenses; [
       psfl
       zpl20


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
