### PR TITLE
octoprint.plugins.fanspeedslider: init at 0.2.3

### DIFF
--- a/pkgs/by-name/oc/octoprint/plugins.nix
+++ b/pkgs/by-name/oc/octoprint/plugins.nix
@@ -186,6 +186,26 @@ in
     };
   };
 
+  fanspeedslider = buildPlugin rec {
+    pname = "fanspeedslider";
+    version = "0.2.3";
+    format = "setuptools";
+
+    src = fetchFromGitHub {
+      owner = "mival";
+      repo = "OctoPrint-FanSpeedSlider";
+      rev = version;
+      sha256 = "sha256-0Gp9EgaKyCnRQv4A1sNHquTRqjag2Oz/fDGVVo95FfY=";
+    };
+
+    meta = {
+      description = "Add a slider to control the speed of a parts cooling fan";
+      homepage = "https://github.com/ntoff/OctoPrint-FanSpeedSlider";
+      license = lib.licenses.agpl3Only;
+      maintainers = with lib.maintainers; [ Superredstone ];
+    };
+  };
+
   firmwareupdater = buildPlugin rec {
     pname = "firmwareupdater";
     version = "1.14.0";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
