### PR TITLE
rumno: 0.1.3 -> 0.1.4

### DIFF
--- a/nixos/modules/services/misc/rumno.nix
+++ b/nixos/modules/services/misc/rumno.nix
@@ -38,9 +38,9 @@ in
       after = [ "graphical-session-pre.target" ];
 
       serviceConfig = {
-        Type = "dbus";
-        BusName = "de.rumno.v1";
-        ExecStart = "${cfg.package}/bin/rumno daemon --foreground ${lib.escapeShellArgs cfg.extraArgs}";
+        Type = "forking";
+        PIDFile = "/tmp/rumno/rumno.pid";
+        ExecStart = lib.escapeShellArgs ([ "${cfg.package}/bin/rumno-background" ] ++ cfg.extraArgs);
         Restart = "on-failure";
         RestartSec = 1;
 

--- a/pkgs/by-name/ru/rumno/package.nix
+++ b/pkgs/by-name/ru/rumno/package.nix
@@ -17,16 +17,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rumno";
-  version = "0.1.3";
+  version = "0.1.4";
 
   src = fetchFromGitLab {
     owner = "ivanmalison";
     repo = "rumno";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-vR6+dNq0sdVtzdBL6GTzqAhl0fE6ulF6UCqIH1fSte4=";
+    hash = "sha256-81apQdjeVud7/2w5ZaacvqMG+MGGhk3XhhRiRfD5VFk=";
   };
 
-  cargoHash = "sha256-1FyDMdOO7m6y2oX/+VH5LxBwimz7fXM59eOeiffBnOI=";
+  cargoHash = "sha256-7OI5t2sX4xNljcIMzynpqncPvhn9Pu65G0/JIzxGnEQ=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
Updates `rumno` to 0.1.4.

Release: https://gitlab.com/ivanmalison/rumno/-/releases/v0.1.4

This also updates the NixOS user service to use the current upstream daemon binary, `rumno-background`, as a forking service with its pid file. The previous module command used the removed `rumno daemon --foreground` interface.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Validation performed:

- `nix build -L .#rumno`
- `nix fmt -- --ci pkgs/by-name/ru/rumno/package.nix nixos/modules/services/misc/rumno.nix`
- `git diff --check`
- NixOS module eval of `services.rumno.enable = true`, confirming `ExecStart`, `Type`, and `PIDFile`
- `./result/bin/rumno --help`

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test