### PR TITLE
thelounge: 4.4.3 -> 4.5.0

### DIFF
--- a/pkgs/by-name/th/thelounge/package.nix
+++ b/pkgs/by-name/th/thelounge/package.nix
@@ -3,11 +3,9 @@
   stdenv,
   fetchFromGitHub,
   fetchYarnDeps,
-  nodejs,
   nodejs-slim,
   yarn,
   fixup-yarn-lock,
-  python3,
   npmHooks,
   sqlite,
   srcOnly,
@@ -18,13 +16,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "thelounge";
-  version = "4.4.3";
+  version = "4.5.0";
 
   src = fetchFromGitHub {
     owner = "thelounge";
     repo = "thelounge";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-lDbyqVFjhF2etRx31ax7KiQ1QKgVhD8xkTog/E3pUlA=";
+    hash = "sha256-I+ITSEm/FCI4omeBM8BCowI6hXBYriJfZ0vP27771Ms=";
   };
 
   # Allow setting package path for the NixOS module.
@@ -37,19 +35,16 @@ stdenv.mkDerivation (finalAttrs: {
 
   offlineCache = fetchYarnDeps {
     yarnLock = "${finalAttrs.src}/yarn.lock";
-    hash = "sha256-csVrgsEy9HjSBXxtgNG0hcBrR9COlcadhMQrw6BWPc4=";
+    hash = "sha256-wgG5AGZvMzdw4QnTNOzAfQGB//VWlV403AgWv4TceGQ=";
   };
 
   nativeBuildInputs = [
-    nodejs
+    nodejs-slim
+    nodejs-slim.npm
     yarn
     fixup-yarn-lock
-    python3
-    python3.pkgs.distutils
     npmHooks.npmInstallHook
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [ xcbuild ];
-  buildInputs = [ sqlite ];
+  ];
 
   configurePhase = ''
     runHook preConfigure
@@ -76,13 +71,6 @@ stdenv.mkDerivation (finalAttrs: {
   preInstall = ''
     yarn install --offline --frozen-lockfile --ignore-platform --ignore-scripts --no-progress --non-interactive --production
     patchShebangs node_modules
-
-    # Build the sqlite3 package.
-    npm_config_nodedir="${srcOnly nodejs}" npm_config_node_gyp="${buildPackages.nodejs}/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" npm rebuild --verbose --sqlite=${sqlite.dev}
-  '';
-
-  postInstall = ''
-    rm -rf node_modules/sqlite3/build-tmp-napi-v6/{Release/obj.target,node_sqlite3.target.mk}
   '';
 
   disallowedReferences = [ nodejs-slim.src ];
@@ -103,7 +91,7 @@ stdenv.mkDerivation (finalAttrs: {
       raitobezarius
     ];
     license = lib.licenses.mit;
-    inherit (nodejs.meta) platforms;
+    inherit (nodejs-slim.meta) platforms;
     mainProgram = "thelounge";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/thelounge/thelounge/releases/tag/v4.5.0

Upstream removed the dependency on sqlite3, allowing us to simplify that derivation a bit

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
