### PR TITLE
nixos/cosmic-greeter: add cosmic icons

### DIFF
--- a/nixos/modules/services/display-managers/cosmic-greeter.nix
+++ b/nixos/modules/services/display-managers/cosmic-greeter.nix
@@ -26,6 +26,7 @@ in
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [
       pkgs.cosmic-comp
+      pkgs.cosmic-icons
       cfg.package
     ];
 


### PR DESCRIPTION
Without this icons don't show up after the recent update.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Tests done:
  - [x] Tested with my configuration (Hyprland, not Cosmic DE)