### PR TITLE
tetranglix: init at 1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4542,6 +4542,12 @@
     githubId = 53847249;
     name = "Casey Avila";
   };
+  castorNova2 = {
+    email = "solemnsquire@gmail.com";
+    github = "castorNova2";
+    githubId = 84083897;
+    name = "Nidhish Chauhan";
+  };
   catap = {
     email = "kirill@korins.ky";
     github = "catap";

--- a/pkgs/by-name/te/tetranglix/package.nix
+++ b/pkgs/by-name/te/tetranglix/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  nasm,
+  fetchFromGitHub,
+  makeWrapper,
+  qemu,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tetranglix";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "nanochess";
+    repo = "tetranglix";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-eQ5whKYcTcFumbeqR54pnrWSweEXGswE+2NQ7Y+IR7w=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+    nasm
+  ];
+
+  buildInputs = [ qemu ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 tetranglix.img \
+      $out/share/tetranglix/tetranglix.img
+
+    makeWrapper ${qemu}/bin/qemu-system-i386 \
+      $out/bin/tetranglix \
+      --add-flags "-drive format=raw,file=$out/share/tetranglix/tetranglix.img,if=floppy,readonly=on"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Bootable 512-byte Tetris clone";
+    homepage = "https://github.com/nanochess/tetranglix";
+    mainProgram = "tetranglix";
+    license = lib.licenses.unlicense;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ castorNova2 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Part of #380688.

Adds a package of [tetranglix](https://github.com/nanochess/tetranglix) which is a 512-byte boot sector tetris clone written in x86 assembly.

- The package assembles the code using nasm into disk image and uses makeWrapper to produce a launcher that boots image under qemu.
- No OS is required, game directly runs on bare metal

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
