### PR TITLE
bootle: init at 0-unstable-2022-02-28

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4542,6 +4542,12 @@
     githubId = 53847249;
     name = "Casey Avila";
   };
+  castorNova2 = {
+    email = "solemnsquire@gmail.com";
+    github = "castorNova2";
+    githubId = 84083897;
+    name = "Nidhish Chauhan";
+  };
   catap = {
     email = "kirill@korins.ky";
     github = "catap";

--- a/pkgs/by-name/bo/bootle/package.nix
+++ b/pkgs/by-name/bo/bootle/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  stdenv,
+  nasm,
+  fetchFromGitHub,
+  makeWrapper,
+  qemu,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bootle";
+  version = "0-unstable-2022-02-28";
+
+  src = fetchFromGitHub {
+    owner = "nanochess";
+    repo = "bootle";
+    rev = "6ea8d9aaf7d4ad9302dcfabc452a595bfe19fddc";
+    hash = "sha256-bGEPViBEUFr41MY3DGlJmbOqeFlSHQd1R+CMl7Dp4A0=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+    nasm
+  ];
+
+  buildInputs = [ qemu ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    make
+
+    nasm -f bin \
+      -o bootle2.img \
+      bootle2.asm
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 bootle.img \
+      $out/share/bootle/bootle.img
+
+    install -Dm644 bootle2.img \
+      $out/share/bootle/bootle2.img
+
+    makeWrapper ${qemu}/bin/qemu-system-i386 \
+      $out/bin/bootle \
+      --add-flags "-drive format=raw,file=$out/share/bootle/bootle.img,if=floppy,readonly=on"
+
+
+
+    makeWrapper ${qemu}/bin/qemu-system-i386 \
+      $out/bin/bootle2 \
+      --add-flags "-drive format=raw,file=$out/share/bootle/bootle2.img,if=floppy,readonly=on"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A Wordle clone in a x86 assembly";
+    homepage = "https://github.com/nanochess/bootle";
+    mainProgram = "bootle";
+    license = lib.licenses.bsd2;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ castorNova2 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Part of https://github.com/NixOS/nixpkgs/issues/380688.

Adds a package of [bootle](https://github.com/nanochess/bootle) which is a 512 byte boot sector wordle clone written in x86 assembly.

- The package assembles the code using nasm into disk image and uses makeWrapper to produce a launcher that boots image under qemu.
- No OS is required, game directly runs on bare metal
- Bootle2 includes a larger dictionary loaded directly from disk sectors.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
