### PR TITLE
coq-lsp: add `$OCAMLFIND_DESTDIR` to wrapper `OCAMLPATH`

### DIFF
--- a/pkgs/development/coq-modules/coq-lsp/default.nix
+++ b/pkgs/development/coq-modules/coq-lsp/default.nix
@@ -66,7 +66,7 @@
   installPhase = ''
     runHook preInstall
     dune install -p ${pname} --prefix=$out --libdir $OCAMLFIND_DESTDIR
-    wrapProgram $out/bin/coq-lsp --prefix OCAMLPATH : $OCAMLPATH
+    wrapProgram $out/bin/coq-lsp --prefix OCAMLPATH : $OCAMLFIND_DESTDIR --prefix OCAMLPATH : $OCAMLPATH
     runHook postInstall
   '';
 


### PR DESCRIPTION
`wrapProgram` in `installPhase` prepends propagated build inputs' `$OCAMLPATH` but omits `$OCAMLFIND_DESTDIR`, coq-lsp's own site-lib containing the compiled serlib `.cmxs` plugins. At runtime Rocq's plugin loader maps plugin names (e.g. `rocq-runtime.plugins.ltac`) to serlib adapters (e.g. `coq-lsp.serlib.ltac`) and calls `Findlib.package_directory()` to locate them. Without coq-lsp's own output in `OCAMLPATH`, findlib fails and seven "not available" warnings are emitted on every `.v` file.

`$OCAMLFIND_DESTDIR` is set by the preceding `dune install` invocation. Prepending it to the wrapper's `OCAMLPATH` ensures coq-lsp can discover its own serlib plugins at runtime.

Assisted-by: Syzygy(tnxwqvtl)/OpenCode(1.14.48):zai-coding-plan/glm-5.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
