### PR TITLE
nginx: 1.30.1 -> 1.30.2

### DIFF
--- a/pkgs/servers/http/nginx/stable.nix
+++ b/pkgs/servers/http/nginx/stable.nix
@@ -1,6 +1,6 @@
 { callPackage, ... }@args:
 
 callPackage ./generic.nix args {
-  version = "1.30.1";
-  hash = "sha256-mXZQANl0iWsxyliC2MJ5zj/n729cb58Kln7X/TQH+cw=";
+  version = "1.30.2";
+  hash = "sha256-ffMJCQf8o8wORW1twAzrIw2nTqiAJs7/Cv/CnbvZrEw=";
 }


### PR DESCRIPTION
Changelog: https://nginx.org/en/CHANGES-1.30
Advisory: https://my.f5.com/manage/s/article/K000161377
Fixes: CVE-2026-9256

Mainline update is at #523149

I tested the configs/URLs from https://github.com/nginx/nginx/commit/ca4f92a27464ae6c2082245e4f67048c633aa032 against nginx before and after these changes under valgrind. Before, various invalid reads and writes are printed. Afterwards, everything seems good.

I'm not sure if backporting to 25.11 is necessary. Those same configurations/URLs don't cause any invalid read/writes under valgrind on 1.28 and 1.29. However, https://github.com/nginx/nginx/commit/ca4f92a27464ae6c2082245e4f67048c633aa032 applies cleanly as a patch to both branches and NixOS tests continue to pass, so maybe it's worth applying since the issue might still be present, just with a different test.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. (x86_64-linux)
  - [x] [Package tests] at `passthru.tests`. (x86_64-linux)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 523220`
Commit: `308c3c352cdbda17ab08b750886d3b5895018a05`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 20 packages built:</summary>
  <ul>
    <li>devpi-client</li>
    <li>devpi-client.dist</li>
    <li>devpi-server</li>
    <li>nginx (nginxStable)</li>
    <li>nginx.doc (nginxStable.doc)</li>
    <li>nginxShibboleth</li>
    <li>nginxShibboleth.doc</li>
    <li>python313Packages.devpi-ldap</li>
    <li>python313Packages.devpi-ldap.dist</li>
    <li>python313Packages.devpi-server</li>
    <li>python313Packages.devpi-server.dist</li>
    <li>python313Packages.devpi-web</li>
    <li>python313Packages.devpi-web.dist</li>
    <li>python314Packages.devpi-ldap</li>
    <li>python314Packages.devpi-ldap.dist</li>
    <li>python314Packages.devpi-server</li>
    <li>python314Packages.devpi-server.dist</li>
    <li>python314Packages.devpi-web</li>
    <li>python314Packages.devpi-web.dist</li>
    <li>tests.testers.lycheeLinkCheck.network</li>
  </ul>
</details>

---
### `aarch64-linux`
<details>
  <summary>:white_check_mark: 20 packages built:</summary>
  <ul>
    <li>devpi-client</li>
    <li>devpi-client.dist</li>
    <li>devpi-server</li>
    <li>nginx (nginxStable)</li>
    <li>nginx.doc (nginxStable.doc)</li>
    <li>nginxShibboleth</li>
    <li>nginxShibboleth.doc</li>
    <li>python313Packages.devpi-ldap</li>
    <li>python313Packages.devpi-ldap.dist</li>
    <li>python313Packages.devpi-server</li>
    <li>python313Packages.devpi-server.dist</li>
    <li>python313Packages.devpi-web</li>
    <li>python313Packages.devpi-web.dist</li>
    <li>python314Packages.devpi-ldap</li>
    <li>python314Packages.devpi-ldap.dist</li>
    <li>python314Packages.devpi-server</li>
    <li>python314Packages.devpi-server.dist</li>
    <li>python314Packages.devpi-web</li>
    <li>python314Packages.devpi-web.dist</li>
    <li>tests.testers.lycheeLinkCheck.network</li>
  </ul>
</details>

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test