### PR TITLE
python3Packages.numpy: fix riscv64-linux build

### DIFF
--- a/pkgs/development/python-modules/numpy/2.nix
+++ b/pkgs/development/python-modules/numpy/2.nix
@@ -149,6 +149,10 @@ buildPythonPackage (finalAttrs: {
     "test_big_arrays" # ValueError: array is too big; `arr.size * arr.dtype.itemsize` is larger tha...
     "test_multinomial_pvals_float32" # Failed: DID NOT RAISE <class 'ValueError'>
   ]
+  ++ lib.optionals stdenv.hostPlatform.isRiscV64 [
+    "test_floor_division_errors" # FloatingPointError: invalid value encountered in floor_divide
+    "test_unary_spurious_fpexception" # AssertionError: Got warnings: [<warnings.WarningMessage ...>]
+  ]
   ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
     # AssertionError: (np.int64(0), np.longdouble('9.9999999999999994515e-21'), np.longdouble('3.9696755572509052902e+20'), 'arctanh')
     "test_loss_of_precision"


### PR DESCRIPTION
Fix this issue : 

```
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED lib/python3.13/site-packages/numpy/_core/tests/test_umath.py::TestDivision::test_floor_division_errors[e] - FloatingPointError: invalid value encountered in floor_divide
FAILED lib/python3.13/site-packages/numpy/_core/tests/test_umath.py::TestDivision::test_floor_division_errors[f] - FloatingPointError: invalid value encountered in floor_divide
FAILED lib/python3.13/site-packages/numpy/_core/tests/test_umath.py::TestDivision::test_floor_division_errors[d] - FloatingPointError: invalid value encountered in floor_divide
FAILED lib/python3.13/site-packages/numpy/_core/tests/test_umath.py::TestSpecialFloats::test_unary_spurious_fpexception[data10-escape10-f-ceil] - AssertionError: Got warnings: [<warnings.WarningMessage object at 0x3fc0059b50>]
FAILED lib/python3.13/site-packages/numpy/_core/tests/test_umath.py::TestSpecialFloats::test_unary_spurious_fpexception[data10-escape10-f-floor] - AssertionError: Got warnings: [<warnings.WarningMessage object at 0x3fc005b140>]
...
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
