### PR TITLE
python3Packages.pytest-notebook: fix build with pytest 9

### DIFF
--- a/pkgs/development/python-modules/pytest-notebook/default.nix
+++ b/pkgs/development/python-modules/pytest-notebook/default.nix
@@ -38,6 +38,11 @@ buildPythonPackage rec {
     hash = "sha256-LoK0wb7rAbVbgyURCbSfckWvJDef3tPY+7V4YU1IBRU=";
   };
 
+  patches = [
+    # Rename pytest_collect_file hook parameter `path` -> `file_path` for pytest 9.
+    ./pytest9-collect-hook.patch
+  ];
+
   postPatch = ''
     # we disable the tests relying on coverage for unrelated reasons
     substituteInPlace tests/test_execution.py \

--- a/pkgs/development/python-modules/pytest-notebook/pytest9-collect-hook.patch
+++ b/pkgs/development/python-modules/pytest-notebook/pytest9-collect-hook.patch
@@ -1,0 +1,31 @@
+--- a/pytest_notebook/plugin.py
++++ b/pytest_notebook/plugin.py
+@@ -11,6 +11,7 @@
+
+ """
+ import os
++from fnmatch import fnmatch
+ import shlex
+
+ import pytest
+@@ -263,16 +264,16 @@
+     return NBRegressionFixture(**kwargs)
+
+
+-def pytest_collect_file(path, parent):
++def pytest_collect_file(file_path, parent):
+     """Collect Jupyter notebooks using the specified pytest hook."""
+     kwargs, other_args = gather_config_options(parent.config)
+     if other_args.get("nb_test_files", False) and any(
+-        path.fnmatch(pat) for pat in other_args.get("nb_file_fnmatch", ["*.ipynb"])
++        fnmatch(file_path.name, pat) for pat in other_args.get("nb_file_fnmatch", ["*.ipynb"])
+     ):
+         try:
+-            return JupyterNbCollector.from_parent(parent, fspath=path)
++            return JupyterNbCollector.from_parent(parent, path=file_path)
+         except AttributeError:
+-            return JupyterNbCollector(path, parent)
++            return JupyterNbCollector(file_path, parent)
+
+
+ class JupyterNbCollector(pytest.File):


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/329459494)](https://hydra.nixos.org/build/329459494)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

