### PR TITLE
mysql-shell: fix build on darwin

### DIFF
--- a/pkgs/development/tools/mysql-shell/8.nix
+++ b/pkgs/development/tools/mysql-shell/8.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   env =
     lib.optionalAttrs stdenv.cc.isClang {
-      NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-literal-operator";
+      NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-literal-operator -Wno-error=nonnull";
     }
     // lib.optionalAttrs stdenv.cc.isGNU {
       NIX_CFLAGS_COMPILE = "-Wno-error=array-bounds";

--- a/pkgs/development/tools/mysql-shell/9.nix
+++ b/pkgs/development/tools/mysql-shell/9.nix
@@ -73,6 +73,10 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace ../mysql/cmake/os/Darwin.cmake --replace-fail /usr/bin/libtool libtool
 
     substituteInPlace cmake/libutils.cmake --replace-fail /usr/bin/libtool libtool
+
+    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+      patch -d .. -p1 < ${./mysql-server-libcxx-21.patch}
+    ''}
   '';
 
   strictDeps = true;

--- a/pkgs/development/tools/mysql-shell/innovation.nix
+++ b/pkgs/development/tools/mysql-shell/innovation.nix
@@ -73,6 +73,10 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace ../mysql/cmake/os/Darwin.cmake --replace-fail /usr/bin/libtool libtool
 
     substituteInPlace cmake/libutils.cmake --replace-fail /usr/bin/libtool libtool
+
+    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+      patch -d .. -p1 < ${./mysql-server-libcxx-21.patch}
+    ''}
   '';
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/mysql-shell/mysql-server-libcxx-21.patch
+++ b/pkgs/development/tools/mysql-shell/mysql-server-libcxx-21.patch
@@ -1,0 +1,22 @@
+diff --git a/mysql/libs/mysql/gtid/tag_plain.h b/mysql/libs/mysql/gtid/tag_plain.h
+index 4703a5b0d6e..914c6a4b777 100644
+--- a/mysql/libs/mysql/gtid/tag_plain.h
++++ b/mysql/libs/mysql/gtid/tag_plain.h
+@@ -28,6 +28,7 @@
+ #include <cstring>
+ #include <memory>
+ #include <string>
++#include <type_traits>
+ 
+ #include "mysql/gtid/gtid_constants.h"  // tag_max_length
+ 
+@@ -80,7 +81,8 @@ struct Tag_plain {
+   unsigned char m_data[tag_max_length + 1];
+ };
+ 
+-static_assert(std::is_trivial_v<Tag_plain>);
++static_assert(std::is_trivially_copyable_v<Tag_plain>);
++static_assert(std::is_trivially_default_constructible_v<Tag_plain>);
+ static_assert(std::is_standard_layout_v<Tag_plain>);
+ 
+ }  // namespace mysql::gtid


### PR DESCRIPTION
Related to : https://github.com/NixOS/nixpkgs/issues/516381
https://zh.fail/failed/by-maintainer/aaronjheng.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
