### PR TITLE
atlauncher: fix aarch64-linux build

### DIFF
--- a/pkgs/by-name/at/atlauncher/package.nix
+++ b/pkgs/by-name/at/atlauncher/package.nix
@@ -36,6 +36,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     hash = "sha256-pRYXzFUbVXYwD7edhBoVcVo/QDo6QSJJQd58Hf3rBGo=";
   };
 
+  patches = [
+    # Launch4j does not publish the Linux workdir artifact selected on aarch64.
+    # Nixpkgs only needs the cross-platform jar, so remove the Windows exe task.
+    ./remove-launch4j.patch
+  ];
+
   nativeBuildInputs = [
     gradle
     makeWrapper
@@ -52,8 +58,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   gradleFlags = [
     "-Dorg.gradle.java.home=${jdk17_headless.home}"
-    "--exclude-task"
-    "createExe"
   ];
 
   installPhase =

--- a/pkgs/by-name/at/atlauncher/remove-launch4j.patch
+++ b/pkgs/by-name/at/atlauncher/remove-launch4j.patch
@@ -1,0 +1,71 @@
+diff --git a/build.gradle b/build.gradle
+index 474c0c0..59fc2d2 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -24,7 +24,6 @@ plugins {
+     id 'org.cadixdev.licenser' version '0.6.1'
+     id 'com.adarshr.test-logger' version '4.0.0'
+     id 'edu.sc.seis.macAppBundle' version '2.3.0'
+-    id 'edu.sc.seis.launch4j' version '3.0.6'
+     id 'de.undercouch.download' version '5.6.0'
+     id 'com.github.johnrengelman.shadow' version '8.1.1'
+     id 'com.github.ben-manes.versions' version '0.52.0'
+@@ -282,34 +281,15 @@ def currentYear() {
+     return df.format(new Date())
+ }
+ 
+-launch4j {
+-    outfile = "ATLauncher-${project.version}.exe"
+-    jreMinVersion = "${project.targetCompatibility.toString()}"
+-    mainClassName = 'com.atlauncher.App'
+-    icon = "${projectDir}/src/main/resources/assets/image/icon.ico"
+-    version = "${project.version}"
+-    textVersion = "${project.version}"
+-    copyright = "2013-${currentYear()} ${project.name}"
+-    companyName = "${project.name}"
+-    bundledJrePath = "jre/;%JAVA_HOME%;%PATH%"
+-    jvmOptions = [
+-        "-Djna.nosys=true",
+-        "-Djava.net.preferIPv4Stack=true",
+-        "-Dawt.useSystemAAFontSettings=on",
+-        "-Dswing.aatext=true"
+-    ]
+-}
+ 
+ artifacts {
+     archives shadowJar
+-    archives file(project.tasks.jar.getArchivePath().getPath().replace('.jar', '.exe').replace('libs', 'launch4j'))
+     archives file(project.tasks.jar.getArchivePath().getPath().replace('.jar', '.zip').replace('libs', 'distributions'))
+ }
+ 
+ task copyArtifacts(type: Copy) {
+     dependsOn build
+     from shadowJar
+-    from file(project.tasks.jar.getArchivePath().getPath().replace('.jar', '.exe').replace('libs', 'launch4j'))
+     from file(project.tasks.jar.getArchivePath().getPath().replace('.jar', '.zip').replace('libs', 'distributions'))
+     into "${projectDir}/dist"
+ }
+@@ -368,14 +348,6 @@ clean.doFirst {
+     delete "${projectDir}/dist"
+ }
+ 
+-project.afterEvaluate {
+-    tasks.check {
+-        dependsOn -= tasks.find {
+-            it.name.equals("checkLicenses")
+-        }
+-    }
+-}
+-
+ def shouldIgnoreUpdate = { String version -> return ['ALPHA', 'BETA', 'RC', '-M'].any { it -> version.toUpperCase(Locale.ENGLISH).contains(it) } }
+ tasks.named("dependencyUpdates").configure {
+     rejectVersionIf {
+@@ -385,8 +357,6 @@ tasks.named("dependencyUpdates").configure {
+ 
+ build.finalizedBy copyArtifacts
+ shadowJar.dependsOn jar
+-build.dependsOn createExe, createMacApp
+ startScripts.dependsOn shadowJar
+-createExe.dependsOn shadowJar
+ createAppZip.dependsOn downloadNewerUniversalJavaApplicationStub
+ createDmg.dependsOn downloadNewerUniversalJavaApplicationStub


### PR DESCRIPTION
This PR fixes the `aarch64-linux` build for `atlauncher`, which was broken by #327592. The issue is that Launch4j doesn't work properly on `aarch64-linux`, so we simply remove it because this package only needs it for the Windows build.

ZHF: #516381

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
