### PR TITLE
python3Packages.nbpreview and dependencies: init

### DIFF
--- a/pkgs/development/python-modules/nbpreview/default.nix
+++ b/pkgs/development/python-modules/nbpreview/default.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  poetry-core,
+  pythonRelaxDepsHook,
+  rich,
+  typer,
+  nbformat,
+  pygments,
+  ipython,
+  lxml,
+  pylatexenc,
+  httpx,
+  jinja2,
+  html2text,
+  pillow,
+  picharsso,
+  validators,
+  yarl,
+  markdown-it-py,
+  mdit-py-plugins,
+  click-help-colors,
+  term-image,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "nbpreview";
+  version = "0.10.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-YUTywDFf/2+D57pSaUnTcggKx3hTzCTJhRSaBO9eWao=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+    pythonRelaxDepsHook
+  ];
+
+  propagatedBuildInputs = [
+    rich
+    typer
+    nbformat
+    pygments
+    ipython
+    lxml
+    pylatexenc
+    httpx
+    jinja2
+    html2text
+    pillow
+    picharsso
+    validators
+    yarl
+    markdown-it-py
+    mdit-py-plugins
+    click-help-colors
+    term-image
+  ];
+
+  pythonRelaxDeps = [
+    "pillow"
+    "markdown-it-py"
+    "typer"
+    "types-click"
+  ];
+
+  postPatch = ''
+    sed -i '/types-click/d' pyproject.toml
+  '';
+
+  doCheck = false;
+
+  meta = {
+    description = "A terminal viewer for Jupyter notebooks";
+    longDescription = ''
+      nbpreview renders Jupyter notebooks in your terminal.
+      It's like cat for .ipynb files — syntax-highlighted code cells,
+      rendered markdown, images, LaTeX, DataFrames, and more.
+    '';
+    homepage = "https://github.com/paw-lu/nbpreview";
+    changelog = "https://github.com/paw-lu/nbpreview/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ alikaansun ];
+    mainProgram = "nbpreview";
+  };
+})

--- a/pkgs/development/python-modules/picharsso/default.nix
+++ b/pkgs/development/python-modules/picharsso/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  click,
+  numpy,
+  pillow,
+  sty,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "picharsso";
+  version = "2.0.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-602LGh/mknh00CNi7rJDb4a/m0/uAswKx2not2HBJ28=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  propagatedBuildInputs = [
+    click
+    numpy
+    pillow
+    sty
+  ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A utility for converting images to text art";
+    homepage = "https://github.com/kelvindecosta/picharsso";
+    license = licenses.mit;
+    maintainers = with maintainers; [ alikaansun ];
+  };
+})

--- a/pkgs/development/python-modules/sty/default.nix
+++ b/pkgs/development/python-modules/sty/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  poetry-core,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "sty";
+  version = "1.0.6";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-1D7Lcbe60LVtYiyyGdC+MDwW/LQUO4TRRl3tIuKbqgA=";
+  };
+
+  nativeBuildInputs = [ poetry-core ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "String styling for your terminal";
+    homepage = "https://github.com/feluxe/sty";
+    license = licenses.mit;
+    maintainers = with maintainers; [ alikaansun ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19797,6 +19797,8 @@ self: super: with self; {
 
   stups-zign = callPackage ../development/python-modules/stups-zign { };
 
+  sty = callPackage ../development/python-modules/sty { };
+
   stytra = callPackage ../development/python-modules/stytra { };
 
   subarulink = callPackage ../development/python-modules/subarulink { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13234,6 +13234,8 @@ self: super: with self; {
 
   piccolo-theme = callPackage ../development/python-modules/piccolo-theme { };
 
+  picharsso = callPackage ../development/python-modules/picharsso { };
+
   pick = callPackage ../development/python-modules/pick { };
 
   pickleshare = callPackage ../development/python-modules/pickleshare { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11591,6 +11591,8 @@ self: super: with self; {
 
   nbmake = callPackage ../development/python-modules/nbmake { };
 
+  nbpreview = callPackage ../development/python-modules/nbpreview { };
+
   nbsmoke = callPackage ../development/python-modules/nbsmoke { };
 
   nbsphinx = callPackage ../development/python-modules/nbsphinx { };


### PR DESCRIPTION
Adds `nbpreview` and its missing dependencies `picharsso` and `sty` to `python3Packages`.

`nbpreview` is a terminal viewer for Jupyter notebooks. It renders `.ipynb` files with syntax-highlighted code cells, markdown, images, and DataFrames right in the terminal.
https://github.com/paw-lu/nbpreview

Converts images to text art
https://github.com/kelvindecosta/picharsso

Sty's goal is to provide Python with a simple, customizable and performant string styling markup, which is decoupled from color palettes and terminal implementations.
https://github.com/feluxe/sty

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
