### PR TITLE
rulibre: add at 0.1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28731,6 +28731,12 @@
     githubId = 98685984;
     name = "utopiatopia";
   };
+  utzuro = {
+    email = "utzuro@pm.me";
+    github = "utzuro";
+    githubId = 57797638;
+    name = "utzuro";
+  };
   uvnikita = {
     email = "uv.nikita@gmail.com";
     github = "uvNikita";

--- a/pkgs/by-name/ru/rulibre/package.nix
+++ b/pkgs/by-name/ru/rulibre/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  rustPlatform,
+  fetchCrate,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  pname = "rulibre";
+  version = "0.1.2";
+
+  src = fetchCrate {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-os/m2DMJ3+mb1ivs7J9M/O8oFdDNy2SBLHblylBlXKk=";
+  };
+
+  cargoHash = "sha256-EtbTOWywfi4MjJj6Z3DCSlF0HvSw2EU1s6r6v5nXFPE=";
+  cargoDepsName = finalAttrs.pname;
+
+  meta = {
+    description = "A lightweight TUI replacement for Calibre's interface — browse your library and transfer books to your e-reader";
+    homepage = "https://github.com/Glydric/Rulibre";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ utzuro ];
+    mainProgram = "rulibre";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Adding a new package rulibre: 
- https://github.com/Glydric/Rulibre
- https://crates.io/crates/rulibre

Using crate as a source.

## Things done

- Built on platform(s)
  - [x] x86_64-linux

## Tested

- `nix-build -A rulibre`
- launched `result/bin/rulibre` locally