### PR TITLE
brscan5: fix pkg and nixos module

### DIFF
--- a/nixos/modules/services/hardware/sane_extra_backends/brscan5_etc_files.nix
+++ b/nixos/modules/services/hardware/sane_extra_backends/brscan5_etc_files.nix
@@ -58,17 +58,17 @@ stdenv.mkDerivation {
   dontConfigure = true;
 
   buildPhase = ''
-    TARGET_DIR="$out/etc/opt/brother/scanner/brscan5"
+    TARGET_DIR="$out/tmp"
     mkdir -p "$TARGET_DIR"
     cp -rp "./models" "$TARGET_DIR"
     cp -rp "./brscan5.ini" "$TARGET_DIR"
     cp -rp "./brsanenetdevice.cfg" "$TARGET_DIR"
-
     export NIX_REDIRECTS="/etc/opt/brother/scanner/brscan5/=$TARGET_DIR/"
-
     printf '${addAllNetDev netDevices}\n'
-
     ${addAllNetDev netDevices}
+
+    mkdir -p "$out/etc/opt/brother/scanner/brscan5"
+    mv -T "$TARGET_DIR" "$out/etc/opt/brother/scanner/brscan5"
   '';
 
   dontInstall = true;

--- a/pkgs/by-name/br/brscan5/package.nix
+++ b/pkgs/by-name/br/brscan5/package.nix
@@ -109,7 +109,7 @@ stdenv.mkDerivation rec {
     makeWrapper \
       "$out/$PATH_TO_BRSCAN5/brsaneconfig5" \
       "$out/bin/brsaneconfig5" \
-      --suffix-each NIX_REDIRECT ":" "/etc/opt/brother/scanner/brscan5=$out/opt/brother/scanner/brscan5 /opt/brother/scanner/brscan5=$out/opt/brother/scanner/brscan5" \
+      --suffix-each NIX_REDIRECTS ":" "/etc/opt/brother/scanner/brscan5=$out/opt/brother/scanner/brscan5 /opt/brother/scanner/brscan5=$out/opt/brother/scanner/brscan5" \
       --set LD_PRELOAD ${libredirect}/lib/libredirect.so
 
     mkdir -p $out/etc/sane.d/dll.d


### PR DESCRIPTION
This PR contains two fixes related to brscan5 (brother scanner driver for sane) due to libredirect misconfiguration:

- fix invalid `brsaneconfig5` binary from `brscan5` package due to a typo
- fix ineffective `hardware.sane.brscan5.netDevices` config due to conflicting path name

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
