### PR TITLE
jitterentropy-rngd: fix systemd service to allow mlock and restict ml…

### DIFF
--- a/nixos/modules/services/security/jitterentropy-rngd.nix
+++ b/nixos/modules/services/security/jitterentropy-rngd.nix
@@ -26,6 +26,11 @@ in
       default = false;
       description = "Force SP800-90B mode for entropy reading";
     };
+    memlockLimit = lib.mkOption {
+      type = lib.types.str;
+      default = "2M";
+      description = "Set limit for lockable memory with mlock";
+    };
     verbose = lib.mkOption {
       type = lib.types.bool;
       default = false;
@@ -55,6 +60,12 @@ in
           ""
           # use service from package with our configured args
           "${cfg.package}/bin/jitterentropy-rngd ${args}"
+        ];
+        LimitMEMLOCK = [
+          # clear old setting from built-in service file
+          ""
+          # use service from package with our configured limit
+          "${cfg.memlockLimit}"
         ];
       };
     };

--- a/pkgs/by-name/ji/jitterentropy-rngd/package.nix
+++ b/pkgs/by-name/ji/jitterentropy-rngd/package.nix
@@ -19,8 +19,8 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # Allow the systemd service to mlock the daemon's entropy buffer.
     (fetchpatch {
-      url = "https://github.com/smuellerDD/jitterentropy-rngd/compare/v1.3.1...61ad2e7c83b95402536b90b52eabe20ce60cfbd7.patch";
-      hash = "sha256-Twg59vrqJGF0bH4pkIewbReCjabOFuqq+MtCnwjO9lw=";
+      url = "https://github.com/smuellerDD/jitterentropy-rngd/compare/v1.3.1...cee0c7a035e9564d161053012c6ea36b2ce27383.patch";
+      hash = "sha256-zwcY9z9EikrhxZa39p4+gl+/EeZ4sAKaItQfrL1DFSo=";
     })
   ];
 


### PR DESCRIPTION
Extend patch. Follow up to https://github.com/NixOS/nixpkgs/pull/519637

https://github.com/smuellerDD/jitterentropy-rngd/compare/v1.3.1...cee0c7a035e9564d161053012c6ea36b2ce27383

There was an error in the previous correction, but it has been corrected upstream
https://github.com/smuellerDD/jitterentropy-rngd/commit/cee0c7a035e9564d161053012c6ea36b2ce27383

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
