### PR TITLE
acl2-minimal: fix aarch64-linux build

### DIFF
--- a/pkgs/by-name/ac/acl2/0002-sbcl-fp-trap-fallback.patch
+++ b/pkgs/by-name/ac/acl2/0002-sbcl-fp-trap-fallback.patch
@@ -1,0 +1,53 @@
+diff --git a/acl2.lisp b/acl2.lisp
+index 036657d902..c2b7e4fad9 100644
+--- a/acl2.lisp
++++ b/acl2.lisp
+@@ -1963,11 +1963,7 @@ ACL2 from scratch.")
+                (* *my-most-positive-double-float*
+                   *my-most-positive-double-float*)
+                (error () 0.0d0))
+-              'double-float))
+-     #+sbcl
+-     (member :overflow
+-             (cadr (member :traps
+-                           (sb-int:get-floating-point-modes)))))
++              'double-float)))
+   (error "This Lisp is unsuitable for ACL2, because it failed ~%a check that ~
+           floating-point overflow causes an error."))
+ 
+diff --git a/float-raw.lisp b/float-raw.lisp
+index 1364491fdf..e6d0417971 100644
+--- a/float-raw.lisp
++++ b/float-raw.lisp
+@@ -46,13 +46,13 @@
+ ; #.*infinity-double* and #.*negative-infinity-double*), so we do so, but we
+ ; don't bother testing for Nan in LispWorks.
+ 
+-; We return form unchanged in other than Allegro CL and LispWorks, because we
++; We return form unchanged in other than Allegro CL, LispWorks, and SBCL, because we
+ ; already know that an error is signalled on overflow for other Lisps that host
+ ; ACL2; see break-on-overflow-and-nan.
+ 
+-  #-(or allegro lispworks)
++  #-(or allegro lispworks sbcl)
+   (declare (ignore op))
+-  #-(or allegro lispworks)
++  #-(or allegro lispworks sbcl)
+   form
+   #+allegro
+   `(let ((result ,form))
+@@ -65,6 +65,14 @@
+      (when (or (= result +1D++0) (= result -1D++0))
+        (error "Floating-point overflow for a call of ~s"
+               ',op))
++     result)
++  #+sbcl
++  `(let ((result ,form))
++     (when (or (sb-ext:float-nan-p result)
++               (= result sb-ext:double-float-positive-infinity)
++               (= result sb-ext:double-float-negative-infinity))
++       (error "Floating-point exception for a call of ~s"
++              ',op))
+      result))
+ 
+ (defmacro defun-df-binary (name op)

--- a/pkgs/by-name/ac/acl2/package.nix
+++ b/pkgs/by-name/ac/acl2/package.nix
@@ -62,6 +62,13 @@ stdenv.mkDerivation rec {
       libssl = "${lib.getLib openssl}/lib/libssl${stdenv.hostPlatform.extensions.sharedLibrary}";
       libcrypto = "${lib.getLib openssl}/lib/libcrypto${stdenv.hostPlatform.extensions.sharedLibrary}";
     })
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.system == "aarch64-linux") [
+    # ACL2 8.6 assumes SBCL can enable floating-point traps. On
+    # aarch64-linux, SBCL can leave :TRAPS NIL after enabling them, so use
+    # ACL2's existing exceptional-float checking path instead. See:
+    # https://github.com/acl2-devel/acl2-devel/commit/0632b37adffb6b5fd71d8438d519133281f837ec
+    ./0002-sbcl-fp-trap-fallback.patch
   ];
 
   # We need the timestamps on the source tree to be stable for certification to


### PR DESCRIPTION
[![](https://hydra-banner.harinn.dev/build/329251400)](https://hydra.nixos.org/build/329251400)

ZHF: #516381

This PR fixes the the `acl2-minimal` package on `aarch64-linux` after its build was broken by #440168. Specifically, acl2-devel/acl2-devel@0632b37adffb6b5fd71d8438d519133281f837ec added a test that fails on this platform with the following error message:

```
  This Lisp is unsuitable for ACL2, because it failed
a check that floating-point overflow causes an error.
```

To deal with this, we add an patch for `aarch64-linux` which uses the same approach ACL2 already takes for [Allegro](https://franz.com/support/documentation/excl-ops.html#exceptional-floating-point-number-p) and LispWorks: check for non-finite values and throw an `error` if you see one.

Upstreaming this seems nontrivial, since the [ACL2 contributing docs](https://www.acl2.org/doc/index.html?topic=ACL2____HOW-TO-CONTRIBUTE) say this:

> While the community is invited to submit contributions to the [Community Books](https://www.acl2.org/doc/index.html?topic=ACL2____COMMUNITY-BOOKS), source files outside of the `books/` directory should not be modified, except by system maintainers.
>
> Suggestions for system changes can be emailed to [Matt Kaufmann](mailto:kaufmann@cs.utexas.edu). (Prospective system developers should see the [developers-guide](https://www.acl2.org/doc/index.html?topic=ACL2____DEVELOPERS-GUIDE).)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
