### PR TITLE
 pihole: fix nix-update, 6.4 -> 6.4.2 

### DIFF
--- a/pkgs/by-name/pi/pihole/package.nix
+++ b/pkgs/by-name/pi/pihole/package.nix
@@ -32,13 +32,13 @@
 
 (resholve.mkDerivation (finalAttrs: {
   pname = "pihole";
-  version = "6.4";
+  version = "6.4.2";
 
   src = fetchFromGitHub {
     owner = "pi-hole";
     repo = "pi-hole";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-aBQO+wAqeuXc9ekByVFlOZQ9SBCGsozGdoS8r1qhGuk=";
+    hash = "sha256-A34LLXI+hmDNXN4MoLLlC9tW3xx+v/1La/qzFSDW0xQ=";
   };
 
   patches = [

--- a/pkgs/by-name/pi/pihole/package.nix
+++ b/pkgs/by-name/pi/pihole/package.nix
@@ -231,6 +231,11 @@
       ];
     };
 
+  passthru = {
+    inherit stateDir;
+    tests = nixosTests.pihole-ftl;
+  };
+
   meta = {
     description = "Black hole for Internet advertisements";
     homepage = "https://pi-hole.net";
@@ -240,12 +245,11 @@
     platforms = lib.platforms.linux;
     mainProgram = "pihole";
   };
-
-  passthru.tests = nixosTests.pihole-ftl;
-
-  passthru = { inherit stateDir; };
 })).overrideAttrs
   (old: {
+    # fixes nix-update trying to update resholve instead of this package
+    inherit (old) version src;
+
     # Resholve can't fix the hardcoded absolute paths, so substitute them before resholving
     preFixup = ''
       scriptsDir=$out/share/pihole


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
