### PR TITLE
ponyc: 0.60.6 -> 0.64.0

### DIFF
--- a/pkgs/by-name/po/pony-corral/package.nix
+++ b/pkgs/by-name/po/pony-corral/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   ponyc,
   nix-update-script,
 }:
@@ -16,6 +17,15 @@ stdenv.mkDerivation (finalAttrs: {
     rev = finalAttrs.version;
     hash = "sha256-WblwyUm7mTdh3GvuSvO9bW6txbJeSS4qrvP4TeYk1uw=";
   };
+
+  patches = [
+    # Should be in the next release, fixes compile on newer versions
+    (fetchpatch {
+      url = "https://github.com/ponylang/corral/commit/10b85e36e5c7ec4503ecb80ff51aa2342e459805.patch";
+      hash = "sha256-wDvoW1t/F3ieNlwS+HtxVzhlFX4TDTbAnxJnJnsCvtc=";
+      includes = [ "corral/semver/version/compare_versions.pony" ];
+    })
+  ];
 
   env.arch =
     if stdenv.hostPlatform.isx86_64 then

--- a/pkgs/by-name/po/ponyc/disable-networking-tests.patch
+++ b/pkgs/by-name/po/ponyc/disable-networking-tests.patch
@@ -1,25 +1,23 @@
-From e49f97eb4b0fd27b26437638db7984fbcfd3a14f Mon Sep 17 00:00:00 2001
+From c1283b82daff94ebac21fc20cb8df0b05aa080f8 Mon Sep 17 00:00:00 2001
 From: Morgan Jones <me@numin.it>
-Date: Sun, 4 May 2025 15:46:07 -0700
-Subject: [PATCH] net: disable tests in the Nix sandbox
+Date: Fri, 22 May 2026 23:06:52 -0700
+Subject: [PATCH] net: disable networking tests
 
 ---
- packages/net/_test.pony | 19 +------------------
- 1 file changed, 1 insertion(+), 18 deletions(-)
+ packages/net/_test.pony | 18 ------------------
+ 1 file changed, 18 deletions(-)
 
 diff --git a/packages/net/_test.pony b/packages/net/_test.pony
-index 05462eb2..c0c6cdfa 100644
+index 1d7b2d6f..69cbeea6 100644
 --- a/packages/net/_test.pony
 +++ b/packages/net/_test.pony
-@@ -15,25 +15,8 @@ actor \nodoc\ Main is TestList
-   new make() => None
- 
-   fun tag tests(test: PonyTest) =>
--    // Tests below function across all systems and are listed alphabetically
-+    // (@numinit): only this test works in the Nix sandbox:
+@@ -20,24 +20,6 @@ actor \nodoc\ Main is TestList
+     // Tests below function across all systems and are listed alphabetically
+     test(_TestOsIpString)
      test(_TestTCPConnectionFailed)
 -    test(_TestTCPExpect)
 -    test(_TestTCPExpectOverBufferSize)
+-    test(_TestTCPExpectSetToZero)
 -    test(_TestTCPMute)
 -    test(_TestTCPProxy)
 -    test(_TestTCPUnmute)
@@ -39,4 +37,5 @@ index 05462eb2..c0c6cdfa 100644
  class \nodoc\ _TestPing is UDPNotify
    let _h: TestHelper
 -- 
-2.47.0
+2.53.0
+

--- a/pkgs/by-name/po/ponyc/fix-darwin-build.patch
+++ b/pkgs/by-name/po/ponyc/fix-darwin-build.patch
@@ -1,7 +1,7 @@
-diff --git a/src/libponyc/codegen/genexe.c b/src/libponyc/codegen/genexe.c
+diff --git a/src/libponyc/codegen/genexe.cc b/src/libponyc/codegen/genexe.cc
 index 3f0348eaa1..76b03030bf 100644
---- a/src/libponyc/codegen/genexe.c
-+++ b/src/libponyc/codegen/genexe.c
+--- a/src/libponyc/codegen/genexe.cc
++++ b/src/libponyc/codegen/genexe.cc
 @@ -308,7 +308,7 @@
    snprintf(ld_cmd, ld_len,
      "%s -execute -arch %.*s "

--- a/pkgs/by-name/po/ponyc/genexe-pony-linker.patch
+++ b/pkgs/by-name/po/ponyc/genexe-pony-linker.patch
@@ -1,0 +1,26 @@
+From ac4b2a65f997f7f779b9c63dbe683ba10a26fc7f Mon Sep 17 00:00:00 2001
+From: Morgan Jones <me@numin.it>
+Date: Fri, 22 May 2026 23:58:29 -0700
+Subject: [PATCH] genexe: take PONY_LINKER into account
+
+---
+ src/libponyc/codegen/genexe.cc | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/libponyc/codegen/genexe.cc b/src/libponyc/codegen/genexe.cc
+index 48f97578..5b9f36f1 100644
+--- a/src/libponyc/codegen/genexe.cc
++++ b/src/libponyc/codegen/genexe.cc
+@@ -1448,6 +1448,9 @@ static bool link_exe(compile_t* c, ast_t* program,
+ {
+   errors_t* errors = c->opt->check.errors;
+ 
++  if(c->opt->linker == NULL)
++    c->opt->linker = getenv("PONY_LINKER");
++
+   // Use embedded LLD for Linux, macOS, and Windows targets unless --linker
+   // escape hatch is specified. Sanitizer builds fall back to the system
+   // compiler driver for native compilation since sanitizer runtime libraries
+-- 
+2.53.0
+

--- a/pkgs/by-name/po/ponyc/package.nix
+++ b/pkgs/by-name/po/ponyc/package.nix
@@ -13,6 +13,7 @@
   pcre2,
   pony-corral,
   python3,
+  zlib,
   # Not really used for anything real, just at build time.
   git,
   replaceVars,
@@ -22,31 +23,31 @@
   procps,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ponyc";
-  version = "0.60.6";
+  version = "0.64.0";
 
   src = fetchFromGitHub {
     owner = "ponylang";
     repo = "ponyc";
-    tag = version;
-    hash = "sha256-mBtSoFOX0dHtb0ojdT+uB1Lmu7Cak/3A8808dv3o1ik=";
+    tag = finalAttrs.version;
+    hash = "sha256-CdsfJO+7y7nvlDdCXdWRB4vmP9pB1Jz5CVwJuha+yds=";
     fetchSubmodules = true;
   };
 
-  benchmarkRev = "1.9.1";
+  benchmarkRev = "1.9.5";
   benchmark = fetchFromGitHub {
     owner = "google";
     repo = "benchmark";
-    rev = "v${benchmarkRev}";
-    hash = "sha256-5xDg1duixLoWIuy59WT0r5ZBAvTR6RPP7YrhBYkMxc8=";
+    rev = "v${finalAttrs.benchmarkRev}";
+    hash = "sha256-Mm4pG7zMB00iof32CxreoNBFnduPZTMp3reHMCIAFPQ=";
   };
 
   googletestRev = "1.17.0";
   googletest = fetchFromGitHub {
     owner = "google";
     repo = "googletest";
-    rev = "v${googletestRev}";
+    rev = "v${finalAttrs.googletestRev}";
     hash = "sha256-HIHMxAUR4bjmFLoltJeIAVSulVQ6kVuIT2Ku+lwAx/4=";
   };
 
@@ -64,12 +65,16 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libxml2
     z3
+    zlib
   ];
 
   patches = [
     # Sandbox disallows network access, so disabling problematic networking tests
     ./disable-networking-tests.patch
     ./disable-process-tests.patch
+
+    # Take PONY_LINKER into account
+    ./genexe-pony-linker.patch
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     (replaceVars ./fix-darwin-build.patch {
@@ -116,6 +121,12 @@ stdenv.mkDerivation rec {
   preBuild = ''
     extraFlags=(build_flags=-j$NIX_BUILD_CORES)
   ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    export PONY_LINKER="$CC"
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    export PONY_LINKER=ld
+  ''
   + lib.optionalString stdenv.hostPlatform.isAarch64 ''
     # See this relnote about building on Raspbian:
     # https://github.com/ponylang/ponyc/blob/0.46.0/.release-notes/0.45.2.md
@@ -129,7 +140,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   makeFlags = [
-    "PONYC_VERSION=${version}"
+    "PONYC_VERSION=${finalAttrs.version}"
     "prefix=${placeholder "out"}"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin ([ "bits=64" ] ++ lib.optional (!lto) "lto=no");
@@ -159,6 +170,7 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/ponyc \
       --prefix PATH ":" "${stdenv.cc}/bin" \
       --set-default CC "$CC" \
+      --set-default PONY_LINKER "$PONY_LINKER" \
       --prefix PONYPATH : "${
         lib.makeLibraryPath [
           pcre2
@@ -192,4 +204,4 @@ stdenv.mkDerivation rec {
       "aarch64-darwin"
     ];
   };
-}
+})


### PR DESCRIPTION
We need a patch to set PONY_LINKER to the same thing as $CC.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
