### PR TITLE
budslink: init at 0.1.5

### DIFF
--- a/pkgs/by-name/bu/budslink/package.nix
+++ b/pkgs/by-name/bu/budslink/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  gjs,
+  glib,
+  gtk4,
+  libadwaita,
+  librsvg,
+  pango,
+  cairo,
+  gobject-introspection,
+  libpulseaudio,
+  wrapGAppsHook4,
+  desktop-file-utils,
+  appstream,
+  appstream-glib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "budslink";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "maniacx";
+    repo = "BudsLink";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-d24FumbPgiJLlW6LiAwLFpg9xU8fi/j9Pjlc17lMnBQ=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gjs
+    glib
+    gobject-introspection
+    wrapGAppsHook4
+    desktop-file-utils
+    appstream
+    appstream-glib
+  ];
+
+  buildInputs = [
+    glib
+    gtk4
+    libadwaita
+    librsvg
+    pango
+    cairo
+    gjs
+    gobject-introspection
+    libpulseaudio
+  ];
+
+  postPatch = ''
+    substituteInPlace src/app.js \
+      --replace-fail "import GLibUnix from 'gi://GLibUnix';" "" \
+      --replace-fail "GLibUnix.signal_add(" "GLib.unix_signal_add("
+  '';
+
+  meta = {
+    description = "Battery tracking and ANC control for various Bluetooth earbuds (AirPods, Beats, Sony, Galaxy Buds, Nothing/CMF)";
+    homepage = "https://github.com/maniacx/BudsLink";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    mainProgram = "budslink";
+  };
+})


### PR DESCRIPTION
BudsLink is a cross-platform application for managing various Bluetooth earbuds, providing features like battery tracking and ANC control for devices such as Galaxy Buds, AirPods, Beats, Sony, and Nothing/CMF earbuds.

Homepage: https://maniacx.github.io/BudsLink/

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
