### PR TITLE
onnxruntime: 1.24.4 -> 1.26.0

### DIFF
--- a/pkgs/by-name/on/onnxruntime/package.nix
+++ b/pkgs/by-name/on/onnxruntime/package.nix
@@ -61,16 +61,16 @@ let
     name = "onnx-src";
     owner = "onnx";
     repo = "onnx";
-    tag = "v1.20.1";
-    hash = "sha256-XZJXD6sBvVJ6cLPyDkKOW8oSkjqcw9whUqDWd7dxY3c=";
+    tag = "v1.21.0";
+    hash = "sha256-eF6BdTwTuHh6ckuLGN1d6z2GLU47lPqtzu4zIv8+cTs=";
   };
 
   cutlass-src = fetchFromGitHub {
     name = "cutlass-src";
     owner = "NVIDIA";
     repo = "cutlass";
-    tag = "v4.2.1";
-    hash = "sha256-iP560D5Vwuj6wX1otJhwbvqe/X4mYVeKTpK533Wr5gY=";
+    tag = "v4.4.2";
+    hash = "sha256-0q9Ad0Z6E/rO2PdM4uQc8H0E0qs9uKc3reHepiHhjEc=";
   };
 
   dlpack-src = fetchFromGitHub {
@@ -109,14 +109,14 @@ let
 in
 effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "onnxruntime";
-  version = "1.24.4";
+  version = "1.26.0";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "onnxruntime";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-CjPgRkPyp7dUPAOo3cePWQvucOlQAwtT4NO5w3NkV+E=";
+    hash = "sha256-+9M4mEPLLJ5N+JomoXIKcUBV85lr6lFJjJQ3qsMRrQY=";
   };
 
   patches = [
@@ -269,7 +269,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "ABSL_ENABLE_INSTALL" true)
     # leads to failing builds, which isn't particularly useful for Nixpkgs
-    (lib.cmakeFeature "CMAKE_CXX_FLAGS" "-Wno-error=unused-variable")
+    (lib.cmakeFeature "CMAKE_CXX_FLAGS" "-Wno-error=unused-variable -Wno-error=deprecated")
     (lib.cmakeBool "FETCHCONTENT_FULLY_DISCONNECTED" true)
     (lib.cmakeBool "FETCHCONTENT_QUIET" false)
     (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_ABSEIL_CPP" "${abseil-cpp_202508.src}")

--- a/pkgs/by-name/on/onnxruntime/package.nix
+++ b/pkgs/by-name/on/onnxruntime/package.nix
@@ -4,6 +4,7 @@
   stdenv,
   fetchFromGitHub,
   abseil-cpp_202508,
+  buildPackages,
   cmake,
   cpuinfo,
   eigen,
@@ -163,7 +164,6 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     cmake
     pkg-config
     python3Packages.python
-    protobuf
   ]
   ++ lib.optionals pythonSupport (
     with python3Packages;
@@ -240,10 +240,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     (darwinMinVersionHook "13.3")
   ];
 
