### PR TITLE
python3Packages.mypy: fix cross compilation

### DIFF
--- a/pkgs/development/python-modules/mypy/default.nix
+++ b/pkgs/development/python-modules/mypy/default.nix
@@ -13,8 +13,10 @@
   types-psutil,
   types-setuptools,
 
-  # propagates
+  # nativeBuildInputs + propagates
   librt,
+
+  # propagates
   mypy-extensions,
   tomli,
   typing-extensions,
@@ -49,6 +51,10 @@ buildPythonPackage rec {
   passthru.updateScript = gitUpdater {
     rev-prefix = "v";
   };
+
+  nativeBuildInputs = [
+    librt
+  ];
 
   build-system = [
     mypy-extensions


### PR DESCRIPTION
Building this package using cross compilation currently results in the following error:
```python
       >   File "<string>", line 150, in <module>
       >   File "/build/source/mypyc/build.py", line 32, in <module>
       >     from mypy.build import BuildSource
       >   File "/build/source/mypy/build.py", line 45, in <module>
       >     from librt.base64 import b64encode
       > ModuleNotFoundError: No module named 'librt.base64'
```
This pr fixes this by adding the missing dependency to `nativeBuildInputs`, to make it available during the build.

Adding it to `build-system` instead also fix the issue, I'm not sure which one is better ?

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] cross x86_64 -> aarch64-multiplaform
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
