### PR TITLE
python31{3,4}Packages.ecdsa: fix build failure

### DIFF
--- a/pkgs/development/python-modules/ecdsa/default.nix
+++ b/pkgs/development/python-modules/ecdsa/default.nix
@@ -34,6 +34,13 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ];
 
+  patches = [
+    # Python update caused one of the tests to fail. A patch that fixes this
+    # has been submitted upstream, yet to be applied.
+    # https://github.com/tlsfuzzer/python-ecdsa/pull/371
+    ./pr-371-fix-test-2026-05-23.patch
+  ];
+
   passthru.updateScript = gitUpdater {
     rev-prefix = "python-ecdsa-";
   };

--- a/pkgs/development/python-modules/ecdsa/pr-371-fix-test-2026-05-23.patch
+++ b/pkgs/development/python-modules/ecdsa/pr-371-fix-test-2026-05-23.patch
@@ -1,0 +1,30 @@
+From f8e0f3a0035b44fa2541e2c447ed1599f220c4b5 Mon Sep 17 00:00:00 2001
+From: Alexander Shadchin <shadchin@yandex-team.com>
+Date: Thu, 9 Apr 2026 12:22:29 +0300
+Subject: [PATCH] Fix tests with new Python
+
+---
+ src/ecdsa/der.py | 9 ++++-----
+ 1 file changed, 4 insertions(+), 5 deletions(-)
+
+diff --git a/src/ecdsa/der.py b/src/ecdsa/der.py
+index 5d35d698..587d7852 100644
+--- a/src/ecdsa/der.py
++++ b/src/ecdsa/der.py
+@@ -464,12 +464,11 @@ def unpem(pem):
+     if isinstance(pem, text_type):  # pragma: no branch
+         pem = pem.encode()
+ 
++    lines = (l.strip() for l in pem.split(b"\n"))
+     d = b"".join(
+-        [
+-            l.strip()
+-            for l in pem.split(b"\n")
+-            if l and not l.startswith(b"-----")
+-        ]
++        l
++        for l in lines
++        if l and not l.startswith(b"-----")
+     )
+     return base64.b64decode(d)
+ 


### PR DESCRIPTION
Python update caused one of the tests to fail. A patch that fixes this
has been submitted upstream, yet to be applied. This commit adds the
patch.

See https://github.com/tlsfuzzer/python-ecdsa/pull/371.

I haven't read the AI policy. Didn't use an LLM for any of this though.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
