### PR TITLE
marelle: init at 1.004

### DIFF
--- a/pkgs/by-name/ma/marelle/package.nix
+++ b/pkgs/by-name/ma/marelle/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitLab,
+  installFonts,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "marelle";
+  version = "1.004";
+
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
+  src = fetchFromGitLab {
+    domain = "forge.apps.education.fr";
+    owner = "marelle";
+    repo = "marelle.forge.apps.education.fr";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-BNUNHQ7Vjh34CPMd+YG2aVc1ttg65LUKH0ToJ1VAw2U=";
+  };
+
+  # public/fonts/ duplicates fonts/webfonts/
+  postPatch = ''
+    rm -rf public/fonts
+  '';
+
+  nativeBuildInputs = [
+    installFonts
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Cursive font for teaching handwritting in primary school";
+    homepage = "https://marelle.forge.apps.education.fr";
+    license = lib.licenses.ofl;
+    maintainers = with lib.maintainers; [ nim65s ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
add a simple font for teaching handwriting to kids
https://marelle.forge.apps.education.fr/ (french)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
