### PR TITLE
python3Packages.salmon-mail: fix test_main exit code on click 8.2+

### DIFF
--- a/pkgs/development/python-modules/salmon-mail/default.nix
+++ b/pkgs/development/python-modules/salmon-mail/default.nix
@@ -23,6 +23,11 @@ buildPythonPackage rec {
     hash = "sha256-ysBO/ridfy7YPoTsVwAxar9UvfM/qxrx2dp0EtDNLvE=";
   };
 
+  patches = [
+    # Fix test_main expecting exit code 0 from click group with no args (click 8.2 returns 2).
+    ./test-main-click-8.2-exit-code.patch
+  ];
+
   nativeCheckInputs = [
     jinja2
     unittestCheckHook

--- a/pkgs/development/python-modules/salmon-mail/test-main-click-8.2-exit-code.patch
+++ b/pkgs/development/python-modules/salmon-mail/test-main-click-8.2-exit-code.patch
@@ -1,0 +1,12 @@
+--- a/tests/test_command.py
++++ b/tests/test_command.py
+@@ -48,7 +48,8 @@
+     def test_main(self):
+         runner = CliRunner()
+         result = runner.invoke(commands.main)
+-        self.assertEqual(result.exit_code, 0)
++        # click 8.2 changed the exit code when no_args_is_help displays help: 0 -> 2.
++        self.assertEqual(result.exit_code, 2)
+
+     @patch('salmon.queue.Queue')
+     def test_queue_command(self, MockQueue):


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/329462795)](https://hydra.nixos.org/build/329462795)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

