### PR TITLE
xbase: unbreak

### DIFF
--- a/pkgs/by-name/xb/xbase/package.nix
+++ b/pkgs/by-name/xb/xbase/package.nix
@@ -4,12 +4,12 @@
   fetchurl,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "xbase";
   version = "3.1.2";
 
   src = fetchurl {
-    url = "mirror://sourceforge/xdb/xbase64-${version}.tar.gz";
+    url = "mirror://sourceforge/xdb/xbase64-${finalAttrs.version}.tar.gz";
     sha256 = "17287kz1nmmm64y7zp9nhhl7slzlba09h6cc83w4mvsqwd9w882r";
   };
 
@@ -30,11 +30,14 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  postPatch = ''
+    sed -i '1i#include <cstdarg>' xbase64/xbstring.cpp
+  '';
+
   meta = {
     homepage = "https://sourceforge.net/projects/xdb/";
     description = "C++ class library formerly known as XDB";
     platforms = lib.platforms.linux;
-    broken = true; # Fails to build against gcc-14, no upstream activity.
     license = lib.licenses.lgpl2;
   };
-}
+})

--- a/pkgs/by-name/xb/xbase/package.nix
+++ b/pkgs/by-name/xb/xbase/package.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     homepage = "https://sourceforge.net/projects/xdb/";
     description = "C++ class library formerly known as XDB";
+    maintainers = with lib.maintainers; [ tbutter ];
     platforms = lib.platforms.linux;
     license = lib.licenses.lgpl2;
   };


### PR DESCRIPTION
Patch to fix build.

Looked for a few easy to fix breakages - not sure if this makes sense or the package should be deleted instead.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
