### PR TITLE
python3Packages.stim: fix build with pybind11 3.0

### DIFF
--- a/pkgs/development/python-modules/stim/default.nix
+++ b/pkgs/development/python-modules/stim/default.nix
@@ -32,6 +32,11 @@ buildPythonPackage rec {
     hash = "sha256-Wls7dJkuV/RXnMizwrYOJOKopWEf1r21FKoKHjmpEQ0=";
   };
 
+  patches = [
+    # Fix measure_kickback lambda return type deduction under pybind11 3.0.
+    ./fix-measure-kickback-lambda-return-type.patch
+  ];
+
   postPatch = ''
     # asked to relax this in https://github.com/quantumlib/Stim/issues/623
     substituteInPlace pyproject.toml \

--- a/pkgs/development/python-modules/stim/fix-measure-kickback-lambda-return-type.patch
+++ b/pkgs/development/python-modules/stim/fix-measure-kickback-lambda-return-type.patch
@@ -1,0 +1,11 @@
+--- a/src/stim/simulators/tableau_simulator.pybind.cc
++++ b/src/stim/simulators/tableau_simulator.pybind.cc
+@@ -2287,7 +2287,7 @@
+
+     c.def(
+         "measure_kickback",
+-        [](TableauSimulator<MAX_BITWORD_WIDTH> &self, uint32_t target) {
++        [](TableauSimulator<MAX_BITWORD_WIDTH> &self, uint32_t target) -> pybind11::tuple {
+             self.ensure_large_enough_for_qubits(target + 1);
+             auto result = self.measure_kickback_z({target});
+             if (result.second.num_qubits == 0) {


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/329541947)](https://hydra.nixos.org/build/329541947)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

