### PR TITLE
kulala-fmt: 1.4.0 -> 2.11.0

### DIFF
--- a/pkgs/by-name/ku/kulala-fmt/package.nix
+++ b/pkgs/by-name/ku/kulala-fmt/package.nix
@@ -1,29 +1,147 @@
 {
   lib,
-  buildGoModule,
+  stdenv,
+  bun,
   fetchFromGitHub,
+  makeBinaryWrapper,
+  nix-update-script,
+  nodejs,
+  patchelf,
+  python3,
+  removeReferencesTo,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
 }:
 
-buildGoModule (finalAttrs: {
+let
+  node-modules-hash = {
+    "aarch64-darwin" = "sha256-z5PS0kaizEJdzTRcIH8X60Ozmteq4tx5w7SdYYMgCPI=";
+    "aarch64-linux" = "sha256-HTSOjo+8jRmCCeBVujpIAqROTpVEVq1UKM+v3urphfU=";
+    "x86_64-darwin" = "sha256-2CRtIKNqy7axoZ9ZsBrzQlkkPGbEDR3khdd56ltzak4=";
+    "x86_64-linux" = "sha256-WDpj1VSs/JI+9mr7LRWE054iiBRfRD75aRj90E23kYw=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
   pname = "kulala-fmt";
-  version = "1.4.0";
+  version = "2.11.0";
 
   src = fetchFromGitHub {
     owner = "mistweaverco";
     repo = "kulala-fmt";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-yq7DMrt+g5wM/tynI7Cf6MBJs/d+fP3IppndKnTJMTw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-cjZaE0iz/Km9bJA58HP9MoZRUFEHs7af1vJttK6wUIY=";
   };
 
-  vendorHash = "sha256-GazDEm/qv0nh8vYT+Tf0n4QDGHlcYtbMIj5rlZBvpKo=";
+  node_modules = stdenv.mkDerivation {
+    pname = "${finalAttrs.pname}-node_modules";
+    inherit (finalAttrs) version src;
 
-  env.CGO_ENABLED = 0;
+    impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
+      "GIT_PROXY_COMMAND"
+      "SOCKS_SERVER"
+    ];
 
-  ldflags = [
-    "-s"
-    "-w"
-    "-X github.com/mistweaverco/kulala-fmt/cmd/kulalafmt.VERSION=${finalAttrs.version}"
+    nativeBuildInputs = [
+      bun
+      nodejs
+      python3
+      writableTmpDirAsHomeHook
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      patchelf
+      removeReferencesTo
+    ];
+
+    dontConfigure = true;
+    dontFixup = true;
+
+    buildPhase = ''
+      runHook preBuild
+
+      export BUN_INSTALL_CACHE_DIR=$(mktemp -d)
+      export npm_config_nodedir=${nodejs}
+      bun install --frozen-lockfile --no-progress --no-cache
+      find node_modules -type f -name "*.node" -exec sh -c \
+        'for binary in "$@"; do strip -S "$binary" 2>/dev/null || true; done' sh {} +
+      rm -f node_modules/lodash/flake.lock
+      ${lib.optionalString stdenv.hostPlatform.isLinux ''
+        find node_modules -type f -name "*.node" -exec sh -c \
+          'for binary in "$@"; do patchelf --remove-rpath "$binary" 2>/dev/null || true; done' sh {} +
+        find node_modules/@mistweaverco -type f -name "*.node" -exec patchelf --set-rpath "" {} \;
+        find node_modules/@mistweaverco -type f -name "*.node" -exec remove-references-to \
+          -t "$out" \
+          -t "${stdenv.cc.libc}" \
+          -t "${stdenv.cc.cc.lib}" \
+          {} \;
+      ''}
+      rm -rf \
+        node_modules/@mistweaverco/node-addon-api/*.target.mk \
+        node_modules/@mistweaverco/tree-sitter-kulala/build/Makefile \
+        node_modules/@mistweaverco/tree-sitter-kulala/build/config.gypi \
+        node_modules/@mistweaverco/tree-sitter-kulala/build/*.target.mk \
+        node_modules/@mistweaverco/tree-sitter-kulala/build/Release/.deps \
+        node_modules/@mistweaverco/tree-sitter-kulala/build/Release/obj.target
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/node_modules
+      cp -R ./node_modules $out
+
+      runHook postInstall
+    '';
+
+    outputHash =
+      node-modules-hash.${stdenv.hostPlatform.system}
+        or (throw "${finalAttrs.pname}: Platform ${stdenv.hostPlatform.system} is not packaged yet. Supported platforms: ${lib.concatStringsSep ", " (builtins.attrNames node-modules-hash)}.");
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+  };
+
+  nativeBuildInputs = [
+    bun
+    makeBinaryWrapper
+    nodejs
   ];
+
+  strictDeps = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    cp -R ${finalAttrs.node_modules}/node_modules .
+    patchShebangs node_modules
+
+    bun run build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/${finalAttrs.pname}/node_modules/@mistweaverco
+    cp -R dist package.json $out/lib/${finalAttrs.pname}/
+    cp -R node_modules/{node-addon-api,node-gyp-build,prettier,tree-sitter} \
+      $out/lib/${finalAttrs.pname}/node_modules/
+    cp -R node_modules/@mistweaverco/tree-sitter-kulala \
+      $out/lib/${finalAttrs.pname}/node_modules/@mistweaverco/
+
+    makeBinaryWrapper ${nodejs}/bin/node $out/bin/${finalAttrs.pname} \
+      --add-flags $out/lib/${finalAttrs.pname}/dist/cli.cjs \
+      --set NODE_ENV production
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Opinionated .http and .rest files linter and formatter";
@@ -31,6 +149,6 @@ buildGoModule (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ CnTeng ];
     mainProgram = "kulala-fmt";
-    platforms = lib.platforms.all;
+    platforms = builtins.attrNames node-modules-hash;
   };
 })


### PR DESCRIPTION
## Description

Updates `kulala-fmt` from `1.4.0` to `2.11.0`.

Supersedes #391575 and #468879:

- uses #468879's version target, `2.11.0`
- uses #391575's build-system correction: upstream is now a JavaScript/Bun project, not the old Go project
- avoids adding a generated `package-lock.json`

## Things done

- Built on platform:
  - [x] `aarch64-darwin`
  - [x] `x86_64-darwin`
  - [x] `aarch64-linux`
  - [x] `x86_64-linux`
- Tested basic functionality:
  - [x] `kulala-fmt --version` returns `2.11.0` on all four platforms above
- Ran `nixpkgs-review rev HEAD`.
  - Result: `1 package updated: kulala-fmt (1.4.0 -> 2.11.0)`

Used AI for help in preparing PR