### PR TITLE
gamescope: feature option `enableWsi`

### DIFF
--- a/nixos/modules/programs/gamescope.nix
+++ b/nixos/modules/programs/gamescope.nix
@@ -26,6 +26,8 @@ in
 
     package = lib.mkPackageOption pkgs "gamescope" { };
 
+    enableWsi = lib.mkEnableOption "gamescope-wsi, the Vulkan WSI layer, alongside gamescope";
+
     capSysNice = lib.mkOption {
       type = lib.types.bool;
       default = false;
@@ -76,6 +78,11 @@ in
     };
 
     environment.systemPackages = lib.mkIf (!cfg.capSysNice) [ gamescope ];
+
+    hardware.graphics = lib.optionalAttrs cfg.enableWsi {
+      extraPackages = with pkgs; [ gamescope-wsi ];
+      extraPackages32 = with pkgs; [ pkgsi686Linux.gamescope-wsi ];
+    };
   };
 
   meta.maintainers = [ ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

featuring a `enableWsi` option for `programs.gamescope`

bypassing the requirement for users to manually write

```nix
environment.systemPackages = with pkgs; [
  gamescope-wsi # HDR won't work without this
];
```

for (legacy compositors / proton) HDR, as [currently recommended in the wiki](https://wiki.nixos.org/wiki/Steam#Gamescope_HDR)

_previously talked in https://matrix.to/#/!JrBtSIugVadKwbhvCc:matrix.org/$RUlCb9jhJYQT4SAGlMfZt3ZK1ascxJsjpIeoCEpmMRA?via=nixos.org&via=matrix.org&via=tchncs.de with @K900_

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
