### PR TITLE
beancount: 3.2.0 -> 3.2.3, fava: 1.30.12 -> 1.30.13

### DIFF
--- a/pkgs/development/python-modules/beancount/default.nix
+++ b/pkgs/development/python-modules/beancount/default.nix
@@ -16,7 +16,7 @@
 }:
 
 buildPythonPackage rec {
-  version = "3.2.0";
+  version = "3.2.3";
   pname = "beancount";
   pyproject = true;
 
@@ -24,21 +24,15 @@ buildPythonPackage rec {
     owner = "beancount";
     repo = "beancount";
     tag = version;
-    hash = "sha256-XWTgaBvB4/SONL44afvprZwJUVrkoda5XLGNxad0kec=";
+    hash = "sha256-WM8SM2ZHphafzXHyVi4Fo9tgsClAnmLsZKZUsf2Twmg=";
   };
 
-  patches = [
-    (fetchpatch2 {
-      name = "accept-date-range-error-message-from-py3.14";
-      url = "https://salsa.debian.org/python-team/packages/beancount/-/raw/debian/sid/debian/patches/0003-Accept-date-range-error-message-from-py3.14.patch";
-      hash = "sha256-wqMTGSi4Gn5VADjV4MjZhFNWB3ThUhxvLYK7sentScQ=";
-    })
-    (fetchpatch2 {
-      name = "skip-ref-count-test-with-py3.14";
-      url = "https://salsa.debian.org/python-team/packages/beancount/-/raw/debian/sid/debian/patches/0004-Skip-refcount-test-with-py3.14.patch";
-      hash = "sha256-6P9xe15WBGaWpVYB2HfGfFHLMMmGkfnDwdjdktlSNxk=";
-    })
-  ];
+  postPatch = ''
+    # We don't need the python binary wrappers, since we provide them via nativeBuildInputs
+    substituteInPlace pyproject.toml \
+      --replace-fail "'flex-bin ; sys_platform == \"linux\" or sys_platform == \"darwin\"'," "" \
+      --replace-fail "'bison-bin ; sys_platform == \"linux\" or sys_platform == \"darwin\"'," ""
+  '';
 
   build-system = [
     meson

--- a/pkgs/development/python-modules/fava/default.nix
+++ b/pkgs/development/python-modules/fava/default.nix
@@ -25,17 +25,17 @@
 let
   src = buildNpmPackage (finalAttrs: {
     pname = "fava-frontend";
-    version = "1.30.12";
+    version = "1.30.13";
 
     src = fetchFromGitHub {
       owner = "beancount";
       repo = "fava";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-krRkcahikP0ChTCXeS/3MBq4v+VmBLViqaYSSGYt6Mc=";
+      hash = "sha256-h4mjZIINR6RLYycGl2RFIEGuPPbJYYSg1TBGlZupCMw=";
     };
     sourceRoot = "${finalAttrs.src.name}/frontend";
 
-    npmDepsHash = "sha256-kZAwvyjPZUFJffYsr5917zX+0tMyydcOzfr/TDnoJKw=";
+    npmDepsHash = "sha256-DQQISV615wZjNbvZwmF/AGJyJJIIs3iBS1tJCNPpT/o=";
     makeCacheWritable = true;
 
     preBuild = ''
@@ -108,6 +108,7 @@ buildPythonPackage {
     maintainers = with lib.maintainers; [
       prince213
       sigmanificient
+      cbrxyz
     ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Tag: https://github.com/beancount/beancount/releases/tag/3.2.3
Diff: https://github.com/beancount/beancount/compare/3.2.0...3.2.3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Broken changes are solely from `fava` (and related packages) and will be addressed in #523227.

## `nixpkgs-review` result for [#523226](https://github.com/NixOS/nixpkgs/pull/523226)

Generated using [`nixpkgs-review-gha`](https://github.com/Defelo/nixpkgs-review-gha)

Command: `nixpkgs-review pr 523226`
Commit: [`88e9b2dfd225e25c25768635baedb8cfaa553b31`](https://github.com/NixOS/nixpkgs/commit/88e9b2dfd225e25c25768635baedb8cfaa553b31) ([subsequent changes](https://github.com/NixOS/nixpkgs/compare/88e9b2dfd225e25c25768635baedb8cfaa553b31..pull/523226/head))
Merge: [`e4dffecf43e9091aa54b9771bda6fcede7f4878a`](https://github.com/NixOS/nixpkgs/commit/e4dffecf43e9091aa54b9771bda6fcede7f4878a)

Logs: https://github.com/cbrxyz/nixpkgs-review-gha/actions/runs/26322826191


---
### `x86_64-linux`
<details>
  <summary>:x: 16 packages failed to build:</summary>
  <ul>
    <li>fava (python313Packages.fava)</li>
    <li>fava-investor (python313Packages.fava-investor)</li>
    <li>fava-investor.dist (python313Packages.fava-investor.dist)</li>
    <li>fava.dist (python313Packages.fava.dist)</li>
    <li>python313Packages.fava-dashboards</li>
    <li>python313Packages.fava-dashboards.dist</li>
    <li>python313Packages.fava-portfolio-returns</li>
    <li>python313Packages.fava-portfolio-returns.dist</li>
    <li>python314Packages.fava</li>
    <li>python314Packages.fava-dashboards</li>
    <li>python314Packages.fava-dashboards.dist</li>
    <li>python314Packages.fava-investor</li>
    <li>python314Packages.fava-investor.dist</li>
    <li>python314Packages.fava-portfolio-returns</li>
    <li>python314Packages.fava-portfolio-returns.dist</li>
    <li>python314Packages.fava.dist</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 31 packages built:</summary>
  <ul>
    <li>beancount (python313Packages.beancount)</li>
    <li>beancount-ing-diba</li>
    <li>beancount-ing-diba.dist</li>
    <li>beancount-share</li>
    <li>beancount-share.dist</li>
    <li>beancount.dist (python313Packages.beancount.dist)</li>
    <li>beanprice</li>
    <li>beanprice.dist</li>
    <li>beanquery (python313Packages.beanquery)</li>
    <li>beanquery.dist (python313Packages.beanquery.dist)</li>
    <li>ledger2beancount</li>
    <li>python313Packages.beancount-docverif</li>
    <li>python313Packages.beancount-docverif.dist</li>
    <li>python313Packages.beancount-periodic</li>
    <li>python313Packages.beancount-periodic.dist</li>
    <li>python313Packages.beancount-plugin-utils</li>
    <li>python313Packages.beancount-plugin-utils.dist</li>
    <li>python313Packages.beangulp</li>
    <li>python313Packages.beangulp.dist</li>
    <li>python314Packages.beancount</li>
    <li>python314Packages.beancount-docverif</li>
    <li>python314Packages.beancount-docverif.dist</li>
    <li>python314Packages.beancount-periodic</li>
    <li>python314Packages.beancount-periodic.dist</li>
    <li>python314Packages.beancount-plugin-utils</li>
    <li>python314Packages.beancount-plugin-utils.dist</li>
    <li>python314Packages.beancount.dist</li>
    <li>python314Packages.beangulp</li>
    <li>python314Packages.beangulp.dist</li>
    <li>python314Packages.beanquery</li>
    <li>python314Packages.beanquery.dist</li>
  </ul>
</details>

---
<details>
<summary>Error logs: `x86_64-linux`</summary>
<details>
<summary>fava</summary>
<pre>            )
E           AssertionError: Snaphot test failed. Snapshots can be updated with `pytest --snapshot-update`
E           assert {&#x27;beancount_o...&#x27;: &#x27;()&#x27;, ...}} == {&#x27;beancount_o...&#x27;: &#x27;()&#x27;, ...}}
E             
E             Omitting 1 identical items, use -vv to show
E             Differing items:
E             {&#x27;beancount_options&#x27;: {&#x27;account_current_conversions&#x27;: &#x27;Conversions:Current&#x27;, &#x27;account_current_earnings&#x27;: &#x27;Earnings:Current&#x27;, &#x27;account_previous_balances&#x27;: &#x27;Opening-Balances&#x27;, [3...
E             
E             ...Full output truncated (2 lines hidden), use &#x27;-vv&#x27; to show

tests/conftest.py:128: AssertionError
=============================== warnings summary ===============================
tests/test_cli.py:69
  /build/fava-frontend-1.30.12/tests/test_cli.py:69: PytestUnknownMarkWarning: Unknown pytest.mark.no_cover - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.no_cover

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED tests/test_json_api.py::test_api[options-/long-example/api/options] - AssertionError: Snaphot test failed. Snapshots can be updated with `pytest ...
============= 1 failed, 457 passed, 2 skipped, 1 warning in 6.84s ==============</pre>
</details>
<details>
<summary>python314Packages.fava</summary>
<pre>            )
E           AssertionError: Snaphot test failed. Snapshots can be updated with `pytest --snapshot-update`
E           assert {&#x27;beancount_o...&#x27;: &#x27;()&#x27;, ...}} == {&#x27;beancount_o...&#x27;: &#x27;()&#x27;, ...}}
E             
E             Omitting 1 identical items, use -vv to show
E             Differing items:
E             {&#x27;beancount_options&#x27;: {&#x27;account_current_conversions&#x27;: &#x27;Conversions:Current&#x27;, &#x27;account_current_earnings&#x27;: &#x27;Earnings:Current&#x27;, &#x27;account_previous_balances&#x27;: &#x27;Opening-Balances&#x27;, [3...
E             
E             ...Full output truncated (2 lines hidden), use &#x27;-vv&#x27; to show

tests/conftest.py:128: AssertionError
=============================== warnings summary ===============================
tests/test_cli.py:69
  /build/fava-frontend-1.30.12/tests/test_cli.py:69: PytestUnknownMarkWarning: Unknown pytest.mark.no_cover - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.no_cover

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED tests/test_json_api.py::test_api[options-/long-example/api/options] - AssertionError: Snaphot test failed. Snapshots can be updated with `pytest ...
============= 1 failed, 457 passed, 2 skipped, 1 warning in 6.39s ==============</pre>
</details>
</details>

---
### `aarch64-linux`
<details>
  <summary>:x: 16 packages failed to build:</summary>
  <ul>
    <li>fava (python313Packages.fava)</li>
    <li>fava-investor (python313Packages.fava-investor)</li>
    <li>fava-investor.dist (python313Packages.fava-investor.dist)</li>
    <li>fava.dist (python313Packages.fava.dist)</li>
    <li>python313Packages.fava-dashboards</li>
    <li>python313Packages.fava-dashboards.dist</li>
    <li>python313Packages.fava-portfolio-returns</li>
    <li>python313Packages.fava-portfolio-returns.dist</li>
    <li>python314Packages.fava</li>
    <li>python314Packages.fava-dashboards</li>
    <li>python314Packages.fava-dashboards.dist</li>
    <li>python314Packages.fava-investor</li>
    <li>python314Packages.fava-investor.dist</li>
    <li>python314Packages.fava-portfolio-returns</li>
    <li>python314Packages.fava-portfolio-returns.dist</li>
    <li>python314Packages.fava.dist</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 31 packages built:</summary>
  <ul>
    <li>beancount (python313Packages.beancount)</li>
    <li>beancount-ing-diba</li>
    <li>beancount-ing-diba.dist</li>
    <li>beancount-share</li>
    <li>beancount-share.dist</li>
    <li>beancount.dist (python313Packages.beancount.dist)</li>
    <li>beanprice</li>
    <li>beanprice.dist</li>
    <li>beanquery (python313Packages.beanquery)</li>
    <li>beanquery.dist (python313Packages.beanquery.dist)</li>
    <li>ledger2beancount</li>
    <li>python313Packages.beancount-docverif</li>
    <li>python313Packages.beancount-docverif.dist</li>
    <li>python313Packages.beancount-periodic</li>
    <li>python313Packages.beancount-periodic.dist</li>
    <li>python313Packages.beancount-plugin-utils</li>
    <li>python313Packages.beancount-plugin-utils.dist</li>
    <li>python313Packages.beangulp</li>
    <li>python313Packages.beangulp.dist</li>
    <li>python314Packages.beancount</li>
    <li>python314Packages.beancount-docverif</li>
    <li>python314Packages.beancount-docverif.dist</li>
    <li>python314Packages.beancount-periodic</li>
    <li>python314Packages.beancount-periodic.dist</li>
    <li>python314Packages.beancount-plugin-utils</li>
    <li>python314Packages.beancount-plugin-utils.dist</li>
    <li>python314Packages.beancount.dist</li>
    <li>python314Packages.beangulp</li>
    <li>python314Packages.beangulp.dist</li>
    <li>python314Packages.beanquery</li>
    <li>python314Packages.beanquery.dist</li>
  </ul>
</details>

---
<details>
<summary>Error logs: `aarch64-linux`</summary>
<details>
<summary>fava</summary>
<pre>            )
E           AssertionError: Snaphot test failed. Snapshots can be updated with `pytest --snapshot-update`
E           assert {&#x27;beancount_o...&#x27;: &#x27;()&#x27;, ...}} == {&#x27;beancount_o...&#x27;: &#x27;()&#x27;, ...}}
E             
E             Omitting 1 identical items, use -vv to show
E             Differing items:
E             {&#x27;beancount_options&#x27;: {&#x27;account_current_conversions&#x27;: &#x27;Conversions:Current&#x27;, &#x27;account_current_earnings&#x27;: &#x27;Earnings:Current&#x27;, &#x27;account_previous_balances&#x27;: &#x27;Opening-Balances&#x27;, [3...
E             
E             ...Full output truncated (2 lines hidden), use &#x27;-vv&#x27; to show

tests/conftest.py:128: AssertionError
=============================== warnings summary ===============================
tests/test_cli.py:69
  /build/fava-frontend-1.30.12/tests/test_cli.py:69: PytestUnknownMarkWarning: Unknown pytest.mark.no_cover - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.no_cover

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED tests/test_json_api.py::test_api[options-/long-example/api/options] - AssertionError: Snaphot test failed. Snapshots can be updated with `pytest ...
============= 1 failed, 457 passed, 2 skipped, 1 warning in 5.00s ==============</pre>
</details>
<details>
<summary>python314Packages.fava</summary>
<pre>            )
E           AssertionError: Snaphot test failed. Snapshots can be updated with `pytest --snapshot-update`
E           assert {&#x27;beancount_o...&#x27;: &#x27;()&#x27;, ...}} == {&#x27;beancount_o...&#x27;: &#x27;()&#x27;, ...}}
E             
E             Omitting 1 identical items, use -vv to show
E             Differing items:
E             {&#x27;beancount_options&#x27;: {&#x27;account_current_conversions&#x27;: &#x27;Conversions:Current&#x27;, &#x27;account_current_earnings&#x27;: &#x27;Earnings:Current&#x27;, &#x27;account_previous_balances&#x27;: &#x27;Opening-Balances&#x27;, [3...
E             
E             ...Full output truncated (2 lines hidden), use &#x27;-vv&#x27; to show

tests/conftest.py:128: AssertionError
=============================== warnings summary ===============================
tests/test_cli.py:69
  /build/fava-frontend-1.30.12/tests/test_cli.py:69: PytestUnknownMarkWarning: Unknown pytest.mark.no_cover - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.no_cover

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED tests/test_json_api.py::test_api[options-/long-example/api/options] - AssertionError: Snaphot test failed. Snapshots can be updated with `pytest ...
============= 1 failed, 457 passed, 2 skipped, 1 warning in 4.99s ==============</pre>
</details>
</details>

---
### `x86_64-darwin` (sandbox = relaxed)
<details>
  <summary>:x: 16 packages failed to build:</summary>
  <ul>
    <li>fava (python313Packages.fava)</li>
    <li>fava-investor (python313Packages.fava-investor)</li>
    <li>fava-investor.dist (python313Packages.fava-investor.dist)</li>
    <li>fava.dist (python313Packages.fava.dist)</li>
    <li>python313Packages.fava-dashboards</li>
    <li>python313Packages.fava-dashboards.dist</li>
    <li>python313Packages.fava-portfolio-returns</li>
    <li>python313Packages.fava-portfolio-returns.dist</li>
    <li>python314Packages.fava</li>
    <li>python314Packages.fava-dashboards</li>
    <li>python314Packages.fava-dashboards.dist</li>
    <li>python314Packages.fava-investor</li>
    <li>python314Packages.fava-investor.dist</li>
    <li>python314Packages.fava-portfolio-returns</li>
    <li>python314Packages.fava-portfolio-returns.dist</li>
    <li>python314Packages.fava.dist</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 31 packages built:</summary>
  <ul>
    <li>beancount (python313Packages.beancount)</li>
    <li>beancount-ing-diba</li>
    <li>beancount-ing-diba.dist</li>
    <li>beancount-share</li>
    <li>beancount-share.dist</li>
    <li>beancount.dist (python313Packages.beancount.dist)</li>
    <li>beanprice</li>
    <li>beanprice.dist</li>
    <li>beanquery (python313Packages.beanquery)</li>
    <li>beanquery.dist (python313Packages.beanquery.dist)</li>
    <li>ledger2beancount</li>
    <li>python313Packages.beancount-docverif</li>
    <li>python313Packages.beancount-docverif.dist</li>
    <li>python313Packages.beancount-periodic</li>
    <li>python313Packages.beancount-periodic.dist</li>
    <li>python313Packages.beancount-plugin-utils</li>
    <li>python313Packages.beancount-plugin-utils.dist</li>
    <li>python313Packages.beangulp</li>
    <li>python313Packages.beangulp.dist</li>
    <li>python314Packages.beancount</li>
    <li>python314Packages.beancount-docverif</li>
    <li>python314Packages.beancount-docverif.dist</li>
    <li>python314Packages.beancount-periodic</li>
    <li>python314Packages.beancount-periodic.dist</li>
    <li>python314Packages.beancount-plugin-utils</li>
    <li>python314Packages.beancount-plugin-utils.dist</li>
    <li>python314Packages.beancount.dist</li>
    <li>python314Packages.beangulp</li>
    <li>python314Packages.beangulp.dist</li>
    <li>python314Packages.beanquery</li>
    <li>python314Packages.beanquery.dist</li>
  </ul>
</details>

---
<details>
<summary>Error logs: `x86_64-darwin`</summary>
<details>
<summary>fava</summary>
<pre>            )
E           AssertionError: Snaphot test failed. Snapshots can be updated with `pytest --snapshot-update`
E           assert {&#x27;beancount_o...&#x27;: &#x27;()&#x27;, ...}} == {&#x27;beancount_o...&#x27;: &#x27;()&#x27;, ...}}
E             
E             Omitting 1 identical items, use -vv to show
E             Differing items:
E             {&#x27;beancount_options&#x27;: {&#x27;account_current_conversions&#x27;: &#x27;Conversions:Current&#x27;, &#x27;account_current_earnings&#x27;: &#x27;Earnings:Current&#x27;, &#x27;account_previous_balances&#x27;: &#x27;Opening-Balances&#x27;, [3...
E             
E             ...Full output truncated (2 lines hidden), use &#x27;-vv&#x27; to show

tests/conftest.py:128: AssertionError
=============================== warnings summary ===============================
tests/test_cli.py:69
  /nix/build/nix-31529-2386382371/fava-frontend-1.30.12/tests/test_cli.py:69: PytestUnknownMarkWarning: Unknown pytest.mark.no_cover - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.no_cover

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED tests/test_json_api.py::test_api[options-/long-example/api/options] - AssertionError: Snaphot test failed. Snapshots can be updated with `pytest ...
============= 1 failed, 452 passed, 2 skipped, 1 warning in 7.73s ==============</pre>
</details>
<details>
<summary>python314Packages.fava</summary>
<pre>            )
E           AssertionError: Snaphot test failed. Snapshots can be updated with `pytest --snapshot-update`
E           assert {&#x27;beancount_o...&#x27;: &#x27;()&#x27;, ...}} == {&#x27;beancount_o...&#x27;: &#x27;()&#x27;, ...}}
E             
E             Omitting 1 identical items, use -vv to show
E             Differing items:
E             {&#x27;beancount_options&#x27;: {&#x27;account_current_conversions&#x27;: &#x27;Conversions:Current&#x27;, &#x27;account_current_earnings&#x27;: &#x27;Earnings:Current&#x27;, &#x27;account_previous_balances&#x27;: &#x27;Opening-Balances&#x27;, [3...
E             
E             ...Full output truncated (2 lines hidden), use &#x27;-vv&#x27; to show

tests/conftest.py:128: AssertionError
=============================== warnings summary ===============================
tests/test_cli.py:69
  /nix/build/nix-31529-2386382373/fava-frontend-1.30.12/tests/test_cli.py:69: PytestUnknownMarkWarning: Unknown pytest.mark.no_cover - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.no_cover

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED tests/test_json_api.py::test_api[options-/long-example/api/options] - AssertionError: Snaphot test failed. Snapshots can be updated with `pytest ...
============= 1 failed, 452 passed, 2 skipped, 1 warning in 6.06s ==============</pre>
</details>
</details>

---
### `aarch64-darwin` (sandbox = relaxed)
<details>
  <summary>:x: 16 packages failed to build:</summary>
  <ul>
    <li>fava (python313Packages.fava)</li>
    <li>fava-investor (python313Packages.fava-investor)</li>
    <li>fava-investor.dist (python313Packages.fava-investor.dist)</li>
    <li>fava.dist (python313Packages.fava.dist)</li>
    <li>python313Packages.fava-dashboards</li>
    <li>python313Packages.fava-dashboards.dist</li>
    <li>python313Packages.fava-portfolio-returns</li>
    <li>python313Packages.fava-portfolio-returns.dist</li>
    <li>python314Packages.fava</li>
    <li>python314Packages.fava-dashboards</li>
    <li>python314Packages.fava-dashboards.dist</li>
    <li>python314Packages.fava-investor</li>
    <li>python314Packages.fava-investor.dist</li>
    <li>python314Packages.fava-portfolio-returns</li>
    <li>python314Packages.fava-portfolio-returns.dist</li>
    <li>python314Packages.fava.dist</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 31 packages built:</summary>
  <ul>
    <li>beancount (python313Packages.beancount)</li>
    <li>beancount-ing-diba</li>
    <li>beancount-ing-diba.dist</li>
    <li>beancount-share</li>
    <li>beancount-share.dist</li>
    <li>beancount.dist (python313Packages.beancount.dist)</li>
    <li>beanprice</li>
    <li>beanprice.dist</li>
    <li>beanquery (python313Packages.beanquery)</li>
    <li>beanquery.dist (python313Packages.beanquery.dist)</li>
    <li>ledger2beancount</li>
    <li>python313Packages.beancount-docverif</li>
    <li>python313Packages.beancount-docverif.dist</li>
    <li>python313Packages.beancount-periodic</li>
    <li>python313Packages.beancount-periodic.dist</li>
    <li>python313Packages.beancount-plugin-utils</li>
    <li>python313Packages.beancount-plugin-utils.dist</li>
    <li>python313Packages.beangulp</li>
    <li>python313Packages.beangulp.dist</li>
    <li>python314Packages.beancount</li>
    <li>python314Packages.beancount-docverif</li>
    <li>python314Packages.beancount-docverif.dist</li>
    <li>python314Packages.beancount-periodic</li>
    <li>python314Packages.beancount-periodic.dist</li>
    <li>python314Packages.beancount-plugin-utils</li>
    <li>python314Packages.beancount-plugin-utils.dist</li>
    <li>python314Packages.beancount.dist</li>
    <li>python314Packages.beangulp</li>
    <li>python314Packages.beangulp.dist</li>
    <li>python314Packages.beanquery</li>
    <li>python314Packages.beanquery.dist</li>
  </ul>
</details>

---
<details>
<summary>Error logs: `aarch64-darwin`</summary>
<details>
<summary>fava</summary>
<pre>            )
E           AssertionError: Snaphot test failed. Snapshots can be updated with `pytest --snapshot-update`
E           assert {&#x27;beancount_o...&#x27;: &#x27;()&#x27;, ...}} == {&#x27;beancount_o...&#x27;: &#x27;()&#x27;, ...}}
E             
E             Omitting 1 identical items, use -vv to show
E             Differing items:
E             {&#x27;beancount_options&#x27;: {&#x27;account_current_conversions&#x27;: &#x27;Conversions:Current&#x27;, &#x27;account_current_earnings&#x27;: &#x27;Earnings:Current&#x27;, &#x27;account_previous_balances&#x27;: &#x27;Opening-Balances&#x27;, [3...
E             
E             ...Full output truncated (2 lines hidden), use &#x27;-vv&#x27; to show

tests/conftest.py:128: AssertionError
=============================== warnings summary ===============================
tests/test_cli.py:69
  /nix/build/nix-6294-3424500907/fava-frontend-1.30.12/tests/test_cli.py:69: PytestUnknownMarkWarning: Unknown pytest.mark.no_cover - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.no_cover

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED tests/test_json_api.py::test_api[options-/long-example/api/options] - AssertionError: Snaphot test failed. Snapshots can be updated with `pytest ...
============= 1 failed, 452 passed, 2 skipped, 1 warning in 4.41s ==============</pre>
</details>
<details>
<summary>python314Packages.fava</summary>
<pre>            )
E           AssertionError: Snaphot test failed. Snapshots can be updated with `pytest --snapshot-update`
E           assert {&#x27;beancount_o...&#x27;: &#x27;()&#x27;, ...}} == {&#x27;beancount_o...&#x27;: &#x27;()&#x27;, ...}}
E             
E             Omitting 1 identical items, use -vv to show
E             Differing items:
E             {&#x27;beancount_options&#x27;: {&#x27;account_current_conversions&#x27;: &#x27;Conversions:Current&#x27;, &#x27;account_current_earnings&#x27;: &#x27;Earnings:Current&#x27;, &#x27;account_previous_balances&#x27;: &#x27;Opening-Balances&#x27;, [3...
E             
E             ...Full output truncated (2 lines hidden), use &#x27;-vv&#x27; to show

tests/conftest.py:128: AssertionError
=============================== warnings summary ===============================
tests/test_cli.py:69
  /nix/build/nix-6294-3424500909/fava-frontend-1.30.12/tests/test_cli.py:69: PytestUnknownMarkWarning: Unknown pytest.mark.no_cover - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.no_cover

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED tests/test_json_api.py::test_api[options-/long-example/api/options] - AssertionError: Snaphot test failed. Snapshots can be updated with `pytest ...
============= 1 failed, 452 passed, 2 skipped, 1 warning in 3.22s ==============</pre>
</details>
</details>
