### PR TITLE
monocle-review: init at 0.46.1

### DIFF
--- a/pkgs/by-name/mo/monocle-review/package.nix
+++ b/pkgs/by-name/mo/monocle-review/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "monocle-review";
+  version = "0.46.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "josephschmitt";
+    repo = "monocle";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2ye2Y/yrJXebGX++B8ILDhZpsm4NxZ5RRRDI/dzfOpY=";
+  };
+
+  vendorHash = "sha256-oajKuhbP+DRXefoJbrOVoyE1rOdtZaPS4c3u0HUP4Kc=";
+
+  subPackages = [ "cmd/monocle" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=main.version=${finalAttrs.version}"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Real-time TUI code review for AI coding agents";
+    homepage = "https://github.com/josephschmitt/monocle";
+    changelog = "https://github.com/josephschmitt/monocle/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ josephschmitt ];
+    mainProgram = "monocle";
+  };
+})


### PR DESCRIPTION
Adds [monocle-review](https://github.com/josephschmitt/monocle), a TUI that runs alongside an AI coding agent so you can review diffs in real time, leave line-level comments (issues, suggestions, notes), and submit a structured review in one batch. The agent receives the feedback via MCP tools or CLI over a Unix socket and addresses it in the same session.

Named \`monocle-review\` here to avoid colliding with the existing [\`monocle\`](https://github.com/NixOS/nixpkgs/tree/master/pkgs/by-name/mo/monocle) package (the bgpkit BGP tool). The installed binary remains \`monocle\`, matching upstream.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at \`passthru.tests\`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and \"core\" functionality.
- [ ] Ran \`nixpkgs-review\` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in \`./result/bin/\`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test