### PR TITLE
python3Packages.viser: 1.0.27 -> 1.0.29; set __darwinAllowLocalNetworking

### DIFF
--- a/pkgs/development/python-modules/viser/default.nix
+++ b/pkgs/development/python-modules/viser/default.nix
@@ -171,6 +171,8 @@ buildPythonPackage (finalAttrs: {
     "viser"
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   meta = {
     changelog = "https://github.com/viser-project/viser/releases/tag/${finalAttrs.src.tag}";
     description = "Web-based 3D visualization in Python";

--- a/pkgs/development/python-modules/viser/default.nix
+++ b/pkgs/development/python-modules/viser/default.nix
@@ -55,14 +55,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "viser";
-  version = "1.0.27";
+  version = "1.0.29";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "viser-project";
     repo = "viser";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-qE9V6KjniKm3vBtf5ger6UHob4go0wTaJnmYtvYqvMc=";
+    hash = "sha256-OeI/aEhJ0k9U2BtDEvwIimNFj74NZLSh4ieKnugn/hk=";
   };
 
   postPatch = ''
@@ -105,15 +105,14 @@ buildPythonPackage (finalAttrs: {
     trimesh
     typing-extensions
     websockets
-    yourdfpy
     zstandard
   ];
 
   optional-dependencies = {
+    urdf = [ yourdfpy ];
     dev = [
       hypothesis
       nodeenv
-      opencv-python
       playwright
       pre-commit
       psutil
@@ -122,7 +121,8 @@ buildPythonPackage (finalAttrs: {
       pytest-playwright
       pytest-xdist
       ruff
-    ];
+    ]
+    ++ finalAttrs.passthru.optional-dependencies.examples;
     examples = [
       gdown
       liblzfse
@@ -134,7 +134,8 @@ buildPythonPackage (finalAttrs: {
       robot-descriptions
       torch
       tyro
-    ];
+    ]
+    ++ finalAttrs.passthru.optional-dependencies.urdf;
   };
 
   nativeCheckInputs = [


### PR DESCRIPTION
- **python3Packages.viser: 1.0.27 -> 1.0.29**
    Changelogs:
    - https://github.com/viser-project/viser/releases/tag/v1.0.28
    - https://github.com/viser-project/viser/releases/tag/v1.0.29

    Diff: https://github.com/viser-project/viser/compare/v1.0.27...v1.0.29
- **python3Packages.viser: set __darwinAllowLocalNetworking**

Closes: #521831

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
