### PR TITLE
python3Packages.sqlalchemy-continuum: drop sqlalchemy-{i18n,utils} removed in 1.5.x

### DIFF
--- a/pkgs/development/python-modules/sqlalchemy-continuum/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy-continuum/default.nix
@@ -6,12 +6,11 @@
   flask,
   flask-login,
   flask-sqlalchemy,
+  packaging,
   psycopg2,
   pymysql,
   pytestCheckHook,
   sqlalchemy,
-  sqlalchemy-i18n,
-  sqlalchemy-utils,
 }:
 
 buildPythonPackage rec {
@@ -29,17 +28,16 @@ buildPythonPackage rec {
 
   dependencies = [
     sqlalchemy
-    sqlalchemy-utils
   ];
 
   optional-dependencies = {
     flask = [ flask ];
     flask-login = [ flask-login ];
     flask-sqlalchemy = [ flask-sqlalchemy ];
-    i18n = [ sqlalchemy-i18n ];
   };
 
   nativeCheckInputs = [
+    packaging
     psycopg2
     pymysql
     pytestCheckHook
@@ -47,11 +45,6 @@ buildPythonPackage rec {
   ++ optional-dependencies.flask
   ++ optional-dependencies.flask-login
   ++ optional-dependencies.flask-sqlalchemy;
-
-  disabledTestPaths = [
-    # requires sqlalchemy-i18n, which is incompatible with sqlalchemy>=2
-    "tests/test_i18n.py"
-  ];
 
   preCheck = ''
     # Indicate tests that we don't have a database server at hand


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/329464793)](https://hydra.nixos.org/build/329464793)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

