### PR TITLE
applgrid: fix Linux build

### DIFF
--- a/pkgs/by-name/ap/applgrid/TFileStringLinkDef.h
+++ b/pkgs/by-name/ap/applgrid/TFileStringLinkDef.h
@@ -1,0 +1,6 @@
+#ifdef __CLING__
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+#pragma link C++ class TFileString+;
+#endif

--- a/pkgs/by-name/ap/applgrid/TFileVectorLinkDef.h
+++ b/pkgs/by-name/ap/applgrid/TFileVectorLinkDef.h
@@ -1,0 +1,6 @@
+#ifdef __CLING__
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+#pragma link C++ class TFileVector+;
+#endif

--- a/pkgs/by-name/ap/applgrid/no-m64.patch
+++ b/pkgs/by-name/ap/applgrid/no-m64.patch
@@ -1,0 +1,10 @@
+--- a/configure
++++ b/configure
+@@ -16130,7 +16130,6 @@
+ $as_echo "$as_me: WARNING: ****************************************************************" >&2;}
+ fi
+ 
+-( echo $CXXFLAGS | grep -q "m64" ) || CXXFLAGS+=" -m64 "
+ 
+ 
+ 

--- a/pkgs/by-name/ap/applgrid/package.nix
+++ b/pkgs/by-name/ap/applgrid/package.nix
@@ -18,7 +18,18 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-h+ZNGj33FIwg4fOCyfGJrUKM2vDDQl76JcLhtboAOtc=";
   };
 
+  patches = [
+    # ROOT 6.40 made rootcling fail when no selection rules are provided
+    # (https://root.cern/doc/v640/release-notes.html#core-libraries). The patch
+    # appends $*LinkDef.h to the dictionary pattern rule so rootcint picks up
+    # the LinkDef.h files we drop into src/ in postPatch.
+    ./rootcling-linkdef.patch
+  ];
+
   postPatch = ''
+    cp ${./TFileStringLinkDef.h} src/TFileStringLinkDef.h
+    cp ${./TFileVectorLinkDef.h} src/TFileVectorLinkDef.h
+
     sed -i appl_grid/serialise_base.h -e '1i#include <cstdint>'
   '';
 

--- a/pkgs/by-name/ap/applgrid/package.nix
+++ b/pkgs/by-name/ap/applgrid/package.nix
@@ -19,6 +19,14 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [
+    # Upstream's configure unconditionally injects `-m64` into CXXFLAGS, which is
+    # invalid on aarch64 (and redundant on x86_64). The line was added in r1946
+    # for applgrid 1.6.17 with the commit message "add default m64 compilation".
+    # There is no public bug tracker upstream, and the line is still present in
+    # trunk. We patch only the generated `configure` (not `configure.ac`) so
+    # that make doesn't try to re-run autotools during the build.
+    ./no-m64.patch
+
     # ROOT 6.40 made rootcling fail when no selection rules are provided
     # (https://root.cern/doc/v640/release-notes.html#core-libraries). The patch
     # appends $*LinkDef.h to the dictionary pattern rule so rootcint picks up

--- a/pkgs/by-name/ap/applgrid/rootcling-linkdef.patch
+++ b/pkgs/by-name/ap/applgrid/rootcling-linkdef.patch
@@ -1,0 +1,11 @@
+--- a/src/Makefile.in
++++ b/src/Makefile.in
+@@ -1027,7 +1027,7 @@
+ 	$(CC) $(AM_CFLAGS) -c $<
+ 
+ @USE_ROOT_TRUE@%Dict.cxx : %.h %.cxx
+-@USE_ROOT_TRUE@	$(CINT) -f $@ -c $< -I.. 
++@USE_ROOT_TRUE@	$(CINT) -f $@ -c $< -I.. $*LinkDef.h
+ 
+ #../appl_grid/$*LinkDef.h
+ 


### PR DESCRIPTION
[![](https://hydra-banner.harinn.dev/build/329730122)](https://hydra.nixos.org/build/329730122)

ZHF: #516381

This PR fixes the `applgrid` package build on `aarch64-linux` by removing the x86-specific (and unnecessary on x86-64) `-m64` flag added by upstream version 1.6.17 via #392892. It also fixes the build failure for both Linux platforms caused by #512884 which brought in a [stricter behavior](https://root.cern/doc/v640/release-notes.html#core-libraries) requiring us to write a couple [`*LinkDef.h` files](https://github.com/root-project/root/blob/v6-40-00/test/EventLinkDef.h):

> `rootcling` fails if no selection rule is specified and if the creation of a C++ module is not requested.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
