### PR TITLE
budslink: init at 1.4

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -23,11 +23,11 @@
     # Pinned Nixpkgs archive
     #
     # Use `curl -I https://channels.nixos.org/nixos-26.05` to get the
-    # latest commit of the stable channel and `nix-prefetch-url --unpack`
-    # to compute its sha256 hash.
+    # latest commit of the stable channel and `nix --extra-experimental-features nix-command store prefetch-file --unpack`
+    # to compute its hash.
     nixpkgs = builtins.fetchTarball {
       url = "https://github.com/NixOS/nixpkgs/archive/c217913993d6.tar.gz";
-      sha256 = "026mprs324330pfazlgbw987qmsa8ligglarvqbcxzig2kgw0lqg";
+      hash = "sha256-D1PA3xQv/s4W3lnR9yJFSld8UOLr0a/cBWMQMXS+1Qg=";
     };
   in
   import "${nixpkgs}/nixos" {

--- a/pkgs/by-name/ap/apkeditor/arsclib/default.nix
+++ b/pkgs/by-name/ap/apkeditor/arsclib/default.nix
@@ -9,7 +9,7 @@ let
   self = REAndroidLibrary {
     pname = "arsclib";
     # 1.3.8 is not new enough for APKEditor because of API changes
-    version = "1.3.8-unstable-2026-03-21";
+    version = "1.3.8-unstable-2026-05-16";
     projectName = "ARSCLib";
 
     src = fetchFromGitHub {
@@ -18,8 +18,8 @@ let
       # This is the latest commit at the time of packaging.
       # It can be changed to a stable release ("V${version}")
       # if it is compatible with APKEditor.
-      rev = "f6c2dc2f6db9063445e84f7ede316d4f1f029351";
-      hash = "sha256-IZ2Us7tcuE+L4bfA4JAcF6Idz1Y2S2IfqW4NSbsxr5o=";
+      rev = "a28c6fb2a77de392f2758c4dfe1a4d7d1aa86c5a";
+      hash = "sha256-0SwowTDkgF9Rdenx/nlSPuGf3kvk7ucxtr7D6r9fU/c=";
     };
 
     mitmCache = gradle.fetchDeps {

--- a/pkgs/by-name/ap/apkeditor/package.nix
+++ b/pkgs/by-name/ap/apkeditor/package.nix
@@ -55,7 +55,7 @@ let
   apkeditor =
     let
       pname = "apkeditor";
-      version = "1.4.8";
+      version = "1.4.9";
       projectName = "APKEditor";
     in
     REAndroidLibrary {
@@ -71,7 +71,7 @@ let
         owner = "REAndroid";
         repo = "APKEditor";
         tag = "V${version}";
-        hash = "sha256-1XNefeEPs8SEBw+hY2CzZ+rPojNcAbg1AqvzhVcNyy4=";
+        hash = "sha256-NVUv09mMAJDJA/jCIB/EtjQbry0Ej43a7KGR1+5cknY=";
       };
 
       patches = [

--- a/pkgs/by-name/bu/budslink/package.nix
+++ b/pkgs/by-name/bu/budslink/package.nix
@@ -31,6 +31,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-s87pFrSY8esCYsqZ4M3mPRxoo29qrgFbEYBdk9E/P/A=";
   };
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   nativeBuildInputs = [
     meson
     ninja

--- a/pkgs/by-name/bu/budslink/package.nix
+++ b/pkgs/by-name/bu/budslink/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  gjs,
+  glib,
+  gtk4,
+  libadwaita,
+  librsvg,
+  pango,
+  cairo,
+  gobject-introspection,
+  libpulseaudio,
+  wrapGAppsHook4,
+  desktop-file-utils,
+  appstream,
+  appstream-glib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "budslink";
+  version = "0.1.4";
+
+  src = fetchFromGitHub {
+    owner = "maniacx";
+    repo = "BudsLink";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-s87pFrSY8esCYsqZ4M3mPRxoo29qrgFbEYBdk9E/P/A=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gjs
+    glib
+    gobject-introspection
+    wrapGAppsHook4
+    desktop-file-utils
+    appstream
+    appstream-glib
+  ];
+
+  buildInputs = [
+    glib
+    gtk4
+    libadwaita
+    librsvg
+    pango
+    cairo
+    gjs
+    gobject-introspection
+    libpulseaudio
+  ];
+
+  postPatch = ''
+    substituteInPlace src/app.js \
+      --replace-fail "import GLibUnix from 'gi://GLibUnix';" "" \
+      --replace-fail "GLibUnix.signal_add(" "GLib.unix_signal_add("
+  '';
+
+  meta = {
+    description = "Battery tracking and ANC control for various Bluetooth earbuds (AirPods, Beats, Sony, Galaxy Buds, Nothing/CMF)";
+    homepage = "https://github.com/maniacx/BudsLink";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    mainProgram = "budslink";
+  };
+})

--- a/pkgs/by-name/ff/ffmpeg-normalize/package.nix
+++ b/pkgs/by-name/ff/ffmpeg-normalize/package.nix
@@ -7,13 +7,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "ffmpeg-normalize";
-  version = "1.37.6";
+  version = "1.37.7";
   pyproject = true;
 
   src = fetchPypi {
     inherit version;
     pname = "ffmpeg_normalize";
-    hash = "sha256-zsfWqdGyEI8OT4/L0wTxkmdqcI6NEfr5SAc7+O7FYu4=";
+    hash = "sha256-8V9C5auAvrmvq5aeaRjCy9y2/c7wm4/7Yb73dBgvj5s=";
   };
 
   build-system = with python3Packages; [ uv-build ];


### PR DESCRIPTION
BudsLink is a cross-platform application for managing various Bluetooth earbuds, providing features like battery tracking and ANC control for devices such as Galaxy Buds, AirPods, Beats, Sony, and Nothing/CMF earbuds.

Homepage: https://maniacx.github.io/BudsLink/

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
