### PR TITLE
libgcrypt: 1.11.2 -> 1.12.2

### DIFF
--- a/pkgs/by-name/li/libgcrypt/package.nix
+++ b/pkgs/by-name/li/libgcrypt/package.nix
@@ -17,11 +17,11 @@ assert enableCapabilities -> stdenv.hostPlatform.isLinux;
 
 stdenv.mkDerivation rec {
   pname = "libgcrypt";
-  version = "1.11.2";
+  version = "1.12.2";
 
   src = fetchurl {
     url = "mirror://gnupg/libgcrypt/${pname}-${version}.tar.bz2";
-    hash = "sha256-a6Wd0ZInDowdIt20GgfZXc28Hw+wLQPEtUsjWBQzCqw=";
+    hash = "sha256-fOM8JJIiGgQ2+WqFACFenz49y1/SanV81BXnqEO6vV4=";
   };
 
   outputs = [
@@ -73,17 +73,6 @@ stdenv.mkDerivation rec {
   postConfigure = ''
     sed -i configure \
         -e 's/NOEXECSTACK_FLAGS=$/NOEXECSTACK_FLAGS="-Wa,--noexecstack"/'
-  ''
-  # The cipher/simd-common-riscv.h wasn't added to the release tarball, please remove this hack on next version update
-  # https://dev.gnupg.org/T7647
-  + lib.optionalString stdenv.hostPlatform.isRiscV ''
-    cp ${
-      fetchurl {
-        url = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgcrypt.git;a=blob_plain;f=cipher/simd-common-riscv.h;h=8381000f9ac148c60a6963a1d9ec14a3fee1c576;hb=81ce5321b1b79bde6dfdc3c164efb40c13cf656b";
-        hash = "sha256-Toe15YLAOYULnLc2fGMMv/xzs/q1t3LsyiqtL7imc+8=";
-        name = "simd-common-riscv.h";
-      }
-    } cipher/simd-common-riscv.h
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
v1.12.0: https://dev.gnupg.org/T7643, https://lists.gnupg.org/pipermail/gnupg-announce/2026q1/000502.html
v1.12.1: https://dev.gnupg.org/T8067
v1.12.2: https://dev.gnupg.org/T8114, https://lists.gnupg.org/pipermail/gnupg-announce/2026q2/000503.html

v1.12.2 ostensibly fixes a few security issues (from the mailing list above):

> This version fixes a security bug [T8211] which can be used used to mount a DoS using ECDH encryption (with NIST, Brainpool, X448, or X25519 curves).  Note that GnuPG versions since 2.5.7 are not affected by this bug due to the use of a different encryption API.
>
> Another security bug [T8208] was fixed in the Dilithium signing algorithm which is available since version 1.12.0.

The v1.12.0 release announcement says that this is API/ABI compatible with v1.11, so given the above, this is probably good to backport:

> This release starts a new stable branch of Libgcrypt with full API and ABI compatibility to the 1.11 series.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`. (x86_64-linux)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
