### PR TITLE
goland: switch to download-cdn.jetbrains.com

### DIFF
--- a/pkgs/applications/editors/jetbrains/ides/goland.nix
+++ b/pkgs/applications/editors/jetbrains/ides/goland.nix
@@ -12,19 +12,19 @@ let
   # update-script-start: urls
   urls = {
     x86_64-linux = {
-      url = "https://download.jetbrains.com/go/goland-2026.1.1.tar.gz";
+      url = "https://download-cdn.jetbrains.com/go/goland-2026.1.1.tar.gz";
       hash = "sha256-ASzqw8xuRaSAwzoiBsL+6PRyuSvBh43tnF4mEmkur9s=";
     };
     aarch64-linux = {
-      url = "https://download.jetbrains.com/go/goland-2026.1.1-aarch64.tar.gz";
+      url = "https://download-cdn.jetbrains.com/go/goland-2026.1.1-aarch64.tar.gz";
       hash = "sha256-25PADBycdas3n6BWSGOJhuMaLcik5P5AfcEO6mY75js=";
     };
     x86_64-darwin = {
-      url = "https://download.jetbrains.com/go/goland-2026.1.1.dmg";
+      url = "https://download-cdn.jetbrains.com/go/goland-2026.1.1.dmg";
       hash = "sha256-kKr5/7z5gbL0YORDET0y7LgczWLEQ31lqsrHgkxrzQ8=";
     };
     aarch64-darwin = {
-      url = "https://download.jetbrains.com/go/goland-2026.1.1-aarch64.dmg";
+      url = "https://download-cdn.jetbrains.com/go/goland-2026.1.1-aarch64.dmg";
       hash = "sha256-zfdJrXBatvAl3wNMQ3LhF9oOxo1dEyo8wr4lCoFdm9I=";
     };
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This change replaces the download URL with the official CDN mirror which provides significantly better download speeds. The binaries served by the CDN are identical to the primary server, the hash remains unchanged.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].


