### PR TITLE
android-cli: init at 1.0.15433482

### DIFF
--- a/pkgs/by-name/an/android-cli/package.nix
+++ b/pkgs/by-name/an/android-cli/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  writableTmpDirAsHomeHook,
+  versionCheckHook,
+}:
+
+let
+  platformData = {
+    x86_64-linux = {
+      url = "https://dl.google.com/android/cli/latest/linux_x86_64/android-cli";
+      hash = "sha256-1F9RVDPqiy60zs2CfWytKSPKeRC9KDTogw4Ml59HaeY=";
+    };
+    x86_64-darwin = {
+      url = "https://dl.google.com/android/cli/latest/darwin_x86_64/android-cli";
+      hash = "sha256-bXP9rRMSqQa3+kfUJnIeDb1LZXh2P2A6ytwunzjyfGs=";
+    };
+    aarch64-darwin = {
+      url = "https://dl.google.com/android/cli/latest/darwin_arm64/android-cli";
+      hash = "sha256-r47LXmilevW0td4N+SRTR7EFnCrPBdG7G/oTUAea90Q=";
+    };
+  };
+
+  systemData =
+    platformData.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+in
+stdenv.mkDerivation {
+  pname = "android-cli";
+  version = "1.0.15433482";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchurl {
+    name = "android-cli";
+    url = systemData.url;
+    hash = systemData.hash;
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -m755 -D $src $out/bin/android
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [
+    writableTmpDirAsHomeHook
+    versionCheckHook
+  ];
+
+  doInstallCheck = true;
+
+  versionCheckKeepEnvironment = [ "HOME" ];
+
+  meta = with lib; {
+    description = "Android Command-Line Tool (CLI) by Google";
+    homepage = "https://developer.android.com/tools/agents/android-cli";
+    license = licenses.unfree;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ kirillrdy ];
+    teams = with teams; [ android ];
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    mainProgram = "android";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
