### PR TITLE
buildkite-agent-metrics: 5.12.2 -> 5.12.3

### DIFF
--- a/pkgs/by-name/bu/buildkite-agent-metrics/package.nix
+++ b/pkgs/by-name/bu/buildkite-agent-metrics/package.nix
@@ -5,7 +5,7 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "buildkite-agent-metrics";
-  version = "5.12.2";
+  version = "5.12.3";
 
   __darwinAllowLocalNetworking = true;
 
@@ -18,7 +18,7 @@ buildGoModule (finalAttrs: {
     owner = "buildkite";
     repo = "buildkite-agent-metrics";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-O/6YGxX7sJEaqmMMzOPxkiIWJs1VRa+tgZ2w8UjfoKk=";
+    hash = "sha256-h6RPAqRNCcsT49d+D+q3FShoPZK4z7e8JCkB1FOHgNY=";
   };
 
   vendorHash = "sha256-2os2V1iyw1k6XwX2wLz0abMnu+X5p+Aqau7ajC3JIRc=";
@@ -35,5 +35,6 @@ buildGoModule (finalAttrs: {
     description = "Command-line tool (and Lambda) for collecting Buildkite agent metrics";
     homepage = "https://github.com/buildkite/buildkite-agent-metrics";
     license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ cbrxyz ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Release: https://github.com/buildkite/buildkite-agent-metrics/releases/tag/v5.12.3
Diff: https://github.com/buildkite/buildkite-agent-metrics/compare/v5.12.2...v5.12.3

I also added myself as a maintainer of the package since it didn't have one.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## `nixpkgs-review` result for [#523210](https://github.com/NixOS/nixpkgs/pull/523210)

Generated using [`nixpkgs-review-gha`](https://github.com/Defelo/nixpkgs-review-gha)

Command: `nixpkgs-review pr 523210`
Commit: [`4c06d98fbecd35f4450deccd3819a02784ce74ba`](https://github.com/NixOS/nixpkgs/commit/4c06d98fbecd35f4450deccd3819a02784ce74ba) ([subsequent changes](https://github.com/NixOS/nixpkgs/compare/4c06d98fbecd35f4450deccd3819a02784ce74ba..pull/523210/head))
Merge: [`45faa312db731a4ad5850f7010ccbc830af772f3`](https://github.com/NixOS/nixpkgs/commit/45faa312db731a4ad5850f7010ccbc830af772f3)

Logs: https://github.com/cbrxyz/nixpkgs-review-gha/actions/runs/26320839882


---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>buildkite-agent-metrics</li>
    <li>buildkite-agent-metrics.lambda</li>
  </ul>
</details>

---
### `aarch64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>buildkite-agent-metrics</li>
    <li>buildkite-agent-metrics.lambda</li>
  </ul>
</details>

---
### `x86_64-darwin` (sandbox = relaxed)
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>buildkite-agent-metrics</li>
    <li>buildkite-agent-metrics.lambda</li>
  </ul>
</details>

---
### `aarch64-darwin` (sandbox = relaxed)
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>buildkite-agent-metrics</li>
    <li>buildkite-agent-metrics.lambda</li>
  </ul>
</details>
