### PR TITLE
otfcc: fix build

### DIFF
--- a/pkgs/by-name/ot/otfcc/package.nix
+++ b/pkgs/by-name/ot/otfcc/package.nix
@@ -24,6 +24,11 @@ stdenv.mkDerivation rec {
     ./move-makefiles.patch
   ];
 
+  postPatch = ''
+    substituteInPlace premake5.lua \
+      --replace-fail 'flags { "StaticRuntime" }' 'staticruntime "On"'
+  '';
+
   buildFlags = lib.optionals stdenv.hostPlatform.isAarch64 [ "config=release_arm" ];
 
   installPhase = ''
@@ -39,11 +44,5 @@ stdenv.mkDerivation rec {
     license = lib.licenses.asl20;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ ttuegel ];
-    # Build fails on all platforms with
-    #        > configure flags: gmake
-    #   > ** Warning: action 'xcode4' sets 'os' field, which is deprecated, use 'targetos' instead.
-    #   > Error: invalid value 'StaticRuntime' for flags
-    broken = true;
   };
-
 }


### PR DESCRIPTION
Fix build 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
