### PR TITLE
stellar-core: fix PostgreSQL check on Hydra

### DIFF
--- a/pkgs/by-name/st/stellar-core/package.nix
+++ b/pkgs/by-name/st/stellar-core/package.nix
@@ -129,10 +129,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
-  postgresqlTestUserOptions = "LOGIN CREATEDB";
+  postgresqlTestUserOptions = "LOGIN SUPERUSER";
 
   postgresqlTestSetupPost = ''
-    for database in $(seq 0 15); do
+    for database in $(seq 0 3); do
       createdb "test$database"
     done
   '';


### PR DESCRIPTION
Trying to fix the test failure on Hydra:

https://hydra.nixos.org/build/329680826
https://hydra.nixos.org/build/329680826/nixlog/1

In my local testing, the check only used 27 PostgreSQL connections and built successfully. I’m not sure whether Hydra differs in connection limits or load, but this change tries to address the failure by running the test user as a superuser, allowing it to use PostgreSQL’s reserved connection slots.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
