### PR TITLE
python3Packages.gio-pyio: init at 0.0.6; gnome-graphs: 1.8.8 -> 2.0.7

### DIFF
--- a/pkgs/by-name/gn/gnome-graphs/package.nix
+++ b/pkgs/by-name/gn/gnome-graphs/package.nix
@@ -14,12 +14,13 @@
   shared-mime-info,
   libadwaita,
   libgee,
+  sqlite,
   nix-update-script,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "gnome-graphs";
-  version = "1.8.8";
+  version = "2.0.3";
   pyproject = false;
 
   src = fetchFromGitLab {
@@ -27,7 +28,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     owner = "World";
     repo = "Graphs";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-XsdrXdIZmAngS52KmjcNbOWwYJsnhNGELSd0p3h/XWE=";
+    hash = "sha256-Fx2/xjr8EVIXmuPzcSVGx5eEPmBffHEqeZUvsN2+prs=";
   };
 
   nativeBuildInputs = [
@@ -46,10 +47,12 @@ python3Packages.buildPythonApplication (finalAttrs: {
   buildInputs = [
     libadwaita
     libgee
+    sqlite
   ];
 
   dependencies = with python3Packages; [
     pygobject3
+    gio-pyio
     numpy
     numexpr
     sympy

--- a/pkgs/by-name/gn/gnome-graphs/package.nix
+++ b/pkgs/by-name/gn/gnome-graphs/package.nix
@@ -14,12 +14,13 @@
   shared-mime-info,
   libadwaita,
   libgee,
+  sqlite,
   nix-update-script,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "gnome-graphs";
-  version = "1.8.8";
+  version = "2.0.7";
   pyproject = false;
 
   src = fetchFromGitLab {
@@ -27,7 +28,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     owner = "World";
     repo = "Graphs";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-XsdrXdIZmAngS52KmjcNbOWwYJsnhNGELSd0p3h/XWE=";
+    hash = "sha256-dyD/Kgzi1bBroKq0ksYWF5YRVHMYa3HO0GWA69rz5iU=";
   };
 
   nativeBuildInputs = [
@@ -46,10 +47,12 @@ python3Packages.buildPythonApplication (finalAttrs: {
   buildInputs = [
     libadwaita
     libgee
+    sqlite
   ];
 
   dependencies = with python3Packages; [
     pygobject3
+    gio-pyio
     numpy
     numexpr
     sympy

--- a/pkgs/development/python-modules/gio-pyio/default.nix
+++ b/pkgs/development/python-modules/gio-pyio/default.nix
@@ -1,0 +1,40 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  glib,
+  lib,
+  pygobject3,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "gio-pyio";
+  version = "0.0.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "cmkohnen";
+    repo = "gio-pyio";
+    tag = finalAttrs.version;
+    hash = "sha256-AwA2Yboa2P13/Ne4GtmBkX4x6Cq1J7SgufBOVZb1IMM=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ pygobject3 ];
+
+  pythonImportsCheck = [ "gio_pyio" ];
+
+  nativeCheckInputs = [
+    glib
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Python like IO for gio";
+    homepage = "https://github.com/cmkohnen/gio-pyio";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ hythera ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6343,6 +6343,8 @@ self: super: with self; {
 
   gin-config = callPackage ../development/python-modules/gin-config { };
 
+  gio-pyio = callPackage ../development/python-modules/gio-pyio { };
+
   gios = callPackage ../development/python-modules/gios { };
 
   gipc = callPackage ../development/python-modules/gipc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6815,6 +6815,8 @@ self: super: with self; {
 
   gin-config = callPackage ../development/python-modules/gin-config { };
 
+  gio-pyio = callPackage ../development/python-modules/gio-pyio { };
+
   gios = callPackage ../development/python-modules/gios { };
 
   gipc = callPackage ../development/python-modules/gipc { };


### PR DESCRIPTION
changelog: https://gitlab.gnome.org/World/Graphs/-/releases/v2.0.7
diff: https://gitlab.gnome.org/World/Graphs/-/compare/v1.8.8...v2.0.7

~~Requires: #505499~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
