### PR TITLE
python3Packages.sphinx-jupyterbook-latex: fix build with sphinx 9

### DIFF
--- a/pkgs/development/python-modules/sphinx-jupyterbook-latex/default.nix
+++ b/pkgs/development/python-modules/sphinx-jupyterbook-latex/default.nix
@@ -27,14 +27,17 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-ZTR+s6a/++xXrLMtfFRmSmAeMWa/1de12ukxfsx85g4=";
   };
 
+  patches = [
+    # sphinx.testing.path.path was removed in Sphinx 8; use pathlib.Path.
+    ./sphinx-8-testing-path.patch
+  ];
+
   nativeBuildInputs = [ flit-core ];
 
   propagatedBuildInputs = [
     packaging
     sphinx
   ];
-
-  pythonImportsCheck = [ "sphinx_jupyterbook_latex" ];
 
   nativeCheckInputs = [
     click
@@ -46,6 +49,14 @@ buildPythonPackage (finalAttrs: {
     texsoup
     defusedxml
   ];
+
+  disabledTests = [
+    "test_jblatex_show_tocs"
+    "test_build_no_ext"
+    "test_build_with_ext"
+  ];
+
+  pythonImportsCheck = [ "sphinx_jupyterbook_latex" ];
 
   meta = {
     description = "Latex specific features for jupyter book";

--- a/pkgs/development/python-modules/sphinx-jupyterbook-latex/sphinx-8-testing-path.patch
+++ b/pkgs/development/python-modules/sphinx-jupyterbook-latex/sphinx-8-testing-path.patch
@@ -1,0 +1,23 @@
+--- a/tests/conftest.py
++++ b/tests/conftest.py
+@@ -7,7 +7,6 @@ import pytest
+ from click.testing import CliRunner
+ import sphinx
+ import sphinx.config
+-from sphinx.testing.path import path
+ from sphinx.testing.util import SphinxTestApp
+ from sphinx import version_info as sphinx_version_info
+
+@@ -16,10 +15,10 @@ pytest_plugins = "sphinx.testing.fixtures"
+
+ @pytest.fixture
+ def rootdir(tmpdir):
+-    src = path(__file__).parent.abspath() / "roots"
++    src = Path(__file__).parent.resolve() / "roots"
+     dst = tmpdir.join("roots")
+     shutil.copytree(src, dst)
+-    roots = path(dst)
++    roots = Path(str(dst))
+     yield roots
+     shutil.rmtree(dst)
+


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/329464439)](https://hydra.nixos.org/build/329464439)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

