### PR TITLE
python3Packages.aiosendspin: 4.4.0 -> 5.3.0, python3Packages.sendspin: 5.9.0 -> 7.3.1

### DIFF
--- a/pkgs/development/python-modules/aiosendspin/default.nix
+++ b/pkgs/development/python-modules/aiosendspin/default.nix
@@ -29,14 +29,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "aiosendspin";
-  version = "4.4.0";
+  version = "5.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Sendspin";
     repo = "aiosendspin";
     tag = finalAttrs.version;
-    hash = "sha256-7edFCGNbECW5rrTbF7vJ4lJUc2IrQZD9VTR3IxJRP08=";
+    hash = "sha256-bPkmLPneeu1+9+131OrgLPt3RV6HfVdbIIxtSXgbSaE=";
   };
 
   # https://github.com/Sendspin/aiosendspin/blob/4.4.0/pyproject.toml#L7

--- a/pkgs/development/python-modules/sendspin/default.nix
+++ b/pkgs/development/python-modules/sendspin/default.nix
@@ -8,6 +8,7 @@
   numpy,
   pulsectl-asyncio,
   pychromecast,
+  pytest-asyncio,
   pytestCheckHook,
   qrcode,
   readchar,
@@ -18,14 +19,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "sendspin";
-  version = "5.9.0";
+  version = "7.3.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Sendspin";
     repo = "sendspin-cli";
     tag = finalAttrs.version;
-    hash = "sha256-g+qw3mDHij50CEDKGjltMGNZoI6/HeJQ8zq8NSvD3Ls=";
+    hash = "sha256-LeRlNgPPK6T0HqaoSO7r6x7a+zWmNzFJqt+5fNHPhTo=";
   };
 
   postPatch = ''
@@ -51,14 +52,16 @@ buildPythonPackage (finalAttrs: {
     cast = [ pychromecast ];
   };
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [ "sendspin" ];
 
   disabledTests = [
-    #  AssertionError: assert None == (1, 'Digital')
-    "test_alsa_available_for_hw_device_with_mixer"
-    "test_hifiberry_dac_discovery"
+    # ConnectionRefusedError: [Errno 111] Connect call failed ('127.0.0.1', 19800)
+    "test_multi_worker_starts_and_serves_status"
   ];
 
   meta = {


### PR DESCRIPTION
fix #511908

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
