### PR TITLE
trurl: fix tests with libcurl 8.20.0 uppercase hex

### DIFF
--- a/pkgs/by-name/tr/trurl/package.nix
+++ b/pkgs/by-name/tr/trurl/package.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation rec {
       url = "https://github.com/curl/trurl/commit/f22a2c45956f35702e437fb83ac05376f1956ec5.patch";
       hash = "sha256-7CkUs5tMk77WKc7SlgE2NslHtU5cViKSGhHj3IBlpWo=";
     })
+    # https://github.com/curl/trurl/pull/441
+    ./tests-uppercase-hex.patch
   ];
 
   postPatch = ''

--- a/pkgs/by-name/tr/trurl/tests-uppercase-hex.patch
+++ b/pkgs/by-name/tr/trurl/tests-uppercase-hex.patch
@@ -1,0 +1,96 @@
+--- a/tests.json
++++ b/tests.json
+@@ -749,6 +749,7 @@
+                 "query=user=me"
+             ]
+         },
++        "excludes": ["uppercase-hex"],
+         "expected": {
+             "stdout": "https://curl.se/hello?user%3dme\n",
+             "stderr": "",
+@@ -761,6 +762,22 @@
+                 "--url",
+                 "https://curl.se/hello",
+                 "--set",
++                "query=user=me"
++            ]
++        },
++        "required": ["uppercase-hex"],
++        "expected": {
++            "stdout": "https://curl.se/hello?user%3Dme\n",
++            "stderr": "",
++            "returncode": 0
++        }
++    },
++    {
++        "input": {
++            "arguments": [
++                "--url",
++                "https://curl.se/hello",
++                "--set",
+                 "fragment= hello"
+             ]
+         },
+@@ -2132,6 +2149,7 @@
+                 "query:=a&b&a%26b"
+             ]
+         },
++        "excludes": ["uppercase-hex"],
+         "expected": {
+             "stdout": "http://localhost/ABC%5c%5c?a&b&a%26b\n",
+             "returncode": 0,
+@@ -2141,6 +2159,26 @@
+     {
+         "input": {
+             "arguments": [
++                "-s",
++                "scheme:=http",
++                "-s",
++                "host:=localhost",
++                "-s",
++                "path:=/ABC%5C%5C",
++                "-s",
++                "query:=a&b&a%26b"
++            ]
++        },
++        "required": ["uppercase-hex"],
++        "expected": {
++            "stdout": "http://localhost/ABC%5C%5C?a&b&a%26b\n",
++            "returncode": 0,
++            "stderr": ""
++        }
++    },
++    {
++        "input": {
++            "arguments": [
+                 "-g",
+                 "{query:b}\\t{query-all:a}\\n{:query:b}\\t{:query-all:a}",
+                 "https://example.org/foo?a=1&b=%23&a=%26#hello"
+@@ -2825,11 +2863,27 @@
+                 "path=%61"
+             ]
+         },
++        "excludes": ["uppercase-hex"],
+         "expected": {
+             "stdout": "https://example.com/one/tao/%2fB/%2561\n",
+             "stderr": "",
+             "returncode": 0
+         }
++    },
++    {
++        "input": {
++            "arguments": [
++                "https://example.com/one/t%61o/%2F%42/",
++                "--append",
++                "path=%61"
++            ]
++        },
++        "required": ["uppercase-hex"],
++        "expected": {
++            "stdout": "https://example.com/one/tao/%2FB/%2561\n",
++            "stderr": "",
++            "returncode": 0
++        }
+     },
+     {
+         "input": {


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/329501195)](https://hydra.nixos.org/build/329501195)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

