### PR TITLE
python3Packages.solidpython2: skip example 18 with missing reference fixture

### DIFF
--- a/pkgs/development/python-modules/solidpython2/difftool_tests.patch
+++ b/pkgs/development/python-modules/solidpython2/difftool_tests.patch
@@ -2,7 +2,16 @@ diff --git a/tests/examples_test.py b/tests/examples_test.py
 index 77204fd..9784389 100644
 --- a/tests/examples_test.py
 +++ b/tests/examples_test.py
-@@ -48,14 +48,19 @@ class ExamplesTest(unittest.TestCase):
+@@ -41,6 +41,8 @@ class ExamplesTest(unittest.TestCase):
+                 continue
+             if f.stem.endswith(".x"):
+                 continue
++            if f.stem.startswith("18-"):
++                continue
+
+             test_scad_file = root / "tests" / "examples_scad" \
+                              / f.with_suffix('.scad').name
+@@ -48,14 +50,19 @@ class ExamplesTest(unittest.TestCase):
              subprocess.check_call(["python3", f.as_posix()])
              # copy generated scad file to examples_scad/
              copyWithRelativeIncludes(f.with_suffix(".scad"), test_scad_file)


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/329464173)](https://hydra.nixos.org/build/329464173)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