-  nativeCheckInputs = [
-    gtest
-  ]
-  ++ lib.optionals pythonSupport (
+  nativeCheckInputs = lib.optionals pythonSupport (
     with python3Packages;
     [
       onnx
@@ -251,6 +248,10 @@ effectiveStdenv.mkDerivation (finalAttrs: {
       sympy
     ]
   );
+
+  checkInputs = [
+    gtest
+  ];
 
   # TODO: build server, and move .so's to lib output
   # Python's wheel is stored in a separate dist output
@@ -281,7 +282,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_SAFEINT" "${safeint-src}")
     (lib.cmakeFeature "FETCHCONTENT_TRY_FIND_PACKAGE_MODE" "ALWAYS")
     # fails to find protoc on darwin, so specify it
-    (lib.cmakeFeature "ONNX_CUSTOM_PROTOC_EXECUTABLE" (lib.getExe protobuf))
+    (lib.cmakeFeature "ONNX_CUSTOM_PROTOC_EXECUTABLE" (lib.getExe buildPackages.protobuf))
     (lib.cmakeBool "onnxruntime_BUILD_SHARED_LIB" true)
     (lib.cmakeBool "onnxruntime_BUILD_UNIT_TESTS" finalAttrs.doCheck)
     (lib.cmakeBool "onnxruntime_USE_FULL_PROTOBUF" withFullProtobuf)
@@ -373,6 +374,8 @@ effectiveStdenv.mkDerivation (finalAttrs: {
       ../include/onnxruntime/core/session/onnxruntime_*.h \
       ../include/onnxruntime/core/providers/coreml/coreml_provider_factory.h
   '';
+
+  strictDeps = true;
 
   # See comments in `cudaPackages.nccl`
   postFixup = lib.optionalString cudaSupport ''

--- a/pkgs/by-name/on/onnxruntime/protobuf34-nodiscard.patch
+++ b/pkgs/by-name/on/onnxruntime/protobuf34-nodiscard.patch
@@ -73,28 +73,6 @@ index 055b255132..3925db8ac7 100644
      ofs.flush();
  
      ASSERT_TRUE(std::filesystem::exists(serialized_model_path));
-diff --git a/onnxruntime/test/framework/inference_session_test.cc b/onnxruntime/test/framework/inference_session_test.cc
-index 1c4e7800b7..8ceb05f0f6 100644
---- a/onnxruntime/test/framework/inference_session_test.cc
-+++ b/onnxruntime/test/framework/inference_session_test.cc
-@@ -1045,7 +1045,7 @@ static void TestBindHelper(const std::string& log_str,
-   CreateMatMulModel(p_model, run_provider_type);
- 
-   std::string s1;
--  p_model->ToProto().SerializeToString(&s1);
-+  ASSERT_TRUE(p_model->ToProto().SerializeToString(&s1));
-   std::stringstream sstr(s1);
-   ASSERT_STATUS_OK(session_object.Load(sstr));
-   ASSERT_STATUS_OK(session_object.Initialize());
-@@ -1078,7 +1078,7 @@ TEST(InferenceSessionTests, TestIOBindingReuse) {
-   CreateMatMulModel(p_model, kCpuExecutionProvider);
- 
-   std::string s1;
--  p_model->ToProto().SerializeToString(&s1);
-+  ASSERT_TRUE(p_model->ToProto().SerializeToString(&s1));
-   std::stringstream sstr(s1);
-   ASSERT_TRUE(session_object.Load(sstr).IsOK());
-   ASSERT_STATUS_OK(session_object.Initialize());
 diff --git a/onnxruntime/test/ir/graph_test.cc b/onnxruntime/test/ir/graph_test.cc
 index 4d80cb7047..c69ac46c05 100644
 --- a/onnxruntime/test/ir/graph_test.cc
@@ -201,3 +179,16 @@ index 5caafa0f37..327463c615 100644
    std::shared_ptr<IExecutionProvider> ep_shared = ep ? std::move(ep) : nullptr;
  
    auto run_model = [&](TransformerLevel level, std::vector<OrtValue>& fetches,
+diff --git a/onnxruntime/test/optimizer/transpose_optimizer_test.cc b/onnxruntime/test/optimizer/transpose_optimizer_test.cc
+index 9e9e9e9e9e..8e8e8e8e8e 100644
+--- a/onnxruntime/test/optimizer/transpose_optimizer_test.cc
++++ b/onnxruntime/test/optimizer/transpose_optimizer_test.cc
+@@ -4532,7 +4532,7 @@ TEST(TransposeOptimizerTests, RegressionTest_Permute1DConstantEmptyPerm) {
+ 
+   // Serialize the model to a string.
+   std::string model_data;
+-  model.ToProto().SerializeToString(&model_data);
++  ASSERT_TRUE(model.ToProto().SerializeToString(&model_data));
+ 
+   SessionOptions session_options;
+   session_options.graph_optimization_level = TransformerLevel::Level1;


### PR DESCRIPTION
update to latest version and fixes #523209 
Additionally this takes over #450107 to fix cross-compilation #306042.

`nix-build -A pkgsCross.aarch64-multiplatform.onnxruntime`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
