### PR TITLE
metadata: fix build with ffmpeg 8.1

### DIFF
--- a/pkgs/by-name/me/metadata/ffmpeg-next-8.1.patch
+++ b/pkgs/by-name/me/metadata/ffmpeg-next-8.1.patch
@@ -1,0 +1,71 @@
+diff --git a/Cargo.lock b/Cargo.lock
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -37,7 +37,7 @@
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "4f72209734318d0b619a5e0f5129918b848c416e122a3c4ce054e03cb87b726f"
+ dependencies = [
+- "bitflags 2.9.3",
++ "bitflags 2.11.1",
+  "cexpr",
+  "clang-sys",
+  "itertools",
+@@ -57,9 +57,9 @@
+ 
+ [[package]]
+ name = "bitflags"
+-version = "2.9.3"
++version = "2.11.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
++checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+ 
+ [[package]]
+ name = "block-buffer"
+@@ -204,20 +204,20 @@
+ 
+ [[package]]
+ name = "ffmpeg-next"
+-version = "8.0.0"
++version = "8.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d658424d233cbd993a972dd73a66ca733acd12a494c68995c9ac32ae1fe65b40"
++checksum = "f7c4bd5ab1ac61f29c634df1175d350ded29cf74c3c6d4f7030431a5ae3c7d5d"
+ dependencies = [
+- "bitflags 2.9.3",
++ "bitflags 2.11.1",
+  "ffmpeg-sys-next",
+  "libc",
+ ]
+ 
+ [[package]]
+ name = "ffmpeg-sys-next"
+-version = "8.0.1"
++version = "8.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9bca20aa4ee774fe384c2490096c122b0b23cf524a9910add0686691003d797b"
++checksum = "a314bc0e022a33a99567ed4bd2576bd58ffd8fcff7891c29194cfecc26a62547"
+ dependencies = [
+  "bindgen",
+  "cc",
+@@ -606,7 +606,7 @@
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+ dependencies = [
+- "bitflags 2.9.3",
++ "bitflags 2.11.1",
+  "errno",
+  "libc",
+  "linux-raw-sys",
+diff --git a/Cargo.toml b/Cargo.toml
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -33,7 +33,7 @@
+ serde_derive = "1.0.198"
+ 
+ [dependencies.ffmpeg-next]
+-version = "8.0.0"
++version = "8.1.0"
+ default-features = false
+ features = ["codec", "format"]
+ 

--- a/pkgs/by-name/me/metadata/package.nix
+++ b/pkgs/by-name/me/metadata/package.nix
@@ -20,7 +20,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-gDOYqPwrWUfUTCx+p+ZpwsP8XxUufDCGem/WzW5cQPc=";
   };
 
-  cargoHash = "sha256-tUVaseaavm746sxaA2A3ua4ZxzoKSnRQ4rJRBeO9t1U=";
+  cargoPatches = [
+    # bump ffmpeg-next 8.0.0 -> 8.1.0 for ffmpeg 8.1 enum variants
+    ./ffmpeg-next-8.1.patch
+  ];
+
+  cargoHash = "sha256-TgF88oaf6567Xk20TkqbtE+H+nEKTiUSyswvxvCNFVI=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/329346706)](https://hydra.nixos.org/build/329346706)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

