### PR TITLE
ballerina: 2201.10.3 -> 2201.13.4

### DIFF
--- a/pkgs/by-name/ba/ballerina/package.nix
+++ b/pkgs/by-name/ba/ballerina/package.nix
@@ -2,16 +2,17 @@
   ballerina,
   lib,
   writeText,
+  writeScript,
   runCommand,
   makeWrapper,
   fetchzip,
   stdenv,
-  openjdk17_headless,
+  openjdk21_headless,
 }:
 let
-  version = "2201.10.3";
+  version = "2201.13.4";
   codeName = "swan-lake";
-  openjdk = openjdk17_headless;
+  openjdk = openjdk21_headless;
 in
 stdenv.mkDerivation {
   pname = "ballerina";
@@ -19,7 +20,7 @@ stdenv.mkDerivation {
 
   src = fetchzip {
     url = "https://dist.ballerina.io/downloads/${version}/ballerina-${version}-${codeName}.zip";
-    hash = "sha256-JVwxWRiOQaUZBkvxoLhKvktyQYnBtbCBZXZa6g6hoRQ=";
+    hash = "sha256-te7ZW9CISAg0ahkFBBWW2Q6pkB9jXGNBDHw6slX2V/E=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -48,12 +49,23 @@ stdenv.mkDerivation {
       [[ $result = "Hello, World!" ]]
     '';
 
+  passthru.updateScript = writeScript "update-ballerina" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p common-updater-scripts curl pcre2
+    set -euo pipefail
+
+    version="$(curl -s https://ballerina.io/downloads/ |
+      pcre2grep -o '(?<=swan-lake-)\d+(?:\.\d+)+(?=)')"
+
+    update-source-version "$UPDATE_NIX_ATTR_PATH" "$version"
+  '';
+
   meta = {
     description = "Open-source programming language for the cloud";
     mainProgram = "bal";
     license = lib.licenses.asl20;
     platforms = openjdk.meta.platforms;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ cbrxyz ];
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Release: https://ballerina.io/downloads/swan-lake-release-notes/swan-lake-2201.13.4

I also added myself as a maintainer since it didn't have one, and created a custom update script for the package!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
