### PR TITLE
android-studio-for-platform: stable 2024.2.2.13 -> 2025.3.2.6, canary 2024.3.1.9 -> 2026.1.2.1

### DIFF
--- a/pkgs/applications/editors/android-studio-for-platform/common.nix
+++ b/pkgs/applications/editors/android-studio-for-platform/common.nix
@@ -25,6 +25,8 @@
   fontsConf,
   fontconfig,
   freetype,
+  libGL,
+  libsecret,
   libx11,
   libxext,
   libxi,
@@ -122,6 +124,9 @@ let
 
             # For Soong sync
             e2fsprogs
+
+            libsecret
+            libGL
           ]
         }"
     '';

--- a/pkgs/applications/editors/android-studio-for-platform/default.nix
+++ b/pkgs/applications/editors/android-studio-for-platform/default.nix
@@ -16,15 +16,14 @@ let
       inherit tiling_wm;
     };
   stableVersion = {
-    version = "2024.2.2.13";
-    # this seems to be a fuckup on google's side
-    versionPrefix = "Ladybug%20Feature%20Drop";
-    sha256Hash = "sha256-yMUTWOpYHa/Aizrgvs/mbofrDqrbL5bJYjuklIdyU/0=";
+    version = "2025.3.2.6";
+    versionPrefix = "Panda%202";
+    sha256Hash = "sha256-mAJPmDSoE9STOh45u0dIejL4TyR8CIqcGMhiixIFIWc=";
   };
   canaryVersion = {
-    version = "2024.3.1.9";
-    versionPrefix = "canary-meerkat";
-    sha256Hash = "sha256-j5KEwHbc+0eFi3GZlD5PMuM/RWw2MJ1PaXZrPMvhCik=";
+    version = "2026.1.2.1";
+    versionPrefix = "canary-Quail%202";
+    sha256Hash = "sha256-UYj+6CSmtxC11HVjPxc+m9r6b5RrXXFOzpDfSkx4mw4=";
   };
 in
 {


### PR DESCRIPTION
[Latest ASfP release note](https://developer.android.com/studio/platform/releases) is still for for 25.1.2 Narwhal, although those changes are new because the previous version was older than that.

Additionally for Canary, [a regression was fixed where "not all directories/files were being shown for paths explicitly included in the project config"](https://groups.google.com/a/android.com/g/asfp-developers/c/YD7awJs23MA/m/BLgxGfLmCgAJ) 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
